### PR TITLE
[19] Code completion completely broken following a record pattern #185

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests19.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests19.java
@@ -331,4 +331,47 @@ public class CompletionTests19 extends AbstractJavaModelCompletionTests {
 					requestor.getResults());
 
 		}
+		//content assist in record pattern -check for when
+		public void test009() throws JavaModelException {
+			this.workingCopies = new ICompilationUnit[1];
+			this.workingCopies[0] = getWorkingCopy(
+					"/Completion/src/X.java",
+					"@SuppressWarnings(\"preview\")"
+							+ "public class X {\n"
+							+ "  public static void printLowerRight(Rectangle r) {\n"
+							+ "    int res = switch(r) {\n"
+							+ "       case Rectangle(ColoredPoint(Point(int x, int y), Color c),\n"
+							+ "                               ColoredPoint lr) r1 whe x > 0 -> {\n"
+							+ "        		yield 1;  \n"
+							+ "        } \n"
+							+ "       case Rectangle(ColoredPoint(Point(int x, int y), Color c),\n"
+							+ "                               ColoredPoint lr) r1 when x <= 0 -> {\n"
+							+ "        		yield -1;  \n"
+							+ "        } \n"
+							+ "        default -> 0;\n"
+							+ "    }; \n"
+							+ "    System.out.println(\"Returns: \" + res);\n"
+							+ "  }\n"
+							+ "  public static void main(String[] args) {\n"
+							+ "    printLowerRight(new Rectangle(new ColoredPoint(new Point(0, 0), Color.BLUE), \n"
+							+ "        new ColoredPoint(new Point(30, 10), Color.RED)));\n"
+							+ "    printLowerRight(new Rectangle(new ColoredPoint(new Point(5, 5), Color.BLUE), \n"
+							+ "        new ColoredPoint(new Point(30, 10), Color.RED)));\n"
+							+ "  }\n"
+							+ "}\n"
+							+ "record Point(int x, int y) {}\n"
+							+ "enum Color { RED, GREEN, BLUE }\n"
+							+ "record ColoredPoint(Point p, Color c) {}\n"
+							+ "record Rectangle(ColoredPoint upperLeft, ColoredPoint lowerRight) {}"
+					);
+			CompletionTestsRequestor2 requestor = new CompletionTestsRequestor2(true);
+			requestor.allowAllRequiredProposals();
+			String str = this.workingCopies[0].getSource();
+			String completeBehind = "whe";
+			int cursorLocation = str.indexOf(completeBehind) + completeBehind.length();
+			this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner);
+			assertResults("when[KEYWORD]{when, null, null, when, null, 49}",
+					requestor.getResults());
+
+		}
 }

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests19.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests19.java
@@ -47,7 +47,7 @@ public class CompletionTests19 extends AbstractJavaModelCompletionTests {
 	public static Test suite() {
 		return buildModelTestSuite(CompletionTests19.class);
 	}
-	//content assist of a java lang class in case statement in switch pattern
+	//content assist just record pattern usage
 	public void test001() throws JavaModelException {
 		this.workingCopies = new ICompilationUnit[1];
 		this.workingCopies[0] = getWorkingCopy(
@@ -84,4 +84,251 @@ public class CompletionTests19 extends AbstractJavaModelCompletionTests {
 				requestor.getResults());
 
 	}
+	//content assist in record pattern switch case just after case
+	public void test002() throws JavaModelException {
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy(
+				"/Completion/src/X.java",
+				"@SuppressWarnings(\"preview\")"
+				+ "public class X {\n"
+				+ "  public static void printLowerRight(Rectangle r) {\n"
+				+ "    int res = switch(r) {\n"
+				+ "       case /*here*/ Rectangl (ColoredPoint(Point(int x, int y), Color c),\n"
+				+ "                               ColoredPoint lr) r1  -> {\n"
+				+ "        		yield 1;  \n"
+				+ "        } \n"
+				+ "        default -> 0;\n"
+				+ "    }; \n"
+				+ "  }\n"
+				+ "  public static void main(String[] args) {\n"
+				+ "    printLowerRight(new Rectangle(new ColoredPoint(new Point(15, 5), Color.BLUE), \n"
+				+ "        new ColoredPoint(new Point(30, 10), Color.RED)));\n"
+				+ "  }\n"
+				+ "}\n"
+				+ "record Point(int x, int y) {}\n"
+				+ "enum Color { RED, GREEN, BLUE }\n"
+				+ "record ColoredPoint(Point p, Color c) {}\n"
+				+ "record Rectangle(ColoredPoint upperLeft, ColoredPoint lowerRight) {}"
+				);
+		CompletionTestsRequestor2 requestor = new CompletionTestsRequestor2(true);
+		requestor.allowAllRequiredProposals();
+		String str = this.workingCopies[0].getSource();
+		String completeBehind = "/*here*/ Rectangl";
+		int cursorLocation = str.indexOf(completeBehind) + completeBehind.length();
+		this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner);
+		assertResults("Rectangle[TYPE_REF]{Rectangle, , LRectangle;, null, null, 52}",
+				requestor.getResults());
+
+	}
+	//content assist in record pattern switch case - 1st level nested
+	public void test003() throws JavaModelException {
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy(
+				"/Completion/src/X.java",
+				"@SuppressWarnings(\"preview\")"
+				+ "public class X {\n"
+				+ "  public static void printLowerRight(Rectangle r) {\n"
+				+ "    int res = switch(r) {\n"
+				+ "       case  Rectangle(/*here*/ ColoredPoin(Point(int x, int y), Color c),\n"
+				+ "                               ColoredPoint lr) r1  -> {\n"
+				+ "        		yield 1;  \n"
+				+ "        } \n"
+				+ "        default -> 0;\n"
+				+ "    }; \n"
+				+ "  }\n"
+				+ "  public static void main(String[] args) {\n"
+				+ "    printLowerRight(new Rectangle(new ColoredPoint(new Point(15, 5), Color.BLUE), \n"
+				+ "        new ColoredPoint(new Point(30, 10), Color.RED)));\n"
+				+ "  }\n"
+				+ "}\n"
+				+ "record Point(int x, int y) {}\n"
+				+ "enum Color { RED, GREEN, BLUE }\n"
+				+ "record ColoredPoint(Point p, Color c) {}\n"
+				+ "record Rectangle(ColoredPoint upperLeft, ColoredPoint lowerRight) {}"
+				);
+		CompletionTestsRequestor2 requestor = new CompletionTestsRequestor2(true);
+		requestor.allowAllRequiredProposals();
+		String str = this.workingCopies[0].getSource();
+		String completeBehind = "/*here*/ ColoredPoin";
+		int cursorLocation = str.indexOf(completeBehind) + completeBehind.length();
+		this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner);
+		assertResults("ColoredPoint[TYPE_REF]{ColoredPoint, , LColoredPoint;, null, null, 52}",
+				requestor.getResults());
+
+	}
+	//content assist in record pattern switch case - 2nd level nested
+	public void test004() throws JavaModelException {
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy(
+				"/Completion/src/X.java",
+				"@SuppressWarnings(\"preview\")"
+				+ "public class X {\n"
+				+ "  public static void printLowerRight(Rectangle r) {\n"
+				+ "    int res = switch(r) {\n"
+				+ "       case  Rectangle(ColoredPoint(/*here*/ Poin(int x, int y), Color c),\n"
+				+ "                               ColoredPoint lr) r1  -> {\n"
+				+ "        		yield 1;  \n"
+				+ "        } \n"
+				+ "        default -> 0;\n"
+				+ "    }; \n"
+				+ "  }\n"
+				+ "  public static void main(String[] args) {\n"
+				+ "    printLowerRight(new Rectangle(new ColoredPoint(new Point(15, 5), Color.BLUE), \n"
+				+ "        new ColoredPoint(new Point(30, 10), Color.RED)));\n"
+				+ "  }\n"
+				+ "}\n"
+				+ "record Point(int x, int y) {}\n"
+				+ "enum Color { RED, GREEN, BLUE }\n"
+				+ "record ColoredPoint(Point p, Color c) {}\n"
+				+ "record Rectangle(ColoredPoint upperLeft, ColoredPoint lowerRight) {}"
+				);
+		CompletionTestsRequestor2 requestor = new CompletionTestsRequestor2(true);
+		requestor.allowAllRequiredProposals();
+		String str = this.workingCopies[0].getSource();
+		String completeBehind = "/*here*/ Poin";
+		int cursorLocation = str.indexOf(completeBehind) + completeBehind.length();
+		this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner);
+		assertResults("Point[TYPE_REF]{Point, , LPoint;, null, null, 52}",
+				requestor.getResults());
+
+	}
+	//content assist in record pattern switch case - 2nd param in nested
+	public void test005() throws JavaModelException {
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy(
+				"/Completion/src/X.java",
+				"@SuppressWarnings(\"preview\")"
+				+ "public class X {\n"
+				+ "  public static void printLowerRight(Rectangle r) {\n"
+				+ "    int res = switch(r) {\n"
+				+ "       case  Rectangle(ColoredPoint( Point(int x, int y), /*here*/ Colo c),\n"
+				+ "                               ColoredPoint lr) r1  -> {\n"
+				+ "        		yield 1;  \n"
+				+ "        } \n"
+				+ "        default -> 0;\n"
+				+ "    }; \n"
+				+ "  }\n"
+				+ "  public static void main(String[] args) {\n"
+				+ "    printLowerRight(new Rectangle(new ColoredPoint(new Point(15, 5), Color.BLUE), \n"
+				+ "        new ColoredPoint(new Point(30, 10), Color.RED)));\n"
+				+ "  }\n"
+				+ "}\n"
+				+ "record Point(int x, int y) {}\n"
+				+ "enum Color { RED, GREEN, BLUE }\n"
+				+ "record ColoredPoint(Point p, Color c) {}\n"
+				+ "record Rectangle(ColoredPoint upperLeft, ColoredPoint lowerRight) {}"
+				);
+		CompletionTestsRequestor2 requestor = new CompletionTestsRequestor2(true);
+		requestor.allowAllRequiredProposals();
+		String str = this.workingCopies[0].getSource();
+		String completeBehind = "/*here*/ Colo";
+		int cursorLocation = str.indexOf(completeBehind) + completeBehind.length();
+		this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner);
+		assertResults("Color[TYPE_REF]{Color, , LColor;, null, null, 52}\n"
+				+ "ColoredPoint[TYPE_REF]{ColoredPoint, , LColoredPoint;, null, null, 52}",
+				requestor.getResults());
+
+	}
+	//content assist in record pattern switch case - use the variable in case statement
+	public void test006() throws JavaModelException {
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy(
+				"/Completion/src/X.java",
+				"@SuppressWarnings(\"preview\")"
+				+ "public class X {\n"
+				+ "  public static void printLowerRight(Rectangle r) {\n"
+				+ "    int res = switch(r) {\n"
+				+ "       case  Rectangle(ColoredPoint( Point(int x, int y),  Color c),\n"
+				+ "                               ColoredPoint lr) r1  -> {\n"
+				+ "        		r1.toStrin ;yield 1;  \n"
+				+ "        } \n"
+				+ "        default -> 0;\n"
+				+ "    }; \n"
+				+ "  }\n"
+				+ "  public static void main(String[] args) {\n"
+				+ "    printLowerRight(new Rectangle(new ColoredPoint(new Point(15, 5), Color.BLUE), \n"
+				+ "        new ColoredPoint(new Point(30, 10), Color.RED)));\n"
+				+ "  }\n"
+				+ "}\n"
+				+ "record Point(int x, int y) {}\n"
+				+ "enum Color { RED, GREEN, BLUE }\n"
+				+ "record ColoredPoint(Point p, Color c) {}\n"
+				+ "record Rectangle(ColoredPoint upperLeft, ColoredPoint lowerRight) {}"
+				);
+		CompletionTestsRequestor2 requestor = new CompletionTestsRequestor2(true);
+		requestor.allowAllRequiredProposals();
+		String str = this.workingCopies[0].getSource();
+		String completeBehind = "r1.toStrin";
+		int cursorLocation = str.indexOf(completeBehind) + completeBehind.length();
+		this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner);
+		assertResults("toString[METHOD_REF]{toString(), LRectangle;, ()Ljava.lang.String;, toString, null, 60}",
+				requestor.getResults());
+
+	}
+	//content assist in record pattern -instanceof record pattern - 2nd param in nested
+	public void test007() throws JavaModelException {
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy(
+				"/Completion/src/X.java",
+				"@SuppressWarnings(\"preview\")"
+				+ "public class X {\n"
+				+ "  static void print(Rectangle r) {\n"
+				+ "    if (r instanceof (Rectangle(ColoredPoint(Point(int x, int y), Color c),\n"
+				+ "                              /*here*/ ColoredPoin lr) r1)) {\n"
+				+ "        System.out.println(\"Upper-left corner: \" + r1);\n"
+				+ "    }\n"
+				+ "  }\n"
+				+ "  public static void main(String[] obj) {\n"
+				+ "    print(new Rectangle(new ColoredPoint(new Point(0, 0), Color.BLUE), \n"
+				+ "                               new ColoredPoint(new Point(10, 15), Color.RED)));\n"
+				+ "  }\n"
+				+ "}\n"
+				+ "record Point(int x, int y) {}\n"
+				+ "enum Color { RED, GREEN, BLUE }\n"
+				+ "record ColoredPoint(Point p, Color c) {}\n"
+				+ "record Rectangle(ColoredPoint upperLeft, ColoredPoint lowerRight) {}"
+				);
+		CompletionTestsRequestor2 requestor = new CompletionTestsRequestor2(true);
+		requestor.allowAllRequiredProposals();
+		String str = this.workingCopies[0].getSource();
+		String completeBehind = "/*here*/ ColoredPoin";
+		int cursorLocation = str.indexOf(completeBehind) + completeBehind.length();
+		this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner);
+		assertResults("ColoredPoint[TYPE_REF]{ColoredPoint, , LColoredPoint;, null, null, 52}",
+				requestor.getResults());
+
+	}
+	//content assist in record pattern -instanceof record pattern - record creation
+		public void test008() throws JavaModelException {
+			this.workingCopies = new ICompilationUnit[1];
+			this.workingCopies[0] = getWorkingCopy(
+					"/Completion/src/X.java",
+					"@SuppressWarnings(\"preview\")"
+					+ "public class X {\n"
+					+ "  static void print(Rectangle r) {\n"
+					+ "    if (r instanceof (Rectangle(ColoredPoint(Point(int x, int y), Color c),\n"
+					+ "                              /*here*/ ColoredPoin lr) r1)) {\n"
+					+ "        System.out.println(\"Upper-left corner: \" + r1);\n"
+					+ "    }\n"
+					+ "  }\n"
+					+ "  public static void main(String[] obj) {\n"
+					+ "    print(new Rectangle(new /*here*/ ColoredPoin(new Point(0, 0), Color.BLUE), \n"
+					+ "                               new ColoredPoint(new Point(10, 15), Color.RED)));\n"
+					+ "  }\n"
+					+ "}\n"
+					+ "record Point(int x, int y) {}\n"
+					+ "enum Color { RED, GREEN, BLUE }\n"
+					+ "record ColoredPoint(Point p, Color c) {}\n"
+					+ "record Rectangle(ColoredPoint upperLeft, ColoredPoint lowerRight) {}"
+					);
+			CompletionTestsRequestor2 requestor = new CompletionTestsRequestor2(true);
+			requestor.allowAllRequiredProposals();
+			String str = this.workingCopies[0].getSource();
+			String completeBehind = "/*here*/ ColoredPoin";
+			int cursorLocation = str.indexOf(completeBehind) + completeBehind.length();
+			this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner);
+			assertResults("ColoredPoint[TYPE_REF]{ColoredPoint, , LColoredPoint;, null, null, 52}",
+					requestor.getResults());
+
+		}
 }

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests19.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests19.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.core.tests.model;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.JavaModelException;
+
+import junit.framework.Test;
+
+public class CompletionTests19 extends AbstractJavaModelCompletionTests {
+
+
+	static {
+		// TESTS_NAMES = new String[]{"test034"};
+	}
+
+	public CompletionTests19(String name) {
+		super(name);
+	}
+
+	public void setUpSuite() throws Exception {
+		if (COMPLETION_PROJECT == null) {
+
+			COMPLETION_PROJECT = setUpJavaProject("Completion", "19");
+		} else {
+			setUpProjectCompliance(COMPLETION_PROJECT, "19");
+		}
+		super.setUpSuite();
+		COMPLETION_PROJECT.setOption(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, JavaCore.ENABLED);
+	}
+
+	public static Test suite() {
+		return buildModelTestSuite(CompletionTests19.class);
+	}
+	//content assist of a java lang class in case statement in switch pattern
+	public void test001() throws JavaModelException {
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy(
+				"/Completion/src/X.java",
+				"@SuppressWarnings(\"preview\")"
+				+ "public class X {\n"
+				+ "  public static void printLowerRight(Rectangle r) {\n"
+				+ "    int res = switch(r) {\n"
+				+ "       case Rectangle(ColoredPoint(Point(int x, int y), Color c),\n"
+				+ "                               ColoredPoint lr) r1  -> {\n"
+				+ "        		yield 1;  \n"
+				+ "        } \n"
+				+ "        default -> 0;\n"
+				+ "    }; \n"
+				+ "    fals \n"
+				+ "  }\n"
+				+ "  public static void main(String[] args) {\n"
+				+ "    printLowerRight(new Rectangle(new ColoredPoint(new Point(15, 5), Color.BLUE), \n"
+				+ "        new ColoredPoint(new Point(30, 10), Color.RED)));\n"
+				+ "  }\n"
+				+ "}\n"
+				+ "record Point(int x, int y) {}\n"
+				+ "enum Color { RED, GREEN, BLUE }\n"
+				+ "record ColoredPoint(Point p, Color c) {}\n"
+				+ "record Rectangle(ColoredPoint upperLeft, ColoredPoint lowerRight) {}"
+				);
+		CompletionTestsRequestor2 requestor = new CompletionTestsRequestor2(true);
+		requestor.allowAllRequiredProposals();
+		String str = this.workingCopies[0].getSource();
+		String completeBehind = "fals";
+		int cursorLocation = str.indexOf(completeBehind) + completeBehind.length();
+		this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner);
+		assertResults("false[KEYWORD]{false, null, null, false, null, 52}",
+				requestor.getResults());
+
+	}
+}

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionParser.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionParser.java
@@ -8,6 +8,11 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
+ * 
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
  * Contributors:
  *		IBM Corporation - initial API and implementation
  *		Stephan Herrmann - Contribution for
@@ -5283,6 +5288,9 @@ boolean computeKeywords(int kind, List<char[]> keywords) {
 		keywords.add(Keywords.TRUE);
 		keywords.add(Keywords.FALSE);
 		keywords.add(Keywords.NULL);
+		if (this.options.complianceLevel >= ClassFileConstants.JDK19) {
+			keywords.add(Keywords.WHEN);
+		}
 		if (kind == K_YIELD_KEYWORD) {
 			keywords.add(Keywords.YIELD);
 		}

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/impl/AssistParser.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/impl/AssistParser.java
@@ -8,6 +8,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
+ *  This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
@@ -1750,7 +1754,7 @@ protected int indexOfAssistIdentifier(){
  */
 protected int indexOfAssistIdentifier(boolean useGenericsStack){
 
-	if (this.identifierLengthPtr < 0){
+	if (this.identifierLengthPtr < 0 || this.identifierPtr < 0 ){
 		return -1; // no awaiting identifier
 	}
 

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/impl/Keywords.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/impl/Keywords.java
@@ -8,6 +8,11 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *      Jesper Steen Møller - Contributions for
@@ -70,5 +75,6 @@ public interface Keywords {
 	char[] FALSE = "false".toCharArray(); //$NON-NLS-1$
 	char[] NULL = "null".toCharArray(); //$NON-NLS-1$
 	char[] VAR = "var".toCharArray(); //$NON-NLS-1$ // Admittedly not a full blown keyword, just "reserved"
+	char[] WHEN = "when".toCharArray(); //$NON-NLS-1$ // Admittedly not a full blown keyword, just "reserved"
 
 }


### PR DESCRIPTION
Change-Id: I5840679c42d791665cfa76ac10f23fbb0883cbeb
Signed-off-by: Vikas Chandra <Vikas.Chandra@in.ibm.com>

java.lang.ArrayIndexOutOfBoundsException: Index -1 out of bounds for length 30
	at org.eclipse.jdt.internal.codeassist.impl.AssistParser.indexOfAssistIdentifier(AssistParser.java:1768)
	at org.eclipse.jdt.internal.codeassist.complete.CompletionParser.indexOfAssistIdentifier(CompletionParser.java:5574)
	at org.eclipse.jdt.internal.codeassist.impl.AssistParser.indexOfAssistIdentifier(AssistParser.java:1742)
breaks the completion.
If indexOfAssistIdentifier is negative, indexOfAssistIdentifier should return -1 similar to identifierLengthPtr check

## What it does
This prevents the AIOB exception.

## How to test
See the issue description

## Author checklist

- I have thoroughly tested my changes
- The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)

