### PR TITLE
Avoid NPE if we are asked to cache non-binary type

### DIFF
--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/MatchLocator.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/MatchLocator.java
@@ -449,6 +449,9 @@ protected BinaryTypeBinding cacheBinaryType(IType type, IBinaryType binaryType) 
 		cacheBinaryType(enclosingType, null); // cache enclosing types first, so that binary type can be found in lookup enviroment
 	if (binaryType == null) {
 		ClassFile classFile = (ClassFile) type.getClassFile();
+		if (classFile == null) {
+			return null;
+		}
 		try {
 			binaryType = getBinaryInfo(classFile, classFile.resource());
 		} catch (CoreException e) {


### PR DESCRIPTION
The callers already check for null return, and method comment explains
exactly that case too.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/142