### PR TITLE
Bug 564052 - [15] JEP 360 - Sealed Types -Formatter Support

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/formatter/FormatterRegressionTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/formatter/FormatterRegressionTests.java
@@ -16207,4 +16207,20 @@ public void testIssue264b() {
 		"	}\n" +
 		"}");
 }
+/**
+ * https://bugs.eclipse.org/564052 - [15] JEP 360 - Sealed Types -Formatter Support
+ */
+public void testBug564052() {
+	setComplianceLevel(CompilerOptions.VERSION_17);
+	this.formatterPrefs.alignment_for_permitted_types_in_type_declaration = Alignment.M_ONE_PER_LINE_SPLIT + Alignment.M_FORCE;
+	String source =
+		"sealed class Example permits C1, C2, C3 {}";
+	formatSource(source,
+		"sealed class Example\n" +
+		"		permits\n" +
+		"		C1,\n" +
+		"		C2,\n" +
+		"		C3 {\n" +
+		"}");
+}
 }

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/core/formatter/DefaultCodeFormatterConstants.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/core/formatter/DefaultCodeFormatterConstants.java
@@ -587,6 +587,17 @@ public class DefaultCodeFormatterConstants {
 	public static final String FORMATTER_ALIGNMENT_FOR_PARAMETERS_IN_METHOD_DECLARATION = JavaCore.PLUGIN_ID + ".formatter.alignment_for_parameters_in_method_declaration";	 //$NON-NLS-1$
 	/**
 	 * <pre>
+	 * FORMATTER / Option for alignment of permitted types in type declaration
+	 *     - option id:         "org.eclipse.jdt.core.formatter.alignment_for_permitted_types_in_type_declaration"
+	 *     - possible values:   values returned by <code>createAlignmentValue(boolean, int, int)</code> call
+	 *     - default:           createAlignmentValue(false, WRAP_COMPACT, INDENT_DEFAULT)
+	 * </pre>
+	 * @see #createAlignmentValue(boolean, int, int)
+	 * @since 3.33
+	 */
+	public static final String FORMATTER_ALIGNMENT_FOR_PERMITTED_TYPES_IN_TYPE_DECLARATION = JavaCore.PLUGIN_ID + ".formatter.alignment_for_permitted_types_in_type_declaration"; //$NON-NLS-1$
+	/**
+	 * <pre>
 	 * FORMATTER / Option for alignment of components in record declaration
 	 *     - option id:         "org.eclipse.jdt.core.formatter.alignment_for_record_components"
 	 *     - possible values:   values returned by <code>createAlignmentValue(boolean, int, int)</code> call

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/DefaultCodeFormatterOptions.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/DefaultCodeFormatterOptions.java
@@ -158,6 +158,7 @@ public class DefaultCodeFormatterOptions {
 	public int alignment_for_parameterized_type_references;
 	public int alignment_for_parameters_in_constructor_declaration;
 	public int alignment_for_parameters_in_method_declaration;
+	public int alignment_for_permitted_types_in_type_declaration;
 	public int alignment_for_record_components;
 	public int alignment_for_selector_in_method_invocation;
 	public int alignment_for_superclass_in_type_declaration;
@@ -607,6 +608,7 @@ public class DefaultCodeFormatterOptions {
 		options.put(DefaultCodeFormatterConstants.FORMATTER_ALIGNMENT_FOR_PARAMETERIZED_TYPE_REFERENCES, getAlignment(this.alignment_for_parameterized_type_references));
 		options.put(DefaultCodeFormatterConstants.FORMATTER_ALIGNMENT_FOR_PARAMETERS_IN_CONSTRUCTOR_DECLARATION, getAlignment(this.alignment_for_parameters_in_constructor_declaration));
 		options.put(DefaultCodeFormatterConstants.FORMATTER_ALIGNMENT_FOR_PARAMETERS_IN_METHOD_DECLARATION, getAlignment(this.alignment_for_parameters_in_method_declaration));
+		options.put(DefaultCodeFormatterConstants.FORMATTER_ALIGNMENT_FOR_PERMITTED_TYPES_IN_TYPE_DECLARATION, getAlignment(this.alignment_for_permitted_types_in_type_declaration));
 		options.put(DefaultCodeFormatterConstants.FORMATTER_ALIGNMENT_FOR_RECORD_COMPONENTS, getAlignment(this.alignment_for_record_components));
 		options.put(DefaultCodeFormatterConstants.FORMATTER_ALIGNMENT_FOR_RESOURCES_IN_TRY, getAlignment(this.alignment_for_resources_in_try));
 		options.put(DefaultCodeFormatterConstants.FORMATTER_ALIGNMENT_FOR_SELECTOR_IN_METHOD_INVOCATION, getAlignment(this.alignment_for_selector_in_method_invocation));
@@ -1170,6 +1172,8 @@ public class DefaultCodeFormatterOptions {
 				this.alignment_for_parameters_in_method_declaration = Alignment.M_COMPACT_SPLIT;
 			}
 		}
+		setInt(settings, DefaultCodeFormatterConstants.FORMATTER_ALIGNMENT_FOR_PERMITTED_TYPES_IN_TYPE_DECLARATION,
+				v -> this.alignment_for_permitted_types_in_type_declaration = v);
 		setInt(settings, DefaultCodeFormatterConstants.FORMATTER_ALIGNMENT_FOR_RECORD_COMPONENTS,
 				v -> this.alignment_for_record_components = v);
 		final Object alignmentForResourcesInTry = settings.get(DefaultCodeFormatterConstants.FORMATTER_ALIGNMENT_FOR_RESOURCES_IN_TRY);
@@ -2991,6 +2995,7 @@ public class DefaultCodeFormatterOptions {
 		this.alignment_for_parameterized_type_references = Alignment.M_NO_ALIGNMENT;
 		this.alignment_for_parameters_in_constructor_declaration = Alignment.M_COMPACT_SPLIT;
 		this.alignment_for_parameters_in_method_declaration = Alignment.M_COMPACT_SPLIT;
+		this.alignment_for_permitted_types_in_type_declaration = Alignment.M_COMPACT_SPLIT;
 		this.alignment_for_record_components = Alignment.M_COMPACT_SPLIT;
 		this.alignment_for_resources_in_try = Alignment.M_NEXT_PER_LINE_SPLIT;
 		this.alignment_for_selector_in_method_invocation = Alignment.M_COMPACT_SPLIT;
@@ -3392,6 +3397,7 @@ public class DefaultCodeFormatterOptions {
 		this.alignment_for_parameterized_type_references = Alignment.M_NO_ALIGNMENT;
 		this.alignment_for_parameters_in_constructor_declaration = Alignment.M_COMPACT_SPLIT;
 		this.alignment_for_parameters_in_method_declaration = Alignment.M_COMPACT_SPLIT;
+		this.alignment_for_permitted_types_in_type_declaration = Alignment.M_COMPACT_SPLIT;
 		this.alignment_for_record_components = Alignment.M_COMPACT_SPLIT;
 		this.alignment_for_resources_in_try = Alignment.M_NEXT_PER_LINE_SPLIT;
 		this.alignment_for_selector_in_method_invocation = Alignment.M_COMPACT_SPLIT;

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/linewrap/WrapPreparator.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/linewrap/WrapPreparator.java
@@ -38,6 +38,7 @@ import static org.eclipse.jdt.internal.compiler.parser.TerminalTokens.TokenNamee
 import static org.eclipse.jdt.internal.compiler.parser.TerminalTokens.TokenNameextends;
 import static org.eclipse.jdt.internal.compiler.parser.TerminalTokens.TokenNameimplements;
 import static org.eclipse.jdt.internal.compiler.parser.TerminalTokens.TokenNamenew;
+import static org.eclipse.jdt.internal.compiler.parser.TerminalTokens.TokenNameRestrictedIdentifierpermits;
 import static org.eclipse.jdt.internal.compiler.parser.TerminalTokens.TokenNamesuper;
 import static org.eclipse.jdt.internal.compiler.parser.TerminalTokens.TokenNamethis;
 import static org.eclipse.jdt.internal.compiler.parser.TerminalTokens.TokenNamethrows;
@@ -318,6 +319,14 @@ public class WrapPreparator extends ASTVisitor {
 			this.wrapIndexes.add(this.tm.firstIndexBefore(superInterfaceTypes.get(0), implementsToken));
 			prepareElementsList(superInterfaceTypes, TokenNameCOMMA, -1);
 			handleWrap(this.options.alignment_for_superinterfaces_in_type_declaration, PREFERRED);
+		}
+
+		List<Type> permittedTypes = node.permittedTypes();
+		if (!permittedTypes.isEmpty()) {
+			this.wrapParentIndex = this.tm.lastIndexIn(node.getName(), -1);
+			this.wrapIndexes.add(this.tm.firstIndexBefore(permittedTypes.get(0), TokenNameRestrictedIdentifierpermits));
+			prepareElementsList(permittedTypes, TokenNameCOMMA, -1);
+			handleWrap(this.options.alignment_for_permitted_types_in_type_declaration, PREFERRED);
 		}
 
 		prepareElementsList(node.typeParameters(), TokenNameCOMMA, TokenNameLESS);


### PR DESCRIPTION
Fix for https://bugs.eclipse.org/bugs/show_bug.cgi?id=564052

Adds a new line wrapping setting for _permits_ clause. Whitespace settings were added in https://bugs.eclipse.org/bugs/show_bug.cgi?id=576373.