### PR TITLE
Bug 576806: Record components prevent undocumented empty block warning

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordsRestrictedClassTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordsRestrictedClassTest.java
@@ -9131,5 +9131,36 @@ public void testBug577251_001() {
 		"Erasure incompatibility in argument X.Entry of canonical constructor in record\n" +
 		"----------\n");
 }
-
+public void testBug576806_001() {
+	Map<String, String> options = getCompilerOptions();
+	options.put(CompilerOptions.OPTION_ReportUndocumentedEmptyBlock, CompilerOptions.ERROR);
+	this.runNegativeTest(
+		false /* skipJavac */,
+		new JavacTestOptions("Xlint:empty"),
+		new String[] {
+				"X.java",
+				"public class X {\n"+
+				"  public static void main(String[] args){\n"+
+				"     System.out.println(0);\n" +
+				"  }\n"+
+				"}\n"+
+				"record Empty(){\n"+
+				"}\n"+
+				"record DocumentedEmpty(){\n"+
+				"  // intentionally empty\n"+
+				"}\n"+
+				"record Point(int x, int y){\n"+
+				"}"
+		},
+		"----------\n" +
+		"1. ERROR in X.java (at line 6)\n" +
+		"	record Empty(){\n" +
+		"}\n" +
+		"	             ^^^^\n" +
+		"Empty block should be documented\n" +
+		"----------\n",
+		null,
+		false,
+		options);
+}
 }

--- a/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/ast/TypeDeclaration.java
+++ b/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/ast/TypeDeclaration.java
@@ -1320,7 +1320,7 @@ public void resolve() {
 			}
 		}
 
-		if ((this.bits & ASTNode.UndocumentedEmptyBlock) != 0) {
+		if ((this.bits & ASTNode.UndocumentedEmptyBlock) != 0 && this.nRecordComponents == 0) {
 			this.scope.problemReporter().undocumentedEmptyBlock(this.bodyStart-1, this.bodyEnd);
 		}
 		boolean needSerialVersion =


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Empty record declarations are not reported as undocumented empty block if at least one record component is present.
This PR fixes the issue by requiring no record components to be present for a type declaration to be empty.

Note: This was previously #127 but was auto-closed as I chose another branch name
and that was previously https://git.eclipse.org/r/c/jdt/eclipse.jdt.core/+/191077

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
For reproduction and reasoning, see https://bugs.eclipse.org/bugs/show_bug.cgi?id=576806.
The existing and the newly added tests should cover this. To be precise, the new test checks that only a record with no record components and no content in the body triggers the warning, and that a record with record components or a comment is not considered an empty block.

## Author checklist

- I have thoroughly tested my changes
- The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)

