### PR TITLE
fix exception in content assist in record pattern

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests19.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests19.java
@@ -427,4 +427,43 @@ public class CompletionTests19 extends AbstractJavaModelCompletionTests {
 					requestor.getResults());
 
 		}
+		//content assist ArrayStoreException fix
+		//https://github.com/eclipse-jdt/eclipse.jdt.core/issues/345
+		public void test011() throws JavaModelException {
+			this.workingCopies = new ICompilationUnit[1];
+			this.workingCopies[0] = getWorkingCopy(
+					"/Completion/src/X.java",
+					"@SuppressWarnings(\"preview\")"
+					+ "public class X {\n"
+					+ "  public static void printLowerRight(Rectangle r) {\n"
+					+ "    int res = switch(r) {\n"
+					+ "       case Rectangle(ColoredPoint(Point(int x, int y), Color c),\n"
+					+ "                               ColoredPoint lr) r1  -> {\n"
+					+ "                               fals "
+					+ "        		yield 1;  \n"
+					+ "        } \n"
+					+ "        default -> 0;\n"
+					+ "    }; \n"
+					+ "     \n"
+					+ "  }\n"
+					+ "  public static void main(String[] args) {\n"
+					+ "    printLowerRight(new Rectangle(new ColoredPoint(new Point(15, 5), Color.BLUE), \n"
+					+ "        new ColoredPoint(new Point(30, 10), Color.RED)));\n"
+					+ "  }\n"
+					+ "}\n"
+					+ "record Point(int x, int y) {}\n"
+					+ "enum Color { RED, GREEN, BLUE }\n"
+					+ "record ColoredPoint(Point p, Color c) {}\n"
+					+ "record Rectangle(ColoredPoint upperLeft, ColoredPoint lowerRight) {}"
+					);
+			CompletionTestsRequestor2 requestor = new CompletionTestsRequestor2(true);
+			requestor.allowAllRequiredProposals();
+			String str = this.workingCopies[0].getSource();
+			String completeBehind = "fals";
+			int cursorLocation = str.indexOf(completeBehind) + completeBehind.length();
+			this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner);
+			assertResults("false[KEYWORD]{false, null, null, false, null, 52}",
+					requestor.getResults());
+
+		}
 }

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionParser.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionParser.java
@@ -8,7 +8,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
- * 
+ *
  * This is an implementation of an early-draft specification developed under the Java
  * Community Process (JCP) and is made available for testing and evaluation purposes
  * only. The code is not compatible with any specification of the JCP.
@@ -4255,6 +4255,9 @@ protected void consumeToken(int token) {
 					// YieldStatement and thus not producing accurate completion, but completion doesn't have
 					// enough information anyway about the LHS anyway.
 					token = this.currentToken = this.getNextToken();
+					if(token == TokenNameIntegerLiteral && this.previousToken == TokenNameIdentifier ) {
+						token = this.currentToken = this.getNextToken();
+					}
 					super.consumeToken(this.currentToken);
 				}
 				if (previous == TokenNameDOT) { // e.g. foo().[fred]()


### PR DESCRIPTION
Signed-off-by: Vikas Chandra <Vikas.Chandra@in.ibm.com>
fixes #345
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
NameIdentifier, yield & NameIntegerLiteral  (coming together without a semicolon) confuses the CompletionParser and 
hence skipping the last token fixes this.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Check bug #345 for recreating or attached test case in this PR

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
