### PR TITLE
Prevent NPE in DiskIndex.readStreamInt()

### DIFF
--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/index/DiskIndex.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/index/DiskIndex.java
@@ -252,7 +252,7 @@ HashtableOfObject addQueryResults(char[][] categories, char[] key, int matchRule
 
 	return results;
 }
-private void cacheDocumentNames() throws IOException {
+private synchronized void cacheDocumentNames() throws IOException {
 	// will need all document names so get them now
 	this.cachedChunks = new String[this.numberOfChunks][];
 	try (InputStream stream = this.indexLocation.getInputStream()) {


### PR DESCRIPTION
This changes makes DiskIndex.cacheDocumentNames() synchronized, so that concurrent calls to it don't result in NPEs when DiskIndex.streamBuffer is accessed. The other methods that access (read & write) streamBuffer are already synchronized.

Fixes: #483
Signed-off-by: Simeon Andreev <simeon.danailov.andreev@gmail.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
