### PR TITLE
Adding Polymorphic method deduction

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/BatchCompilerTest2.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/BatchCompilerTest2.java
@@ -26,7 +26,7 @@ import junit.framework.Test;
 public class BatchCompilerTest2 extends AbstractBatchCompilerTest {
 
 	static {
-		TESTS_NAMES = new String[] { "testIssue147" };
+//		TESTS_NAMES = new String[] { "testIssue147" };
 //		TESTS_NUMBERS = new int[] { 306 };
 //		TESTS_RANGE = new int[] { 298, -1 };
 	}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/BatchCompilerTest2.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/BatchCompilerTest2.java
@@ -461,7 +461,7 @@ public void testIssue147() throws Exception {
 			"}\n"
 		},
 		"\"" + OUTPUT_DIR +  File.separator + "X.java\"" +
-				" --release " + CompilerOptions.VERSION_11 + " ",
+				" --release " + CompilerOptions.VERSION_9 + " ",
 				"",
 				"",
 				true);

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/BatchCompilerTest2.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/BatchCompilerTest2.java
@@ -26,7 +26,7 @@ import junit.framework.Test;
 public class BatchCompilerTest2 extends AbstractBatchCompilerTest {
 
 	static {
-//		TESTS_NAMES = new String[] { "test440477" };
+		TESTS_NAMES = new String[] { "testIssue147" };
 //		TESTS_NUMBERS = new int[] { 306 };
 //		TESTS_RANGE = new int[] { 298, -1 };
 	}
@@ -438,4 +438,34 @@ public void testIssue114() {
 		);
 }
 
+public void testIssue147() throws Exception {
+	runConformTest(
+		new String[] {
+			"X.java",
+			"import java.lang.invoke.MethodHandle;\n" +
+			"import java.lang.invoke.MethodHandles;\n" +
+			"import java.lang.reflect.Method;\n" +
+			"\n" +
+			"\n" +
+			"public class X {\n" +
+			"	public final Object invoke(Object self) throws Throwable {\n" +
+			"\n" +
+			"			Method method = null;\n" +
+			"			try {\n" +
+			"				MethodHandle methodHandle = MethodHandles.lookup().unreflect(method );\n" +
+			"				return methodHandle.invoke(self);\n" +
+			"			} catch (IllegalArgumentException e) {\n" +
+			"				throw e;\n" +
+			"			} \n" +
+			"		}\n" +
+			"}\n"
+		},
+		"\"" + OUTPUT_DIR +  File.separator + "X.java\"" +
+				" --release " + CompilerOptions.VERSION_11 + " ",
+				"",
+				"",
+				true);
+	String expectedOutput = "java.lang.invoke.MethodHandle.invoke(java.lang.Object)";
+	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+}
 }

--- a/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/lookup/MethodBinding.java
+++ b/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/lookup/MethodBinding.java
@@ -1489,8 +1489,8 @@ public boolean hasPolymorphicSignature(Scope scope) {
 		 */
 		if (this.parameters[0].leafComponentType().id == TypeIds.T_JavaLangObject) {
 			ReferenceBinding declaringClassLocal = this.declaringClass;
-			if ((declaringClassLocal != null)
-					&&(declaringClassLocal.id == scope.getJavaLangInvokeMethodHandle().id||declaringClassLocal.id == scope.getJavaLangInvokeVarHandle().id)) {
+			if ((declaringClassLocal != null) && (declaringClassLocal.id == scope.getJavaLangInvokeMethodHandle().id
+					|| declaringClassLocal.id == scope.getJavaLangInvokeVarHandle().id)) {
 				return true;
 			}
 		}

--- a/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/lookup/MethodBinding.java
+++ b/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/lookup/MethodBinding.java
@@ -1464,4 +1464,38 @@ public void updateTypeVariableBinding(TypeVariableBinding previousBinding, TypeV
 		}
 	}
 }
+
+/**
+ * Identifies whether the method has Polymorphic signature based on <a href=https://docs.oracle.com/javase/specs/jls/se11/html/jls-15.html#jls-15.12.3>jls-15.12.3</a><br/>
+ *
+ * Definition reproduced here. <br/><br/>
+ *
+ * A method is signature polymorphic if all of the following are true:
+ *  <li> It is declared in the java.lang.invoke.MethodHandle class or the java.lang.invoke.VarHandle class. </li>
+ *  <li> It has a single variable arity parameter (§8.4.1) whose declared type is Object[]. </li>
+ *  <li> It is native. </li>
+ * <br/>
+ * @param  scope
+ * @return true if the method has Polymorphic Signature
+ */
+public boolean hasPolymorphicSignature(Scope scope) {
+	if ((this.tagBits & TagBits.AnnotationPolymorphicSignature) != 0) {
+		return true;
+	}
+	if (this.isNative()	&& this.isVarargs() && this.parameters.length == 1) {
+		/*
+		 *  here type will be arrayType we will come here only if the method is of type
+		 *  varargs(represented by arraytype) and with only one parameter.
+		 */
+		if (this.parameters[0].leafComponentType().id == TypeIds.T_JavaLangObject) {
+			ReferenceBinding declaringClassLocal = this.declaringClass;
+			if ((declaringClassLocal != null)
+					&&(declaringClassLocal.id == scope.getJavaLangInvokeMethodHandle().id||declaringClassLocal.id == scope.getJavaLangInvokeVarHandle().id)) {
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
 }

--- a/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/lookup/TypeConstants.java
+++ b/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/lookup/TypeConstants.java
@@ -245,6 +245,9 @@ public interface TypeConstants {
 	char[][] JAVA_LANG_INVOKE_LAMBDAMETAFACTORY = {JAVA, LANG, INVOKE, "LambdaMetafactory".toCharArray()}; //$NON-NLS-1$
 	char[][] JAVA_LANG_INVOKE_SERIALIZEDLAMBDA = {JAVA, LANG, INVOKE, "SerializedLambda".toCharArray()}; //$NON-NLS-1$
 	char[][] JAVA_LANG_INVOKE_METHODHANDLES = {JAVA, LANG, INVOKE, "MethodHandles".toCharArray()}; //$NON-NLS-1$
+	char[][] JAVA_LANG_INVOKE_METHODHANDLE = {JAVA, LANG, INVOKE, "MethodHandle".toCharArray()}; //$NON-NLS-1$
+	char[][] JAVA_LANG_INVOKE_VARHANDLE = {JAVA, LANG, INVOKE, "VarHandle".toCharArray()}; //$NON-NLS-1$
+
 	char[][] JAVA_LANG_AUTOCLOSEABLE =  {JAVA, LANG, "AutoCloseable".toCharArray()}; //$NON-NLS-1$
 	char[] CLOSE = "close".toCharArray(); //$NON-NLS-1$
 	char[][] JAVA_LANG_RUNTIME_OBJECTMETHODS = {JAVA, LANG, RUNTIME, "ObjectMethods".toCharArray()}; //$NON-NLS-1$

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/BindingKeyResolver.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/BindingKeyResolver.java
@@ -423,7 +423,9 @@ public class BindingKeyResolver extends BindingKeyParser {
 					this.methodBinding = method;
 					this.compilerBinding = this.methodBinding;
 					return;
-				} else if ((method.tagBits & TagBits.AnnotationPolymorphicSignature) != 0) {
+				} else if (method.hasPolymorphicSignature(this.scope)) {
+					// set polymorphic tagbits
+					method.tagBits |= TagBits.AnnotationPolymorphicSignature;
 					this.typeBinding = null;
 					char[][] typeParameters = Signature.getParameterTypes(signature);
 					int length = typeParameters.length;


### PR DESCRIPTION
## What it does
We are depending on PolymorphicSignature annotation to determine whether
the method is polymorphic or not. But according to
https://docs.oracle.com/javase/specs/jls/se11/html/jls-15.html#jls-15.12.3

A method is signature polymorphic if all of the following are true:

- It is declared in the java.lang.invoke.MethodHandle class or the java.lang.invoke.VarHandle class.
- It has a single variable arity parameter (§8.4.1) whose declared type is Object[].
- It is native.

I guess we should deduce PolymorphicSignature annotation based on above definition

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/147

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->


<!-- Include relevant issues and describe how they are addressed. -->

## How to test
Test case has been added for this particular issue

Can test with code snippet in https://github.com/eclipse-jdt/eclipse.jdt.core/issues/147#issuecomment-1160323735 with --release and and without --release
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- I have thoroughly tested my changes
- The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)

