### PR TITLE
Fix #339 - In the Java 5-6 era, ECJ was patched to be bug-compatible …

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AnnotationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AnnotationTest.java
@@ -9869,7 +9869,7 @@ public void test292() {
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=316456
 public void test293() {
-	this.runNegativeTest(
+	this.runConformTest(
 		new String[] {
 				"X.java",
 				"@A(name = X.QUERY_NAME, query = X.QUERY)\n" +
@@ -9882,12 +9882,7 @@ public void test293() {
 				"    String query();\n" +
 				"}\n"
 		},
-		"----------\n" +
-		"1. ERROR in X.java (at line 1)\n" +
-		"	@A(name = X.QUERY_NAME, query = X.QUERY)\n" +
-		"	                                  ^^^^^\n" +
-		"The field X.QUERY is not visible\n" +
-		"----------\n");
+		"");
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=179566
 public void test294() {
@@ -12349,4 +12344,23 @@ public void testBug490698_comment16() {
 			"}\n"
 		});
 }
+
+public void testBugVisibility() {
+	if (this.complianceLevel < ClassFileConstants.JDK1_5) {
+		return;
+	}
+	runConformTest(
+		new String[] {
+			"X.java",
+			"public class X {\n" +
+			"	String z() { return Y.MSG; }\n" +
+			"	@Deprecated(since = Y.MSG)\n" +
+			"	static class Y {\n" +
+			"		private final static String MSG = \"msg\";\n" +
+			"	}\n" +
+			"}",
+		},
+		"");
+}
+
 }

--- a/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/lookup/Scope.java
+++ b/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/lookup/Scope.java
@@ -1435,13 +1435,11 @@ public abstract class Scope {
 
 		currentType.initializeForStaticImports();
 		FieldBinding field = currentType.getField(fieldName, needResolve);
-		// https://bugs.eclipse.org/bugs/show_bug.cgi?id=316456
-		boolean insideTypeAnnotations = this instanceof MethodScope && ((MethodScope) this).insideTypeAnnotation;
 		if (field != null) {
 			if (invisibleFieldsOk) {
 				return field;
 			}
-			if (invocationSite == null || insideTypeAnnotations
+			if (invocationSite == null
 				? field.canBeSeenBy(getCurrentPackage())
 				: field.canBeSeenBy(currentType, invocationSite, this))
 					return field;


### PR DESCRIPTION
…with Javac of that time.

Luckily, Javac fixed so the hack is not needed anymore - infact this makes ECJ not following JLS properly

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
 Described in #339

## How to test

Try compiling the code:

```
public class X {
	
	String z() { return Y.MSG; }

	@WithMsg(Y.MSG)
	static class Y {
		private final static String MSG = "msg";
	}
}
@interface WithMsg {
	String value();
}

```

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
