### PR TITLE
Remove obsoleted MatchLocator.isJarOrClass() code (#422)

### DIFF
--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/MatchLocator.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/MatchLocator.java
@@ -3455,13 +3455,7 @@ protected boolean typeInHierarchy(ReferenceBinding binding) {
 private IJavaElement createHandleFromNestAncestors(AbstractMethodDeclaration method, IJavaElement type) throws JavaModelException {
 	BinaryType binaryType = getBinaryType(type);
 	if (binaryType != null) {
-		boolean isJarOrClass = isJarOrClass(binaryType);
-		if (isJarOrClass) {
-			return findMethodInNestAncestors(method, binaryType);
-		} else {
-			// TODO: JAVA 9 - JIMAGE to be included later - currently assuming that only .class
-			// files will be dealt here.
-		}
+		return findMethodInNestAncestors(method, binaryType);
 	}
 	return null;
 }
@@ -3500,13 +3494,4 @@ private BinaryType getBinaryType(IJavaElement type) {
 	return binaryType;
 }
 
-private boolean isJarOrClass(BinaryType binaryType) {
-	if (binaryType != null) {
-		String fileName = binaryType.getPath().toOSString();
-		if (fileName != null) {
-			return fileName.endsWith("jar") || fileName.endsWith(SuffixConstants.SUFFIX_STRING_class); //$NON-NLS-1$
-		}
-	}
-	return false;
-}
 }


### PR DESCRIPTION
The method was added during Java 9 transition as it was not clear how binary types will be packaged in the JDK.

We don't need to check the path from the class file to determine if it is a class file from "jar" or "class" or whatever else. If we were able to compile related code, we should be able to find that binary type - if not, it is a bug on its own.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/422