### PR TITLE
meta-index fix for for move/rename #638

### DIFF
--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/IndexSelector.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/IndexSelector.java
@@ -23,7 +23,16 @@ import java.util.stream.Stream;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.jdt.core.*;
+import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IJavaModel;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IMethod;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.ITypeHierarchy;
+import org.eclipse.jdt.core.ITypeRoot;
+import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.core.search.IJavaSearchScope;
 import org.eclipse.jdt.core.search.SearchPattern;
@@ -312,6 +321,15 @@ public IndexLocation[] getIndexLocations() {
 			Set<String> indexNames = indexNamesResult.get();
 			filtered = Stream.of(this.indexLocations).filter(l -> indexNames.contains(l.fileName()))
 					.toArray(IndexLocation[]::new);
+			if (filtered.length == 0) {
+				if (JobManager.VERBOSE) {
+					Util.verbose(String.format(
+							"-> current index selection and qualifying indexes has no intersection, " + //$NON-NLS-1$
+									"to keep search backward compatible using selected index locations - %s", //$NON-NLS-1$
+							this.toString()));
+				}
+				filtered = this.indexLocations;
+			}
 		}
 	}
 	if (JobManager.VERBOSE) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
When performing rectorings such as move/rename meta-index doesn't have correct information, therefore when we do index filtering based on meta-index results if we find that none of the selected indexes are not present in meta index, to keep search backward compatible, we return the original selection to search engine.

On edge cases this could lead to more wider search which should have stopped by the meta-index, but until we find a proper solution this will restore the previous behavior.

Related issue: #638 

## How to test
Execute RenamePackageTests.testImportFromMultiRoots4 on jdt.ui

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
