### PR TITLE
jenkins should cancel builds on previous patch sets if the new one is submitted (#44)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,7 @@ pipeline {
 	options {
 		timeout(time: 60, unit: 'MINUTES')
 		buildDiscarder(logRotator(numToKeepStr:'15'))
+		disableConcurrentBuilds(abortPrevious: true)
 		timestamps()
 	}
 	agent {


### PR DESCRIPTION
Fixes issue https://github.com/eclipse-jdt/eclipse.jdt.core/issues/44