### PR TITLE
Revert "Temporarily bump heap used by model tests to 2G"

### DIFF
--- a/org.eclipse.jdt.core.tests.model/pom.xml
+++ b/org.eclipse.jdt.core.tests.model/pom.xml
@@ -34,7 +34,7 @@
       	<artifactId>tycho-surefire-plugin</artifactId>
       	<version>${tycho.version}</version>
       	<configuration>
-      	  <argLine>-Xmx2G -Djdt.default.test.compliance=1.8 ${tycho.surefire.argLine}</argLine>
+      	  <argLine>-Xmx1G -Djdt.default.test.compliance=1.8 ${tycho.surefire.argLine}</argLine>
       	  <includes>
       	  	<include>org/eclipse/jdt/core/tests/model/AllJavaModelTestsTracing.class</include>
       	  	<include>org/eclipse/jdt/core/tests/dom/RunAllTestsTracing.class</include>


### PR DESCRIPTION
This reverts commit 660f46303d4b4030e77523e1608732f026be4218.

Tycho should be hopefully fixed now and don't leak memory anymore.