### PR TITLE
NPE in CompilationUnitResolver.getSourceClassPaths(IJavaProject) since

### DIFF
--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/CompilationUnitResolver.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/CompilationUnitResolver.java
@@ -377,6 +377,8 @@ class CompilationUnitResolver extends Compiler {
 		} catch (JavaModelException e) {
 			//do nothing
 		}
+		if(resolvedClasspath == null)
+			return srcClassPath;
 
 		for (IClasspathEntry entry : resolvedClasspath) {
 		    if (entry.getEntryKind() == IClasspathEntry.CPE_SOURCE) {


### PR DESCRIPTION
https://bugs.eclipse.org/578928 #19

Change-Id: I7afa76a5e06a0b73c448cfad3b60ba29ec7d72ef
Signed-off-by: Vikas Chandra <Vikas.Chandra@in.ibm.com>