### PR TITLE
testBug576735 from #327 should only run at 1.5+

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ProblemTypeAndMethodTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ProblemTypeAndMethodTest.java
@@ -8784,6 +8784,8 @@ public void testBug542829() {
 	runner.runConformTest();
 }
 public void testBug576735() {
+	if (this.complianceLevel < ClassFileConstants.JDK1_5) return;
+
 	String path = getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "lib576735.jar";
 	String[] libs = getDefaultClassPaths();
 	int len = libs.length;


### PR DESCRIPTION
## What it does
Avoid test failure due to "`Syntax error, annotations are only available if source level is 1.5 or greater`" as seen in https://download.eclipse.org/eclipse/downloads/drops4/I20220910-1800/testresults/html/org.eclipse.jdt.core.tests.compiler_ep426I-unit-cen64-gtk3-java18_linux.gtk.x86_64_18.html