### PR TITLE
Add support for array type completions #504

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests.java
@@ -15919,7 +15919,7 @@ public void testConstructor1() throws JavaModelException {
 	this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner, monitor);
 
 	assertResults(
-			"TestConstructor1[TYPE_REF]{TestConstructor1, test, Ltest.TestConstructor1;, null, null, "+(R_DEFAULT + R_RESOLVED + R_INTERESTING + R_CASE + R_UNQUALIFIED + R_NON_RESTRICTED)+"}\n" +
+			"TestConstructor1[TYPE_REF<ARRAY>]{TestConstructor1[], test, Ltest.TestConstructor1;, null, null, "+(R_DEFAULT + R_RESOLVED + R_INTERESTING + R_CASE + R_UNQUALIFIED + R_NON_RESTRICTED)+"}\n" +
 			"TestConstructor1[CONSTRUCTOR_INVOCATION]{(), Ltest.TestConstructor1;, (I)V, TestConstructor1, (i), "+(R_DEFAULT + R_RESOLVED + R_INTERESTING + R_CASE + R_UNQUALIFIED + R_NON_RESTRICTED + R_CONSTRUCTOR)+"}\n" +
 			"   TestConstructor1[TYPE_REF]{TestConstructor1, test, Ltest.TestConstructor1;, null, null, "+(R_DEFAULT + R_RESOLVED + R_INTERESTING + R_CASE + R_UNQUALIFIED + R_NON_RESTRICTED + R_CONSTRUCTOR)+"}",
 			requestor.getResults());
@@ -15951,7 +15951,7 @@ public void testConstructor2() throws JavaModelException {
 	this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner, monitor);
 
 	assertResults(
-			"TestConstructor1[TYPE_REF]{TestConstructor1, test, Ltest.TestConstructor1;, null, null, "+(R_DEFAULT + R_RESOLVED + R_INTERESTING + R_CASE + R_UNQUALIFIED + R_NON_RESTRICTED)+"}\n" +
+			"TestConstructor1[TYPE_REF<ARRAY>]{TestConstructor1[], test, Ltest.TestConstructor1;, null, null, "+(R_DEFAULT + R_RESOLVED + R_INTERESTING + R_CASE + R_UNQUALIFIED + R_NON_RESTRICTED)+"}\n" +
 			"TestConstructor1[CONSTRUCTOR_INVOCATION]{(), Ltest.TestConstructor1;, (I)V, TestConstructor1, (i), "+(R_DEFAULT + R_RESOLVED + R_INTERESTING + R_CASE + R_UNQUALIFIED + R_NON_RESTRICTED + R_CONSTRUCTOR)+"}\n" +
 			"   TestConstructor1[TYPE_REF]{TestConstructor1, test, Ltest.TestConstructor1;, null, null, "+(R_DEFAULT + R_RESOLVED + R_INTERESTING + R_CASE + R_UNQUALIFIED + R_NON_RESTRICTED + R_CONSTRUCTOR)+"}",
 			requestor.getResults());
@@ -15983,7 +15983,7 @@ public void testConstructor3() throws JavaModelException {
 	this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner, monitor);
 
 	assertResults(
-			"TestConstructor1[TYPE_REF]{TestConstructor1, test, Ltest.TestConstructor1;, null, null, "+(R_DEFAULT + R_RESOLVED + R_INTERESTING + R_CASE + R_UNQUALIFIED + R_NON_RESTRICTED)+"}\n" +
+			"TestConstructor1[TYPE_REF<ARRAY>]{TestConstructor1[], test, Ltest.TestConstructor1;, null, null, "+(R_DEFAULT + R_RESOLVED + R_INTERESTING + R_CASE + R_UNQUALIFIED + R_NON_RESTRICTED)+"}\n" +
 			"TestConstructor1[CONSTRUCTOR_INVOCATION]{(), Ltest.TestConstructor1;, (I)V, TestConstructor1, (i), "+(R_DEFAULT + R_RESOLVED + R_INTERESTING + R_CASE + R_UNQUALIFIED + R_NON_RESTRICTED + R_CONSTRUCTOR)+"}\n" +
 			"   TestConstructor1[TYPE_REF]{TestConstructor1, test, Ltest.TestConstructor1;, null, null, "+(R_DEFAULT + R_RESOLVED + R_INTERESTING + R_CASE + R_UNQUALIFIED + R_NON_RESTRICTED + R_CONSTRUCTOR)+"}",
 			requestor.getResults());
@@ -16016,7 +16016,7 @@ public void testConstructor4() throws JavaModelException {
 	this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner, monitor);
 
 	assertResults(
-			"TestConstructor1[TYPE_REF]{TestConstructor1, test, Ltest.TestConstructor1;, null, null, "+(R_DEFAULT + R_RESOLVED + R_INTERESTING + R_CASE + R_UNQUALIFIED + R_NON_RESTRICTED)+"}\n" +
+			"TestConstructor1[TYPE_REF<ARRAY>]{TestConstructor1[], test, Ltest.TestConstructor1;, null, null, "+(R_DEFAULT + R_RESOLVED + R_INTERESTING + R_CASE + R_UNQUALIFIED + R_NON_RESTRICTED)+"}\n" +
 			"TestConstructor1[CONSTRUCTOR_INVOCATION]{(), Ltest.TestConstructor1;, (I)V, TestConstructor1, (i), "+(R_DEFAULT + R_RESOLVED + R_INTERESTING + R_CASE + R_UNQUALIFIED + R_NON_RESTRICTED + R_CONSTRUCTOR)+"}\n" +
 			"   TestConstructor1[TYPE_REF]{TestConstructor1, test, Ltest.TestConstructor1;, null, null, "+(R_DEFAULT + R_RESOLVED + R_INTERESTING + R_CASE + R_UNQUALIFIED + R_NON_RESTRICTED + R_CONSTRUCTOR)+"}",
 			requestor.getResults());

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTestsRequestor2.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTestsRequestor2.java
@@ -399,6 +399,9 @@ public class CompletionTestsRequestor2 extends CompletionRequestor {
 				break;
 			case CompletionProposal.TYPE_REF :
 				buffer.append("TYPE_REF"); //$NON-NLS-1$
+				if (proposal.isArray()) {
+					buffer.append("<ARRAY>"); //$NON-NLS-1$
+				}
 				break;
 			case CompletionProposal.VARIABLE_DECLARATION :
 				buffer.append("VARIABLE_DECLARATION"); //$NON-NLS-1$

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/CompletionEngine.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/CompletionEngine.java
@@ -12083,135 +12083,160 @@ public final class CompletionEngine
 
 				checkCancel();
 
+				ReferenceBinding refBinding;
+				boolean receiverIsArrayType = false;
 				if(this.expectedTypes[i] instanceof ReferenceBinding) {
-					ReferenceBinding refBinding = (ReferenceBinding)this.expectedTypes[i];
+					refBinding = (ReferenceBinding) this.expectedTypes[i];
+				} else if (this.expectedTypes[i] instanceof ArrayBinding) {
+					receiverIsArrayType = true;
+					TypeBinding leaf = ((ArrayBinding) this.expectedTypes[i]).leafComponentType();
+					refBinding = this.lookupEnvironment
+							.getType(CharOperation.splitOn('.', CharOperation.concat(leaf.qualifiedPackageName(),
+									leaf.qualifiedSourceName(), '.')));
+				} else {
+					return;
+				}
 
-					if (typeLength > 0) {
-						if (typeLength > refBinding.sourceName.length) continue next;
-
-						if (isFailedMatch(token, refBinding.sourceName)) continue next;
-					}
-
-
-					if(refBinding.isTypeVariable() && this.assistNodeIsConstructor) {
-						// don't propose type variable if the completion is a constructor ('new |')
-						continue next;
-					}
-					if (this.options.checkDeprecation &&
-							refBinding.isViewedAsDeprecated() &&
-							!scope.isDefinedInSameUnit(refBinding))
+				if (typeLength > 0) {
+					if (typeLength > refBinding.sourceName.length)
 						continue next;
 
-					int accessibility = IAccessRule.K_ACCESSIBLE;
-					if(refBinding.hasRestrictedAccess()) {
-						AccessRestriction accessRestriction = this.lookupEnvironment.getAccessRestriction(refBinding);
-						if(accessRestriction != null) {
-							switch (accessRestriction.getProblemId()) {
-								case IProblem.ForbiddenReference:
-									if (this.options.checkForbiddenReference) {
-										continue next;
-									}
-									accessibility = IAccessRule.K_NON_ACCESSIBLE;
-									break;
-								case IProblem.DiscouragedReference:
-									if (this.options.checkDiscouragedReference) {
-										continue next;
-									}
-									accessibility = IAccessRule.K_DISCOURAGED;
-									break;
-							}
-						}
-					}
-					if(isForbidden(refBinding)) continue next;
+					if (isFailedMatch(token, refBinding.sourceName))
+						continue next;
+				}
 
-					for (int j = 0; j < typesFound.size(); j++) {
-						ReferenceBinding typeFound = (ReferenceBinding)typesFound.elementAt(j);
-						if (TypeBinding.equalsEquals(typeFound, refBinding.erasure())) {
-							continue next;
-						}
-					}
 
-					typesFound.add(refBinding);
+				if (refBinding.isTypeVariable() && this.assistNodeIsConstructor) {
+					// don't propose type variable if the completion is a constructor ('new |')
+					continue next;
+				}
+				if (this.options.checkDeprecation &&
+						refBinding.isViewedAsDeprecated() &&
+						!scope.isDefinedInSameUnit(refBinding))
+					continue next;
 
-					boolean inSameUnit = this.unitScope.isDefinedInSameUnit(refBinding);
-
-					// top level types of the current unit are already proposed.
-					if(!inSameUnit || (inSameUnit && refBinding.isMemberType())) {
-						char[] packageName = refBinding.qualifiedPackageName();
-						char[] typeName = refBinding.sourceName();
-						char[] completionName = typeName;
-
-						boolean isQualified = false;
-						if (!this.insideQualifiedReference && !refBinding.isMemberType()) {
-							if (mustQualifyType(packageName, typeName, null, refBinding.modifiers)) {
-								if (packageName == null || packageName.length == 0)
-									if (this.unitScope != null && this.unitScope.fPackage.compoundName != CharOperation.NO_CHAR_CHAR)
-										continue next; // ignore types from the default package from outside it
-								completionName = CharOperation.concat(packageName, typeName, '.');
-								isQualified = true;
-							}
-						}
-
-						if (this.assistNodeIsExtendedType && refBinding.isFinal()) continue next;
-						if (this.assistNodeIsInterfaceExcludingAnnotation && refBinding.isAnnotationType()) continue next;
-						if(this.assistNodeIsClass) {
-							if(!refBinding.isClass()) continue next;
-						} else if(this.assistNodeIsInterface) {
-							if(!refBinding.isInterface() && !refBinding.isAnnotationType()) continue next;
-						} else if (this.assistNodeIsAnnotation) {
-							if(!refBinding.isAnnotationType()) continue next;
-						}
-
-						int relevance = computeBaseRelevance();
-						relevance += computeRelevanceForResolution();
-						relevance += computeRelevanceForInterestingProposal(refBinding);
-						relevance += computeRelevanceForCaseMatching(token, typeName);
-						relevance += computeRelevanceForExpectingType(refBinding);
-						relevance += computeRelevanceForQualification(isQualified);
-						relevance += computeRelevanceForRestrictions(accessibility);
-
-						if(refBinding.isClass()) {
-							relevance += computeRelevanceForClass();
-							relevance += computeRelevanceForException(typeName);
-						} else if(refBinding.isEnum()) {
-							relevance += computeRelevanceForEnum();
-						} else if(refBinding.isInterface()) {
-							relevance += computeRelevanceForInterface();
-						}
-
-						if (proposeType &&
-								(!this.assistNodeIsConstructor ||
-										!allowingLongComputationProposals ||
-										hasStaticMemberTypes(refBinding, scope.enclosingSourceType() ,this.unitScope)) ||
-										hasArrayTypeAsExpectedSuperTypes()) {
-							this.noProposal = false;
-							if(!this.requestor.isIgnored(CompletionProposal.TYPE_REF)) {
-								InternalCompletionProposal proposal =  createProposal(CompletionProposal.TYPE_REF, this.actualCompletionPosition);
-								proposal.setDeclarationSignature(packageName);
-								proposal.setSignature(getSignature(refBinding));
-								proposal.setPackageName(packageName);
-								proposal.setTypeName(typeName);
-								proposal.setCompletion(completionName);
-								proposal.setFlags(refBinding.modifiers);
-								proposal.setReplaceRange(this.startPosition - this.offset, this.endPosition - this.offset);
-								proposal.setTokenRange(this.tokenStart - this.offset, this.tokenEnd - this.offset);
-								proposal.setRelevance(relevance);
-								proposal.setAccessibility(accessibility);
-								this.requestor.accept(proposal);
-								if(DEBUG) {
-									this.printDebug(proposal);
+				int accessibility = IAccessRule.K_ACCESSIBLE;
+				if (refBinding.hasRestrictedAccess()) {
+					AccessRestriction accessRestriction = this.lookupEnvironment.getAccessRestriction(refBinding);
+					if (accessRestriction != null) {
+						switch (accessRestriction.getProblemId()) {
+							case IProblem.ForbiddenReference:
+								if (this.options.checkForbiddenReference) {
+									continue next;
 								}
+								accessibility = IAccessRule.K_NON_ACCESSIBLE;
+								break;
+							case IProblem.DiscouragedReference:
+								if (this.options.checkDiscouragedReference) {
+									continue next;
+								}
+								accessibility = IAccessRule.K_DISCOURAGED;
+								break;
+						}
+					}
+				}
+				if (isForbidden(refBinding))
+					continue next;
+
+				for (int j = 0; j < typesFound.size(); j++) {
+					ReferenceBinding typeFound = (ReferenceBinding) typesFound.elementAt(j);
+					if (TypeBinding.equalsEquals(typeFound, refBinding.erasure())) {
+						continue next;
+					}
+				}
+
+				typesFound.add(refBinding);
+
+				boolean inSameUnit = this.unitScope.isDefinedInSameUnit(refBinding);
+
+				// top level types of the current unit are already proposed.
+				if (!inSameUnit || (inSameUnit && refBinding.isMemberType())) {
+					char[] packageName = refBinding.qualifiedPackageName();
+					char[] typeName = refBinding.sourceName();
+					char[] completionName = typeName;
+
+					boolean isQualified = false;
+					if (!this.insideQualifiedReference && !refBinding.isMemberType()) {
+						if (mustQualifyType(packageName, typeName, null, refBinding.modifiers)) {
+							if (packageName == null || packageName.length == 0)
+								if (this.unitScope != null
+										&& this.unitScope.fPackage.compoundName != CharOperation.NO_CHAR_CHAR)
+									continue next; // ignore types from the default package from outside it
+							completionName = CharOperation.concat(packageName, typeName, '.');
+							isQualified = true;
+						}
+					}
+
+					if (this.assistNodeIsExtendedType && refBinding.isFinal())
+						continue next;
+					if (this.assistNodeIsInterfaceExcludingAnnotation && refBinding.isAnnotationType())
+						continue next;
+					if (this.assistNodeIsClass) {
+						if (!refBinding.isClass())
+							continue next;
+					} else if (this.assistNodeIsInterface) {
+						if (!refBinding.isInterface() && !refBinding.isAnnotationType())
+							continue next;
+					} else if (this.assistNodeIsAnnotation) {
+						if (!refBinding.isAnnotationType())
+							continue next;
+					}
+
+					int relevance = computeBaseRelevance();
+					relevance += computeRelevanceForResolution();
+					relevance += computeRelevanceForInterestingProposal(refBinding);
+					relevance += computeRelevanceForCaseMatching(token, typeName);
+					relevance += computeRelevanceForExpectingType(refBinding);
+					relevance += computeRelevanceForQualification(isQualified);
+					relevance += computeRelevanceForRestrictions(accessibility);
+
+					if (refBinding.isClass()) {
+						relevance += computeRelevanceForClass();
+						relevance += computeRelevanceForException(typeName);
+					} else if (refBinding.isEnum()) {
+						relevance += computeRelevanceForEnum();
+					} else if (refBinding.isInterface()) {
+						relevance += computeRelevanceForInterface();
+					}
+
+					if (proposeType &&
+							(!this.assistNodeIsConstructor ||
+									!allowingLongComputationProposals ||
+									hasStaticMemberTypes(refBinding, scope.enclosingSourceType(), this.unitScope))
+							||
+							hasArrayTypeAsExpectedSuperTypes()) {
+						this.noProposal = false;
+						if (!this.requestor.isIgnored(CompletionProposal.TYPE_REF)) {
+							InternalCompletionProposal proposal = createProposal(CompletionProposal.TYPE_REF,
+									this.actualCompletionPosition);
+							proposal.setDeclarationSignature(packageName);
+							proposal.setSignature(getSignature(refBinding));
+							proposal.setPackageName(packageName);
+							proposal.setTypeName(typeName);
+							if (receiverIsArrayType) {
+								completionName = CharOperation.concat(completionName, new char[] { '[', ']' });
+							}
+							proposal.setArray(receiverIsArrayType);
+							proposal.setCompletion(completionName);
+							proposal.setFlags(refBinding.modifiers);
+							proposal.setReplaceRange(this.startPosition - this.offset, this.endPosition - this.offset);
+							proposal.setTokenRange(this.tokenStart - this.offset, this.tokenEnd - this.offset);
+							proposal.setRelevance(relevance);
+							proposal.setAccessibility(accessibility);
+							this.requestor.accept(proposal);
+							if (DEBUG) {
+								this.printDebug(proposal);
 							}
 						}
+					}
 
-						if (proposeConstructor) {
-							findConstructorsOrAnonymousTypes(
-									refBinding,
-									scope,
-									FakeInvocationSite,
-									isQualified,
-									relevance);
-						}
+					if (proposeConstructor) {
+						findConstructorsOrAnonymousTypes(
+								refBinding,
+								scope,
+								FakeInvocationSite,
+								isQualified,
+								relevance);
 					}
 				}
 			}

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/InternalCompletionProposal.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/InternalCompletionProposal.java
@@ -65,6 +65,7 @@ public class InternalCompletionProposal extends CompletionProposal {
 	protected int accessibility = IAccessRule.K_ACCESSIBLE;
 
 	protected boolean isConstructor = false;
+	protected boolean isArray = false;
 
 	/**
 	 * Kind of completion request.
@@ -1083,6 +1084,9 @@ public class InternalCompletionProposal extends CompletionProposal {
 				break;
 			case CompletionProposal.TYPE_REF :
 				buffer.append("TYPE_REF"); //$NON-NLS-1$
+				if (this.isArray) {
+					buffer.append("<ARRAY>"); //$NON-NLS-1$
+				}
 				break;
 			case CompletionProposal.VARIABLE_DECLARATION :
 				buffer.append("VARIABLE_DECLARATION"); //$NON-NLS-1$
@@ -1199,5 +1203,14 @@ public class InternalCompletionProposal extends CompletionProposal {
 		else {
 			return false;
 		}
+	}
+
+	@Override
+	public boolean isArray() {
+		return this.isArray;
+	}
+
+	protected void setArray(boolean isArray) {
+		this.isArray = isArray;
 	}
 }

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/core/CompletionProposal.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/core/CompletionProposal.java
@@ -1815,4 +1815,24 @@ public class CompletionProposal {
 	public boolean canUseDiamond(CompletionContext coreContext) {
 		return false; // default overridden by concrete implementation
 	}
+
+	/**
+	 * Returns whether this proposal is an array type reference.
+	 * <p>
+	 * This field is available for the following kinds of
+	 * completion proposals:
+	 * <ul>
+	 * <li><code>TYPE_REF</code> - return <code>true</code>
+	 * if the referenced type is an array</li>
+	 * </ul>
+	 * For other kinds of completion proposals, this method returns
+	 * <code>false</code>.
+	 *
+	 * @return <code>true</code> if the proposal is an array type reference.
+	 * @since 3.32
+	 */
+	public boolean isArray() {
+		return false; // default overridden by concrete implementation
+	}
+
 }


### PR DESCRIPTION
Enhance the existing support for discovering array component type by
adding extra information into CompletionProposal so that the consumers
can decide how the edits should be handled in the editors like jdt.ui
and jdt.ls