### PR TITLE
Adding new JavaDocTextElement after carving out AbstractTextElement

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTStructuralPropertyTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTStructuralPropertyTest.java
@@ -372,7 +372,7 @@ public class ASTStructuralPropertyTest extends org.eclipse.jdt.core.tests.junit.
 				// oops - guess that's not valid
 			}
 		}
-		assertEquals("Wrong last known type", 111, hi); // last known one
+		assertEquals("Wrong last known type", 112, hi); // last known one
 		assertEquals("Wrong number of distinct types",  hi, classes.size()); // all classes are distinct
 	}
 }

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTTest.java
@@ -9499,7 +9499,8 @@ public class ASTTest extends org.eclipse.jdt.core.tests.junit.extension.TestCase
 			ASTNode.NULL_PATTERN,
 			ASTNode.CASE_DEFAULT_EXPRESSION,
 			ASTNode.TAG_PROPERTY,
-			ASTNode.JAVADOC_REGION
+			ASTNode.JAVADOC_REGION,
+			ASTNode.JAVADOC_TEXT_ELEMENT
 		};
 
 		// assert that nodeType values are correct:

--- a/org.eclipse.jdt.core/.settings/.api_filters
+++ b/org.eclipse.jdt.core/.settings/.api_filters
@@ -22,6 +22,20 @@
             </message_arguments>
         </filter>
     </resource>
+    <resource path="dom/org/eclipse/jdt/core/dom/AbstractTextElement.java" type="org.eclipse.jdt.core.dom.AbstractTextElement">
+        <filter id="576725006">
+            <message_arguments>
+                <message_argument value="IDocElement"/>
+                <message_argument value="AbstractTextElement"/>
+            </message_arguments>
+        </filter>
+        <filter id="576778288">
+            <message_arguments>
+                <message_argument value="ASTNode"/>
+                <message_argument value="AbstractTextElement"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="dom/org/eclipse/jdt/core/dom/Annotation.java" type="org.eclipse.jdt.core.dom.Annotation">
         <filter id="576725006">
             <message_arguments>
@@ -197,14 +211,6 @@
             <message_arguments>
                 <message_argument value="ASTNode"/>
                 <message_argument value="TagProperty"/>
-            </message_arguments>
-        </filter>
-    </resource>
-    <resource path="dom/org/eclipse/jdt/core/dom/TextElement.java" type="org.eclipse.jdt.core.dom.TextElement">
-        <filter id="576725006">
-            <message_arguments>
-                <message_argument value="IDocElement"/>
-                <message_argument value="TextElement"/>
             </message_arguments>
         </filter>
     </resource>

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/AST.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/AST.java
@@ -2109,6 +2109,22 @@ public final class AST {
 	}
 
 	/**
+	 * Creates and returns a new text element node.
+	 * Initially the new node has an empty text string.
+	 * <p>
+	 * Note that this node type is used only inside doc comments
+	 * ({@link Javadoc Javadoc}).
+	 * </p>
+	 *
+	 * @return a new unparented JavaDoc text element node
+	 * @since 3.31
+	 */
+	public JavaDocTextElement newJavaDocTextElement() {
+		JavaDocTextElement result = new JavaDocTextElement(this);
+		return result;
+	}
+
+	/**
 	 * Creates a new unparented labeled statement node owned by this AST.
 	 * By default, the label and statement are both unspecified, but legal.
 	 *

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ASTMatcher.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ASTMatcher.java
@@ -1319,6 +1319,29 @@ public class ASTMatcher {
 	}
 
 	/**
+	 * Returns whether the given node and the other object match.
+	 * <p>
+	 * The default implementation provided by this class tests whether the
+	 * other object is a node of the same type with structurally isomorphic
+	 * child subtrees. Subclasses may override this method as needed.
+	 * </p>
+	 *
+	 * @param node the node
+	 * @param other the other object, or <code>null</code>
+	 * @return <code>true</code> if the subtree matches, or
+	 *   <code>false</code> if they do not match or the other object has a
+	 *   different node type or is <code>null</code>
+	 * @since 3.31
+	 */
+	public boolean match(JavaDocTextElement node, Object other) {
+		if (!(other instanceof JavaDocTextElement)) {
+			return false;
+		}
+		JavaDocTextElement o = (JavaDocTextElement) other;
+		return safeEquals(node.getText(), o.getText());
+	}
+
+	/**
 	 * Return whether the deprecated comment strings of the given java doc are equals.
 	 * <p>
 	 * Note the only purpose of this method is to hide deprecated warnings.

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ASTNode.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ASTNode.java
@@ -1051,6 +1051,14 @@ public abstract class ASTNode {
 	 */
 	public static final int JAVADOC_REGION = 111;
 
+	/**
+	 * Node type constant indicating a node of type
+	 * <code>TextElement</code>.
+	 * @see TextElement
+	 * @since 3.31
+	 */
+	public static final int JAVADOC_TEXT_ELEMENT = 112;
+
 
 	/**
 	 * Returns the node class for the corresponding node type.
@@ -1152,6 +1160,8 @@ public abstract class ASTNode {
 				return Javadoc.class;
 			case JAVADOC_REGION :
 				return JavaDocRegion.class;
+			case JAVADOC_TEXT_ELEMENT :
+				return JavaDocTextElement.class;
 			case LABELED_STATEMENT :
 				return LabeledStatement.class;
 			case LAMBDA_EXPRESSION :

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ASTVisitor.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ASTVisitor.java
@@ -931,6 +931,23 @@ public abstract class ASTVisitor {
 	 * @return <code>true</code> if the children of this node should be
 	 * visited, and <code>false</code> if the children of this node should
 	 * be skipped
+	 * @since 3.31
+	 */
+	public boolean visit(JavaDocTextElement node) {
+		return true;
+	}
+
+	/**
+	 * Visits the given type-specific AST node.
+	 * <p>
+	 * The default implementation does nothing and return true.
+	 * Subclasses may reimplement.
+	 * </p>
+	 *
+	 * @param node the node to visit
+	 * @return <code>true</code> if the children of this node should be
+	 * visited, and <code>false</code> if the children of this node should
+	 * be skipped
 	 */
 	public boolean visit(LabeledStatement node) {
 		return true;
@@ -2577,6 +2594,19 @@ public abstract class ASTVisitor {
 	 * @since 3.30
 	 */
 	public void endVisit(JavaDocRegion node) {
+		// default implementation: do nothing
+	}
+
+	/**
+	 * End of visit the given type-specific AST node.
+	 * <p>
+	 * The default implementation does nothing. Subclasses may reimplement.
+	 * </p>
+	 *
+	 * @param node the node to visit
+	 * @since 3.31
+	 */
+	public void endVisit(JavaDocTextElement node) {
 		// default implementation: do nothing
 	}
 

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/AbstractTextElement.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/AbstractTextElement.java
@@ -1,0 +1,159 @@
+/*******************************************************************************
+ * Copyright (c) 2022 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.core.dom;
+
+import org.eclipse.jdt.internal.compiler.util.Util;
+
+/**
+ * AST node for a text element within a doc comment.
+ * <pre>
+ * AbstractTextElement:
+ *     Sequence of characters not including a close comment delimiter <b>*</b><b>/</b>
+ * </pre>
+ *
+ * @see TextElement
+ * @see JavaDocTextElement
+ * @since 3.31
+ */
+
+@SuppressWarnings("rawtypes")
+public abstract class AbstractTextElement extends ASTNode implements IDocElement {
+
+	/**
+	 * The "text" structural property of this node type (type: {@link String}).
+	 *
+	 */
+	public static final SimplePropertyDescriptor internalTextPropertyFactory(Class nodeClass) {
+		return new SimplePropertyDescriptor(nodeClass, "text", String.class, MANDATORY); //$NON-NLS-1$
+ 	}
+
+
+	/**
+	 * The text element; defaults to the empty string.
+	 */
+	String text = Util.EMPTY_STRING;
+
+
+	/**
+	 * Creates a new AST node for a text element owned by the given AST.
+	 * <p>
+	 * N.B. This constructor is package-private; all subclasses must be
+	 * declared in the same package; clients are unable to declare
+	 * additional subclasses.
+	 * </p>
+	 *
+	 * @param ast the AST that is to own this node
+	 */
+	AbstractTextElement(AST ast) {
+		super(ast);
+	}
+
+	/**
+	 * Returns structural property descriptor for the "text" property
+	 * of this node (element type: {@link String}).
+	 *
+	 * @return the property descriptor
+	 */
+	abstract SimplePropertyDescriptor internalTextPropertyFactory();
+
+
+	/**
+	 * Returns structural property descriptor for the "text" property
+	 * of this node (child type: {@link String}).
+	 *
+	 * @return the property descriptor
+	 */
+	public final SimplePropertyDescriptor getTextNameProperty() {
+		return internalTextPropertyFactory();
+	}
+
+	@Override
+	final Object internalGetSetObjectProperty(SimplePropertyDescriptor property, boolean get, Object value) {
+		if (property == internalTextPropertyFactory()) {
+			if (get) {
+				return getText();
+			} else {
+				setText((String) value);
+				return null;
+			}
+		}
+		// allow default implementation to flag the error
+		return super.internalGetSetObjectProperty(property, get, value);
+	}
+	/**
+	 * Returns this node's tag name, or <code>null</code> if none.
+	 * For top level doc tags such as parameter tags, the tag name
+     * includes the "@" character ("@param").
+	 * For inline doc tags such as link tags, the tag name
+     * includes the "@" character ("@link").
+     * The tag name may also be <code>null</code>; this is used to
+     * represent the material at the start of a doc comment preceding
+     * the first explicit tag.
+     *
+	 * @return the tag name, or <code>null</code> if none
+	 */
+	public String getText() {
+		return this.text;
+	}
+
+	/**
+	 * Sets the text of this node to the given value.
+	 * <p>
+	 * The text element typically includes leading and trailing
+	 * whitespace that separates it from the immediately preceding
+	 * or following elements.
+	 * </p>
+	 *
+	 * @param text the text of this node
+	 * @exception IllegalArgumentException if the text is null
+	 */
+	public void setText(String text) {
+		if (text == null) {
+			throw new IllegalArgumentException();
+		}
+	}
+
+	/**
+	 * Returns whether this tag element is nested within another
+	 * tag element. Nested tag elements appears enclosed in
+	 * "{" and "}"; certain doc tags, including "@link" and
+	 * "@linkplain" are only meaningful as nested tags.
+	 * Top-level (i.e., non-nested) doc tags begin on a new line;
+	 * certain doc tags, including "@param" and
+	 * "@see" are only meaningful as top-level tags.
+	 * <p>
+	 * This convenience methods checks to see whether the parent
+	 * of this node is of type {@link org.eclipse.jdt.core.dom.AbstractTextElement}.
+	 * </p>
+	 *
+	 * @return <code>true</code> if this node is a nested tag element,
+	 * and false if this node is either parented by a doc comment node
+	 * ({@link Javadoc}), or is unparented
+	 */
+	public boolean isNested() {
+		return (getParent() instanceof AbstractTextElement);
+	}
+
+	@Override
+	int memSize() {
+		int size = BASE_NODE_SIZE + 2 * 3 + stringSize(this.text);
+		return size;
+	}
+
+	@Override
+	int treeSize() {
+		return memSize();
+	}
+}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/DefaultASTVisitor.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/DefaultASTVisitor.java
@@ -206,6 +206,10 @@ class DefaultASTVisitor extends ASTVisitor {
 		endVisitNode(node);
 	}
 	@Override
+	public void endVisit(JavaDocTextElement node) {
+		endVisitNode(node);
+	}
+	@Override
 	public void endVisit(LabeledStatement node) {
 		endVisitNode(node);
 	}
@@ -638,6 +642,10 @@ class DefaultASTVisitor extends ASTVisitor {
 	}
 	@Override
 	public boolean visit(JavaDocRegion node) {
+		return visitNode(node);
+	}
+	@Override
+	public boolean visit(JavaDocTextElement node) {
 		return visitNode(node);
 	}
 	@Override

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/JavaDocTextElement.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/JavaDocTextElement.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2013 IBM Corporation and others.
+ * Copyright (c) 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -23,35 +23,33 @@ import org.eclipse.jdt.internal.compiler.util.Util;
  * AST node for a text element within a doc comment.
  * <pre>
  * TextElement:
- *     Sequence of characters not including a close comment delimiter <b>*</b><b>/</b>
+ *     Sequence of characters including a close comment delimiter <b>*</b><b>/</b>
  * </pre>
  *
  * @see Javadoc
- * @since 3.0
+ * @since 3.31
  * @noinstantiate This class is not intended to be instantiated by clients.
  */
 @SuppressWarnings("rawtypes")
-public final class TextElement extends AbstractTextElement {
-
+public final class JavaDocTextElement extends AbstractTextElement {
 
 	/**
 	 * The "text" structural property of this node type (type: {@link String}).
 	 */
 
 	public static final SimplePropertyDescriptor TEXT_PROPERTY =
-			internalTextPropertyFactory(TextElement.class);
+			internalTextPropertyFactory(JavaDocTextElement.class);
 
 	/**
 	 * A list of property descriptors (element type:
 	 * {@link StructuralPropertyDescriptor}),
 	 * or null if uninitialized.
-	 * @since 3.0
 	 */
 	private static final List PROPERTY_DESCRIPTORS;
 
 	static {
 		List propertyList = new ArrayList(2);
-		createPropertyList(TextElement.class, propertyList);
+		createPropertyList(JavaDocTextElement.class, propertyList);
 		addProperty(TEXT_PROPERTY, propertyList);
 		PROPERTY_DESCRIPTORS = reapPropertyList(propertyList);
 	}
@@ -64,11 +62,11 @@ public final class TextElement extends AbstractTextElement {
 	 * <code>AST.JLS*</code> constants
 	 * @return a list of property descriptors (element type:
 	 * {@link StructuralPropertyDescriptor})
-	 * @since 3.0
 	 */
 	public static List propertyDescriptors(int apiLevel) {
 		return PROPERTY_DESCRIPTORS;
 	}
+
 
 	@Override
 	final SimplePropertyDescriptor internalTextPropertyFactory() {
@@ -86,7 +84,7 @@ public final class TextElement extends AbstractTextElement {
 	 *
 	 * @param ast the AST that is to own this node
 	 */
-	TextElement(AST ast) {
+	JavaDocTextElement(AST ast) {
 		super(ast);
 	}
 
@@ -98,12 +96,12 @@ public final class TextElement extends AbstractTextElement {
 
 	@Override
 	final int getNodeType0() {
-		return TEXT_ELEMENT;
+		return JAVADOC_TEXT_ELEMENT;
 	}
 
 	@Override
 	ASTNode clone0(AST target) {
-		TextElement result = new TextElement(target);
+		JavaDocTextElement result = new JavaDocTextElement(target);
 		result.setSourceRange(getStartPosition(), getLength());
 		result.setText(getText());
 		return result;
@@ -126,8 +124,7 @@ public final class TextElement extends AbstractTextElement {
 	 * <p>
 	 * The text element typically includes leading and trailing
 	 * whitespace that separates it from the immediately preceding
-	 * or following elements. The text element must not include
-	 * a block comment closing delimiter "*"+"/".
+	 * or following elements.
 	 * </p>
 	 *
 	 * @param text the text of this node
@@ -137,9 +134,6 @@ public final class TextElement extends AbstractTextElement {
 	@Override
 	public void setText(String text) {
 		super.setText(text);
-		if (text.indexOf("*/") > 0) { //$NON-NLS-1$
-			throw new IllegalArgumentException();
-		}
 		preValueChange(TEXT_PROPERTY);
 		this.text = text;
 		postValueChange(TEXT_PROPERTY);

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/Javadoc.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/Javadoc.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2013 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -270,7 +270,7 @@ public class Javadoc extends Comment {
 	 * The first tag element of a typical doc comment represents
 	 * all the material before the first explicit doc tag; this
 	 * first tag element has a <code>null</code> tag name and
-	 * generally contains 1 or more {@link TextElement}s,
+	 * generally contains 1 or more {@link AbstractTextElement}s,
 	 * and possibly interspersed with tag elements for nested tags
 	 * like "{@link String String}".
 	 * Subsequent tag elements represent successive top-level doc

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/TagElement.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/TagElement.java
@@ -453,10 +453,10 @@ public final class TagElement extends AbstractTagElement {
 	public List tagRegionsStartingAtTextElement(ASTNode docElem) {
 		unsupportedBelow18();
 		List<JavaDocRegion> regions = new ArrayList<>();
-		if (docElem == null || !(docElem instanceof TextElement)) {
+		if (docElem == null || !(docElem instanceof AbstractTextElement)) {
 			return regions;
 		} else {
-			TextElement textElem= (TextElement) docElem;
+			AbstractTextElement textElem= (AbstractTextElement) docElem;
 			List<JavaDocRegion> javaDocRegions = this.tagRegions();
 			for (JavaDocRegion region : javaDocRegions) {
 				if (!region.isDummyRegion()) {

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/NaiveASTFlattener.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/NaiveASTFlattener.java
@@ -935,6 +935,12 @@ public class NaiveASTFlattener extends ASTVisitor {
 	}
 
 	@Override
+	public boolean visit(JavaDocTextElement node) {
+		this.buffer.append(node.getText());
+		return false;
+	}
+
+	@Override
 	public boolean visit(LabeledStatement node) {
 		printIndent();
 		node.getLabel().accept(this);

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/ASTRewriteAnalyzer.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/ASTRewriteAnalyzer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -3226,6 +3226,17 @@ public final class ASTRewriteAnalyzer extends ASTVisitor {
 		String separator= getLineDelimiter() + getIndentAtOffset(node.getStartPosition())  + " * "; //$NON-NLS-1$
 
 		rewriteNodeList(node, Javadoc.TAGS_PROPERTY, startPos, separator, separator);
+		return false;
+	}
+
+	@Override
+	public boolean visit(JavaDocTextElement node) {
+		if (!hasChildrenChanges(node)) {
+			return doVisitUnchangedChildren(node);
+		}
+		String newText= (String) getNewValue(node, JavaDocTextElement.TEXT_PROPERTY);
+		TextEditGroup group = getEditGroup(node, JavaDocTextElement.TEXT_PROPERTY);
+		doTextReplace(node.getStartPosition(), node.getLength(), newText, group);
 		return false;
 	}
 

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/ASTRewriteFlattener.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/ASTRewriteFlattener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -679,6 +679,11 @@ public class ASTRewriteFlattener extends ASTVisitor {
 		return false;
 	}
 
+	@Override
+	public boolean visit(JavaDocTextElement node) {
+		this.result.append(getAttribute(node, JavaDocTextElement.TEXT_PROPERTY));
+		return false;
+	}
 	@Override
 	public boolean visit(LabeledStatement node) {
 		getChildNode(node, LabeledStatement.LABEL_PROPERTY).accept(this);

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/ASTRewriteFormatter.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/ASTRewriteFormatter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -348,6 +348,7 @@ public final class ASTRewriteFormatter {
 				case ASTNode.METHOD_REF_PARAMETER:
 				case ASTNode.TAG_ELEMENT:
 				case ASTNode.TEXT_ELEMENT:
+				case ASTNode.JAVADOC_TEXT_ELEMENT:
 					// javadoc formatting disabled due to bug 93644
 					return null;
 


### PR DESCRIPTION
https://github.com/eclipse-jdt/eclipse.jdt.core/issues/323

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
