### PR TITLE
Improve `JavaSearchScope` encloses checking to O(n)

### DIFF
--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/JavaSearchScope.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/JavaSearchScope.java
@@ -52,9 +52,10 @@ import org.eclipse.jdt.internal.core.util.Util;
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class JavaSearchScope extends AbstractJavaSearchScope {
 
-	private ArrayList elements;
+	private HashSet elements;
+	private boolean[] elementTypes;
 
-	/* The paths of the resources in this search scope
+	/** The paths of the resources in this search scope
 	    (or the classpath entries' paths if the resources are projects)
 	*/
 	private ArrayList projectPaths = new ArrayList(); // container paths projects
@@ -273,9 +274,11 @@ public void add(IJavaElement element) throws JavaModelException {
 			// remember sub-cu (or sub-class file) java elements
 			if (element instanceof IMember) {
 				if (this.elements == null) {
-					this.elements = new ArrayList();
+					this.elements = new HashSet();
+					this.elementTypes = new boolean[IJavaElement.JAVA_MODULE+1];
 				}
 				this.elements.add(element);
+				this.elementTypes[element.getElementType()] = true;
 			}
 			root = (PackageFragmentRoot) element.getAncestor(IJavaElement.PACKAGE_FRAGMENT_ROOT);
 			projectPath = root.getJavaProject().getPath().toString();
@@ -455,15 +458,10 @@ private boolean encloses(String enclosingPath, String path, int index) {
 @Override
 public boolean encloses(IJavaElement element) {
 	if (this.elements != null) {
-		for (int i = 0, length = this.elements.size(); i < length; i++) {
-			IJavaElement scopeElement = (IJavaElement)this.elements.get(i);
-			IJavaElement searchedElement = element;
-			while (searchedElement != null) {
-				if (searchedElement.equals(scopeElement))
-					return true;
-				searchedElement = searchedElement.getParent();
-			}
-		}
+		do {
+			if (this.elementTypes[element.getElementType()] && this.elements.contains(element))
+				return true;
+		} while ((element = element.getParent()) != null);
 		return false;
 	}
 	IPackageFragmentRoot root = (IPackageFragmentRoot) element.getAncestor(IJavaElement.PACKAGE_FRAGMENT_ROOT);
@@ -661,10 +659,9 @@ public String toString() {
 	StringBuilder result = new StringBuilder("JavaSearchScope on "); //$NON-NLS-1$
 	if (this.elements != null) {
 		result.append("["); //$NON-NLS-1$
-		for (int i = 0, length = this.elements.size(); i < length; i++) {
-			JavaElement element = (JavaElement)this.elements.get(i);
+		for (Object element : this.elements) {
 			result.append("\n\t"); //$NON-NLS-1$
-			result.append(element.toStringWithAncestors());
+			result.append(((JavaElement) element).toStringWithAncestors());
 		}
 		result.append("\n]"); //$NON-NLS-1$
 	} else {


### PR DESCRIPTION
## What it does
As noted in #474, `JavaSearchScope` runs with O(n*m) complexity currently.  Switching the `elements` collection to a `HashSet` and adding a guard to prevent checking for element types that do not exist, the complexity can be reduced to O(n).  There is more discussion in the issue in how this reduces the time to launch JUnit for RxJava project.

## How to test
Run As > JUnit for a sizeable project like RxJava was reduced from 45s to 20s.

## Author checklist
- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)