### PR TITLE
Add cmd.-line opt. to take optional warn. prop. file

### DIFF
--- a/org.eclipse.jdt.compiler.apt/src/org/eclipse/jdt/internal/compiler/apt/util/Options.java
+++ b/org.eclipse.jdt.compiler.apt/src/org/eclipse/jdt/internal/compiler/apt/util/Options.java
@@ -93,6 +93,7 @@ public final class Options {
 		Options.ONE_ARGUMENT_OPTIONS.add("-processor");//$NON-NLS-1$
 		Options.ONE_ARGUMENT_OPTIONS.add("-classNames");//$NON-NLS-1$
 		Options.ONE_ARGUMENT_OPTIONS.add("-properties");//$NON-NLS-1$
+		Options.ONE_ARGUMENT_OPTIONS.add("-optprops");//$NON-NLS-1$
 
 	}
 	public static int processOptionsFileManager(String option) {

--- a/org.eclipse.jdt.compiler.tool/src/org/eclipse/jdt/internal/compiler/tool/Options.java
+++ b/org.eclipse.jdt.compiler.tool/src/org/eclipse/jdt/internal/compiler/tool/Options.java
@@ -95,6 +95,7 @@ public final class Options {
 		Options.ONE_ARGUMENT_OPTIONS.add("-processor");//$NON-NLS-1$
 		Options.ONE_ARGUMENT_OPTIONS.add("-classNames");//$NON-NLS-1$
 		Options.ONE_ARGUMENT_OPTIONS.add("-properties");//$NON-NLS-1$
+		Options.ONE_ARGUMENT_OPTIONS.add("-optprops");//$NON-NLS-1$
 
 	}
 	public static int processOptionsFileManager(String option) {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/BatchCompilerTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/BatchCompilerTest.java
@@ -724,6 +724,8 @@ public void test012(){
         "                         file contents. This option can be used with -nowarn,\n" +
         "                         -err:.., -info: or -warn:.. options, but the last one\n" +
         "                         on the command line sets the options to be used.\n" +
+        "    -optprops <file>     same as -properties except that no error is given if\n" +
+        "                         the file does not exist.\n" +
         " \n" +
         " Debug options:\n" +
         "    -g[:lines,vars,source] custom debug info\n" +

--- a/org.eclipse.jdt.core/batch/org/eclipse/jdt/internal/compiler/batch/Main.java
+++ b/org.eclipse.jdt.core/batch/org/eclipse/jdt/internal/compiler/batch/Main.java
@@ -1899,6 +1899,7 @@ public void configure(String[] argv) {
 	boolean printUsageRequired = false;
 	String usageSection = null;
 	boolean printVersionRequired = false;
+	boolean propertiesAreOptional = false;
 
 	boolean didSpecifyDeprecation = false;
 	boolean didSpecifyCompliance = false;
@@ -2629,6 +2630,12 @@ public void configure(String[] argv) {
 					continue;
 				}
 				if (currentArg.equals("-properties")) { //$NON-NLS-1$
+					propertiesAreOptional = false;
+					mode = INSIDE_WARNINGS_PROPERTIES;
+					continue;
+				}
+				if (currentArg.equals("-optprops")) { //$NON-NLS-1$
+					propertiesAreOptional = true;
 					mode = INSIDE_WARNINGS_PROPERTIES;
 					continue;
 				}
@@ -2908,7 +2915,7 @@ public void configure(String[] argv) {
 				mode = DEFAULT;
 				continue;
 			case INSIDE_WARNINGS_PROPERTIES :
-				initializeWarnings(currentArg);
+				initializeWarnings(currentArg, propertiesAreOptional);
 				mode = DEFAULT;
 				continue;
 			case INSIDE_ANNOTATIONPATH_start:
@@ -3271,10 +3278,16 @@ private static String getAllEncodings(Set<String> encodings) {
 	return String.valueOf(buffer);
 }
 @SuppressWarnings("rawtypes")
-private void initializeWarnings(String propertiesFile) {
+private void initializeWarnings(String propertiesFile, boolean propertiesAreOptional) {
 	File file = new File(propertiesFile);
 	if (!file.exists()) {
-		throw new IllegalArgumentException(this.bind("configure.missingwarningspropertiesfile", propertiesFile)); //$NON-NLS-1$
+		if (propertiesAreOptional) {
+			// intentionally, no message is printed
+			return;
+		}
+		else {
+			throw new IllegalArgumentException(this.bind("configure.missingwarningspropertiesfile", propertiesFile)); //$NON-NLS-1$
+		}
 	}
 	BufferedInputStream stream = null;
 	Properties properties = null;

--- a/org.eclipse.jdt.core/batch/org/eclipse/jdt/internal/compiler/batch/messages.properties
+++ b/org.eclipse.jdt.core/batch/org/eclipse/jdt/internal/compiler/batch/messages.properties
@@ -294,6 +294,8 @@ misc.usage = {1} {2}\n\
 \                         file contents. This option can be used with -nowarn,\n\
 \                         -err:.., -info: or -warn:.. options, but the last one\n\
 \                         on the command line sets the options to be used.\n\
+\    -optprops <file>     same as -properties except that no error is given if\n\
+\                         the file does not exist.\n\
 \ \n\
 \ Debug options:\n\
 \    -g[:lines,vars,source] custom debug info\n\

--- a/org.eclipse.jdt.core/scripts/ecj.1
+++ b/org.eclipse.jdt.core/scripts/ecj.1
@@ -34,7 +34,7 @@ Compliance Options
 .ul
 Warning Options
 .sp
-.B \-?:warn \-help:warn \-warn:... \-nowarn \-err:... \-deprecation \-properties 
+.B \-?:warn \-help:warn \-warn:... \-nowarn \-err:... \-deprecation \-properties \-optprops
 .sp
 .ul 
 Debug Options
@@ -752,6 +752,12 @@ To ensure that a property file has the same effect when used in the IDE and for 
 .B \-enableJavadoc\fR \t\tdefault changed to enabled
 .br
 error/warning \fBforbidden\fR \tdefault changed to error
+
+.B
+.IP "\-optprops <file>"
+Equivalent to \-properties except that it is not considered an error but instead the option is silently ignored if the file does not exist.
+
+Use this option instead of \-properties if can only specify one set of compiler arguments for a number of directories, but only some of them contains a property file.
 
 .P
 .ul


### PR DESCRIPTION
When the Eclipse Java Language Server analyze a multi-module Maven
project, the lack of a .settings/org.eclipse.jdt.core.prefs file in
some of the modules is silently ignored, as if this file existed but
simply had no contents.

Attempting to recreate this effect when compiling the same project
with the Eclipse Java batch compiler, for instance by using the
org.codehaus.plexus:plexus-compiler-eclipse add-on to the
maven-compiler-plugin, and passing -properties as compilerArgs, is not
possible, because the compiler will emit an error on those projects
which do not have a warnings property file.

This patch introduce an -optprops command-line option, which has the
same semantics as the -properties option, except that missing files
are silently ignored. By specifying this in the root POM, the entire
project may be compiled with the Eclipse Java compiler without having
to commit an empty warnings properties file in each of the
sub-modules.

