### PR TITLE
Split package error not detected via QualifiedNameReference fixes #470

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/UnnamedModuleTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/UnnamedModuleTest.java
@@ -181,4 +181,31 @@ public void testIgnoreUnnamedModule4() {
 			"",
 			JavacTestOptions.DEFAULT);
 }
+public void testConflictWithUnnamedModule() {
+	String path = this.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "ignore-unnamed-module-test.jar";
+	String[] defaultLibs = getDefaultClassPaths();
+	int len = defaultLibs.length;
+	String[] libs = new String[len+1];
+	System.arraycopy(defaultLibs, 0, libs, 0, len);
+	libs[len] = path;
+	Runner runner = new Runner();
+	runner.classLibraries = libs;
+	runner.testFiles =
+			new String[] {
+				"X.java",
+				"public class X {\n" +
+				"	void foo() {\n" +
+				"		String s = org.xml.sax.helpers.NamespaceSupport.XMLNS;\n" +
+				"	}\n" +
+				"}"
+			};
+	runner.expectedErrorString =
+			"----------\n" +
+			"1. ERROR in X.java (at line 3)\n" +
+			"	String s = org.xml.sax.helpers.NamespaceSupport.XMLNS;\n" +
+			"	           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
+			"The package org.xml.sax.helpers is accessible from more than one module: <unnamed>, java.xml\n" +
+			"----------\n";
+	runner.runNegativeTest();
+}
 }

--- a/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/lookup/BlockScope.java
+++ b/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/lookup/BlockScope.java
@@ -586,6 +586,13 @@ public Binding getBinding(char[][] compoundName, int mask, InvocationSite invoca
 						CharOperation.subarray(compoundName, 0, currentIndex),
 						(ReferenceBinding) binding,
 						ProblemReasons.NotVisible);
+				if (packageBinding instanceof SplitPackageBinding) {
+					packageBinding = packageBinding.getVisibleFor(module(), false);
+					if (packageBinding instanceof SplitPackageBinding) {
+						problemReporter().conflictingPackagesFromModules((SplitPackageBinding) packageBinding, module(),
+								invocationSite.sourceStart(), invocationSite.sourceEnd());
+					}
+				}
 				break foundType;
 			}
 			packageBinding = (PackageBinding) binding;


### PR DESCRIPTION
## What it does
* ensures package conflict is reported in one more syntactic situation

## How to test
* use a fully qualified name to reference a static member in a class that is accessed via an illegally split package.
