### PR TITLE
JavaSearchScopeTests.testModuleJarSearchBugGh332 fails on Windows #463

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchScopeTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchScopeTests.java
@@ -1173,7 +1173,7 @@ public void testModuleJarSearchBugGh332() throws Exception {
 
 		String foundReferences = resultCollector.toString();
 		assertFalse("Expected search to find references of method: " + schedMethod, foundReferences.isEmpty());
-		List<String> results = Arrays.asList(foundReferences.split(System.lineSeparator()));
+		List<String> results = Arrays.asList(foundReferences.split("\n"));
 		String[] expectedResults = {
 				"void java.util.Timer.schedule(java.util.TimerTask, long)",
 				"void java.util.Timer.schedule(java.util.TimerTask, java.util.Date)",


### PR DESCRIPTION
This change fixes a fail in
JavaSearchScopeTests.testModuleJarSearchBugGh332() on Windows.

Fixes: #463

Signed-off-by: Simeon Andreev <simeon.danailov.andreev@gmail.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
