### PR TITLE
Investigate if this.scanner.previewEnabled should be removed in

### DIFF
--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionParser.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionParser.java
@@ -4242,7 +4242,7 @@ protected void consumeToken(int token) {
 			case TokenNameIdentifier:
 				if (this.inReferenceExpression)
 					break;
-				if (this.scanner.previewEnabled && isInsideSwitch() && checkYieldKeyword()) {
+				if (isInsideSwitch() && checkYieldKeyword()) {
 					pushOnElementStack(K_YIELD_KEYWORD);
 					// Take the short cut here.
 					// Instead of injecting the TokenNameRestrictedIdentifierYield, totally ignore it


### PR DESCRIPTION
CompletionParser for yield
fixes #254

## What it does
Removes preview check for yield

## How to test
Ensure all tests pass

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
