### PR TITLE
Improve scanner "when" token disambiguation

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ScannerTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ScannerTest.java
@@ -1836,4 +1836,25 @@ public class ScannerTest extends AbstractRegressionTest {
 			assertTrue(false);
 		}
 	}
+
+	public void testWhenAsIdentifier() {
+		String source =
+				"public void when(Object when) {\n" +
+				"	Predicate<Object> condition = o -> when(o);\n" +
+				"	SomeClass.when(condition).when();\n" +
+				"	SomeClass./*comment*/when(condition,/*comment*/when(false)). when(true);\n" +
+				"}";
+		IScanner scanner = ToolFactory.createScanner(true, true, true, "19", "19", true);
+		scanner.setSource(source.toCharArray());
+		try {
+			int token;
+			while ((token = scanner.getNextToken()) != ITerminalSymbols.TokenNameEOF) {
+				if (token == ITerminalSymbols.TokenNameRestrictedIdentifierWhen) {
+					fail("TokenNameRestrictedIdentifierWhen must not be detected");
+				}
+			}
+		} catch (InvalidInputException e) {
+			assertTrue(false);
+		}
+	}
 }

--- a/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/parser/Parser.java
+++ b/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/parser/Parser.java
@@ -12819,12 +12819,12 @@ protected boolean moveRecoveryCheckpoint() {
 	do {
 		try {
 			this.scanner.multiCaseLabelComma = false;
-			this.scanner.lookBack[0] = this.scanner.lookBack[1] = TokenNameNotAToken; // stay clear of the voodoo in the present method
+			this.scanner.resetLookBack(); // stay clear of the voodoo in the present method
 			this.nextIgnoredToken = this.scanner.getNextNotFakedToken();
 		} catch(InvalidInputException e){
 			pos = this.scanner.currentPosition;
 		} finally {
-			this.scanner.lookBack[0] = this.scanner.lookBack[1] = TokenNameNotAToken; // steer clear of the voodoo in the present method
+			this.scanner.resetLookBack(); // steer clear of the voodoo in the present method
 			this.scanner.multiCaseLabelComma = false;
 		}
 	} while (this.nextIgnoredToken < 0);

--- a/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/parser/Scanner.java
+++ b/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/parser/Scanner.java
@@ -5081,16 +5081,18 @@ protected boolean mayBeAtGuard(int token) {
 		return false;
 	if (!JavaFeature.PATTERN_MATCHING_IN_SWITCH.isSupported(this.complianceLevel, this.previewEnabled))
 		return false;
-	switch (this.lookBack[1]) { // a simple elimination optimization for some common possible cases
-		case TokenNameCOMMA:
-		case TokenNamecase:
-		case TokenNamedefault:
-		case TokenNameSEMICOLON:
-		case TokenNameRestrictedIdentifierWhen:
-		case TokenNameOR_OR:
-			return false;
+	/*
+	 * A simple elimination optimization for some common possible cases. According to the JLS 19 including
+	 * patterns-switch and record-patterns Section 14.30.1, a guard may only be preceded by either right parentheses or
+	 * an identifier. However, we may still encounter comments, whitespace or the not-a-token token.
+	 */
+	switch (this.lookBack[1]) {
+		case TokenNameRPAREN:
+		case TokenNameIdentifier:
+		case TokenNameNotAToken: // TODO is this useful? Some tests start scanning at "when", but this makes not sense as a Pattern is required by the JLS
+			return true;
 	}
-	return true;
+	return false;
 }
 protected final boolean mayBeAtBreakPreview() {
 	return !isInModuleDeclaration() && this.breakPreviewAllowed && this.lookBack[1] != TokenNameARROW;

--- a/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/parser/Scanner.java
+++ b/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/parser/Scanner.java
@@ -177,6 +177,17 @@ public class Scanner implements TerminalTokens {
 	public boolean returnOnlyGreater = false;
 
 	public boolean insideRecovery = false;
+	/**
+	 * Look back for the two most recent tokens.
+	 * <ul>
+	 * <li><code>lookBack[1]</code> is the previous token</li>
+	 * <li><code>lookBack[0]</code> is the token before <code>lookBack[1]</code></li>
+	 * </ul>
+	 * As this look back is intended for resolving ambiguities and conflicts, it ignores whitespace and comments.
+	 *
+	 * @see #resetLookBack() Reset the lock back and clear all stored tokens
+	 * @see #addTokenToLookBack(int) Add a token to the look back, removing the oldest entry
+	 */
 	int lookBack[] = new int[2]; // fall back to spring forward.
 	protected int nextToken = TokenNameNotAToken; // allows for one token push back, only the most recent token can be reliably ungotten.
 	private VanguardScanner vanguardScanner;
@@ -223,7 +234,8 @@ public Scanner(
 	this.tokenizeComments = tokenizeComments;
 	this.tokenizeWhiteSpace = tokenizeWhiteSpace;
 	this.sourceLevel = sourceLevel;
-	this.lookBack[0] = this.lookBack[1] = this.nextToken = TokenNameNotAToken;
+	this.resetLookBack();
+	this.nextToken = TokenNameNotAToken;
 	this.consumingEllipsisAnnotations = false;
 	this.complianceLevel = complianceLevel;
 	this.checkNonExternalizedStringLiterals = checkNonExternalizedStringLiterals;
@@ -1413,8 +1425,7 @@ public int getNextToken() throws InvalidInputException {
 	}
 	if (this.activeParser == null) { // anybody interested in the grammatical structure of the program should have registered.
 		if (token != TokenNameWHITESPACE) {
-			this.lookBack[0] = this.lookBack[1];
-			this.lookBack[1] = token;
+			addTokenToLookBack(token);
 			this.multiCaseLabelComma = false;
 		}
 		return token;
@@ -1426,8 +1437,7 @@ public int getNextToken() throws InvalidInputException {
 	} else if (mayBeAtCasePattern(token)) {
 		token = disambiguateCasePattern(token, this);
 	}
-	this.lookBack[0] = this.lookBack[1];
-	this.lookBack[1] = token;
+	addTokenToLookBack(token);
 	this.multiCaseLabelComma = false;
 	return token;
 }
@@ -3020,13 +3030,34 @@ public void resetTo(int begin, int end, boolean isModuleInfo, ScanContext contex
 	}
 	this.commentPtr = -1; // reset comment stack
 	this.foundTaskCount = 0;
-	this.lookBack[0] = this.lookBack[1] = this.nextToken = TokenNameNotAToken;
+	resetLookBack();
+	this.nextToken = TokenNameNotAToken;
 	this.consumingEllipsisAnnotations = false;
 	this.insideModuleInfo = isModuleInfo;
 	this.scanContext = context == null ? getScanContext(begin) : context;
 	this.multiCaseLabelComma = false;
 }
-
+/**
+ * @see #lookBack
+ */
+final void resetLookBack() {
+	this.lookBack[0] = this.lookBack[1] = TokenNameNotAToken;
+}
+/**
+ * @see #lookBack
+ */
+final void addTokenToLookBack(int newToken) {
+	// ignore whitespace and comments
+	switch (newToken) {
+		case TokenNameWHITESPACE:
+		case TokenNameCOMMENT_LINE:
+		case TokenNameCOMMENT_BLOCK:
+		case TokenNameCOMMENT_JAVADOC:
+			return;
+	}
+	this.lookBack[0] = this.lookBack[1];
+	this.lookBack[1] = newToken;
+}
 private ScanContext getScanContext(int begin) {
 	if (!isInModuleDeclaration())
 		return ScanContext.INACTIVE;
@@ -4731,8 +4762,7 @@ private static final class VanguardScanner extends Scanner {
 				token = TokenNameAT308;
 			}
 		}
-		this.lookBack[0] = this.lookBack[1];
-		this.lookBack[1] = token;
+		this.addTokenToLookBack(token);
 		this.multiCaseLabelComma = false;
 		return token == TokenNameEOF ? TokenNameNotAToken : token;
 	}
@@ -5159,7 +5189,7 @@ protected final boolean atTypeAnnotation() { // Did the '@' we saw just now hera
 
 public void setActiveParser(ConflictedParser parser) {
 	this.activeParser  = parser;
-	this.lookBack[0] = this.lookBack[1] = TokenNameNotAToken;  // no hand me downs please.
+	this.resetLookBack();  // no hand me downs please.
 	if (parser != null) {
 		this.insideModuleInfo = parser.isParsingModuleDeclaration();
 	}

--- a/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/parser/Scanner.java
+++ b/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/parser/Scanner.java
@@ -185,7 +185,7 @@ public class Scanner implements TerminalTokens {
 	 * </ul>
 	 * As this look back is intended for resolving ambiguities and conflicts, it ignores whitespace and comments.
 	 *
-	 * @see #resetLookBack() Reset the lock back and clear all stored tokens
+	 * @see #resetLookBack() Reset the look back and clear all stored tokens
 	 * @see #addTokenToLookBack(int) Add a token to the look back, removing the oldest entry
 	 */
 	int lookBack[] = new int[2]; // fall back to spring forward.
@@ -5089,7 +5089,7 @@ protected boolean mayBeAtGuard(int token) {
 	switch (this.lookBack[1]) {
 		case TokenNameRPAREN:
 		case TokenNameIdentifier:
-		case TokenNameNotAToken: // TODO is this useful? Some tests start scanning at "when", but this makes not sense as a Pattern is required by the JLS
+		case TokenNameNotAToken: // TODO is this useful? Some tests start scanning at "when", but this makes no sense as a Pattern is required by the JLS
 			return true;
 	}
 	return false;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
The contextual keyword "when" for the JLS 19 preview feature pattern matching in switch is currently not detected correctly.

Example:
```java
class X {
    void someMethod(Predicate<Object> condition) {
        SomeClass.when(condition).doSomething();
    }
}
```
The problem:
```
Syntax error on token "RestrictedIdentifierWhen", Identifier expected
```
I noticed that problem with JavaFX EasyBind, but this is probably a common method name in libraries.

This PR also contains a refactoring and small semantic change regarding `lookBack` in the `Scanner`, see the provided Javadoc + test case for that and the commit messages.

The new rules for `when` are based on https://docs.oracle.com/javase/specs/jls/se19/preview/specs/patterns-switch-record-patterns-jls.html#jls-14.11.1

## How to test
See the provided example or the provided test.

## Author checklist

- [x] I have thoroughly tested my changes (on my machine, all parser and compiler regression tests still pass)
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
