### PR TITLE
[19] Class Cast exception with Record pattern example in editor #157

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractRegressionTest9.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractRegressionTest9.java
@@ -115,7 +115,7 @@ public class AbstractRegressionTest9 extends AbstractRegressionTest {
 		return null;
 	}
 
-	private Parser createParser() {
+	public Parser createParser() {
 		Map<String,String> opts = new HashMap<String, String>();
 		opts.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_9);
 		return new Parser(

--- a/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/lookup/BinaryTypeBinding.java
+++ b/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/lookup/BinaryTypeBinding.java
@@ -8,6 +8,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Stephan Herrmann - Contributions for
@@ -1290,7 +1294,7 @@ public RecordComponentBinding[] components() {
 	for (int i = this.components.length; --i >= 0;) {
 		resolveTypeFor(this.components[i]);
 	}
-	this.tagBits |= ExtendedTagBits.AreRecordComponentsComplete;
+	this.extendedTagBits |= ExtendedTagBits.AreRecordComponentsComplete;
 	return this.components;
 }
 // NOTE: the type of each field of a binary type is resolved when needed


### PR DESCRIPTION
AreRecordComponentsComplete bit should be saved in extendedTagBits for records and _not_ tagBits.