### PR TITLE
Create compile error in case 'var' is used with type arguments. Fixes #600

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/core/compiler/IProblem.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/core/compiler/IProblem.java
@@ -2180,7 +2180,7 @@ void setSourceStart(int sourceStart);
 	int VarIsNotAllowedHere = Syntax + 1511; // ''var'' is not allowed here
 	/** @since 3.16 */
 	int VarCannotBeMixedWithNonVarParams = Syntax + 1512; // ''var'' cannot be mixed with explicit or implicit parameters
-	/** @since 3.33 */
+	/** @since 3.35 */
 	int VarCannotBeUsedWithTypeArguments = Syntax + 1513; // ''var'' cannot be used with type arguments (e.g. as in ''var<Integer> x = List.of(42)'')
 
 	/** @since 3.18

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/core/compiler/IProblem.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/core/compiler/IProblem.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -2180,6 +2180,9 @@ void setSourceStart(int sourceStart);
 	int VarIsNotAllowedHere = Syntax + 1511; // ''var'' is not allowed here
 	/** @since 3.16 */
 	int VarCannotBeMixedWithNonVarParams = Syntax + 1512; // ''var'' cannot be mixed with explicit or implicit parameters
+	/** @since 3.33 */
+	int VarCannotBeUsedWithTypeArguments = Syntax + 1513; // ''var'' cannot be used with type arguments (e.g. as in ''var<Integer> x = List.of(42)'')
+
 	/** @since 3.18
 	 * @deprecated preview related error - will be removed
 	 * @noreference preview related error */

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LocalDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LocalDeclaration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -266,6 +266,10 @@ public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext, Fl
 		boolean variableTypeInferenceError = false;
 		boolean isTypeNameVar = isTypeNameVar(scope);
 		if (isTypeNameVar && !isPatternVariable) {
+			if (this.type.isParameterizedTypeReference()) {
+				scope.problemReporter().varCannotBeUsedWithTypeArguments(this.type);
+				return;
+			}
 			if ((this.bits & ASTNode.IsForeachElementVariable) == 0) {
 				// infer a type from the initializer
 				if (this.initialization != null) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LocalDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LocalDeclaration.java
@@ -268,7 +268,6 @@ public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext, Fl
 		if (isTypeNameVar && !isPatternVariable) {
 			if (this.type.isParameterizedTypeReference()) {
 				scope.problemReporter().varCannotBeUsedWithTypeArguments(this.type);
-				return;
 			}
 			if ((this.bits & ASTNode.IsForeachElementVariable) == 0) {
 				// infer a type from the initializer

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
@@ -10026,6 +10026,14 @@ public void varCannotBeMixedWithNonVarParams(ASTNode astNode) {
 		astNode.sourceStart,
 		astNode.sourceEnd);
 }
+public void varCannotBeUsedWithTypeArguments(ASTNode astNode) {
+	this.handle(
+			IProblem.VarCannotBeUsedWithTypeArguments,
+			NoArgument,
+			NoArgument,
+			astNode.sourceStart,
+			astNode.sourceEnd);
+}
 public void variableTypeCannotBeVoidArray(AbstractVariableDeclaration varDecl) {
 	this.handle(
 		IProblem.CannotAllocateVoidArray,

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/messages.properties
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/messages.properties
@@ -994,6 +994,7 @@
 1510 = 'var' should not be used as an type name, since it is a reserved word from source level 10 on
 1511 = 'var' is not allowed here
 1512 = 'var' cannot be mixed with non-var parameters
+1513 = 'var' cannot be used with type arguments
 
 # Switch-Expressions Java 12 Preview
 1600 = Incompatible switch results expressions {0}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/CompilerInvocationTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/CompilerInvocationTests.java
@@ -1173,6 +1173,7 @@ public void test011_problem_categories() {
 		expectedProblemAttributes.put("UsingTerminallyDeprecatedSinceVersionPackage", new ProblemAttributes(CategorizedProblem.CAT_MODULE));
 		expectedProblemAttributes.put("UsingTerminallyDeprecatedSinceVersionType", new ProblemAttributes(CategorizedProblem.CAT_DEPRECATION));
 		expectedProblemAttributes.put("UsingTerminallyDeprecatedSinceVersionType", new ProblemAttributes(CategorizedProblem.CAT_DEPRECATION));
+		expectedProblemAttributes.put("VarCannotBeUsedWithTypeArguments", new ProblemAttributes(CategorizedProblem.CAT_SYNTAX));
 		expectedProblemAttributes.put("VarCannotBeMixedWithNonVarParams", new ProblemAttributes(CategorizedProblem.CAT_SYNTAX));
 		expectedProblemAttributes.put("VarIsNotAllowedHere", new ProblemAttributes(CategorizedProblem.CAT_SYNTAX));
 		expectedProblemAttributes.put("VarIsReserved", new ProblemAttributes(CategorizedProblem.CAT_SYNTAX));
@@ -2284,6 +2285,7 @@ public void test012_compiler_problems_tuning() {
 		expectedProblemAttributes.put("DisallowedExplicitThisParameter", SKIP);
 		expectedProblemAttributes.put("IllegalArrayOfUnionType", SKIP);
 		expectedProblemAttributes.put("IllegalArrayTypeInIntersectionCast", SKIP);
+		expectedProblemAttributes.put("VarCannotBeUsedWithTypeArguments", SKIP);
 		expectedProblemAttributes.put("VarCannotBeMixedWithNonVarParams", SKIP);
 		expectedProblemAttributes.put("VarIsNotAllowedHere", SKIP);
 		expectedProblemAttributes.put("VarIsReserved", SKIP);

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JEP286Test.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JEP286Test.java
@@ -1399,6 +1399,7 @@ public void testIssue600_1() {
 	this.runNegativeTest(
 			new String[] {
 				"X.java",
+				"import java.util.List;\n" +
 				"public class X {\n" +
 				"	public static void main(String [] args) {\n" +
 				"		var<Integer> x = List.of(42);\n" +
@@ -1406,7 +1407,7 @@ public void testIssue600_1() {
 				"}\n"
 			},
 			"----------\n" +
-			"1. ERROR in X.java (at line 3)\n" +
+			"1. ERROR in X.java (at line 4)\n" +
 			"	var<Integer> x = List.of(42);\n" +
 			"	^^^\n" +
 			"\'var\' cannot be used with type arguments\n" +
@@ -1418,15 +1419,57 @@ public void testIssue600_2() {
 				"X.java",
 				"public class X {\n" +
 				"	public static void main(String [] args) {\n" +
-				"		for (var<Integer> i = 0; i < 100; i++) {};\n" +
+				"		for (var<Integer> i = 0; i < 5; i++) {\n"
+				+ "			System.out.println(i);\n"
+				+ "		}" +
 				"	}\n" +
 				"}\n"
 			},
 			"----------\n"
-			+ "1. ERROR in X.java (at line 3)\\n\n"
-			+ "	for (var<Integer> i = 0; i < 100; i++) {};\n"
+			+ "1. ERROR in X.java (at line 3)\n"
+			+ "	for (var<Integer> i = 0; i < 5; i++) {\n"
 			+ "	     ^^^\n"
-			+ "'var' cannot be used with type arguments\\n\n"
+			+ "'var' cannot be used with type arguments\n"
+			+ "----------\n");
+}
+public void testIssue600_3() {
+	this.runNegativeTest(
+			new String[] {
+					"X.java",
+					"import java.util.List;\n" +
+					"public class X {\n" +
+					"	public static void main(String [] args) {\n" +
+					"		for (var<Integer> i : List.of(2, 3, 5)) {\n"
+					+ "			System.out.println(i);\n"
+					+ "		}" +
+					"	}\n" +
+					"}\n"
+			},
+			"----------\n"
+			+ "1. ERROR in X.java (at line 4)\n"
+			+ "	for (var<Integer> i : List.of(2, 3, 5)) {\n"
+			+ "	     ^^^\n"
+			+ "'var' cannot be used with type arguments\n"
+			+ "----------\n");
+}
+public void testIssue600_4() {
+	this.runNegativeTest(
+			new String[] {
+					"X.java",
+					"public class X {\n" +
+					"    public static void main(String [] args) throws Exception {\n" +
+					"		try(var<String> w = new java.io.StringWriter()) {\n" +
+					"			w.write(\"SUCCESS\\n\");" +
+					"			System.out.println(w.toString());\n" +
+					"       }\n" +
+					"    }\n" +
+					"}\n"
+			},
+			"----------\n"
+			+ "1. ERROR in X.java (at line 3)\n"
+			+ "	try(var<String> w = new java.io.StringWriter()) {\n"
+			+ "	    ^^^\n"
+			+ "'var' cannot be used with type arguments\n"
 			+ "----------\n");
 }
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JEP286Test.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JEP286Test.java
@@ -1395,7 +1395,7 @@ public void testBug567183_4() {
 			"The type Item is not visible\n" +
 			"----------\n");
 }
-public void testIssue600() {
+public void testIssue600_1() {
 	this.runNegativeTest(
 			new String[] {
 				"X.java",
@@ -1411,5 +1411,22 @@ public void testIssue600() {
 			"	^^^\n" +
 			"\'var\' cannot be used with type arguments\n" +
 			"----------\n");
+}
+public void testIssue600_2() {
+	this.runNegativeTest(
+			new String[] {
+				"X.java",
+				"public class X {\n" +
+				"	public static void main(String [] args) {\n" +
+				"		for (var<Integer> i = 0; i < 100; i++) {};\n" +
+				"	}\n" +
+				"}\n"
+			},
+			"----------\n"
+			+ "1. ERROR in X.java (at line 3)\\n\n"
+			+ "	for (var<Integer> i = 0; i < 100; i++) {};\n"
+			+ "	     ^^^\n"
+			+ "'var' cannot be used with type arguments\\n\n"
+			+ "----------\n");
 }
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JEP286Test.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JEP286Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2020 Jesper Steen Møller and others.
+ * Copyright (c) 2018, 2023 Jesper Steen Møller and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -1393,6 +1393,23 @@ public void testBug567183_4() {
 			"	var item1 = container.items.get(0).get(0);\n" +
 			"	            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
 			"The type Item is not visible\n" +
+			"----------\n");
+}
+public void testIssue600() {
+	this.runNegativeTest(
+			new String[] {
+				"X.java",
+				"public class X {\n" +
+				"	public static void main(String [] args) {\n" +
+				"		var<Integer> x = List.of(42);\n" +
+				"	}\n" +
+				"}\n"
+			},
+			"----------\n" +
+			"1. ERROR in X.java (at line 3)\n" +
+			"	var<Integer> x = List.of(42);\n" +
+			"	^^^\n" +
+			"\'var\' cannot be used with type arguments\n" +
 			"----------\n");
 }
 }


### PR DESCRIPTION
## What it does
In issue #600 it was noted that the JDT compiler accepts statements like 

`var<Integer> x = List.of(42);`

which do violate the Java language specification (see [here](https://docs.oracle.com/javase/specs/jls/se19/html/jls-14.html#jls-14.4)).

I've addressed this issue by adding a check in the resolve method of the _LocalDeclaration_ class, which will report a compile error using _ProblemReporter_ class. Additionally, I've created a new test in _JEP286Test_.

## How to test
Can be tested by running  _JEP286Test_ / letting the parser loose on statements like the one quoted above.

## Author checklist

- [x] I have thoroughly tested my changes (I ran _RunCompilerTests_)
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
