### PR TITLE
IllegalStateException: Preference node "org.eclipse.jdt.core" has been removed (fixes #54)

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaProject.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaProject.java
@@ -1918,7 +1918,10 @@ public class JavaProject
 		if (!JavaProject.hasJavaNature(this.project)) return null;
 		// Get cached preferences if exist
 		JavaModelManager.PerProjectInfo perProjectInfo = JavaModelManager.getJavaModelManager().getPerProjectInfo(this.project, true);
-		if (perProjectInfo.preferences != null) return perProjectInfo.preferences;
+		IEclipsePreferences preferences = perProjectInfo.preferences;
+		if (checkPreferencesExist(preferences)) {
+			return preferences;
+		}
 		// Init project preferences
 		IScopeContext context = new ProjectScope(getProject());
 		final IEclipsePreferences eclipsePreferences = context.getNode(JavaCore.PLUGIN_ID);
@@ -1998,6 +2001,23 @@ public class JavaProject
 		};
 		eclipsePreferences.addPreferenceChangeListener(this.preferencesChangeListener);
 		return eclipsePreferences;
+	}
+
+	private boolean checkPreferencesExist(IEclipsePreferences preferences) {
+		if (preferences == null) {
+			return false;
+		}
+		try {
+			// check the root node ("")
+			if (preferences.nodeExists("")) { //$NON-NLS-1$
+				return true;
+			}
+		} catch (BackingStoreException e1) {
+			// shouldn't happen, but if happens, we continue below
+		}
+		JavaModelManager manager = JavaModelManager.getJavaModelManager();
+		manager.resetProjectPreferences(this);
+		return false;
 	}
 
 	@Override
@@ -2145,7 +2165,17 @@ public class JavaProject
 	 */
 	@Override
 	public String getOption(String optionName, boolean inheritJavaCoreOptions) {
-		return JavaModelManager.getJavaModelManager().getOption(optionName, inheritJavaCoreOptions, getEclipsePreferences());
+		IEclipsePreferences preferences = getEclipsePreferences();
+		JavaModelManager manager = JavaModelManager.getJavaModelManager();
+		String option;
+		try {
+			option = manager.getOption(optionName, inheritJavaCoreOptions, preferences);
+		} catch (IllegalStateException e) {
+			// preferences deleted right after the check? let's retry once
+			preferences = getEclipsePreferences();
+			option = manager.getOption(optionName, inheritJavaCoreOptions, preferences);
+		}
+		return option;
 	}
 
 	/**


### PR DESCRIPTION
Don't fail the build on IllegalStateException if someone (git/user)
deleted/replaced project settings while build was running. Let retry
once again (would either read updated file or fall back to defaults).

See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/54