### PR TITLE
[19] Rewrite dominance rules for record patterns #184

### DIFF
--- a/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/ast/RecordPattern.java
+++ b/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/ast/RecordPattern.java
@@ -117,6 +117,9 @@ public class RecordPattern extends TypePattern {
 		} else {
 			this.resolvedType = this.type.resolveType(scope);
 		}
+		if (!this.resolvedType.isValidBinding())
+			return this.resolvedType;
+
 		initSecretPatternVariable(scope);
 
 		// check whether the give type reference is a record
@@ -157,7 +160,22 @@ public class RecordPattern extends TypePattern {
 	}
 	@Override
 	public boolean dominates(Pattern p) {
-		return isTotalForType(p.resolvedType);
+		if (!this.resolvedType.isValidBinding())
+			return false;
+		if (!super.isTotalForType(p.resolvedType)) {
+			return false;
+		}
+		if (p instanceof RecordPattern) {
+			RecordPattern rp = (RecordPattern) p;
+			if (this.patterns.length != rp.patterns.length)
+				return false;
+			for(int i = 0; i < this.patterns.length; i++) {
+				if (!this.patterns[i].dominates(rp.patterns[i])) {
+					return false;
+				}
+			}
+		}
+		return true;
 	}
 	@Override
 	public void generateCode(BlockScope currentScope, CodeStream codeStream) {


### PR DESCRIPTION
Implement the following two new rules from the JLS 14.30.3:

    _A pattern p dominates a record pattern with type R if p is unconditional at R.

    A record pattern with type R and record component pattern list L dominates another record pattern with type S and record component pattern list M if (i) the erasure of S is a subtype of the erasure of R, and (ii) every pattern, if any, in L dominates the corresponding pattern in M._
