### PR TITLE
Provide ClasspathEntry.isModular(IClasspathEntry)

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ClasspathEntry.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ClasspathEntry.java
@@ -1503,12 +1503,7 @@ public class ClasspathEntry implements IClasspathEntry {
 		return false;
 	}
 	public boolean isModular() {
-		for (int i = 0, length = this.extraAttributes.length; i < length; i++) {
-			IClasspathAttribute attribute = this.extraAttributes[i];
-			if (IClasspathAttribute.MODULE.equals(attribute.getName()) && "true".equals(attribute.getValue())) //$NON-NLS-1$
-				return true;
-		}
-		return false;
+		return isModular(this);
 	}
 
 	public String getSourceAttachmentEncoding() {
@@ -2586,5 +2581,20 @@ public class ClasspathEntry implements IClasspathEntry {
 		} else {
 			throw new IllegalArgumentException("Cannot set index location for specified test class"); //$NON-NLS-1$
 		}
+	}
+
+	/**
+	 * Checks if the specified classpath entry is on the module path for compilation.
+	 * @param classpathEntry The entry for which to check.
+	 * @return {@code true} if this classpath entry is on the compile module path, {@code false} otherwise.
+	 */
+	public static boolean isModular(IClasspathEntry classpathEntry) {
+		IClasspathAttribute[] extraAttributes = classpathEntry.getExtraAttributes();
+		for (int i = 0, length = extraAttributes.length; i < length; i++) {
+			IClasspathAttribute attribute = extraAttributes[i];
+			if (IClasspathAttribute.MODULE.equals(attribute.getName()) && "true".equals(attribute.getValue())) //$NON-NLS-1$
+				return true;
+		}
+		return false;
 	}
 }


### PR DESCRIPTION
This change adds a static method to ClasspathEntry, which allows checking whether a classpath entry is on the module path (is modular) or is on the classpath (is not modular).

Fixes: #680
Signed-off-by: Simeon Andreev <simeon.danailov.andreev@gmail.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
