### PR TITLE
NPE in MatchLocator.createHandle (#247)

### DIFF
--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/MatchLocator.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/MatchLocator.java
@@ -525,7 +525,14 @@ protected IJavaElement createHandle(AbstractMethodDeclaration method, IJavaEleme
 			for (int i = 0; i < argCount; i++) {
 				char[] typeName = null;
 				if (i == 0 && firstIsSynthetic) {
-					typeName = type.getDeclaringType().getFullyQualifiedName().toCharArray();
+					IType declaringType = type.getDeclaringType();
+					if(declaringType != null) {
+						typeName = declaringType.getFullyQualifiedName().toCharArray();
+					} else {
+						if (BasicSearchEngine.VERBOSE) {
+							System.out.println("Null declaring type for " + type); //$NON-NLS-1$
+						}
+					}
 				} else if (arguments != null) {
 					TypeReference typeRef = arguments[firstIsSynthetic ? i - 1 : i].type;
 					typeName = CharOperation.concatWith(typeRef.getTypeName(), '.');


### PR DESCRIPTION
Searching of constructor references with "*" as name runs into NPE if
the source code is attached to guava.

The JDT fails to properly create search result for a constructor
reference for "new MapEntry" of a MapEntry class defined inside an
anonymous class inside a member like below:

Iterator<Entry<K, V>> entryIterator() {
  return new Itr<Entry<K, V>>() { // <- anonymous class
    @Override
    Entry<K, V> output(BiEntry<K, V> entry) {
      return new MapEntry(entry); // <- reference to constuctor
    }

    class MapEntry extends AbstractMapEntry<K, V> {
      BiEntry<K, V> delegate;

      MapEntry(BiEntry<K, V> entry) {  // <- constructor
        this.delegate = entry;
      }

It looks like for com.google.common.collect.HashBiMap$1$MapEntry.class
anonymous parent type HashBiMap$1 can't be found in JDT model.

According to javadoc, type.getDeclaringType() can be null.
Added null check to workaround JDT type hierarchy bug.

See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/247