### PR TITLE
[null] Consider javax.annotation.Nullable/NonNull by default

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullAnnotationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullAnnotationTest.java
@@ -8707,7 +8707,6 @@ public void testBug418236() {
 }
 public void testBug461878() {
 	Map compilerOptions = getCompilerOptions();
-	compilerOptions.put(JavaCore.COMPILER_NONNULL_ANNOTATION_NAME, "javax.annotation.Nonnull");
 	runNegativeTest(
 		true, /*flush*/
 		new String[] {

--- a/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/impl/CompilerOptions.java
+++ b/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/impl/CompilerOptions.java
@@ -47,6 +47,8 @@ import org.eclipse.jdt.internal.compiler.util.Util;
 @SuppressWarnings({ "rawtypes", "unchecked" })
 public class CompilerOptions {
 
+	private static final String[] NO_STRINGS = new String[0];
+
 	/**
 	 * Option IDs
 	 */
@@ -188,6 +190,9 @@ public class CompilerOptions {
 	static final char[][] DEFAULT_NULLABLE_ANNOTATION_NAME = CharOperation.splitOn('.', "org.eclipse.jdt.annotation.Nullable".toCharArray()); //$NON-NLS-1$
 	static final char[][] DEFAULT_NONNULL_ANNOTATION_NAME = CharOperation.splitOn('.', "org.eclipse.jdt.annotation.NonNull".toCharArray()); //$NON-NLS-1$
 	static final char[][] DEFAULT_NONNULLBYDEFAULT_ANNOTATION_NAME = CharOperation.splitOn('.', "org.eclipse.jdt.annotation.NonNullByDefault".toCharArray()); //$NON-NLS-1$
+	static final String[] DEFAULT_NULLABLE_ANNOTATION_SECONDARY_NAMES = { "javax.annotation.Nullable" }; //$NON-NLS-1$
+	static final String[] DEFAULT_NONNULL_ANNOTATION_SECONDARY_NAMES = { "javax.annotation.Nonnull" }; //$NON-NLS-1$
+	static final String[] DEFAULT_NONNULLBYDEFAULT_ANNOTATION_SECONDARY_NAMES = NO_STRINGS;
 	public static final String OPTION_ReportMissingNonNullByDefaultAnnotation = "org.eclipse.jdt.core.compiler.annotation.missingNonNullByDefaultAnnotation";  //$NON-NLS-1$
 	public static final String OPTION_SyntacticNullAnalysisForFields = "org.eclipse.jdt.core.compiler.problem.syntacticNullAnalysisForFields"; //$NON-NLS-1$
 	public static final String OPTION_InheritNullAnnotations = "org.eclipse.jdt.core.compiler.annotation.inheritNullAnnotations";  //$NON-NLS-1$
@@ -255,8 +260,6 @@ public class CompilerOptions {
 	public static final String RETURN_TAG = "return_tag";	//$NON-NLS-1$
 	public static final String NO_TAG = "no_tag";	//$NON-NLS-1$
 	public static final String ALL_STANDARD_TAGS = "all_standard_tags";	//$NON-NLS-1$
-
-	private static final String[] NO_STRINGS = new String[0];
 
 	/**
 	 * Bit mask for configurable problems (error/warning threshold)
@@ -1581,6 +1584,9 @@ public class CompilerOptions {
 		this.nullableAnnotationName = DEFAULT_NULLABLE_ANNOTATION_NAME;
 		this.nonNullAnnotationName = DEFAULT_NONNULL_ANNOTATION_NAME;
 		this.nonNullByDefaultAnnotationName = DEFAULT_NONNULLBYDEFAULT_ANNOTATION_NAME;
+		this.nullableAnnotationSecondaryNames = DEFAULT_NULLABLE_ANNOTATION_SECONDARY_NAMES;
+		this.nonNullAnnotationSecondaryNames = DEFAULT_NONNULL_ANNOTATION_SECONDARY_NAMES;
+		this.nonNullByDefaultAnnotationSecondaryNames = DEFAULT_NONNULLBYDEFAULT_ANNOTATION_SECONDARY_NAMES;
 		this.intendedDefaultNonNullness = 0;
 		this.enableSyntacticNullAnalysisForFields = false;
 		this.inheritNullAnnotations = false;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does

This adds support for `javax.annotation.Nonnull` and `javax.annotation.Nullable`, which are popular becaues of JSR-305 by default in JDT null analysis. So users of JSR-305 do not require specific configuration to leverage JDT null analysis

## How to test

Enable null annotation and try
```java
class A {
  @javax.annotation.Nonnull String s = null;
}
```

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
