### PR TITLE
Bug 380786 - [compiler][null] missed "Potential Nullpointer Access" on mutable method argument

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullReferenceTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullReferenceTest.java
@@ -18485,4 +18485,43 @@ public void testBug561280() {
 			"}\n"
 		});
 }
+public void testBug380786() {
+	if (this.complianceLevel < ClassFileConstants.JDK1_5)
+		return; // uses foreach
+	runNegativeTest(
+		new String[] {
+			"PNA.java",
+			"public class PNA {\n" +
+			"  void missedPNA(String s) {\n" +
+			"    if (s != null)\n" +
+			"      s = \"1,2\";\n" +
+			"    final String[] sa = s.split(\",\");\n" +
+			"    for (final String ss : sa)\n" +
+			"      System.out.println(ss);\n" +
+			"  }\n" +
+			"\n" +
+			"  void detectedPNA(final String ps) {\n" +
+			"    String s = ps;\n" +
+			"    if (s != null)\n" +
+			"      s = \"1,2\";\n" +
+			"    final String[] sa = s.split(\",\");\n" +
+			"    for (final String ss : sa)\n" +
+			"      System.out.println(ss);\n" +
+			"  }\n" +
+			"  \n" +
+			"}\n"
+		},
+		"----------\n" +
+		"1. ERROR in PNA.java (at line 5)\n" +
+		"	final String[] sa = s.split(\",\");\n" +
+		"	                    ^\n" +
+		"Potential null pointer access: The variable s may be null at this location\n" +
+		"----------\n" +
+		"2. ERROR in PNA.java (at line 14)\n" +
+		"	final String[] sa = s.split(\",\");\n" +
+		"	                    ^\n" +
+		"Potential null pointer access: The variable s may be null at this location\n" +
+		"----------\n"
+			);
+}
 }

--- a/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/ast/AbstractMethodDeclaration.java
+++ b/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/ast/AbstractMethodDeclaration.java
@@ -225,9 +225,8 @@ public abstract class AbstractMethodDeclaration
 						flowInfo.markAsDefinitelyNonNull(methodArguments[i].binding);
 					else if (tagBits == TagBits.AnnotationNullable)
 						flowInfo.markPotentiallyNullBit(methodArguments[i].binding);
-					else if (methodBinding.parameters[i].isFreeTypeVariable()) {
+					else if (methodBinding.parameters[i].isFreeTypeVariable())
 						flowInfo.markNullStatus(methodArguments[i].binding, FlowInfo.FREE_TYPEVARIABLE);
-					}
 				} else {
 					if (methodBinding.parameterNonNullness != null) {
 						// leverage null-info from parameter annotations:
@@ -240,6 +239,8 @@ public abstract class AbstractMethodDeclaration
 						}
 					}
 				}
+				if (!flowInfo.hasNullInfoFor(methodArguments[i].binding))
+					flowInfo.markNullStatus(methodArguments[i].binding, FlowInfo.UNKNOWN); // ensure nullstatus is initialized
 				// tag parameters as being set:
 				flowInfo.markAsDefinitelyAssigned(methodArguments[i].binding);
 			}


### PR DESCRIPTION
Initialize method arguments as unknown nullness by default

See https://bugs.eclipse.org/bugs/show_bug.cgi?id=380786