### PR TITLE
No callers for method found in anonymous types in a jar #375

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchTests.java
@@ -16,8 +16,10 @@ package org.eclipse.jdt.core.tests.model;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Hashtable;
+import java.util.List;
 
 import junit.framework.Test;
 
@@ -26,6 +28,7 @@ import org.eclipse.core.runtime.*;
 import org.eclipse.jdt.core.*;
 import org.eclipse.jdt.core.search.*;
 import org.eclipse.jdt.core.tests.util.Util;
+import org.eclipse.jdt.internal.core.JarPackageFragmentRoot;
 import org.eclipse.jdt.internal.core.JavaModelStatus;
 
 /**
@@ -4503,5 +4506,91 @@ public void testBug383908() throws CoreException {
 		deleteProject("P");
 	}
 }
+/*
+ * Test that we can find methods called in an anonymous type from a jar,
+ * if the primary type contains multiple anonymous types.
+ * https://github.com/eclipse-jdt/eclipse.jdt.core/issues/375
+ */
+public void testAnonymousTypeMethodReferenceJarSearchGh375() throws Exception {
+	try {
+		IJavaProject project = createJavaProject("P", new String[] { "src" }, new String[] { "/P/libGh375.jar", "JCL18_LIB" }, "bin", "1.8");
+		createFile(
+			"/P/src/X.java",
+			"public class X {\n" +
+			"	@SuppressWarnings({ \"rawtypes\", \"unchecked\" })\n" +
+			"	public static void main(String[] args) {\n" +
+			"		IY y = s -> foo(0);\n" +
+			"		y.accept(0);\n" +
+			"	}\n" +
+			"	static private void foo(int i) {}\n" +
+			"}\n"
+		);
 
+		String libSource = String.join(System.lineSeparator(), new String[] {
+				"public class TestGh375 {",
+				"	public void foo() {",
+				"		Runnable r = new Runnable() {",
+				"			@Override",
+				"			public void run() {",
+				"				System.out.println(\"foo\");",
+				"			}",
+				"		};",
+				"		r.run();",
+				"	}",
+				"	public void bar() throws Exception {",
+				"		java.util.concurrent.Callable<Void> r = new java.util.concurrent.Callable<Void>() {",
+				"			@Override",
+				"			public Void call() {",
+				"				System.out.println(\"bar\");",
+				"				helloWorld();",
+				"				return null;",
+				"			}",
+				"		};",
+				"		r.call();",
+				"	}",
+				"	public void helloWorld() {",
+				"		System.out.println(\"hello world\");",
+				"	}",
+				"}",
+		});
+
+		String jarFileName = "libGh375.jar";
+		String srcZipName = "libGh375.src.zip";
+		createLibrary(project, jarFileName, srcZipName, new String[] { "TestGh375.java", libSource}, new String[0], JavaCore.VERSION_1_8);
+		IFile srcZip = (IFile) project.getProject().findMember(srcZipName);
+		IFile jar = (IFile) project.getProject().findMember(jarFileName);
+		JarPackageFragmentRoot root = (JarPackageFragmentRoot) project.getPackageFragmentRoot(jar);
+		root.attachSource(srcZip.getFullPath(), null, null);
+		waitUntilIndexesReady();
+
+		JavaSearchResultCollector testResultCollector = new JavaSearchResultCollector();
+		String typeFqn = "TestGh375";
+		IType testType = project.findType(typeFqn);
+		assertNotNull("Failed to find test type: " + typeFqn, testType);
+		String methodName = "helloWorld";
+		IMethod testMethod = null;
+		for (IMethod method : testType.getMethods()) {
+			if (methodName.equals(method.getElementName())) {
+				testMethod = method;
+			}
+		}
+		IJavaSearchScope scope = SearchEngine.createJavaSearchScope(new IJavaElement[] { testMethod.getAncestor(IJavaElement.PACKAGE_FRAGMENT) });
+		assertNotNull("Failed to find method: " + methodName + ", in type: " + typeFqn, testMethod);
+		int agnosticMatchRule = SearchPattern.R_EXACT_MATCH | SearchPattern.R_CASE_SENSITIVE | SearchPattern.R_ERASURE_MATCH;
+		SearchPattern pattern = SearchPattern.createPattern(testMethod, IJavaSearchConstants.REFERENCES, agnosticMatchRule);
+		SearchEngine searchEngine = new SearchEngine();
+		searchEngine.search(pattern, new SearchParticipant[] {SearchEngine.getDefaultSearchParticipant()}, scope, testResultCollector, new NullProgressMonitor());
+
+		String foundReferences = testResultCollector.toString();
+		assertFalse("Expected search to find references of method: " + testMethod, foundReferences.isEmpty());
+		List<String> results = Arrays.asList(foundReferences.split(System.lineSeparator()));
+		String[] expectedResults = {
+				"libGh375.jar java.lang.Void <anonymous>.call()",
+		};
+		assertEquals("Unexpected search result", String.join(System.lineSeparator(), expectedResults), String.join(System.lineSeparator(), results));
+	} finally {
+		JavaCore.setOptions(getDefaultJavaCoreOptions());
+		deleteProject("P");
+	}
+}
 }

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/MatchLocator.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/MatchLocator.java
@@ -2638,6 +2638,9 @@ protected void reportMatching(AbstractMethodDeclaration method, TypeDeclaration 
 			if ((this.matchContainer & PatternLocator.METHOD_CONTAINER) != 0) {
 				if (enclosingElement == null) {
 					enclosingElement = createHandle(method, parent);
+					if (enclosingElement == null && (type.bits & ASTNode.IsAnonymousType) != 0) {
+						enclosingElement = createHandleFromNestAncestors(method, parent);
+					}
 				}
 				if (encloses(enclosingElement)) {
 					if (this.pattern.mustResolve) {
@@ -2670,6 +2673,7 @@ protected void reportMatching(AbstractMethodDeclaration method, TypeDeclaration 
 		}
 	}
 }
+
 /**
  * Report matching in annotations.
  * @param otherElements TODO
@@ -3138,24 +3142,7 @@ protected void reportMatching(TypeDeclaration type, IJavaElement parent, int acc
 	} else if (enclosingElement instanceof IMember) {
 	    IMember member = (IMember) parent;
 		if (member.isBinary())  {
-			IOpenable openable = enclosingElement.getOpenable();
-			IJavaElement anonType = null;
-			if (openable instanceof ClassFile) {
-				BinaryType binaryType = (BinaryType)((ClassFile) openable).getType();
-				String fileName = binaryType.getPath().toOSString();
-				if ((type.bits & ASTNode.IsAnonymousType) != 0) {
-					if (fileName != null) {
-						if (fileName.endsWith("jar") || fileName.endsWith(SuffixConstants.SUFFIX_STRING_class)) { //$NON-NLS-1$
-							IOrdinaryClassFile classFile= binaryType.getPackageFragment().getOrdinaryClassFile(binaryType.getTypeQualifiedName() +
-									"$" + Integer.toString(occurrenceCount) + SuffixConstants.SUFFIX_STRING_class);//$NON-NLS-1$
-							anonType =  classFile.getType();
-						}
-					} else {
-						// TODO: JAVA 9 - JIMAGE to be included later - currently assuming that only .class files will be dealt here.
-					}
-				}
-			}
-			enclosingElement = anonType != null ? anonType : ((IOrdinaryClassFile)this.currentPossibleMatch.openable).getType() ;
+			enclosingElement = ((IOrdinaryClassFile)this.currentPossibleMatch.openable).getType();
 		} else {
 			enclosingElement = member.getType(new String(type.name), occurrenceCount);
 		}
@@ -3454,6 +3441,71 @@ protected boolean typeInHierarchy(ReferenceBinding binding) {
 		for (int i = 0, length = this.allSuperTypeNames.length; i < length; i++)
 			if (CharOperation.equals(compoundName, this.allSuperTypeNames[i]))
 				return true;
+	}
+	return false;
+}
+/*
+ * Go through the nest hierarchy of a type, to try to create a method handle for a method declaration.
+ * Does not try to create a method handle for the specified type, only for types higher in the nest hierarchy.
+ *
+ * See:
+ * https://github.com/eclipse-jdt/eclipse.jdt.core/issues/375
+ * https://bugs.eclipse.org/bugs/show_bug.cgi?id=468127
+ */
+private IJavaElement createHandleFromNestAncestors(AbstractMethodDeclaration method, IJavaElement type) throws JavaModelException {
+	BinaryType binaryType = getBinaryType(type);
+	if (binaryType != null) {
+		boolean isJarOrClass = isJarOrClass(binaryType);
+		if (isJarOrClass) {
+			return findMethodInNestAncestors(method, binaryType);
+		} else {
+			// TODO: JAVA 9 - JIMAGE to be included later - currently assuming that only .class
+			// files will be dealt here.
+		}
+	}
+	return null;
+}
+
+/*
+ * Tries to find a method in the nest ancestors of a type. E.g. for Type$2$1, nest ancestors are: Type$1, Type
+ */
+private IJavaElement findMethodInNestAncestors(AbstractMethodDeclaration method, BinaryType binaryType) {
+	IJavaElement methodHandle = null;
+	int index = 0;
+	String typeQualifiedName = binaryType.getTypeQualifiedName();
+	// loop until we find the method or arrive at the nested classes host, e.g. for Type$2$1 the "visited" types are: Type$1, Type
+	while (methodHandle == null && index != -1) {
+		index = typeQualifiedName.lastIndexOf('$');
+		if (index != -1) {
+			typeQualifiedName = typeQualifiedName.substring(0, index);
+		}
+		String className = typeQualifiedName + SuffixConstants.SUFFIX_STRING_class;
+		IOrdinaryClassFile classFile = binaryType.getPackageFragment()
+				.getOrdinaryClassFile(className);
+		IType parentType = classFile.getType();
+		methodHandle = createHandle(method, parentType);
+	}
+	return methodHandle;
+}
+
+private BinaryType getBinaryType(IJavaElement type) {
+	BinaryType binaryType = null;
+	IMember member = (IMember) type;
+	if (member.isBinary()) {
+		IOpenable openable = member.getOpenable();
+		if (openable instanceof ClassFile) {
+			binaryType = (BinaryType) ((ClassFile) openable).getType();
+		}
+	}
+	return binaryType;
+}
+
+private boolean isJarOrClass(BinaryType binaryType) {
+	if (binaryType != null) {
+		String fileName = binaryType.getPath().toOSString();
+		if (fileName != null) {
+			return fileName.endsWith("jar") || fileName.endsWith(SuffixConstants.SUFFIX_STRING_class); //$NON-NLS-1$
+		}
 	}
 	return false;
 }


### PR DESCRIPTION
Changes added for bug
https://bugs.eclipse.org/bugs/show_bug.cgi?id=468127 can use the wrong
anonymous type .class file (in particular, always the "$1" file is
used). This can result in wrong call hierarchy results / wrong method
reference search results, since visited methods are not found in the
wrong .class file and so the search doesn't visit the the bodies of such
methods.

This change moves the fix for bug 468127 to
MatchLocator.reportMatching() for method declarations, adjusting it to
incrementally go up an anonymous types nested hierarchy to find the
method declaration.

A test for the bug is also added.

Fixes: #375

Signed-off-by: Simeon Andreev <simeon.danailov.andreev@gmail.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
