### PR TITLE
Bug 562764 - ClasspathLocation.forJrtSystem creates ClasspathJrtWithReleaseOption for Java 11 projects on Java 11

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/util/JrtUtilTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/util/JrtUtilTest.java
@@ -62,7 +62,7 @@ public class JrtUtilTest extends TestCase {
 		int majorVersionSegment = getMajorVersionSegment(this.jdkRelease);
 		Object jrtSystem = JRTUtil.getJrtSystem(this.image);
 		Object jrtSystem2 = JRTUtil.getJrtSystem(this.image, String.valueOf(majorVersionSegment));
-		assertNotSame(jrtSystem, jrtSystem2);
+		assertSame(jrtSystem, jrtSystem2);
 
 		jrtSystem2 = JRTUtil.getJrtSystem(this.image, String.valueOf(--majorVersionSegment));
 		assertNotSame(jrtSystem, jrtSystem2);

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ClasspathLocationTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ClasspathLocationTest.java
@@ -45,7 +45,7 @@ public class ClasspathLocationTest extends AbstractJavaModelTests {
 		Path jrtPath = Paths.get(javaHome, jrt);
 		int majorSegment = getMajorVersionSegment(releaseVersion);
 		ClasspathJrt classpathJrt = ClasspathLocation.forJrtSystem(jrtPath.toString(), null, null, String.valueOf(majorSegment));
-		assertEquals(ClasspathJrtWithReleaseOption.class, classpathJrt.getClass());
+		assertEquals(ClasspathJrt.class, classpathJrt.getClass());
 
 		int olderVersion = majorSegment - 1;
 

--- a/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/util/JRTUtil.java
+++ b/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/util/JRTUtil.java
@@ -137,7 +137,7 @@ public class JRTUtil {
 			e.printStackTrace();
 			return null;
 		}
-		if (release != null /*&& !jdk.sameRelease(release)*/) {
+		if (release != null && !jdk.sameRelease(release)) {
 			key = key + "|" + release; //$NON-NLS-1$
 		}
 		JrtFileSystem system = images.computeIfAbsent(key, x -> {
@@ -466,7 +466,7 @@ class JrtFileSystem {
 	final String release;
 
 	public static JrtFileSystem getNewJrtFileSystem(Jdk jdk, String release) throws IOException {
-		if (release == null /*|| jdk.sameRelease(release)*/) {
+		if (release == null || jdk.sameRelease(release)) {
 			return new JrtFileSystem(jdk, null);
 		} else {
 			return new JrtFileSystemWithOlderRelease(jdk, release);


### PR DESCRIPTION
Don't use ClasspathJrtWithReleaseOption / JrtFileSystemWithOlderRelease
if we are compiling against same JDK version (compared to given release
version), use ClasspathJrt/JrtFileSystem instead.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/191

Original version was submitted at https://git.eclipse.org/r/c/jdt/eclipse.jdt.core/+/161966
Original bug was https://bugs.eclipse.org/bugs/show_bug.cgi?id=562764