### PR TITLE
Cleanup JrtFileSystem init code (fixes #216)

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TestAll.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TestAll.java
@@ -26,6 +26,7 @@ package org.eclipse.jdt.core.tests.compiler.regression;
 import java.util.ArrayList;
 
 import org.eclipse.jdt.core.tests.compiler.util.HashtableOfObjectTest;
+import org.eclipse.jdt.core.tests.compiler.util.JrtUtilTest;
 import org.eclipse.jdt.core.tests.dom.StandAloneASTParserTest;
 import org.eclipse.jdt.core.tests.junit.extension.TestCase;
 import org.eclipse.jdt.core.tests.util.AbstractCompilerTest;
@@ -231,6 +232,7 @@ public static Test suite() {
 	TestSuite all = new TestSuite(TestAll.class.getName());
 	all.addTest(new TestSuite(StandAloneASTParserTest.class));
 	all.addTest(new TestSuite(HashtableOfObjectTest.class));
+	all.addTest(new TestSuite(JrtUtilTest.class));
 	int possibleComplianceLevels = AbstractCompilerTest.getPossibleComplianceLevels();
 	if ((possibleComplianceLevels & AbstractCompilerTest.F_1_3) != 0) {
 		ArrayList tests_1_3 = (ArrayList)standardTests.clone();

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/util/HashtableOfObjectTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/util/HashtableOfObjectTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Andrey Loskujtov, and others.
+ * Copyright (c) 2022 Andrey Loskutov, and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -18,6 +18,7 @@ import static org.eclipse.jdt.internal.compiler.util.HashtableOfObject.calculate
 
 import org.eclipse.jdt.core.tests.junit.extension.TestCase;
 import org.eclipse.jdt.internal.compiler.util.HashtableOfObject;
+import org.junit.Test;
 
 public class HashtableOfObjectTest extends TestCase {
 
@@ -25,6 +26,7 @@ public class HashtableOfObjectTest extends TestCase {
 		super(name);
 	}
 
+	@Test
 	public void testCalculateNewSize() {
 		int input;
 		int expected;
@@ -124,6 +126,7 @@ public class HashtableOfObjectTest extends TestCase {
 		}
 	}
 
+	@Test
 	public void testCreateNewTable() {
 		int input;
 		int expected;

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/util/JrtUtilTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/util/JrtUtilTest.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Andrey Loskutov, and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Andrey Loskutov (loskutov@gmx.de) - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.core.tests.compiler.util;
+
+import java.io.File;
+import java.nio.file.Paths;
+
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.tests.junit.extension.TestCase;
+import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
+import org.eclipse.jdt.internal.compiler.util.JRTUtil;
+import org.junit.Before;
+import org.junit.Test;
+
+public class JrtUtilTest extends TestCase {
+
+	private String javaSpecVersion;
+	private String javaHome;
+	private File image;
+	private String jdkRelease;
+
+	public JrtUtilTest(String name) {
+		super(name);
+	}
+
+	@Before
+	@Override
+	protected void setUp() throws Exception {
+		super.setUp();
+		this.javaSpecVersion = System.getProperty("java.specification.version", null);
+		assertNotNull("java.specification.version is not defined", this.javaSpecVersion);
+		this.javaHome = System.getProperty("java.home", null);
+		assertNotNull("java.home is not defined", this.javaHome);
+		this.image = Paths.get(this.javaHome).toFile();
+		assertTrue("java.home points to invalid path", this.image.isDirectory());
+		this.jdkRelease = JRTUtil.getJdkRelease(this.image);
+	}
+
+	@Test
+	public void testGetReleaseVersion() {
+		long expectedLevel = CompilerOptions.versionToJdkLevel(this.javaSpecVersion);
+		long seenLevel = CompilerOptions.versionToJdkLevel(this.jdkRelease);
+		assertEquals("Unexpected version: " + this.jdkRelease + ", not matching " + this.javaSpecVersion, expectedLevel, seenLevel);
+
+		int sameRelease = JavaCore.compareJavaVersions(this.javaSpecVersion, this.jdkRelease);
+		assertEquals("Unexpected version: " + this.jdkRelease + ", not matching " + this.javaSpecVersion, sameRelease, 0);
+	}
+
+	@Test
+	public void testGetNewJrtFileSystem() {
+		int majorVersionSegment = getMajorVersionSegment(this.jdkRelease);
+		Object jrtSystem = JRTUtil.getJrtSystem(this.image);
+		Object jrtSystem2 = JRTUtil.getJrtSystem(this.image, String.valueOf(majorVersionSegment));
+		assertNotSame(jrtSystem, jrtSystem2);
+
+		jrtSystem2 = JRTUtil.getJrtSystem(this.image, String.valueOf(--majorVersionSegment));
+		assertNotSame(jrtSystem, jrtSystem2);
+
+		Object jrtSystem3 = JRTUtil.getJrtSystem(this.image);
+		assertSame(jrtSystem, jrtSystem3);
+	}
+
+	private static int getMajorVersionSegment(String releaseVersion) {
+		int dot = releaseVersion.indexOf('.');
+		if (dot > 0) {
+			return Integer.parseInt(releaseVersion.substring(0, dot));
+		}
+		return Integer.parseInt(releaseVersion);
+	}
+}

--- a/org.eclipse.jdt.core.tests.model/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.tests.model/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.core.tests.model;singleton:=true
-Bundle-Version: 3.11.200.qualifier
+Bundle-Version: 3.11.300.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jdt.core.tests,

--- a/org.eclipse.jdt.core.tests.model/pom.xml
+++ b/org.eclipse.jdt.core.tests.model/pom.xml
@@ -19,7 +19,7 @@
     <relativePath>../tests-pom/</relativePath>
   </parent>
   <artifactId>org.eclipse.jdt.core.tests.model</artifactId>
-  <version>3.11.200-SNAPSHOT</version>
+  <version>3.11.300-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AllJavaModelTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AllJavaModelTests.java
@@ -214,6 +214,7 @@ private static Class[] getAllTestClasses() {
 
 		JavaCoreOptionsTests.class,
 		JavaCorePreferenceModifyListenerTest.class,
+		ClasspathLocationTest.class,
 
 		// Tests regarding null-annotations:
 		NullAnnotationModelTests.class,

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ClasspathLocationTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ClasspathLocationTest.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Andrey Loskutov and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Andrey Loskutov (loskutov@gmx.de) - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.core.tests.model;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.eclipse.jdt.internal.compiler.util.JRTUtil;
+import org.eclipse.jdt.internal.core.builder.ClasspathJrt;
+import org.eclipse.jdt.internal.core.builder.ClasspathJrtWithReleaseOption;
+import org.eclipse.jdt.internal.core.builder.ClasspathLocation;
+import org.junit.Test;
+
+public class ClasspathLocationTest extends AbstractJavaModelTests {
+
+	public ClasspathLocationTest(String name) {
+		super(name);
+	}
+
+	public static junit.framework.Test suite() {
+		return buildModelTestSuite(ClasspathLocationTest.class);
+	}
+
+	@Test
+	public void testForJrtSystem() throws Exception {
+		String javaHome = System.getProperty("java.home", null);
+		assertNotNull("java.home is not defined", javaHome);
+		File image = Paths.get(javaHome).toFile();
+		assertTrue("java.home points to invalid path", image.isDirectory());
+		String releaseVersion = JRTUtil.getJdkRelease(image);
+
+		String jrt = "lib/" + org.eclipse.jdt.internal.compiler.util.JRTUtil.JRT_FS_JAR; //$NON-NLS-1$
+		Path jrtPath = Paths.get(javaHome, jrt);
+		int majorSegment = getMajorVersionSegment(releaseVersion);
+		ClasspathJrt classpathJrt = ClasspathLocation.forJrtSystem(jrtPath.toString(), null, null, String.valueOf(majorSegment));
+		assertEquals(ClasspathJrtWithReleaseOption.class, classpathJrt.getClass());
+
+		int olderVersion = majorSegment - 1;
+
+		classpathJrt = ClasspathLocation.forJrtSystem(jrtPath.toString(), null, null, String.valueOf(olderVersion));
+		assertEquals(ClasspathJrtWithReleaseOption.class, classpathJrt.getClass());
+	}
+
+	private static int getMajorVersionSegment(String releaseVersion) {
+		int dot = releaseVersion.indexOf('.');
+		if (dot > 0) {
+			return Integer.parseInt(releaseVersion.substring(0, dot));
+		}
+		return Integer.parseInt(releaseVersion);
+	}
+}


### PR DESCRIPTION
- Removed code only required if JDT would run on Java 8 (we run only on
11+)
- Removed some code duplication
- Fixed really unnecessary complicated init sequence
- added some basic tests
