### PR TITLE
Allow JobManager.performConcurrentJob() temporarily enable indexer

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/junit/extension/TestCase.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/junit/extension/TestCase.java
@@ -824,8 +824,8 @@ public boolean isIndexDisabledForTest() {
 }
 
 protected void setUp() throws Exception {
-	if (JavaCore.getPlugin() != null && isIndexDisabledForTest() && JavaModelManager.getIndexManager().isEnabled()) {
-		JavaModelManager.getIndexManager().disable();
+	if (JavaCore.getPlugin() != null && isIndexDisabledForTest()) {
+		disableIndexer();
 	}
 	super.setUp();
 
@@ -871,6 +871,19 @@ protected void setUp() throws Exception {
 		}
 	}
 }
+
+protected void disableIndexer() {
+	while(JavaModelManager.getIndexManager().isEnabled()) {
+		JavaModelManager.getIndexManager().disable();
+	}
+}
+
+protected void enableIndexer() {
+	while(!JavaModelManager.getIndexManager().isEnabled()) {
+		JavaModelManager.getIndexManager().enable();
+	}
+}
+
 private String format(long number) {
 	long n = number;
 	long q = n;
@@ -916,7 +929,7 @@ protected void tearDown() throws Exception {
 	super.tearDown();
 
 	if (JavaCore.getPlugin() != null && isIndexDisabledForTest()) {
-		JavaModelManager.getIndexManager().enable();
+		enableIndexer();
 	}
 
 	// Memory storage if specified
@@ -948,6 +961,7 @@ protected void tearDown() throws Exception {
 		}
 	}
 }
+
 static public void assertSame(int expected, int actual) {
 	assertSame(null, expected, actual);
 }

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AbstractJavaModelTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AbstractJavaModelTests.java
@@ -3029,7 +3029,7 @@ public abstract class AbstractJavaModelTests extends SuiteOfTestCases {
 	protected void search(IJavaElement element, int limitTo, int matchRule, IJavaSearchScope scope, SearchRequestor requestor) throws CoreException {
 		boolean indexDisabled = isIndexDisabledForTest();
 		if(indexDisabled) {
-			JavaModelManager.getIndexManager().enable();
+			enableIndexer();
 		}
 		try {
 			SearchPattern pattern = SearchPattern.createPattern(element, limitTo, matchRule);
@@ -3043,7 +3043,7 @@ public abstract class AbstractJavaModelTests extends SuiteOfTestCases {
 			);
 		} finally {
 			if(indexDisabled) {
-				JavaModelManager.getIndexManager().disable();
+				disableIndexer();
 			}
 		}
 	}
@@ -3053,7 +3053,7 @@ public abstract class AbstractJavaModelTests extends SuiteOfTestCases {
 	protected void search(String patternString, int searchFor, int limitTo, int matchRule, IJavaSearchScope scope, SearchRequestor requestor) throws CoreException {
 		boolean indexDisabled = isIndexDisabledForTest();
 		if(indexDisabled) {
-			JavaModelManager.getIndexManager().enable();
+			enableIndexer();
 		}
 		try {
 		if (patternString.indexOf('*') != -1 || patternString.indexOf('?') != -1)
@@ -3072,7 +3072,7 @@ public abstract class AbstractJavaModelTests extends SuiteOfTestCases {
 			null);
 		} finally {
 			if(indexDisabled) {
-				JavaModelManager.getIndexManager().disable();
+				disableIndexer();
 			}
 		}
 	}

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests2.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests2.java
@@ -21,8 +21,6 @@ import java.util.Hashtable;
 import java.util.Map;
 import java.util.StringTokenizer;
 
-import junit.framework.Test;
-
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
@@ -52,7 +50,8 @@ import org.eclipse.jdt.internal.codeassist.RelevanceConstants;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jdt.internal.core.JavaModelManager;
 import org.eclipse.jdt.internal.core.SourceType;
-import org.eclipse.jdt.internal.core.search.indexing.IndexManager;
+
+import junit.framework.Test;
 
 @SuppressWarnings({"rawtypes", "unchecked", "hiding"})
 public class CompletionTests2 extends AbstractJavaModelCompletionTests {
@@ -5258,14 +5257,13 @@ public void testBug281598b() throws Exception {
 }
 public void testBug281598c() throws Exception {
 	boolean indexState = isIndexDisabledForTest();
-	IndexManager indexManager = JavaModelManager.getIndexManager();
 	try {
 		// Create project
 		IJavaProject p = createJavaProject("P", new String[] {"src"}, new String[]{"JCL_LIB"}, "bin", "1.4");
 		waitUntilIndexesReady();
 
 		// Disable indexing
-		indexManager.disable();
+		disableIndexer();
 
 		// Create compilation unit in which completion occurs
 		String path = "/P/src/test/Test.java";
@@ -5293,7 +5291,7 @@ public void testBug281598c() throws Exception {
 			"String[TYPE_REF]{String, java.lang, Ljava.lang.String;, null, null, "+(R_DEFAULT+R_RESOLVED+R_INTERESTING+R_CASE+R_UNQUALIFIED+R_NON_RESTRICTED)+"}",
 			requestor.getResults());
 	} finally {
-		indexManager.enable();
+		enableIndexer();
 		deleteProject("P");
 		this.indexDisabledForTest = indexState;
 	}

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchBugsTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchBugsTests.java
@@ -12432,7 +12432,6 @@ public void testBug323514() throws Exception {
 	} finally {
 		deleteExternalFile(libPath);
 		deleteProject("P");
-		org.eclipse.jdt.internal.core.search.processing.JobManager.VERBOSE = false;
 	}
 }
 public void testBug323514a() throws Exception {
@@ -12493,8 +12492,8 @@ public void testBug323514a() throws Exception {
 public void testBug323514b() throws Exception {
 	String libPath = getExternalResourcePath("lib323514.jar");
 	waitUntilIndexesReady();
-	boolean isDebugging = false; // turn to true to verify using the trace that the external jar file is not re-indexed while opening the project
-	org.eclipse.jdt.internal.core.search.processing.JobManager.VERBOSE = isDebugging;
+//	boolean isDebugging = false; // turn to true to verify using the trace that the external jar file is not re-indexed while opening the project
+//	org.eclipse.jdt.internal.core.search.processing.JobManager.VERBOSE = isDebugging;
 	try {
 		// Create project and external jar file
 		Util.createJar(

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ReconcilerStatementsRecoveryTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ReconcilerStatementsRecoveryTests.java
@@ -90,7 +90,7 @@ protected void assertNoProblem(char[] source, ICompilationUnit unit) throws Inte
 	if (this.problemRequestor.problemCount > 0) {
 		// If errors then wait for indexes to finish
 		while (indexManager.awaitingJobsCount() > 0) {
-			Thread.sleep(100);
+			waitUntilIndexesReady();
 		}
 		// Reconcile again to see if error goes away
 		this.problemRequestor.initialize(source);

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ReconcilerTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ReconcilerTests.java
@@ -188,7 +188,7 @@ protected void assertNoProblem(char[] source, ICompilationUnit unit) throws Inte
 	if (this.problemRequestor.problemCount > 0) {
 		// If errors then wait for indexes to finish
 		while (indexManager.awaitingJobsCount() > 0) {
-			Thread.sleep(100);
+			waitUntilIndexesReady();
 		}
 		// Reconcile again to see if error goes away
 		this.problemRequestor.initialize(source);

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/SearchTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/SearchTests.java
@@ -230,12 +230,16 @@ public class SearchTests extends ModifyingResourceTests implements IJavaSearchCo
 		}
 		public void runAndSuspend(IWorkspaceRunnable runnable) throws Semaphore.TimeOutException, CoreException {
 	 		IndexManager indexManager = JavaModelManager.getIndexManager();
-			indexManager.disable();
+	 		while(indexManager.isEnabled()) {
+	 			indexManager.disable();
+	 		}
 			if (runnable != null) {
 				runnable.run(null);
 			}
 			indexManager.request(this);
-			indexManager.enable();
+			while(!indexManager.isEnabled()) {
+	 			indexManager.enable();
+	 		}
 			this.startingSem.acquire(30000); // wait for job to start (wait 30s max)
 		}
 
@@ -358,7 +362,7 @@ public void tearDownSuite() throws Exception {
 public void testChangeClasspath() throws CoreException, TimeOutException {
 	boolean indexDisabled = isIndexDisabledForTest();
 	if(indexDisabled) {
-		JavaModelManager.getIndexManager().enable();
+		enableIndexer();
 	}
 	WaitingJob job = new WaitingJob();
 	try {
@@ -396,7 +400,7 @@ public void testChangeClasspath() throws CoreException, TimeOutException {
 		job.resume();
 		deleteProject("P1");
 		if(indexDisabled) {
-			JavaModelManager.getIndexManager().disable();
+			disableIndexer();
 		}
 	}
 }


### PR DESCRIPTION
If JobManager.performConcurrentJob() arrives into "WaitUntilReady" case
with awaiting jobs and disabled indexer, it loops forever.

To break the loop, allow performConcurrentJob() to temporarily enable
indexer until all awaiting jobs are done.

Additionally changed tests to call enabled/disabled indexer until the
indexer "enabled" count reaches expected state.

See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/41