### PR TITLE
ModuleBuilderTests.testAddExportsIllegal test is unstable

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ModuleBuilderTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ModuleBuilderTests.java
@@ -4807,6 +4807,7 @@ public class ModuleBuilderTests extends ModifyingResourceTests {
 			p.setOption(JavaCore.COMPILER_RELEASE, JavaCore.ENABLED);
 			p.getProject().getWorkspace().build(IncrementalProjectBuilder.AUTO_BUILD, null);
 			markers = p.getProject().findMarkers(null, true, IResource.DEPTH_INFINITE);
+			sortMarkers(markers);
 			assertMarkers("Unexpected markers", expectedMarkers, markers);
 		} finally {
 			ContainerInitializer.setInitializer(null);


### PR DESCRIPTION
Ensure marker order before assert

See https://github.com/eclipse-jdt/eclipse.jdt.core/pull/203