### PR TITLE
Failed to infer types during nested generic method invocation

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ASTNode.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ASTNode.java
@@ -788,7 +788,7 @@ public abstract class ASTNode implements TypeConstants, TypeIds {
 		}
 		if (method instanceof ParameterizedGenericMethodBinding) {
 			InferenceContext18 ic18 = invocation.getInferenceContext((ParameterizedMethodBinding) method);
-			if (ic18 != null)
+			if (ic18 != null && !ic18.isInexactVarargsInference())
 				ic18.flushBoundOutbox(); // overload resolution is done, now perform the push of bounds from inner to outer
 		}
 		if (problemMethod != null)

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ConstraintExpressionFormula.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ConstraintExpressionFormula.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2019 GK Software AG.
+ * Copyright (c) 2013, 2022 GK Software AG.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -121,6 +121,12 @@ class ConstraintExpressionFormula extends ConstraintFormula {
 							if (exprType == null || !exprType.isValidBinding())
 								return FALSE;
 							return ConstraintTypeFormula.create(exprType, this.right, COMPATIBLE, this.isSoft);
+						}
+						if (innerCtx.isInexactVarargsInference()) {
+							// See https://github.com/eclipse-jdt/eclipse.jdt.core/pull/508
+							// Skip the inner inference result for now until the varargs method
+							// is inferred a second time by a proper target type.
+							return TRUE;
 						}
 						if (innerCtx.stepCompleted >= InferenceContext18.APPLICABILITY_INFERRED) {
 							inferenceContext.integrateInnerInferenceB2(innerCtx);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ConstraintExpressionFormula.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ConstraintExpressionFormula.java
@@ -123,7 +123,7 @@ class ConstraintExpressionFormula extends ConstraintFormula {
 							return ConstraintTypeFormula.create(exprType, this.right, COMPATIBLE, this.isSoft);
 						}
 						if (innerCtx.isInexactVarargsInference()) {
-							// See https://github.com/eclipse-jdt/eclipse.jdt.core/pull/508
+							// See https://github.com/eclipse-jdt/eclipse.jdt.core/pull/524
 							// Skip the inner inference result for now until the varargs method
 							// is inferred a second time by a proper target type.
 							return TRUE;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
@@ -483,6 +483,7 @@ public class InferenceContext18 {
 				this.currentBounds = solution; // this is final, keep the result:
 			return solution;
 		} finally {
+			assert !(step == TYPE_INFERRED_FINAL && this.isInexactVarargsInference);
 			this.stepCompleted = step;
 		}
 	}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2019 GK Software AG, and others.
+ * Copyright (c) 2013, 2022 GK Software AG, and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -173,6 +173,7 @@ public class InferenceContext18 {
 	private boolean directlyAcceptingInnerBounds = false;
 	/** Not per JLS: pushing bounds from inner to outer may have to be deferred till after overload resolution, store here a runnable to perform the push. */
 	private Runnable pushToOuterJob = null;
+	private boolean isInexactVarargsInference = false;
 
 	public static boolean isSameSite(InvocationSite site1, InvocationSite site2) {
 		if (site1 == site2)
@@ -708,7 +709,7 @@ public class InferenceContext18 {
 			if (innerMethod instanceof ParameterizedGenericMethodBinding)
 				 innerContext = invocation.getInferenceContext((ParameterizedGenericMethodBinding) innerMethod);
 
-			if (innerContext != null) {
+			if (innerContext != null && !innerContext.isInexactVarargsInference()) {
 				MethodBinding shallowMethod = innerMethod.shallowOriginal();
 				innerContext.outerContext = this;
 				if (innerContext.stepCompleted < InferenceContext18.APPLICABILITY_INFERRED) // shouldn't happen, but let's play safe
@@ -2184,5 +2185,13 @@ public class InferenceContext18 {
 			}
 		}
 		return typeVariables;
+	}
+
+	public boolean isInexactVarargsInference() {
+		return this.isInexactVarargsInference;
+	}
+
+	public void setInexactVarargsInference(boolean isInexactVarargsInference) {
+		this.isInexactVarargsInference = isInexactVarargsInference;
 	}
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_1_8.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_1_8.java
@@ -10384,4 +10384,63 @@ public void testBug508834_comment0() {
 				"}\n"
 			});
 	}
+
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/506
+	// Verify that ECJ can infer the case including nested generic method invocation.
+	public void testGH506_a() {
+		this.runConformTest(
+			new String[] {
+				"Convert.java",
+				"import java.util.function.Function;\n"
+				+ "class Convert<A> {\n"
+				+ "    public static <B> void test(final B a) {\n"
+				+ "        Convert<B> res1 = convert(arg -> create(arg), a); // ok\n"
+				+ "\n"
+				+ "        Convert<B> res2 = convert(arg -> wrap(create(arg)), a); // error: Type mismatch\n"
+				+ "    }\n"
+				+ "\n"
+				+ "    public static <C, D> Convert<D> convert(final Function<C, Convert<D>> func, final C value) {\n"
+				+ "        return null;\n"
+				+ "    }\n"
+				+ "\n"
+				+ "    public static <E> E wrap(final E a) {\n"
+				+ "        return null;\n"
+				+ "    }\n"
+				+ "\n"
+				+ "    public static <F> Convert<F> create(final F initial) {\n"
+				+ "        return null;\n"
+				+ "    }\n"
+				+ "}"
+			}
+		);
+	}
+
+	// Verify that ECJ still infers well when the nested method invocation is a varargs method.
+	public void testGH506_b() {
+		this.runConformTest(
+			new String[] {
+				"Convert.java",
+				"import java.util.function.Function;\n"
+				+ "class Convert<A> {\n"
+				+ "    public static <B> void test(final B a) {\n"
+				+ "        Convert<B> res1 = convert(arg -> create(arg), a); // ok\n"
+				+ "\n"
+				+ "        Convert<B> res2 = convert(arg -> wrap(create(arg)), a); // error: Type mismatch\n"
+				+ "    }\n"
+				+ "\n"
+				+ "    public static <C, D> Convert<D> convert(final Function<C, Convert<D>> func, final C value) {\n"
+				+ "        return null;\n"
+				+ "    }\n"
+				+ "\n"
+				+ "    public static <E> E wrap(final E a) {\n"
+				+ "        return null;\n"
+				+ "    }\n"
+				+ "\n"
+				+ "    public static <F> Convert<F> create(final F... initial) {\n"
+				+ "        return null;\n"
+				+ "    }\n"
+				+ "}"
+			}
+		);
+	}
 }


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

Fixes #506

It substitutes the PR https://github.com/eclipse-jdt/eclipse.jdt.core/pull/508 to cover varargs case as well.
