### PR TITLE
[19] Pattern variable declared in a guard containing instanceof

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordPatternTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordPatternTest.java
@@ -1548,4 +1548,27 @@ public class RecordPatternTest extends AbstractRegressionTest9 {
 			"Pattern of type long is not compatible with type int\n" +
 			"----------\n");
 	}
+	public void test45() {
+		runNegativeTest(new String[] {
+				"X.java",
+						"@SuppressWarnings(\"preview\")\n"
+						+ "public class X {\n"
+						+ "	static void print(Object r) {\n"
+						+ "		switch (r) {\n"
+						+ "			case Rectangle r1 when (r instanceof (Rectangle(ColoredPoint upperLeft2, ColoredPoint lowerRight) r2)):\n"
+						+ "				System.out.println(r2);// error should not be reported here\n"
+						+ "			break;\n"
+						+ "		}\n"
+						+ "	}\n"
+						+ "}\n"
+						+ "record ColoredPoint() {}\n"
+						+ "record Rectangle(ColoredPoint upperLeft, ColoredPoint lowerRight) {} "
+		},
+			"----------\n" +
+			"1. ERROR in X.java (at line 4)\n" +
+			"	switch (r) {\n" +
+			"	        ^\n" +
+			"An enhanced switch statement should be exhaustive; a default label expected\n" +
+			"----------\n");
+	}
 }

--- a/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/ast/TypePattern.java
+++ b/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/ast/TypePattern.java
@@ -63,6 +63,10 @@ public class TypePattern extends Pattern {
 			if (this.patternVarsWhenTrue == null) {
 				this.patternVarsWhenTrue = new LocalVariableBinding[1];
 				this.patternVarsWhenTrue[0] = binding;
+			} else {
+				LocalVariableBinding[] vars = new LocalVariableBinding[1];
+				vars[0] = binding;
+				this.addPatternVariablesWhenTrue(vars);
 			}
 		}
 	}

--- a/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/parser/Parser.java
+++ b/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/parser/Parser.java
@@ -10871,7 +10871,6 @@ protected void consumeGuard() {
 	pushOnAstStack(gPattern);
 }
 protected void consumeTypePattern() {
-
 	//name
 	char[] identifierName = this.identifierStack[this.identifierPtr];
 	long namePosition = this.identifierPositionStack[this.identifierPtr];
@@ -10951,6 +10950,7 @@ protected void consumeRecordPatternWithId() {
 	recPattern.sourceStart = this.intStack[this.intPtr--];
 	local.modifiers =  this.intStack[this.intPtr--];
 	local.declarationSourceStart = type.sourceStart;
+	problemReporter().validateJavaFeatureSupport(JavaFeature.RECORD_PATTERNS, type.sourceStart, local.declarationEnd);
 	pushOnAstStack(recPattern);
 }
 protected void consumeRecordStructure() {


### PR DESCRIPTION
expression is not visible in the case block #371

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
