### PR TITLE
Avoid multiple computation of hashCode on InferenceVariable

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LambdaExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LambdaExpression.java
@@ -1468,6 +1468,9 @@ public class LambdaExpression extends FunctionalExpression implements IPolyExpre
 			return null;
 
 		class LambdaTypeBinding extends ReferenceBinding {
+			LambdaTypeBinding() {
+				super((char[][]) null);
+			}
 			@Override
 			public MethodBinding[] methods() {
 				return new MethodBinding [] { getMethodBinding() };

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ReferenceExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ReferenceExpression.java
@@ -1161,10 +1161,7 @@ public class ReferenceExpression extends FunctionalExpression implements IPolyEx
 		int parametersLength = sam.parameters.length;
 		TypeBinding[] descriptorParameters = new TypeBinding[parametersLength];
 		for (int i = 0; i < parametersLength; i++) {
-			descriptorParameters[i] = new ReferenceBinding() {
-				{
-					this.compoundName = CharOperation.NO_CHAR_CHAR;
-				}
+			descriptorParameters[i] = new ReferenceBinding(CharOperation.NO_CHAR_CHAR) {
 				@Override
 				public boolean isCompatibleWith(TypeBinding otherType, Scope captureScope) {
 					return true;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BinaryTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BinaryTypeBinding.java
@@ -257,7 +257,8 @@ public static TypeBinding resolveType(TypeBinding type, LookupEnvironment enviro
 /**
  * Default empty constructor for subclasses only.
  */
-protected BinaryTypeBinding() {
+protected BinaryTypeBinding(char[][] compoundName) {
+	super(compoundName);
 	// only for subclasses
 	this.prototype = this;
 }
@@ -294,9 +295,8 @@ public BinaryTypeBinding(PackageBinding packageBinding, IBinaryType binaryType, 
  * @param needFieldsAndMethods
  */
 public BinaryTypeBinding(PackageBinding packageBinding, IBinaryType binaryType, LookupEnvironment environment, boolean needFieldsAndMethods) {
-
+	super(CharOperation.splitOn('/', binaryType.getName()));
 	this.prototype = this;
-	this.compoundName = CharOperation.splitOn('/', binaryType.getName());
 	computeId();
 
 	this.tagBits |= TagBits.IsBinaryBinding;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceVariable.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceVariable.java
@@ -83,8 +83,8 @@ public class InferenceVariable extends TypeVariableBinding {
 	}
 
 
-	InvocationSite site;
-	TypeBinding typeParameter;
+	final InvocationSite site;
+	final TypeBinding typeParameter;
 	long nullHints; // one of TagBits.{AnnotationNonNull,AnnotationNullable} may steer inference into inferring nullness as well; set both bits to request avoidance.
 	private InferenceVariable prototype;
 	int varId; // this is used for constructing a source name like T#0.
@@ -209,14 +209,20 @@ public class InferenceVariable extends TypeVariableBinding {
 		return debugName();
 	}
 
+	private int hashCode;
 	@Override
 	public int hashCode() {
-		int code = this.typeParameter.hashCode() + 17 * this.rank;
-		if (this.site != null) {
-			code = 31 * code + this.site.sourceStart();
-			code = 31 * code + this.site.sourceEnd();
+		if (this.hashCode == 0 || (this.typeParameter instanceof WildcardBinding
+				&& ((WildcardBinding) this.typeParameter).hashCode() == 0)) {
+			int code = this.typeParameter.hashCode() + 17 * this.rank;
+			if (this.site != null) {
+				// sourceStart and sourceEnd should not change at this point
+				code = 31 * code + this.site.sourceStart();
+				code = 31 * code + this.site.sourceEnd();
+			}
+			this.hashCode = code;
 		}
-		return code;
+		return this.hashCode;
 	}
 	@Override
 	public boolean equals(Object obj) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/IntersectionTypeBinding18.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/IntersectionTypeBinding18.java
@@ -44,6 +44,7 @@ public class IntersectionTypeBinding18 extends ReferenceBinding {
 	int length;
 
 	public IntersectionTypeBinding18(ReferenceBinding[] intersectingTypes, LookupEnvironment environment) {
+		super((char[][]) null);
 		this.intersectingTypes = intersectingTypes;
 		this.length = intersectingTypes.length;
 		if (!intersectingTypes[0].isClass()) {
@@ -53,6 +54,7 @@ public class IntersectionTypeBinding18 extends ReferenceBinding {
 	}
 
 	private IntersectionTypeBinding18(IntersectionTypeBinding18 prototype) {
+		super((char[][]) null);
 		this.intersectingTypes = prototype.intersectingTypes;
 		this.length = prototype.length;
 		if (!this.intersectingTypes[0].isClass()) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/LocalTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/LocalTypeBinding.java
@@ -57,8 +57,8 @@ public LocalTypeBinding(ClassScope scope, SourceTypeBinding enclosingType, CaseS
 	}
 }
 
-public LocalTypeBinding(LocalTypeBinding prototype) {
-	super(prototype);
+public LocalTypeBinding(LocalTypeBinding prototype, SourceTypeBinding enclosingType) {
+	super(prototype, enclosingType);
 	this.dependents = prototype.dependents;
 	this.enclosingCase = prototype.enclosingCase;
 	this.sourceStart = prototype.sourceStart;
@@ -161,9 +161,7 @@ public char[] constantPoolName() /* java/lang/Object */ {
 
 @Override
 public TypeBinding clone(TypeBinding outerType) {
-	LocalTypeBinding copy = new LocalTypeBinding(this);
-	copy.enclosingType = (SourceTypeBinding) outerType;
-	return copy;
+	return new LocalTypeBinding(this, (SourceTypeBinding) outerType);
 }
 
 @Override

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MemberTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MemberTypeBinding.java
@@ -22,8 +22,8 @@ public MemberTypeBinding(char[][] compoundName, ClassScope scope, SourceTypeBind
 	this.tagBits |= TagBits.MemberTypeMask;
 }
 
-public MemberTypeBinding(MemberTypeBinding prototype) {
-	super(prototype);
+public MemberTypeBinding(MemberTypeBinding prototype, SourceTypeBinding enclosingType) {
+	super(prototype, enclosingType);
 }
 
 void checkSyntheticArgsAndFields() {
@@ -56,9 +56,7 @@ public char[] constantPoolName() /* java/lang/Object */ {
 
 @Override
 public TypeBinding clone(TypeBinding outerType) {
-	MemberTypeBinding copy = new MemberTypeBinding(this);
-	copy.enclosingType = (SourceTypeBinding) outerType;
-	return copy;
+	return new MemberTypeBinding(this, (SourceTypeBinding) outerType);
 }
 
 /**

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MissingTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MissingTypeBinding.java
@@ -28,7 +28,7 @@ public class MissingTypeBinding extends BinaryTypeBinding {
  * @param environment
  */
 public MissingTypeBinding(PackageBinding packageBinding, char[][] compoundName, LookupEnvironment environment) {
-	this.compoundName = compoundName;
+	super(compoundName);
 	computeId();
 	this.tagBits |= TagBits.IsBinaryBinding | TagBits.HierarchyHasProblems | TagBits.HasMissingType;
 	this.environment = environment;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/NestedTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/NestedTypeBinding.java
@@ -20,7 +20,7 @@ package org.eclipse.jdt.internal.compiler.lookup;
 
 public abstract class NestedTypeBinding extends SourceTypeBinding {
 
-	public SourceTypeBinding enclosingType;
+	public final SourceTypeBinding enclosingType;
 
 	public SyntheticArgumentBinding[] enclosingInstances;
 	private ReferenceBinding[] enclosingTypes = Binding.UNINITIALIZED_REFERENCE_TYPES;
@@ -33,7 +33,7 @@ public NestedTypeBinding(char[][] typeName, ClassScope scope, SourceTypeBinding 
 	this.enclosingType = enclosingType;
 }
 
-public NestedTypeBinding(NestedTypeBinding prototype) {
+public NestedTypeBinding(NestedTypeBinding prototype, SourceTypeBinding enclosingType) {
 	super(prototype);
 	this.enclosingType = prototype.enclosingType;
 	this.enclosingInstances = prototype.enclosingInstances;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedTypeBinding.java
@@ -80,6 +80,7 @@ public class ParameterizedTypeBinding extends ReferenceBinding implements Substi
 	protected ReferenceBinding enclosingType;
 
 	public ParameterizedTypeBinding(ReferenceBinding type, TypeBinding[] arguments,  ReferenceBinding enclosingType, LookupEnvironment environment){
+		super(type.compoundName);
 		this.environment = environment;
 		this.enclosingType = enclosingType; // never unresolved, but if type is an unresolved nested type, enclosingType is null here but set later in swapUnresolved.
 		if (!type.hasEnclosingInstanceContext() && arguments == null && !(this instanceof RawTypeBinding))
@@ -899,7 +900,6 @@ public class ParameterizedTypeBinding extends ReferenceBinding implements Substi
 	void initialize(ReferenceBinding someType, TypeBinding[] someArguments) {
 		this.type = someType;
 		this.sourceName = someType.sourceName;
-		this.compoundName = someType.compoundName;
 		this.fPackage = someType.fPackage;
 		this.fileName = someType.fileName;
 		// should not be set yet

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ProblemReferenceBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ProblemReferenceBinding.java
@@ -26,7 +26,7 @@ public class ProblemReferenceBinding extends ReferenceBinding {
 // NOTE: must only answer the subset of the name related to the problem
 
 public ProblemReferenceBinding(char[][] compoundName, ReferenceBinding closestMatch, int problemReason) {
-	this.compoundName = compoundName;
+	super(compoundName);
 	this.closestMatch = closestMatch;
 	if (closestMatch != null) {
 		this.sourceName = closestMatch.sourceName;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
@@ -79,7 +79,7 @@ null is NOT a valid value for a non-public field... it just means the field is n
 
 abstract public class ReferenceBinding extends TypeBinding {
 
-	public char[][] compoundName;
+	public final char[][] compoundName;
 	public char[] sourceName;
 	public int modifiers;
 	public PackageBinding fPackage;
@@ -92,7 +92,7 @@ abstract public class ReferenceBinding extends TypeBinding {
 	int typeBits; // additional bits characterizing this type
 	protected MethodBinding [] singleAbstractMethod;
 
-	public static final ReferenceBinding LUB_GENERIC = new ReferenceBinding() { /* used for lub computation */
+	public static final ReferenceBinding LUB_GENERIC = new ReferenceBinding((char[][]) null) { /* used for lub computation */
 		{ this.id = TypeIds.T_undefined; }
 		@Override
 		public boolean hasTypeBit(int bit) { return false; }
@@ -133,8 +133,9 @@ abstract public class ReferenceBinding extends TypeBinding {
 	this.singleAbstractMethod = prototype.singleAbstractMethod;
 }
 
-public ReferenceBinding() {
+public ReferenceBinding(char[][] compoundName) {
 	super();
+	this.compoundName = compoundName;
 }
 
 public static FieldBinding binarySearch(char[] name, FieldBinding[] sortedFields) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SourceTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SourceTypeBinding.java
@@ -138,7 +138,7 @@ public class SourceTypeBinding extends ReferenceBinding {
 	private MethodBinding[] recordComponentAccessors = null; // hash maybe an overkill
 
 public SourceTypeBinding(char[][] compoundName, PackageBinding fPackage, ClassScope scope) {
-	this.compoundName = compoundName;
+	super(compoundName);
 	this.fPackage = fPackage;
 	this.fileName = scope.referenceCompilationUnit().getFileName();
 	this.modifiers = scope.referenceContext.modifiers;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeBinding.java
@@ -64,7 +64,7 @@ abstract public class TypeBinding extends Binding {
 	protected AnnotationBinding [] typeAnnotations = Binding.NO_ANNOTATIONS;
 
 	// jsr 308
-	public static final ReferenceBinding TYPE_USE_BINDING = new ReferenceBinding() { /* used for type annotation resolution. */
+	public static final ReferenceBinding TYPE_USE_BINDING = new ReferenceBinding((char[][]) null) { /* used for type annotation resolution. */
 		{ this.id = TypeIds.T_undefined; }
 		@Override
 		public int kind() { return Binding.TYPE_USE; }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeSystem.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeSystem.java
@@ -73,6 +73,7 @@ public class TypeSystem {
 			public TypeBinding[] arguments;
 			private ReferenceBinding enclosingType;
 			public PTBKey(ReferenceBinding type, TypeBinding[] arguments, ReferenceBinding enclosingType, LookupEnvironment environment) {
+				super((char[][]) null);
 				this.type = type;
 				this.arguments = arguments;
 				this.enclosingType = enclosingType;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeVariableBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeVariableBinding.java
@@ -63,7 +63,7 @@ import org.eclipse.jdt.internal.compiler.lookup.TypeConstants.BoundCheckStatus;
 public class TypeVariableBinding extends ReferenceBinding {
 
 	public Binding declaringElement; // binding of declaring type or method
-	public int rank; // declaration rank, can be used to match variable in parameterized type
+	public final int rank; // declaration rank, can be used to match variable in parameterized type
 
 	/**
 	 * Denote the first explicit (binding) bound amongst the supertypes (from declaration in source)
@@ -78,6 +78,7 @@ public class TypeVariableBinding extends ReferenceBinding {
 	LookupEnvironment environment;
 
 	public TypeVariableBinding(char[] sourceName, Binding declaringElement, int rank, LookupEnvironment environment) {
+		super((char[][]) null);
 		this.sourceName = sourceName;
 		this.declaringElement = declaringElement;
 		this.rank = rank;
@@ -90,11 +91,13 @@ public class TypeVariableBinding extends ReferenceBinding {
 
 	// for subclass CaptureBinding
 	protected TypeVariableBinding(char[] sourceName, LookupEnvironment environment) {
+		super((char[][]) null);
 		this.sourceName = sourceName;
 		this.modifiers = ClassFileConstants.AccPublic | ExtraCompilerModifiers.AccGenericSignature; // treat type var as public
 		this.tagBits |= TagBits.HasTypeVariable;
 		this.environment = environment;
 		this.typeBits = TypeIds.BitUninitialized;
+		this.rank = 0;
 		// don't yet compute the ID!
 	}
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/UnresolvedReferenceBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/UnresolvedReferenceBinding.java
@@ -28,7 +28,7 @@ UnresolvedReferenceBinding prototype;
 ReferenceBinding requestingType;
 
 UnresolvedReferenceBinding(char[][] compoundName, PackageBinding packageBinding, ReferenceBinding requestingType) {
-	this.compoundName = compoundName;
+	super(compoundName);
 	this.sourceName = compoundName[compoundName.length - 1]; // reasonable guess
 	this.fPackage = packageBinding;
 	this.requestingType = requestingType;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/WildcardBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/WildcardBinding.java
@@ -58,6 +58,8 @@ public class WildcardBinding extends ReferenceBinding {
 	 * When unbound, the bound denotes the corresponding type variable (so as to retrieve its bound lazily)
 	 */
 	public WildcardBinding(ReferenceBinding genericType, int rank, TypeBinding bound, TypeBinding[] otherBounds, int boundKind, LookupEnvironment environment) {
+		super((char[][]) null);
+		this.genericType = genericType;
 		this.rank = rank;
 	    this.boundKind = boundKind;
 		this.modifiers = ClassFileConstants.AccPublic | ExtraCompilerModifiers.AccGenericSignature; // treat wildcard as public
@@ -614,9 +616,13 @@ public class WildcardBinding extends ReferenceBinding {
         return this.genericSignature;
     }
 
+	private int hashCode;
 	@Override
 	public int hashCode() {
-		return this.genericType.hashCode();
+		if (this.hashCode == 0) {
+			this.hashCode = this.genericType.hashCode();
+		}
+		return this.hashCode;
 	}
 
 	@Override
@@ -635,7 +641,6 @@ public class WildcardBinding extends ReferenceBinding {
 	}
 
 	void initialize(ReferenceBinding someGenericType, TypeBinding someBound, TypeBinding[] someOtherBounds) {
-		this.genericType = someGenericType;
 		this.bound = someBound;
 		this.otherBounds = someOtherBounds;
 		if (someGenericType != null) {
@@ -960,6 +965,7 @@ public class WildcardBinding extends ReferenceBinding {
 		boolean affected = false;
 		if (this.genericType == unresolvedType) { //$IDENTITY-COMPARISON$
 			this.genericType = resolvedType; // no raw conversion
+			this.hashCode = 0;
 			affected = true;
 		}
 		if (this.bound == unresolvedType) { //$IDENTITY-COMPARISON$


### PR DESCRIPTION
Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/623

Computation of hashCode on InferenceVariable is very time comsuming because of WildcardBinding#hasCode and a lot of hash computation in BoundSet#ThreeSets for InferenceContext18.

By doing this, the compilation time on my project is reduced by 7%.

## What it does
Avoid multiple computation of hashCode on InferenceVariable.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
