### PR TITLE
NPE's on writing index (#235)

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaIndexTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaIndexTests.java
@@ -40,6 +40,8 @@ import org.eclipse.jdt.core.tests.util.Util;
 import org.eclipse.jdt.internal.core.ClasspathEntry;
 import org.eclipse.jdt.internal.core.JavaModelManager;
 import org.eclipse.jdt.internal.core.UserLibraryClasspathContainer;
+import org.eclipse.jdt.internal.core.index.Index;
+import org.eclipse.jdt.internal.core.search.indexing.IndexManager;
 import org.osgi.service.prefs.BackingStoreException;
 
 public class JavaIndexTests extends AbstractJavaSearchTests  {
@@ -801,7 +803,9 @@ public class JavaIndexTests extends AbstractJavaSearchTests  {
 			setClasspath(p, new IClasspathEntry[] {entry});
 			waitUntilIndexesReady();
 
-			assertEquals(url,JavaModelManager.getIndexManager().getIndex(libPath, false, false).getIndexLocation().getUrl().toString());
+			IndexManager indexManager = JavaModelManager.getIndexManager();
+			Index index = indexManager.getIndex(libPath, false, false);
+			assertEquals(url, index.getIndexLocation().getUrl().toString());
 
 			search("Test", TYPE, DECLARATIONS, EXACT_RULE, SearchEngine.createJavaSearchScope(new IJavaElement[]{p}));
 			assertSearchResults(getExternalPath() + "Test.jar pkg.Test");
@@ -811,7 +815,8 @@ public class JavaIndexTests extends AbstractJavaSearchTests  {
 			waitUntilIndexesReady();
 
 			this.resultCollector = new JavaSearchResultCollector();
-			assertEquals(url,JavaModelManager.getIndexManager().getIndex(libPath, false, false).getIndexLocation().getUrl().toString());
+			index = indexManager.getIndex(libPath, false, false);
+			assertEquals(url, index.getIndexLocation().getUrl().toString());
 			search("Test", TYPE, DECLARATIONS, EXACT_RULE, SearchEngine.createJavaSearchScope(new IJavaElement[]{p}));
 			assertSearchResults(getExternalPath() + "Test.jar pkg.Test");
 		} finally {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ClasspathChange.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ClasspathChange.java
@@ -565,7 +565,7 @@ public class ClasspathChange {
 									try {
 										pathHasChanged = !Objects.equals(newurl.toURI(),oldurl.toURI());
 									} catch (URISyntaxException e) {
-										// ignore
+										pathHasChanged = !Objects.equals(newurl, oldurl);
 									}
 								} else if (oldurl != null) {
 									indexManager.removeIndex(newPath);

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ClasspathEntry.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ClasspathEntry.java
@@ -1790,7 +1790,7 @@ public class ClasspathEntry implements IClasspathEntry {
 						CRC32 checksumCalculator = new CRC32();
 						checksumCalculator.update(pathString.getBytes());
 						String fileName = Long.toString(checksumCalculator.getValue()) + ".index"; //$NON-NLS-1$
-						return new URL("file", null, Paths.get(SHARED_INDEX_LOCATION, fileName).toString()); //$NON-NLS-1$
+						return Paths.get(SHARED_INDEX_LOCATION, fileName).toUri().toURL();
 					} catch (MalformedURLException e1) {
 						Util.log(e1); // should not happen if protocol known (eg. 'file')
 					}

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/index/IndexLocation.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/index/IndexLocation.java
@@ -73,7 +73,7 @@ public abstract class IndexLocation {
 			tempUrl = tempUri.toURL();
 		} catch (MalformedURLException e) {
 			// should not happen
-			Util.log(e, "Unexpected uri to url failure"); //$NON-NLS-1$
+			Util.log(e, "Unexpected uri to url conversion failure"); //$NON-NLS-1$
 		}
 		this.url = tempUrl;
 		this.uri = tempUri;
@@ -85,8 +85,11 @@ public abstract class IndexLocation {
 		try {
 			tempUri = url.toURI();
 		} catch (URISyntaxException e) {
-			// should not happen
-			Util.log(e, "Unexpected url to uri failure"); //$NON-NLS-1$
+			if (this instanceof JarIndexLocation) {
+				// ignore this: we have jar:file: URL's that can't be converted to URI's
+			} else {
+				Util.log(e, "Unexpected uri to url conversion failure"); //$NON-NLS-1$
+			}
 		}
 		this.uri = tempUri;
 	}
@@ -124,10 +127,6 @@ public abstract class IndexLocation {
 		return this.url;
 	}
 
-	public URI getUri() {
-		return this.uri;
-	}
-
 	@Override
 	public int hashCode() {
 		return this.uri != null ? this.uri.hashCode() : this.url.hashCode();
@@ -151,6 +150,8 @@ public abstract class IndexLocation {
 
 	@Override
 	public String toString() {
-		return this.uri.toString();
+		// Note: this is used in IndexManager.writeIndexMapFile() to persist index location and
+		// in readIndexMap() to read it back to URL
+		return this.url.toString();
 	}
 }

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/index/JarIndexLocation.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/index/JarIndexLocation.java
@@ -17,7 +17,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.JarURLConnection;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Objects;
 import java.util.jar.JarEntry;
@@ -61,11 +60,7 @@ public class JarIndexLocation extends IndexLocation {
 	@Override
 	public boolean equals(Object other) {
 		if (!(other instanceof JarIndexLocation)) return false;
-		try {
-			return Objects.equals(this.localUrl.toURI(),((JarIndexLocation) other).localUrl.toURI());
-		} catch (URISyntaxException e) {
-			return false;
-		}
+		return Objects.equals(this.localUrl, ((JarIndexLocation) other).localUrl);
 	}
 
 	@Override

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/IndexManager.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/IndexManager.java
@@ -302,7 +302,7 @@ public synchronized IndexLocation computeIndexLocation(IPath containerPath, fina
 			try {
 				urisarequal = Objects.equals(newIndexURL.toURI(), existingURL.toURI());
 			} catch (URISyntaxException e) {
-				// ignore missing RFC 2396 compliance
+				urisarequal = Objects.equals(newIndexURL, existingURL);
 			}
 			if(!urisarequal) {
 				// URL has changed so remove the old index and create a new one


### PR DESCRIPTION
In large parts https://git.eclipse.org/r/c/jdt/eclipse.jdt.core/+/174169
was wrong and as side effect we have NPE's trying to persist jar index
location that has no valid URI and also
org.eclipse.jdt.core.tests.model.JavaIndexTests.testIndexInJar failure
on Windows (is there since 4.24).

URL's are not as strict as URI's but the code that supports such crazy
constructs like jar:file: syntax (see
org.eclipse.jdt.core.tests.model.JavaIndexTests.testIndexInJar()) is
failing now.

Revisited all places from original gerrit that changed URL to URI and
changed to something that actually works.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/235