### PR TITLE
Issue 155 / proposal 1

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/CodeStream.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/CodeStream.java
@@ -2964,7 +2964,7 @@ public void generateSyntheticBodyForDeserializeLambda(SyntheticMethodBinding met
 			invoke(Opcodes.OPC_invokevirtual, 1, 1, ConstantPool.JavaLangInvokeSerializedLambdaConstantPoolName,
 					ConstantPool.GetImplMethodSignature, ConstantPool.GetImplMethodSignatureSignature,
 					getPopularBinding(ConstantPool.JavaLangStringConstantPoolName));
-			ldc(new String(mb.signature())); // e.g. "(I)I"
+			ldc(new String(mb.original().signature())); // e.g. "(I)I"
 			invokeObjectEquals();
 			ifeq(nextOne);
 

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SerializableLambdaTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SerializableLambdaTest.java
@@ -2306,6 +2306,55 @@ public class SerializableLambdaTest extends AbstractRegressionTest {
 		String data = printLambdaMethods(OUTPUT_DIR + File.separator + "OuterClass.class");
 		checkExpected(expectedOutput,data);
 	}
+	public void testbugGH155() {
+		// before resolution, $deserializeLambda$ expects java.lang.Object return type
+		// while SerializedLambda advertises java.lang.Comparable return type
+		// deserialization fails as $deserializeLambda$ cannot find appropriate deserializer.
+		this.runConformTest(new String[] {
+				"TestSerializableLambda.java",
+				"import java.io.*;\n"+
+				"import java.util.function.Function;\n"+
+				"\n"+
+				"public class TestSerializableLambda {\n"+
+				"	private static Object serializeDeserialize(Object obj) throws IOException, ClassNotFoundException {\n" +
+				"		try (\n" +
+				"			ByteArrayOutputStream buffer = new ByteArrayOutputStream(); //\n" +
+				"			ObjectOutputStream output = new ObjectOutputStream(buffer)) {\n" +
+				"			output.writeObject(obj);\n" +
+				"			try (ObjectInputStream input = new ObjectInputStream(new ByteArrayInputStream(buffer.toByteArray()))) {\n" +
+				"				return input.readObject();\n" +
+				"			}\n" +
+				"		}\n" +
+				"	}\n" +
+				"	public static void main(String[] args) {\n" +
+				"		try {\n" +
+				"			SerializableHolder<LambdaProvider<Long>> r = new SerializableHolder<>();\n" +
+				"			serializeDeserialize(r);\n" +
+				"			System.out.println(\"OK\");\n" +
+				"		} catch (ClassNotFoundException | IOException e) {\n" +
+				"			// TODO Auto-generated catch block\n" +
+				"			e.printStackTrace();\n" +
+				"		}\n" +
+				"	}\n" +
+				"	\n"+
+				"	public static class SerializableHolder<E extends LambdaProvider<?>> implements Serializable {\n"+
+				"		private static final long serialVersionUID = -2775595600924717218L;\n"+
+				"		private Function<E, ?> idExpression;\n"+
+				"\n"+
+				"		public SerializableHolder() {\n"+
+				"			this.idExpression = (Serializable & Function<E, ?>) LambdaProvider::getId;\n"+
+				"		}\n"+
+				"	}\n"+
+				"\n"+
+				"	public static class LambdaProvider<I extends Comparable<I>> {\n"+
+				"		public I getId() {\n"+
+				"			return null;\n"+
+				"		}\n"+
+				"	}\n"+
+				"}"
+				},
+				"OK");
+	}
 	// ---
 
 	private void checkExpected(String expected, String actual) {


### PR DESCRIPTION
Please see #155 
## What it does
This is a testcase and a fix to handle a deserialization error where `$deserializeLambda$` and `SerializedLambda` informations are inconsistent. This proposal fixes the issue by modifying expected return type in `$deserializeLambda$`.

## How to test
This PR includes a test case that is fixed by the proposal. All SerializableLambdaTest are still successful.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
