### PR TITLE
Bug 577974 - Full Java indexing on large project with many jar dependies

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/ClasspathJar.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/ClasspathJar.java
@@ -19,6 +19,7 @@ package org.eclipse.jdt.internal.core.builder;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.ref.WeakReference;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.Enumeration;
@@ -52,11 +53,13 @@ public class ClasspathJar extends ClasspathLocation {
 final boolean isOnModulePath;
 
 static class PackageCacheEntry {
+	WeakReference<ZipFile> zipFile;
 	long lastModified;
 	long fileSize;
 	SimpleSet packageSet;
 
-	PackageCacheEntry(long lastModified, long fileSize, SimpleSet packageSet) {
+	PackageCacheEntry(ZipFile zipFile, long lastModified, long fileSize, SimpleSet packageSet) {
+		this.zipFile = new WeakReference<>(zipFile);
 		this.lastModified = lastModified;
 		this.fileSize = fileSize;
 		this.packageSet = packageSet;
@@ -84,15 +87,19 @@ protected static void addToPackageSet(SimpleSet packageSet, String fileName, boo
 protected SimpleSet findPackageSet() {
 	String zipFileName = this.zipFilename;
 	PackageCacheEntry cacheEntry = (PackageCacheEntry) PackageCache.get(zipFileName);
+	if(cacheEntry != null && cacheEntry.zipFile.get() == this.zipFile) {
+		return cacheEntry.packageSet;
+	}
 	long timestamp = this.lastModified();
 	long fileSize = new File(zipFileName).length();
 	if (cacheEntry != null && cacheEntry.lastModified == timestamp && cacheEntry.fileSize == fileSize) {
+		cacheEntry.zipFile = new WeakReference<ZipFile>(this.zipFile);
 		return cacheEntry.packageSet;
 	}
 	final SimpleSet packageSet = new SimpleSet(41);
 	packageSet.add(""); //$NON-NLS-1$
 	readJarContent(packageSet);
-	PackageCache.put(zipFileName, new PackageCacheEntry(timestamp, fileSize, packageSet));
+	PackageCache.put(zipFileName, new PackageCacheEntry(this.zipFile, timestamp, fileSize, packageSet));
 	return packageSet;
 }
 protected String readJarContent(final SimpleSet packageSet) {


### PR DESCRIPTION
is very slow

- new File(zipFileName).length() in findPackageSet is IO time consumming
- Use of WeakReference for ZifFile in PackageCacheEntry to avoid
MemoryLeak

Change-Id: Ia073c86ce6c347de0d1bfcc4774c454ec797bb4e