### PR TITLE
Use ToolFactory.createScanner() with source compliance set if possible

### DIFF
--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/NodeFinder.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/NodeFinder.java
@@ -14,8 +14,10 @@
 package org.eclipse.jdt.core.dom;
 
 import org.eclipse.jdt.core.IBuffer;
+import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.ISourceRange;
 import org.eclipse.jdt.core.ITypeRoot;
+import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.ToolFactory;
 import org.eclipse.jdt.core.compiler.IScanner;
@@ -148,7 +150,15 @@ public final class NodeFinder {
 		if (start <= nodeStart && ((nodeStart + result.getLength()) <= (start + length))) {
 			IBuffer buffer= source.getBuffer();
 			if (buffer != null) {
-				IScanner scanner= ToolFactory.createScanner(false, false, false, false);
+				IScanner scanner;
+		        IJavaProject project = source.getJavaProject();
+		        if (project != null) {
+		            String sourceLevel = project.getOption(JavaCore.COMPILER_SOURCE, true);
+		            String complianceLevel = project.getOption(JavaCore.COMPILER_COMPLIANCE, true);
+		            scanner = ToolFactory.createScanner(false, false, false, sourceLevel, complianceLevel);
+		        } else {
+		        	scanner= ToolFactory.createScanner(false, false, false, false);
+		        }
 				try {
 					scanner.setSource(buffer.getText(start, length).toCharArray());
 					int token= scanner.getNextToken();

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/Member.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/Member.java
@@ -313,7 +313,15 @@ public ISourceRange getJavadocRange() throws JavaModelException {
 	final int start= range.getOffset();
 	final int length= range.getLength();
 	if (length > 0 && buf.getChar(start) == '/') {
-		IScanner scanner= ToolFactory.createScanner(true, false, false, false);
+		IScanner scanner;
+		IJavaProject project = getJavaProject();
+        if (project != null) {
+            String sourceLevel = project.getOption(JavaCore.COMPILER_SOURCE, true);
+            String complianceLevel = project.getOption(JavaCore.COMPILER_COMPLIANCE, true);
+            scanner = ToolFactory.createScanner(true, false, false, sourceLevel, complianceLevel);
+        } else {
+        	scanner= ToolFactory.createScanner(true, false, false, false);
+        }
 		try {
 			scanner.setSource(buf.getText(start, length).toCharArray());
 			int docOffset= -1;


### PR DESCRIPTION
To avoid InvalidInputException if the source code contains elements not
covered by Java 1.3 JLS, specify proper source/target arguments while
creating scanner.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/292