### PR TITLE
Use hash of enclosingType if it is a ParameterizedTypeBinding

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeSystem.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeSystem.java
@@ -98,6 +98,10 @@ public class TypeSystem {
 					ReferenceBinding enclosing = resolvedType.enclosingType();
 					if (enclosing != null) {
 						this.enclosingType = resolvedType.isStatic() ? enclosing : (ReferenceBinding) env.convertUnresolvedBinaryToRawType(enclosing); // needed when binding unresolved member type
+						if (this.enclosingType.getClass() == ParameterizedTypeBinding.class) {
+							throw new IllegalStateException("unexpected: resolved enclosing type of " //$NON-NLS-1$
+									+ new String(this.type.readableName(false)) + " is a ParameterizedTypeBinding"); //$NON-NLS-1$
+						}
 					}
 				}
 				if (this.arguments != null) {
@@ -123,6 +127,11 @@ public class TypeSystem {
 			public int hashCode() {
 				final int prime=31;
 				int hashCode = 1 + hash(this.type);
+				if (this.enclosingType != null && this.enclosingType.getClass() == ParameterizedTypeBinding.class) {
+					// Note: this works as in swapUnresolved, a null enclosingType is never replaced by a
+					// ParameterizedTypeBinding (just by a non-generic or RawTypeBinding)
+					hashCode = hashCode * prime + System.identityHashCode(this.enclosingType);
+				}
 				for (int i = 0, length = this.arguments == null ? 0 : this.arguments.length; i < length; i++) {
 					hashCode = hashCode * prime + hash(this.arguments[i]);
 				}


### PR DESCRIPTION
Fixes "Increased compilation time with Eclipse 4.12+" #549

