### PR TITLE
No match found for method reference in anonymous class #432

### DIFF
--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/SourceIndexer.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/SourceIndexer.java
@@ -196,7 +196,14 @@ public class SourceIndexer extends AbstractIndexer implements ITypeRequestor, Su
 		AbstractMethodDeclaration[] methods = type.methods;
 		for (int j = 0, length = methods == null ? 0 : methods.length; j < length; j++) {
 			AbstractMethodDeclaration method = methods[j];
-			if (method != null && (method.bits & ASTNode.HasFunctionalInterfaceTypes) == 0) {
+			/*
+			 * In case the method defines a local type, skip purging the method body.
+			 * We don't know if the local type defines a method that uses a method reference or a lambda.
+			 * See:
+			 *   https://github.com/eclipse-jdt/eclipse.jdt.core/issues/432
+			 *   https://bugs.eclipse.org/bugs/show_bug.cgi?id=566435
+			 */
+			if (method != null && (method.bits & (ASTNode.HasFunctionalInterfaceTypes | ASTNode.HasLocalType)) == 0) {
 				method.statements = null;
 				method.javadoc = null;
 			}


### PR DESCRIPTION
The performance improvement done for Eclipse bug 429279 introduces
pruning of method bodies, if a method does not have functional interface
types. Checking for the presence of functional interface types however
does not consider anonymous types defined in the method body.

This change prevents the pruning done for bug 429279, in case a method
defines an anonymous type.

A test is also added for a few example cases.

See:
* https://bugs.eclipse.org/bugs/show_bug.cgi?id=429279
* https://bugs.eclipse.org/bugs/show_bug.cgi?id=566435

Fixes: #432

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
