### PR TITLE
Build can't be cancelled during cleanOutputFolders() task (Fixes #79)

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/BatchImageBuilder.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/BatchImageBuilder.java
@@ -259,6 +259,7 @@ protected void copyExtraResourcesBack(ClasspathMultiDirectory sourceLocation, fi
 						copyResource(resource, copiedResource);
 						return false;
 					case IResource.FOLDER :
+						BatchImageBuilder.this.notifier.checkCancel();
 						resource = proxy.requestResource();
 						if (BatchImageBuilder.this.javaBuilder.filterExtraResource(resource)) return false;
 						if (isAlsoProject && isExcludedFromProject(resource.getFullPath())) return false; // the sourceFolder == project


### PR DESCRIPTION
It is not possible to cancel autobuild, any attempts to "cancel" build
job are ignored by JDT during BatchImageBuilder.cleanOutputFolders()
operation.

On big projects or projects located on NFS this lead to the problem,
that user can't do any task related to the workspace, not even shutdown
Eclipse and have to wait till the build detects cancellation after
BatchImageBuilder.cleanOutputFolders() is done.

The patch adds cancellation check for each directory visited in
BatchImageBuilder.copyExtraResourcesBack() method.

See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/79