### PR TITLE
Failed to infer types during nested generic method invocation

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_1_8.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_1_8.java
@@ -10379,4 +10379,31 @@ public void testBug508834_comment0() {
 				"}\n"
 			});
 	}
+	public void testIssue506() {
+		runConformTest(
+			new String[] {
+				"Convert.java",
+				"import java.util.function.Function;\n" +
+				"\n" +
+				"class Convert<A> {\n" +
+				"    public static <B> void test(final B a) {\n" +
+				"        Convert<B> res1 = convert(arg -> create(arg), a); // ok\n" +
+				"\n" +
+				"        Convert<B> res2 = convert(arg -> wrap(create(arg)), a); // error: Type mismatch\n" +
+				"    }\n" +
+				"\n" +
+				"    public static <C, D> Convert<D> convert(final Function<C, Convert<D>> func, final C value) {\n" +
+				"        return null;\n" +
+				"    }\n" +
+				"\n" +
+				"    public static <E> E wrap(final E a) {\n" +
+				"        return null;\n" +
+				"    }\n" +
+				"\n" +
+				"    public static <F> Convert<F> create(final F initial) {\n" +
+				"        return null;\n" +
+				"    }\n" +
+				"}\n"
+			});
+	}
 }

--- a/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/lookup/ParameterizedGenericMethodBinding.java
+++ b/org.eclipse.jdt.core/compiler/org/eclipse/jdt/internal/compiler/lookup/ParameterizedGenericMethodBinding.java
@@ -299,7 +299,7 @@ public class ParameterizedGenericMethodBinding extends ParameterizedMethodBindin
 							methodSubstitute = new PolyParameterizedGenericMethodBinding(methodSubstitute);
 						}
 					} finally {
-						if (allArgumentsAreProper) {
+						if (allArgumentsAreProper || !methodSubstitute.isVarargs()) {
 							if (invocationSite instanceof Invocation)
 								((Invocation) invocationSite).registerInferenceContext(methodSubstitute, infCtx18); // keep context so we can finish later
 							else if (invocationSite instanceof ReferenceExpression)


### PR DESCRIPTION
Fixes #506

## What it does
This is an opportunistic attempt at reconciling the existing fix in https://github.com/eclipse-jdt/eclipse.jdt.core/commit/51ed0947dc59c8e4cadd7d626d5ed089ccf3bd98  with the example in #506

I glimpsed that https://bugs.eclipse.org/511252#c17 motivated changes in 51ed0947 by the need to defer decision between strict vs. varargs modes of inference. Obviously this is only relevant if the target method is indeed varargs.

## How to test
See the new test case, but beware that we have no backing by JLS in this area. Other corner cases not yet covered by our test suite may regress due to this change.

It would be interesting to see if the same problem in #506 can actually be reproduced with a varargs method, in which case the attempted fix is expected to fail.