### PR TITLE
Add Java 20 class version and other constants

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/Main.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/Main.java
@@ -3173,6 +3173,9 @@ private String optionStringToVersion(String currentArg) {
 		case "19": //$NON-NLS-1$
 		case "19.0": //$NON-NLS-1$
 			return CompilerOptions.VERSION_19;
+		case "20": //$NON-NLS-1$
+		case "20.0": //$NON-NLS-1$
+			return CompilerOptions.VERSION_20;
 		default:
 			return null;
 	}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/messages.properties
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/messages.properties
@@ -67,7 +67,7 @@ configure.duplicateTarget = duplicate target compliance setting specification: {
 configure.unsupportedReleaseOption = option --release is supported only when run with JDK 9 or above
 configure.unsupportedWithRelease = option {0} is not supported when --release is used
 configure.unsupportedReleaseVersion = release version {0} is not supported
-configure.source = source level should be in ''1.1''...''1.8'',''9''...''19'' (or ''5.0''..''19.0''): {0}
+configure.source = source level should be in ''1.1''...''1.8'',''9''...''20'' (or ''5.0''..''20.0''): {0}
 configure.invalidSystem = invalid location for system libraries: {0}
 configure.unsupportedOption = option {0} not supported at compliance level 9 and above
 configure.duplicateOutputPath = duplicate output path specification: {0}
@@ -85,7 +85,7 @@ configure.invalidDebugOption = invalid debug option: {0}
 configure.invalidWarningConfiguration = invalid warning configuration: ''{0}''
 configure.invalidWarning = invalid warning token: ''{0}''. Ignoring warning and compiling
 configure.invalidWarningOption = invalid warning option: ''{0}''. Must specify a warning token
-configure.targetJDK = target level should be in ''1.1''...''1.8'',''9''...''19'' (or ''5.0''..''19.0'') or cldc1.1: {0}
+configure.targetJDK = target level should be in ''1.1''...''1.8'',''9''...''20'' (or ''5.0''..''20.0'') or cldc1.1: {0}
 configure.incompatibleTargetForSource = Target level ''{0}'' is incompatible with source level ''{1}''. A target level ''{1}'' or better is required
 configure.incompatibleTargetForGenericSource = Target level ''{0}'' is incompatible with source level ''{1}''. A source level ''1.5'' or better is required
 configure.incompatibleComplianceForSource = Compliance level ''{0}'' is incompatible with source level ''{1}''. A compliance level ''{1}'' or better is required
@@ -256,9 +256,10 @@ misc.usage = {1} {2}\n\
 \    -17 -17.0          use 17  compliance (-source 17  -target 17)\n\
 \    -18 -18.0          use 18  compliance (-source 18  -target 18)\n\
 \    -19 -19.0          use 19  compliance (-source 19  -target 19)\n\
-\    -source <version>  set source level: 1.3 to 1.9, 10 to 19\n\
+\    -20 -20.0          use 20  compliance (-source 20  -target 20)\n\
+\    -source <version>  set source level: 1.3 to 1.9, 10 to 20\n\
 \                       (or 6, 6.0, etc)\n\
-\    -target <version>  set classfile target: 1.3 to 1.9, 10 to 19\n\
+\    -target <version>  set classfile target: 1.3 to 1.9, 10 to 20\n\
 \                       (or 6, 6.0, etc)\n\
 \                       cldc1.1 can also be used to generate the StackMap\n\
 \                       attribute\n\

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/ClassFileConstants.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/ClassFileConstants.java
@@ -136,9 +136,10 @@ public interface ClassFileConstants {
 	int MAJOR_VERSION_17 = 61;
 	int MAJOR_VERSION_18 = 62;
 	int MAJOR_VERSION_19 = 63;
+	int MAJOR_VERSION_20 = 64;
 
 	int MAJOR_VERSION_0 = 44;
-	int MAJOR_LATEST_VERSION = MAJOR_VERSION_19;
+	int MAJOR_LATEST_VERSION = MAJOR_VERSION_20;
 
 	int MINOR_VERSION_0 = 0;
 	int MINOR_VERSION_1 = 1;
@@ -168,6 +169,7 @@ public interface ClassFileConstants {
 	long JDK17 = ((long)ClassFileConstants.MAJOR_VERSION_17 << 16) + ClassFileConstants.MINOR_VERSION_0;
 	long JDK18 = ((long)ClassFileConstants.MAJOR_VERSION_18 << 16) + ClassFileConstants.MINOR_VERSION_0;
 	long JDK19 = ((long)ClassFileConstants.MAJOR_VERSION_19 << 16) + ClassFileConstants.MINOR_VERSION_0;
+	long JDK20 = ((long)ClassFileConstants.MAJOR_VERSION_20 << 16) + ClassFileConstants.MINOR_VERSION_0;
 
 	public static long getLatestJDKLevel() {
 		return ((long)ClassFileConstants.MAJOR_LATEST_VERSION << 16) + ClassFileConstants.MINOR_VERSION_0;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/impl/CompilerOptions.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/impl/CompilerOptions.java
@@ -241,6 +241,7 @@ public class CompilerOptions {
 	public static final String VERSION_17 = "17"; //$NON-NLS-1$
 	public static final String VERSION_18 = "18"; //$NON-NLS-1$
 	public static final String VERSION_19 = "19"; //$NON-NLS-1$
+	public static final String VERSION_20 = "20"; //$NON-NLS-1$
 	/*
 	 * Note: Whenever a new version is added, make sure getLatestVersion()
 	 * is updated with it.
@@ -614,7 +615,7 @@ public class CompilerOptions {
 	 * Return the latest Java language version supported by the Eclipse compiler
 	 */
 	public static String getLatestVersion() {
-		return VERSION_19;
+		return VERSION_20;
 	}
 	/**
 	 * Return the most specific option key controlling this irritant. Note that in some case, some irritant is controlled by

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/util/AbstractCompilerTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/util/AbstractCompilerTest.java
@@ -51,6 +51,7 @@ public class AbstractCompilerTest extends TestCase {
 	public static final int F_17  = 0x4000;
 	public static final int F_18  = 0x8000;
 	public static final int F_19  = 0x10000;
+	public static final int F_20  = 0x12000;
 
 	public static final boolean RUN_JAVAC = CompilerOptions.ENABLED.equals(System.getProperty("run.javac"));
 	public static final boolean PERFORMANCE_ASSERTS = !CompilerOptions.DISABLED.equals(System.getProperty("jdt.performance.asserts"));
@@ -72,6 +73,7 @@ public class AbstractCompilerTest extends TestCase {
 	protected static boolean isJRE17Plus = false;
 	protected static boolean isJRE18Plus = false;
 	protected static boolean isJRE19Plus = false;
+	protected static boolean isJRE20Plus = false;
 	protected static boolean reflectNestedClassUseDollar;
 
 	public static int[][] complianceTestLevelMapping = new int[][] {
@@ -92,6 +94,7 @@ public class AbstractCompilerTest extends TestCase {
 		new int[] {F_17, ClassFileConstants.MAJOR_VERSION_17},
 		new int[] {F_18, ClassFileConstants.MAJOR_VERSION_18},
 		new int[] {F_19, ClassFileConstants.MAJOR_VERSION_19},
+		new int[] {F_20, ClassFileConstants.MAJOR_VERSION_20},
 	};
 
 	/**
@@ -330,7 +333,8 @@ public class AbstractCompilerTest extends TestCase {
 			if (spec > Integer.parseInt(CompilerOptions.getLatestVersion())) {
 				specVersion = CompilerOptions.getLatestVersion();
 			}
-			isJRE19Plus = CompilerOptions.VERSION_19.equals(specVersion);
+			isJRE20Plus = CompilerOptions.VERSION_20.equals(specVersion);
+			isJRE19Plus = isJRE20Plus || CompilerOptions.VERSION_19.equals(specVersion);
 			isJRE18Plus = isJRE19Plus || CompilerOptions.VERSION_18.equals(specVersion);
 			isJRE17Plus = isJRE18Plus || CompilerOptions.VERSION_17.equals(specVersion);
 			isJRE16Plus = isJRE17Plus || CompilerOptions.VERSION_16.equals(specVersion);

--- a/org.eclipse.jdt.core/.settings/.api_filters
+++ b/org.eclipse.jdt.core/.settings/.api_filters
@@ -1,19 +1,18 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <component id="org.eclipse.jdt.core" version="2">
-    <resource path="compiler/org/eclipse/jdt/core/compiler/CategorizedProblem.java" type="org.eclipse.jdt.core.compiler.CategorizedProblem">
-        <filter comment="Java 14" id="576725006">
-            <message_arguments>
-                <message_argument value="IProblem"/>
-                <message_argument value="CategorizedProblem"/>
-            </message_arguments>
-        </filter>
-    </resource>
     <resource path="dom/org/eclipse/jdt/core/dom/AST.java" type="org.eclipse.jdt.core.dom.AST">
         <filter id="388194388">
             <message_arguments>
                 <message_argument value="org.eclipse.jdt.core.dom.AST"/>
                 <message_argument value="JLS_Latest"/>
                 <message_argument value="18"/>
+            </message_arguments>
+        </filter>
+        <filter comment="Java 20 constants addition https://github.com/eclipse-jdt/eclipse.jdt.core/pull/541" id="388194388">
+            <message_arguments>
+                <message_argument value="org.eclipse.jdt.core.dom.AST"/>
+                <message_argument value="JLS_Latest"/>
+                <message_argument value="19"/>
             </message_arguments>
         </filter>
     </resource>

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/AST.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/AST.java
@@ -419,9 +419,27 @@ public final class AST {
 	 * up to and including Java SE 18(aka JDK 18).
 	 * </p>
 	 *
+	 * @deprecated
 	 * @since 3.32
 	 */
 	public static final int JLS19 = 19;
+
+	/**
+	 * Constant for indicating the AST API that handles JLS20.
+	 * <p>
+	 * This API is capable of handling all constructs in the
+	 * Java language as described in the Java Language
+	 * Specification, Java SE 20 Edition (JLS20).
+	 * JLS20 is a superset of all earlier versions of the
+	 * Java language, and the JLS20 API can be used to manipulate
+	 * programs written in all versions of the Java language
+	 * up to and including Java SE 20(aka JDK 20).
+	 * </p>
+	 *
+	 * @since 3.33
+	 */
+	public static final int JLS20 = 20;
+
 	/**
 	 * Internal synonym for {@link #JLS15}. Use to alleviate
 	 * deprecation warnings once JLS15 is deprecated
@@ -448,10 +466,15 @@ public final class AST {
 	 */
 	static final int JLS19_INTERNAL = JLS19;
 	/**
+	 * Internal synonym for {@link #JLS20}. Use to alleviate
+	 * deprecation warnings once JLS20 is deprecated
+	 */
+	static final int JLS20_INTERNAL = JLS20;
+	/**
 	 * Internal property for latest supported JLS level
 	 * This provides the latest JLS level.
 	 */
-	private static final int JLS_INTERNAL_Latest = JLS19;
+	private static final int JLS_INTERNAL_Latest = JLS20;
 
 	/**
 	 * @since 3.26

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/core/JavaCore.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/core/JavaCore.java
@@ -3182,6 +3182,12 @@ public final class JavaCore extends Plugin {
 	public static final String VERSION_19 = "19"; //$NON-NLS-1$
 	/**
 	 * Configurable option value: {@value}.
+	 * @since 3.33
+	 * @category OptionValue
+	 */
+	public static final String VERSION_20 = "20"; //$NON-NLS-1$
+	/**
+	 * Configurable option value: {@value}.
 	 * @since 3.4
 	 * @category OptionValue
 	 */


### PR DESCRIPTION
Constants for jvm version, bytecode version, tests runtime detection. 
Started with https://github.com/eclipse-jdt/eclipse.jdt.core/issues/529 but continues here as these have to go to a branch.
