### PR TITLE
Bug 579205 - java indexer became slower

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ExternalAnnotations18Test.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ExternalAnnotations18Test.java
@@ -2465,7 +2465,7 @@ public class ExternalAnnotations18Test extends ModifyingResourceTests {
 				"}\n",
 				"/UnannotatedLib/libs/List.java",
 				"package libs;\n" +
-				"public interface List<T> extends java.util.Collection<T> {\n" +
+				"public interface List<T> {\n" +
 				"	Stream<T> stream();\n" +
 				"}\n",
 				"Collector.java",
@@ -2517,7 +2517,7 @@ public class ExternalAnnotations18Test extends ModifyingResourceTests {
 				"}\n",
 				"/UnannotatedLib/libs/List.java",
 				"package libs;\n" +
-				"public interface List<T> extends java.util.Collection<T> {\n" +
+				"public interface List<T> {\n" +
 				"	Stream<T> stream();\n" +
 				"}\n",
 				"/UnannotatedLib/libs/Collector.java",

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/ClasspathJar.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/ClasspathJar.java
@@ -194,16 +194,10 @@ ClasspathJar(String zipFilename, long lastModified, AccessRuleSet accessRuleSet,
 	this.isOnModulePath = isOnModulePath;
 }
 
-public ClasspathJar(ZipFile zipFile, AccessRuleSet accessRuleSet, IPath externalAnnotationPath, boolean isOnModulePath) {
-	this(zipFile.getName(), accessRuleSet, externalAnnotationPath, isOnModulePath);
+public ClasspathJar(ZipFile zipFile, AccessRuleSet accessRuleSet, boolean isOnModulePath) {
+	this(zipFile.getName(), 0, accessRuleSet, null, isOnModulePath);
 	this.zipFile = zipFile;
 	this.closeZipFileAtEnd = true;
-}
-
-public ClasspathJar(String fileName, AccessRuleSet accessRuleSet, IPath externalAnnotationPath, boolean isOnModulePath) {
-	this(fileName, 0, accessRuleSet, externalAnnotationPath, isOnModulePath);
-	if (externalAnnotationPath != null)
-		this.externalAnnotationPath = externalAnnotationPath.toString();
 }
 
 @Override

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/ClasspathLocation.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/ClasspathLocation.java
@@ -168,11 +168,10 @@ public static ClasspathLocation forLibrary(IFile library, AccessRuleSet accessRu
 			new ClasspathJar(library, accessRuleSet, annotationsPath, isOnModulePath) :
 				new ClasspathMultiReleaseJar(library, accessRuleSet, annotationsPath, isOnModulePath, compliance);
 }
-public static ClasspathLocation forLibrary(ZipFile zipFile, AccessRuleSet accessRuleSet, IPath externalAnnotationPath,
-										boolean isOnModulePath, String compliance) {
+public static ClasspathLocation forLibrary(ZipFile zipFile, AccessRuleSet accessRuleSet, boolean isOnModulePath, String compliance) {
 	return (CompilerOptions.versionToJdkLevel(compliance) < ClassFileConstants.JDK9) ?
-			new ClasspathJar(zipFile, accessRuleSet, externalAnnotationPath, isOnModulePath) :
-				new ClasspathMultiReleaseJar(zipFile, accessRuleSet, externalAnnotationPath, isOnModulePath, compliance);
+			new ClasspathJar(zipFile, accessRuleSet, isOnModulePath) :
+				new ClasspathMultiReleaseJar(zipFile, accessRuleSet, isOnModulePath, compliance);
 }
 
 public abstract IPath getProjectRelativePath();

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/ClasspathMultiReleaseJar.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/ClasspathMultiReleaseJar.java
@@ -39,19 +39,10 @@ public class ClasspathMultiReleaseJar extends ClasspathJar {
 		this.compliance = compliance;
 	}
 
-	public ClasspathMultiReleaseJar(ZipFile zipFile, AccessRuleSet accessRuleSet, IPath externalAnnotationPath,
-			boolean isOnModulePath, String compliance) {
-		this(zipFile.getName(), accessRuleSet, externalAnnotationPath, isOnModulePath, compliance);
+	public ClasspathMultiReleaseJar(ZipFile zipFile, AccessRuleSet accessRuleSet, boolean isOnModulePath, String compliance) {
+		this(zipFile.getName(), 0, accessRuleSet, null, isOnModulePath, compliance);
 		this.zipFile = zipFile;
 		this.closeZipFileAtEnd = true;
-	}
-
-	public ClasspathMultiReleaseJar(String fileName, AccessRuleSet accessRuleSet, IPath externalAnnotationPath,
-			boolean isOnModulePath, String compliance) {
-		this(fileName, 0, accessRuleSet, externalAnnotationPath, isOnModulePath, compliance);
-		if (externalAnnotationPath != null) {
-			this.externalAnnotationPath = externalAnnotationPath.toString();
-		}
 	}
 
 	@Override

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/JavaSearchNameEnvironment.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/JavaSearchNameEnvironment.java
@@ -10,14 +10,11 @@
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
- *     Stephan Herrmann - Contribution for
- *								Bug 440477 - [null] Infrastructure for feeding external annotations into compilation
  *******************************************************************************/
 package org.eclipse.jdt.internal.core.search.matching;
 
 import static java.util.stream.Collectors.joining;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
@@ -197,7 +194,7 @@ private LinkedHashSet<ClasspathLocation> computeClasspathLocations(JavaProject j
 	int length = roots.length;
 	JavaModelManager manager = JavaModelManager.getJavaModelManager();
 	for (int i = 0; i < length; i++) {
-		ClasspathLocation cp = mapToClassPathLocation(manager, (PackageFragmentRoot) roots[i], imd, locations);
+		ClasspathLocation cp = mapToClassPathLocation(manager, (PackageFragmentRoot) roots[i], imd);
 		if (cp != null) {
 			try {
 				indexPackageNames(cp, roots[i]);
@@ -255,7 +252,7 @@ private void computeModules() {
 	}
 }
 
-private ClasspathLocation mapToClassPathLocation(JavaModelManager manager, PackageFragmentRoot root, IModuleDescription defaultModule, Collection<ClasspathLocation> allLocations) {
+private ClasspathLocation mapToClassPathLocation(JavaModelManager manager, PackageFragmentRoot root, IModuleDescription defaultModule) {
 	ClasspathLocation cp = null;
 	IPath path = root.getPath();
 	try {
@@ -264,11 +261,8 @@ private ClasspathLocation mapToClassPathLocation(JavaModelManager manager, Packa
 			IJavaProject project = (IJavaProject) root.getParent();
 			String compliance = project.getOption(JavaCore.COMPILER_COMPLIANCE, true);
 			cp = (root instanceof JrtPackageFragmentRoot) ?
-					ClasspathLocation.forJrtSystem(path.toOSString(), rawClasspathEntry.getAccessRuleSet(),
-							rawClasspathEntry.getExternalAnnotationPath(project.getProject(), true), compliance) :
-									ClasspathLocation.forLibrary(manager.getZipFile(path), rawClasspathEntry.getAccessRuleSet(),
-												rawClasspathEntry.getExternalAnnotationPath(((IJavaProject) root.getParent()).getProject(), true),
-												rawClasspathEntry.isModular(), compliance) ;
+					ClasspathLocation.forJrtSystem(path.toOSString(), rawClasspathEntry.getAccessRuleSet(), null, compliance) :
+					ClasspathLocation.forLibrary(manager.getZipFile(path), rawClasspathEntry.getAccessRuleSet(), rawClasspathEntry.isModular(), compliance) ;
 		} else {
 			Object target = JavaModel.getTarget(path, true);
 			if (target != null) {
@@ -277,8 +271,7 @@ private ClasspathLocation mapToClassPathLocation(JavaModelManager manager, Packa
 				} else {
 					ClasspathEntry rawClasspathEntry = (ClasspathEntry) root.getRawClasspathEntry();
 					cp = ClasspathLocation.forBinaryFolder((IContainer) target, false, rawClasspathEntry.getAccessRuleSet(),
-														rawClasspathEntry.getExternalAnnotationPath(((IJavaProject)root.getParent()).getProject(), true),
-														rawClasspathEntry.isModular());
+														null, rawClasspathEntry.isModular());
 				}
 			}
 		}
@@ -289,9 +282,6 @@ private ClasspathLocation mapToClassPathLocation(JavaModelManager manager, Packa
 	JavaProject javaProject = root.getJavaProject();
 	if (isComplianceJava9OrHigher(javaProject)) {
 		addModuleClassPathInfo(root, defaultModule, cp);
-	}
-	if (allLocations != null && cp != null && JavaCore.ENABLED.equals(javaProject.getOption(JavaCore.CORE_JAVA_BUILD_EXTERNAL_ANNOTATIONS_FROM_ALL_LOCATIONS, true))) {
-		cp.connectAllLocationsForEEA(allLocations, false/*allLocations is already accumulated by our caller*/);
 	}
 	return cp;
 }


### PR DESCRIPTION
Withdraw all .eea handling from JavaSearchNameEnvironment

Plus: add robustness to ExternalAnnotations18Test run at compliance=11
