### PR TITLE
Fix completions for lambda variables under nested if blocks. Fixes #109

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/parser/NameReferenceCompletionTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/parser/NameReferenceCompletionTest.java
@@ -499,7 +499,40 @@ public void testInIfThenStatement() {
 		"  Bar() {\n" +
 		"  }\n" +
 		"  void foo() {\n" +
-		"    if (bar())\n" +
+		"    <CompleteOnName:>;\n" +
+		"  }\n" +
+		"}\n",
+		// expectedCompletionIdentifier:
+		"",
+		// expectedReplacedSource:
+		"",
+		// test name
+		"<complete in if then statement>"
+	);
+}
+/*
+ * Completion in the statement following an if expression.
+ */
+public void testInIfThenWithInstanceOfStatement() {
+	this.runTestCheckMethodParse(
+		// compilationUnit:
+		"class Bar {								\n" +
+		"	void foo() {							\n" +
+		"		if (this instanceof Bar) 			\n" +
+		"											\n" +
+		"											\n" +
+		"	}										\n" +
+		"}											\n",
+		// completeBehind:
+		"\n			",
+		// expectedCompletionNodeToString:
+		"<CompleteOnName:>",
+		// expectedUnitDisplayString:
+		"class Bar {\n" +
+		"  Bar() {\n" +
+		"  }\n" +
+		"  void foo() {\n" +
+		"    if ((this instanceof Bar))\n" +
 		"        <CompleteOnName:>;\n" +
 		"  }\n" +
 		"}\n",

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests18.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests18.java
@@ -6524,4 +6524,81 @@ public void testBug578817() throws JavaModelException {
 				+ "getClass[METHOD_REF]{getClass(), Ljava.lang.Object;, ()Ljava.lang.Class<*>;, null, null, getClass, null, [229, 232], "+(R_DEFAULT+R_PACKAGE_EXPECTED_TYPE+30)+"}\n"
 				+ "getLastName[METHOD_REF]{getLastName(), LPerson;, ()Ljava.lang.String;, null, null, getLastName, null, [229, 232], "+(R_DEFAULT+R_EXACT_EXPECTED_TYPE+30)+"}", requestor.getResults());
 	}
+public void testGH109_expectCompletions_insideLambdaNestedBlocks() throws JavaModelException {
+	this.workingCopies = new ICompilationUnit[1];
+	this.workingCopies[0] = getWorkingCopy(
+			"Completion/src/GH109.java",
+			"import java.util.stream.Stream;\n"
+			+ "\n"
+			+ "public class GH109\n"
+			+ "{\n"
+			+ "  public static void main(String[] args)\n"
+			+ "  {\n"
+			+ "    if(args.length > 0) {\n"
+			+ "      Stream.of(args).forEach(name -> {\n"
+			+ "        try\n"
+			+ "        {\n"
+			+ "          if (name.startsWith(\"A\"))\n"
+			+ "          {\n"
+			+ "            name.\n"
+			+ "          }\n"
+			+ "          \n"
+			+ "        }\n"
+			+ "        catch (Exception e)\n"
+			+ "        {\n"
+			+ "        }\n"
+			+ "      });\n"
+			+ "    }\n"
+			+ "  }\n"
+			+ "}");
+
+	CompletionTestsRequestor2 requestor = new CompletionTestsRequestor2(true);
+	requestor.allowAllRequiredProposals();
+	String str = this.workingCopies[0].getSource();
+	String completeBehind = "  name.";
+	int cursorLocation = str.indexOf(completeBehind) + completeBehind.length();
+	this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner);
+	String result = requestor.getResults();
+	assertTrue(result.contains("startsWith[METHOD_REF]{startsWith(), Ljava.lang.String;, (Ljava.lang.String;)Z, startsWith, (arg0), 60}\n"
+			+ "startsWith[METHOD_REF]{startsWith(), Ljava.lang.String;, (Ljava.lang.String;I)Z, startsWith, (arg0, arg1), 60}\n"));
+}
+
+public void testGH109_expectCompletionsWithCast_insideLambdaNestedBlocksWithInstanceOf() throws JavaModelException {
+	this.workingCopies = new ICompilationUnit[1];
+	this.workingCopies[0] = getWorkingCopy(
+			"Completion/src/GH109.java",
+			"import java.util.stream.Stream;\n"
+			+ "\n"
+			+ "public class GH109\n"
+			+ "{\n"
+			+ "  public static void main(String[] args)\n"
+			+ "  {\n"
+			+ "    if(args.length > 0) {\n"
+			+ "      Stream.of(args).map(Object.class::cast).forEach(name -> {\n"
+			+ "        try\n"
+			+ "        {\n"
+			+ "          if (name instanceof String)\n"
+			+ "          {\n"
+			+ "            name.sta\n"
+			+ "          }\n"
+			+ "          \n"
+			+ "        }\n"
+			+ "        catch (Exception e)\n"
+			+ "        {\n"
+			+ "        }\n"
+			+ "      });\n"
+			+ "    }\n"
+			+ "  }\n"
+			+ "}");
+
+	CompletionTestsRequestor2 requestor = new CompletionTestsRequestor2(true);
+	requestor.allowAllRequiredProposals();
+	String str = this.workingCopies[0].getSource();
+	String completeBehind = "  name.sta";
+	int cursorLocation = str.indexOf(completeBehind) + completeBehind.length();
+	this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner);
+	String result = requestor.getResults();
+	assertTrue(result.contains("startsWith[METHOD_REF_WITH_CASTED_RECEIVER]{((String)name).startsWith(), Ljava.lang.String;, (Ljava.lang.String;)Z, Ljava.lang.String;, startsWith, (arg0), 60}\n"
+			+ "startsWith[METHOD_REF_WITH_CASTED_RECEIVER]{((String)name).startsWith(), Ljava.lang.String;, (Ljava.lang.String;I)Z, Ljava.lang.String;, startsWith, (arg0, arg1), 60}"));
+}
 }

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionParser.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionParser.java
@@ -1270,12 +1270,15 @@ private Statement buildMoreCompletionEnclosingContext(Statement statement) {
 		index = blockIndex != -1 && controlIndex < blockIndex ? blockIndex : controlIndex;
 	}
 	while (index >= 0) {
-		// Try to find an enclosing if statement even if one is not found immediately preceding the completion node.
+		// Try to find an enclosing if statement with instanceof even if one is not found immediately preceding the completion node.
+		// A if statement is only chosen if it has a instanceof or the completion node is in the if statment it self.
+		Object elementObjectInfo = this.elementObjectInfoStack[index];
 		int kind = this.elementKindStack[index];
 		if ((kind == K_BLOCK_DELIMITER || kind == K_CONTROL_STATEMENT_DELIMITER || kind == K_BETWEEN_INSTANCEOF_AND_RPAREN) // same set as above
-			&& this.elementInfoStack[index] == IF && this.elementObjectInfoStack[index] != null)
+			&& this.elementInfoStack[index] == IF && elementObjectInfo != null
+			&& (isInstanceOfGuard(elementObjectInfo) || (this.assistNode == elementObjectInfo)))
 		{
-			Expression condition = (Expression)this.elementObjectInfoStack[index];
+			Expression condition = (Expression)elementObjectInfo;
 
 			// If currentElement is a RecoveredLocalVariable then it can be contained in the if statement
 			if (this.currentElement instanceof RecoveredLocalVariable &&


### PR DESCRIPTION
## What it does
The fix adds a additional guard when trying to build the enclosing context by collecting if conditions which supposed to have instanceof. The additional guard added by the fix check if we have a instanceof before the first if statement is added to enclosing context.

## How to test
Use the code snippets in issue #109 

## Author checklist

- I have thoroughly tested my changes
- The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)

