### PR TITLE
Wrong call hierarchy computed for type in conflicting modules

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AbstractJavaModelTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AbstractJavaModelTests.java
@@ -4041,6 +4041,25 @@ public abstract class AbstractJavaModelTests extends SuiteOfTestCases {
 		}
 	}
 
+	protected void makeJCLModular(IJavaProject javaProject) throws JavaModelException {
+		IClasspathEntry[] classpath = javaProject.getRawClasspath();
+		for (int i = 0, length = classpath.length; i < length; i++) {
+			IClasspathEntry entry = classpath[i];
+			final IPath path = entry.getPath();
+			if (isJCLPath(path)) {
+					classpath[i] = JavaCore.newVariableEntry(
+							entry.getPath(),
+							entry.getSourceAttachmentPath(),
+							entry.getSourceAttachmentRootPath(),
+							entry.getAccessRules(),
+							moduleAttribute(),
+							entry.isExported());
+					break;
+			}
+		}
+		javaProject.setRawClasspath(classpath, null);
+	}
+
 	private static void logError(String errorMessage, CoreException e) {
 		Plugin plugin = JavaCore.getPlugin();
 		if (plugin != null) {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchBugs15Tests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchBugs15Tests.java
@@ -135,6 +135,7 @@ public class JavaSearchBugs15Tests extends AbstractJavaSearchTests {
 	public void setUpSuite() throws Exception {
 		super.setUpSuite();
 		JAVA_PROJECT = setUpJavaProject("JavaSearchBugs", "16");
+		makeJCLModular(JAVA_PROJECT);
 	}
 
 	public void tearDownSuite() throws Exception {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchBugs9Tests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchBugs9Tests.java
@@ -503,7 +503,7 @@ public void testBug501162_008() throws Exception {
 				"package pack22;\n" +
 				"public interface I22 {}\n");
 
-		addClasspathEntry(project1, JavaCore.newProjectEntry(project2.getPath()));
+		addModularProjectEntry(project1, project2);
 		project1.close(); // sync
 		project2.close();
 		project2.open(null);
@@ -1081,7 +1081,7 @@ public void testBug501162_019() throws Exception {
 				"    public ITwo i2;\n" +
 				"    public XOne X1;\n" +
 				"}\n");
-		addLibraryEntry(project1, "/JavaSearchBugs/lib/bzero501162.jar", false);
+		addModularLibraryEntry(project1, new Path("/JavaSearchBugs/lib/bzero501162.jar"), null);
 		project1.close(); // sync
 		project1.open(null);
 		SearchPattern pattern = SearchPattern.createPattern("pack.one",
@@ -1120,7 +1120,7 @@ public void testBug501162_020() throws Exception {
 				"    public ITwo i2;\n" +
 				"    public XOne X1;\n" +
 				"}\n");
-		addLibraryEntry(project1, "/JavaSearchBugs/lib/bzero501162.jar", false);
+		addModularLibraryEntry(project1, new Path("/JavaSearchBugs/lib/bzero501162.jar"), null);
 		project1.close(); // sync
 		project1.open(null);
 		SearchPattern pattern = SearchPattern.createPattern("pack.two",
@@ -1160,7 +1160,7 @@ public void testBug501162_021() throws Exception {
 				"    public ITwo i2;\n" +
 				"    public XOne X1;\n" +
 				"}\n");
-		addLibraryEntry(project1, "/JavaSearchBugs/lib/bzero501162.jar", false);
+		addModularLibraryEntry(project1, new Path("/JavaSearchBugs/lib/bzero501162.jar"), null);
 		project1.close(); // sync
 		project1.open(null);
 		SearchPattern pattern = SearchPattern.createPattern("pack.three",
@@ -1200,7 +1200,7 @@ public void testBug501162_022() throws Exception {
 				"    public ITwo i2;\n" +
 				"    public XOne X1;\n" +
 				"}\n");
-		addLibraryEntry(project1, "/JavaSearchBugs/lib/bzero501162.jar", false);
+		addModularLibraryEntry(project1, new Path("/JavaSearchBugs/lib/bzero501162.jar"), null);
 		project1.close(); // sync
 		project1.open(null);
 		SearchPattern pattern = SearchPattern.createPattern("java.base",
@@ -1386,7 +1386,7 @@ public void testBug501162_027() throws Exception {
 				"    public ITwo i2;\n" +
 				"    public XOne X1;\n" +
 				"}\n");
-		addLibraryEntry(project1, "/JavaSearchBugs/lib/bzero501162.jar", false);
+		addModularLibraryEntry(project1, new Path("/JavaSearchBugs/lib/bzero501162.jar"), null);
 		project1.close(); // sync
 		project1.open(null);
 		SearchPattern pattern = SearchPattern.createPattern("XOne",
@@ -1425,7 +1425,7 @@ public void testBug501162_028() throws Exception {
 				"    public ITwo i2;\n" +
 				"    public XOne X1;\n" +
 				"}\n");
-		addLibraryEntry(project1, "/JavaSearchBugs/lib/bzero501162.jar", false);
+		addModularLibraryEntry(project1, new Path("/JavaSearchBugs/lib/bzero501162.jar"), null);
 		project1.close(); // sync
 		project1.open(null);
 		SearchPattern pattern = SearchPattern.createPattern("XFourOne",
@@ -1462,7 +1462,7 @@ public void testBug501162_029() throws Exception {
 				"    public ITwo i2;\n" +
 				"    public XOne X1;\n" +
 				"}\n");
-		addLibraryEntry(project1, "/JavaSearchBugs/lib/bzero501162.jar", false);
+		addModularLibraryEntry(project1, new Path("/JavaSearchBugs/lib/bzero501162.jar"), null);
 		project1.close(); // sync
 		project1.open(null);
 		SearchPattern pattern = SearchPattern.createPattern("ITwo",
@@ -1502,7 +1502,7 @@ public void testBug501162_030() throws Exception {
 				"    public ITwo i2;\n" +
 				"    public XOne X1;\n" +
 				"}\n");
-		addLibraryEntry(project1, "/JavaSearchBugs/lib/bzero501162.jar", false);
+		addModularLibraryEntry(project1, new Path("/JavaSearchBugs/lib/bzero501162.jar"), null);
 		project1.close(); // sync
 		project1.open(null);
 		SearchPattern pattern = SearchPattern.createPattern("IThreeOne",
@@ -1539,7 +1539,7 @@ public void testBug501162_031() throws Exception {
 				"    public ITwo i2;\n" +
 				"    public XOne X1;\n" +
 				"}\n");
-		addLibraryEntry(project1, "/JavaSearchBugs/lib/bzero501162.jar", false);
+		addModularLibraryEntry(project1, new Path("/JavaSearchBugs/lib/bzero501162.jar"), null);
 		project1.close(); // sync
 		project1.open(null);
 		SearchPattern pattern = SearchPattern.createPattern("XThreeOne",
@@ -1576,7 +1576,7 @@ public void testBug501162_032() throws Exception {
 				"    public ITwo i2;\n" +
 				"    public XOne X1;\n" +
 				"}\n");
-		addLibraryEntry(project1, "/JavaSearchBugs/lib/bzero501162.jar", false);
+		addModularLibraryEntry(project1, new Path("/JavaSearchBugs/lib/bzero501162.jar"), null);
 		project1.close(); // sync
 		project1.open(null);
 		SearchPattern pattern = SearchPattern.createPattern("zero",
@@ -1918,7 +1918,7 @@ public void testBug501162_041() throws Exception {
 				"    public ITwo i2;\n" +
 				"    public XOne X1;\n" +
 				"}\n");
-		addLibraryEntry(project1, "/JavaSearchBugs/lib/bzero.src.501162.jar", false);
+		addModularLibraryEntry(project1, new Path("/JavaSearchBugs/lib/bzero.src.501162.jar"), null);
 		project1.close(); // sync
 		project1.open(null);
 		SearchPattern pattern = SearchPattern.createPattern("XOne",
@@ -1994,7 +1994,7 @@ public void testBug501162_043() throws Exception {
 				"    public ITwo i2;\n" +
 				"    public XOne X1;\n" +
 				"}\n");
-		addLibraryEntry(project1, "/JavaSearchBugs/lib/bzero.src.501162.jar", false);
+		addModularLibraryEntry(project1, new Path("/JavaSearchBugs/lib/bzero.src.501162.jar"), null);
 		project1.close(); // sync
 		project1.open(null);
 		SearchPattern pattern = SearchPattern.createPattern("ITwo",
@@ -2074,7 +2074,7 @@ public void testBug501162_045() throws Exception {
 				"    public ITwo i2;\n" +
 				"    public XOne X1;\n" +
 				"}\n");
-		addLibraryEntry(project1, "/JavaSearchBugs/lib/bzero.src.501162.jar", false);
+		addModularLibraryEntry(project1, new Path("/JavaSearchBugs/lib/bzero.src.501162.jar"), null);
 		project1.close(); // sync
 		project1.open(null);
 		SearchPattern pattern = SearchPattern.createPattern("XThreeOne",
@@ -3516,7 +3516,7 @@ public void testBug519151_023() throws Exception {
 				"module second {\n" +
 				"}\n";
 		createFile("/second/src/module-info.java",	secondFile);
-		addLibraryEntry(project2, "/JavaSearchBugs/lib/lib519151.jar", false);
+		addModularLibraryEntry(project2, new Path("/JavaSearchBugs/lib/lib519151.jar"), null);
 		project1.close(); // sync
 		project2.close(); // sync
 		project2.open(null);

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/JavaSearchNameEnvironment.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/JavaSearchNameEnvironment.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
+import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IModuleDescription;
@@ -281,7 +282,24 @@ private ClasspathLocation mapToClassPathLocation(JavaModelManager manager, Packa
 	}
 	JavaProject javaProject = root.getJavaProject();
 	if (isComplianceJava9OrHigher(javaProject)) {
-		addModuleClassPathInfo(root, defaultModule, cp);
+		boolean isOnModulePath = true; // if an exception occurs, assume yes
+		try {
+			IClasspathEntry classpathEntry = root.getRawClasspathEntry();
+			if (classpathEntry.getEntryKind() == IClasspathEntry.CPE_SOURCE) {
+				/*
+				 * Source classpath entries of a project never have the module attribute set,
+				 * so we cannot rely on the attribute.
+				 */
+				isOnModulePath = isModularProject(javaProject);
+			} else {
+				isOnModulePath = ClasspathEntry.isModular(classpathEntry);
+			}
+		} catch (JavaModelException e) {
+			Util.log(e, "Error checking whether PackageFragmentRoot is on module path!"); //$NON-NLS-1$
+		}
+		if (isOnModulePath) {
+			addModuleClassPathInfo(root, defaultModule, cp);
+		}
 	}
 	return cp;
 }
@@ -562,5 +580,11 @@ private static boolean isComplianceJava9OrHigher(IJavaProject javaProject) {
 		return false;
 	}
 	return CompilerOptions.versionToJdkLevel(javaProject.getOption(JavaCore.COMPILER_COMPLIANCE, true)) >= ClassFileConstants.JDK9;
+}
+
+private static boolean isModularProject(IJavaProject project) throws JavaModelException {
+	IModuleDescription module = project.getModuleDescription();
+	String modName = module == null ? null : module.getElementName();
+	return modName != null && modName.length() > 0;
 }
 }


### PR DESCRIPTION
JavaSearchNameEnvironment adds module infos to each PackageFragmentRoot of a project, whether the root fragment is on the compile classpath or module path. However the module info is only valid for fragments that are on the module path.

As a result, a search (call hierarchy, references) can encounter non-existent compile errors such as module conflicts. The project itself compiles fine, but the search detects such conflicts due to the module infos attached to each PackageFragmentRoot.

This change adjusts JavaSearchNameEnvironment to not add module info for a PackageFragmentRoot which is not on the module path of the project.

Fixes: #675

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
