### PR TITLE
Export o.e.jdt.core.compiler.batch package in same named bundle

### DIFF
--- a/org.eclipse.jdt.core/scripts/binary/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core/scripts/binary/META-INF/MANIFEST.MF
@@ -8,6 +8,7 @@ Bundle-ClassPath: .
 Bundle-Vendor: Eclipse.org
 Export-Package: org.eclipse.jdt.core,
  org.eclipse.jdt.core.compiler,
+ org.eclipse.jdt.core.compiler.batch,
  org.eclipse.jdt.internal.antadapter;x-internal:=true,
  org.eclipse.jdt.internal.compiler;x-internal:=true,
  org.eclipse.jdt.internal.compiler.apt.dispatch;x-internal:=true,


### PR DESCRIPTION
This package is exported by org.eclipse.jdt.core so this looks like simply being forgotten rather than on purpose