### PR TITLE
Bug 501652 - [1.8][impl] inconsistent call to ITypeAnnotationWalker.toSupertype(..)

### DIFF
--- a/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/lookup/BinaryTypeBinding.java
+++ b/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/lookup/BinaryTypeBinding.java
@@ -530,7 +530,7 @@ void cachePartsFrom(IBinaryType binaryType, boolean needFieldsAndMethods) {
 					this.superInterfaces = new ReferenceBinding[size];
 					for (short i = 0; i < size; i++)
 						// attempt to find each superinterface if it exists in the cache (otherwise - resolve it when requested)
-						this.superInterfaces[i] = this.environment.getTypeFromConstantPoolName(interfaceNames[i], 0, -1, false, missingTypeNames, toplevelWalker.toSupertype(i, superclassName));
+						this.superInterfaces[i] = this.environment.getTypeFromConstantPoolName(interfaceNames[i], 0, -1, false, missingTypeNames, toplevelWalker.toSupertype(i, interfaceNames[i]));
 					this.tagBits |= TagBits.HasUnresolvedSuperinterfaces;
 				}
 			}


### PR DESCRIPTION
From https://bugs.eclipse.org/501652

## What it does
Pass the correct type name (super interface not super class)

## How to test
Actually this cannot be tested, because
* "normal" type annotation walkers rely only on the `short index` argument
* only DispatchingAnnotationWalker uses the `char[] superTypeSignature` signature to weave in information **from eea**
  * eea - being specialized for null annotations - use super type information only for type arguments, since it doesn't make sense to say `implements @Nullable IFoo`.
  * since the super type must have type arguments for eea to make sense here,`BTB.cachePartsFrom()` will find non-null `binaryType.getGenericSignature()`
* To challenge the wrongly passed type name, these two would have to coincide which cannot happen at the same time:
  * the super type must be generic to host type argument annotations in eea
  * the super type must be non-generic for `BTB.cachePartsFrom()` to enter the code branch in question.

Still, cleaning up the code makes sense simply to avoid future confusion :)
