### PR TITLE
Bug 499730 - [null][1.8] NullPointerException on array contents access, even though null analysis says the program is OK

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/CompilerInvocationTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/CompilerInvocationTests.java
@@ -862,6 +862,7 @@ public void test011_problem_categories() {
 		expectedProblemAttributes.put("NonGenericConstructor", new ProblemAttributes(CategorizedProblem.CAT_TYPE));
 		expectedProblemAttributes.put("NonGenericMethod", new ProblemAttributes(CategorizedProblem.CAT_TYPE));
 		expectedProblemAttributes.put("NonGenericType", new ProblemAttributes(CategorizedProblem.CAT_TYPE));
+		expectedProblemAttributes.put("NonNullArrayContentNotInitialized", new ProblemAttributes(CategorizedProblem.CAT_POTENTIAL_PROGRAMMING_PROBLEM));
 		expectedProblemAttributes.put("NonNullDefaultDetailIsNotEvaluated", new ProblemAttributes(CategorizedProblem.CAT_INTERNAL));
 		expectedProblemAttributes.put("NonNullExpressionComparisonYieldsFalse", new ProblemAttributes(CategorizedProblem.CAT_POTENTIAL_PROGRAMMING_PROBLEM));
 		expectedProblemAttributes.put("NonNullMessageSendComparisonYieldsFalse", new ProblemAttributes(CategorizedProblem.CAT_POTENTIAL_PROGRAMMING_PROBLEM));
@@ -1948,6 +1949,7 @@ public void test012_compiler_problems_tuning() {
 		expectedProblemAttributes.put("NonGenericConstructor", SKIP);
 		expectedProblemAttributes.put("NonGenericMethod", SKIP);
 		expectedProblemAttributes.put("NonGenericType", SKIP);
+		expectedProblemAttributes.put("NonNullArrayContentNotInitialized", SKIP);
 		expectedProblemAttributes.put("NonNullDefaultDetailIsNotEvaluated", SKIP);
 		expectedProblemAttributes.put("NonNullExpressionComparisonYieldsFalse", new ProblemAttributes(JavaCore.COMPILER_PB_REDUNDANT_NULL_CHECK));
 		expectedProblemAttributes.put("NonNullSpecdFieldComparisonYieldsFalse", new ProblemAttributes(JavaCore.COMPILER_PB_REDUNDANT_NULL_CHECK));

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullTypeAnnotationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullTypeAnnotationTest.java
@@ -3741,6 +3741,55 @@ public class NullTypeAnnotationTest extends AbstractNullAnnotationTest {
 			"----------\n");
 	}
 
+	public void testArray4() {
+		Map options = getCompilerOptions();
+		options.put(JavaCore.COMPILER_PB_ANNOTATED_TYPE_ARGUMENT_TO_UNANNOTATED, JavaCore.WARNING);
+		runNegativeTestWithLibs(
+			new String[] {
+				"X.java",
+				"import org.eclipse.jdt.annotation.NonNull;\n" +
+				"\n" +
+				"public class X<T> {\n" +
+				"   \n" +
+				"	void ok() {\n" +
+				"		@NonNull String @NonNull [] s0 = new @NonNull String @NonNull [0];\n" + // array exists, but no contents that could be null
+				"		@NonNull String @NonNull[]@NonNull[] s2 = new @NonNull String @NonNull[2]@NonNull[0];\n" + // inner arrays will be null
+				"		String []@NonNull[] s4 = new String [getDims()]@NonNull[1];\n" + // leaves are null but that's ok
+				"		@NonNull String @NonNull[][] s5 = new @NonNull String @NonNull[5][];\n" + // OK: outer array exists, inner arrays are unannotated
+				"	}\n" +
+				"	void nok() {\n" +
+				"		@NonNull String @NonNull [] s1 = new @NonNull String @NonNull [1];\n" +
+				"		@NonNull String @NonNull[]@NonNull[] s2 = new @NonNull String @NonNull[2]@NonNull[];\n" + // inner arrays will be null
+				"		@NonNull String @NonNull[][] s3 = new @NonNull String @NonNull[1][3];\n" + // leaf cells will be null
+				"		@NonNull String @NonNull[]@NonNull[] s6 = new @NonNull String @NonNull[5]@NonNull[];\n" +
+				"	}\n" +
+				"	int getDims() { return 1; }\n" +
+				"}"
+			},
+			options,
+			"----------\n" +
+			"1. INFO in X.java (at line 12)\n" +
+			"	@NonNull String @NonNull [] s1 = new @NonNull String @NonNull [1];\n" +
+			"	                                                              ^^^\n" +
+			"This array dimension with declared element type @NonNull String will be initialized with \'null\' entries\n" +
+			"----------\n" +
+			"2. INFO in X.java (at line 13)\n" +
+			"	@NonNull String @NonNull[]@NonNull[] s2 = new @NonNull String @NonNull[2]@NonNull[];\n" +
+			"	                                                                      ^^^\n" +
+			"This array dimension with declared element type @NonNull String @NonNull[] will be initialized with \'null\' entries\n" +
+			"----------\n" +
+			"3. INFO in X.java (at line 14)\n" +
+			"	@NonNull String @NonNull[][] s3 = new @NonNull String @NonNull[1][3];\n" +
+			"	                                                                 ^^^\n" +
+			"This array dimension with declared element type @NonNull String will be initialized with \'null\' entries\n" +
+			"----------\n" +
+			"4. INFO in X.java (at line 15)\n" +
+			"	@NonNull String @NonNull[]@NonNull[] s6 = new @NonNull String @NonNull[5]@NonNull[];\n" +
+			"	                                                                      ^^^\n" +
+			"This array dimension with declared element type @NonNull String @NonNull[] will be initialized with \'null\' entries\n" +
+			"----------\n");
+	}
+
 	public void testBug417759() {
 		runNegativeTestWithLibs(
 			new String[] {
@@ -4456,7 +4505,12 @@ public void testBug427163c() {
 		"	                                         ^^^^^^^^^^^^^^^^^^\n" +
 		"Contradictory null specification; only one of @NonNull and @Nullable can be specified at any location\n" +
 		"----------\n" +
-		"5. ERROR in X.java (at line 8)\n" +
+		"5. INFO in X.java (at line 7)\n" +
+		"	String[] strings4 = new @NonNull String  @Nullable @NonNull[1];\n" +
+		"	                                                           ^^^\n" +
+		"This array dimension with declared element type @NonNull String will be initialized with \'null\' entries\n" +
+		"----------\n" +
+		"6. ERROR in X.java (at line 8)\n" +
 		"	String[][] strings5 = new String[] @NonNull @Nullable[] {};\n" +
 		"	                                   ^^^^^^^^^^^^^^^^^^\n" +
 		"Contradictory null specification; only one of @NonNull and @Nullable can be specified at any location\n" +

--- a/org.eclipse.jdt.core/compiler/org/eclipse/jdt/core/compiler/IProblem.java
+++ b/org.eclipse.jdt.core/compiler/org/eclipse/jdt/core/compiler/IProblem.java
@@ -1940,6 +1940,8 @@ void setSourceStart(int sourceStart);
 	int AnnotatedTypeArgumentToUnannotated = Internal + 983;
 	/** @since 3.21 */
 	int AnnotatedTypeArgumentToUnannotatedSuperHint = Internal + 984;
+	/** @since 3.31 */
+	int NonNullArrayContentNotInitialized = Internal + 985;
 
 
 	// Java 8 work

--- a/org.eclipse.jdt.core/compiler/org/eclipse/jdt/core/compiler/IProblem.java
+++ b/org.eclipse.jdt.core/compiler/org/eclipse/jdt/core/compiler/IProblem.java
@@ -1940,7 +1940,7 @@ void setSourceStart(int sourceStart);
 	int AnnotatedTypeArgumentToUnannotated = Internal + 983;
 	/** @since 3.21 */
 	int AnnotatedTypeArgumentToUnannotatedSuperHint = Internal + 984;
-	/** @since 3.31 */
+	/** @since 3.32 */
 	int NonNullArrayContentNotInitialized = Internal + 985;
 
 

--- a/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
+++ b/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
@@ -847,7 +847,7 @@ public static int getProblemCategory(int severity, int problemID) {
 				break categorizeOnIrritant;
 		}
 	}
-	// categorize fatal problems per ID
+	// categorize fatal / non-configurable problems per ID
 	switch (problemID) {
 		case IProblem.IsClassPathCorrect :
 		case IProblem.IsClassPathCorrectWithReferencingType :
@@ -857,6 +857,8 @@ public static int getProblemCategory(int severity, int problemID) {
 			return CategorizedProblem.CAT_BUILDPATH;
 		case IProblem.ProblemNotAnalysed :
 			return CategorizedProblem.CAT_UNNECESSARY_CODE;
+		case IProblem.NonNullArrayContentNotInitialized :
+			return CategorizedProblem.CAT_POTENTIAL_PROGRAMMING_PROBLEM;
 		default :
 			if ((problemID & IProblem.Syntax) != 0)
 				return CategorizedProblem.CAT_SYNTAX;
@@ -10898,6 +10900,17 @@ public void arrayReferencePotentialNullReference(ArrayReference arrayReference) 
 	this.handle(IProblem.ArrayReferencePotentialNullReference, NoArgument, NoArgument, arrayReference.sourceStart, arrayReference.sourceEnd);
 
 }
+
+public void nonNullArrayContentNotInitialized(Expression dimension, LookupEnvironment lookupEnvironment, TypeBinding elementType) {
+	this.handle(
+			IProblem.NonNullArrayContentNotInitialized,
+			new String[] {new String(elementType.nullAnnotatedReadableName(lookupEnvironment.globalOptions, false))},
+			new String[] {new String(elementType.nullAnnotatedReadableName(lookupEnvironment.globalOptions, true))},
+			ProblemSeverities.Info,
+			dimension.sourceStart-1, // optimistically try to include '[' and ']'
+			dimension.sourceEnd+1);
+}
+
 public void nullityMismatchingTypeAnnotation(Expression expression, TypeBinding providedType, TypeBinding requiredType, NullAnnotationMatching status)
 {
 	if (providedType == requiredType) return; //$IDENTITY-COMPARISON$

--- a/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/problem/messages.properties
+++ b/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/problem/messages.properties
@@ -863,6 +863,7 @@
 982 = Annotation type ''{0}'' cannot be found on the build path, which is implicitly needed for null analysis
 983 = Unsafe null type conversion (type annotations): The value of type ''{1}'' is made accessible using the less-annotated type ''{0}''
 984 = Unsafe null type conversion (type annotations): The value of type ''{1}'' is made accessible using the less-annotated type ''{0}'', corresponding supertype is ''{2}''
+985 = This array dimension with declared element type {0} will be initialized with ''null'' entries
 
 # Java 8
 1001 = Syntax error, modifiers and annotations are not allowed for the lambda parameter {0} as its type is elided


### PR DESCRIPTION
From https://bugs.eclipse.org/499730

- raise info for uninitialized array content declared as @NonNull
