### PR TITLE
Bug 539826 - BranchLabel: return value of delegate.forwardReference*() ignored

### DIFF
--- a/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/codegen/BranchLabel.java
+++ b/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/codegen/BranchLabel.java
@@ -160,11 +160,11 @@ void branchWide() {
 }
 
 public int forwardReferenceCount() {
-	if (this.delegate != null) this.delegate.forwardReferenceCount();
+	if (this.delegate != null) return this.delegate.forwardReferenceCount();
 	return this.forwardReferenceCount;
 }
 public int[] forwardReferences() {
-	if (this.delegate != null) this.delegate.forwardReferences();
+	if (this.delegate != null) return this.delegate.forwardReferences();
 	return this.forwardReferences;
 }
 public void initialize(CodeStream stream) {


### PR DESCRIPTION
See https://git.eclipse.org/r/c/jdt/eclipse.jdt.core/+/127623