### PR TITLE
JavaModelManager: Use custom ForkJoinWorkerThreadFactory

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelManager.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelManager.java
@@ -55,6 +55,7 @@ import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ForkJoinWorkerThread;
 import java.util.zip.ZipException;
 import java.util.zip.ZipFile;
 
@@ -4695,8 +4696,14 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 			infos = new ArrayList<>(this.perProjectInfos.values());
 		}
 		int parallelism = Math.max(1, SAVE_THREAD_COUNT == null ? ForkJoinPool.getCommonPoolParallelism() : SAVE_THREAD_COUNT.intValue());
-		// never use a shared ForkJoinPool.commonPool() as it may be busy with other tasks, which might deadlock:
-		ForkJoinPool forkJoinPool =  new ForkJoinPool(parallelism);
+		// Never use a shared ForkJoinPool.commonPool() as it may be busy with other tasks, which might deadlock.
+		// Also use a custom ForkJoinWorkerThreadFactory, to prevent issues with a
+		// potential SecurityManager, since the threads created by it get no permissions.
+		// See related problem in eclipse-platform https://github.com/eclipse-platform/eclipse.platform/issues/294
+		ForkJoinPool forkJoinPool = new ForkJoinPool(parallelism, //
+				pool -> new ForkJoinWorkerThread(pool) {
+					// anonymous subclass to access protected constructor
+				}, null, false);
 		IStatus[] stats;
 		try {
 			stats = forkJoinPool.submit(() -> infos.stream().parallel().map(info -> {


### PR DESCRIPTION
## What it does
In case a SecurityManager is installed, using the defaultForkJoinWorkerThreadFactory would result in worker threads with no permissions, which could prevent the model from being saved.

Use a custom ForkJoinWorkerThreadFactory implementation to work around this.

The same fix was also applied to org.eclipse.core.resources SaveManager.

See also:
https://github.com/eclipse-platform/eclipse.platform/issues/294
https://github.com/eclipse-platform/eclipse.platform/pull/295

<!-- Include relevant issues and describe how they are addressed. -->

## How to test
1. Have any Eclipse-plugin that installs a `SecurityManager`. Use attached demo plugin [foo.bar.securitymanager.zip](https://github.com/eclipse-platform/eclipse.platform/files/10208024/foo.bar.securitymanager.zip) (Main Menu `SecurityManager -> Install SecurityManager`) or the following snippet:
```java
Policy.getPolicy(); // init
Policy.setPolicy(new Policy() {
    @Override
    public boolean implies(ProtectionDomain domain, Permission permission) {
        return true;
    }
});
System.setSecurityManager(new SecurityManager());
```
2. Open ja Java project, edit some file, do not save
3. Close Eclipse -> Answer 'yes' when asked to save files

-> 
![image](https://user-images.githubusercontent.com/14908423/207617191-7a636faf-d414-49fc-a42d-17d2ef0f13fd.png)
```
Problems occurred while trying to save the state of the workbench.
  Problems occurred during save.
    Error saving build states
    java.security.AccessControlException: access denied ("java.io.FilePermission" "C:\eclipse_workspaces\runtime-EclipseContribute\.metadata\.plugins\org.eclipse.core.resources\.projects\A\org.eclipse.jdt.core" "read")
```

## Author checklist
- [X] I have thoroughly tested my changes
- [X]  The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
