### PR TITLE
NumberFormatException: For input string: "17.8" #167

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ModuleBuilderTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ModuleBuilderTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2020 IBM Corporation and others.
+ * Copyright (c) 2016, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -8986,6 +8986,34 @@ public class ModuleBuilderTests extends ModifyingResourceTests {
 
 		} finally {
 			deleteProject("ztest");
+		}
+	}
+	public void testIssue23() throws CoreException {
+		IJavaProject p1 = createJava9Project("Issue23", "18");
+		Map<String, String> options = new HashMap<>();
+		// Make sure the new options map doesn't reset.
+		options.put(CompilerOptions.OPTION_Compliance, "17.8");
+		options.put(CompilerOptions.OPTION_Source, "17.8");
+		options.put(CompilerOptions.OPTION_TargetPlatform, "17.8");
+		options.put(CompilerOptions.OPTION_Release, "enabled");
+		p1.setOptions(options);
+		try {
+			createFolder("/Issue23/src/p1");
+			createFile("/Issue23/src/p1/X.java",
+					"package p1;\n" +
+					"public class X {\n" +
+					"	public java.util.stream.Stream<String> emptyStream() {\n" +
+					"		return null;\n" +
+					"	}\n" +
+					"}");
+
+			waitForManualRefresh();
+			waitForAutoBuild();
+			p1.getProject().build(IncrementalProjectBuilder.FULL_BUILD, null);
+			IMarker[] markers = p1.getProject().findMarkers(null, true, IResource.DEPTH_INFINITE);
+			assertMarkers("Unexpected markers", "The project was not built due to \"Invalid value for --release argument:17.8\". Fix the problem, then try refreshing this project and building it since it may be inconsistent", markers);
+		} finally {
+			deleteProject(p1);
 		}
 	}
 	protected void assertNoErrors() throws CoreException {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JarPackageFragmentRoot.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JarPackageFragmentRoot.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -132,7 +132,7 @@ public class JarPackageFragmentRoot extends PackageFragmentRoot {
 				List<String> versions = new ArrayList<>();
 				if (projectLevel >= ClassFileConstants.JDK9 && jar.getEntry(version) != null) {
 					int earliestJavaVersion = ClassFileConstants.MAJOR_VERSION_9;
-					long latestJDK = CompilerOptions.releaseToJDKLevel(projectCompliance);
+					long latestJDK = CompilerOptions.versionToJdkLevel(projectCompliance);
 					int latestJavaVer = (int) (latestJDK >> 16);
 
 					for(int i = latestJavaVer; i >= earliestJavaVersion; i--) {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/ClasspathJrtWithReleaseOption.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/ClasspathJrtWithReleaseOption.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2021 IBM Corporation and others.
+ * Copyright (c) 2016, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -87,7 +87,7 @@ public class ClasspathJrtWithReleaseOption extends ClasspathJrt {
 	 * if the compliance is below 6, we simply return the lowest supported
 	 * release, which is 6.
 	 */
-	private String getReleaseOptionFromCompliance(String comp) {
+	private String getReleaseOptionFromCompliance(String comp) throws CoreException {
 		if (JavaCore.compareJavaVersions(comp, JavaCore.VERSION_1_5) <= 0) {
 			return "6"; //$NON-NLS-1$
 		}
@@ -95,7 +95,11 @@ public class ClasspathJrtWithReleaseOption extends ClasspathJrt {
 		if (index != -1) {
 			return comp.substring(index + 2, comp.length());
 		} else {
-			return comp;
+			if (comp.indexOf('.') == -1) {
+				return comp;
+			}
+			throw new CoreException(new Status(IStatus.ERROR, ClasspathJrtWithReleaseOption.class,
+						"Invalid value for --release argument:" + comp)); //$NON-NLS-1$
 		}
 	}
 


### PR DESCRIPTION
ClasspathJrtWithReleaseOption accepts any version that is of the format x.y. But it should only be accepted when it's of the format 1.x. When this condition is not met, we should throw a better error rather than failing with an exception.