### PR TITLE
Prevent AIOOBE in ProblemReporter.invalidType() #286

### DIFF
--- a/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
+++ b/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
@@ -4912,7 +4912,9 @@ public void invalidType(ASTNode location, TypeBinding type) {
 		if (isRecoveredName(ref.tokens)) return;
 		if (type instanceof ReferenceBinding) {
 			char[][] name = ((ReferenceBinding) type).compoundName;
-			end = (int) ref.sourcePositions[name.length - 1];
+			if (name.length <= ref.sourcePositions.length) {
+				end = (int) ref.sourcePositions[name.length - 1];
+			}
 		}
 	} else if (location instanceof ArrayQualifiedTypeReference) {
 		ArrayQualifiedTypeReference arrayQualifiedTypeReference = (ArrayQualifiedTypeReference) location;
@@ -4920,7 +4922,9 @@ public void invalidType(ASTNode location, TypeBinding type) {
 		TypeBinding leafType = type.leafComponentType();
 		if (leafType instanceof ReferenceBinding) {
 			char[][] name = ((ReferenceBinding) leafType).compoundName; // problem type will tell how much got resolved
-			end = (int) arrayQualifiedTypeReference.sourcePositions[name.length-1];
+			if (name.length <= arrayQualifiedTypeReference.sourcePositions.length) {
+				end = (int) arrayQualifiedTypeReference.sourcePositions[name.length-1];
+			}
 		} else {
 			long[] positions = arrayQualifiedTypeReference.sourcePositions;
 			end = (int) positions[positions.length - 1];


### PR DESCRIPTION
This change adds index checks for ParameterizedQualifiedTypeReference
and ArrayQualifiedTypeReference in ProblemReporter.invalidType(),
similar to the existing index check for QualifiedTypeReference in the
same method.

Fixes: #286

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
