### PR TITLE
Change jenkins config to run tests at Java 18 (#253)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,9 +31,9 @@ pipeline {
 					# export MAVEN_OPTS="-Xmx2G"
 					
 					mvn -U clean verify --batch-mode --fail-at-end -Dmaven.repo.local=$WORKSPACE/.m2/repository \
-					-Pbuild-individual-bundles -Ptest-on-javase-17 -Pbree-libs -Papi-check \
+					-Pbuild-individual-bundles -Ptest-on-javase-18 -Pbree-libs -Papi-check \
 					-Djava.io.tmpdir=$WORKSPACE/tmp -Dproject.build.sourceEncoding=UTF-8 \
-					-Dtycho.surefire.argLine="--add-modules ALL-SYSTEM -Dcompliance=1.8,11,17 -Djdt.performance.asserts=disabled"
+					-Dtycho.surefire.argLine="--add-modules ALL-SYSTEM -Dcompliance=1.8,11,17,18 -Djdt.performance.asserts=disabled"
 					"""
 				}
 			}


### PR DESCRIPTION
* Change jenkins config to mention -Dcompliance=1.8,11,17,18

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
