### PR TITLE
Bug 543842 - [1.8][inference] passing conditionally selected method to map

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ConditionalExpressionTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ConditionalExpressionTest.java
@@ -254,11 +254,6 @@ public class ConditionalExpressionTest extends AbstractRegressionTest {
 				"----------\n" +
 				"1. ERROR in X.java (at line 9)\n" +
 				"	foo(false ? (a,b)->a+b :new StringCatenation());\n" +
-				"	^^^\n" +
-				"The method foo(BinaryOperation<Integer>) in the type X is not applicable for the arguments ((false ? (<no type> a, <no type> b) -> (a + b) : new StringCatenation()))\n" +
-				"----------\n" +
-				"2. ERROR in X.java (at line 9)\n" +
-				"	foo(false ? (a,b)->a+b :new StringCatenation());\n" +
 				"	                        ^^^^^^^^^^^^^^^^^^^^^^\n" +
 				"Type mismatch: cannot convert from StringCatenation to BinaryOperation<Integer>\n" +
 				"----------\n"
@@ -288,11 +283,6 @@ public class ConditionalExpressionTest extends AbstractRegressionTest {
 				},
 				"----------\n" +
 				"1. ERROR in X.java (at line 9)\n" +
-				"	foo(false ? new StringCatenation() : (a,b)->a+b);\n" +
-				"	^^^\n" +
-				"The method foo(BinaryOperation<Integer>) in the type X is not applicable for the arguments ((false ? new StringCatenation() : (<no type> a, <no type> b) -> (a + b)))\n" +
-				"----------\n" +
-				"2. ERROR in X.java (at line 9)\n" +
 				"	foo(false ? new StringCatenation() : (a,b)->a+b);\n" +
 				"	            ^^^^^^^^^^^^^^^^^^^^^^\n" +
 				"Type mismatch: cannot convert from StringCatenation to BinaryOperation<Integer>\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_1_8.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_1_8.java
@@ -10361,4 +10361,22 @@ public void testBug508834_comment0() {
 				"}\n"
 			});
 	}
+	public void testBug543842() {
+		runConformTest(
+			new String[] {
+				"X.java",
+				"import java.math.BigDecimal;\n" +
+				"import java.util.Optional;\n" +
+				"import java.util.function.Function;\n" +
+				"\n" +
+				"public class X {\n" +
+				"	void test() {\n" +
+				"		BigDecimal b =\n" +
+				"		Optional.ofNullable(BigDecimal.ZERO)\n" +
+				"			.map((1 == 2) ? BigDecimal::negate : java.util.function.Function.identity())\n" +
+				"			.orElse(BigDecimal.ZERO);\n" +
+				"	}\n" +
+				"}\n"
+			});
+	}
 }

--- a/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/ast/Expression.java
+++ b/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/ast/Expression.java
@@ -1365,7 +1365,9 @@ public Expression [] getPolyExpressions() {
 }
 
 public boolean isPotentiallyCompatibleWith(TypeBinding targetType, Scope scope) {
-	return isCompatibleWith(targetType, scope); // for all but functional expressions, potential compatibility is the same as compatibility.
+	// A class instance creation expression, a method invocation expression, or an
+	// expression of a standalone form (§15.2) is potentially compatible with any type.
+	return true;
 }
 
 protected Constant optimizedNullComparisonConstant() {


### PR DESCRIPTION
Implement last bullet of JLS 15.12.2.1

Change in ConditionalExpressionTest demonstrates that error messages are
now better aligned with javac

See https://bugs.eclipse.org/bugs/show_bug.cgi?id=543842