### PR TITLE
ModularClassFile should not use JavaElementInfo for missing info (#661)

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ModularClassFile.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ModularClassFile.java
@@ -298,14 +298,18 @@ public class ModularClassFile extends AbstractClassFile implements IModularClass
 
 	@Override
 	public IModuleDescription getModule() throws JavaModelException {
-		BinaryModule module = (BinaryModule) ((ClassFileInfo) getElementInfo()).getModule();
+		Object info = getElementInfo();
+		if(info == notExists) {
+			throw newNotPresentException();
+		}
+		BinaryModule module = (BinaryModule) ((ClassFileInfo) info).getModule();
 		if (module == null) {
 			throw newNotPresentException();
 		}
 		return module;
 	}
 
-	private static final JavaElementInfo notExists = new JavaElementInfo();
+	private static final ClassFileInfo notExists = new ClassFileInfo();
 
 	@Override
 	public boolean exists() {


### PR DESCRIPTION
ModularClassFile.notExists was created as JavaElementInfo, but this is not allowed because ModularClassFile.getModule() expects ClassFileInfo objects to be returned from model.

This creates CCE & confusion if the getModule() code is called on a ModularClassFile that does not exist.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/661