### PR TITLE
Check if file is a regular file before constructing a ClasspathJar

### DIFF
--- a/org.eclipse.jdt.core/batch/org/eclipse/jdt/internal/compiler/batch/ClasspathJar.java
+++ b/org.eclipse.jdt.core/batch/org/eclipse/jdt/internal/compiler/batch/ClasspathJar.java
@@ -88,7 +88,10 @@ public List<Classpath> fetchLinkedJars(FileSystem.ClasspathSectionProblemReporte
 				int lastSeparator = directoryPath.lastIndexOf(File.separatorChar);
 				directoryPath = directoryPath.substring(0, lastSeparator + 1); // potentially empty (see bug 214731)
 				while (calledFilesIterator.hasNext()) {
-					result.add(new ClasspathJar(new File(directoryPath + (String) calledFilesIterator.next()), this.closeZipFileAtEnd, this.accessRuleSet, this.destinationPath));
+					File linkedFile = new File(directoryPath + (String) calledFilesIterator.next());
+					if (linkedFile.isFile()) {
+						result.add(new ClasspathJar(linkedFile, this.closeZipFileAtEnd, this.accessRuleSet, this.destinationPath));
+					}
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/batch/org/eclipse/jdt/internal/compiler/batch/FileSystem.java
+++ b/org.eclipse.jdt.core/batch/org/eclipse/jdt/internal/compiler/batch/FileSystem.java
@@ -340,7 +340,7 @@ public static Classpath getClasspath(String classpathName, String encoding,
 						}
 						JRT_CLASSPATH_CACHE.put(file, result);
 					}
-				} else {
+				} else if (file.isFile()){
 					result =
 							(release == null) ?
 									new ClasspathJar(file, true, accessRuleSet, null) :


### PR DESCRIPTION
Fix https://github.com/eclipse-jdt/eclipse.jdt.core/issues/261

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
Check before constructing a ClasspathJar that the file points to a regular file

## How to test
Run the PDE build, there are some exceptions that complain about missing folders/jar files

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
