### PR TITLE
Bug 575436 - rework JavaModelManager.getZipFile()

### DIFF
--- a/org.eclipse.jdt.compiler.apt.tests/src/org/eclipse/jdt/compiler/apt/tests/FileManagerTests.java
+++ b/org.eclipse.jdt.compiler.apt.tests/src/org/eclipse/jdt/compiler/apt/tests/FileManagerTests.java
@@ -41,7 +41,7 @@ import javax.tools.StandardJavaFileManager;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.jdt.internal.compiler.apt.util.EclipseFileManager;
 import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles;
-import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles.ThreadLocalZipFile;
+import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles.ZipFileResource;
 import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles.ThreadLocalZipFileHolder;
 
 import junit.framework.TestCase;
@@ -246,20 +246,20 @@ public class FileManagerTests extends TestCase {
 		File src = new File(BatchTestUtils.getPluginDirectoryPath(), "resources/targets/filemanager/dependency.zip");
 		Path copy = Files.copy(src.toPath(), target);
 		IPath copyPath=new org.eclipse.core.runtime.Path(copy.toFile().getPath());
-		try (ThreadLocalZipFile zipFile1 = ThreadLocalZipFiles.createZipFile(copyPath)) {
-			try (ThreadLocalZipFile zipFile2 = ThreadLocalZipFiles.createZipFile(copyPath)) {
+		try (ZipFileResource zipFile1 = ThreadLocalZipFiles.createZipFile(copyPath)) {
+			try (ZipFileResource zipFile2 = ThreadLocalZipFiles.createZipFile(copyPath)) {
 				assertSame("same zipfileInstances expected", zipFile1, zipFile2);
-				try (ThreadLocalZipFile zipFile3 = ThreadLocalZipFiles.createZipFile(copyPath)) {
+				try (ZipFileResource zipFile3 = ThreadLocalZipFiles.createZipFile(copyPath)) {
 					assertSame("same zipfileInstances expected", zipFile1, zipFile3);
 				}
 			}
 		}
-		ThreadLocalZipFile z1;
-		try (ThreadLocalZipFile zipFile1 = ThreadLocalZipFiles.createZipFile(copyPath)) {
+		ZipFileResource z1;
+		try (ZipFileResource zipFile1 = ThreadLocalZipFiles.createZipFile(copyPath)) {
 			z1 = zipFile1;
 		}
-		ThreadLocalZipFile z2;
-		try (ThreadLocalZipFile zipFile2 = ThreadLocalZipFiles.createZipFile(copyPath)) {
+		ZipFileResource z2;
+		try (ZipFileResource zipFile2 = ThreadLocalZipFiles.createZipFile(copyPath)) {
 			z2 = zipFile2;
 		}
 		assertNotSame("different zipfileInstances expected", z1, z2);
@@ -273,43 +273,43 @@ public class FileManagerTests extends TestCase {
 		File src = new File(BatchTestUtils.getPluginDirectoryPath(), "resources/targets/filemanager/dependency.zip");
 		Path copy = Files.copy(src.toPath(), target);
 		IPath copyPath=new org.eclipse.core.runtime.Path(copy.toFile().getPath());
-		ThreadLocalZipFile z1a;
-		ThreadLocalZipFile z1b;
-		ThreadLocalZipFile z2a;
-		ThreadLocalZipFile z2b;
-		ThreadLocalZipFile z3a;
-		ThreadLocalZipFile z3b;
+		ZipFileResource z1a;
+		ZipFileResource z1b;
+		ZipFileResource z2a;
+		ZipFileResource z2b;
+		ZipFileResource z3a;
+		ZipFileResource z3b;
 		try (ThreadLocalZipFileHolder holder1 = ThreadLocalZipFiles.createZipHolder(this)) {
 			try (ThreadLocalZipFileHolder holder2 = ThreadLocalZipFiles.createZipHolder(new Object())) {
 				try (ThreadLocalZipFileHolder holder3 = ThreadLocalZipFiles.createZipHolder(new Object())) {
-					try (ThreadLocalZipFile zipFileA = ThreadLocalZipFiles.createZipFile(copyPath)) {
+					try (ZipFileResource zipFileA = ThreadLocalZipFiles.createZipFile(copyPath)) {
 						z3a = zipFileA;
 					}
-					try (ThreadLocalZipFile zipFileB = ThreadLocalZipFiles.createZipFile(copyPath)) {
+					try (ZipFileResource zipFileB = ThreadLocalZipFiles.createZipFile(copyPath)) {
 						z3b = zipFileB;
 					}
 					assertSame("same zipfileInstances expected", z3a, z3b);
 				}
-				try (ThreadLocalZipFile zipFileA = ThreadLocalZipFiles.createZipFile(copyPath)) {
+				try (ZipFileResource zipFileA = ThreadLocalZipFiles.createZipFile(copyPath)) {
 					z2a = zipFileA;
 				}
-				try (ThreadLocalZipFile zipFileB = ThreadLocalZipFiles.createZipFile(copyPath)) {
+				try (ZipFileResource zipFileB = ThreadLocalZipFiles.createZipFile(copyPath)) {
 					z2b = zipFileB;
 				}
 				assertSame("same zipfileInstances expected", z2a, z2b);
 				assertSame("same zipfileInstances expected", z2a, z3a);
 			}
-			try (ThreadLocalZipFile zipFileA = ThreadLocalZipFiles.createZipFile(copyPath)) {
+			try (ZipFileResource zipFileA = ThreadLocalZipFiles.createZipFile(copyPath)) {
 				z1a = zipFileA;
 			}
-			try (ThreadLocalZipFile zipFileB = ThreadLocalZipFiles.createZipFile(copyPath)) {
+			try (ZipFileResource zipFileB = ThreadLocalZipFiles.createZipFile(copyPath)) {
 				z1b = zipFileB;
 			}
 			assertSame("same zipfileInstances expected", z1a, z1b);
 			assertSame("same zipfileInstances expected", z1a, z3a);
 		}
-		ThreadLocalZipFile z0a;
-		try (ThreadLocalZipFile zipFileA = ThreadLocalZipFiles.createZipFile(copyPath)) {
+		ZipFileResource z0a;
+		try (ZipFileResource zipFileA = ThreadLocalZipFiles.createZipFile(copyPath)) {
 			z0a = zipFileA;
 		}
 		assertNotSame("different zipfileInstances expected", z1a, z0a);

--- a/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/classfmt/ClassFileReader.java
+++ b/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/classfmt/ClassFileReader.java
@@ -123,18 +123,16 @@ public static ClassFileReader read(InputStream stream, String fileName) throws C
 
 public static ClassFileReader read(InputStream stream, String fileName, boolean fullyInitialize) throws ClassFormatException, IOException {
 	byte classFileBytes[] = Util.getInputStreamAsByteArray(stream);
-	ClassFileReader classFileReader = new ClassFileReader(classFileBytes, fileName.toCharArray());
-	if (fullyInitialize) {
-		classFileReader.initialize();
-	}
-	return classFileReader;
+	return read(classFileBytes, fileName, fullyInitialize);
 }
 
-public static ClassFileReader read(
-	java.util.zip.ZipFile zip,
-	String filename)
-	throws ClassFormatException, java.io.IOException {
-		return read(zip, filename, false);
+public static ClassFileReader read(java.util.zip.ZipFile zip, String filename)
+		throws ClassFormatException, java.io.IOException {
+	java.util.zip.ZipEntry ze = zip.getEntry(filename);
+	if (ze == null)
+		return null;
+	byte classFileBytes[] = Util.getZipEntryByteContent(ze, zip);
+	return read(classFileBytes, filename, false);
 }
 
 public static ClassFileReader readFromJrt(
@@ -154,15 +152,8 @@ public static ClassFileReader readFromModule(
 		throws ClassFormatException, java.io.IOException {
 		return JRTUtil.getClassfile(jrt, filename, moduleName, moduleNameFilter);
 }
-public static ClassFileReader read(
-	java.util.zip.ZipFile zip,
-	String filename,
-	boolean fullyInitialize)
-	throws ClassFormatException, java.io.IOException {
-	java.util.zip.ZipEntry ze = zip.getEntry(filename);
-	if (ze == null)
-		return null;
-	byte classFileBytes[] = Util.getZipEntryByteContent(ze, zip);
+public static ClassFileReader read(byte[] classFileBytes, String filename, boolean fullyInitialize )
+		throws ClassFormatException {
 	ClassFileReader classFileReader = new ClassFileReader(classFileBytes, filename.toCharArray());
 	if (fullyInitialize) {
 		classFileReader.initialize();

--- a/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/classfmt/ExternalAnnotationDecorator.java
+++ b/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/classfmt/ExternalAnnotationDecorator.java
@@ -223,22 +223,28 @@ public class ExternalAnnotationDecorator implements IBinaryType {
 			ZipFile zipFile) throws IOException {
 		String qualifiedBinaryFileName = qualifiedBinaryTypeName + ExternalAnnotationProvider.ANNOTATION_FILE_SUFFIX;
 		if (zipFile == null) {
-			File annotationBase = new File(basePath);
-			if (annotationBase.isDirectory()) {
-				String filePath = annotationBase.getAbsolutePath() + '/' + qualifiedBinaryFileName;
-				try {
-					return new ExternalAnnotationProvider(new FileInputStream(filePath), qualifiedBinaryTypeName);
-				} catch (FileNotFoundException e) {
-					// Expected, no need to report an error here
-					return null;
-				}
-			}
+			return externalAnnotationProviderFile(basePath, qualifiedBinaryTypeName, qualifiedBinaryFileName);
 		} else {
 			ZipEntry entry = zipFile.getEntry(qualifiedBinaryFileName);
 			if (entry != null) {
 				try(InputStream is = zipFile.getInputStream(entry)) {
 					return new ExternalAnnotationProvider(is, qualifiedBinaryTypeName);
 				}
+			}
+			return null;
+		}
+	}
+
+	public static ExternalAnnotationProvider externalAnnotationProviderFile(String basePath, String qualifiedBinaryTypeName, String qualifiedBinaryFileName)
+			throws IOException {
+		File annotationBase = new File(basePath);
+		if (annotationBase.isDirectory()) {
+			String filePath = annotationBase.getAbsolutePath() + '/' + qualifiedBinaryFileName;
+			try {
+				return new ExternalAnnotationProvider(new FileInputStream(filePath), qualifiedBinaryTypeName);
+			} catch (FileNotFoundException e) {
+				// Expected, no need to report an error here
+				return null;
 			}
 		}
 		return null;

--- a/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/util/QuietClose.java
+++ b/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/util/QuietClose.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Joerg Kubitz and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Joerg Kubitz - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.internal.compiler.util;
+
+/** Wrapper around AutoCloseable. The close() does not throw any Exception.
+ *  Useful for try-with-resource when close() exceptions should be ignored. **/
+public class QuietClose<T extends AutoCloseable> implements AutoCloseable {
+	T resource;
+
+	public QuietClose(T resource) {
+		this.resource = resource;
+	}
+
+	/** using @SuppressWarnings("resource") when you use this method is safe **/
+	public T get() {
+		return this.resource;
+	}
+
+	@Override
+	public void close() {
+		try {
+			if (this.resource != null) {
+				this.resource.close();
+			}
+		} catch (Exception e) {
+			// quiet
+		}
+	}
+}

--- a/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/util/Util.java
+++ b/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/util/Util.java
@@ -608,23 +608,18 @@ public class Util implements SuffixConstants {
 	 * Returns the contents of the given zip entry as a byte array.
 	 * @throws IOException if a problem occurred reading the zip entry.
 	 */
-	public static byte[] getZipEntryByteContent(ZipEntry ze, ZipFile zip)
-		throws IOException {
+	public static byte[] getZipEntryByteContent(ZipEntry ze, ZipFile zip) throws IOException {
+		try (QuietClose<InputStream> q = new QuietClose<>(zip.getInputStream(ze))) {
+			InputStream stream = q.get();
+			return read(stream, ze);
+		}
+	}
 
-		InputStream stream = null;
-		try {
-			InputStream inputStream = zip.getInputStream(ze);
-			if (inputStream == null) throw new IOException("Invalid zip entry name : " + ze.getName()); //$NON-NLS-1$
-			stream = new BufferedInputStream(inputStream);
+	private static byte[] read(InputStream inputStream, ZipEntry ze) throws IOException {
+		if (inputStream == null)
+			throw new IOException("Invalid zip entry name : " + ze.getName()); //$NON-NLS-1$
+		try (InputStream stream = new BufferedInputStream(inputStream)){
 			return readNBytes(stream, (int) ze.getSize());
-		} finally {
-			if (stream != null) {
-				try {
-					stream.close();
-				} catch (IOException e) {
-					// ignore
-				}
-			}
 		}
 	}
 	public static int hashCode(Object[] array) {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/core/ToolFactory.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/core/ToolFactory.java
@@ -32,11 +32,13 @@ import org.eclipse.jdt.core.util.IClassFileReader;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jdt.internal.compiler.util.SuffixConstants;
+import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles;
 import org.eclipse.jdt.internal.compiler.util.Util;
 import org.eclipse.jdt.internal.core.JarPackageFragmentRoot;
 import org.eclipse.jdt.internal.core.JavaElement;
 import org.eclipse.jdt.internal.core.JavaModelManager;
 import org.eclipse.jdt.internal.core.PackageFragment;
+import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles.ThreadLocalZipFile;
 import org.eclipse.jdt.internal.core.util.ClassFileReader;
 import org.eclipse.jdt.internal.core.util.Disassembler;
 import org.eclipse.jdt.internal.core.util.PublicScanner;
@@ -263,12 +265,8 @@ public class ToolFactory {
 			try {
 				if (root instanceof JarPackageFragmentRoot) {
 					String archiveName = null;
-					ZipFile jar = null;
-					try {
-						jar = ((JarPackageFragmentRoot)root).getJar();
+					try (ThreadLocalZipFile jar =  ((JarPackageFragmentRoot)root).getJar()){
 						archiveName = jar.getName();
-					} finally {
-						JavaModelManager.getJavaModelManager().closeZipFile(jar);
 					}
 					PackageFragment packageFragment = (PackageFragment) classfile.getParent();
 					String classFileName = classfile.getElementName();
@@ -357,7 +355,7 @@ public class ToolFactory {
 	public static IClassFileReader createDefaultClassFileReader(String zipFileName, String zipEntryName, int decodingFlag){
 		ZipFile zipFile = null;
 		try {
-			if (JavaModelManager.ZIP_ACCESS_VERBOSE) {
+			if (ThreadLocalZipFiles.verboseLogging()) {
 				System.out.println("(" + Thread.currentThread() + ") [ToolFactory.createDefaultClassFileReader()] Creating ZipFile on " + zipFileName); //$NON-NLS-1$	//$NON-NLS-2$
 			}
 			zipFile = new ZipFile(zipFileName);

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/core/ToolFactory.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/core/ToolFactory.java
@@ -38,7 +38,7 @@ import org.eclipse.jdt.internal.core.JarPackageFragmentRoot;
 import org.eclipse.jdt.internal.core.JavaElement;
 import org.eclipse.jdt.internal.core.JavaModelManager;
 import org.eclipse.jdt.internal.core.PackageFragment;
-import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles.ThreadLocalZipFile;
+import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles.ZipFileResource;
 import org.eclipse.jdt.internal.core.util.ClassFileReader;
 import org.eclipse.jdt.internal.core.util.Disassembler;
 import org.eclipse.jdt.internal.core.util.PublicScanner;
@@ -265,7 +265,7 @@ public class ToolFactory {
 			try {
 				if (root instanceof JarPackageFragmentRoot) {
 					String archiveName = null;
-					try (ThreadLocalZipFile jar =  ((JarPackageFragmentRoot)root).getJar()){
+					try (ZipFileResource jar =  ((JarPackageFragmentRoot)root).getJar()){
 						archiveName = jar.getName();
 					}
 					PackageFragment packageFragment = (PackageFragment) classfile.getParent();

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/AbstractClassFile.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/AbstractClassFile.java
@@ -33,7 +33,7 @@ import org.eclipse.core.runtime.Path;
 import org.eclipse.jdt.core.*;
 import org.eclipse.jdt.core.compiler.IProblem;
 import org.eclipse.jdt.internal.compiler.util.SuffixConstants;
-import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles.ThreadLocalZipFile;
+import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles.ZipFileResource;
 import org.eclipse.jdt.internal.core.util.Util;
 
 /**
@@ -222,7 +222,7 @@ public abstract class AbstractClassFile extends Openable implements IClassFile, 
 					className,
 					root.getElementName());
 		} else {
-			try (ThreadLocalZipFile zip = root.getJar()){
+			try (ZipFileResource zip = root.getJar()){
 				ZipEntry ze = zip.getEntry(className);
 				if (ze != null) {
 					contents = Util.getZipEntryByteContent(ze, zip);

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/AbstractClassFile.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/AbstractClassFile.java
@@ -20,8 +20,6 @@ package org.eclipse.jdt.internal.core;
 import java.io.File;
 import java.io.IOException;
 import java.util.zip.ZipEntry;
-import java.util.zip.ZipFile;
-
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
@@ -35,6 +33,7 @@ import org.eclipse.core.runtime.Path;
 import org.eclipse.jdt.core.*;
 import org.eclipse.jdt.core.compiler.IProblem;
 import org.eclipse.jdt.internal.compiler.util.SuffixConstants;
+import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles.ThreadLocalZipFile;
 import org.eclipse.jdt.internal.core.util.Util;
 
 /**
@@ -223,14 +222,11 @@ public abstract class AbstractClassFile extends Openable implements IClassFile, 
 					className,
 					root.getElementName());
 		} else {
-			ZipFile zip = root.getJar();
-			try {
+			try (ThreadLocalZipFile zip = root.getJar()){
 				ZipEntry ze = zip.getEntry(className);
 				if (ze != null) {
-					contents = org.eclipse.jdt.internal.compiler.util.Util.getZipEntryByteContent(ze, zip);
+					contents = Util.getZipEntryByteContent(ze, zip);
 				}
-			} finally {
-				JavaModelManager.getJavaModelManager().closeZipFile(zip);
 			}
 		}
 		if (contents == null && Thread.interrupted()) // reading from JRT is interruptible

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ClassFile.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ClassFile.java
@@ -58,7 +58,7 @@ import org.eclipse.jdt.internal.compiler.env.IBinaryType;
 import org.eclipse.jdt.internal.compiler.env.IDependent;
 import org.eclipse.jdt.internal.compiler.env.IModule;
 import org.eclipse.jdt.internal.compiler.util.SuffixConstants;
-import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles.ThreadLocalZipFile;
+import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles.ZipFileResource;
 import org.eclipse.jdt.internal.core.nd.java.model.BinaryTypeDescriptor;
 import org.eclipse.jdt.internal.core.nd.java.model.BinaryTypeFactory;
 import org.eclipse.jdt.internal.core.util.MementoTokenizer;
@@ -286,7 +286,7 @@ private IBinaryType getJarBinaryTypeInfo() throws CoreException, IOException, Cl
 	return result;
 }
 
-public static ThreadLocalZipFile getAnnotationZipFile(String resolvedPath, IPath externalAnnotationPath) throws IOException {
+public static ZipFileResource getAnnotationZipFile(String resolvedPath, IPath externalAnnotationPath) throws IOException {
 	File annotationBase = new File(resolvedPath);
 	if (!annotationBase.isFile()) {
 		return null;
@@ -324,7 +324,7 @@ private IBinaryType setupExternalAnnotationProvider(IProject project, final IPat
 	} else {
 		resolvedPath = externalAnnotationPath.toString(); // not in workspace, use as is
 	}
-	try (ThreadLocalZipFile	annotationZip = getAnnotationZipFile(resolvedPath,externalAnnotationPath)){
+	try (ZipFileResource annotationZip = getAnnotationZipFile(resolvedPath,externalAnnotationPath)){
 
 		ExternalAnnotationProvider annotationProvider = externalAnnotationProvider(resolvedPath, typeName, annotationZip);
 		result = new ExternalAnnotationDecorator(reader, annotationProvider);
@@ -342,7 +342,7 @@ private IBinaryType setupExternalAnnotationProvider(IProject project, final IPat
 }
 
 public static ExternalAnnotationProvider externalAnnotationProvider(String basePath, String qualifiedBinaryTypeName,
-		ThreadLocalZipFile zipFile) throws IOException {
+		ZipFileResource zipFile) throws IOException {
 	String qualifiedBinaryFileName = qualifiedBinaryTypeName + ExternalAnnotationProvider.ANNOTATION_FILE_SUFFIX;
 	if (zipFile == null) {
 		return ExternalAnnotationDecorator.externalAnnotationProviderFile(basePath, qualifiedBinaryTypeName, qualifiedBinaryFileName);

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ClasspathEntry.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ClasspathEntry.java
@@ -71,7 +71,7 @@ import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jdt.internal.compiler.lookup.TypeConstants;
 import org.eclipse.jdt.internal.compiler.util.ManifestAnalyzer;
 import org.eclipse.jdt.internal.compiler.util.QuietClose;
-import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles.ThreadLocalZipFile;
+import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles.ZipFileResource;
 import org.eclipse.jdt.internal.core.util.Messages;
 import org.eclipse.jdt.internal.core.util.Util;
 import org.eclipse.jdt.internal.core.util.ZipState;
@@ -1004,7 +1004,7 @@ public class ClasspathEntry implements IClasspathEntry {
 
 	private static char[] getManifestContents(IPath jarPath) throws CoreException, IOException {
 		JavaModelManager manager = JavaModelManager.getJavaModelManager();
-		try (ThreadLocalZipFile zip = manager.getZipFile(jarPath)) {
+		try (ZipFileResource zip = manager.getZipFile(jarPath)) {
 			ZipEntry manifest = zip.getEntry(TypeConstants.META_INF_MANIFEST_MF);
 			if (manifest == null) {
 				return null;

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/CompilationUnit.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/CompilationUnit.java
@@ -32,6 +32,8 @@ import org.eclipse.jdt.internal.compiler.lookup.TypeConstants;
 import org.eclipse.jdt.internal.compiler.problem.AbortCompilationUnit;
 import org.eclipse.jdt.internal.compiler.problem.DefaultProblemFactory;
 import org.eclipse.jdt.internal.compiler.util.SuffixConstants;
+import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles;
+import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles.ThreadLocalZipFileHolder;
 import org.eclipse.jdt.internal.core.util.MementoTokenizer;
 import org.eclipse.jdt.internal.core.util.Messages;
 import org.eclipse.jdt.internal.core.util.Util;
@@ -1313,12 +1315,10 @@ public org.eclipse.jdt.core.dom.CompilationUnit reconcile(
 		stats.startRun(new String(getFileName()));
 	}
 	ReconcileWorkingCopyOperation op = new ReconcileWorkingCopyOperation(this, astLevel, reconcileFlags, workingCopyOwner);
-	JavaModelManager manager = JavaModelManager.getJavaModelManager();
-	try {
-		manager.cacheZipFiles(this); // cache zip files for performance (see https://bugs.eclipse.org/bugs/show_bug.cgi?id=134172)
+
+	// cache zip files for performance (see https://bugs.eclipse.org/bugs/show_bug.cgi?id=134172)
+	try (ThreadLocalZipFileHolder h=ThreadLocalZipFiles.createZipHolder(this)) {
 		op.runOperation(monitor);
-	} finally {
-		manager.flushZipFiles(this);
 	}
 	if(ReconcileWorkingCopyOperation.PERF) {
 		stats.endRun();

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JarEntryFile.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JarEntryFile.java
@@ -28,7 +28,7 @@ import org.eclipse.jdt.core.IPackageFragmentRoot;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.internal.compiler.util.JRTUtil;
 import org.eclipse.jdt.internal.compiler.util.Util;
-import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles.ThreadLocalZipFile;
+import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles.ZipFileResource;
 
 /**
  * A jar entry that represents a non-java file found in a JAR.
@@ -63,7 +63,7 @@ public class JarEntryFile  extends JarEntryResource {
 			}
 			return null;
 		} else {
-			try (ThreadLocalZipFile zipFile = getZipFile()){
+			try (ZipFileResource zipFile = getZipFile()){
 				String entryName = getEntryName();
 				ZipEntry zipEntry = zipFile.getEntry(entryName);
 				if (zipEntry == null){

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JarEntryResource.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JarEntryResource.java
@@ -20,7 +20,7 @@ import org.eclipse.core.runtime.PlatformObject;
 import org.eclipse.jdt.core.IJarEntryResource;
 import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
-import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles.ThreadLocalZipFile;
+import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles.ZipFileResource;
 import org.eclipse.jdt.internal.core.util.Util;
 
 public abstract class JarEntryResource  extends PlatformObject implements IJarEntryResource {
@@ -81,7 +81,7 @@ public abstract class JarEntryResource  extends PlatformObject implements IJarEn
 		}
 	}
 
-	protected ThreadLocalZipFile getZipFile() throws CoreException {
+	protected ZipFileResource getZipFile() throws CoreException {
 		if (this.parent instanceof IPackageFragment) {
 			JarPackageFragmentRoot root = (JarPackageFragmentRoot) ((IPackageFragment) this.parent).getParent();
 			return root.getJar();

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JarEntryResource.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JarEntryResource.java
@@ -13,8 +13,6 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.core;
 
-import java.util.zip.ZipFile;
-
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
@@ -22,6 +20,7 @@ import org.eclipse.core.runtime.PlatformObject;
 import org.eclipse.jdt.core.IJarEntryResource;
 import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles.ThreadLocalZipFile;
 import org.eclipse.jdt.internal.core.util.Util;
 
 public abstract class JarEntryResource  extends PlatformObject implements IJarEntryResource {
@@ -82,7 +81,7 @@ public abstract class JarEntryResource  extends PlatformObject implements IJarEn
 		}
 	}
 
-	protected ZipFile getZipFile() throws CoreException {
+	protected ThreadLocalZipFile getZipFile() throws CoreException {
 		if (this.parent instanceof IPackageFragment) {
 			JarPackageFragmentRoot root = (JarPackageFragmentRoot) ((IPackageFragment) this.parent).getParent();
 			return root.getJar();

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JarPackageFragmentRoot.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JarPackageFragmentRoot.java
@@ -42,7 +42,7 @@ import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jdt.internal.compiler.lookup.TypeConstants;
 import org.eclipse.jdt.internal.core.JavaModelManager.PerProjectInfo;
-import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles.ThreadLocalZipFile;
+import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles.ZipFileResource;
 import org.eclipse.jdt.internal.core.util.HashtableOfArrayToObject;
 import org.eclipse.jdt.internal.core.util.Util;
 
@@ -125,7 +125,7 @@ public class JarPackageFragmentRoot extends PackageFragmentRoot {
 			long classLevel = Util.getJdkLevel(file);
 			String projectCompliance = this.getJavaProject().getOption(JavaCore.COMPILER_COMPLIANCE, true);
 			long projectLevel = CompilerOptions.versionToJdkLevel(projectCompliance);
-			try (ThreadLocalZipFile jar = getJar()){
+			try (ZipFileResource jar = getJar()){
 				String version = "META-INF/versions/";  //$NON-NLS-1$
 				List<String> versions = new ArrayList<>();
 				if (projectLevel >= ClassFileConstants.JDK9 && jar.getEntry(version) != null) {
@@ -242,7 +242,7 @@ public class JarPackageFragmentRoot extends PackageFragmentRoot {
 	 *
 	 * @exception CoreException if an error occurs accessing the jar
 	 */
-	public ThreadLocalZipFile getJar() throws CoreException {
+	public ZipFileResource getJar() throws CoreException {
 		return JavaModelManager.getJavaModelManager().getZipFile(getPath());
 	}
 	/**
@@ -449,7 +449,7 @@ public class JarPackageFragmentRoot extends PackageFragmentRoot {
 
 	@Override
 	public Manifest getManifest() {
-		try (ThreadLocalZipFile jar = getJar()){
+		try (ZipFileResource jar = getJar()){
 			ZipEntry mfEntry = jar.getEntry(TypeConstants.META_INF_MANIFEST_MF);
 			if (mfEntry != null) {
 				try (InputStream is = jar.getInputStream(mfEntry)) {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModel.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModel.java
@@ -412,9 +412,6 @@ static private boolean isExternalFile(IPath path) {
 	if (JavaModelManager.getJavaModelManager().isExternalFile(path)) {
 		return true;
 	}
-	if (JavaModelManager.ZIP_ACCESS_VERBOSE) {
-		System.out.println("(" + Thread.currentThread() + ") [JavaModel.isExternalFile(...)] Checking existence of " + path.toString()); //$NON-NLS-1$ //$NON-NLS-2$
-	}
 	boolean isFile = path.toFile().isFile();
 	if (isFile) {
 		JavaModelManager.getJavaModelManager().addExternalFile(path);

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelManager.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelManager.java
@@ -142,7 +142,7 @@ import org.eclipse.jdt.internal.compiler.util.ObjectVector;
 import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles;
 import org.eclipse.jdt.internal.core.DeltaProcessor.RootInfo;
 import org.eclipse.jdt.internal.core.JavaProjectElementInfo.ProjectCache;
-import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles.ThreadLocalZipFile;
+import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles.ZipFileResource;
 import org.eclipse.jdt.internal.core.builder.JavaBuilder;
 import org.eclipse.jdt.internal.core.dom.SourceRangeVerifier;
 import org.eclipse.jdt.internal.core.dom.rewrite.RewriteEventStore;
@@ -2696,7 +2696,7 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 	 * {@link FileNotFoundException} if the file does not exist, or a
 	 * {@link IOException} if we were unable to read the file.
 	 */
-	public ThreadLocalZipFile getZipFile(IPath path) throws CoreException {
+	public ZipFileResource getZipFile(IPath path) throws CoreException {
 		return ZipState.createZipFile(path);
 	}
 

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SourceMapper.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SourceMapper.java
@@ -70,7 +70,7 @@ import org.eclipse.jdt.internal.compiler.util.JRTUtil;
 import org.eclipse.jdt.internal.compiler.util.SuffixConstants;
 import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles;
 import org.eclipse.jdt.internal.compiler.util.Util;
-import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles.ThreadLocalZipFile;
+import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles.ZipFileResource;
 import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles.ThreadLocalZipFileHolder;
 import org.eclipse.jdt.internal.core.util.ReferenceInfoAdapter;
 
@@ -574,7 +574,7 @@ public class SourceMapper
 			}
 		} else if (root.isArchive()) {
 			JavaModelManager manager = JavaModelManager.getJavaModelManager();
-			try (ThreadLocalZipFile zip = manager.getZipFile(pkgFragmentRootPath)) {
+			try (ZipFileResource zip = manager.getZipFile(pkgFragmentRootPath)) {
 				for (Enumeration entries = zip.entries(); entries.hasMoreElements(); ) {
 					ZipEntry entry = (ZipEntry) entries.nextElement();
 					String entryName = entry.getName();
@@ -645,7 +645,7 @@ public class SourceMapper
 				computeRootPath(folder, firstLevelPackageNames, containsADefaultPackage, tempRoots, folder.getFullPath().segmentCount()/*if external folder, this is the linked folder path*/);
 			} else {
 				JavaModelManager manager = JavaModelManager.getJavaModelManager();
-				try (ThreadLocalZipFile zip = manager.getZipFile(this.sourcePath)){
+				try (ZipFileResource zip = manager.getZipFile(this.sourcePath)){
 					for (Enumeration entries = zip.entries(); entries.hasMoreElements(); ) {
 						ZipEntry entry = (ZipEntry) entries.nextElement();
 						String entryName;
@@ -1245,7 +1245,7 @@ public class SourceMapper
 			}
 
 			// try to get the entry
-			try (ThreadLocalZipFile zip =  JavaModelManager.getJavaModelManager().getZipFile(this.sourcePath)){
+			try (ZipFileResource zip =  JavaModelManager.getJavaModelManager().getZipFile(this.sourcePath)){
 				ZipEntry entry = zip.getEntry(fullName);
 				if (entry != null) {
 					// now read the source code
@@ -1624,7 +1624,7 @@ public class SourceMapper
 			this.typeDepth = -1;
 		}
 	}
-	private char[] readSource(ZipEntry entry, ThreadLocalZipFile zip, String charSet) {
+	private char[] readSource(ZipEntry entry, ZipFileResource zip, String charSet) {
 		try {
 			byte[] bytes = org.eclipse.jdt.internal.core.util.Util.getZipEntryByteContent(entry, zip);
 			if (bytes != null) {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/ClasspathJMod.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/ClasspathJMod.java
@@ -30,7 +30,7 @@ import org.eclipse.jdt.internal.compiler.env.IModule;
 import org.eclipse.jdt.internal.compiler.env.NameEnvironmentAnswer;
 import org.eclipse.jdt.internal.compiler.util.SimpleSet;
 import org.eclipse.jdt.internal.compiler.util.SuffixConstants;
-import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles.ThreadLocalZipFile;
+import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles.ZipFileResource;
 
 public class ClasspathJMod extends ClasspathJar {
 
@@ -72,7 +72,7 @@ public class ClasspathJMod extends ClasspathJar {
 		if (moduleNameFilter != null && this.module != null && !moduleNameFilter.test(String.valueOf(this.module.name())))
 			return null;
 
-		try (ThreadLocalZipFile zipFile = createZipFile()) {
+		try (ZipFileResource zipFile = createZipFile()) {
 			qualifiedBinaryFileName = new String(CharOperation.append(CLASSES_FOLDER, qualifiedBinaryFileName.toCharArray()));
 			IBinaryType reader = org.eclipse.jdt.internal.core.util.Util.read(zipFile, qualifiedBinaryFileName);
 			if (reader != null) {
@@ -95,7 +95,7 @@ public class ClasspathJMod extends ClasspathJar {
 	@Override
 	protected String readJarContent(final SimpleSet packageSet) {
 		String modInfo = null;
-		try (ThreadLocalZipFile zipFile = createZipFile()) {
+		try (ZipFileResource zipFile = createZipFile()) {
 			for (Enumeration<? extends ZipEntry> e = zipFile.entries(); e.hasMoreElements(); ) {
 				ZipEntry entry = e.nextElement();
 				char[] entryName = entry.getName().toCharArray();

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/ClasspathJar.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/ClasspathJar.java
@@ -47,7 +47,7 @@ import org.eclipse.jdt.internal.compiler.util.SimpleLookupTable;
 import org.eclipse.jdt.internal.compiler.util.SimpleSet;
 import org.eclipse.jdt.internal.compiler.util.SuffixConstants;
 import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles;
-import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles.ThreadLocalZipFile;
+import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles.ZipFileResource;
 import org.eclipse.jdt.internal.core.JavaModelManager;
 import org.eclipse.jdt.internal.core.PackageFragmentRoot;
 import org.eclipse.jdt.internal.core.util.Messages;
@@ -109,7 +109,7 @@ protected SimpleSet findPackageSet() {
 }
 protected String readJarContent(final SimpleSet packageSet) {
 	String modInfo = null;
-	try (ThreadLocalZipFile zipFile = createZipFile()) {
+	try (ZipFileResource zipFile = createZipFile()) {
 		for (Enumeration e = zipFile.entries(); e.hasMoreElements(); ) {
 			String fileName = ((ZipEntry) e.nextElement()).getName();
 			if (fileName.startsWith("META-INF/")) //$NON-NLS-1$
@@ -287,7 +287,7 @@ public boolean equals(Object o) {
 public NameEnvironmentAnswer findClass(String binaryFileName, String qualifiedPackageName, String moduleName, String qualifiedBinaryFileName, boolean asBinaryOnly, Predicate<String> moduleNameFilter) {
 	if (!isPackage(qualifiedPackageName, moduleName)) return null; // most common case
 
-	try (ThreadLocalZipFile zipFile = createZipFile()) {
+	try (ZipFileResource zipFile = createZipFile()) {
 		IBinaryType reader = Util.read(zipFile, qualifiedBinaryFileName);
 		if (reader != null) {
 			char[] modName = this.module == null ? null : this.module.name();
@@ -340,7 +340,7 @@ public boolean hasCompilationUnit(String pkgName, String moduleName) {
 		// Even if knownPackageNames contained the pkg we're looking for, we still need to verify
 		// that the package in this jar actually contains at least one .class file (since
 		// knownPackageNames includes empty packages)
-		try (ThreadLocalZipFile zipFile = createZipFile()) {
+		try (ZipFileResource zipFile = createZipFile()) {
 			for (Enumeration<? extends ZipEntry> e = zipFile.entries(); e.hasMoreElements(); ) {
 				String fileName = e.nextElement().getName();
 				if (fileName.startsWith(pkgName)
@@ -404,7 +404,7 @@ public NameEnvironmentAnswer findClass(String typeName, String qualifiedPackageN
 public Manifest getManifest() {
 	if (!scanContent()) // ensure zipFile is initialized
 		return null;
-	try (ThreadLocalZipFile zipFile = createZipFile()) {
+	try (ZipFileResource zipFile = createZipFile()) {
 		ZipEntry entry = zipFile.getEntry(TypeConstants.META_INF_MANIFEST_MF);
 		if (entry == null) {
 			return null;
@@ -438,7 +438,7 @@ public char[][] listPackages() {
 protected IBinaryType decorateWithExternalAnnotations(IBinaryType reader, String fileNameWithoutExtension) {
 	if (scanContent()) { // ensure zipFile is initialized
 		String qualifiedBinaryFileName = fileNameWithoutExtension + ExternalAnnotationProvider.ANNOTATION_FILE_SUFFIX;
-		try (ThreadLocalZipFile zipFile = createZipFile()) {
+		try (ZipFileResource zipFile = createZipFile()) {
 			ZipEntry entry = zipFile.getEntry(qualifiedBinaryFileName);
 			if (entry != null) {
 				try(InputStream is = zipFile.getInputStream(entry)) {
@@ -458,7 +458,7 @@ protected IBinaryType decorateWithExternalAnnotations(IBinaryType reader, String
  * @return the zipFile
  * @throws CoreException
  */
-public ThreadLocalZipFile createZipFile() throws CoreException {
+public ZipFileResource createZipFile() throws CoreException {
 	if (this.resource==null) {
 		try {
 			return ThreadLocalZipFiles.createZipFile(new Path(this.zipFilename));

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/ClasspathLocation.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/ClasspathLocation.java
@@ -42,6 +42,8 @@ import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jdt.internal.compiler.lookup.ModuleBinding;
 import org.eclipse.jdt.internal.compiler.lookup.BinaryTypeBinding.ExternalAnnotationStatus;
 import org.eclipse.jdt.internal.compiler.util.Util;
+import org.eclipse.jdt.internal.core.PackageFragmentRoot;
+import org.eclipse.jdt.internal.core.builder.ClasspathJar.ResourceOrExternalFile;
 
 public abstract class ClasspathLocation {
 
@@ -168,11 +170,11 @@ public static ClasspathLocation forLibrary(IFile library, AccessRuleSet accessRu
 			new ClasspathJar(library, accessRuleSet, annotationsPath, isOnModulePath) :
 				new ClasspathMultiReleaseJar(library, accessRuleSet, annotationsPath, isOnModulePath, compliance);
 }
-public static ClasspathLocation forLibrary(ZipFile zipFile, AccessRuleSet accessRuleSet, IPath externalAnnotationPath,
-										boolean isOnModulePath, String compliance) {
+public static ClasspathLocation forLibrary(PackageFragmentRoot root, AccessRuleSet accessRuleSet, IPath externalAnnotationPath, boolean isOnModulePath, String compliance) throws CoreException {
+	ResourceOrExternalFile library=ResourceOrExternalFile.of(root);
 	return (CompilerOptions.versionToJdkLevel(compliance) < ClassFileConstants.JDK9) ?
-			new ClasspathJar(zipFile, accessRuleSet, externalAnnotationPath, isOnModulePath) :
-				new ClasspathMultiReleaseJar(zipFile, accessRuleSet, externalAnnotationPath, isOnModulePath, compliance);
+				new ClasspathJar(library, null,accessRuleSet, externalAnnotationPath, isOnModulePath) :
+				new ClasspathMultiReleaseJar(library, accessRuleSet, externalAnnotationPath, isOnModulePath, compliance);
 }
 
 public abstract IPath getProjectRelativePath();

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/ClasspathMultiReleaseJar.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/ClasspathMultiReleaseJar.java
@@ -6,9 +6,9 @@ import java.util.Enumeration;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.zip.ZipEntry;
-import java.util.zip.ZipFile;
 
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader;
@@ -20,6 +20,7 @@ import org.eclipse.jdt.internal.compiler.env.NameEnvironmentAnswer;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jdt.internal.compiler.util.SimpleSet;
 import org.eclipse.jdt.internal.compiler.util.SuffixConstants;
+import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles.ThreadLocalZipFile;
 import org.eclipse.jdt.internal.core.util.Util;
 
 public class ClasspathMultiReleaseJar extends ClasspathJar {
@@ -39,29 +40,20 @@ public class ClasspathMultiReleaseJar extends ClasspathJar {
 		this.compliance = compliance;
 	}
 
-	public ClasspathMultiReleaseJar(ZipFile zipFile, AccessRuleSet accessRuleSet, IPath externalAnnotationPath,
+	ClasspathMultiReleaseJar(ResourceOrExternalFile library, AccessRuleSet accessRuleSet, IPath externalAnnotationPath,
 			boolean isOnModulePath, String compliance) {
-		this(zipFile.getName(), accessRuleSet, externalAnnotationPath, isOnModulePath, compliance);
-		this.zipFile = zipFile;
-		this.closeZipFileAtEnd = true;
-	}
-
-	public ClasspathMultiReleaseJar(String fileName, AccessRuleSet accessRuleSet, IPath externalAnnotationPath,
-			boolean isOnModulePath, String compliance) {
-		this(fileName, 0, accessRuleSet, externalAnnotationPath, isOnModulePath, compliance);
-		if (externalAnnotationPath != null) {
-			this.externalAnnotationPath = externalAnnotationPath.toString();
-		}
+		super(library, null, accessRuleSet, externalAnnotationPath, isOnModulePath);
+		this.compliance = compliance;
 	}
 
 	@Override
 	IModule initializeModule() {
 		IModule mod = null;
-		try (ZipFile file = new ZipFile(this.zipFilename)){
+		try (ThreadLocalZipFile file = createZipFile()){
 			ClassFileReader classfile = null;
 			try {
 				for (String path : supportedVersions(file)) {
-					classfile = ClassFileReader.read(file, path.toString() + '/' + IModule.MODULE_INFO_CLASS);
+					classfile = org.eclipse.jdt.internal.core.util.Util.read(file, path.toString() + '/' + IModule.MODULE_INFO_CLASS);
 					if (classfile != null) {
 						break;
 					}
@@ -72,18 +64,18 @@ public class ClasspathMultiReleaseJar extends ClasspathJar {
 				// move on to the default
 			}
 			if (classfile == null) {
-				classfile = ClassFileReader.read(file, IModule.MODULE_INFO_CLASS); // FIXME: use jar cache
+				classfile = org.eclipse.jdt.internal.core.util.Util.read(file, IModule.MODULE_INFO_CLASS); // FIXME: use jar cache
 			}
 			if (classfile != null) {
 				mod = classfile.getModuleDeclaration();
 			}
-		} catch (ClassFormatException | IOException e) {
+		} catch (ClassFormatException | IOException | CoreException e) {
 			Util.log(e, "Failed to initialize module for: " + this);  //$NON-NLS-1$
 		}
 		return mod;
 	}
 
-	private static String[] initializeVersions(ZipFile zipFile, String compliance) {
+	private static String[] initializeVersions(ThreadLocalZipFile zipFile, String compliance) {
 		int earliestJavaVersion = ClassFileConstants.MAJOR_VERSION_9;
 		long latestJDK = CompilerOptions.versionToJdkLevel(compliance);
 		int latestJavaVer = (int) (latestJDK >> 16);
@@ -98,10 +90,10 @@ public class ClasspathMultiReleaseJar extends ClasspathJar {
 		return versions.toArray(new String[versions.size()]);
 	}
 
-	private String[] supportedVersions(ZipFile file) {
+	private String[] supportedVersions(ThreadLocalZipFile zipFile) {
 		String[] versions = this.supportedVersions;
 		if (versions == null) {
-			versions = initializeVersions(file, this.compliance);
+			versions = initializeVersions(zipFile, this.compliance);
 			this.supportedVersions = versions;
 		}
 		return versions;
@@ -110,22 +102,26 @@ public class ClasspathMultiReleaseJar extends ClasspathJar {
 	@Override
 	protected String readJarContent(final SimpleSet packageSet) {
 		String modInfo = null;
-		for (Enumeration<? extends ZipEntry> e = this.zipFile.entries(); e.hasMoreElements(); ) {
-			String fileName = ((ZipEntry) e.nextElement()).getName();
-			if (fileName.startsWith(META_INF_VERSIONS) && fileName.length() > META_INF_LENGTH) {
-				int i = fileName.indexOf('/', META_INF_LENGTH);
-				fileName = fileName.substring(i + 1);
-			} else if (fileName.startsWith("META-INF/")) //$NON-NLS-1$
-				continue;
-			if (modInfo == null) {
-				int folderEnd = fileName.lastIndexOf('/');
-				folderEnd += 1;
-				String className = fileName.substring(folderEnd, fileName.length());
-				if (className.equalsIgnoreCase(IModule.MODULE_INFO_CLASS)) {
-					modInfo = fileName;
+		try (ThreadLocalZipFile zipFile = createZipFile()) {
+			for (Enumeration<? extends ZipEntry> e = zipFile.entries(); e.hasMoreElements(); ) {
+				String fileName = ((ZipEntry) e.nextElement()).getName();
+				if (fileName.startsWith(META_INF_VERSIONS) && fileName.length() > META_INF_LENGTH) {
+					int i = fileName.indexOf('/', META_INF_LENGTH);
+					fileName = fileName.substring(i + 1);
+				} else if (fileName.startsWith("META-INF/")) //$NON-NLS-1$
+					continue;
+				if (modInfo == null) {
+					int folderEnd = fileName.lastIndexOf('/');
+					folderEnd += 1;
+					String className = fileName.substring(folderEnd, fileName.length());
+					if (className.equalsIgnoreCase(IModule.MODULE_INFO_CLASS)) {
+						modInfo = fileName;
+					}
 				}
+				addToPackageSet(packageSet, fileName, false);
 			}
-			addToPackageSet(packageSet, fileName, false);
+		} catch (CoreException e1) {
+			// nothing
 		}
 		return modInfo;
 	}
@@ -136,32 +132,36 @@ public class ClasspathMultiReleaseJar extends ClasspathJar {
 		if (!isPackage(qualifiedPackageName, moduleName)) {
 			return null; // most common case
 		}
-		for (String path : supportedVersions(this.zipFile)) {
-			String s = null;
-			try {
-				s = META_INF_VERSIONS + path + "/" + binaryFileName;  //$NON-NLS-1$
-				ZipEntry entry = this.zipFile.getEntry(s);
-				if (entry == null)
-					continue;
-				IBinaryType reader = ClassFileReader.read(this.zipFile, s);
-				if (reader != null) {
-					char[] modName = this.module == null ? null : this.module.name();
-					if (reader instanceof ClassFileReader) {
-						ClassFileReader classReader = (ClassFileReader) reader;
-						if (classReader.moduleName == null) {
-							classReader.moduleName = modName;
-						} else {
-							modName = classReader.moduleName;
+		try (ThreadLocalZipFile zipFile = createZipFile()) {
+			for (String path : supportedVersions(zipFile)) {
+				String s = null;
+				try {
+					s = META_INF_VERSIONS + path + "/" + binaryFileName;  //$NON-NLS-1$
+					ZipEntry entry =zipFile.getEntry(s);
+					if (entry == null)
+						continue;
+					IBinaryType reader = Util.read(zipFile, s);
+					if (reader != null) {
+						char[] modName = this.module == null ? null : this.module.name();
+						if (reader instanceof ClassFileReader) {
+							ClassFileReader classReader = (ClassFileReader) reader;
+							if (classReader.moduleName == null) {
+								classReader.moduleName = modName;
+							} else {
+								modName = classReader.moduleName;
+							}
 						}
+						String fileNameWithoutExtension = qualifiedBinaryFileName.substring(0,
+								qualifiedBinaryFileName.length() - SuffixConstants.SUFFIX_CLASS.length);
+						return createAnswer(fileNameWithoutExtension, reader, modName);
 					}
-					String fileNameWithoutExtension = qualifiedBinaryFileName.substring(0,
-							qualifiedBinaryFileName.length() - SuffixConstants.SUFFIX_CLASS.length);
-					return createAnswer(fileNameWithoutExtension, reader, modName);
+				} catch (IOException | ClassFormatException e) {
+					Util.log(e, "Failed to find class for: " + s + " in: " + this);  //$NON-NLS-1$ //$NON-NLS-2$
+					// treat as if class file is missing
 				}
-			} catch (IOException | ClassFormatException e) {
-				Util.log(e, "Failed to find class for: " + s + " in: " + this);  //$NON-NLS-1$ //$NON-NLS-2$
-				// treat as if class file is missing
 			}
+		} catch (CoreException e1) {
+			// treat as if class file is missing
 		}
 		return super.findClass(binaryFileName, qualifiedPackageName, moduleName, qualifiedBinaryFileName, asBinaryOnly,
 				moduleNameFilter);

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/ClasspathMultiReleaseJar.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/ClasspathMultiReleaseJar.java
@@ -20,7 +20,7 @@ import org.eclipse.jdt.internal.compiler.env.NameEnvironmentAnswer;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jdt.internal.compiler.util.SimpleSet;
 import org.eclipse.jdt.internal.compiler.util.SuffixConstants;
-import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles.ThreadLocalZipFile;
+import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles.ZipFileResource;
 import org.eclipse.jdt.internal.core.util.Util;
 
 public class ClasspathMultiReleaseJar extends ClasspathJar {
@@ -49,7 +49,7 @@ public class ClasspathMultiReleaseJar extends ClasspathJar {
 	@Override
 	IModule initializeModule() {
 		IModule mod = null;
-		try (ThreadLocalZipFile file = createZipFile()){
+		try (ZipFileResource file = createZipFile()){
 			ClassFileReader classfile = null;
 			try {
 				for (String path : supportedVersions(file)) {
@@ -75,7 +75,7 @@ public class ClasspathMultiReleaseJar extends ClasspathJar {
 		return mod;
 	}
 
-	private static String[] initializeVersions(ThreadLocalZipFile zipFile, String compliance) {
+	private static String[] initializeVersions(ZipFileResource zipFile, String compliance) {
 		int earliestJavaVersion = ClassFileConstants.MAJOR_VERSION_9;
 		long latestJDK = CompilerOptions.versionToJdkLevel(compliance);
 		int latestJavaVer = (int) (latestJDK >> 16);
@@ -90,7 +90,7 @@ public class ClasspathMultiReleaseJar extends ClasspathJar {
 		return versions.toArray(new String[versions.size()]);
 	}
 
-	private String[] supportedVersions(ThreadLocalZipFile zipFile) {
+	private String[] supportedVersions(ZipFileResource zipFile) {
 		String[] versions = this.supportedVersions;
 		if (versions == null) {
 			versions = initializeVersions(zipFile, this.compliance);
@@ -102,7 +102,7 @@ public class ClasspathMultiReleaseJar extends ClasspathJar {
 	@Override
 	protected String readJarContent(final SimpleSet packageSet) {
 		String modInfo = null;
-		try (ThreadLocalZipFile zipFile = createZipFile()) {
+		try (ZipFileResource zipFile = createZipFile()) {
 			for (Enumeration<? extends ZipEntry> e = zipFile.entries(); e.hasMoreElements(); ) {
 				String fileName = ((ZipEntry) e.nextElement()).getName();
 				if (fileName.startsWith(META_INF_VERSIONS) && fileName.length() > META_INF_LENGTH) {
@@ -132,7 +132,7 @@ public class ClasspathMultiReleaseJar extends ClasspathJar {
 		if (!isPackage(qualifiedPackageName, moduleName)) {
 			return null; // most common case
 		}
-		try (ThreadLocalZipFile zipFile = createZipFile()) {
+		try (ZipFileResource zipFile = createZipFile()) {
 			for (String path : supportedVersions(zipFile)) {
 				String s = null;
 				try {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/JavaBuilder.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/JavaBuilder.java
@@ -22,6 +22,8 @@ import org.eclipse.jdt.core.compiler.*;
 import org.eclipse.jdt.internal.compiler.util.SimpleLookupTable;
 import org.eclipse.jdt.internal.core.*;
 import org.eclipse.jdt.internal.core.util.Messages;
+import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles;
+import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles.ThreadLocalZipFileHolder;
 import org.eclipse.jdt.internal.core.util.Util;
 
 import java.io.*;
@@ -167,6 +169,12 @@ public static void writeState(Object state, DataOutputStream out) throws IOExcep
 
 @Override
 protected IProject[] build(int kind, Map ignored, IProgressMonitor monitor) throws CoreException {
+	try (ThreadLocalZipFileHolder holder = ThreadLocalZipFiles.createZipHolder(this)) {
+		return buildCached(kind, ignored, monitor);
+	}
+}
+
+protected IProject[] buildCached(int kind, Map ignored, IProgressMonitor monitor) throws CoreException {
 	this.currentProject = getProject();
 	if (this.currentProject == null || !this.currentProject.isAccessible()) return new IProject[0];
 

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/hierarchy/RegionBasedHierarchyBuilder.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/hierarchy/RegionBasedHierarchyBuilder.java
@@ -27,10 +27,11 @@ import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
-import org.eclipse.jdt.internal.core.JavaModelManager;
 import org.eclipse.jdt.internal.core.JavaProject;
 import org.eclipse.jdt.internal.core.Openable;
 import org.eclipse.jdt.internal.core.SearchableEnvironment;
+import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles;
+import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles.ThreadLocalZipFileHolder;
 
 @SuppressWarnings({ "rawtypes", "unchecked" })
 public class RegionBasedHierarchyBuilder extends HierarchyBuilder {
@@ -44,10 +45,9 @@ public class RegionBasedHierarchyBuilder extends HierarchyBuilder {
 @Override
 public void build(boolean computeSubtypes) {
 
-	JavaModelManager manager = JavaModelManager.getJavaModelManager();
-	try {
-		// optimize access to zip files while building hierarchy
-		manager.cacheZipFiles(this);
+	// optimize access to zip files while building hierarchy
+	try (ThreadLocalZipFileHolder h = ThreadLocalZipFiles
+				.createZipHolder(this)) {
 
 		if (this.hierarchy.focusType == null || computeSubtypes) {
 			HashMap allOpenablesInRegion = determineOpenablesInRegion(this.hierarchy.progressMonitor.split(30));
@@ -58,8 +58,6 @@ public void build(boolean computeSubtypes) {
 			this.hierarchy.initialize(1);
 			buildSupertypes();
 		}
-	} finally {
-		manager.flushZipFiles(this);
 	}
 }
 /**

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/ThreadLocalZipFiles.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/ThreadLocalZipFiles.java
@@ -212,11 +212,7 @@ public final class ThreadLocalZipFiles {
 	}
 
 	public static boolean verboseLogging() {
-		if (java.util.Arrays.stream(Thread.currentThread().getStackTrace()).anyMatch(s->(""+s).contains("JavaSearchBugsTests$"))) {  //$NON-NLS-1$//$NON-NLS-2$
-			(new RuntimeException()).printStackTrace(System.out);
-		}
-		return true;
-//		return ZIP_ACCESS_VERBOSE;
+		return ZIP_ACCESS_VERBOSE;
 	}
 
 	public static boolean isPresent(IPath path) {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/ThreadLocalZipFiles.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/ThreadLocalZipFiles.java
@@ -1,0 +1,225 @@
+/*******************************************************************************
+ * Copyright (c) 2021 IBM Joerg Kubitz and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Joerg Kubitz - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.internal.core.util;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.jdt.internal.core.JavaModelManager;
+
+/**
+ * * A factory for ThreadLocalZipFile. Cache zip files for performance (see
+ * https://bugs.eclipse.org/bugs/show_bug.cgi?id=134172) It keeps a thread-local cache of AutoCloseable Wrappers around
+ * ZipFile until all Wrapper and all AutoCloseable Holder closed.
+ *
+ * @see java.util.zip.ZipFile
+ * @see ThreadLocalZipFile
+ **/
+public final class ThreadLocalZipFiles {
+	public static boolean ZIP_ACCESS_VERBOSE = false;
+
+	/**
+	 * A cache of opened zip files per thread. (for a given thread, the object value is a HashMap from IPath to
+	 * java.io.ZipFile)
+	 */
+	private static ThreadLocal<Map<IPath, ThreadLocalZipFile>> threadlocalZipMap = ThreadLocal
+			.withInitial(() -> new HashMap<>());
+	private static ThreadLocal<Integer> holderReferenceCount = ThreadLocal.withInitial(() -> 0);
+
+	/**
+	 * A java.lang.AutoCloseable wrapper to leave all ZipFiles open while the wrapper is open
+	 *
+	 * @see java.util.zip.ZipFile
+	 **/
+	public static final class ThreadLocalZipFileHolder implements AutoCloseable {
+		ThreadLocalZipFileHolder() {
+			int r = holderReferenceCount.get();
+			if (verboseLogging()) {
+				System.out.println(this + " locked " + r); //$NON-NLS-1$
+			}
+			r++;
+			holderReferenceCount.set(r);
+		}
+
+		@Override
+		public void close() {
+			int r = holderReferenceCount.get();
+			if (verboseLogging()) {
+				System.out.println(this + " unlocked " + r); //$NON-NLS-1$
+			}
+			r--;
+			holderReferenceCount.set(r);
+			if (r == 0) {
+				flushThreadLocalZipFiles();
+				holderReferenceCount.remove();
+			}
+		}
+
+		@Override
+		public String toString() {
+			return "(" + Thread.currentThread().getName() + ") [" + this.getClass().getSimpleName() + "@" //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+					+ System.identityHashCode(this) + "]"; //$NON-NLS-1$
+		}
+	}
+
+	private static void flushThreadLocalZipFiles() {
+		for (ThreadLocalZipFile zip : new ArrayList<>(threadlocalZipMap.get().values())) {
+			zip.close();
+		}
+		threadlocalZipMap.remove();
+	}
+
+	/** returns a lock Resource that the receiver must close after use.
+	 * While the lock is open createZipFile() will create only a single ZipFile.
+	 * Successive calls to createZipFile() will return the same instance.
+	 * The ZipFile will be not be closed until the lock is closed.
+	 * If multiple locking resources are nested only the closing of the outermost lock
+	 * will close the ZipFiles. Use this to cache ZipFiles within a block. **/
+	public static ThreadLocalZipFileHolder createZipHolder(Object holder) {
+		// ignore the holder
+		return new ThreadLocalZipFileHolder();
+	}
+
+	/**
+	 * A java.lang.AutoCloseable wrapper around java.util.zip.ZipFile which holds the Zipfile open within this thread
+	 *
+	 * @see java.util.zip.ZipFile
+	 **/
+	public static final class ThreadLocalZipFile implements AutoCloseable {
+
+		private java.util.zip.ZipFile zipFile;
+		private int referenceCount;
+		private IPath path;
+
+		public ThreadLocalZipFile(IPath path) throws IOException, CoreException {
+			this.path = path;
+			if (verboseLogging()) {
+				System.out.println(this + " Opened"); //$NON-NLS-1$
+			}
+			try {
+				File localFile=JavaModelManager.getLocalFile(path);
+				java.util.zip.ZipFile zip = new java.util.zip.ZipFile(localFile);
+				this.zipFile = zip;
+			} catch (IOException e) {
+				if (verboseLogging()) {
+					System.out.println(this + " Error Opening"); //$NON-NLS-1$
+				}
+				throw e;
+			}
+		}
+
+		@Override
+		public void close() {
+			if (verboseLogging()) {
+				System.out.println(this + " Dereferenced " + this.referenceCount); //$NON-NLS-1$
+			}
+			if (this.path == null) {
+				return; // already closed
+			}
+			this.referenceCount--;
+			if (this.referenceCount == 0 && ((int) holderReferenceCount.get()) == 0) {
+				realyClose();
+				this.path = null;
+			}
+		}
+
+		@SuppressWarnings("resource") // remove returns this
+		private void realyClose() {
+			try {
+				threadlocalZipMap.get().remove(this.path);
+				if (verboseLogging()) {
+					System.out.println(this + " Closed"); //$NON-NLS-1$
+				}
+				this.zipFile.close();
+			} catch (IOException e) {
+				// problem occured closing zip file: cannot do much more
+//				JavaCore.getPlugin().getLog().log(
+//						new Status(IStatus.ERROR, JavaCore.PLUGIN_ID, "Error closing " + this.zipFile.getName(), e)); //$NON-NLS-1$
+			}
+		}
+
+		public Enumeration<? extends ZipEntry> entries() {
+			return this.zipFile.entries();
+		}
+
+		public ZipEntry getEntry(String name) {
+			return this.zipFile.getEntry(name);
+		}
+
+		public int size() {
+			return this.zipFile.size();
+		}
+
+		public String getComment() {
+			return this.zipFile.getComment();
+		}
+
+		public InputStream getInputStream(ZipEntry entry) throws IOException {
+			return this.zipFile.getInputStream(entry);
+		}
+
+		public String getName() {
+			return this.zipFile.getName();
+		}
+
+		@Override
+		public String toString() {
+			return "(" + Thread.currentThread().getName() + ") [" + this.getClass().getSimpleName() + "@" //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+					+ System.identityHashCode(this) + "] " + this.path; //$NON-NLS-1$
+		}
+	}
+
+	/** returns either a new Wrapper around ZipFile or a previously cached instance.
+	 * The receiver must close the returned resource after use.
+	 * @throws CoreException **/
+	@SuppressWarnings("resource") // create method forwards ownership to caller
+	public static ThreadLocalZipFile createZipFile(IPath path) throws IOException, CoreException {
+		{
+			ThreadLocalZipFile existing = threadlocalZipMap.get().get(path);
+			if (existing != null) {
+				existing.referenceCount++;
+				if (verboseLogging()) {
+					System.out.println(existing + " Referenced " + existing.referenceCount); //$NON-NLS-1$
+				}
+				return existing;
+			}
+		}
+		{
+			ThreadLocalZipFile newZipFile = new ThreadLocalZipFile(path);
+			threadlocalZipMap.get().put(path, newZipFile);
+			newZipFile.referenceCount += 1 + (holderReferenceCount.get() > 0 ? 1 : 0);
+			return newZipFile;
+		}
+	}
+
+	public static boolean verboseLogging() {
+		if (java.util.Arrays.stream(Thread.currentThread().getStackTrace()).anyMatch(s->(""+s).contains("JavaSearchBugsTests$"))) {  //$NON-NLS-1$//$NON-NLS-2$
+			(new RuntimeException()).printStackTrace(System.out);
+		}
+		return true;
+//		return ZIP_ACCESS_VERBOSE;
+	}
+
+	public static boolean isPresent(IPath path) {
+		return threadlocalZipMap.get().get(path) != null;
+	}
+}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/Util.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/Util.java
@@ -75,7 +75,7 @@ import org.eclipse.jdt.internal.core.Member;
 import org.eclipse.jdt.internal.core.MemberValuePair;
 import org.eclipse.jdt.internal.core.PackageFragment;
 import org.eclipse.jdt.internal.core.PackageFragmentRoot;
-import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles.ThreadLocalZipFile;
+import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles.ZipFileResource;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.text.edits.MalformedTreeException;
 import org.eclipse.text.edits.TextEdit;
@@ -883,7 +883,7 @@ public class Util {
 					if (JavaModelManager.isJrt(path)) {
 						return ClassFileConstants.JDK9;
 					} else {
-						try (ThreadLocalZipFile jar = JavaModelManager.getJavaModelManager().getZipFile(path)) {
+						try (ZipFileResource jar = JavaModelManager.getJavaModelManager().getZipFile(path)) {
 							for (Enumeration e = jar.entries(); e.hasMoreElements();) {
 								ZipEntry member = (ZipEntry) e.nextElement();
 								String entryName = member.getName();
@@ -3364,7 +3364,7 @@ public class Util {
 		return method;
 	}
 
-	public static byte[] getZipEntryByteContent(ZipEntry ze, ThreadLocalZipFiles.ThreadLocalZipFile zip) throws IOException {
+	public static byte[] getZipEntryByteContent(ZipEntry ze, ThreadLocalZipFiles.ZipFileResource zip) throws IOException {
 		try (QuietClose<InputStream> q = new QuietClose<>(zip.getInputStream(ze))) {
 			InputStream stream = q.get();
 			return read(stream, ze);
@@ -3378,7 +3378,7 @@ public class Util {
 		}
 	}
 
-	public static org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader read(ThreadLocalZipFile zip, String filename)
+	public static org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader read(ZipFileResource zip, String filename)
 			throws org.eclipse.jdt.internal.compiler.classfmt.ClassFormatException, java.io.IOException {
 		java.util.zip.ZipEntry ze = zip.getEntry(filename);
 		if (ze == null)

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/ZipState.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/ZipState.java
@@ -1,0 +1,180 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2021 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Joerg Kubitz - initial API
+ *******************************************************************************/
+package org.eclipse.jdt.internal.core.util;
+
+import java.io.IOException;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles.ThreadLocalZipFile;
+import org.eclipse.jdt.internal.core.JavaModelManager;
+import org.eclipse.jdt.internal.core.JavaProject;
+
+/**
+ * A factory for ThreadLocalZipFile
+ *
+ * @see java.util.zip.ZipFile
+ **/
+public final class ZipState {
+	public static boolean DEBUG_INVALID_ARCHIVES = false;
+
+	/*
+	 * A map of IPaths for jars with known validity (such as being in a valid/known format or not), to an eviction
+	 * timestamp. Synchronize on validityMap before accessing.
+	 */
+	private static final ConcurrentHashMap<IPath, ArchiveValidityInfo> validityMap = new ConcurrentHashMap<>();
+
+	// The amount of time from when an invalid archive is first sensed until that state is considered stale.
+	private static long INVALID_ARCHIVE_TTL_MILLISECONDS = 2 * 60 * 1000;
+
+	private static class ArchiveValidityInfo {
+		/**
+		 * Time at which this entry will be removed from the validityMap.
+		 */
+		final long evictionTimestamp;
+
+		/**
+		 * Reason the entry was added to the invalid validityMap.
+		 */
+		final ArchiveValidity reason;
+
+		ArchiveValidityInfo(long evictionTimestamp, ArchiveValidity reason) {
+			this.evictionTimestamp = evictionTimestamp;
+			this.reason = reason;
+		}
+	}
+
+	public enum ArchiveValidity {
+		INVALID, VALID;
+
+		public boolean isValid() {
+			return this == VALID;
+		}
+	}
+
+	/** returns either a new Wrapper around ZipFile or a previously cached instance.
+	 * The receiver must close the returned resource after use. **/
+	public static ThreadLocalZipFile createZipFile(IPath path) throws CoreException {
+		getArchiveValidity(path); // evicts validity after some time
+		return createZipFileWithoutEvict(path);
+	}
+
+	private static ThreadLocalZipFile createZipFileWithoutEvict(IPath path) throws CoreException {
+		try {
+			ThreadLocalZipFile zipFile = ThreadLocalZipFiles.createZipFile(path);
+			setArchiveValidity(path, ArchiveValidity.VALID); // remember its valid & update TTL
+			return zipFile;
+		} catch (IOException e) {
+			// file may exist but for some reason is inaccessible
+			setArchiveValidity(path, ArchiveValidity.INVALID); // update TTL
+			throw new CoreException(new Status(IStatus.ERROR, JavaCore.PLUGIN_ID, -1, Messages.status_IOException, e));
+		}
+	}
+
+	public static void setArchiveValidity(IPath path, ArchiveValidity reason) {
+		if (DEBUG_INVALID_ARCHIVES) {
+			System.out.println("JAR cache: adding " + reason + " " + path); //$NON-NLS-1$//$NON-NLS-2$
+		}
+		synchronized (validityMap) {
+			validityMap.put(path,
+					new ArchiveValidityInfo(System.currentTimeMillis() + INVALID_ARCHIVE_TTL_MILLISECONDS, reason));
+		}
+	}
+
+	public static void removeArchiveValidity(IPath path) {
+		synchronized (validityMap) {
+			ArchiveValidityInfo entry = validityMap.get(path);
+			if (entry != null && entry.reason == ArchiveValidity.VALID) {
+				if (DEBUG_INVALID_ARCHIVES) {
+					System.out.println("JAR cache: keep VALID " + path); //$NON-NLS-1$
+				}
+				return; // do not remove the VALID information
+			}
+			if (validityMap.remove(path) != null) {
+				if (DEBUG_INVALID_ARCHIVES) {
+					System.out.println("JAR cache: removed INVALID " + path); //$NON-NLS-1$
+				}
+				try {
+					// Bug 455042: Force an update of the JavaProjectElementInfo project caches.
+					JavaModelManager javaModelManager = JavaModelManager.getJavaModelManager();
+					for (IJavaProject project : javaModelManager.getJavaModel().getJavaProjects()) {
+						if (project.findPackageFragmentRoot(path) != null) {
+							((JavaProject) project).resetCaches();
+						}
+					}
+				} catch (JavaModelException e) {
+					Util.log(e, "Unable to retrieve the Java model."); //$NON-NLS-1$
+				}
+			}
+		}
+	}
+
+	private static boolean isArchiveStateKnownToBeValid(IPath path) throws CoreException {
+		ArchiveValidity validity = getArchiveValidity(path);
+		if (validity == null || validity == ArchiveValidity.INVALID) {
+			return false; // chance the file has become accessible/readable now.
+		}
+		return true;
+	}
+
+	public static ArchiveValidity getArchiveValidity(IPath path) {
+		ArchiveValidityInfo invalidArchiveInfo;
+		synchronized (validityMap) {
+			invalidArchiveInfo = validityMap.get(path);
+		}
+		if (invalidArchiveInfo == null) {
+			if (DEBUG_INVALID_ARCHIVES) {
+				System.out.println("JAR cache: UNKNOWN validity for " + path); //$NON-NLS-1$
+			}
+			return null;
+		}
+		long now = System.currentTimeMillis();
+
+		// If the TTL for this cache entry has expired, directly check whether the archive is still invalid.
+		// If it transitioned to being valid, remove it from the cache and force an update to project caches.
+		if (now > invalidArchiveInfo.evictionTimestamp) {
+			try (ThreadLocalZipFile zipFile = createZipFileWithoutEvict(path)) {
+				removeArchiveValidity(path);
+			} catch (CoreException e) {
+				// Archive is still invalid, fall through to reporting it is invalid.
+			}
+			// Retry the test from the start, now that we have an up-to-date result
+			return getArchiveValidity(path);
+		}
+		if (DEBUG_INVALID_ARCHIVES) {
+			System.out.println("JAR cache: " + invalidArchiveInfo.reason + " " + path); //$NON-NLS-1$ //$NON-NLS-2$
+		}
+		return invalidArchiveInfo.reason;
+	}
+
+	public static void verifyArchiveContent(IPath path) throws CoreException {
+		// TODO: we haven't finalized what path the JRT is represented by. Don't attempt to validate it.
+		if (JavaModelManager.isJrt(path)) {
+			return;
+		}
+		if (isArchiveStateKnownToBeValid(path)) {
+			return; // known to be valid
+		}
+		try (ThreadLocalZipFile file = createZipFile(path)) {
+			// just check
+		}
+	}
+
+}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/ZipState.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/ZipState.java
@@ -23,7 +23,7 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
-import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles.ThreadLocalZipFile;
+import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles.ZipFileResource;
 import org.eclipse.jdt.internal.core.JavaModelManager;
 import org.eclipse.jdt.internal.core.JavaProject;
 
@@ -71,14 +71,14 @@ public final class ZipState {
 
 	/** returns either a new Wrapper around ZipFile or a previously cached instance.
 	 * The receiver must close the returned resource after use. **/
-	public static ThreadLocalZipFile createZipFile(IPath path) throws CoreException {
+	public static ZipFileResource createZipFile(IPath path) throws CoreException {
 		getArchiveValidity(path); // evicts validity after some time
 		return createZipFileWithoutEvict(path);
 	}
 
-	private static ThreadLocalZipFile createZipFileWithoutEvict(IPath path) throws CoreException {
+	private static ZipFileResource createZipFileWithoutEvict(IPath path) throws CoreException {
 		try {
-			ThreadLocalZipFile zipFile = ThreadLocalZipFiles.createZipFile(path);
+			ZipFileResource zipFile = ThreadLocalZipFiles.createZipFile(path);
 			setArchiveValidity(path, ArchiveValidity.VALID); // remember its valid & update TTL
 			return zipFile;
 		} catch (IOException e) {
@@ -150,7 +150,7 @@ public final class ZipState {
 		// If the TTL for this cache entry has expired, directly check whether the archive is still invalid.
 		// If it transitioned to being valid, remove it from the cache and force an update to project caches.
 		if (now > invalidArchiveInfo.evictionTimestamp) {
-			try (ThreadLocalZipFile zipFile = createZipFileWithoutEvict(path)) {
+			try (ZipFileResource zipFile = createZipFileWithoutEvict(path)) {
 				removeArchiveValidity(path);
 			} catch (CoreException e) {
 				// Archive is still invalid, fall through to reporting it is invalid.
@@ -172,7 +172,7 @@ public final class ZipState {
 		if (isArchiveStateKnownToBeValid(path)) {
 			return; // known to be valid
 		}
-		try (ThreadLocalZipFile file = createZipFile(path)) {
+		try (ZipFileResource file = createZipFile(path)) {
 			// just check
 		}
 	}

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/nd/java/model/BinaryModuleFactory.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/nd/java/model/BinaryModuleFactory.java
@@ -38,7 +38,7 @@ import org.eclipse.jdt.internal.core.JavaModelManager;
 import org.eclipse.jdt.internal.core.JrtPackageFragmentRoot;
 import org.eclipse.jdt.internal.core.ModularClassFile;
 import org.eclipse.jdt.internal.core.PackageFragmentRoot;
-import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles.ThreadLocalZipFile;
+import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles.ZipFileResource;
 
 /**
  * <strong>FIXME:</strong> this class is a stub as of now, it does not support modules in the new index.
@@ -122,7 +122,7 @@ public class BinaryModuleFactory {
 			return null;
 		}
 		if (descriptor.isInJarFile()) {
-			try (ThreadLocalZipFile zip = JavaModelManager.getJavaModelManager().getZipFile(new Path(new String(descriptor.workspacePath)))){
+			try (ZipFileResource zip = JavaModelManager.getJavaModelManager().getZipFile(new Path(new String(descriptor.workspacePath)))){
 				String entryName = TypeConstants.MODULE_INFO_CLASS_NAME_STRING;
 				ZipEntry ze = zip.getEntry(entryName);
 				if (ze != null) {

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/nd/java/model/BinaryTypeFactory.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/nd/java/model/BinaryTypeFactory.java
@@ -42,7 +42,7 @@ import org.eclipse.jdt.internal.core.JarPackageFragmentRoot;
 import org.eclipse.jdt.internal.core.JavaModelManager;
 import org.eclipse.jdt.internal.core.PackageFragment;
 import org.eclipse.jdt.internal.core.PackageFragmentRoot;
-import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles.ThreadLocalZipFile;
+import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles.ZipFileResource;
 import org.eclipse.jdt.internal.core.nd.util.CharArrayUtils;
 import org.eclipse.jdt.internal.core.util.Util;
 
@@ -139,7 +139,7 @@ public class BinaryTypeFactory {
 		}
 		if (descriptor.isInJarFile()) {
 			if (CharOperation.indexOf("jrt-fs.jar".toCharArray(), descriptor.location, false) == -1) { //$NON-NLS-1$
-				try (ThreadLocalZipFile zip = JavaModelManager.getJavaModelManager().getZipFile(new Path(new String(descriptor.workspacePath)))){
+				try (ZipFileResource zip = JavaModelManager.getJavaModelManager().getZipFile(new Path(new String(descriptor.workspacePath)))){
 					char[] entryNameCharArray = CharArrayUtils.concat(
 							fieldDescriptorToBinaryName(descriptor.fieldDescriptor), SuffixConstants.SUFFIX_class);
 					String entryName = new String(entryNameCharArray);

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/BasicSearchEngine.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/BasicSearchEngine.java
@@ -33,6 +33,8 @@ import org.eclipse.jdt.internal.compiler.lookup.*;
 import org.eclipse.jdt.internal.compiler.parser.Parser;
 import org.eclipse.jdt.internal.compiler.problem.DefaultProblemFactory;
 import org.eclipse.jdt.internal.compiler.problem.ProblemReporter;
+import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles;
+import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles.ThreadLocalZipFileHolder;
 import org.eclipse.jdt.internal.core.*;
 import org.eclipse.jdt.internal.core.search.indexing.*;
 import org.eclipse.jdt.internal.core.search.matching.*;
@@ -208,7 +210,8 @@ public class BasicSearchEngine {
 	 * @param requestor a callback object to which each match is reported
 	 */
 	void findMatches(SearchPattern pattern, SearchParticipant[] participants, IJavaSearchScope scope, SearchRequestor requestor, IProgressMonitor monitor) throws CoreException {
-		try {
+		// cache zipfiles from core.builder.ClasspathJar in JavaSearchNameEnvironment.locationSet:
+		try (ThreadLocalZipFileHolder holder=ThreadLocalZipFiles.createZipHolder(this)){
 			if (VERBOSE) {
 				Util.verbose("Searching for pattern: " + pattern.toString()); //$NON-NLS-1$
 				Util.verbose(scope.toString());

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/AddJarFileToIndex.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/AddJarFileToIndex.java
@@ -40,7 +40,7 @@ import org.eclipse.jdt.internal.compiler.util.SimpleLookupTable;
 import org.eclipse.jdt.internal.compiler.util.Util;
 import org.eclipse.jdt.internal.core.JavaModelManager;
 import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles;
-import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles.ThreadLocalZipFile;
+import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles.ZipFileResource;
 import org.eclipse.jdt.internal.core.index.Index;
 import org.eclipse.jdt.internal.core.index.IndexLocation;
 import org.eclipse.jdt.internal.core.search.JavaSearchDocument;
@@ -157,7 +157,7 @@ class AddJarFileToIndex extends BinaryContainer {
 					zipFilePath = (Path) this.containerPath;
 					// path is already canonical since coming from a library classpath entry
 				}
-				try (ThreadLocalZipFile zip = ThreadLocalZipFiles.createZipFile(zipFilePath)) {
+				try (ZipFileResource zip = ThreadLocalZipFiles.createZipFile(zipFilePath)) {
 
 					if (this.isCancelled) {
 						if (JobManager.VERBOSE)

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/AddJarFileToIndex.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/AddJarFileToIndex.java
@@ -21,7 +21,6 @@ import java.nio.file.NoSuchFileException;
 import java.util.Enumeration;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipError;
-import java.util.zip.ZipFile;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.CoreException;
@@ -40,6 +39,8 @@ import org.eclipse.jdt.internal.compiler.lookup.TypeConstants;
 import org.eclipse.jdt.internal.compiler.util.SimpleLookupTable;
 import org.eclipse.jdt.internal.compiler.util.Util;
 import org.eclipse.jdt.internal.core.JavaModelManager;
+import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles;
+import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles.ThreadLocalZipFile;
 import org.eclipse.jdt.internal.core.index.Index;
 import org.eclipse.jdt.internal.core.index.IndexLocation;
 import org.eclipse.jdt.internal.core.search.JavaSearchDocument;
@@ -123,18 +124,16 @@ class AddJarFileToIndex extends BinaryContainer {
 				return true; // index got deleted since acquired
 			}
 			index.separator = JAR_SEPARATOR;
-			ZipFile zip = null;
 			try {
 				// this path will be a relative path to the workspace in case the zipfile in the workspace otherwise it will be a path in the
 				// local file system
 				Path zipFilePath = null;
 
 				monitor.enterWrite(); // ask permission to write
+				File zipFile;
 				if (this.resource != null) {
 					URI location = this.resource.getLocationURI();
 					if (location == null) return false;
-					if (JavaModelManager.ZIP_ACCESS_VERBOSE)
-						System.out.println("(" + Thread.currentThread() + ") [AddJarFileToIndex.execute()] Creating ZipFile on " + location.getPath()); //$NON-NLS-1$	//$NON-NLS-2$
 					File file = null;
 					try {
 						file = org.eclipse.jdt.internal.core.util.Util.toLocalFile(location, progressMonitor);
@@ -149,140 +148,134 @@ class AddJarFileToIndex extends BinaryContainer {
 							org.eclipse.jdt.internal.core.util.Util.verbose("-> failed to index " + location.getPath() + " because the file could not be fetched"); //$NON-NLS-1$ //$NON-NLS-2$
 						return false;
 					}
-					if (JavaModelManager.ZIP_ACCESS_VERBOSE)
-						System.out.println("(" + Thread.currentThread() + ") [AddJarFileToIndex.execute()] Creating ZipFile on " + this.containerPath); //$NON-NLS-1$	//$NON-NLS-2$
-					zip = new ZipFile(file);
+					zipFile = file;
 					zipFilePath = (Path) this.resource.getFullPath().makeRelative();
 					// absolute path relative to the workspace
 				} else {
-					if (JavaModelManager.ZIP_ACCESS_VERBOSE)
-						System.out.println("(" + Thread.currentThread() + ") [AddJarFileToIndex.execute()] Creating ZipFile on " + this.containerPath); //$NON-NLS-1$	//$NON-NLS-2$
 					// external file -> it is ok to use toFile()
-					zip = new ZipFile(this.containerPath.toFile());
+					zipFile = this.containerPath.toFile();
 					zipFilePath = (Path) this.containerPath;
 					// path is already canonical since coming from a library classpath entry
 				}
+				try (ThreadLocalZipFile zip = ThreadLocalZipFiles.createZipFile(zipFilePath)) {
 
-				if (this.isCancelled) {
-					if (JobManager.VERBOSE)
-						org.eclipse.jdt.internal.core.util.Util.verbose("-> indexing of " + zip.getName() + " has been cancelled"); //$NON-NLS-1$ //$NON-NLS-2$
-					return false;
-				}
-
-				if (JobManager.VERBOSE)
-					org.eclipse.jdt.internal.core.util.Util.verbose("-> indexing " + zip.getName()); //$NON-NLS-1$
-				long initialTime = System.currentTimeMillis();
-
-				String[] paths = index.queryDocumentNames(""); // all file names //$NON-NLS-1$
-				if (paths != null) {
-					int max = paths.length;
-					/* check integrity of the existing index file
-					 * if the length is equal to 0, we want to index the whole jar again
-					 * If not, then we want to check that there is no missing entry, if
-					 * one entry is missing then we recreate the index
-					 */
-					String EXISTS = "OK"; //$NON-NLS-1$
-					String DELETED = "DELETED"; //$NON-NLS-1$
-					SimpleLookupTable indexedFileNames = new SimpleLookupTable(max == 0 ? 33 : max + 11);
-					for (int i = 0; i < max; i++)
-						indexedFileNames.put(paths[i], DELETED);
-					for (Enumeration e = zip.entries(); e.hasMoreElements();) {
-						// iterate each entry to index it
-						ZipEntry ze = (ZipEntry) e.nextElement();
-						String zipEntryName = ze.getName();
-						if (Util.isClassFileName(zipEntryName) && isValidPackageNameForClassOrisModule(zipEntryName))
-								// the class file may not be there if the package name is not valid
-							indexedFileNames.put(zipEntryName, EXISTS);
-					}
-					boolean needToReindex = indexedFileNames.elementSize != max; // a new file was added
-					if (!needToReindex) {
-						Object[] valueTable = indexedFileNames.valueTable;
-						for (int i = 0, l = valueTable.length; i < l; i++) {
-							if (valueTable[i] == DELETED) {
-								needToReindex = true; // a file was deleted so re-index
-								break;
-							}
-						}
-						if (!needToReindex) {
-							if (JobManager.VERBOSE)
-								org.eclipse.jdt.internal.core.util.Util.verbose("-> no indexing required (index is consistent with library) for " //$NON-NLS-1$
-								+ zip.getName() + " (" //$NON-NLS-1$
-								+ (System.currentTimeMillis() - initialTime) + "ms)"); //$NON-NLS-1$
-							this.manager.saveIndex(index); // to ensure its placed into the saved state
-							return true;
-						}
-					}
-				}
-
-				// Index the jar for the first time or reindex the jar in case the previous index file has been corrupted
-				// index already existed: recreate it so that we forget about previous entries
-				SearchParticipant participant = SearchEngine.getDefaultSearchParticipant();
-				if (!this.manager.resetIndex(this.containerPath)) {
-					// failed to recreate index, see 73330
-					this.manager.removeIndex(this.containerPath);
-					return false;
-				}
-				index.separator = JAR_SEPARATOR;
-				IPath indexPath = null;
-				IndexLocation indexLocation;
-				if ((indexLocation = index.getIndexLocation()) != null) {
-					indexPath = new Path(indexLocation.getCanonicalFilePath());
-				}
-				boolean hasModuleInfoClass = false;
-				for (Enumeration e = zip.entries(); e.hasMoreElements();) {
 					if (this.isCancelled) {
 						if (JobManager.VERBOSE)
 							org.eclipse.jdt.internal.core.util.Util.verbose("-> indexing of " + zip.getName() + " has been cancelled"); //$NON-NLS-1$ //$NON-NLS-2$
 						return false;
 					}
 
-					// iterate each entry to index it
-					ZipEntry ze = (ZipEntry) e.nextElement();
-					String zipEntryName = ze.getName();
-					if (Util.isClassFileName(zipEntryName) &&
-							isValidPackageNameForClassOrisModule(zipEntryName)) {
-						hasModuleInfoClass |= zipEntryName.contains(TypeConstants.MODULE_INFO_NAME_STRING);
-						// index only classes coming from valid packages - https://bugs.eclipse.org/bugs/show_bug.cgi?id=293861
-						final byte[] classFileBytes = org.eclipse.jdt.internal.compiler.util.Util.getZipEntryByteContent(ze, zip);
-						JavaSearchDocument entryDocument = new JavaSearchDocument(ze, zipFilePath, classFileBytes, participant);
-						this.manager.indexDocument(entryDocument, participant, index, indexPath);
+					if (JobManager.VERBOSE)
+						org.eclipse.jdt.internal.core.util.Util.verbose("-> indexing " + zip.getName()); //$NON-NLS-1$
+					long initialTime = System.currentTimeMillis();
+
+					String[] paths = index.queryDocumentNames(""); // all file names //$NON-NLS-1$
+					if (paths != null) {
+						int max = paths.length;
+						/* check integrity of the existing index file
+						 * if the length is equal to 0, we want to index the whole jar again
+						 * If not, then we want to check that there is no missing entry, if
+						 * one entry is missing then we recreate the index
+						 */
+
+						String EXISTS = "OK"; //$NON-NLS-1$
+						String DELETED = "DELETED"; //$NON-NLS-1$
+						SimpleLookupTable indexedFileNames = new SimpleLookupTable(max == 0 ? 33 : max + 11);
+						for (int i = 0; i < max; i++)
+							indexedFileNames.put(paths[i], DELETED);
+						for (Enumeration e = zip.entries(); e.hasMoreElements();) {
+							// iterate each entry to index it
+							ZipEntry ze = (ZipEntry) e.nextElement();
+							String zipEntryName = ze.getName();
+							if (Util.isClassFileName(zipEntryName) && isValidPackageNameForClassOrisModule(zipEntryName))
+								// the class file may not be there if the package name is not valid
+								indexedFileNames.put(zipEntryName, EXISTS);
+						}
+						boolean needToReindex = indexedFileNames.elementSize != max; // a new file was added
+						if (!needToReindex) {
+							Object[] valueTable = indexedFileNames.valueTable;
+							for (int i = 0, l = valueTable.length; i < l; i++) {
+								if (valueTable[i] == DELETED) {
+									needToReindex = true; // a file was deleted so re-index
+									break;
+								}
+							}
+							if (!needToReindex) {
+								if (JobManager.VERBOSE)
+									org.eclipse.jdt.internal.core.util.Util.verbose("-> no indexing required (index is consistent with library) for " //$NON-NLS-1$
+													+ zip.getName() + " (" //$NON-NLS-1$
+													+ (System.currentTimeMillis() - initialTime) + "ms)"); //$NON-NLS-1$
+								this.manager.saveIndex(index); // to ensure its placed into the saved state
+								return true;
+							}
+						}
 					}
-				}
-				if (!hasModuleInfoClass) {
-					String s;
-					try {
-						s = this.resource == null ? this.containerPath.toOSString() :
-							JavaModelManager.getLocalFile(this.resource.getFullPath()).toPath().toAbsolutePath().toString();
-						char[] autoModuleName = AutomaticModuleNaming.determineAutomaticModuleName(s);
-						final char[] contents = CharOperation.append(CharOperation.append(TypeConstants.AUTOMATIC_MODULE_NAME.toCharArray(), ':'), autoModuleName);
-						// adding only the automatic module entry here - can be extended in the future to include other fields.
-						ZipEntry ze = new ZipEntry(TypeConstants.AUTOMATIC_MODULE_NAME);
-						JavaSearchDocument entryDocument = new JavaSearchDocument(ze, zipFilePath, new String(contents).getBytes(Charset.defaultCharset()), participant);
-						this.manager.indexDocument(entryDocument, participant, index, indexPath);
-					} catch (CoreException e) {
-						// TODO Auto-generated catch block
-//						e.printStackTrace();
+
+					// Index the jar for the first time or reindex the jar in case the previous index file has been corrupted
+					// index already existed: recreate it so that we forget about previous entries
+					SearchParticipant participant = SearchEngine.getDefaultSearchParticipant();
+					if (!this.manager.resetIndex(this.containerPath)) {
+						// failed to recreate index, see 73330
+						this.manager.removeIndex(this.containerPath);
+						return false;
 					}
+					index.separator = JAR_SEPARATOR;
+					IPath indexPath = null;
+					IndexLocation indexLocation;
+					if ((indexLocation = index.getIndexLocation()) != null) {
+						indexPath = new Path(indexLocation.getCanonicalFilePath());
+					}
+					boolean hasModuleInfoClass = false;
+					for (Enumeration e = zip.entries(); e.hasMoreElements();) {
+						if (this.isCancelled) {
+							if (JobManager.VERBOSE)
+								org.eclipse.jdt.internal.core.util.Util.verbose("-> indexing of " + zip.getName() + " has been cancelled"); //$NON-NLS-1$ //$NON-NLS-2$
+							return false;
+						}
+
+						// iterate each entry to index it
+						ZipEntry ze = (ZipEntry) e.nextElement();
+						String zipEntryName = ze.getName();
+						if (Util.isClassFileName(zipEntryName) &&
+								isValidPackageNameForClassOrisModule(zipEntryName)) {
+							hasModuleInfoClass |= zipEntryName.contains(TypeConstants.MODULE_INFO_NAME_STRING);
+							// index only classes coming from valid packages - https://bugs.eclipse.org/bugs/show_bug.cgi?id=293861
+							final byte[] classFileBytes = org.eclipse.jdt.internal.core.util.Util.getZipEntryByteContent(ze, zip);
+							JavaSearchDocument entryDocument = new JavaSearchDocument(ze, zipFilePath, classFileBytes, participant);
+							this.manager.indexDocument(entryDocument, participant, index, indexPath);
+						}
+					}
+					if (!hasModuleInfoClass) {
+						String s;
+						try {
+							s = this.resource == null ? this.containerPath.toOSString() :
+								JavaModelManager.getLocalFile(this.resource).toPath().toAbsolutePath().toString();
+							char[] autoModuleName = AutomaticModuleNaming.determineAutomaticModuleName(s);
+							final char[] contents = CharOperation.append(CharOperation.append(TypeConstants.AUTOMATIC_MODULE_NAME.toCharArray(), ':'), autoModuleName);
+							// adding only the automatic module entry here - can be extended in the future to include other fields.
+							ZipEntry ze = new ZipEntry(TypeConstants.AUTOMATIC_MODULE_NAME);
+							JavaSearchDocument entryDocument = new JavaSearchDocument(ze, zipFilePath, new String(contents).getBytes(Charset.defaultCharset()), participant);
+							this.manager.indexDocument(entryDocument, participant, index, indexPath);
+						} catch (CoreException e) {
+							// TODO Auto-generated catch block
+//							e.printStackTrace();
+						}
+					}
+					if(this.forceIndexUpdate) {
+						this.manager.savePreBuiltIndex(index);
+					}
+					else {
+						this.manager.saveIndex(index);
+					}
+					if (JobManager.VERBOSE)
+						org.eclipse.jdt.internal.core.util.Util.verbose("-> done indexing of " //$NON-NLS-1$
+							+ zip.getName() + " (" //$NON-NLS-1$
+							+ (System.currentTimeMillis() - initialTime) + "ms)"); //$NON-NLS-1$
 				}
-				if(this.forceIndexUpdate) {
-					this.manager.savePreBuiltIndex(index);
-				}
-				else {
-					this.manager.saveIndex(index);
-				}
-				if (JobManager.VERBOSE)
-					org.eclipse.jdt.internal.core.util.Util.verbose("-> done indexing of " //$NON-NLS-1$
-						+ zip.getName() + " (" //$NON-NLS-1$
-						+ (System.currentTimeMillis() - initialTime) + "ms)"); //$NON-NLS-1$
 			} finally {
-				if (zip != null) {
-					if (JavaModelManager.ZIP_ACCESS_VERBOSE)
-						System.out.println("(" + Thread.currentThread() + ") [AddJarFileToIndex.execute()] Closing ZipFile " + this.containerPath); //$NON-NLS-1$	//$NON-NLS-2$
-					zip.close();
-				}
 				monitor.exitWrite(); // free write lock
 			}
-		} catch (IOException | ZipError e) {
+		} catch (IOException | ZipError | CoreException e) {
 			if (e instanceof NoSuchFileException) {
 				IStatus info = new Status(IStatus.INFO, JavaCore.PLUGIN_ID, "File no longer exists: " + this.containerPath, e); //$NON-NLS-1$
 				org.eclipse.jdt.internal.core.util.Util.log(info);

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/JavaSearchNameEnvironment.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/JavaSearchNameEnvironment.java
@@ -266,7 +266,7 @@ private ClasspathLocation mapToClassPathLocation(JavaModelManager manager, Packa
 			cp = (root instanceof JrtPackageFragmentRoot) ?
 					ClasspathLocation.forJrtSystem(path.toOSString(), rawClasspathEntry.getAccessRuleSet(),
 							rawClasspathEntry.getExternalAnnotationPath(project.getProject(), true), compliance) :
-									ClasspathLocation.forLibrary(manager.getZipFile(path), rawClasspathEntry.getAccessRuleSet(),
+									ClasspathLocation.forLibrary(root, rawClasspathEntry.getAccessRuleSet(),
 												rawClasspathEntry.getExternalAnnotationPath(((IJavaProject) root.getParent()).getProject(), true),
 												rawClasspathEntry.isModular(), compliance) ;
 		} else {

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/MatchLocator.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/MatchLocator.java
@@ -91,7 +91,7 @@ import org.eclipse.jdt.internal.core.SourceMethod;
 import org.eclipse.jdt.internal.core.SourceType;
 import org.eclipse.jdt.internal.core.SourceTypeElementInfo;
 import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles;
-import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles.ThreadLocalZipFile;
+import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles.ZipFileResource;
 import org.eclipse.jdt.internal.core.util.ThreadLocalZipFiles.ThreadLocalZipFileHolder;
 import org.eclipse.jdt.internal.core.index.Index;
 import org.eclipse.jdt.internal.core.search.*;
@@ -282,7 +282,7 @@ public static IBinaryType classFileReader(IType type) {
 			return ClassFileReader.readFromJrt(new File(rootPath), null, path);
 		} else {
 			IPath zipPath = root.getPath();
-			try (ThreadLocalZipFile zipFile = manager.getZipFile(zipPath)){
+			try (ZipFileResource zipFile = manager.getZipFile(zipPath)){
 				String classFileName = classFile.getElementName();
 				String path = Util.concatWith(pkg.names, classFileName, '/');
 				return Util.read(zipFile, path);
@@ -891,7 +891,7 @@ protected IBinaryType getBinaryInfo(ClassFile classFile, IResource resource) thr
 			// class file in a jar
 			String classFileName = classFile.getElementName();
 			String classFilePath = Util.concatWith(pkg.names, classFileName, '/');
-			try (ThreadLocalZipFile zipFile =  ((JarPackageFragmentRoot)root).getJar()){
+			try (ZipFileResource zipFile =  ((JarPackageFragmentRoot)root).getJar()){
 				info = Util.read(zipFile, classFilePath);
 			}
 		} else {


### PR DESCRIPTION
### High level overview
on the client side:

```
	JavaModelManager manager = JavaModelManager.getJavaModelManager();
	try {
		zip = manager.getZipFile(jarPath);
		...
	} finally {
		manager.closeZipFile(zip);
	}
```
to be replaced by

```
	JavaModelManager manager = JavaModelManager.getJavaModelManager();
	try (ThreadLocalZipFile zip = manager.getZipFile(jarPath)) {
	...
	}
```
which allows resource checking and prevents left open Zip files.
... and actually at least one possible **resource leak** was discovered and **fixed**.

### Details
Moved code from JavaModelManager to new seperate Classes:
*ThreadLocalZipFiles: general caching for ZipFiles
*ZipState: java model handling of invalid ZipFiles

"throwIoExceptionsInGetZipFile" was not moved but deleted to avoid
testcode in production code. Therefore
testTransitionFromInvalidToValidJar() was adapted to produce a real
invalid jar.

ThreadLocalZipFiles contains now AutoCloseable Helper for
try-with-resource resource management.

Calls to the refactored code (in "jdt.core") where refactored to use new
the new try-with-resource pattern.

There is a little difference between the new behavior of old
JavaModelManager.getZipFile() during a JavaModelManager.cacheZipFiles()
block() and new ZipState.createZipFile() in a
ThreadLocalZipFiles.createZipHolder() block:
When blocks are nested they now return the same instance on any nesting
level while previously new instance of ZipFile had been created on every
nesting level.

There is a little difference between the new behavior of old
JavaModelManager.flushZipFiles and new ZipState.close():
Previously flushZipFiles did close all zipFiles in the innermost block;
Now ZipState.close() does only close a zipFile if it was not allocated
in a outer block.

I.e. we have now well defined try-with-resource block: During execution
of any block there is only a single instance of ZipFile for each file.

To use this new behavior builder.ClasspathJar (and its subclasses)
needed to be updated to not hold a local instance of ZipFile (which
could have been leaked).

--
JavaModelManager.getLocalFile(IPath) did return a wrong (relative) path
for deleted workspace resource. Did not matter much as the file did not
exist anyway but it destroyed JavaSearchBugsTests.testBug261722() when
caching filename instead of IPath.

--
In AddJarFileToIndex there is a big block indent that git-diff doesnt
show as such.

Change-Id: Idd94ae90b375db3e475432e710ae7babb99cc5ac