### PR TITLE
[20] Ensure any premature access of java.specification.version without

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/util/JrtUtilTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/util/JrtUtilTest.java
@@ -64,7 +64,7 @@ public class JrtUtilTest extends TestCase {
 		Object jrtSystem2 = JRTUtil.getJrtSystem(this.image, String.valueOf(majorVersionSegment));
 		assertSame(jrtSystem, jrtSystem2);
 
-		jrtSystem2 = JRTUtil.getJrtSystem(this.image, String.valueOf(--majorVersionSegment));
+		jrtSystem2 = JRTUtil.getJrtSystem(this.image, String.valueOf(majorVersionSegment-2));
 		assertNotSame(jrtSystem, jrtSystem2);
 
 		Object jrtSystem3 = JRTUtil.getJrtSystem(this.image);

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/util/AbstractCompilerTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/util/AbstractCompilerTest.java
@@ -321,6 +321,15 @@ public class AbstractCompilerTest extends TestCase {
 	public static int getPossibleComplianceLevels() {
 		if (possibleComplianceLevels == UNINITIALIZED) {
 			String specVersion = System.getProperty("java.specification.version");
+			// During the EA phase of development, the above property is set to the
+			// latest version, for e.g. "20", but the java.version that will be tested
+			// inside initReflectionVersion() later on will be of the format "20-ea" thus
+			// causing an exception. The following code will ensure that we ignore such cases
+			// until the latest version has been properly added in CompilerOptions.
+			int spec = Integer.parseInt(specVersion);
+			if (spec > Integer.parseInt(CompilerOptions.getLatestVersion())) {
+				specVersion = CompilerOptions.getLatestVersion();
+			}
 			isJRE19Plus = CompilerOptions.VERSION_19.equals(specVersion);
 			isJRE18Plus = isJRE19Plus || CompilerOptions.VERSION_18.equals(specVersion);
 			isJRE17Plus = isJRE18Plus || CompilerOptions.VERSION_17.equals(specVersion);


### PR DESCRIPTION
the matching version in CompilerOptions is ignored.

In such cases, we should simply be using the
CompilerOptions.getLatestVersion()

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
