### PR TITLE
Call hierarchy doesn't work for Java 11 java.util.Timer.sched #332

### DIFF
--- a/org.eclipse.jdt.core.tests.model/workspace/gh322ModuleJarSearchBug/.classpath
+++ b/org.eclipse.jdt.core.tests.model/workspace/gh322ModuleJarSearchBug/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.MODULE_PATH"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/org.eclipse.jdt.core.tests.model/workspace/gh322ModuleJarSearchBug/.project
+++ b/org.eclipse.jdt.core.tests.model/workspace/gh322ModuleJarSearchBug/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>gh322ModuleJarSearchBug</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>


### PR DESCRIPTION
During the call hierarchy computation of Timer.sched() from JRE 11,
JavaSearchScope.encloses() is called with the following values:

path=java.base|java/util/Timer.class
enclosingPath=java/util

The check then fails, since the provided enclosing path does not enclose
the path of the type - its missing the module name.

This change adjusts JavaSearchScope to remove the module part of the
path, before checking whether the path is enclosed. In addition, a
warning is logged if JavaSearchScope.encloses(String, String, int) is
reached with a path that contains the symbol '|'.

Fixes: #332

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
