### PR TITLE
Block Comment support in external snippets. Fixes #323

### DIFF
--- a/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/parser/AbstractCommentParser.java
+++ b/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/parser/AbstractCommentParser.java
@@ -1876,14 +1876,15 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 				previousPosition = indexPos;
 				tokenType = snippetScanner.getNextToken();
 
-				if (tokenType == TokenNameEOF)
+				if (tokenType == TokenNameEOF) {
+					if (!resetTextStartPos) {
+						pushExternalSnippetText(snippetScanner.source, textStartPosition, textEndPosition, false, snippetTag);
+					}
 					break;
+				}
 
 				indexPos = snippetScanner.currentPosition;
 				textEndPosition = indexPos;
-				if (tokenType == TerminalTokens.TokenNameEOF) {
-					break;
-				}
 				if (resetTextStartPos) {
 					textStartPosition = snippetScanner.getCurrentTokenStartPosition();
 					newLineStarted = true;
@@ -1892,7 +1893,7 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 				switch (tokenType) {
 					case TerminalTokens.TokenNameWHITESPACE:
 						if (containsNewLine(snippetScanner.getCurrentTokenString())) {
-							pushSnippetText(snippetScanner.source, textStartPosition, textEndPosition, false, snippetTag);
+							pushExternalSnippetText(snippetScanner.source, textStartPosition, textEndPosition, false, snippetTag);
 							resetTextStartPos = true;
 							newLineStarted = false;
 						}
@@ -1928,7 +1929,7 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 								textStartPosition = previousPosition;
 							}
 							if (textStartPosition != -1 && textStartPosition < indexPos) {
-								pushSnippetText(snippetScanner.source, textStartPosition,(innerTag!=null &&  indexOfLastComment >=0) ? textPos+indexOfLastComment+2:textPos, true, snippetTag);
+								pushExternalSnippetText(snippetScanner.source, textStartPosition,(innerTag!=null &&  indexOfLastComment >=0) ? textPos+indexOfLastComment+2:textPos, true, snippetTag);
 								resetTextStartPos = true;
 								newLineStarted = false;
 								if (handleNow) {
@@ -3055,7 +3056,7 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 	protected abstract void closeJavaDocRegion(String name, Object snippetTag, int end);
 	protected abstract boolean areRegionsClosed();
 
-	protected void pushExternalSnippetText(String text, int start, int end) {
+	protected void pushExternalSnippetText(char[] text, int start, int end, boolean addNewLine, Object snippetTag) {
 		// do not store text by default
 	}
 

--- a/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/parser/JavadocParser.java
+++ b/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/parser/JavadocParser.java
@@ -1017,7 +1017,7 @@ public class JavadocParser extends AbstractCommentParser {
 	}
 
 	@Override
-	protected void pushExternalSnippetText(String text, int start, int end) {
+	protected void pushExternalSnippetText(char[] text, int start, int end, boolean addNewLine, Object snippetTag) {
 		// The tag gets its description => clear the flag
 		this.tagWaitingForDescription = TAG_SNIPPET_VALUE;
 	}


### PR DESCRIPTION
Signed-off-by: Kalyan Prasad Tatavarthi <kalyan_prasad@in.ibm.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
The Javadoc view shows the preview of the code snippets that refer to a class or file, if the code has a block comment , then the external snippet was ignored. This fix handles block comments and the external snippet is not ignored.

## How to test
Use the test case given in the bug description.

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
