### PR TITLE
Increase timeout for Jenkins, from 60 to 90 minutes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 pipeline {
 	options {
-		timeout(time: 60, unit: 'MINUTES')
+		timeout(time: 90, unit: 'MINUTES')
 		buildDiscarder(logRotator(numToKeepStr:'15'))
 		disableConcurrentBuilds(abortPrevious: true)
 		timestamps()


### PR DESCRIPTION
Otherwise tests can't finish execution and are aborted.