### PR TITLE
Version bumps for 4.27 stream

### DIFF
--- a/org.eclipse.jdt.core.tests.model/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.tests.model/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.core.tests.model;singleton:=true
-Bundle-Version: 3.11.400.qualifier
+Bundle-Version: 3.11.500.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jdt.core.tests,

--- a/org.eclipse.jdt.core.tests.model/pom.xml
+++ b/org.eclipse.jdt.core.tests.model/pom.xml
@@ -19,7 +19,7 @@
     <relativePath>../tests-pom/</relativePath>
   </parent>
   <artifactId>org.eclipse.jdt.core.tests.model</artifactId>
-  <version>3.11.400-SNAPSHOT</version>
+  <version>3.11.500-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>

--- a/org.eclipse.jdt.core.tests.performance/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.tests.performance/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.core.tests.performance
-Bundle-Version: 3.11.50.qualifier
+Bundle-Version: 3.11.100.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jdt.core.tests.performance,

--- a/org.eclipse.jdt.core.tests.performance/pom.xml
+++ b/org.eclipse.jdt.core.tests.performance/pom.xml
@@ -19,7 +19,7 @@
     <relativePath>../tests-pom/</relativePath>
   </parent>
   <artifactId>org.eclipse.jdt.core.tests.performance</artifactId>
-  <version>3.11.50-SNAPSHOT</version>
+  <version>3.11.100-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <properties>
   	<testSuite>${project.artifactId}</testSuite>


### PR DESCRIPTION
As reported at
https://download.eclipse.org/eclipse/downloads/drops4/I20221206-1800/buildlogs/reporeports/reports/versionChecks.html :
IUs in current repo that increase versions but with qualifier only

Count: 4

| IU id |	Reference (old) version |	Current (new) version |
| ----------- | ----------- |
| org.eclipse.jdt.core.tests.model |	3.11.400.v20221101-1149 |	3.11.400.v20221112-1125 | 
| org.eclipse.jdt.core.tests.performance |	3.11.50.v20210914-1429 |	3.11.50.v20221205-1755 |
