### PR TITLE
Bug 578815 - More completion candidates after new keyword for interface

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -26445,6 +26445,29 @@ public void testBug574982() throws JavaModelException {
 			"A3[TYPE_REF]{A3, , LA3;, null, null, 52}\n" +
 			"ArrayTest[TYPE_REF]{ArrayTest, , LArrayTest;, null, null, 52}\n" +
 			"A[TYPE_REF]{A, , LA;, null, null, 56}",
+			requestor.getResults());
+}
+/**
+ * https://bugs.eclipse.org/bugs/show_bug.cgi?id=578815
+ * @throws IOException
+ */
+public void testCompletionConstructorsForSubTypes() throws JavaModelException, IOException {
+	ICompilationUnit cu= getCompilationUnit("Completion", "src", "", "CompletionConstructorsForSubTypes.java");
+	String str = cu.getSource();
+	String completeBehind = "new ";
+	int cursorLocation = str.lastIndexOf(completeBehind) + completeBehind.length();
+
+	CompletionTestsRequestor2 requestor = new CompletionTestsRequestor2(true, false, false, true, true);
+	requestor.allowAllRequiredProposals();
+	cu.codeComplete(cursorLocation, requestor, new NullProgressMonitor());
+
+	assertEquals(
+			"CompletionConstructorsForSubTypes[CONSTRUCTOR_INVOCATION]{(), LCompletionConstructorsForSubTypes;, ()V, CompletionConstructorsForSubTypes, null, 55}\n" +
+			"   CompletionConstructorsForSubTypes[TYPE_REF]{CompletionConstructorsForSubTypes, , LCompletionConstructorsForSubTypes;, null, null, 55}\n" +
+			"CompletionConstructorsForSubTypes2[CONSTRUCTOR_INVOCATION]{(), LCompletionConstructorsForSubTypes2;, ()V, CompletionConstructorsForSubTypes2, null, 75}\n" +
+			"   CompletionConstructorsForSubTypes2[TYPE_REF]{CompletionConstructorsForSubTypes2, , LCompletionConstructorsForSubTypes2;, null, null, 75}\n" +
+			"CompletionConstructorsForSubTypes1[ANONYMOUS_CLASS_CONSTRUCTOR_INVOCATION]{(), LCompletionConstructorsForSubTypes1;, ()V, CompletionConstructorsForSubTypes1, null, 82}\n" +
+			"   CompletionConstructorsForSubTypes1[TYPE_REF]{CompletionConstructorsForSubTypes1, , LCompletionConstructorsForSubTypes1;, null, null, 82}",
 			requestor.getResults());
 }
 }

--- a/org.eclipse.jdt.core.tests.model/workspace/Completion/src/CompletionConstructorsForSubTypes.java
+++ b/org.eclipse.jdt.core.tests.model/workspace/Completion/src/CompletionConstructorsForSubTypes.java
@@ -1,0 +1,5 @@
+public class CompletionConstructorsForSubTypes {
+	public void test() {
+		CompletionConstructorsForSubTypes1 i = new 
+	}
+}

--- a/org.eclipse.jdt.core.tests.model/workspace/Completion/src/CompletionConstructorsForSubTypes1.java
+++ b/org.eclipse.jdt.core.tests.model/workspace/Completion/src/CompletionConstructorsForSubTypes1.java
@@ -1,0 +1,2 @@
+public interface CompletionConstructorsForSubTypes1 {
+}

--- a/org.eclipse.jdt.core.tests.model/workspace/Completion/src/CompletionConstructorsForSubTypes2.java
+++ b/org.eclipse.jdt.core.tests.model/workspace/Completion/src/CompletionConstructorsForSubTypes2.java
@@ -1,0 +1,2 @@
+public class CompletionConstructorsForSubTypes2 implements CompletionConstructorsForSubTypes1 {
+}

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/CompletionEngine.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/CompletionEngine.java
@@ -17,6 +17,7 @@
  *     Gábor Kövesdán - Contribution for Bug 350000 - [content assist] Include non-prefix matches in auto-complete suggestions
  *     Microsoft Corporation - Contribution for bug 575562 - improve completion search performance
  *     							Bug 578817 - skip the ignored types before creating CompletionProposals
+ *     Microsoft Corporation - Contribution for bug 578815 - more candidates when completion after new keyword for an interface
  *******************************************************************************/
 package org.eclipse.jdt.internal.codeassist;
 
@@ -11658,6 +11659,8 @@ public final class CompletionEngine
 		if (isEmptyPrefix && !this.assistNodeIsAnnotation) {
 			if (!proposeConstructor) {
 				findTypesFromExpectedTypes(token, scope, typesFound, proposeType, proposeConstructor);
+			} else {
+				findConstructorsFromSubTypes(scope, typesFound);
 			}
 		} else {
 			if(!isEmptyPrefix && !this.requestor.isIgnored(CompletionProposal.KEYWORD)) {
@@ -11736,6 +11739,144 @@ public final class CompletionEngine
 				checkCancel();
 
 				this.nameEnvironment.findPackages(token, this);
+			}
+		}
+	}
+
+	/**
+	 * Find all the constructors of the expected types' sub types.
+	 */
+	private void findConstructorsFromSubTypes(Scope scope, ObjectVector typesFound) {
+		SearchPattern pattern = null;
+		for (TypeBinding typeBinding : this.expectedTypes) {
+			if (typeBinding == null || !typeBinding.isInterface()) {
+				continue;
+			}
+			if (pattern == null) {
+				pattern = SearchPattern.createPattern(String.valueOf(typeBinding.qualifiedPackageName()) +
+						"." + String.valueOf(typeBinding.qualifiedSourceName()), //$NON-NLS-1$
+						IJavaSearchConstants.CLASS, IJavaSearchConstants.IMPLEMENTORS,
+						SearchPattern.R_EXACT_MATCH);
+			} else {
+				pattern = SearchPattern.createOrPattern(pattern, SearchPattern.createPattern(String.valueOf(
+						typeBinding.qualifiedPackageName()) + "." + String.valueOf(typeBinding.qualifiedSourceName()), //$NON-NLS-1$
+						IJavaSearchConstants.CLASS, IJavaSearchConstants.IMPLEMENTORS,
+						SearchPattern.R_EXACT_MATCH));
+			}
+		}
+		if (pattern == null) {
+			return;
+		}
+
+		List<IType> types = new ArrayList<>();
+		IJavaSearchScope searchScope = SearchEngine.createJavaSearchScope(new IJavaElement[] {this.javaProject});
+		SearchRequestor searchRequstor = new SearchRequestor() {
+			@Override
+			public void acceptSearchMatch(SearchMatch match) {
+				Object element = match.getElement();
+				if (!(element instanceof IType)) {
+					return;
+				}
+				types.add((IType) element);
+			}
+		};
+		try {
+			new SearchEngine().search(pattern,
+					new SearchParticipant[] { SearchEngine.getDefaultSearchParticipant() },
+					searchScope,
+					searchRequstor,
+					null
+			);
+		} catch (CoreException e) {
+			if(DEBUG) {
+				System.out.println("Exception caught by CompletionEngine:"); //$NON-NLS-1$
+				e.printStackTrace(System.out);
+			}
+		}
+
+		checkCancel();
+
+		for (IType type : types) {
+			ReferenceBinding typeBinding = this.lookupEnvironment.getType(CharOperation.splitOn('.', type.getFullyQualifiedName().toCharArray()));
+			if (typeBinding == null) {
+				continue;
+			}
+
+			int accessibility = IAccessRule.K_ACCESSIBLE;
+			if(typeBinding.hasRestrictedAccess()) {
+				AccessRestriction accessRestriction = this.lookupEnvironment.getAccessRestriction(typeBinding);
+				if(accessRestriction != null) {
+					switch (accessRestriction.getProblemId()) {
+						case IProblem.ForbiddenReference:
+							if (this.options.checkForbiddenReference) {
+								continue;
+							}
+							accessibility = IAccessRule.K_NON_ACCESSIBLE;
+							break;
+						case IProblem.DiscouragedReference:
+							if (this.options.checkDiscouragedReference) {
+								continue;
+							}
+							accessibility = IAccessRule.K_DISCOURAGED;
+							break;
+					}
+				}
+			}
+
+			if (typesFound.contains(typeBinding)) continue;
+
+			typesFound.add(typeBinding);
+
+			if (this.assistNodeIsExtendedType && typeBinding.isFinal()) continue;
+			if (this.assistNodeIsInterfaceExcludingAnnotation && typeBinding.isAnnotationType()) continue;
+			if(this.assistNodeIsClass) {
+				if(!typeBinding.isClass()) continue;
+			} else if(this.assistNodeIsInterface) {
+				if(!typeBinding.isInterface() && !typeBinding.isAnnotationType()) continue;
+			} else if (this.assistNodeIsAnnotation) {
+				if(!typeBinding.isAnnotationType()) continue;
+			}
+
+			int relevance = computeBaseRelevance();
+			relevance += computeRelevanceForResolution();
+			relevance += computeRelevanceForInterestingProposal(typeBinding);
+			relevance += R_EXACT_EXPECTED_TYPE;	// all found types are sub-types
+			relevance += computeRelevanceForQualification(false);
+			relevance += computeRelevanceForRestrictions(accessibility);
+
+			if (typeBinding.isAnnotationType()) {
+				relevance += computeRelevanceForAnnotation();
+				relevance += computeRelevanceForAnnotationTarget(typeBinding);
+			} else if (typeBinding.isInterface()) {
+				relevance += computeRelevanceForInterface();
+			} else if(typeBinding.isClass()){
+				relevance += computeRelevanceForClass();
+				relevance += computeRelevanceForException(typeBinding.sourceName);
+			}
+
+			if (!isIgnored(CompletionProposal.CONSTRUCTOR_INVOCATION, CompletionProposal.TYPE_REF)) {
+				boolean isQualified = false;
+				if (!this.insideQualifiedReference && !typeBinding.isMemberType()) {
+					char[] packageName = typeBinding.qualifiedPackageName();
+					char[] typeName = typeBinding.sourceName();
+					if (mustQualifyType(packageName, typeName, null, typeBinding.modifiers)) {
+						isQualified = true;
+					}
+				}
+				findConstructors(
+					typeBinding,
+					null,
+					scope,
+					FakeInvocationSite,
+					false,
+					null,
+					null,
+					null,
+					false,
+					false,
+					isQualified,
+					relevance
+				);
 			}
 		}
 	}


### PR DESCRIPTION

- when the expected type is an interface, search all its direct sub types,
  and add their constructors to the completion candidates.

Change-Id: I533368c3e9627966995b20f3f019b63fe7435913
Signed-off-by: Sheng Chen <sheche@microsoft.com>