### PR TITLE
Improve type compatibility checks in pattern resolution #134

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/CompilerInvocationTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/CompilerInvocationTests.java
@@ -1312,6 +1312,7 @@ public void test011_problem_categories() {
 	    expectedProblemAttributes.put("UnexpectedTypeinSwitchPattern", new ProblemAttributes(true));
 	    expectedProblemAttributes.put("UnexpectedTypeinRecordPattern", new ProblemAttributes(true));
 	    expectedProblemAttributes.put("RecordPatternMismatch", new ProblemAttributes(true));
+	    expectedProblemAttributes.put("PatternTypeMismatch", new ProblemAttributes(true));
 	    expectedProblemAttributes.put("ClassExtendFinalRecord", new ProblemAttributes(CategorizedProblem.CAT_TYPE));
 	    expectedProblemAttributes.put("RecordErasureIncompatibilityInCanonicalConstructor", new ProblemAttributes(CategorizedProblem.CAT_TYPE));
 	    expectedProblemAttributes.put("JavadocInvalidModule", new ProblemAttributes(CategorizedProblem.CAT_INTERNAL));
@@ -2400,6 +2401,7 @@ public void test012_compiler_problems_tuning() {
 	    expectedProblemAttributes.put("UnexpectedTypeinSwitchPattern", SKIP);
 	    expectedProblemAttributes.put("UnexpectedTypeinRecordPattern", SKIP);
 	    expectedProblemAttributes.put("RecordPatternMismatch", SKIP);
+	    expectedProblemAttributes.put("PatternTypeMismatch", SKIP);
 	    expectedProblemAttributes.put("ClassExtendFinalRecord", SKIP);
 	    expectedProblemAttributes.put("RecordErasureIncompatibilityInCanonicalConstructor", SKIP);
 	    expectedProblemAttributes.put("JavadocInvalidModule", SKIP);

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PatternMatching16Test.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PatternMatching16Test.java
@@ -3932,59 +3932,55 @@ public class PatternMatching16Test extends AbstractRegressionTest {
     			"        }\n" +
     		    "    }\n" +
     			"}";
-    	String expectedOutput = ""
-    			+ "  // Method descriptor #15 ([Ljava/lang/String;)V\n"
-    			+ "  // Stack: 4, Locals: 4\n"
-    			+ "  public static void main(String[] args);\n"
-    			+ "     0  ldc <String \"OK: \"> [16]\n"
-    			+ "     2  astore_1 [y]\n"
-    			+ "     3  ldc <String \"local\"> [18]\n"
-    			+ "     5  astore_3 [ instanceOfPatternExpressionValue]\n"
-    			+ "     6  aload_3 [ instanceOfPatternExpressionValue]\n"
-    			+ "     7  instanceof String [20]\n"
-    			+ "    10  ifeq 50\n"
-    			+ "    13  aload_3 [ instanceOfPatternExpressionValue]\n"
-    			+ "    14  checkcast String [20]\n"
-    			+ "    17  dup\n"
-    			+ "    18  astore_2\n"
-    			+ "    19  aload_3\n"
-    			+ "    20  checkcast String [20]\n"
-    			+ "    23  if_acmpne 50\n"
-    			+ "    26  getstatic System.out : PrintStream [22]\n"
-    			+ "    29  new StringBuilder [28]\n"
-    			+ "    32  dup\n"
-    			+ "    33  aload_1 [y]\n"
-    			+ "    34  invokestatic String.valueOf(Object) : String [30]\n"
-    			+ "    37  invokespecial StringBuilder(String) [34]\n"
-    			+ "    40  aload_2 [x]\n"
-    			+ "    41  invokevirtual StringBuilder.append(String) : StringBuilder [37]\n"
-    			+ "    44  invokevirtual StringBuilder.toString() : String [41]\n"
-    			+ "    47  invokevirtual PrintStream.println(String) : void [45]\n"
-    			+ "    50  return\n"
-    			+ "      Line numbers:\n"
-    			+ "        [pc: 0, line: 13]\n"
-    			+ "        [pc: 3, line: 14]\n"
-    			+ "        [pc: 26, line: 15]\n"
-    			+ "        [pc: 50, line: 17]\n"
-    			+ "      Local variable table:\n"
-    			+ "        [pc: 0, pc: 51] local: args index: 0 type: String[]\n"
-    			+ "        [pc: 3, pc: 51] local: y index: 1 type: String\n"
-    			+ "        [pc: 26, pc: 50] local: x index: 2 type: String\n"
-    			+ "        [pc: 6, pc: 20] local:  instanceOfPatternExpressionValue index: 3 type: Object\n"
-    			+ "      Stack map table: number of frames 1\n"
-    			+ "        [pc: 50, append: {String}]\n"
-    			+ "    RuntimeVisibleTypeAnnotations: \n"
-    			+ "      #59 @Type(\n"
-    			+ "        target type = 0x40 LOCAL_VARIABLE\n"
-    			+ "        local variable entries:\n"
-    			+ "          [pc: 3, pc: 51] index: 1\n"
-    			+ "      )\n"
-    			+ "      #59 @Type(\n"
-    			+ "        target type = 0x40 LOCAL_VARIABLE\n"
-    			+ "        local variable entries:\n"
-    			+ "          [pc: 26, pc: 50] index: 2\n"
-    			+ "      )\n"
-    			+ "\n";
+    	String expectedOutput =  "  public static void main(String[] args);\n" +
+    					"     0  ldc <String \"OK: \"> [16]\n" +
+    					"     2  astore_1 [y]\n" +
+    					"     3  ldc <String \"local\"> [18]\n" +
+    					"     5  astore 4\n" +
+    					"     7  aload 4\n" +
+    					"     9  instanceof String [20]\n" +
+    					"    12  ifeq 54\n" +
+    					"    15  aload 4\n" +
+    					"    17  checkcast String [20]\n" +
+    					"    20  dup\n" +
+    					"    21  astore_2\n" +
+    					"    22  aload 4\n" +
+    					"    24  checkcast String [20]\n" +
+    					"    27  if_acmpne 54\n" +
+    					"    30  getstatic System.out : PrintStream [22]\n" +
+    					"    33  new StringBuilder [28]\n" +
+    					"    36  dup\n" +
+    					"    37  aload_1 [y]\n" +
+    					"    38  invokestatic String.valueOf(Object) : String [30]\n" +
+    					"    41  invokespecial StringBuilder(String) [34]\n" +
+    					"    44  aload_2 [x]\n" +
+    					"    45  invokevirtual StringBuilder.append(String) : StringBuilder [37]\n" +
+    					"    48  invokevirtual StringBuilder.toString() : String [41]\n" +
+    					"    51  invokevirtual PrintStream.println(String) : void [45]\n" +
+    					"    54  return\n" +
+    					"      Line numbers:\n" +
+    					"        [pc: 0, line: 13]\n" +
+    					"        [pc: 3, line: 14]\n" +
+    					"        [pc: 30, line: 15]\n" +
+    					"        [pc: 54, line: 17]\n" +
+    					"      Local variable table:\n" +
+    					"        [pc: 0, pc: 55] local: args index: 0 type: String[]\n" +
+    					"        [pc: 3, pc: 55] local: y index: 1 type: String\n" +
+    					"        [pc: 30, pc: 54] local: x index: 2 type: String\n" +
+    					"      Stack map table: number of frames 1\n" +
+    					"        [pc: 54, append: {String}]\n" +
+    					"    RuntimeVisibleTypeAnnotations: \n" +
+    					"      #57 @Type(\n" +
+    					"        target type = 0x40 LOCAL_VARIABLE\n" +
+    					"        local variable entries:\n" +
+    					"          [pc: 3, pc: 55] index: 1\n" +
+    					"      )\n" +
+    					"      #57 @Type(\n" +
+    					"        target type = 0x40 LOCAL_VARIABLE\n" +
+    					"        local variable entries:\n" +
+    					"          [pc: 30, pc: 54] index: 2\n" +
+    					"      )\n" +
+    					"\n";
     	checkClassFile("Test", source, expectedOutput, ClassFileBytesDisassembler.DETAILED | ClassFileBytesDisassembler.COMPACT);
         runConformTest(
                 new String[] {

--- a/org.eclipse.jdt.core/compiler/org/eclipse/jdt/core/compiler/IProblem.java
+++ b/org.eclipse.jdt.core/compiler/org/eclipse/jdt/core/compiler/IProblem.java
@@ -2517,4 +2517,9 @@ void setSourceStart(int sourceStart);
 	 * @noreference preview feature
 	 */
 	int RecordPatternMismatch =  PreviewRelated + 1913;
+	/**
+	 * @since 3.30
+	 * @noreference preview feature
+	 */
+	int PatternTypeMismatch =  PreviewRelated + 1914;
 }

--- a/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/ast/CaseStatement.java
+++ b/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/ast/CaseStatement.java
@@ -163,8 +163,10 @@ private void casePatternExpressionGenerateCode(BlockScope currentScope, CodeStre
 	if (this.patternIndex != -1) {
 		LocalVariableBinding local = currentScope.findVariable(SwitchStatement.SecretPatternVariableName, null);
 		codeStream.load(local);
-		Pattern patternExpression = ((Pattern) this.constantExpressions[this.patternIndex]);
-		patternExpression.generateCode(currentScope, codeStream);
+		Pattern pattern = ((Pattern) this.constantExpressions[this.patternIndex]);
+		pattern.generateCode(currentScope, codeStream);
+		if (!(pattern instanceof GuardedPattern))
+			codeStream.goto_(pattern.thenTarget);
 	}
 }
 

--- a/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/ast/InstanceOfExpression.java
+++ b/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/ast/InstanceOfExpression.java
@@ -169,10 +169,13 @@ public void generateOptimizedBoolean(BlockScope currentScope, CodeStream codeStr
 	codeStream.ifeq(nextSibling);
 	codeStream.load(this.secretInstanceOfPatternExpressionValue);
 	codeStream.checkcast(this.type, this.type.resolvedType, codeStream.position);
-	codeStream.dup();
-	if (this.pattern instanceof RecordPattern)
-		this.pattern.generateCode(currentScope, codeStream);
+	if (this.pattern instanceof RecordPattern) {
+		this.pattern.generateOptimizedBoolean(currentScope, codeStream, trueLabel, falseLabel);
+		codeStream.load(this.secretInstanceOfPatternExpressionValue);
+		codeStream.checkcast(this.type, this.type.resolvedType, codeStream.position);
+	}
 	else {
+		codeStream.dup();
 		codeStream.store(this.elementVariable.binding, false);
 	}
 
@@ -321,7 +324,6 @@ private void addSecretInstanceOfPatternExpressionValue(BlockScope scope1) {
 				false);
 	local.setConstant(Constant.NotAConstant);
 	local.useFlag = LocalVariableBinding.USED;
-	local.declaration = new LocalDeclaration(InstanceOfExpression.SECRET_INSTANCEOF_PATTERN_EXPRESSION_VALUE, 0, 0);
 	scope1.addLocalVariable(local);
 	this.secretInstanceOfPatternExpressionValue = local;
 }

--- a/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
+++ b/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
@@ -12339,5 +12339,12 @@ public void recordPatternSignatureMismatch(TypeBinding type, ASTNode element) {
 			element.sourceStart,
 			element.sourceEnd);
 }
-
+public void incompatiblePatternType(ASTNode element, TypeBinding type, TypeBinding expected) {
+	this.handle(
+			IProblem.PatternTypeMismatch,
+			new String[] {new String(type.readableName()), new String(expected.readableName())},
+			new String[] {new String(type.shortReadableName()), new String(expected.readableName())},
+			element.sourceStart,
+			element.sourceEnd);
+}
 }

--- a/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/problem/messages.properties
+++ b/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/problem/messages.properties
@@ -1142,6 +1142,7 @@
 # Record patterns = Java 19 JEP 405 preview
 1912 = Only record types are permitted in a record pattern
 1913 = Record pattern should match the signature of the record declaration
+1914 = Pattern of type {0} is not compatible with type {1}
 
 ### ELABORATIONS
 ## Access restrictions

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ASTConverter.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ASTConverter.java
@@ -5,7 +5,7 @@
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * https://www.eclipse.org/legal/epl-2.0/
- * 
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * This is an implementation of an early-draft specification developed under the Java
@@ -2246,7 +2246,7 @@ class ASTConverter {
 		if (this.resolveBindings) {
 			recordNodes(typePattern, pattern);
 		}
-		int startPosition = pattern.typePattern.sourceStart;
+		int startPosition = pattern.local.sourceStart;
 		int sourceEnd= pattern.sourceEnd;
 		typePattern.setSourceRange(startPosition, sourceEnd - startPosition + 1);
 		return typePattern;


### PR DESCRIPTION
Pattern resolution and code generation must take care of scenarios where
the pattern signature could be using a subtype or a super type of the
record declaraion.
