### PR TITLE
compiler.batch.ClasspathJrt is not MT safe

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/BatchCompilerTest_17.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/BatchCompilerTest_17.java
@@ -1,0 +1,150 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Andrey Loskutov (loskutov@gmx.de) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Andrey Loskutov (loskutov@gmx.de) - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.core.tests.compiler.regression;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.Optional;
+import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.eclipse.jdt.core.tests.compiler.regression.BatchCompilerTest.SubstringMatcher;
+
+import junit.framework.Test;
+
+public class BatchCompilerTest_17 extends AbstractBatchCompilerTest {
+
+	/**
+	 * This test suite only needs to be run on one compliance.
+	 *
+	 * @see TestAll
+	 */
+	public static Test suite() {
+		return buildMinimalComplianceTestSuite(testClass(), F_17);
+	}
+
+	public static Class<BatchCompilerTest_17> testClass() {
+		return BatchCompilerTest_17.class;
+	}
+
+	public BatchCompilerTest_17(String name) {
+		super(name);
+	}
+
+	/**
+	 * Test tries to compile same sources <b>in parallel</b> to different output directories.
+	 * There should be no interdependencies between compiler threads, but the test failed
+	 * due some error in the initialization of shared static compiler data.
+	 * @see <a href="https://github.com/eclipse-jdt/eclipse.jdt.core/issues/183">bug 183</a>
+	 */
+	public void testParallelCompilation() throws Throwable {
+		Path root = Files.createDirectories(Paths.get(OUTPUT_DIR));
+		String[] sources = new String[] {
+				"X.java",
+				"public class X {\n"
+				+ "	public static void main(String[] args) {\n"
+				+ "		new X().printHello();\n"
+				+ "		new Thread(() -> {\n"
+				+ "			new X().printHello();\n"
+				+ "		}).start();\n"
+				+ "	}\n"
+				+ "	private void printHello() {\n"
+				+ "		System.out.println(\"Hello \" + Thread.currentThread());\n"
+				+ "	}\n"
+				+ "}",
+				"ExampleEnum.java",
+				"public enum ExampleEnum {\n"
+				+ "	A, B, C;\n"
+				+ "}\n"
+				+ ""
+			};
+
+		for (int i = 0; i < sources.length; i += 2) {
+			Files.writeString(root.resolve(sources[i]), sources[i + 1]);
+		}
+
+		Map<String, Object> map = new TreeMap<>(compileParallel(sources));
+		Optional<Object> err = map.values().stream().filter(x -> (x instanceof Throwable)).findFirst();
+		if (err.isPresent()) {
+			throw (Throwable) err.get();
+		}
+	}
+
+	public Map<String, Object> compileParallel(String[] sources) throws Exception {
+		int threads = Math.max(16, 2 * Runtime.getRuntime().availableProcessors());
+		CountDownLatch startLatch = new CountDownLatch(1);
+		CountDownLatch finishLatch = new CountDownLatch(threads);
+		ExecutorService executor = Executors.newFixedThreadPool(threads);
+		Map<String, Object> results = new ConcurrentHashMap<>();
+		for (int i = 0; i < threads; i++) {
+			String name = String.format("Compile-Thread-%02d", i);
+			executor.execute(() -> {
+				Thread.currentThread().setName(name);
+				try {
+					results.put(name, compile(sources, startLatch));
+				} catch (Throwable e) {
+					results.put(name, e);
+				} finally {
+					finishLatch.countDown();
+				}
+			});
+		}
+		startLatch.countDown();
+		finishLatch.await();
+		executor.shutdownNow();
+		return results;
+	}
+
+	private String compile(String[] sources, CountDownLatch startLatch) throws Exception {
+		String folder = "BatchCompilerTest_17_" + Thread.currentThread().getName();
+		File outputFolder = new File(OUTPUT_DIR, folder);
+		Files.createDirectories(outputFolder.toPath());
+		StringBuilder output = new StringBuilder();
+		StringBuilder error = new StringBuilder();
+		startLatch.await();
+		runTest(
+				true,
+				sources,
+		        "\"" + OUTPUT_DIR +  File.separator + sources[0] + "\""
+		        + " -g -nowarn -target 11 -source 11 --release 11"
+		        + " -encoding UTF-8"
+		        + " -d \"" + outputFolder + "\"",
+		        new SubstringMatcher("") {
+		    		@Override
+		    		boolean match(String out) {
+		    			output.append(out);
+		    			return super.match(out);
+		    		}
+		    	},
+		        new Matcher() {
+		    		@Override
+		    		String expected() {
+		    			return org.eclipse.jdt.internal.compiler.util.Util.EMPTY_STRING;
+		    		}
+		    		@Override
+		    		boolean match(String err) {
+		    			error.append(err);
+		    			return err != null && err.length() == 0;
+		    		}
+		    	},
+		        false);
+
+		return "StdErr: " + error + " StdOut: " + output;
+	}
+}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TestAll.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TestAll.java
@@ -221,6 +221,7 @@ public static Test suite() {
 	 ArrayList since_17 = new ArrayList();
 	 since_17.add(SealedTypesTests.class);
 	 since_17.add(InstanceofPrimaryPatternTest.class);
+	 since_17.add(BatchCompilerTest_17.class);
 
 	 // add 18 specific test here (check duplicates)
 	 ArrayList since_18 = new ArrayList();

--- a/org.eclipse.jdt.core/batch/org/eclipse/jdt/internal/compiler/batch/ClasspathJep247.java
+++ b/org.eclipse.jdt.core/batch/org/eclipse/jdt/internal/compiler/batch/ClasspathJep247.java
@@ -129,55 +129,58 @@ public class ClasspathJep247 extends ClasspathJrt {
 			throw new IllegalArgumentException("release " + this.compliance + " is not found in the system");  //$NON-NLS-1$//$NON-NLS-2$
 		}
 		this.modulePath = this.file.getPath() + "|" + modPath.toString(); //$NON-NLS-1$
-		Map<String, IModule> cache = ModulesCache.get(this.modulePath);
-		if (cache == null) {
+		Map<String, IModule> cache = ModulesCache.computeIfAbsent(this.modulePath, key -> {
+			Map<String,IModule> newCache = new HashMap<>();
 			try (DirectoryStream<java.nio.file.Path> stream = Files.newDirectoryStream(modPath)) {
-				HashMap<String,IModule> newCache = new HashMap<>();
 				for (final java.nio.file.Path subdir: stream) {
-						Files.walkFileTree(subdir, new FileVisitor<java.nio.file.Path>() {
+					Files.walkFileTree(subdir, new FileVisitor<java.nio.file.Path>() {
 
-							@Override
-							public FileVisitResult preVisitDirectory(java.nio.file.Path dir, BasicFileAttributes attrs)
-									throws IOException {
-								return FileVisitResult.CONTINUE;
-							}
+						@Override
+						public FileVisitResult preVisitDirectory(java.nio.file.Path dir, BasicFileAttributes attrs)
+								throws IOException {
+							return FileVisitResult.CONTINUE;
+						}
 
-							@Override
-							public FileVisitResult visitFile(java.nio.file.Path f, BasicFileAttributes attrs) throws IOException {
-								byte[] content = null;
-								if (Files.exists(f)) {
-									content = JRTUtil.safeReadBytes(f);
-									if (content == null)
-										return FileVisitResult.CONTINUE;
-									ClasspathJep247.this.acceptModule(content, newCache);
-									ClasspathJep247.this.moduleNamesCache.add(JRTUtil.sanitizedFileName(f));
+						@Override
+						public FileVisitResult visitFile(java.nio.file.Path f, BasicFileAttributes attrs) throws IOException {
+							byte[] content = null;
+							if (Files.exists(f)) {
+								content = JRTUtil.safeReadBytes(f);
+								if (content == null) {
+									return FileVisitResult.CONTINUE;
 								}
-								return FileVisitResult.CONTINUE;
+								ClasspathJep247.this.acceptModule(content, newCache);
 							}
+							return FileVisitResult.CONTINUE;
+						}
 
-							@Override
-							public FileVisitResult visitFileFailed(java.nio.file.Path f, IOException exc) throws IOException {
-								return FileVisitResult.CONTINUE;
-							}
+						@Override
+						public FileVisitResult visitFileFailed(java.nio.file.Path f, IOException exc) throws IOException {
+							return FileVisitResult.CONTINUE;
+						}
 
-							@Override
-							public FileVisitResult postVisitDirectory(java.nio.file.Path dir, IOException exc) throws IOException {
-								return FileVisitResult.CONTINUE;
-							}
-						});
-				}
-				synchronized(ModulesCache) {
-					if (ModulesCache.get(this.modulePath) == null) {
-						ModulesCache.put(this.modulePath, Collections.unmodifiableMap(newCache));
-					}
+						@Override
+						public FileVisitResult postVisitDirectory(java.nio.file.Path dir, IOException exc) throws IOException {
+							return FileVisitResult.CONTINUE;
+						}
+					});
 				}
 			} catch (IOException e) {
-				e.printStackTrace();
+				String error = "Failed to walk modules for " + key; //$NON-NLS-1$
+				if (JRTUtil.PROPAGATE_IO_ERRORS) {
+					throw new IllegalStateException(error, e);
+				} else {
+					System.err.println(error);
+					e.printStackTrace();
+					return null;
+				}
 			}
-		} else {
-			this.moduleNamesCache.addAll(cache.keySet());
-		}
+			return newCache.isEmpty() ? null : Collections.unmodifiableMap(newCache);
+		});
+
+		this.moduleNamesCache.addAll(cache.keySet());
 	}
+
 	@Override
 	void acceptModule(ClassFileReader reader, Map<String, IModule> cache) {
 		// Modules below level 9 are not dealt with here. Leave it to ClasspathJrt

--- a/org.eclipse.jdt.core/batch/org/eclipse/jdt/internal/compiler/batch/ClasspathJep247Jdk12.java
+++ b/org.eclipse.jdt.core/batch/org/eclipse/jdt/internal/compiler/batch/ClasspathJep247Jdk12.java
@@ -145,16 +145,15 @@ public class ClasspathJep247Jdk12 extends ClasspathJep247 {
 		}
 		final Path modPath = this.fs.getPath(this.releaseInHex);
 		this.modulePath = this.file.getPath() + "|" + modPath.toString(); //$NON-NLS-1$
-		this.modules = ModulesCache.get(this.modulePath);
-		if (this.modules == null) {
+		Map<String, IModule> cache = ModulesCache.computeIfAbsent(this.modulePath, key -> {
+			HashMap<String,IModule> newCache = new HashMap<>();
 			try (DirectoryStream<java.nio.file.Path> stream = Files.newDirectoryStream(this.releasePath)) {
-				HashMap<String,IModule> newCache = new HashMap<>();
 				for (final java.nio.file.Path subdir: stream) {
 					String rel = JRTUtil.sanitizedFileName(subdir);
 					if (!rel.contains(this.releaseInHex)) {
 						continue;
 					}
-					Files.walkFileTree(subdir, Collections.EMPTY_SET, 2, new FileVisitor<java.nio.file.Path>() {
+					Files.walkFileTree(subdir, Collections.emptySet(), 2, new FileVisitor<java.nio.file.Path>() {
 
 						@Override
 						public FileVisitResult preVisitDirectory(java.nio.file.Path dir, BasicFileAttributes attrs)
@@ -164,16 +163,17 @@ public class ClasspathJep247Jdk12 extends ClasspathJep247 {
 
 						@Override
 						public FileVisitResult visitFile(java.nio.file.Path f, BasicFileAttributes attrs) throws IOException {
-							if (attrs.isDirectory() || f.getNameCount() < 3)
+							if (attrs.isDirectory() || f.getNameCount() < 3) {
 								return FileVisitResult.CONTINUE;
+							}
 							if (f.getFileName().toString().equals(MODULE_INFO) && Files.exists(f)) {
 								byte[] content = JRTUtil.safeReadBytes(f);
-								if (content == null)
+								if (content == null) {
 									return FileVisitResult.CONTINUE;
+								}
 								Path m = f.subpath(1, f.getNameCount() - 1);
 								String name = JRTUtil.sanitizedFileName(m);
 								ClasspathJep247Jdk12.this.acceptModule(name, content, newCache);
-								ClasspathJep247Jdk12.this.moduleNamesCache.add(name);
 							}
 							return FileVisitResult.SKIP_SIBLINGS;
 						}
@@ -189,18 +189,20 @@ public class ClasspathJep247Jdk12 extends ClasspathJep247 {
 						}
 					});
 				}
-				synchronized(ModulesCache) {
-					if (ModulesCache.get(this.modulePath) == null) {
-						this.modules = Collections.unmodifiableMap(newCache);
-						ModulesCache.put(this.modulePath, this.modules);
-					}
-				}
 			} catch (IOException e) {
-				e.printStackTrace();
+				String error = "Failed to walk modules for " + key; //$NON-NLS-1$
+				if (JRTUtil.PROPAGATE_IO_ERRORS) {
+					throw new IllegalStateException(error, e);
+				} else {
+					System.err.println(error);
+					e.printStackTrace();
+					return null;
+				}
 			}
-		} else {
-			this.moduleNamesCache.addAll(this.modules.keySet());
-		}
+			return newCache.isEmpty() ? null : Collections.unmodifiableMap(newCache);
+		});
+		this.modules = cache;
+		this.moduleNamesCache.addAll(cache.keySet());
 	}
 	@Override
 	public Collection<String> getModuleNames(Collection<String> limitModule, Function<String, IModule> getModule) {

--- a/org.eclipse.jdt.core/batch/org/eclipse/jdt/internal/compiler/batch/ClasspathJrt.java
+++ b/org.eclipse.jdt.core/batch/org/eclipse/jdt/internal/compiler/batch/ClasspathJrt.java
@@ -15,7 +15,6 @@ package org.eclipse.jdt.internal.compiler.batch;
 
 import java.io.File;
 import java.io.IOException;
-
 import java.nio.file.FileVisitResult;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
@@ -27,6 +26,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.zip.ZipFile;
 
@@ -37,9 +37,9 @@ import org.eclipse.jdt.internal.compiler.classfmt.ExternalAnnotationDecorator;
 import org.eclipse.jdt.internal.compiler.env.AccessRuleSet;
 import org.eclipse.jdt.internal.compiler.env.IBinaryType;
 import org.eclipse.jdt.internal.compiler.env.IModule;
+import org.eclipse.jdt.internal.compiler.env.IModule.IPackageExport;
 import org.eclipse.jdt.internal.compiler.env.IMultiModuleEntry;
 import org.eclipse.jdt.internal.compiler.env.NameEnvironmentAnswer;
-import org.eclipse.jdt.internal.compiler.env.IModule.IPackageExport;
 import org.eclipse.jdt.internal.compiler.lookup.BinaryTypeBinding.ExternalAnnotationStatus;
 import org.eclipse.jdt.internal.compiler.util.JRTUtil;
 import org.eclipse.jdt.internal.compiler.util.SuffixConstants;
@@ -49,7 +49,7 @@ public class ClasspathJrt extends ClasspathLocation implements IMultiModuleEntry
 	public File file;
 	protected ZipFile annotationZipFile;
 	protected boolean closeZipFileAtEnd;
-	protected static HashMap<String, Map<String,IModule>> ModulesCache = new HashMap<>();
+	protected static Map<String, Map<String,IModule>> ModulesCache = new ConcurrentHashMap<>();
 	public final Set<String> moduleNamesCache;
 	//private Set<String> packageCache;
 	protected List<String> annotationPaths;
@@ -192,17 +192,11 @@ public class ClasspathJrt extends ClasspathLocation implements IMultiModuleEntry
 	public void initialize() throws IOException {
 		loadModules();
 	}
-//	public void acceptModule(IModuleDeclaration mod) {
-//		if (this.isJrt)
-//			return;
-//		this.module = mod;
-//	}
-	public void loadModules() {
-		Map<String,IModule> cache = ModulesCache.get(this.file.getPath());
 
-		if (cache == null) {
+	public void loadModules() {
+		Map<String, IModule> cache = ModulesCache.computeIfAbsent(this.file.getPath(), key -> {
+			HashMap<String,IModule> newCache = new HashMap<>();
 			try {
-				HashMap<String,IModule> newCache = new HashMap<>();
 				org.eclipse.jdt.internal.compiler.util.JRTUtil.walkModuleImage(this.file,
 						new org.eclipse.jdt.internal.compiler.util.JRTUtil.JrtFileVisitor<Path>() {
 
@@ -221,23 +215,25 @@ public class ClasspathJrt extends ClasspathLocation implements IMultiModuleEntry
 					@Override
 					public FileVisitResult visitModule(Path p, String name) throws IOException {
 						ClasspathJrt.this.acceptModule(JRTUtil.getClassfileContent(ClasspathJrt.this.file, IModule.MODULE_INFO_CLASS, name), newCache);
-						ClasspathJrt.this.moduleNamesCache.add(name);
 						return FileVisitResult.SKIP_SUBTREE;
 					}
 				}, JRTUtil.NOTIFY_MODULES);
 
-				synchronized(ModulesCache) {
-					if (ModulesCache.get(this.file.getPath()) == null) {
-						ModulesCache.put(this.file.getPath(), Collections.unmodifiableMap(newCache));
-					}
-				}
 			} catch (IOException e) {
-				// TODO: Java 9 Should report better
+				String error = "Failed to walk modules for " + key; //$NON-NLS-1$
+				if (JRTUtil.PROPAGATE_IO_ERRORS) {
+					throw new IllegalStateException(error, e);
+				} else {
+					System.err.println(error);
+					e.printStackTrace();
+					return null;
+				}
 			}
-		} else {
-			this.moduleNamesCache.addAll(cache.keySet());
-		}
+			return newCache.isEmpty() ? null : Collections.unmodifiableMap(newCache);
+		});
+		this.moduleNamesCache.addAll(cache.keySet());
 	}
+
 	void acceptModule(ClassFileReader reader, Map<String, IModule> cache) {
 		if (reader != null) {
 			IModule moduleDecl = reader.getModuleDeclaration();


### PR DESCRIPTION
compiler.batch.ClasspathJrt and ClasspathJep* are not MT safe

Initialization of the
org.eclipse.jdt.internal.compiler.batch.ClasspathJrt.ModulesCache should
be properly synchronized.

- Changed static ModulesCache to ConcurrentHashMap
- fixed MT init of ModulesCache to use computeIfAbsent() instead of
broken synchronization code
- added test

See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/183