### PR TITLE
fix #319: method arguments are not discarded (memory leak)

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaElementInfo.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaElementInfo.java
@@ -38,4 +38,7 @@ public class JavaElementInfo implements Cloneable {
 	public IJavaElement[] getChildren() {
 		return JavaElement.NO_ELEMENTS;
 	}
+	public IJavaElement[] getExtendedChildren() {
+		return JavaElement.NO_ELEMENTS;
+	}
 }

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelManager.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelManager.java
@@ -4068,11 +4068,16 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 
 	private void closeChildren(Object info) {
 		if (info instanceof JavaElementInfo) {
-			IJavaElement[] children = ((JavaElementInfo)info).getChildren();
-			for (int i = 0, size = children.length; i < size; ++i) {
-				JavaElement child = (JavaElement) children[i];
+			for (IJavaElement child: ((JavaElementInfo)info).getChildren()) {
 				try {
-					child.close();
+					((JavaElement)child).close();
+				} catch (JavaModelException e) {
+					// ignore
+				}
+			}
+			for (IJavaElement child: ((JavaElementInfo)info).getExtendedChildren()) {
+				try {
+					((JavaElement)child).close();
 				} catch (JavaModelException e) {
 					// ignore
 				}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SourceMethodElementInfo.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SourceMethodElementInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2011 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -14,7 +14,6 @@
 package org.eclipse.jdt.internal.core;
 
 import org.eclipse.jdt.core.*;
-import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.internal.compiler.env.ISourceMethod;
 
@@ -99,4 +98,10 @@ protected void setExceptionTypeNames(char[][] types) {
 	this.exceptionTypes = types;
 }
 protected abstract void setReturnType(char[] type);
+
+@Override
+public IJavaElement[] getExtendedChildren() {
+	return this.arguments != null ? this.arguments : JavaElement.NO_ELEMENTS;
+}
+
 }


### PR DESCRIPTION
CompilationUnit.discardWorkingCopy() is meant to dispose the workingcopy
with all its child elements. But SourceMethodElementInfo did not report
its arguments as children. As a consequence working copies where never
removed from JavaModelManager.childrenCache which ended up in slow
"organize imports".

