### PR TITLE
1100 formatter tests failed with exact same problem (#42)

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AbstractJavaModelCompletionTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AbstractJavaModelCompletionTests.java
@@ -40,6 +40,8 @@ public abstract class AbstractJavaModelCompletionTests extends AbstractJavaModel
 	}
 	Hashtable<String, String> oldOptions;
 	ICompilationUnit wc = null;
+	private Hashtable<String, String> defaultOptions;
+
 public AbstractJavaModelCompletionTests(String name) {
 	super(name);
 }
@@ -168,6 +170,7 @@ public void setUpSuite() throws Exception {
 	Hashtable<String, String> options = new Hashtable<>(this.oldOptions);
 	options.put(JavaCore.CODEASSIST_SUBWORD_MATCH, JavaCore.DISABLED);
 	JavaCore.setOptions(options);
+	this.defaultOptions = options;
 	System.setProperty(AssistOptions.PROPERTY_SubstringMatch, "false");
 	waitUntilIndexesReady();
 }
@@ -191,6 +194,12 @@ public void tearDownSuite() throws Exception {
 	}
 	super.tearDownSuite();
 }
+
+@Override
+protected Hashtable<String, String> getDefaultJavaCoreOptions() {
+	return this.defaultOptions;
+}
+
 @Override
 protected void tearDown() throws Exception {
 	if(this.wc != null) {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AbstractJavaModelTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AbstractJavaModelTests.java
@@ -3905,12 +3905,31 @@ public abstract class AbstractJavaModelTests extends SuiteOfTestCases {
 
 		// ensure workspace options have been restored to their default
 		Hashtable options = JavaCore.getOptions();
-		Hashtable defaultOptions = JavaCore.getDefaultOptions();
-		assertEquals(
-			"Workspace options should be back to their default",
-			new CompilerOptions(defaultOptions).toString(),
-			new CompilerOptions(options).toString());
+		Hashtable defaultOptions = getDefaultJavaCoreOptions();
+		boolean resetToDefault = true;
+		try {
+			String expected = new CompilerOptions(defaultOptions).toString();
+			String actual = new CompilerOptions(options).toString();
+			assertEquals("Workspace options should be back to their default", expected, actual);
+			resetToDefault = false;
+		} finally {
+			if(resetToDefault) {
+				// Don't let all following tests use broken defaults and fail too
+				JavaCore.setOptions(defaultOptions);
+			}
+		}
 		super.tearDown();
+	}
+
+	/**
+	 * Override to supply "test class default JavaCore options"
+	 * so that these options will be restored for other tests in the class
+	 * even if one the test changes them without restoring in teardown.
+	 *
+	 * @return by default {@link JavaCore#getDefaultOptions()}
+	 */
+	protected Hashtable<String, String> getDefaultJavaCoreOptions() {
+		return JavaCore.getDefaultOptions();
 	}
 
 	protected IPath getJRE9Path() {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/SubwordCompletionTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/SubwordCompletionTests.java
@@ -25,6 +25,8 @@ import junit.framework.Test;
 
 public class SubwordCompletionTests extends AbstractJavaModelCompletionTests {
 
+private Hashtable<String, String> defaultOptions;
+
 public static Test suite() {
 	return buildModelTestSuite(SubwordCompletionTests.class, BYTECODE_DECLARATION_ORDER);
 }
@@ -40,6 +42,7 @@ public void setUpSuite() throws Exception {
 	super.setUpSuite();
 	Hashtable<String, String> options = new Hashtable<>(this.oldOptions);
 	options.put(JavaCore.CODEASSIST_SUBWORD_MATCH, JavaCore.ENABLED);
+	this.defaultOptions = options;
 	JavaCore.setOptions(options);
 }
 public void tearDownSuite() throws Exception {
@@ -57,6 +60,12 @@ public void tearDownSuite() throws Exception {
 	}
 	super.tearDownSuite();
 }
+
+@Override
+protected Hashtable<String, String> getDefaultJavaCoreOptions() {
+	return this.defaultOptions;
+}
+
 private CompletionTestsRequestor2 createFilteredRequestor() {
 	CompletionTestsRequestor2 requestor = new CompletionTestsRequestor2(true);
 	Predicate<CompletionProposal> javaTypeRef = p -> p.getKind() == CompletionProposal.TYPE_REF && new String(p.getSignature()).startsWith("Ljava.");

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/rewrite/modifying/ASTRewritingModifyingTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/rewrite/modifying/ASTRewritingModifyingTest.java
@@ -55,7 +55,8 @@ public abstract class ASTRewritingModifyingTest extends AbstractJavaModelTests {
 	protected IJavaProject javaProject;
 	protected IPackageFragmentRoot sourceFolder;
 
-	private Hashtable oldOptions;
+	private Hashtable<String, String> oldOptions;
+	private Hashtable<String, String> defaultOptions;
 
 	public ASTRewritingModifyingTest(String name) {
 		super(name);
@@ -79,20 +80,28 @@ public abstract class ASTRewritingModifyingTest extends AbstractJavaModelTests {
 		this.javaProject = createJavaProject("P", new String[] {"src"}, null, "bin", "1.5");
 		this.sourceFolder = getPackageFragmentRoot("P", "src");
 
-		Hashtable options = JavaCore.getOptions();
+		Hashtable<String, String> options = JavaCore.getOptions();
 		this.oldOptions = (Hashtable)options.clone();
 		options.put(DefaultCodeFormatterConstants.FORMATTER_TAB_CHAR, JavaCore.SPACE);
 		options.put(DefaultCodeFormatterConstants.FORMATTER_TAB_SIZE, "4");
+		this.defaultOptions = options;
 		JavaCore.setOptions(options);
 
 		waitUntilIndexesReady();
 	}
+
 	@Override
 	public void tearDownSuite() throws Exception {
 		deleteProject("P");
 		JavaCore.setOptions(this.oldOptions);
 		super.tearDownSuite();
 	}
+
+	@Override
+	protected Hashtable<String, String> getDefaultJavaCoreOptions() {
+		return this.defaultOptions;
+	}
+
 	public CompilationUnit createCU(
 		ICompilationUnit unit,
 		boolean resolveBindings,


### PR DESCRIPTION
Restore expected workspace options on teardown and don't let all
following tests use broken defaults and fail too

Should fix https://github.com/eclipse-jdt/eclipse.jdt.core/issues/42