### PR TITLE
GH472: substitute and then erasure if unchecked conversion was necessary 

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericTypeTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericTypeTest.java
@@ -50642,23 +50642,10 @@ public void test1436() {
 			"	^^^^^^^^^^^\n" +
 			"Type safety: Unchecked invocation foo(List, IllegalArgumentException) of the generic method foo(List<U>, T) of type X\n" +
 			"----------\n" +
-			(this.complianceLevel < ClassFileConstants.JDK1_8
-			?
-				"3. WARNING in X.java (at line 8)\n" +
-				"	foo(l, iae);\n" +
-				"	    ^\n" +
-				"Type safety: The expression of type List needs unchecked conversion to conform to List<List<?>>\n"
-			:
-				"3. ERROR in X.java (at line 8)\n" +
-				"	foo(l, iae);\n" +
-				"	^^^^^^^^^^^\n" +
-				"Unhandled exception type Throwable\n" + // new error since 1.8 (bug 473657)
-				"----------\n" +
-				"4. WARNING in X.java (at line 8)\n" +
-				"	foo(l, iae);\n" +
-				"	    ^\n" +
-				"Type safety: The expression of type List needs unchecked conversion to conform to List<List<?>>\n"
-			) +
+			"3. WARNING in X.java (at line 8)\n" +
+			"	foo(l, iae);\n" +
+			"	    ^\n" +
+			"Type safety: The expression of type List needs unchecked conversion to conform to List<List<?>>\n" +
 			"----------\n");
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=258798 - variation
@@ -50690,23 +50677,10 @@ public void test1437() {
 			"	^^^^^^^^^^^^^\n" +
 			"Type safety: Unchecked invocation X(List, IllegalArgumentException) of the generic constructor X(List<U>, T) of type X\n" +
 			"----------\n" +
-			(this.complianceLevel < ClassFileConstants.JDK1_8
-			?
-				"3. WARNING in X.java (at line 8)\n" +
-				"	new X(l, iae);\n" +
-				"	      ^\n" +
-				"Type safety: The expression of type List needs unchecked conversion to conform to List<List<?>>\n"
-			:
-				"3. ERROR in X.java (at line 8)\n" +
-				"	new X(l, iae);\n" +
-				"	^^^^^^^^^^^^^\n" +
-				"Unhandled exception type Throwable\n" + // new error since 1.8 (bug 473657)
-				"----------\n" +
-				"4. WARNING in X.java (at line 8)\n" +
-				"	new X(l, iae);\n" +
-				"	      ^\n" +
-				"Type safety: The expression of type List needs unchecked conversion to conform to List<List<?>>\n"
-			) +
+			"3. WARNING in X.java (at line 8)\n" +
+			"	new X(l, iae);\n" +
+			"	      ^\n" +
+			"Type safety: The expression of type List needs unchecked conversion to conform to List<List<?>>\n" +
 			"----------\n");
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=258798 - variation
@@ -50738,23 +50712,10 @@ public void test1438() {
 			"	^^^^^^^^^^^^^^^\n" +
 			"Type safety: Unchecked invocation X(List, IllegalArgumentException) of the generic constructor X(List<U>, T) of type X\n" +
 			"----------\n" +
-			(this.complianceLevel < ClassFileConstants.JDK1_8
-			?
-				"3. WARNING in X.java (at line 8)\n" +
-				"	new X(l, iae){};\n" +
-				"	      ^\n" +
-				"Type safety: The expression of type List needs unchecked conversion to conform to List<List<?>>\n"
-			:
-				"3. ERROR in X.java (at line 8)\n" +
-				"	new X(l, iae){};\n" +
-				"	^^^^^^^^^^^^^^^\n" +
-				"Unhandled exception type Throwable\n" + // new error since 1.8 (bug 473657)
-				"----------\n" +
-				"4. WARNING in X.java (at line 8)\n" +
-				"	new X(l, iae){};\n" +
-				"	      ^\n" +
-				"Type safety: The expression of type List needs unchecked conversion to conform to List<List<?>>\n"
-			) +
+			"3. WARNING in X.java (at line 8)\n" +
+			"	new X(l, iae){};\n" +
+			"	      ^\n" +
+			"Type safety: The expression of type List needs unchecked conversion to conform to List<List<?>>\n" +
 			"----------\n");
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=258798 - variation
@@ -50783,11 +50744,14 @@ public void test1439() {
 			"	^^^^^^^^^^^^^^^^^^^^^^^^\n" +
 			"Type safety: Unchecked invocation X(List, null) of the generic constructor X(List<U>, T) of type X\n" +
 			"----------\n" +
+			(this.complianceLevel < ClassFileConstants.JDK1_8 ?
 			"2. ERROR in X.java (at line 7)\n" +
 			"	this((List) null, null);\n" +
 			"	^^^^^^^^^^^^^^^^^^^^^^^^\n" +
 			"Unhandled exception type Throwable\n" +
-			"----------\n" +
+			"----------\n"
+			: "" // no error in 1.8 (bug GH472)
+			) +
 			"3. WARNING in X.java (at line 7)\n" +
 			"	this((List) null, null);\n" +
 			"	     ^^^^^^^^^^^\n" +
@@ -51071,16 +51035,22 @@ public void test1445() {
 			"	^^^^^^^^^^^^^^^\n" +
 			"Type safety: Unchecked invocation foo(List) of the generic method foo(List<T>) of type X\n" +
 			"----------\n" +
+			(this.complianceLevel < ClassFileConstants.JDK1_8 ?
 			"4. ERROR in X.java (at line 9)\n" +
 			"	new X(l).foo(l);\n" +
 			"	^^^^^^^^\n" +
 			"Unhandled exception type Throwable\n" +
-			"----------\n" +
+			"----------\n"
+			: "" // no error in 1.8 (bug GH472)
+			) +
+			(this.complianceLevel < ClassFileConstants.JDK1_8 ?
 			"5. ERROR in X.java (at line 9)\n" +
 			"	new X(l).foo(l);\n" +
 			"	^^^^^^^^^^^^^^^\n" +
 			"Unhandled exception type Throwable\n" +
-			"----------\n" +
+			"----------\n"
+			: "" // no error in 1.8 (bug GH472)
+			) +
 			"6. WARNING in X.java (at line 9)\n" +
 			"	new X(l).foo(l);\n" +
 			"	      ^\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -6678,6 +6678,95 @@ public void testBug576524() {
 				"}"
 			},
 			"SUCCESS"
+		);
+	}
+}
+
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/472
+// If unchecked conversion was necessary for the arguments,
+// substitute and erase the return type.
+public void testBugGH472_a() {
+	if (this.complianceLevel >= ClassFileConstants.JDK1_8) {
+		this.runConformTest(
+			new String[] {
+				"ReturnTypeTest.java",
+				"public class ReturnTypeTest {\n"
+				+ "    <T> T m(Class<T> arg1, Class<T> arg2) { return null; }\n"
+				+ "\n"
+				+ "    void test(Class c1, Class<Class<String>> c2) throws Exception {\n"
+				+ "        m(c1, c2).newInstance();\n"
+				+ "    }\n"
+				+ "}"
+			}
+		);
+	}
+}
+
+// A variation for the unchecked conversion test case.
+// the type arguments contain wildcards like <? extends T>.
+public void testBugGH472_b() {
+	if (this.complianceLevel >= ClassFileConstants.JDK1_8) {
+		this.runConformTest(
+			new String[] {
+				"ReturnTypeTest.java",
+				"public class ReturnTypeTest {\n"
+				+ "    <T> T m(Class<T> arg1, Class<? extends T> arg2) { return null; }\n"
+				+ "\n"
+				+ "    void test(Class c1, Class<Class<String>> c2) throws Exception {\n"
+				+ "        m(c1, c2).newInstance();\n"
+				+ "    }\n"
+				+ "}"
+			}
+		);
+	}
+}
+
+// A variation for the unchecked conversion test case.
+// the type arguments contain wildcards like <? super T>.
+public void testBugGH472_c() {
+	if (this.complianceLevel >= ClassFileConstants.JDK1_8) {
+		this.runConformTest(
+			new String[] {
+				"ReturnTypeTest.java",
+				"public class ReturnTypeTest {\n"
+				+ "    <T> T m(Class<T> arg1, Class<? super T> arg2) { return null; }\n"
+				+ "\n"
+				+ "    void test(Class c1, Class<Class<String>> c2) throws Exception {\n"
+				+ "        m(c1, c2).newInstance();\n"
+				+ "    }\n"
+				+ "}"
+			}
+		);
+	}
+}
+
+// If unchecked conversion was necessary for the arguments,
+// substitute and erase the thrown type.
+public void testBugGH472_d() {
+	if (this.complianceLevel >= ClassFileConstants.JDK1_8) {
+		this.runConformTest(
+			new String[] {
+				"ThrowTest.java",
+				"public class ThrowTest {\n"
+				+ "\n"
+				+ "    public static void test(MyDerivedException e, MyType t) {\n"
+				+ "        try {\n"
+				+ "            new Foo(e, t);\n"
+				+ "        } catch (MyDerivedException e2) {}\n"
+				+ "    }\n"
+				+ "}\n"
+				+ "\n"
+				+ "class MyException extends Exception {}\n"
+				+ "class MyDerivedException extends MyException {}\n"
+				+ "\n"
+				+ "class MyType<T> {}\n"
+				+ "\n"
+				+ "class Foo {\n"
+				+ "    public <E1 extends MyException> Foo(E1 e, MyType<String> a) throws E1 {\n"
+				+ "        throw e;\n"
+				+ "    }\n"
+				+ "}"
+			}
 		);
 	}
 }

--- a/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/lookup/ParameterizedGenericMethodBinding.java
+++ b/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/lookup/ParameterizedGenericMethodBinding.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -560,10 +560,10 @@ public class ParameterizedGenericMethodBinding extends ParameterizedMethodBindin
 	    this.parameters = Scope.substitute(this, originalMethod.parameters);
 	    // error case where exception type variable would have been substituted by a non-reference type (207573)
 	    if (inferredWithUncheckConversion) { // JSL 18.5.2: "If unchecked conversion was necessary..."
-	    	this.returnType = getErasure18_5_2(originalMethod.returnType, environment, hasReturnProblem); // propagate simulation of Bug JDK_8026527
+	    	this.returnType = getErasure18_5_2(originalMethod.returnType, environment);
 	    	this.thrownExceptions = new ReferenceBinding[originalMethod.thrownExceptions.length];
 	    	for (int i = 0; i < originalMethod.thrownExceptions.length; i++) {
-	    		this.thrownExceptions[i] = (ReferenceBinding) getErasure18_5_2(originalMethod.thrownExceptions[i], environment, false); // no excuse for exceptions
+	    		this.thrownExceptions[i] = (ReferenceBinding) getErasure18_5_2(originalMethod.thrownExceptions[i], environment);
 			}
 	    } else {
 	    	this.returnType = Scope.substitute(this, originalMethod.returnType);
@@ -608,13 +608,12 @@ public class ParameterizedGenericMethodBinding extends ParameterizedMethodBindin
 	    }
 	}
 
-	TypeBinding getErasure18_5_2(TypeBinding type, LookupEnvironment env, boolean substitute) {
+	TypeBinding getErasure18_5_2(TypeBinding type, LookupEnvironment env) {
 		// opportunistic interpretation of (JLS 18.5.2):
 		// "If unchecked conversion was necessary ..., then ...
 		// the return type and thrown types of the invocation type of m are given by
 		// the erasure of the return type and thrown types of m's type."
-		if (substitute)
-			type = Scope.substitute(this, type);
+		type = Scope.substitute(this, type); // compliant with Bug JDK-8135087: Erasure for unchecked invocation happens after inference
 		return env.convertToRawType(type.erasure(), true);
 	}
 


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>
Change-Id: I524ac3308c9a63aa66aab2c8bcaa5fce6f6b5ad6

## What it does
Fixes #472 
```java
import java.util.Collections;
import java.util.HashMap;
import java.util.Map;
import java.util.function.Function;

public class GenericTypeTest {
    public static void main(String[] args) {
    	GenericTypeTest test = new GenericTypeTest();
        test.raw.put("first-entry", new HashMap<>());

        System.out.println(test.getFirstEntry());
    }

    private Map<String, Object> raw = new HashMap<>();

    public Map<Object, Object> getFirstEntry() {
        // JDT compiler reports the error "Type mismatch: cannot convert from Object to Map<Object,Object>" on the next line
        return getAndMap("first-entry", Map.class, Collections::unmodifiableMap);
    }

    <I, T> T getAndMap(String entry, Class<I> type, Function<I, T> f) {
        I value = get(entry, type);
        return value == null ? null : f.apply(value);
    }

    <T> T get(String entry, Class<T> type) {
        Object value = raw.get(entry);
        return value == null ? null : type.cast(value);
    }
}
```

When the code uses some raw types, the compiler will use unchecked conversion to infer their type. The problem with bug 472 is that the return type of the original method `getAndMap` is a type variable `T`, erasing a type variable provides nothing. The fix is to substitue the type variable with the relevant parameterized type before doing the erasure.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
