### PR TITLE
[null][external] Option to refer to a dependency in a container for external annotations (#23)

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/junit/extension/TestCase.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/junit/extension/TestCase.java
@@ -824,7 +824,7 @@ public boolean isIndexDisabledForTest() {
 }
 
 protected void setUp() throws Exception {
-	if (JavaCore.getPlugin() != null && isIndexDisabledForTest()) {
+	if (JavaCore.getPlugin() != null && isIndexDisabledForTest() && JavaModelManager.getIndexManager().isEnabled()) {
 		JavaModelManager.getIndexManager().disable();
 	}
 	super.setUp();

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ExternalAnnotations18Test.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ExternalAnnotations18Test.java
@@ -150,6 +150,8 @@ public class ExternalAnnotations18Test extends ModifyingResourceTests {
 				String annotsPath = elementsAndAnnotationPaths[i+1];
 				if ("self".equals(annotsPath))
 					this.elementAnnotationPaths.put(entryPath, entryPath);
+				else if (annotsPath != null)
+					this.elementAnnotationPaths.put(entryPath, annotsPath);
 			}
 		}
 
@@ -2894,94 +2896,58 @@ public class ExternalAnnotations18Test extends ModifyingResourceTests {
 				"Null type mismatch: required '@NonNull String' but the provided value is null",
 				markers);
 	}
+
+	// re-usable file contents for the subsequent set of tests (which exercise different configurations with same content):
+	static String mixedArtifacts_CGen_eea_content =
+			"class lib/pgen/CGen\n" +
+			"\n" +
+			"get\n" +
+			" (Ljava/lang/String;)Ljava/lang/String;\n" +
+			" (L1java/lang/String;)L1java/lang/String;\n";
+	static String mixedArtifacts_CGen2_eea_content =
+			"class lib/pgen2/CGen2\n" +
+			"\n" +
+			"get2\n" +
+			" (Ljava/lang/Exception;)Ljava/lang/String;\n" +
+			" (L1java/lang/Exception;)L1java/lang/String;\n";
+	static String mixedArtifacts_CGen_java_content =
+			"package lib.pgen;\n" +
+			"public class CGen {\n" +
+			"	public String get(String in) { return in; }\n" +
+			"}\n";
+	static String mixedArtifacts_CGen2_java_content =
+			"package lib.pgen2;\n" +
+			"public class CGen2 {\n" +
+			"	public String get2(Exception in) { return in.toString(); }\n" +
+			"}\n";
+
 	public void testMultiProject1() throws CoreException {
+		// PrjTest depends on two projects bundled with eea for their respective generated classes
+		// accessed using CORE_JAVA_BUILD_EXTERNAL_ANNOTATIONS_FROM_ALL_LOCATIONS
 		IJavaProject prj1 = null, prj2 = null;
 		myCreateJavaProject("Prj1");
 		addSourceFolderWithExternalAnnotations(this.project, "/Prj1/src-gen", null, "/Prj1/annot-gen");
 		prj1 = this.project;
 		try {
-			createFileInProject("annot-gen/pgen", "CGen.eea",
-					"class pgen/CGen\n" +
-					"\n" +
-					"get\n" +
-					" (Ljava/lang/String;)Ljava/lang/String;\n" +
-					" (L1java/lang/String;)L1java/lang/String;\n");
-
-			createFileInProject("src-gen/pgen", "CGen.java",
-					"package pgen;\n" +
-					"public class CGen {\n" +
-					"	public String get(String in) { return in; }\n" +
-					"}\n");
+			createFileInProject("annot-gen/lib/pgen", "CGen.eea",  mixedArtifacts_CGen_eea_content);
+			createFileInProject("src-gen/lib/pgen",   "CGen.java", mixedArtifacts_CGen_java_content);
 			this.project.getProject().build(IncrementalProjectBuilder.FULL_BUILD, null);
 
 			myCreateJavaProject("Prj2");
-			addSourceFolderWithExternalAnnotations(this.project, "/Prj2/src-gen", null, "/Prj2/annot-gen");
 			prj2 = this.project;
-			createFileInProject("annot-gen/pgen2", "CGen2.eea",
-					"class pgen2/CGen2\n" +
-					"\n" +
-					"get2\n" +
-					" (Ljava/lang/Exception;)Ljava/lang/String;\n" +
-					" (L1java/lang/Exception;)L1java/lang/String;\n");
-
-			createFileInProject("src-gen/pgen2", "CGen2.java",
-					"package pgen2;\n" +
-					"public class CGen2 {\n" +
-					"	public String get2(Exception in) { return in.toString(); }\n" +
-					"}\n");
+			addSourceFolderWithExternalAnnotations(this.project, "/Prj2/src-gen", null, "/Prj2/annot-gen");
+			createFileInProject("annot-gen/lib/pgen2", "CGen2.eea",  mixedArtifacts_CGen2_eea_content);
+			createFileInProject("src-gen/lib/pgen2",   "CGen2.java", mixedArtifacts_CGen2_java_content);
 			this.project.getProject().build(IncrementalProjectBuilder.FULL_BUILD, null);
 
 			myCreateJavaProject("PrjTest");
-			IClasspathEntry entry = JavaCore.newProjectEntry(
-					new Path("/Prj1"),
-					null/*access rules*/,
-					false/*combine access rules*/,
-					null,
-					false/*exported*/);
-			addClasspathEntry(this.project, entry);
-			entry = JavaCore.newProjectEntry(
-					new Path("/Prj2"),
-					null/*access rules*/,
-					false/*combine access rules*/,
-					null,
-					false/*exported*/);
-			addClasspathEntry(this.project, entry);
+			addClasspathEntry(this.project,
+					JavaCore.newProjectEntry(new Path("/Prj1"), null/*access rules*/, false/*combine access rules*/, null, false/*exported*/));
+			addClasspathEntry(this.project,
+					JavaCore.newProjectEntry(new Path("/Prj2"), null/*access rules*/, false/*combine access rules*/, null, false/*exported*/));
 			this.project.setOption(JavaCore.CORE_JAVA_BUILD_EXTERNAL_ANNOTATIONS_FROM_ALL_LOCATIONS, JavaCore.ENABLED);
 
-			createFileInProject("src/p", "Use.java",
-					"package p;\n" +
-					"import pgen.CGen;\n" +
-					"import pgen2.CGen2;\n" +
-					"import org.eclipse.jdt.annotation.NonNull;\n" +
-					"public class Use {\n" +
-					"	public @NonNull String test(CGen c) {\n" +
-					"		String s = c.get(null);\n" + // problem here (7)
-					"		return s;\n" + // no problem here
-					"	}\n" +
-					"	public @NonNull String test2(CGen2 c) {\n" +
-					"		String s = c.get2(null);\n" + // problem here (11)
-					"		return s;\n" + // no problem here
-					"	}\n" +
-					"}\n");
-			this.project.getProject().build(IncrementalProjectBuilder.FULL_BUILD, null);
-			IMarker[] markers = this.project.getProject().findMarkers(IJavaModelMarker.JAVA_MODEL_PROBLEM_MARKER, false, IResource.DEPTH_INFINITE);
-			sortMarkers(markers);
-			assertMarkers("Unexpected markers",
-					"Null type mismatch: required '@NonNull Exception' but the provided value is null\n" +
-					"Null type mismatch: required '@NonNull String' but the provided value is null",
-					markers);
-
-			ICompilationUnit unit = JavaCore.createCompilationUnitFrom(this.project.getProject().getFile("src/p/Use.java")).getWorkingCopy(null);
-			CompilationUnit reconciled = unit.reconcile(getJLS8(), true, null, new NullProgressMonitor());
-			IProblem[] problems = reconciled.getProblems();
-			assertProblems(problems,
-				new String[] {
-					"Pb(910) Null type mismatch: required '@NonNull String' but the provided value is null",
-					"Pb(910) Null type mismatch: required '@NonNull Exception' but the provided value is null"
-				},
-				new int[] {
-					7, 11
-				});
+			internalTestMixedArtifactsTest();
 		} finally {
 			if (prj1 != null)
 				prj1.getProject().delete(true, true , null);
@@ -2995,156 +2961,181 @@ public class ExternalAnnotations18Test extends ModifyingResourceTests {
 		this.project.setOption(JavaCore.CORE_JAVA_BUILD_EXTERNAL_ANNOTATIONS_FROM_ALL_LOCATIONS, JavaCore.ENABLED);
 
 		String projectLoc = this.project.getProject().getLocation().toString();
-		Util.createJar(new String[] {
-				"pgen/CGen.java",
-				"package pgen;\n" +
-				"public class CGen {\n" +
-				"	public String get(String in) { return in; }\n" +
-				"}\n"
-			},
-			new String[] {
-				"pgen/CGen.eea",
-				"class pgen/CGen\n" +
-				"\n" +
-				"get\n" +
-				" (Ljava/lang/String;)Ljava/lang/String;\n" +
-				" (L1java/lang/String;)L1java/lang/String;\n"
-			},
-			projectLoc+"/lib/prj1.jar",
-			"1.8");
-		IClasspathEntry entry = JavaCore.newLibraryEntry(
-				new Path("/PrjTest/lib/prj1.jar"),
-				null/*access rules*/,
-				null,
-				false/*exported*/);
-		addClasspathEntry(this.project, entry);
+		Util.createJar(
+			new String[] { "lib/pgen/CGen.java", mixedArtifacts_CGen_java_content },
+			new String[] { "lib/pgen/CGen.eea",  mixedArtifacts_CGen_eea_content },
+			projectLoc+"/lib/prj1.jar", "1.8");
+		addClasspathEntry(this.project,
+				JavaCore.newLibraryEntry(new Path("/PrjTest/lib/prj1.jar"), null/*access rules*/, null, false/*exported*/));
 
-		Util.createJar(new String[] {
-				"pgen2/CGen2.java",
-				"package pgen2;\n" +
-				"public class CGen2 {\n" +
-				"	public String get2(Exception in) { return in.toString(); }\n" +
-				"}\n"
-			},
-			new String[] {
-				"pgen2/CGen2.eea",
-				"class pgen2/CGen2\n" +
-				"\n" +
-				"get2\n" +
-				" (Ljava/lang/Exception;)Ljava/lang/String;\n" +
-				" (L1java/lang/Exception;)L1java/lang/String;\n",
-			},
-			projectLoc+"/lib/prj2.jar",
-			"1.8");
-		entry = JavaCore.newLibraryEntry(
-				new Path("/PrjTest/lib/prj2.jar"),
-				null/*access rules*/,
-				null,
-				false/*exported*/);
-		addClasspathEntry(this.project, entry);
-		this.project.getProject().refreshLocal(IResource.DEPTH_INFINITE, null);
+		Util.createJar(
+			new String[] { "lib/pgen2/CGen2.java", mixedArtifacts_CGen2_java_content },
+			new String[] { "lib/pgen2/CGen2.eea",  mixedArtifacts_CGen2_eea_content },
+			projectLoc+"/lib/prj2.jar", "1.8");
+		addClasspathEntry(this.project,
+				JavaCore.newLibraryEntry(new Path("/PrjTest/lib/prj2.jar"), null/*access rules*/, null, false/*exported*/));
 
-		createFileInProject("src/p", "Use.java",
-				"package p;\n" +
-				"import pgen.CGen;\n" +
-				"import pgen2.CGen2;\n" +
-				"import org.eclipse.jdt.annotation.NonNull;\n" +
-				"public class Use {\n" +
-				"	public @NonNull String test(CGen c) {\n" +
-				"		String s = c.get(null);\n" + // problem here (7)
-				"		return s;\n" + // no problem here
-				"	}\n" +
-				"	public @NonNull String test2(CGen2 c) {\n" +
-				"		String s = c.get2(null);\n" + // problem here (11)
-				"		return s;\n" + // no problem here
-				"	}\n" +
-				"}\n");
-		this.project.getProject().build(IncrementalProjectBuilder.FULL_BUILD, null);
-		IMarker[] markers = this.project.getProject().findMarkers(IJavaModelMarker.JAVA_MODEL_PROBLEM_MARKER, false, IResource.DEPTH_INFINITE);
-		sortMarkers(markers);
-		assertMarkers("Unexpected markers",
-				"Null type mismatch: required '@NonNull Exception' but the provided value is null\n" +
-				"Null type mismatch: required '@NonNull String' but the provided value is null",
-				markers);
-
-		ICompilationUnit unit = JavaCore.createCompilationUnitFrom(this.project.getProject().getFile("src/p/Use.java")).getWorkingCopy(null);
-		CompilationUnit reconciled = unit.reconcile(getJLS8(), true, null, new NullProgressMonitor());
-		IProblem[] problems = reconciled.getProblems();
-		assertProblems(problems,
-			new String[] {
-				"Pb(910) Null type mismatch: required '@NonNull String' but the provided value is null",
-				"Pb(910) Null type mismatch: required '@NonNull Exception' but the provided value is null"
-			},
-			new int[] {
-				7, 11
-			});
-
+		internalTestMixedArtifactsTest();
 	}
+
 	public void testSeparateAnnotationJar() throws CoreException, IOException {
-		// similar to selfAnnotatedJars(), but here all .eeas are deployed in a separate jar on the build path
+		// all .eeas are deployed in a separate jar on the build path
+		// accessed using CORE_JAVA_BUILD_EXTERNAL_ANNOTATIONS_FROM_ALL_LOCATIONS
 		myCreateJavaProject("PrjTest");
 		this.project.setOption(JavaCore.CORE_JAVA_BUILD_EXTERNAL_ANNOTATIONS_FROM_ALL_LOCATIONS, JavaCore.ENABLED);
 
 		String projectLoc = this.project.getProject().getLocation().toString();
-		Util.createJar(new String[0],
-			new String[] {
-				"lib/pgen/CGen.eea",
-				"class lib/pgen/CGen\n" +
-				"\n" +
-				"get\n" +
-				" (Ljava/lang/String;)Ljava/lang/String;\n" +
-				" (L1java/lang/String;)L1java/lang/String;\n",
+		Util.createJar(new String[0], new String[] {
+					"lib/pgen/CGen.eea", mixedArtifacts_CGen_eea_content,
+					"lib/pgen2/CGen2.eea", mixedArtifacts_CGen2_eea_content,
+				},
+				projectLoc+"/lib/eeas.jar", "1.8");
+		addClasspathEntry(this.project,
+				JavaCore.newLibraryEntry(new Path("/PrjTest/lib/eeas.jar"), null/*access rules*/, null, false/*exported*/));
 
-				"lib/pgen2/CGen2.eea",
-				"class lib/pgen2/CGen2\n" +
-				"\n" +
-				"get2\n" +
-				" (Ljava/lang/Exception;)Ljava/lang/String;\n" +
-				" (L1java/lang/Exception;)L1java/lang/String;\n",
-			},
-			projectLoc+"/lib/eeas.jar",
-			"1.8");
-		IClasspathEntry entry = JavaCore.newLibraryEntry(
-				new Path("/PrjTest/lib/eeas.jar"),
-				null/*access rules*/,
-				null,
-				false/*exported*/);
-		addClasspathEntry(this.project, entry);
+		// one jar dependency in the workspace
+		Util.createJar(
+				new String[] { "lib/pgen/CGen.java", mixedArtifacts_CGen_java_content },
+				projectLoc+"/lib/prj1.jar", "1.8");
+		addClasspathEntry(this.project,
+				JavaCore.newLibraryEntry(new Path("/PrjTest/lib/prj1.jar"), null/*access rules*/, null, false/*exported*/));
 
-		Util.createJar(new String[] {
-				"lib/pgen/CGen.java",
-				"package lib.pgen;\n" +
-				"public class CGen {\n" +
-				"	public String get(String in) { return in; }\n" +
-				"}\n"
-			},
-			projectLoc+"/lib/prj1.jar",
-			"1.8");
-		entry = JavaCore.newLibraryEntry(
-				new Path("/PrjTest/lib/prj1.jar"),
-				null/*access rules*/,
-				null,
-				false/*exported*/);
-		addClasspathEntry(this.project, entry);
-
+		// second dependency is external jar file
 		String externalJarLoc = Util.getOutputDirectory()+"/lib/prj2.jar";
-		Util.createJar(new String[] {
-				"lib.pgen2/CGen2.java",
-				"package lib.pgen2;\n" +
-				"public class CGen2 {\n" +
-				"	public String get2(Exception in) { return in.toString(); }\n" +
-				"}\n"
-			},
-			externalJarLoc,
-			"1.8");
-		entry = JavaCore.newLibraryEntry(
-				new Path(externalJarLoc),
-				null/*access rules*/,
-				null,
-				false/*exported*/);
-		addClasspathEntry(this.project, entry);
-		this.project.getProject().refreshLocal(IResource.DEPTH_INFINITE, null);
+		Util.createJar(
+				new String[] { "lib.pgen2/CGen2.java", mixedArtifacts_CGen2_java_content },
+				externalJarLoc, "1.8");
+		addClasspathEntry(this.project,
+				JavaCore.newLibraryEntry(new Path(externalJarLoc), null/*access rules*/, null, false/*exported*/));
 
+		internalTestMixedArtifactsTest();
+	}
+
+	public void testSeparateAnnotationJarInContainer() throws CoreException, IOException {
+		// .eeas are deployed as a member of a classpath container
+		// referenced relative to the container.
+		myCreateJavaProject("PrjTest");
+		String projectLoc = this.project.getProject().getLocation().toString();
+
+		ITestInitializer prev = ContainerInitializer.initializer;
+		String fullPathToEEA = projectLoc+"/lib/my.eeas-0.1.jar";
+		String fullPathToPrj1 = projectLoc+"/lib/prj1.jar";
+		ContainerInitializer.setInitializer(new TestCustomContainerInitializer(
+				fullPathToEEA, null,
+				fullPathToPrj1, null));
+
+		try {
+			Util.createJar(new String[0], new String[] {
+						"lib/pgen/CGen.eea",   mixedArtifacts_CGen_eea_content,
+						"lib/pgen2/CGen2.eea", mixedArtifacts_CGen2_eea_content },
+					fullPathToEEA, "1.8");
+
+			Util.createJar(
+					new String[] { "lib/pgen/CGen.java", mixedArtifacts_CGen_java_content },
+					fullPathToPrj1, "1.8");
+
+			// eeas & prj1 accessed via the Container:
+			IClasspathEntry entry = JavaCore.newContainerEntry(new Path(TestContainerInitializer.TEST_CONTAINER_NAME), null/*access rules*/,
+					externalAnnotationExtraAttributes(TestContainerInitializer.TEST_CONTAINER_NAME+"/my.eeas"),
+					false/*exported*/);
+			addClasspathEntry(this.project, entry);
+
+			// other jar accessed via separate entry, also annotated using eea in container
+			String externalJarLoc = Util.getOutputDirectory() + "/lib/prj2.jar";
+			Util.createJar(
+					new String[] { "lib.pgen2/CGen2.java", mixedArtifacts_CGen2_java_content },
+					externalJarLoc, "1.8");
+			entry = JavaCore.newLibraryEntry(new Path(externalJarLoc), null, null, null,
+					externalAnnotationExtraAttributes(TestContainerInitializer.TEST_CONTAINER_NAME+"/my.eeas"),
+					false/*exported*/);
+			addClasspathEntry(this.project, entry);
+
+			internalTestMixedArtifactsTest();
+		} finally {
+			ContainerInitializer.setInitializer(prev);
+		}
+	}
+
+	public void testAnnotationsInProjectReferencedViaContainer() throws CoreException, IOException {
+		// undeployed version of testSeparateAnnotationJarInContainer:
+		// container "resolved" the eea-artifact to a workspace project
+		myCreateJavaProject("PrjTest");
+		String projectLoc = this.project.getProject().getLocation().toString();
+
+		ITestInitializer prev = ContainerInitializer.initializer;
+		String eeaProjectName = "my.eeas";
+		String fullPathToPrj1 = projectLoc+"/lib/prj1.jar";
+		ContainerInitializer.setInitializer(new TestCustomContainerInitializer(
+				'/'+eeaProjectName, null,
+				fullPathToPrj1, null));
+
+		try {
+			createJavaProject(eeaProjectName);
+			createFolder('/'+eeaProjectName+"/lib/pgen");
+			createFolder('/'+eeaProjectName+"/lib/pgen2");
+			createFile(eeaProjectName+"/lib/pgen/CGen.eea",   mixedArtifacts_CGen_eea_content);
+			createFile(eeaProjectName+"/lib/pgen2/CGen2.eea", mixedArtifacts_CGen2_eea_content);
+
+			Util.createJar(
+					new String[] { "lib/pgen/CGen.java", mixedArtifacts_CGen_java_content },
+					fullPathToPrj1, "1.8");
+
+			// eeas & prj1 accessed via the Container:
+			IClasspathEntry entry = JavaCore.newContainerEntry(
+					new Path(TestContainerInitializer.TEST_CONTAINER_NAME), null/*access rules*/,
+					externalAnnotationExtraAttributes(TestContainerInitializer.TEST_CONTAINER_NAME+"/my.eeas"),
+					false/*exported*/);
+			addClasspathEntry(this.project, entry);
+
+			// other jar accessed via separate entry, also annotated using eea in container
+			String externalJarLoc = Util.getOutputDirectory() + "/lib/prj2.jar";
+			Util.createJar(
+					new String[] { "lib.pgen2/CGen2.java", mixedArtifacts_CGen2_java_content },
+					externalJarLoc, "1.8");
+			entry = JavaCore.newLibraryEntry(
+					new Path(externalJarLoc), null, null, null,
+					externalAnnotationExtraAttributes(TestContainerInitializer.TEST_CONTAINER_NAME+"/my.eeas"),
+					false/*exported*/);
+			addClasspathEntry(this.project, entry);
+
+			internalTestMixedArtifactsTest();
+		} finally {
+			ContainerInitializer.setInitializer(prev);
+		}
+	}
+
+	public void testMixedElementAndContainerAnnotation() throws Exception {
+		// container mixes annotations from internal resolving ("self") and client-side annotation path
+		myCreateJavaProject("PrjTest");
+		String projectLoc = this.project.getProject().getLocation().toString();
+		ITestInitializer prev = ContainerInitializer.initializer;
+		ContainerInitializer.setInitializer(new TestCustomContainerInitializer(projectLoc+"/lib1.jar", "self", projectLoc+"/lib2.jar", null));
+		try {
+
+			// jar with external annotations for its own class
+			Util.createJar(
+				new String[] { "lib/pgen/CGen.java", mixedArtifacts_CGen_java_content },
+				new String[] { "lib/pgen/CGen.eea",  mixedArtifacts_CGen_eea_content, },
+				projectLoc+"/lib1.jar", "1.8");
+			Util.createJar(
+				new String[] { "lib/pgen2/CGen2.java", mixedArtifacts_CGen2_java_content },
+				projectLoc+"/lib2.jar", "1.8");
+			IClasspathEntry containerEntry = JavaCore.newContainerEntry(
+					new Path(TestContainerInitializer.TEST_CONTAINER_NAME),
+					null,
+					externalAnnotationExtraAttributes("/PrjTest/annots"),
+					false);
+			addClasspathEntry(this.project, containerEntry);
+
+			createFileInProject("annots/lib/pgen2", "CGen2.eea", mixedArtifacts_CGen2_eea_content);
+
+			internalTestMixedArtifactsTest();
+		} finally {
+			ContainerInitializer.setInitializer(prev);
+		}
+	}
+	protected void internalTestMixedArtifactsTest() throws CoreException, JavaModelException {
+		this.project.getProject().refreshLocal(IResource.DEPTH_INFINITE, null);
 		createFileInProject("src/p", "Use.java",
 				"package p;\n" +
 				"import lib.pgen.CGen;\n" +
@@ -3161,14 +3152,16 @@ public class ExternalAnnotations18Test extends ModifyingResourceTests {
 				"	}\n" +
 				"}\n");
 		this.project.getProject().build(IncrementalProjectBuilder.FULL_BUILD, null);
-		IMarker[] markers = this.project.getProject().findMarkers(IJavaModelMarker.JAVA_MODEL_PROBLEM_MARKER, false, IResource.DEPTH_INFINITE);
+		IMarker[] markers = this.project.getProject()
+				.findMarkers(IJavaModelMarker.JAVA_MODEL_PROBLEM_MARKER, false, IResource.DEPTH_INFINITE);
 		sortMarkers(markers);
 		assertMarkers("Unexpected markers",
 				"Null type mismatch: required '@NonNull Exception' but the provided value is null\n" +
 				"Null type mismatch: required '@NonNull String' but the provided value is null",
 				markers);
-
-		ICompilationUnit unit = JavaCore.createCompilationUnitFrom(this.project.getProject().getFile("src/p/Use.java")).getWorkingCopy(null);
+		ICompilationUnit unit = JavaCore
+				.createCompilationUnitFrom(this.project.getProject().getFile("src/p/Use.java"))
+				.getWorkingCopy(null);
 		CompilationUnit reconciled = unit.reconcile(getJLS8(), true, null, new NullProgressMonitor());
 		IProblem[] problems = reconciled.getProblems();
 		assertProblems(problems,
@@ -3176,101 +3169,9 @@ public class ExternalAnnotations18Test extends ModifyingResourceTests {
 				"Pb(910) Null type mismatch: required '@NonNull String' but the provided value is null",
 				"Pb(910) Null type mismatch: required '@NonNull Exception' but the provided value is null"
 			},
-			new int[] {
-				7, 11
-			});
+			new int[] { 7, 11 });
 	}
 
-	public void testMixedElementAndContainerAnnotation() throws Exception {
-		myCreateJavaProject("PrjTest");
-		String projectLoc = this.project.getProject().getLocation().toString();
-		ITestInitializer prev = ContainerInitializer.initializer;
-		ContainerInitializer.setInitializer(new TestCustomContainerInitializer(projectLoc+"/lib1.jar", "self", projectLoc+"/lib2.jar", null));
-		try {
-
-			// jar with external annotations for its own class
-			Util.createJar(new String[] {
-					"lib/pgen/CGen.java",
-					"package lib.pgen;\n" +
-					"public class CGen {\n" +
-					"	public String get(String in) { return in; }\n" +
-					"}\n"
-				},
-				new String[] {
-					"lib/pgen/CGen.eea",
-					"class lib/pgen/CGen\n" +
-					"\n" +
-					"get\n" +
-					" (Ljava/lang/String;)Ljava/lang/String;\n" +
-					" (L1java/lang/String;)L1java/lang/String;\n",
-				},
-				projectLoc+"/lib1.jar",
-				"1.8");
-			Util.createJar(new String[] {
-					"lib2/C2.java",
-					"package lib2;\n" +
-					"public class C2 {\n" +
-					"	public String get2(Exception in) { return in.toString(); }\n" +
-					"}\n"
-				},
-				projectLoc+"/lib2.jar",
-				"1.8");
-			IClasspathEntry containerEntry = JavaCore.newContainerEntry(
-					new Path("org.eclipse.jdt.core.tests.model.TEST_CONTAINER"),
-					null,
-					new IClasspathAttribute[] {
-							JavaCore.newClasspathAttribute(IClasspathAttribute.EXTERNAL_ANNOTATION_PATH, "/PrjTest/annots")
-					},
-					false);
-			addClasspathEntry(this.project, containerEntry);
-
-			createFileInProject("annots/lib2", "C2.eea",
-					"class lib2/C2\n" +
-					"\n" +
-					"get2\n" +
-					" (Ljava/lang/Exception;)Ljava/lang/String;\n" +
-					" (L1java/lang/Exception;)L1java/lang/String;\n");
-
-			createFileInProject("src/p", "Use.java",
-					"package p;\n" +
-					"import lib.pgen.CGen;\n" +
-					"import lib2.C2;\n" +
-					"import org.eclipse.jdt.annotation.NonNull;\n" +
-					"public class Use {\n" +
-					"	public @NonNull String test(CGen c) {\n" +
-					"		String s = c.get(null);\n" + // problem here (7)
-					"		return s;\n" + // no problem here
-					"	}\n" +
-					"	public @NonNull String test2(C2 c) {\n" +
-					"		String s = c.get2(null);\n" + // problem here (11)
-					"		return s;\n" + // no problem here
-					"	}\n" +
-					"}\n");
-
-
-			this.project.getProject().build(IncrementalProjectBuilder.FULL_BUILD, null);
-			IMarker[] markers = this.project.getProject().findMarkers(IJavaModelMarker.JAVA_MODEL_PROBLEM_MARKER, false, IResource.DEPTH_INFINITE);
-			sortMarkers(markers);
-			assertMarkers("Unexpected markers",
-					"Null type mismatch: required '@NonNull Exception' but the provided value is null\n" +
-					"Null type mismatch: required '@NonNull String' but the provided value is null",
-					markers);
-
-			ICompilationUnit unit = JavaCore.createCompilationUnitFrom(this.project.getProject().getFile("src/p/Use.java")).getWorkingCopy(null);
-			CompilationUnit reconciled = unit.reconcile(getJLS8(), true, null, new NullProgressMonitor());
-			IProblem[] problems = reconciled.getProblems();
-			assertProblems(problems,
-				new String[] {
-					"Pb(910) Null type mismatch: required '@NonNull String' but the provided value is null",
-					"Pb(910) Null type mismatch: required '@NonNull Exception' but the provided value is null"
-				},
-				new int[] {
-					7, 11
-				});
-		} finally {
-			ContainerInitializer.setInitializer(prev);
-		}
-	}
 	public void testAnnotatedSourceSharesOutputFolder() throws CoreException {
 		IJavaProject prj1 = null;
 		myCreateJavaProject("Prj1");

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/core/IClasspathEntry.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/core/IClasspathEntry.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.jdt.core;
 
+import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.IPath;
 
 /**
@@ -507,4 +508,24 @@ public interface IClasspathEntry {
 		}
 		return false;
 	}
+
+	/**
+	 * Answer the path for external annotations (for null analysis) associated with this classpath entry.
+	 * Five shapes of paths are supported:
+	 * <ol>
+	 * <li>relative, variable (VAR/relpath): resolve classpath variable VAR and append relpath</li>
+	 * <li>relative, container (CON/relpath): locate relpath among the elements within container CON</li>
+	 * <li>relative, project (relpath): interpret relpath as a relative path within the given project</li>
+	 * <li>absolute, workspace (/Proj/relpath): an absolute path in the workspace</li>
+	 * <li>absolute, filesystem (/abspath): an absolute path in the filesystem</li>
+	 * </ol>
+	 * In case of ambiguity, workspace lookup has higher priority than filesystem lookup
+	 * (in fact filesystem paths are never validated).
+	 *
+	 * @param project project whose classpath we are analysing
+	 * @param resolve if true, any workspace-relative paths will be resolved to filesystem paths.
+	 * @return a path (in the workspace or filesystem-absolute) or null
+	 * @since 3.30
+	 */
+	IPath getExternalAnnotationPath(IProject project, boolean resolve);
 }

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/core/util/ExternalAnnotationUtil.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/core/util/ExternalAnnotationUtil.java
@@ -41,7 +41,6 @@ import org.eclipse.jdt.core.dom.ITypeBinding;
 import org.eclipse.jdt.internal.compiler.classfmt.ExternalAnnotationProvider;
 import org.eclipse.jdt.internal.compiler.codegen.ConstantPool;
 import org.eclipse.jdt.internal.compiler.lookup.SignatureWrapper;
-import org.eclipse.jdt.internal.core.ClasspathEntry;
 import org.eclipse.jdt.internal.core.util.KeyToSignature;
 
 /**
@@ -207,7 +206,7 @@ public final class ExternalAnnotationUtil {
 
 		IPackageFragmentRoot packageRoot = (IPackageFragmentRoot) targetType.getAncestor(IJavaElement.PACKAGE_FRAGMENT_ROOT);
 		IClasspathEntry entry = packageRoot.getResolvedClasspathEntry();
-		IPath annotationPath = ClasspathEntry.getExternalAnnotationPath(entry, project.getProject(), false);
+		IPath annotationPath = entry.getExternalAnnotationPath(project.getProject(), false);
 
 		if (annotationPath == null)
 			return null;

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ClassFile.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ClassFile.java
@@ -270,7 +270,7 @@ private IBinaryType getJarBinaryTypeInfo() throws CoreException, IOException, Cl
 			entryName = new String(Util.concat(
 					BinaryTypeFactory.fieldDescriptorToBinaryName(descriptor.fieldDescriptor), SuffixConstants.SUFFIX_CLASS));
 			IProject project = javaProject.getProject();
-			IPath externalAnnotationPath = ClasspathEntry.getExternalAnnotationPath(entry, project, false); // unresolved for use in ExternalAnnotationTracker
+			IPath externalAnnotationPath = entry.getExternalAnnotationPath(project, false); // unresolved for use in ExternalAnnotationTracker
 			if (externalAnnotationPath != null) {
 				result = setupExternalAnnotationProvider(project, externalAnnotationPath, result,
 						entryName.substring(0, entryName.length() - SuffixConstants.SUFFIX_CLASS.length));

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ClasspathEntry.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ClasspathEntry.java
@@ -1312,26 +1312,9 @@ public class ClasspathEntry implements IClasspathEntry {
 		return this.sourceAttachmentRootPath;
 	}
 
-	/**
-	 * Internal API: answer the path for external annotations (for null analysis) associated with
-	 * the given classpath entry.
-	 * Four shapes of paths are supported:
-	 * <ol>
-	 * <li>relative, variable (VAR/relpath): resolve classpath variable VAR and append relpath</li>
-	 * <li>relative, project (relpath): interpret relpath as a relative path within the given project</li>
-	 * <li>absolute, workspace (/Proj/relpath): an absolute path in the workspace</li>
-	 * <li>absolute, filesystem (/abspath): an absolute path in the filesystem</li>
-	 * </ol>
-	 * In case of ambiguity, workspace lookup has higher priority than filesystem lookup
-	 * (in fact filesystem paths are never validated).
-	 *
-	 * @param entry classpath entry to work on
-	 * @param project project whose classpath we are analysing
-	 * @param resolve if true, any workspace-relative paths will be resolved to filesystem paths.
-	 * @return a path (in the workspace or filesystem-absolute) or null
-	 */
-	public static IPath getExternalAnnotationPath(IClasspathEntry entry, IProject project, boolean resolve) {
-		String rawAnnotationPath = getRawExternalAnnotationPath(entry);
+	@Override
+	public IPath getExternalAnnotationPath(IProject project, boolean resolve) {
+		String rawAnnotationPath = getRawExternalAnnotationPath(this);
 		if (rawAnnotationPath != null) {
 			IPath annotationPath = new Path(rawAnnotationPath);
 			if (annotationPath.isAbsolute()) {
@@ -1358,12 +1341,75 @@ public class ClasspathEntry implements IClasspathEntry {
 						IResource member = project.findMember(annotationPath);
 						if (member != null)
 							return member.getLocation();
+					}
+					// try container relative:
+					IPath containerMemberPath = findAnnotationPathViaContainer(project, rawAnnotationPath, resolve);
+					if (containerMemberPath != null)
+						return containerMemberPath;
+
+					if (resolve) {
 						invalidExternalAnnotationPath(project);
 					} else {
 						return new Path(project.getName()).append(annotationPath).makeAbsolute();
 					}
 				}
 			}
+		}
+		return null;
+	}
+
+	public static IPath findAnnotationPathViaContainer(IProject project, String rawAnnotationPath, boolean resolve) {
+		if (rawAnnotationPath.indexOf('/') == -1)
+			return null;
+		IJavaProject jProject = JavaCore.create(project);
+		try {
+			IClasspathContainer container = null;
+			String relative = null;
+			// scan containers:
+			for (IClasspathEntry rawEntry : jProject.getRawClasspath()) {
+				if (rawEntry.getEntryKind() == IClasspathEntry.CPE_CONTAINER) {
+					String containerName = rawEntry.getPath().toString()+'/';
+					if (rawAnnotationPath.startsWith(containerName)) {
+						// this is the container referenced in the annotation path
+						container = JavaCore.getClasspathContainer(rawEntry.getPath(), jProject);
+						relative = rawAnnotationPath.substring(containerName.length());
+						break;
+					}
+				}
+			}
+			if (container != null) {
+				// now search container entries for the one matching the tail 'relative':
+				for (IClasspathEntry containerEntry : container.getClasspathEntries()) {
+					IPath path = containerEntry.getPath();
+					String entryName = path.lastSegment();
+					if (entryName.startsWith(relative)) {
+						// found a prefix match, check if the prefix ends at some kind of "boundary":
+						int endPos = relative.length();
+						if (endPos >= entryName.length() || !Character.isLetterOrDigit(entryName.charAt(endPos))) {
+							if (path.isAbsolute() && path.segmentCount() == 1) {
+								// resolved entry could point to a workspace project
+								IWorkspaceRoot wsRoot = project.getWorkspace().getRoot();
+								IProject tgtProject = wsRoot.getProject(path.toString());
+								IJavaProject tgtJProject = JavaCore.create(tgtProject);
+								if (tgtJProject.exists()) {
+									if (resolve) {
+										// resolve the project's output location:
+										return wsRoot.getLocation().append(tgtJProject.getOutputLocation());
+									}
+									// in non-resolving scenarii return the unresolved source folder path
+									for (IClasspathEntry classpathEntry : tgtJProject.getRawClasspath()) {
+										if (classpathEntry.getEntryKind() == CPE_SOURCE && classpathEntry.getOutputLocation() == null)
+											return classpathEntry.getPath();
+									}
+								}
+							}
+							return path; // assumed to be a file system path
+						}
+					}
+				}
+			}
+		} catch (JavaModelException e) {
+			Util.log(e);
 		}
 		return null;
 	}
@@ -1403,6 +1449,9 @@ public class ClasspathEntry implements IClasspathEntry {
 			if (JavaCore.getResolvedVariablePath(annotationPath) != null // variable (relative)
 					|| project.exists(annotationPath))					 // project relative
 			{
+				return null;
+			}
+			if (findAnnotationPathViaContainer(project, annotationPath.toString(), false) != null) {
 				return null;
 			}
 		}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SearchableEnvironment.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SearchableEnvironment.java
@@ -223,7 +223,7 @@ public class SearchableEnvironment
 	private String getExternalAnnotationPath(IClasspathEntry entry) {
 		if (entry == null)
 			return null;
-		IPath path = ClasspathEntry.getExternalAnnotationPath(entry, this.project.getProject(), true);
+		IPath path = entry.getExternalAnnotationPath(this.project.getProject(), true);
 		if (path == null)
 			return null;
 		return path.toOSString();

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/NameEnvironment.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/NameEnvironment.java
@@ -141,7 +141,7 @@ private void computeClasspathLocations(
 		ClasspathEntry entry = (ClasspathEntry) classpathEntries[i];
 		IPath path = entry.getPath();
 		Object target = JavaModel.getTarget(path, true);
-		IPath externalAnnotationPath = ClasspathEntry.getExternalAnnotationPath(entry, javaProject.getProject(), true);
+		IPath externalAnnotationPath = entry.getExternalAnnotationPath(javaProject.getProject(), true);
 		if (target == null) continue nextEntry;
 		boolean isOnModulePath = isOnModulePath(entry);
 
@@ -208,7 +208,7 @@ private void computeClasspathLocations(
 							continue nextPrereqEntry;
 						IPath srcExtAnnotPath = (externalAnnotationPath != null)
 							? externalAnnotationPath
-							: ClasspathEntry.getExternalAnnotationPath(prereqEntry, javaProject.getProject(), true);
+							: prereqEntry.getExternalAnnotationPath(javaProject.getProject(), true);
 						Object prereqTarget = JavaModel.getTarget(prereqEntry.getPath(), true);
 						if (!(prereqTarget instanceof IContainer)) continue nextPrereqEntry;
 						if (srcExtAnnotPath == null) {
@@ -219,7 +219,7 @@ private void computeClasspathLocations(
 								if (other.getEntryKind() == IClasspathEntry.CPE_SOURCE) {
 									IPath otherOutput = other.getOutputLocation();
 									if ((outputLoc == null) ? otherOutput == null : outputLoc.equals(otherOutput)) {
-										srcExtAnnotPath = ClasspathEntry.getExternalAnnotationPath(other, javaProject.getProject(),  true);
+										srcExtAnnotPath = other.getExternalAnnotationPath(javaProject.getProject(),  true);
 										if (srcExtAnnotPath != null)
 											break; // TODO: merging of several .eea?
 									}

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/JavaSearchNameEnvironment.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/JavaSearchNameEnvironment.java
@@ -265,10 +265,9 @@ private ClasspathLocation mapToClassPathLocation(JavaModelManager manager, Packa
 			String compliance = project.getOption(JavaCore.COMPILER_COMPLIANCE, true);
 			cp = (root instanceof JrtPackageFragmentRoot) ?
 					ClasspathLocation.forJrtSystem(path.toOSString(), rawClasspathEntry.getAccessRuleSet(),
-							ClasspathEntry.getExternalAnnotationPath(rawClasspathEntry, project.getProject(), true), compliance) :
+							rawClasspathEntry.getExternalAnnotationPath(project.getProject(), true), compliance) :
 									ClasspathLocation.forLibrary(manager.getZipFile(path), rawClasspathEntry.getAccessRuleSet(),
-												ClasspathEntry.getExternalAnnotationPath(rawClasspathEntry,
-														((IJavaProject) root.getParent()).getProject(), true),
+												rawClasspathEntry.getExternalAnnotationPath(((IJavaProject) root.getParent()).getProject(), true),
 												rawClasspathEntry.isModular(), compliance) ;
 		} else {
 			Object target = JavaModel.getTarget(path, true);
@@ -278,7 +277,7 @@ private ClasspathLocation mapToClassPathLocation(JavaModelManager manager, Packa
 				} else {
 					ClasspathEntry rawClasspathEntry = (ClasspathEntry) root.getRawClasspathEntry();
 					cp = ClasspathLocation.forBinaryFolder((IContainer) target, false, rawClasspathEntry.getAccessRuleSet(),
-														ClasspathEntry.getExternalAnnotationPath(rawClasspathEntry, ((IJavaProject)root.getParent()).getProject(), true),
+														rawClasspathEntry.getExternalAnnotationPath(((IJavaProject)root.getParent()).getProject(), true),
 														rawClasspathEntry.isModular());
 				}
 			}


### PR DESCRIPTION
- includes new API for JDT/UI to facilitate supporting this new option
- streamlined tests to focus on configuration, not content