### PR TITLE
Implement CompilationUnit.hashCode to fix #319

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/CompilationUnit.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/CompilationUnit.java
@@ -523,6 +523,12 @@ public boolean equals(Object obj) {
 	CompilationUnit other = (CompilationUnit)obj;
 	return this.owner.equals(other.owner) && super.equals(obj);
 }
+
+@Override
+public int hashCode() {
+	return Util.combineHashCodes(super.hashCode(), this.owner.hashCode());
+}
+
 /**
  * @see ICompilationUnit#findElements(IJavaElement)
  */


### PR DESCRIPTION
To avoid hash collisions between JavaElements of different
WorkingCopyOwner in JavaModelCache.childrenCache.
Should improve slow Organize imports.
