### PR TITLE
Fix class file generic varargs method reference signature

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericTypeSignatureTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericTypeSignatureTest.java
@@ -1397,13 +1397,11 @@ public class GenericTypeSignatureTest extends AbstractRegressionTest {
 
 				IBinaryMethod m1Lambda = methods[2];
 				assertEquals("Wrong name", "lambda$2", new String(m1Lambda.getSelector()));
-				assertNull("Synthetic method for lambda in m1 must not have a generic signature",
-						m1Lambda.getGenericSignature());
+				assertEquals("Wrong signature", "()Ljava/util/stream/Stream<TT;>;", new String(m1Lambda.getGenericSignature()));
 
-				IBinaryMethod m2Lambda = methods[2];
+				IBinaryMethod m2Lambda = methods[3];
 				assertEquals("Wrong name", "lambda$3", new String(m2Lambda.getSelector()));
-				assertNull("Synthetic method for lambda in m2 must not have a generic signature",
-						m2Lambda.getGenericSignature());
+				assertEquals("Wrong signature", "()Ljava/util/stream/Stream<TT;>;", new String(m2Lambda.getGenericSignature()));
 			} catch (ClassFormatException e) {
 				assertTrue(false);
 			} catch (IOException e) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
This fixes the problem that
```java
import java.util.Optional;
import java.util.stream.Stream;

public interface ClassFileBug {

	static void signatureBug1() {
		Optional.<Stream<String>>empty().orElseGet(Stream::of);
	}

	static <T> Stream<T> signatureBug2() {
		return Optional.<Stream<T>>empty().orElseGet(Stream::of);
	}

	public static void main(String[] args) {
		for (var m : ClassFileBug.class.getDeclaredMethods())
			m.toGenericString();
	}
}
```
fails with 
```
Exception in thread "main" java.lang.reflect.GenericSignatureFormatError: Signature Parse error: Expected Field Type Signature
	Remaining input: +Ljava/util/stream/Stream<Ljava/lang/String;>;
```
due to the `+` in the signature and also other problems related to the generic types that get "disconnected" in the lambda signature. Currently, this is only a test that expects the same behavior as the `javac` compiler does, which is no method signature in such cases.

## How to test
See the provided automatic JUnit test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
