### PR TITLE
Java editor cannot resolve import due to classpath filter #485

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/InclusionPatternsTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/InclusionPatternsTests.java
@@ -458,6 +458,14 @@ public void testIncludeCUOnly01_new() throws CoreException {
 			workingCopy.discardWorkingCopy();
 	}
 }
+
+/**
+ * Same test as above but checking in modular environment, where search failed to see package in unnamed module
+ */
+public void testIncludeCUOnly01_new_modular() throws CoreException {
+	this.project.setOption(JavaCore.COMPILER_COMPLIANCE, "11");
+	testIncludeCUOnly01_new();
+}
 /**
  * Ensure that a type can be resolved if it is included but not its super packages.
  * (regression test for bug 119161 classes in "deep" packages not fully recognized when using tight inclusion filters)

--- a/org.eclipse.jdt.core.tests.model/workspace/gh485ClasspathFilterUnnamedModuleBugProject1/.classpath
+++ b/org.eclipse.jdt.core.tests.model/workspace/gh485ClasspathFilterUnnamedModuleBugProject1/.classpath
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.MODULE_PATH"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/gh485ClasspathFilterUnnamedModuleBugProject2"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/org.eclipse.jdt.core.tests.model/workspace/gh485ClasspathFilterUnnamedModuleBugProject1/.project
+++ b/org.eclipse.jdt.core.tests.model/workspace/gh485ClasspathFilterUnnamedModuleBugProject1/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>gh485ClasspathFilterUnnamedModuleBugProject1</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/org.eclipse.jdt.core.tests.model/workspace/gh485ClasspathFilterUnnamedModuleBugProject2/.classpath
+++ b/org.eclipse.jdt.core.tests.model/workspace/gh485ClasspathFilterUnnamedModuleBugProject2/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.MODULE_PATH"/>
+	<classpathentry including="com/g/f/t/f/" kind="src" path="src"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/org.eclipse.jdt.core.tests.model/workspace/gh485ClasspathFilterUnnamedModuleBugProject2/.project
+++ b/org.eclipse.jdt.core.tests.model/workspace/gh485ClasspathFilterUnnamedModuleBugProject2/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>gh485ClasspathFilterUnnamedModuleBugProject2</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SearchableEnvironment.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SearchableEnvironment.java
@@ -87,6 +87,8 @@ public class SearchableEnvironment
 	private long timeSpentInGetModulesDeclaringPackage;
 	private long timeSpentInFindTypes;
 
+	private List<IPackageFragmentRoot> unnamedModulePackageFragmentRoots;
+
 	@Deprecated
 	public SearchableEnvironment(JavaProject project, org.eclipse.jdt.core.ICompilationUnit[] workingCopies) throws JavaModelException {
 		this(project, workingCopies, false);
@@ -102,10 +104,10 @@ public class SearchableEnvironment
 			|| !JavaCore.IGNORE.equals(project.getOption(JavaCore.COMPILER_PB_DISCOURAGED_REFERENCE, true));
 		this.workingCopies = workingCopies;
 		this.nameLookup = project.newNameLookup(workingCopies, excludeTestCode);
-		if (CompilerOptions.versionToJdkLevel(project.getOption(JavaCore.COMPILER_COMPLIANCE, true)) >= ClassFileConstants.JDK9) {
+		boolean java9plus = CompilerOptions.versionToJdkLevel(project.getOption(JavaCore.COMPILER_COMPLIANCE, true)) >= ClassFileConstants.JDK9;
+		if (java9plus) {
 			this.knownModuleLocations = new HashMap<>();
-		}
-		if (CompilerOptions.versionToJdkLevel(project.getOption(JavaCore.COMPILER_COMPLIANCE, true)) >= ClassFileConstants.JDK9) {
+
 			this.moduleUpdater = new ModuleUpdater(project);
 			if (!excludeTestCode) {
 				IClasspathEntry[] expandedClasspath = project.getExpandedClasspath();
@@ -114,8 +116,18 @@ public class SearchableEnvironment
 				}
 			}
 			for (IClasspathEntry entry : project.getRawClasspath())
-				if(!excludeTestCode || !entry.isTest())
+				if(!excludeTestCode || !entry.isTest()) {
 					this.moduleUpdater.computeModuleUpdates(entry);
+				}
+
+			this.unnamedModulePackageFragmentRoots = new ArrayList<>();
+			IPackageFragmentRoot[] packageFragmentRoots = project.getAllPackageFragmentRoots();
+			for (IPackageFragmentRoot packageFragmentRoot : packageFragmentRoots) {
+				IModuleDescription moduleDescription = packageFragmentRoot.getModuleDescription();
+				if (moduleDescription == null) {
+					this.unnamedModulePackageFragmentRoots.add(packageFragmentRoot);
+				}
+			}
 		}
 	}
 
@@ -1026,6 +1038,16 @@ private void findPackagesFromRequires(char[] prefix, boolean isMatchAllPrefix, I
 								}
 							}
 						}
+						/*
+						 * Check if we have a sub-package in the unnamed module,
+						 * since classpath filters can result in top level packages
+						 * not listed by nameLookup.findPackageFragementRoots().
+						 * See: https://github.com/eclipse-jdt/eclipse.jdt.core/issues/485
+						 * and https://github.com/eclipse-jdt/eclipse.jdt.core/issues/646
+						 */
+						if (!containsUnnamed && hasSubPackageInUnnamedModule(pkgName)) {
+							names = CharOperation.arrayConcat(names, ModuleBinding.UNNAMED);
+						}
 					}
 					return names == CharOperation.NO_CHAR_CHAR ? null : names;
 				default:
@@ -1268,5 +1290,26 @@ private void findPackagesFromRequires(char[] prefix, boolean isMatchAllPrefix, I
 		Util.verbose(" -> findTypes...................." +  this.timeSpentInFindTypes + "ms");  //$NON-NLS-1$ //$NON-NLS-2$
 
 		this.nameLookup.printTimeSpent();
+	}
+
+	private boolean hasSubPackageInUnnamedModule(String[] pkgName) {
+		List<IPackageFragmentRoot> packageFragmentRoots = this.unnamedModulePackageFragmentRoots;
+		if (packageFragmentRoots != null) {
+			String name = String.join(".", pkgName); //$NON-NLS-1$
+			for (IPackageFragmentRoot packageFragmentRoot : packageFragmentRoots) {
+				try {
+					IJavaElement[] children = packageFragmentRoot.getChildren();
+					for (IJavaElement child : children) {
+						String childName = child.getElementName();
+						if (childName.startsWith(name)) {
+							return true;
+						}
+					}
+				} catch (JavaModelException e) {
+					Util.log(e, "Failed to retrieve children for " + packageFragmentRoot); //$NON-NLS-1$
+				}
+			}
+		}
+		return false;
 	}
 }


### PR DESCRIPTION
When using the classpath "including" and "excluding" entry properties, its possible that a top level package is not listed as a IPackageFragmentRoot. As a result,
SearchableEnvironment.getModulesDeclaringPackage() fails to recognize such a package as belonging to the unnamed module. This can result in Java editor unresolvable type compile errors.

This change adjusts SearchableEnvironment.getModulesDeclaringPackage() to consider parents of packages in the unnamed module to also belong in the unnamed module.

Fixes: #485
Signed-off-by: Simeon Andreev <simeon.danailov.andreev@gmail.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
