### PR TITLE
Don't hide IO exceptions in batch compiler where possible

### DIFF
--- a/org.eclipse.jdt.core/batch/org/eclipse/jdt/internal/compiler/batch/ClasspathJep247.java
+++ b/org.eclipse.jdt.core/batch/org/eclipse/jdt/internal/compiler/batch/ClasspathJep247.java
@@ -241,8 +241,14 @@ public class ClasspathJep247 extends ClasspathJrt {
 					});
 				}
 			} catch (IOException e) {
-				e.printStackTrace();
-				// Rethrow
+				String error = "Failed to find module " + moduleName + " defining package " + qualifiedPackageName //$NON-NLS-1$ //$NON-NLS-2$
+						+ " in release " + this.releasePath + " in " + this; //$NON-NLS-1$ //$NON-NLS-2$
+				if (JRTUtil.PROPAGATE_IO_ERRORS) {
+					throw new IllegalStateException(error, e);
+				} else {
+					System.err.println(error);
+					e.printStackTrace();
+				}
 			}
 			this.subReleases = sub.toArray(new String[sub.size()]);
 		}

--- a/org.eclipse.jdt.core/batch/org/eclipse/jdt/internal/compiler/batch/ClasspathJep247Jdk12.java
+++ b/org.eclipse.jdt.core/batch/org/eclipse/jdt/internal/compiler/batch/ClasspathJep247Jdk12.java
@@ -132,7 +132,13 @@ public class ClasspathJep247Jdk12 extends ClasspathJep247 {
 			}
 			this.subReleases = sub.toArray(new String[sub.size()]);
 		} catch (IOException e) {
-			//e.printStackTrace();
+			String error = "Failed to walk subreleases for release " + this.releasePath + " in " + filePath; //$NON-NLS-1$ //$NON-NLS-2$
+			if (JRTUtil.PROPAGATE_IO_ERRORS) {
+				throw new IllegalStateException(error, e);
+			} else {
+				System.err.println(error);
+				e.printStackTrace();
+			}
 		}
 		super.initialize();
 	}
@@ -297,8 +303,14 @@ public class ClasspathJep247Jdk12 extends ClasspathJep247 {
 					}
 				}
 			} catch (IOException e) {
-				e.printStackTrace();
-				// Rethrow
+				String error = "Failed to find module " + moduleName + " defining package " + qualifiedPackageName //$NON-NLS-1$ //$NON-NLS-2$
+						+ " in release " + this.releasePath + " in " + this; //$NON-NLS-1$ //$NON-NLS-2$
+				if (JRTUtil.PROPAGATE_IO_ERRORS) {
+					throw new IllegalStateException(error, e);
+				} else {
+					System.err.println(error);
+					e.printStackTrace();
+				}
 			}
 		}
 		return singletonModuleNameIf(this.packageCache.contains(qualifiedPackageName));

--- a/org.eclipse.jdt.core/batch/org/eclipse/jdt/internal/compiler/batch/ClasspathJrt.java
+++ b/org.eclipse.jdt.core/batch/org/eclipse/jdt/internal/compiler/batch/ClasspathJrt.java
@@ -166,7 +166,14 @@ public class ClasspathJrt extends ClasspathLocation implements IMultiModuleEntry
 
 			}, JRTUtil.NOTIFY_ALL);
 		} catch (IOException e) {
-			// Ignore and move on
+			String error = "Failed to find module " + moduleName + " defining package " + qualifiedPackageName //$NON-NLS-1$ //$NON-NLS-2$
+					+ " in " + this; //$NON-NLS-1$
+			if (JRTUtil.PROPAGATE_IO_ERRORS) {
+				throw new IllegalStateException(error, e);
+			} else {
+				System.err.println(error);
+				e.printStackTrace();
+			}
 		}
 
 		int size = answers.size();

--- a/org.eclipse.jdt.core/batch/org/eclipse/jdt/internal/compiler/batch/FileSystem.java
+++ b/org.eclipse.jdt.core/batch/org/eclipse/jdt/internal/compiler/batch/FileSystem.java
@@ -210,7 +210,13 @@ protected FileSystem(String[] classpathNames, String[] initialFileNames, String 
 				this.moduleLocations.put(moduleName, classpath);
 			this.classpaths[counter++] = classpath;
 		} catch (IOException e) {
-			// ignore
+			String error = "Failed to init " + classpath; //$NON-NLS-1$
+			if (JRTUtil.PROPAGATE_IO_ERRORS) {
+				throw new IllegalStateException(error, e);
+			} else {
+				System.err.println(error);
+				e.printStackTrace();
+			}
 		}
 	}
 	if (counter != classpathSize) {
@@ -230,9 +236,17 @@ protected FileSystem(Classpath[] paths, String[] initialFileNames, boolean annot
 			for (String moduleName : classpath.getModuleNames(limitedModules))
 				this.moduleLocations.put(moduleName, classpath);
 			this.classpaths[counter++] = classpath;
-		} catch(IOException | InvalidPathException exception) {
+		} catch(InvalidPathException exception) {
 			// JRE 9 could throw an IAE if the linked JAR paths have invalid chars, such as ":"
 			// ignore
+		} catch (IOException e) {
+			String error = "Failed to init " + classpath; //$NON-NLS-1$
+			if (JRTUtil.PROPAGATE_IO_ERRORS) {
+				throw new IllegalStateException(error, e);
+			} else {
+				System.err.println(error);
+				e.printStackTrace();
+			}
 		}
 	}
 	if (counter != length) {

--- a/org.eclipse.jdt.core/batch/org/eclipse/jdt/internal/compiler/batch/ModuleFinder.java
+++ b/org.eclipse.jdt.core/batch/org/eclipse/jdt/internal/compiler/batch/ModuleFinder.java
@@ -34,6 +34,7 @@ import org.eclipse.jdt.internal.compiler.env.IModule;
 import org.eclipse.jdt.internal.compiler.env.PackageExportImpl;
 import org.eclipse.jdt.internal.compiler.env.IModule.IPackageExport;
 import org.eclipse.jdt.internal.compiler.parser.Parser;
+import org.eclipse.jdt.internal.compiler.util.JRTUtil;
 import org.eclipse.jdt.internal.compiler.util.Util;
 
 public class ModuleFinder {
@@ -130,6 +131,13 @@ public class ModuleFinder {
 		try (JarFile jar = new JarFile(file)) {
 			return jar.getManifest();
 		} catch (IOException e) {
+			String error = "Failed to read manifest from " + file; //$NON-NLS-1$
+			if (JRTUtil.PROPAGATE_IO_ERRORS) {
+				throw new IllegalStateException(error, e);
+			} else {
+				System.err.println(error);
+				e.printStackTrace();
+			}
 			return null;
 		}
 	}
@@ -249,8 +257,16 @@ public class ModuleFinder {
 				return reader.getModuleDeclaration();
 			}
 			return null;
-		} catch (ClassFormatException | IOException e) {
+		} catch (ClassFormatException e) {
 			// Nothing to be done here
+		} catch (IOException e) {
+			String error = "Failed to read module for path " + path + " and release " + release + " from " + file; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+			if (JRTUtil.PROPAGATE_IO_ERRORS) {
+				throw new IllegalStateException(error, e);
+			} else {
+				System.err.println(error);
+				e.printStackTrace();
+			}
 		} finally {
 			if (zipFile != null) {
 				try {
@@ -271,8 +287,16 @@ public class ModuleFinder {
 				return reader.getModuleDeclaration();
 			}
 			return null;
-		} catch (ClassFormatException | IOException e) {
+		} catch (ClassFormatException e) {
 			e.printStackTrace();
+		} catch (IOException e) {
+			String error = "Failed to read module from " + classfilePath; //$NON-NLS-1$
+			if (JRTUtil.PROPAGATE_IO_ERRORS) {
+				throw new IllegalStateException(error, e);
+			} else {
+				System.err.println(error);
+				e.printStackTrace();
+			}
 		}
 		return null;
 	}


### PR DESCRIPTION
Issues like #183 might also be caused by some IO errors that are not
reproducible with single threaded compilation. Hiding IO errors prevent
proper problem analysis.

Where appropriate, either print errors and stack traces or re-throw IO
exceptions as IllegalStateException if system property
-Dorg.eclipse.jdt.propagate_io_errors=true is set.

See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/183