### PR TITLE
Enhance the BuildContext with the discovered annotations

### DIFF
--- a/org.eclipse.jdt.apt.tests/src-annotations/org/eclipse/jdt/apt/tests/annotations/generic/AbstractGenericProcessor.java
+++ b/org.eclipse.jdt.apt.tests/src-annotations/org/eclipse/jdt/apt/tests/annotations/generic/AbstractGenericProcessor.java
@@ -12,10 +12,12 @@ package org.eclipse.jdt.apt.tests.annotations.generic;
 
 import java.util.Collection;
 
-import junit.framework.AssertionFailedError;
+import com.sun.mirror.apt.AnnotationProcessor;
+import com.sun.mirror.apt.AnnotationProcessorEnvironment;
+import com.sun.mirror.declaration.AnnotationTypeDeclaration;
+import com.sun.mirror.declaration.Declaration;
 
-import com.sun.mirror.apt.*;
-import com.sun.mirror.declaration.*;
+import junit.framework.AssertionFailedError;
 
 public abstract class AbstractGenericProcessor implements AnnotationProcessor {
 	protected AnnotationProcessorEnvironment env;
@@ -28,20 +30,27 @@ public abstract class AbstractGenericProcessor implements AnnotationProcessor {
 		decls = env.getDeclarationsAnnotatedWith(genericAnnotation);
 	}
 
-	public abstract void _process();
-
 	/**
 	 * This method is abstract, so that subclasses need to implement
 	 * _process. We'll handle catching any errant throwables
 	 * and fail any junit tests.
 	 */
+	public abstract void _process();
+
+	@Override
 	public final void process() {
 		try {
 			_process();
 		}
 		catch (Throwable t) {
+			if (t instanceof AssertionFailedError) {
+				throw t;
+			}
 			t.printStackTrace();
-			throw new AssertionFailedError("Processor threw an exception during processing");
+			AssertionFailedError assertionFailedError = new AssertionFailedError(
+					"Processor threw an exception during processing: " + t);
+			assertionFailedError.initCause(t);
+			throw assertionFailedError;
 		}
 	}
 

--- a/org.eclipse.jdt.apt.tests/src/org/eclipse/jdt/apt/tests/MirrorDeclarationTests.java
+++ b/org.eclipse.jdt.apt.tests/src/org/eclipse/jdt/apt/tests/MirrorDeclarationTests.java
@@ -18,9 +18,6 @@ package org.eclipse.jdt.apt.tests;
 import java.util.Collection;
 import java.util.Map;
 
-import junit.framework.Test;
-import junit.framework.TestSuite;
-
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.jdt.apt.core.env.EnvironmentFactory;
@@ -42,6 +39,9 @@ import com.sun.mirror.declaration.AnnotationValue;
 import com.sun.mirror.declaration.Declaration;
 import com.sun.mirror.declaration.TypeDeclaration;
 import com.sun.mirror.util.SourcePosition;
+
+import junit.framework.Test;
+import junit.framework.TestSuite;
 
 public class MirrorDeclarationTests extends APTTestBase {
 
@@ -340,7 +340,7 @@ public class MirrorDeclarationTests extends APTTestBase {
 		public void _process() {
 			called = true;
 			AnnotationTypeDeclaration annoDecl = (AnnotationTypeDeclaration)env.getTypeDeclaration("pkg.PkgAnnotation");
-			assertNotNull(annoDecl);
+			assertNotNull("Type declaration 'pkg.PkgAnnotation' not found!", annoDecl);
 			// get the annotated declarations
 			Collection<Declaration> annotatedDecls = env.getDeclarationsAnnotatedWith(annoDecl);
 			// don't return the package declaration - well, apt is doing that..

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/CompilationResult.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/CompilationResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -10,9 +10,11 @@
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
+ *     Christoph Läubrich -  Enhance the BuildContext with the discovered annotations #674
  *******************************************************************************/
 package org.eclipse.jdt.internal.compiler;
 
+import java.util.ArrayList;
 /**
  * A compilation result consists of all information returned by the compiler for
  * a single compiled compilation source unit.  This includes:
@@ -39,6 +41,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Hashtable;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -48,6 +51,7 @@ import org.eclipse.jdt.core.compiler.IProblem;
 import org.eclipse.jdt.internal.compiler.ast.AbstractMethodDeclaration;
 import org.eclipse.jdt.internal.compiler.env.ICompilationUnit;
 import org.eclipse.jdt.internal.compiler.impl.ReferenceContext;
+import org.eclipse.jdt.internal.compiler.lookup.AnnotationBinding;
 import org.eclipse.jdt.internal.compiler.lookup.SourceTypeBinding;
 import org.eclipse.jdt.internal.compiler.lookup.TypeConstants;
 import org.eclipse.jdt.internal.compiler.parser.RecoveryScannerData;
@@ -81,6 +85,7 @@ public class CompilationResult {
 	public boolean checkSecondaryTypes = false; // check for secondary types which were created after the initial buildTypeBindings call
 	private int numberOfErrors;
 	private boolean hasMandatoryErrors;
+	public List<AnnotationBinding[]> annotations = new ArrayList<>(1);
 
 	private static final int[] EMPTY_LINE_ENDS = Util.EMPTY_INT_ARRAY;
 	private static final Comparator PROBLEM_COMPARATOR = new Comparator() {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SourceTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SourceTypeBinding.java
@@ -50,6 +50,8 @@
  *                          	Bug 405104 - [1.8][compiler][codegen] Implement support for serializeable lambdas
  *      Sebastian Zarnekow - Contributions for
  *								bug 544921 - [performance] Poor performance with large source files
+ *      Christoph Läubrich - Contributions for
+ *								Issue 674 - Enhance the BuildContext with the discovered annotations
  *******************************************************************************/
 package org.eclipse.jdt.internal.compiler.lookup;
 
@@ -3336,6 +3338,12 @@ SimpleLookupTable storedAnnotations(boolean forceInitialize, boolean forceStore)
 		this.storedAnnotations = new SimpleLookupTable(3);
 	}
 	return this.storedAnnotations;
+}
+
+@Override
+void storeAnnotations(Binding binding, AnnotationBinding[] annotations, boolean forceStore) {
+	super.storeAnnotations(binding, annotations, forceStore);
+	this.scope.referenceCompilationUnit().compilationResult.annotations.add(annotations);
 }
 
 @Override

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/core/compiler/BuildContext.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/core/compiler/BuildContext.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2018 IBM Corporation and others.
+ * Copyright (c) 2006, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -10,7 +10,7 @@
  *
  * Contributors:
  *    IBM Corporation - initial API and implementation
- *
+ *    Christoph Läubrich -  Enhance the BuildContext with the discovered annotations #674
  *******************************************************************************/
 
 package org.eclipse.jdt.core.compiler;
@@ -57,6 +57,18 @@ public IFile getFile() {
  * @return whether the compilation unit contained any annotations when it was compiled
  */
 public boolean hasAnnotations() {
+	return false; // default overridden by concrete implementation
+}
+
+/**
+ * Returns whether the compilation unit contained any annotations with a given type when it was compiled.
+ *
+ * NOTE: This is only valid during {@link CompilationParticipant#processAnnotations(BuildContext[])}.
+ * @param fqn the fully qualified name of the annotation to check for presence
+ * @return whether the compilation unit contained any annotations of the given type when it was compiled
+ * @since 3.35
+ */
+public boolean hasAnnotations(String fqn) {
 	return false; // default overridden by concrete implementation
 }
 


### PR DESCRIPTION
## What it does
Currently one can only get the information that annotations are present on a file in a `BuildContext` / `CompilationParticipant` but sometimes it is much more interesting to know if a specific annotation is present so one don't need to scan files unnecessary.

This captures the found low-level annotations and adds a new method based on this `BuildContext.hasAnnotations(String)` so that `CompilationParticipant` can check if the file is of any interest for them.

Fix https://github.com/eclipse-jdt/eclipse.jdt.core/issues/674

## How to test

- Have a `CompilationParticipant`
- Have a project with a source file that contains an specific annotation and one without but containing another
- in the method `CompilationParticipant.processAnnotations(BuildContext[])` check that `buildContext.hasAnnotations("...")` returns true for you annotation of interest.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
