### PR TITLE
Fix type hierarchy for cyclic static imports #269

### DIFF
--- a/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/lookup/CompilationUnitScope.java
+++ b/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/lookup/CompilationUnitScope.java
@@ -25,6 +25,7 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.internal.compiler.ast.*;
@@ -240,8 +241,34 @@ void checkAndSetImports() {
 	resolvedImports[0] = getDefaultImports()[0];
 	int index = 1;
 
+	Predicate<ImportReference> isStaticImport = i -> i.isStatic();
+	Predicate<ImportReference> isNotStaticImport = Predicate.not(isStaticImport);
+
+	// GitHub 269: resolve non-static imports first, so that cyclic static imports can be resolved correctly
+	index = resolveImports(numberOfStatements, resolvedImports, index, isNotStaticImport);
+
+	// non-static imports are resolved now, "store" them before continuing with static imports
+	ImportBinding[] temp = new ImportBinding[index];
+	System.arraycopy(resolvedImports, 0, temp, 0, index);
+	this.imports = temp;
+
+	// GitHub 269: non-static imports are resolved, now we can resolve static imports
+	index = resolveImports(numberOfStatements, resolvedImports, index, isStaticImport);
+
+	// shrink resolvedImports... only happens if an error was reported
+	if (resolvedImports.length > index) {
+		System.arraycopy(resolvedImports, 0, resolvedImports = new ImportBinding[index], 0, index);
+	}
+	this.imports = resolvedImports;
+}
+
+private int resolveImports(int numberOfStatements, ImportBinding[] resolvedImports, int index, Predicate<ImportReference> filter) {
 	nextImport : for (int i = 0; i < numberOfStatements; i++) {
 		ImportReference importReference = this.referenceContext.imports[i];
+		if (!filter.test(importReference)) {
+			continue;
+		}
+
 		char[][] compoundName = importReference.tokens;
 
 		// skip duplicates or imports of the current package
@@ -269,12 +296,7 @@ void checkAndSetImports() {
 			resolvedImports[index++] = new ImportBinding(compoundName, false, null, importReference);
 		}
 	}
-
-	// shrink resolvedImports... only happens if an error was reported
-	if (resolvedImports.length > index) {
-		System.arraycopy(resolvedImports, 0, resolvedImports = new ImportBinding[index], 0, index);
-	}
-	this.imports = resolvedImports;
+	return index;
 }
 
 /**


### PR DESCRIPTION
If two classes import each other with static imports, computing a type
hierarchy can run into problems. In particular:

1. CompilationUnitScope.checkAndSetImports() will try to resolve the
static import in the 1st type.
2. checkAndSetImports() for the 2nd type will try to resolve the static
import.
3. This will result in using the (currently) incomplete scope of the 1st
type.
4. Super types (interfaces in the case of #269) are not resolved
correctly, since the bindings of the 1st type are not yet fully
computed.

This change adjusts CompilationUnitScope.checkAndSetImports() to first
resolve non-static imports and then resolve static imports. This ensures
the statically imported types are resolved as correctly.

Fixes: https://github.com/eclipse-jdt/eclipse.jdt.core/issues/269

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
