### PR TITLE
Distinguish shared indexes with different index versions

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaIndexTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaIndexTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2019 IBM Corporation and others.
+ * Copyright (c) 2012, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -40,6 +40,7 @@ import org.eclipse.jdt.core.tests.util.Util;
 import org.eclipse.jdt.internal.core.ClasspathEntry;
 import org.eclipse.jdt.internal.core.JavaModelManager;
 import org.eclipse.jdt.internal.core.UserLibraryClasspathContainer;
+import org.eclipse.jdt.internal.core.index.DiskIndex;
 import org.eclipse.jdt.internal.core.index.Index;
 import org.eclipse.jdt.internal.core.search.indexing.IndexManager;
 import org.osgi.service.prefs.BackingStoreException;
@@ -890,7 +891,7 @@ public class JavaIndexTests extends AbstractJavaSearchTests  {
 		CRC32 checksumCalculator = new CRC32();
 		checksumCalculator.update(jarFilePath.getBytes());
 		String fileName = Long.toString(checksumCalculator.getValue()) + ".index";
-		String indexFilePath = Paths.get(sharedIndexDir, fileName).toString();
+		String indexFilePath = Paths.get(sharedIndexDir, DiskIndex.INDEX_VERSION, fileName).toString();
 		try {
 			createJar(new String[] {
 					"pkg/Test.java",

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ClasspathEntry.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ClasspathEntry.java
@@ -71,6 +71,7 @@ import org.eclipse.jdt.internal.compiler.env.AccessRuleSet;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jdt.internal.compiler.lookup.TypeConstants;
 import org.eclipse.jdt.internal.compiler.util.ManifestAnalyzer;
+import org.eclipse.jdt.internal.core.index.DiskIndex;
 import org.eclipse.jdt.internal.core.util.Messages;
 import org.eclipse.jdt.internal.core.util.Util;
 import org.w3c.dom.DOMException;
@@ -1790,7 +1791,7 @@ public class ClasspathEntry implements IClasspathEntry {
 						CRC32 checksumCalculator = new CRC32();
 						checksumCalculator.update(pathString.getBytes());
 						String fileName = Long.toString(checksumCalculator.getValue()) + ".index"; //$NON-NLS-1$
-						return Paths.get(SHARED_INDEX_LOCATION, fileName).toUri().toURL();
+						return Paths.get(SHARED_INDEX_LOCATION, DiskIndex.INDEX_VERSION, fileName).toUri().toURL();
 					} catch (MalformedURLException e1) {
 						Util.log(e1); // should not happen if protocol known (eg. 'file')
 					}

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/index/DiskIndex.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/index/DiskIndex.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corporation and others.
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -53,7 +53,8 @@ private int bufferIndex, bufferEnd; // used when reading from the file into the 
 private int streamEnd; // used when writing data from the streamBuffer to the file
 char separator = Index.DEFAULT_SEPARATOR;
 
-public static final String SIGNATURE = "INDEX VERSION 1.132"; //$NON-NLS-1$
+public static final String INDEX_VERSION = "1.132"; //$NON-NLS-1$
+public static final String SIGNATURE = "INDEX VERSION " + INDEX_VERSION; //$NON-NLS-1$
 private static final char[] SIGNATURE_CHARS = SIGNATURE.toCharArray();
 public static boolean DEBUG = false;
 


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

This is an enhancement to previous commit "[shared JDT Index folder among different workspaces](https://git.eclipse.org/r/c/jdt/eclipse.jdt.core/+/152349/)". The problem with shared indexes is that the index schema can evolve over time, and reusing outdated indexes from shared folders does not work. Currently, unless you read the original contents of the *.index file, it is not clear what index version is being used in the shared folder. To make it more intuitive, one suggestion is to force the shared folder structure to be organized as `<base_path>/<index_version>/*.index`, then you have to enable the system property in the format like `-Djdt.core.sharedIndexLocation=<base_path>`. 

This is also similar to a shared m2 dir, and allows multiple versions of indexes to coexist.
