### PR TITLE
[19] VerifyError when a boxed boolean is used in a 'when' clause #658

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/GuardedPattern.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/GuardedPattern.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 IBM Corporation and others.
+ * Copyright (c) 2022, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -109,7 +109,10 @@ public class GuardedPattern extends Pattern {
 		if (this.resolvedType != null || this.primaryPattern == null)
 			return this.resolvedType;
 		this.resolvedType = this.primaryPattern.resolveType(scope);
-		this.condition.resolveType(scope);
+		// The following call (as opposed to resolveType() ensures that
+		// the implicitConversion code is set properly and thus the correct
+		// unboxing calls are generated.
+		this.condition.resolveTypeExpecting(scope, TypeBinding.BOOLEAN);
 		LocalDeclaration PatternVar = this.primaryPattern.getPatternVariable();
 		LocalVariableBinding lvb = PatternVar == null ? null : PatternVar.binding;
 		this.condition.traverse(new ASTVisitor() {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchPatternTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchPatternTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2022 IBM Corporation and others.
+ * Copyright (c) 2021, 2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -5337,5 +5337,33 @@ public class SwitchPatternTest extends AbstractRegressionTest9 {
 					"}"
 				},
 				"1");
+	}
+	public void testIssue658() {
+		runConformTest(
+				new String[] {
+					"X.java",
+					"@SuppressWarnings(\"preview\")\n"
+					+ "public class X {\n"
+					+ "	public static void main(String argv[]) {\n"
+					+ "		(new X()).foo(\"abc\");\n"
+					+ "	}\n"
+					+ "	public void foo(String s) {\n"
+					+ "		int v = 0;\n"
+					+ "		Boolean b1 = Boolean.valueOf(true);\n"
+					+ "		switch (s) {\n"
+					+ "			case String obj when b1 -> v = 1;\n"
+					+ "			default -> v = 0;\n"
+					+ "		}\n"
+					+ "		System.out.println(v);\n"
+					+ "		Boolean b2 = Boolean.valueOf(false);\n"
+					+ "		switch (s) {\n"
+					+ "			case String obj when b2 -> v = 1;\n"
+					+ "			default -> v = 0;\n"
+					+ "		}\n"
+					+ "		System.out.println(v);\n"
+					+ "	}\n"
+					+ "}"
+				},
+				"1\n0");
 	}
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
