### PR TITLE
Incorrect behavior of the possible static method check for generic

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/BatchCompilerTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/BatchCompilerTest.java
@@ -13316,17 +13316,17 @@ public void test413873() {
 	this.runConformTest(
 		new String[] {
 			"OuterClass.java",
-			"public class OuterClass<T> {\n" + 
-			"	private final class InnerClass {\n" + 
-			"	}\n" + 
-			"\n" + 
-			"	private InnerClass foo(final InnerClass object) {\n" + 
-			"		return object;\n" + 
-			"	}\n" + 
-			"	\n" + 
-			"	public void doStuff() {\n" + 
-			"		foo(new InnerClass());\n" + 
-			"	}\n" + 
+			"public class OuterClass<T> {\n" +
+			"	private final class InnerClass {\n" +
+			"	}\n" +
+			"\n" +
+			"	private InnerClass foo(final InnerClass object) {\n" +
+			"		return object;\n" +
+			"	}\n" +
+			"	\n" +
+			"	public void doStuff() {\n" +
+			"		foo(new InnerClass());\n" +
+			"	}\n" +
 			"}"
 			},
 			"\"" + OUTPUT_DIR +  File.separator + "OuterClass.java\""
@@ -13334,5 +13334,146 @@ public void test413873() {
 			"",
 			"",
 			true);
+}
+//https://github.com/eclipse-jdt/eclipse.jdt.core/issues/89
+public void testIssue89_1() {
+	this.runNegativeTest(
+			new String[] {
+				"X.java",
+				"import java.util.Set;\n"
+				+ "public class X<T> {\n"
+				+ "	public boolean method1(final Set<Integer> a) {\n"
+				+ "		return a.isEmpty();\n"
+				+ "	}\n"
+				+ "	public String method2(final X a) {\n"
+				+ "		return a.toString();\n"
+				+ "	}\n"
+				+ "}"
+				},
+				"\"" + OUTPUT_DIR +  File.separator + "X.java\" "
+				+ " -failOnWarning"
+				+ " -1.6 -warn:all-static-method -proc:none -d none",
+				"",
+				"----------\n" +
+				"1. WARNING in ---OUTPUT_DIR_PLACEHOLDER---/X.java (at line 3)\n" +
+				"	public boolean method1(final Set<Integer> a) {\n" +
+				"	               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
+				"The method method1(Set<Integer>) from the type X<T> can potentially be declared as static\n" +
+				"----------\n" +
+				"2. WARNING in ---OUTPUT_DIR_PLACEHOLDER---/X.java (at line 6)\n" +
+				"	public String method2(final X a) {\n" +
+				"	              ^^^^^^^^^^^^^^^^^^\n" +
+				"The method method2(X) from the type X<T> can potentially be declared as static\n" +
+				"----------\n" +
+				"2 problems (2 warnings)\n" +
+				"error: warnings found and -failOnWarning specified\n",
+				true);
+}
+public void testIssue89_2() {
+	this.runConformTest(
+			new String[] {
+				"X.java",
+				"import java.util.Set;\n"
+				+ "public class X<T> {\n"
+				+ " @SuppressWarnings(\"static-method\")"
+				+ "	public boolean method1(final Set<Integer> a) {\n"
+				+ "		return a.isEmpty();\n"
+				+ "	}\n"
+				+ " @SuppressWarnings(\"static-method\")"
+				+ "	public String method2(final X a) {\n"
+				+ "		return a.toString();\n"
+				+ "	}\n"
+				+ "}"
+				},
+				"\"" + OUTPUT_DIR +  File.separator + "X.java\" "
+				+ " -failOnWarning"
+				+ " -1.6 -warn:all-static-method -proc:none -d none",
+				"",
+				"",
+				true);
+}
+public void testIssue89_3() {
+	this.runNegativeTest(
+			new String[] {
+				"X.java",
+				"import java.util.Set;\n"
+				+ "public class X<T> {\n"
+				+ " private final class InnerClass{}\n"
+				+ "	public boolean method1(final Set<Integer> a) {\n"
+				+ "		return a.isEmpty();\n"
+				+ "	}\n"
+				+ "	public String method2(final InnerClass i) {\n"
+				+ "		return i.toString();\n"
+				+ "	}\n"
+				+ "}"
+				},
+				"\"" + OUTPUT_DIR +  File.separator + "X.java\" "
+				+ " -failOnWarning"
+				+ " -1.6 -warn:all-static-method -proc:none -d none",
+				"",
+				"----------\n" +
+				"1. WARNING in ---OUTPUT_DIR_PLACEHOLDER---/X.java (at line 4)\n" +
+				"	public boolean method1(final Set<Integer> a) {\n" +
+				"	               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
+				"The method method1(Set<Integer>) from the type X<T> can potentially be declared as static\n" +
+				"----------\n" +
+				"1 problem (1 warning)\n" +
+				"error: warnings found and -failOnWarning specified\n",
+				true);
+}
+public void testIssue89_4() {
+	this.runNegativeTest(
+			new String[] {
+				"X.java",
+				"import java.util.Set;\n"
+				+ "public class X<T> {\n"
+				+ " private final class InnerClass{}\n"
+				+ "	public boolean method1(final Set<Integer> a) {\n"
+				+ "		return a.isEmpty();\n"
+				+ "	}\n"
+				+ "	public InnerClass method2() {\n"
+				+ "		return null;\n"
+				+ "	}\n"
+				+ "}"
+				},
+				"\"" + OUTPUT_DIR +  File.separator + "X.java\" "
+				+ " -failOnWarning"
+				+ " -1.6 -warn:all-static-method -proc:none -d none",
+				"",
+				"----------\n" +
+				"1. WARNING in ---OUTPUT_DIR_PLACEHOLDER---/X.java (at line 4)\n" +
+				"	public boolean method1(final Set<Integer> a) {\n" +
+				"	               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
+				"The method method1(Set<Integer>) from the type X<T> can potentially be declared as static\n" +
+				"----------\n" +
+				"1 problem (1 warning)\n" +
+				"error: warnings found and -failOnWarning specified\n",
+				true);
+}
+public void testIssue89_5() {
+	this.runNegativeTest(
+			new String[] {
+				"X.java",
+				"import java.util.Set;\n"
+				+ "public class X<T> {\n"
+				+ " private final class InnerClass{}"
+				+ "	public boolean method1(final Set<InnerClass> a) {\n"
+				+ "		return a.isEmpty();\n"
+				+ "	}\n"
+				+ "}"
+				},
+				"\"" + OUTPUT_DIR +  File.separator + "X.java\" "
+				+ " -failOnWarning"
+				+ " -1.6 -warn:all-static-method -proc:none -d none",
+				"",
+				"----------\n" +
+				"1. WARNING in ---OUTPUT_DIR_PLACEHOLDER---/X.java (at line 3)\n" +
+				"	private final class InnerClass{}	public boolean method1(final Set<InnerClass> a) {\n" +
+				"	                                	               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
+				"The method method1(Set<X<T>.InnerClass>) from the type X<T> can potentially be declared as static\n" +
+				"----------\n" +
+				"1 problem (1 warning)\n" +
+				"error: warnings found and -failOnWarning specified\n",
+				true);
 }
 }

--- a/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/ast/MethodDeclaration.java
+++ b/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/ast/MethodDeclaration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -30,10 +30,13 @@
 package org.eclipse.jdt.internal.compiler.ast;
 
 import java.util.List;
+import java.util.function.BiPredicate;
 
 import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.internal.compiler.ASTVisitor;
 import org.eclipse.jdt.internal.compiler.CompilationResult;
+import org.eclipse.jdt.internal.compiler.ast.TypeReference.AnnotationCollector;
+import org.eclipse.jdt.internal.compiler.ast.TypeReference.AnnotationPosition;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 import org.eclipse.jdt.internal.compiler.flow.ExceptionHandlingFlowContext;
 import org.eclipse.jdt.internal.compiler.flow.FlowContext;
@@ -44,7 +47,7 @@ import org.eclipse.jdt.internal.compiler.lookup.ClassScope;
 import org.eclipse.jdt.internal.compiler.lookup.ExtraCompilerModifiers;
 import org.eclipse.jdt.internal.compiler.lookup.LocalTypeBinding;
 import org.eclipse.jdt.internal.compiler.lookup.MemberTypeBinding;
-import org.eclipse.jdt.internal.compiler.lookup.ParameterizedTypeBinding;
+import org.eclipse.jdt.internal.compiler.lookup.ReferenceBinding;
 import org.eclipse.jdt.internal.compiler.lookup.TagBits;
 import org.eclipse.jdt.internal.compiler.lookup.TypeBinding;
 import org.eclipse.jdt.internal.compiler.lookup.TypeConstants;
@@ -52,8 +55,6 @@ import org.eclipse.jdt.internal.compiler.lookup.TypeVariableBinding;
 import org.eclipse.jdt.internal.compiler.parser.Parser;
 import org.eclipse.jdt.internal.compiler.problem.AbortMethod;
 import org.eclipse.jdt.internal.compiler.problem.ProblemSeverities;
-import org.eclipse.jdt.internal.compiler.ast.TypeReference.AnnotationCollector;
-import org.eclipse.jdt.internal.compiler.ast.TypeReference.AnnotationPosition;
 
 public class MethodDeclaration extends AbstractMethodDeclaration {
 
@@ -116,17 +117,30 @@ public class MethodDeclaration extends AbstractMethodDeclaration {
 			// nullity and mark as assigned
 			analyseArguments(classScope.environment(), flowInfo, this.arguments, this.binding);
 
-			boolean hasMemberTypeParameter = false;
-			if (this.binding.parameters != null && this.arguments != null) {
-				int length = Math.min(this.binding.parameters.length, this.arguments.length);
-				for (int i = 0; i < length; i++) {
-					if (this.binding.parameters[i] instanceof ParameterizedTypeBinding) {
-						hasMemberTypeParameter = true;
-						break;
+			BiPredicate<TypeBinding, ReferenceBinding> condition = (argType, declClass) -> {
+				ReferenceBinding enclosingType = argType.enclosingType();
+				if (enclosingType != null && TypeBinding.equalsEquals(declClass, enclosingType.actualType())) {
+					return true;
+				}
+				return false;
+			};
+			boolean referencesGenericType = false;
+			ReferenceBinding declaringClass = this.binding.declaringClass;
+			if (declaringClass.isGenericType()) {
+				if (condition.test(this.binding.returnType, declaringClass)) {
+					referencesGenericType = true;
+				}
+				if (!referencesGenericType && this.binding.parameters != null && this.arguments != null) {
+					int length = Math.min(this.binding.parameters.length, this.arguments.length);
+					for (int i = 0; i < length; i++) {
+						if (condition.test(this.binding.parameters[i], this.binding.declaringClass)) {
+							referencesGenericType = true;
+							break;
+						}
 					}
 				}
 			}
-			if (this.binding.declaringClass instanceof MemberTypeBinding && !this.binding.declaringClass.isStatic() || hasMemberTypeParameter) {
+			if (this.binding.declaringClass instanceof MemberTypeBinding && !this.binding.declaringClass.isStatic() || referencesGenericType) {
 				// method of a non-static member type can't be static.
 				this.bits &= ~ASTNode.CanBeStatic;
 			}


### PR DESCRIPTION
Issue #89

What was done in https://github.com/eclipse-jdt/eclipse.jdt.core/pull/17 is not correct. It simply assumes that checking whether a method argument type is parameterized or not is sufficient. But that's clearly wrong as even a Set<Integer> will satisfy that condition. I have rewritten it based on the conditions we use to allow a method to be static. There are already several scenarios working well and I am only testing for argument type's enclosing type is same as the method's declaring class and that the declaring class satisfies isGenericType(). 

And the same has also been extended to method's return types as well, as reported in https://bugs.eclipse.org/bugs/show_bug.cgi?id=413873#c5
