### PR TITLE
Improve indexing performance for .jar in classpath.

### DIFF
--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/SourceIndexer.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/SourceIndexer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -162,7 +162,6 @@ public class SourceIndexer extends AbstractIndexer implements ITypeRequestor, Su
 			this.basicParser.reportOnlyOneSyntaxError = true;
 			this.basicParser.scanner.taskTags = null;
 			this.cud = this.basicParser.parse(this.compilationUnit, new CompilationResult(this.compilationUnit, 0, 0, this.options.maxProblemsPerUnit));
-			JavaModelManager.getJavaModelManager().cacheZipFiles(this); // use model only for caching
 			// Use a non model name environment to avoid locks, monitors and such.
 			INameEnvironment nameEnvironment = new JavaSearchNameEnvironment(javaProject, JavaModelManager.getJavaModelManager().getWorkingCopies(DefaultWorkingCopyOwner.PRIMARY, true/*add primary WCs*/));
 			this.lookupEnvironment = new LookupEnvironment(this, this.options, problemReporter, nameEnvironment);
@@ -175,8 +174,6 @@ public class SourceIndexer extends AbstractIndexer implements ITypeRequestor, Su
 			if (JobManager.VERBOSE) {
 				e.printStackTrace();
 			}
-		} finally {
-			JavaModelManager.getJavaModelManager().flushZipFiles(this);
 		}
 	}
 


### PR DESCRIPTION
Reuse open zip files while indexing until indexing is finished.

When multiple .java files are indexed which depend on the same .jar
libraries in the classpath then it is faster to only close those files
after indexing is done.

- I have thoroughly tested my changes
- The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
