### PR TITLE
Don't open InputStreamReader without closing it

### DIFF
--- a/org.eclipse.jdt.core.tests.model/workspace/Compiler/src/org/eclipse/jdt/internal/compiler/impl/CompilerOptions.java
+++ b/org.eclipse.jdt.core.tests.model/workspace/Compiler/src/org/eclipse/jdt/internal/compiler/impl/CompilerOptions.java
@@ -431,11 +431,9 @@ public class CompilerOptions implements ProblemReasons, ProblemSeverities, Class
 				this.defaultEncoding = null;
 				String stringValue = (String) optionValue;
 				if (stringValue.length() > 0){
-					try { 
-						new InputStreamReader(new ByteArrayInputStream(new byte[0]), stringValue);
+					// ensure encoding is supported
+					if(isCharsetSupported(stringValue)) {
 						this.defaultEncoding = stringValue;
-					} catch(UnsupportedEncodingException e){
-						// ignore unsupported encoding
 					}
 				}
 			}

--- a/org.eclipse.jdt.core/batch/org/eclipse/jdt/internal/compiler/batch/Main.java
+++ b/org.eclipse.jdt.core/batch/org/eclipse/jdt/internal/compiler/batch/Main.java
@@ -33,7 +33,6 @@
 package org.eclipse.jdt.internal.compiler.batch;
 
 import java.io.BufferedInputStream;
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -41,7 +40,6 @@ import java.io.FileOutputStream;
 import java.io.FileReader;
 import java.io.FilenameFilter;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.io.LineNumberReader;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
@@ -51,6 +49,7 @@ import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.DateFormat;
@@ -2027,11 +2026,10 @@ public void configure(String[] argv) {
 					if (encodingStart >= 1) {
 						if (encodingStart < encodingEnd) {
 							customEncoding = currentArg.substring(encodingStart, encodingEnd);
-							try { // ensure encoding is supported
-								new InputStreamReader(new ByteArrayInputStream(new byte[0]), customEncoding);
-							} catch (UnsupportedEncodingException e) {
+							// ensure encoding is supported
+							if(!isCharsetSupported(customEncoding)) {
 								throw new IllegalArgumentException(
-									this.bind("configure.unsupportedEncoding", customEncoding), e); //$NON-NLS-1$
+									this.bind("configure.unsupportedEncoding", customEncoding)); //$NON-NLS-1$
 							}
 						}
 						currentArg = currentArg.substring(0, encodingStart - 1);
@@ -2757,11 +2755,10 @@ public void configure(String[] argv) {
 				} else {
 					specifiedEncodings = new HashSet<>();
 				}
-				try { // ensure encoding is supported
-					new InputStreamReader(new ByteArrayInputStream(new byte[0]), currentArg);
-				} catch (UnsupportedEncodingException e) {
+				// ensure encoding is supported
+				if(!isCharsetSupported(currentArg)) {
 					throw new IllegalArgumentException(
-						this.bind("configure.unsupportedEncoding", currentArg), e); //$NON-NLS-1$
+						this.bind("configure.unsupportedEncoding", currentArg)); //$NON-NLS-1$
 				}
 				specifiedEncodings.add(currentArg);
 				this.options.put(CompilerOptions.OPTION_Encoding, currentArg);
@@ -5616,5 +5613,9 @@ protected void validateOptions(boolean didSpecifyCompliance) {
 			}
 		}
 	}
+}
+
+boolean isCharsetSupported(String name) {
+    return Charset.availableCharsets().keySet().contains(name);
 }
 }

--- a/org.eclipse.jdt.core/batch/org/eclipse/jdt/internal/compiler/batch/Main.java
+++ b/org.eclipse.jdt.core/batch/org/eclipse/jdt/internal/compiler/batch/Main.java
@@ -5616,6 +5616,21 @@ protected void validateOptions(boolean didSpecifyCompliance) {
 }
 
 boolean isCharsetSupported(String name) {
-    return Charset.availableCharsets().keySet().contains(name);
+	/**
+	 * java.nio uses different encoding names than java.io
+	 * see https://docs.oracle.com/javase/7/docs/technotes/guides/intl/encoding.doc.html
+	 */
+	Map<String,String> io2nio= new HashMap<String, String>();
+	io2nio.put("Cp1250", "windows-1250"); //$NON-NLS-1$ //$NON-NLS-2$
+	io2nio.put("Cp1251", "windows-1251"); //$NON-NLS-1$ //$NON-NLS-2$
+	io2nio.put("Cp1252", "windows-1252"); //$NON-NLS-1$ //$NON-NLS-2$
+	io2nio.put("Cp1253", "windows-1253"); //$NON-NLS-1$ //$NON-NLS-2$
+	io2nio.put("Cp1254", "windows-1254"); //$NON-NLS-1$ //$NON-NLS-2$
+	io2nio.put("Cp1257", "windows-1257"); //$NON-NLS-1$ //$NON-NLS-2$
+	if(io2nio.containsKey(name)) {
+		return Charset.availableCharsets().keySet().contains(io2nio.get(name));
+	} else {
+		return Charset.availableCharsets().keySet().contains(name);
+	}
 }
 }

--- a/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/impl/CompilerOptions.java
+++ b/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/impl/CompilerOptions.java
@@ -30,9 +30,7 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.compiler.impl;
 
-import java.io.ByteArrayInputStream;
-import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -1682,11 +1680,9 @@ public class CompilerOptions {
 			this.defaultEncoding = null;
 			String stringValue = optionValue;
 			if (stringValue.length() > 0){
-				try {
-					new InputStreamReader(new ByteArrayInputStream(new byte[0]), stringValue);
+				// ensure encoding is supported
+				if(isCharsetSupported(stringValue)) {
 					this.defaultEncoding = stringValue;
-				} catch(UnsupportedEncodingException e){
-					// ignore unsupported encoding
 				}
 			}
 		}
@@ -2293,5 +2289,9 @@ public class CompilerOptions {
 			return this.useNullTypeAnnotations;
 		return this.isAnnotationBasedNullAnalysisEnabled
 				&& this.sourceLevel >=  ClassFileConstants.JDK1_8;
+	}
+
+	boolean isCharsetSupported(String name) {
+	    return Charset.availableCharsets().keySet().contains(name);
 	}
 }


### PR DESCRIPTION
Just a pull request as base for tests how long explicitly unclosed stream/reader need to be closed automatically. (depending on java vm?)

## What it does
Instead of open and never explicitly closing stream/reader to check for UnsupportedEncodingException to find out if an encoding is supported it makes use of explicit api.

Charset.availableCharsets().keySet().contains(name)

instead of 

new InputStreamReader(new ByteArrayInputStream(new byte[0]), stringValue);

Should there ever be interest to merge it Charset.availableCharsets().keySet() might better be cached.
But for a test through the build this is not necessary.

![image](https://user-images.githubusercontent.com/3164220/174877464-bece2619-7ad1-45a1-8dc4-b8e50afd9156.png)

So no single word about what specification the *encoding name* has to follow.
In fact it is the java.io name that is expected as long as you do not make use of nio methods. This is however changed using this patch - so I'm not sure this would be possible at all for commandline parameters. Many encoding names are the same but some important ones are not. I added a small mapping but I'm not sure if it is worth it.
Here you can see the currently used encoding names in the column "Canonical Name for java.io API and java.lang API".
https://docs.oracle.com/javase/7/docs/technotes/guides/intl/encoding.doc.html
So I want to check if I can see how long the GC needs to close the readers. After that we can close - don't care..

## How to test
Check non standard and not existing encodings on the platform.

## Author checklist

- I have thoroughly tested my changes
- The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)

