### PR TITLE
Get rid of org.eclipse.jdt.core.tests.binaries project references (#644)

### DIFF
--- a/org.eclipse.jdt.apt.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.apt.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.apt.tests; singleton:=true
-Bundle-Version: 3.5.100.qualifier
+Bundle-Version: 3.5.200.qualifier
 Bundle-ClassPath: apt.jar,
  aptext.jar,
  .
@@ -40,7 +40,6 @@ Require-Bundle: org.junit,
  org.eclipse.core.resources,
  org.eclipse.core.runtime,
  org.eclipse.test.performance,
- org.eclipse.jdt.core.tests.binaries;bundle-version="1.0.0",
  org.eclipse.pde.core
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-11

--- a/org.eclipse.jdt.apt.tests/pom.xml
+++ b/org.eclipse.jdt.apt.tests/pom.xml
@@ -19,7 +19,7 @@
     <relativePath>../tests-pom/</relativePath>
   </parent>
   <artifactId>org.eclipse.jdt.apt.tests</artifactId>
-  <version>3.5.100-SNAPSHOT</version>
+  <version>3.5.200-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <properties>
   	<testSuite>${project.artifactId}</testSuite>

--- a/org.eclipse.jdt.core.tests.performance/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.tests.performance/META-INF/MANIFEST.MF
@@ -15,8 +15,7 @@ Require-Bundle: org.eclipse.core.resources;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.jdt.core.tests.model;bundle-version="[3.4.0,4.0.0)",
  org.junit;bundle-version="3.8.1",
  org.eclipse.test.performance;bundle-version="[3.1.0,4.0.0)",
- org.eclipse.text;bundle-version="[3.1.0,4.0.0)",
- org.eclipse.jdt.core.tests.binaries;bundle-version="1.0.0"
+ org.eclipse.text;bundle-version="[3.1.0,4.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Eclipse-BundleShape: dir
 Automatic-Module-Name: org.eclipse.jdt.core.tests.performance

--- a/org.eclipse.jdt.core.tests.performance/src/org/eclipse/jdt/core/tests/performance/FullSourceWorkspaceBuildTests.java
+++ b/org.eclipse.jdt.core.tests.performance/src/org/eclipse/jdt/core/tests/performance/FullSourceWorkspaceBuildTests.java
@@ -280,20 +280,17 @@ public class FullSourceWorkspaceBuildTests extends FullSourceWorkspaceTests {
 		compile(sources, options, classpath, null, log, logFileName);
 	}
 
-	// compile the sources present in this plugin directory using batch compiler
-	void compile (String[] srcPaths, String options, String compliance, boolean log) throws IOException {
+	// compile the file from org.eclipse.jdt.core.tests.binaries bundle using batch compiler
+	void compile (String srcPath, long fileSize, String options, String compliance, boolean log) throws IOException {
 		final String targetWorkspacePath = ResourcesPlugin.getWorkspace().getRoot().getLocation().toFile().getCanonicalPath();
 		String logFileName = targetWorkspacePath + File.separator + getName()+".log";
 
-		String pluginDir = getPluginBinariesDirectoryPath();
-		String sources = "";
-		for (int i=0, l=srcPaths.length; i<l; i++) {
-			String path = pluginDir + File.separator + srcPaths[i];
-			if (path.indexOf(" ") > 0) {
-				path = "\"" + path + "\"";
-			}
-			sources += " " + path;
+		File file = fetchFromBinariesProject(srcPath, fileSize);
+		String path = file.getAbsolutePath();
+		if (path.indexOf(" ") > 0) {
+			path = "\"" + path + "\"";
 		}
+		String sources = " " + path;
 		compile(sources, options, "", compliance, log, logFileName);
 	}
 
@@ -794,7 +791,7 @@ public class FullSourceWorkspaceBuildTests extends FullSourceWorkspaceTests {
 	 */
 	public void testBuildGenericType() throws IOException, CoreException {
 		tagAsSummary("Build Generic Type ", false); // do NOT put in fingerprint
-		compile(new String[] {"EclipseVisitorBug.java"}, "", "1.6", false /*no log*/ );
+		compile("EclipseVisitorBug.java", 37_884, "", "1.6", false /*no log*/ );
 	}
 
 	/**
@@ -802,6 +799,6 @@ public class FullSourceWorkspaceBuildTests extends FullSourceWorkspaceTests {
 	 */
 	public void testBug434326() throws IOException, CoreException {
 		tagAsSummary("Build with Generic Types ", false); // do NOT put in fingerprint
-		compile(new String[] {"GenericsTest.java"}, "", "1.8", false /*no log*/ );
+		compile("GenericsTest.java", 12_629_541, "", "1.8", false /*no log*/ );
 	}
 }

--- a/org.eclipse.jdt.core.tests.performance/src/org/eclipse/jdt/core/tests/performance/FullSourceWorkspaceFormatterTests.java
+++ b/org.eclipse.jdt.core.tests.performance/src/org/eclipse/jdt/core/tests/performance/FullSourceWorkspaceFormatterTests.java
@@ -69,14 +69,14 @@ protected void setUp() throws Exception {
 
 	// Read big file
 	System.out.print("	- Read big file source...");
+	File file = fetchFromBinariesProject("GenericTypeTest.java", 1_258_374);
+	String sourceFilePath = file.getAbsolutePath();
+
 	long start = System.currentTimeMillis();
-	FORMAT_TYPE_SOURCE = Util.fileContent(getPluginBinariesDirectoryPath()+File.separator+"GenericTypeTest.java");
+	FORMAT_TYPE_SOURCE = Util.fileContent(sourceFilePath);
 	System.out.println("("+(System.currentTimeMillis()-start)+"ms)");
 }
 
-/* (non-Javadoc)
- * @see junit.framework.TestCase#tearDown()
- */
 @Override
 protected void tearDown() throws Exception {
 


### PR DESCRIPTION
While updating
https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md I've stumbled again over
https://github.com/eclipse-jdt/eclipse.jdt.core.binaries repository.

This one usually surprises first time JDT contributors because it is one that need to be cloned additionally to jdt core repo and the test bundles can't compile because they refer to (usually missing) org.eclipse.jdt.core.tests.binaries project.

However, the only purpose of that repository is to host few big files used by some (mostly not running) performance tests.

This commit removes references to that project from JDT core test code and fetches the few binary files directly from github during tests.

Note: the tests we talk about aren't usually executed at all, not during Jenkins build nor during SDK builds! So the "usual" contributor will not notice any performance impact.

Fetched files are stored in system temp directory and should not be fetched again if executing on same machine by same user on same day.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/644