### PR TITLE
Compilation with --release on Java 11 fails with NPE (#242)

### DIFF
--- a/org.eclipse.jdt.core.tests.builder/src/org/eclipse/jdt/core/tests/builder/BuilderTests11.java
+++ b/org.eclipse.jdt.core.tests.builder/src/org/eclipse/jdt/core/tests/builder/BuilderTests11.java
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ * Copyright (c) 2022, Andrey Loskutov (loskutov@gmx.de) and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Andrey Loskutov (loskutov@gmx.de) - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.core.tests.builder;
+
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.tests.util.AbstractCompilerTest;
+import org.eclipse.jdt.core.tests.util.Util;
+import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
+
+import junit.framework.Test;
+
+/**
+ * Test tries to compile trivial snippet with --release option on Java 11 as host
+ */
+public class BuilderTests11 extends BuilderTests {
+
+	public BuilderTests11(String name) {
+		super(name);
+	}
+
+	public static Test suite() {
+		return AbstractCompilerTest.buildUniqueComplianceTestSuite(BuilderTests11.class, ClassFileConstants.JDK11);
+	}
+
+	public void testBuildWithRelease_1_8() throws JavaModelException, Exception {
+		String compliance = "1.8";
+		runTest(compliance);
+	}
+
+	public void testBuildWithRelease_1_7() throws JavaModelException, Exception {
+		String compliance = "1.7";
+		runTest(compliance);
+	}
+
+	public void testBuildWithRelease_1_6() throws JavaModelException, Exception {
+		String compliance = "1.6";
+		runTest(compliance);
+	}
+
+	// TODO: this test fails in 4.25 M1, probably also before.
+	// Cannot find the class file for java.lang.Object
+	public void XtestBuilderWithRelease_9() throws JavaModelException, Exception {
+		String compliance = "9";
+		runTest(compliance);
+	}
+
+	public void testBuildWithRelease_10() throws JavaModelException, Exception {
+		String compliance = "10";
+		runTest(compliance);
+	}
+
+	public void testBuildWithRelease_11() throws JavaModelException, Exception {
+		String compliance = "11";
+		runTest(compliance);
+	}
+
+	/**
+	 * Test tries to compile trivial snippet with --release option on Java 11 as host
+	 */
+	private void runTest(String compliance) throws JavaModelException {
+		IPath projectPath = env.addProject("BugTest", compliance);
+		env.getJavaProject(projectPath).setOption(JavaCore.COMPILER_RELEASE, JavaCore.ENABLED);
+		env.removePackageFragmentRoot(projectPath, "");
+		IPath src = env.addPackageFragmentRoot(projectPath, "src");
+		env.addExternalJars(projectPath, Util.getJavaClassLibs());
+		env.addClass(src, "bug", "A1",
+				"package bug;\n" +
+						"\n" +
+						"public class A1 {\n" +
+						"\n" +
+				"}\n");
+		fullBuild();
+		expectingNoProblems();
+	}
+}

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/RunAllJava11Tests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/RunAllJava11Tests.java
@@ -16,6 +16,7 @@ package org.eclipse.jdt.core.tests;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
+import org.eclipse.jdt.core.tests.builder.BuilderTests11;
 import org.eclipse.jdt.core.tests.dom.ConverterTestSetup;
 import org.eclipse.jdt.core.tests.model.CompletionTests11;
 import org.eclipse.jdt.core.tests.util.AbstractCompilerTest;
@@ -33,6 +34,7 @@ public class RunAllJava11Tests extends TestCase {
 	public static Class[] getAllTestClasses() {
 		return new Class[] {
 //			JavaSearchBugs11Tests.class,
+			BuilderTests11.class,
 			CompletionTests11.class,
 		};
 	}

--- a/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/util/JRTUtil.java
+++ b/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/util/JRTUtil.java
@@ -446,7 +446,7 @@ class Jdk {
 	}
 
 	static String toJdkHome(File jrt) {
-		String home = null;
+		String home;
 		Path normalized = jrt.toPath().normalize();
 		if (jrt.getName().equals(JRTUtil.JRT_FS_JAR)) {
 			home = normalized.getParent().getParent().toString();

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/ClasspathJrt.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/ClasspathJrt.java
@@ -80,6 +80,9 @@ void setZipFile(String zipFilename) {
  * @return A SimpleSet with the all the package names in the zipFile.
  */
 static Map<String, SimpleSet> findPackagesInModules(final ClasspathJrt jrt) {
+	if (jrt.zipFilename == null) {
+		return Map.of();
+	}
 	Map<String, SimpleSet> cache = PackageCache.computeIfAbsent(jrt.zipFilename, zipFileName -> {
 		final Map<String, SimpleSet> packagesInModule = new HashMap<>();
 		try {
@@ -119,7 +122,11 @@ static final class JrtPackageVisitor implements JRTUtil.JrtFileVisitor<Path> {
 }
 
 public static void loadModules(final ClasspathJrt jrt) {
-	ModulesCache.computeIfAbsent(jrt.getKey(), key -> {
+	String jrtKey = jrt.getKey();
+	if (jrtKey == null) {
+		return;
+	}
+	ModulesCache.computeIfAbsent(jrtKey, key -> {
 		Map<String, IModule> newCache = new HashMap<>();
 		try {
 			final File imageFile = jrt.jrtFile;
@@ -240,6 +247,9 @@ public IModule getModule(char[] moduleName) {
 	return getModule(String.valueOf(moduleName));
 }
 public IModule getModule(String moduleName) {
+	if (!hasModule()) {
+		return null;
+	}
 	Map<String, IModule> modules = ModulesCache.get(getKey());
 	if (modules != null) {
 		return modules.get(moduleName);

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/ClasspathJrtWithReleaseOption.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/ClasspathJrtWithReleaseOption.java
@@ -130,6 +130,9 @@ public class ClasspathJrtWithReleaseOption extends ClasspathJrt {
 		if (this.fs == null || !this.ctSym.isJRE12Plus()) {
 			return ClasspathJrt.findPackagesInModules(this);
 		}
+		if (this.modPathString == null) {
+			return Map.of();
+		}
 		Map<String, SimpleSet> cache = PackageCache.computeIfAbsent(this.modPathString, key -> {
 			final Map<String, SimpleSet> packagesInModule = new HashMap<>();
 			try {


### PR DESCRIPTION
ClasspathJrtWithReleaseOption.modPathString is not set on Java 11 if
compiling with --release, so the code that tries to init modules cache
fails with NPE.

See init code in ClasspathJrtWithReleaseOption.initialize().

The problem resulted from the fact that HashMap allowed to use null keys
and all ClasspathJrtWithReleaseOption instances created on Java 11 JDK
for release < 11 were using "null" key.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/242