### PR TITLE
Added batch compiler source files missing in source build (#181)

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/build.properties
+++ b/org.eclipse.jdt.core.compiler.batch/build.properties
@@ -17,5 +17,7 @@ output.. = bin/
 bin.includes = META-INF/,\
                .,\
                about.html
-src.includes = about.html
+src.includes = about.html,\
+               META-INF/services/,\
+               META-INF/eclipse.inf
 jars.extra.classpath = lib/javax18api.jar,platform:/plugin/org.apache.ant/lib/ant.jar


### PR DESCRIPTION
See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/181
