### PR TITLE
Add note about typo in method declaration parethesis position formatter option

### DIFF
--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/core/formatter/DefaultCodeFormatterConstants.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/core/formatter/DefaultCodeFormatterConstants.java
@@ -1178,6 +1178,10 @@ public class DefaultCodeFormatterConstants {
 	 *     - possible values:   { COMMON_LINES, SEPARATE_LINES_IF_NOT_EMPTY, SEPARATE_LINES_IF_WRAPPED, SEPARATE_LINES, PRESERVE_POSITIONS }
 	 *     - default:           COMMON_LINES
 	 * </pre>
+	 *
+	 * Note that there is a typo ({@code delcaration} vs. {@code declaration})
+	 * in the option name. It has to remain, as fixing it would be a breaking
+	 * change.
 	 * @see #COMMON_LINES
 	 * @see #SEPARATE_LINES_IF_NOT_EMPTY
 	 * @see #SEPARATE_LINES_IF_WRAPPED


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Added a note to a configuration option that contains a typo to highlight it for people manually editing a formatter configuration file and to explain that it has to remain.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
