### PR TITLE
Jenkinsfile should use 2G max heap for tests and keep more builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
 	options {
 		timeout(time: 60, unit: 'MINUTES')
-		buildDiscarder(logRotator(numToKeepStr:'5'))
+		buildDiscarder(logRotator(numToKeepStr:'15'))
 		timestamps()
 	}
 	agent {
@@ -25,7 +25,7 @@ pipeline {
 					
 					unset JAVA_TOOL_OPTIONS
 					unset _JAVA_OPTIONS
-					MAVEN_OPTS="-Xmx4G"
+					MAVEN_OPTS="-Xmx2G"
 					mvn -U clean verify --batch-mode --fail-at-end -Dmaven.repo.local=$WORKSPACE/.m2/repository \
 					-Pbuild-individual-bundles -Ptest-on-javase-17 -Pbree-libs -Papi-check -Dtycho.version=2.7.0 \
 					-Djava.io.tmpdir=$WORKSPACE/tmp -Dcompare-version-with-baselines.skip=false -Dproject.build.sourceEncoding=UTF-8 \


### PR DESCRIPTION
Fixes issue https://github.com/eclipse-jdt/eclipse.jdt.core/issues/8