### PR TITLE
Bug 443576 - False positive fall-through case warning from dead code

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2019 IBM Corporation and others.
+ * Copyright (c) 2005, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -3185,6 +3185,89 @@ public void testBug576093b() {
 				+ "}",
 			},
 			"Success");
+}
+public void testBug443576_1() {
+	if (this.complianceLevel < ClassFileConstants.JDK11) {
+		return;
+	}
+	Map options = getCompilerOptions();
+	options.put(CompilerOptions.OPTION_ReportFallthroughCase, CompilerOptions.ERROR);
+	this.runNegativeTest(new String[] {
+		"X.java",
+		"public class X {\n"
+		+ "    public enum E { A, B; }\n"
+		+ "    public String f(E e) {\n"
+		+ "        switch (e) {\n"
+		+ "            case A: return \"a\";\n"
+		+ "                break; //<-- ERROR: Unreachable code\n"
+		+ "            case B: return \"b\";   //<-- WARNING: Switch case may be entered by falling through previous case\n"
+		+ "                break; //<-- ERROR: Unreachable code\n"
+		+ "            default: return \"?\";  //<-- WARNING: Switch case may be entered by falling through previous case\n"
+		+ "                break; //<-- ERROR: Unreachable code\n"
+		+ "        }\n"
+		+ "    }  \n"
+		+ "}",
+	},
+		"----------\n" +
+		"1. ERROR in X.java (at line 6)\n" +
+		"	break; //<-- ERROR: Unreachable code\n" +
+		"	^^^^^^\n" +
+		"Unreachable code\n" +
+		"----------\n" +
+		"2. ERROR in X.java (at line 8)\n" +
+		"	break; //<-- ERROR: Unreachable code\n" +
+		"	^^^^^^\n" +
+		"Unreachable code\n" +
+		"----------\n" +
+		"3. ERROR in X.java (at line 10)\n" +
+		"	break; //<-- ERROR: Unreachable code\n" +
+		"	^^^^^^\n" +
+		"Unreachable code\n" +
+		"----------\n",
+	null,
+	true,
+	options);
+}
+// Same as above, but keep swap the return and break statements
+public void testBug443576_2() {
+	if (this.complianceLevel < ClassFileConstants.JDK11) {
+		return;
+	}
+	Map options = getCompilerOptions();
+	options.put(CompilerOptions.OPTION_ReportFallthroughCase, CompilerOptions.ERROR);
+	this.runNegativeTest(new String[] {
+		"X.java",
+		"public class X {\n"
+		+ "    public enum E { A, B; }\n"
+		+ "    public String f(E e) {\n"
+		+ "        switch (e) {\n"
+		+ "            case A: break;\n"
+		+ "                return \"a\"; //<-- ERROR: Unreachable code\n"
+		+ "            default: return \"?\";  //<-- WARNING: Switch case may be entered by falling through previous case\n"
+		+ "                break; //<-- ERROR: Unreachable code\n"
+		+ "        }\n"
+		+ "    }  \n"
+		+ "}",
+	},
+			"----------\n" +
+			"1. ERROR in X.java (at line 3)\n" +
+			"	public String f(E e) {\n" +
+			"	              ^^^^^^\n" +
+			"This method must return a result of type String\n" +
+			"----------\n" +
+			"2. ERROR in X.java (at line 6)\n" +
+			"	return \"a\"; //<-- ERROR: Unreachable code\n" +
+			"	^^^^^^^^^^^\n" +
+			"Unreachable code\n" +
+			"----------\n" +
+			"3. ERROR in X.java (at line 8)\n" +
+			"	break; //<-- ERROR: Unreachable code\n" +
+			"	^^^^^^\n" +
+			"Unreachable code\n" +
+			"----------\n",
+	null,
+	true,
+	options);
 }
 public static Class testClass() {
 	return SwitchTest.class;

--- a/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
+++ b/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
@@ -173,7 +173,7 @@ public class SwitchStatement extends Expression {
 					if ((caseIndex < this.caseCount) && (statement == this.cases[caseIndex])) { // statement is a case
 						this.scope.enclosingCase = this.cases[caseIndex]; // record entering in a switch case block
 						caseIndex++;
-						if (fallThroughState == FALLTHROUGH) {
+						if (fallThroughState == FALLTHROUGH && complaintLevel <= NOT_COMPLAINED) {
 							if (((CaseStatement) statement).containsPatternVariable())
 								this.scope.problemReporter().IllegalFallThroughToPattern(this.scope.enclosingCase);
 							else if ((statement.bits & ASTNode.DocumentedFallthrough) == 0) { // the case is not fall-through protected by a line comment
@@ -186,6 +186,7 @@ public class SwitchStatement extends Expression {
 					} else if (statement == this.defaultCase) { // statement is the default case
 						this.scope.enclosingCase = this.defaultCase; // record entering in a switch case block
 						if (fallThroughState == FALLTHROUGH
+								&& complaintLevel <= NOT_COMPLAINED
 								&& (statement.bits & ASTNode.DocumentedFallthrough) == 0) {
 							this.scope.problemReporter().possibleFallThroughCase(this.scope.enclosingCase);
 						}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
This is copied from the original bug 443576:

Initial investigation shows it's not really a fake reachable but marked as COMPLAINED_UNREACHABLE. So, I suppose to cover all the cases, we can omit the fall-through warning if the complaint level is > NOT_COMPLAINED.

## How to test
Try to compile the code given in the [description](https://bugs.eclipse.org/bugs/show_bug.cgi?id=443576#c0). The compiler should not report the "case fall-through" errors.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
