### PR TITLE
MT fixes for jdt.internal.core.builder.ClasspathJrt (#242)

### DIFF
--- a/org.eclipse.jdt.compiler.apt/src/org/eclipse/jdt/internal/compiler/apt/util/JrtFileSystem.java
+++ b/org.eclipse.jdt.compiler.apt/src/org/eclipse/jdt/internal/compiler/apt/util/JrtFileSystem.java
@@ -78,19 +78,6 @@ public class JrtFileSystem extends Archive {
 
 		org.eclipse.jdt.internal.compiler.util.JRTUtil.walkModuleImage(this.file,
 				new org.eclipse.jdt.internal.compiler.util.JRTUtil.JrtFileVisitor<Path>() {
-
-			@Override
-			public FileVisitResult visitPackage(Path dir, Path mod, BasicFileAttributes attrs)
-					throws IOException {
-				return FileVisitResult.CONTINUE;
-			}
-
-			@Override
-			public FileVisitResult visitFile(Path f, Path mod, BasicFileAttributes attrs)
-					throws IOException {
-				return FileVisitResult.CONTINUE;
-			}
-
 			@Override
 			public FileVisitResult visitModule(Path path, String name) throws IOException {
 				JrtFileSystem.this.modulePathMap.put(name, path);

--- a/org.eclipse.jdt.compiler.tool/src/org/eclipse/jdt/internal/compiler/tool/JrtFileSystem.java
+++ b/org.eclipse.jdt.compiler.tool/src/org/eclipse/jdt/internal/compiler/tool/JrtFileSystem.java
@@ -78,19 +78,6 @@ public class JrtFileSystem extends Archive {
 
 		org.eclipse.jdt.internal.compiler.util.JRTUtil.walkModuleImage(this.file,
 				new org.eclipse.jdt.internal.compiler.util.JRTUtil.JrtFileVisitor<Path>() {
-
-			@Override
-			public FileVisitResult visitPackage(Path dir, Path mod, BasicFileAttributes attrs)
-					throws IOException {
-				return FileVisitResult.CONTINUE;
-			}
-
-			@Override
-			public FileVisitResult visitFile(Path f, Path mod, BasicFileAttributes attrs)
-					throws IOException {
-				return FileVisitResult.CONTINUE;
-			}
-
 			@Override
 			public FileVisitResult visitModule(Path path, String name) throws IOException {
 				JrtFileSystem.this.modulePathMap.put(name, path);

--- a/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/util/JRTUtil.java
+++ b/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/util/JRTUtil.java
@@ -79,19 +79,26 @@ public class JRTUtil {
 
 	public interface JrtFileVisitor<T> {
 
-		public FileVisitResult visitPackage(T dir, T mod, BasicFileAttributes attrs) throws IOException;
+		public default FileVisitResult visitPackage(T dir, T mod, BasicFileAttributes attrs) throws IOException {
+			return FileVisitResult.CONTINUE;
+		}
 
-		public FileVisitResult visitFile(T file, T mod, BasicFileAttributes attrs) throws IOException;
+		public default FileVisitResult visitFile(T file, T mod, BasicFileAttributes attrs) throws IOException {
+			return FileVisitResult.CONTINUE;
+		}
+
 		/**
 		 * Invoked when a root directory of a module being visited. The element returned
 		 * contains only the module name segment - e.g. "java.base". Clients can use this to control
 		 * how the JRT needs to be processed, for e.g., clients can skip a particular module
 		 * by returning FileVisitResult.SKIP_SUBTREE
 		 */
-		public FileVisitResult visitModule(T path, String name) throws IOException;
+		public default FileVisitResult visitModule(T path, String name) throws IOException  {
+			return FileVisitResult.CONTINUE;
+		}
 	}
 
-	static abstract class AbstractFileVisitor<T> implements FileVisitor<T> {
+	public static abstract class AbstractFileVisitor<T> implements FileVisitor<T> {
 		@Override
 		public FileVisitResult preVisitDirectory(T dir, BasicFileAttributes attrs) throws IOException {
 			return FileVisitResult.CONTINUE;

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/ClasspathJrtWithReleaseOption.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/ClasspathJrtWithReleaseOption.java
@@ -16,7 +16,6 @@ package org.eclipse.jdt.internal.core.builder;
 import java.io.IOException;
 import java.nio.file.FileSystem;
 import java.nio.file.FileVisitResult;
-import java.nio.file.FileVisitor;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -25,6 +24,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Predicate;
 
 import org.eclipse.core.runtime.CoreException;
@@ -124,50 +124,41 @@ public class ClasspathJrtWithReleaseOption extends ClasspathJrt {
 		}
 	}
 
-	HashMap<String, SimpleSet> findPackagesInModules() {
+	Map<String, SimpleSet> findPackagesInModules() {
 		// In JDK 11 and before, classes are not listed under their respective modules
 		// Hence, we simply go to the default module system for package-module mapping
 		if (this.fs == null || !this.ctSym.isJRE12Plus()) {
 			return ClasspathJrt.findPackagesInModules(this);
 		}
-		HashMap<String, SimpleSet> cache = PackageCache.get(this.modPathString);
-		if (cache != null) {
-			return cache;
-		}
-		final HashMap<String, SimpleSet> packagesInModule = new HashMap<>();
-		PackageCache.put(this.modPathString, packagesInModule);
-		try {
-			JRTUtil.walkModuleImage(this.jrtFile, this.release, new JRTUtil.JrtFileVisitor<Path>() {
-						SimpleSet packageSet = null;
+		Map<String, SimpleSet> cache = PackageCache.computeIfAbsent(this.modPathString, key -> {
+			final Map<String, SimpleSet> packagesInModule = new HashMap<>();
+			try {
+				JRTUtil.walkModuleImage(this.jrtFile, this.release, new JRTUtil.JrtFileVisitor<Path>() {
+					SimpleSet packageSet;
 
-						@Override
-						public FileVisitResult visitPackage(Path dir, Path mod, BasicFileAttributes attrs)
-								throws IOException {
-							ClasspathJar.addToPackageSet(this.packageSet, dir.toString(), true);
-							return FileVisitResult.CONTINUE;
-						}
+					@Override
+					public FileVisitResult visitPackage(Path dir, Path mod, BasicFileAttributes attrs) throws IOException {
+						ClasspathJar.addToPackageSet(this.packageSet, dir.toString(), true);
+						return FileVisitResult.CONTINUE;
+					}
 
-						@Override
-						public FileVisitResult visitFile(Path file, Path mod, BasicFileAttributes attrs)
-								throws IOException {
-							return FileVisitResult.CONTINUE;
+					@Override
+					public FileVisitResult visitModule(Path path, String name) throws IOException {
+						this.packageSet = new SimpleSet(41);
+						this.packageSet.add(""); //$NON-NLS-1$
+						if (name.endsWith("/")) { //$NON-NLS-1$
+							name = name.substring(0, name.length() - 1);
 						}
-
-						@Override
-						public FileVisitResult visitModule(Path path, String name) throws IOException {
-							this.packageSet = new SimpleSet(41);
-							this.packageSet.add(""); //$NON-NLS-1$
-							if (name.endsWith("/")) { //$NON-NLS-1$
-								name = name.substring(0, name.length() - 1);
-							}
-							packagesInModule.put(name, this.packageSet);
-							return FileVisitResult.CONTINUE;
-						}
-					}, JRTUtil.NOTIFY_PACKAGES | JRTUtil.NOTIFY_MODULES);
-		} catch (IOException e) {
-			// return empty handed
-		}
-		return packagesInModule;
+						packagesInModule.put(name, this.packageSet);
+						return FileVisitResult.CONTINUE;
+					}
+				}, JRTUtil.NOTIFY_PACKAGES | JRTUtil.NOTIFY_MODULES);
+			} catch (IOException e) {
+				Util.log(e, "Failed to init packages for " + this.modPathString); //$NON-NLS-1$
+			}
+			return packagesInModule.isEmpty() ? null : Collections.unmodifiableMap(packagesInModule);
+		});
+		return cache;
 	}
 
 	public void loadModules() {
@@ -178,21 +169,14 @@ public class ClasspathJrtWithReleaseOption extends ClasspathJrt {
 		if (this.modPathString == null) {
 			return;
 		}
-		HashMap<String, IModule> cache = ModulesCache.get(this.modPathString);
-		if (cache == null) {
+		ModulesCache.computeIfAbsent(this.modPathString, key -> {
 			List<Path> releaseRoots = this.ctSym.releaseRoots(this.releaseCode);
+			Map<String, IModule> newCache = new HashMap<>();
 			for (Path root : releaseRoots) {
 				try {
-					Files.walkFileTree(root, Collections.EMPTY_SET, 2, new FileVisitor<java.nio.file.Path>() {
+					Files.walkFileTree(root, Collections.emptySet(), 2, new JRTUtil.AbstractFileVisitor<Path>() {
 						@Override
-						public FileVisitResult preVisitDirectory(java.nio.file.Path dir, BasicFileAttributes attrs)
-								throws IOException {
-							return FileVisitResult.CONTINUE;
-						}
-
-						@Override
-						public FileVisitResult visitFile(java.nio.file.Path f, BasicFileAttributes attrs)
-								throws IOException {
+						public FileVisitResult visitFile(Path f, BasicFileAttributes attrs)	throws IOException {
 							if (attrs.isDirectory() || f.getNameCount() < 3) {
 								return FileVisitResult.CONTINUE;
 							}
@@ -201,28 +185,17 @@ public class ClasspathJrtWithReleaseOption extends ClasspathJrt {
 								if (content == null) {
 									return FileVisitResult.CONTINUE;
 								}
-								ClasspathJrtWithReleaseOption.this.acceptModule(content, f.getParent().getFileName().toString());
+								ClasspathJrtWithReleaseOption.this.acceptModule(content, f.getParent().getFileName().toString(), newCache);
 							}
 							return FileVisitResult.SKIP_SIBLINGS;
 						}
-
-						@Override
-						public FileVisitResult visitFileFailed(java.nio.file.Path f, IOException exc)
-								throws IOException {
-							return FileVisitResult.CONTINUE;
-						}
-
-						@Override
-						public FileVisitResult postVisitDirectory(java.nio.file.Path dir, IOException exc)
-								throws IOException {
-							return FileVisitResult.CONTINUE;
-						}
 					});
 				} catch (IOException e) {
-					// Nothing much to do
+					Util.log(e, "Failed to init modules cache for " + key); //$NON-NLS-1$
 				}
 			}
-		}
+			return newCache.isEmpty() ? null : Collections.unmodifiableMap(newCache);
+		});
 	}
 
 
@@ -278,7 +251,7 @@ public class ClasspathJrtWithReleaseOption extends ClasspathJrt {
 
 	@Override
 	public Collection<String> getModuleNames(Collection<String> limitModules) {
-		HashMap<String, SimpleSet> cache = findPackagesInModules();
+		Map<String, SimpleSet> cache = findPackagesInModules();
 		if (cache != null)
 			return selectModules(cache.keySet(), limitModules);
 		return Collections.emptyList();

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/ClasspathJrtWithReleaseOption.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/ClasspathJrtWithReleaseOption.java
@@ -133,26 +133,7 @@ public class ClasspathJrtWithReleaseOption extends ClasspathJrt {
 		Map<String, SimpleSet> cache = PackageCache.computeIfAbsent(this.modPathString, key -> {
 			final Map<String, SimpleSet> packagesInModule = new HashMap<>();
 			try {
-				JRTUtil.walkModuleImage(this.jrtFile, this.release, new JRTUtil.JrtFileVisitor<Path>() {
-					SimpleSet packageSet;
-
-					@Override
-					public FileVisitResult visitPackage(Path dir, Path mod, BasicFileAttributes attrs) throws IOException {
-						ClasspathJar.addToPackageSet(this.packageSet, dir.toString(), true);
-						return FileVisitResult.CONTINUE;
-					}
-
-					@Override
-					public FileVisitResult visitModule(Path path, String name) throws IOException {
-						this.packageSet = new SimpleSet(41);
-						this.packageSet.add(""); //$NON-NLS-1$
-						if (name.endsWith("/")) { //$NON-NLS-1$
-							name = name.substring(0, name.length() - 1);
-						}
-						packagesInModule.put(name, this.packageSet);
-						return FileVisitResult.CONTINUE;
-					}
-				}, JRTUtil.NOTIFY_PACKAGES | JRTUtil.NOTIFY_MODULES);
+				JRTUtil.walkModuleImage(this.jrtFile, this.release, new JrtPackageVisitor(packagesInModule), JRTUtil.NOTIFY_PACKAGES | JRTUtil.NOTIFY_MODULES);
 			} catch (IOException e) {
 				Util.log(e, "Failed to init packages for " + this.modPathString); //$NON-NLS-1$
 			}


### PR DESCRIPTION
Follow up on issue #183 findings. Similar static caches that were found
in unsafe code in org.eclipse.jdt.internal.compiler.*batch*.ClasspathJrt
exist in org.eclipse.jdt.internal.core.*builder*.ClasspathJrt in the IDE
related builder code.

Fixed MT init/access of ModulesCache & PackageCache, simplified code around JRT visitors.

See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/242