### PR TITLE
Really fix jdtCompilerAdapter.jar generation for pde/ant support (#181)

### DIFF
--- a/org.eclipse.jdt.core/pom.xml
+++ b/org.eclipse.jdt.core/pom.xml
@@ -40,6 +40,12 @@
 						<replace token="bundle_version" value="${unqualifiedVersion}" dir="${project.build.directory}/classes">
 							<include name="org/eclipse/jdt/internal/compiler/batch/messages.properties"/>
 						</replace>
+						<copy todir="${project.build.directory}/jdtCompilerAdapter.jar-classes">
+							<fileset dir="${project.build.directory}/../../org.eclipse.jdt.core.compiler.batch/target/classes">
+								<include name="org/eclipse/jdt/core/*.class"/>
+								<include name="org/eclipse/jdt/internal/antadapter/**"/>
+							</fileset>
+						</copy>
 					</target>
 				</configuration>
 				<goals>


### PR DESCRIPTION
Add moved classes located now in org.eclipse.jdt.core.compiler.batch to the jdtCompilerAdapter.jar used by pde.build & Ant (see org.eclipse.ant.internal.ui.datatransfer.BuildFileCreator).

See
https://github.com/eclipse-pde/eclipse.pde/issues/419 https://github.com/eclipse-jdt/eclipse.jdt.core/issues/181