### PR TITLE
Fix for -Bug 572367 - [15] Record: Javadoc warning though comment exists

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypeDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypeDeclaration.java
@@ -1436,6 +1436,9 @@ public void resolve() {
 						 ((Initializer) field).lastVisibleFieldID = lastVisibleFieldID + 1;
 						break;
 				}
+				if (this.isRecord()) {
+					field.javadoc = this.javadoc;
+				}
 				field.resolve(field.isStatic() ? this.staticInitializerScope : this.initializerScope);
 			}
 		}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocTestForRecord.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocTestForRecord.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 IBM Corporation and others.
+ * Copyright (c) 2020,2023 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -268,6 +268,25 @@ public class JavadocTestForRecord extends JavadocTest {
 				"Javadoc: Invalid param tag name\n" +
 				"----------\n",
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
+	}
+	public void test_bug572367() {
+		if(this.complianceLevel < ClassFileConstants.JDK14) {
+			return;
+		}
+
+		this.reportMissingJavadocCommentsVisibility = CompilerOptions.PRIVATE;
+		runConformTest(new String[] { "X.java",
+				"		/**  \n" +
+				"		 * @param a\n" +
+				"		 */  \n" +
+				"		public record X(int a) {\n" +
+				"			/**  \n" +
+				"			 *   @param args \n" + "		 */  \n" +
+				"			public static void main(String[] args){\n" +
+				"				System.out.println(0);\n" +
+				"			}\n" +
+				"		}" },
+				"0");
 	}
 
 }


### PR DESCRIPTION
Signed-off-by: Vikas Chandra <Vikas.Chandra@in.ibm.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
