### PR TITLE
Fixed divergent implementations of JrtFileSystem

### DIFF
--- a/org.eclipse.jdt.compiler.apt/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.compiler.apt/META-INF/MANIFEST.MF
@@ -2,10 +2,10 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %fragmentName
 Bundle-SymbolicName: org.eclipse.jdt.compiler.apt;singleton:=true
-Bundle-Version: 1.4.100.qualifier
+Bundle-Version: 1.4.200.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Bundle-Vendor: %providerName
-Fragment-Host: org.eclipse.jdt.core;bundle-version="[3.27.0,4.0.0)"
+Fragment-Host: org.eclipse.jdt.core;bundle-version="[3.30.100,4.0.0)"
 Bundle-Localization: compiler_apt_fragment
 Export-Package: org.eclipse.jdt.internal.compiler.apt.dispatch;x-friends:="org.eclipse.jdt.apt.pluggable.core",
  org.eclipse.jdt.internal.compiler.apt.model;x-friends:="org.eclipse.jdt.apt.pluggable.core",

--- a/org.eclipse.jdt.compiler.apt/pom.xml
+++ b/org.eclipse.jdt.compiler.apt/pom.xml
@@ -17,7 +17,7 @@
     <version>4.25.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.eclipse.jdt.compiler.apt</artifactId>
-  <version>1.4.100-SNAPSHOT</version>
+  <version>1.4.200-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <build>

--- a/org.eclipse.jdt.compiler.tool/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.compiler.tool/META-INF/MANIFEST.MF
@@ -2,12 +2,12 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %fragmentName
 Bundle-SymbolicName: org.eclipse.jdt.compiler.tool;singleton:=true
-Bundle-Version: 1.3.150.qualifier
+Bundle-Version: 1.3.200.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: compiler_tool_fragment
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Export-Package: META-INF.services,
  org.eclipse.jdt.internal.compiler.tool;x-internal:=true
-Fragment-Host: org.eclipse.jdt.core;bundle-version="[3.28.100,4.0.0)"
+Fragment-Host: org.eclipse.jdt.core;bundle-version="[3.30.100,4.0.0)"
 Bundle-ClassPath: .
 Automatic-Module-Name: org.eclipse.jdt.compiler.tool

--- a/org.eclipse.jdt.compiler.tool/pom.xml
+++ b/org.eclipse.jdt.compiler.tool/pom.xml
@@ -17,7 +17,7 @@
     <version>4.25.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.eclipse.jdt.compiler.tool</artifactId>
-  <version>1.3.150-SNAPSHOT</version>
+  <version>1.3.200-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <build>

--- a/org.eclipse.jdt.compiler.tool/src/org/eclipse/jdt/internal/compiler/tool/JrtFileSystem.java
+++ b/org.eclipse.jdt.compiler.tool/src/org/eclipse/jdt/internal/compiler/tool/JrtFileSystem.java
@@ -143,6 +143,7 @@ public class JrtFileSystem extends Archive {
 		private JrtFileObject(File file, Path path, String module, Charset charset) {
 			super(file, path.toString(), charset);
 			this.path = path;
+			this.module = module;
 		}
 
 		@Override


### PR DESCRIPTION
apt/compiler tool versions differ in a single line assigning module
field. This line is missing in compiler.tool and it looks like a bug.

The "apt" version was fixed in
https://git.eclipse.org/r/c/jdt/eclipse.jdt.core/+/164693/

However the compiler.tool wasn't.

See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/220