### PR TITLE
[null] Incomplete handling of @NonNullByDefault - fixes #682

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ASTNode.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ASTNode.java
@@ -56,6 +56,7 @@ import java.util.Map;
 
 import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.internal.compiler.ASTVisitor;
+import org.eclipse.jdt.internal.compiler.ast.TypeReference.AnnotationPosition;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 import org.eclipse.jdt.internal.compiler.env.AccessRestriction;
 import org.eclipse.jdt.internal.compiler.lookup.AnnotationBinding;
@@ -851,8 +852,11 @@ public abstract class ASTNode implements TypeConstants, TypeIds {
 					}
 					break;
 				case Binding.TYPE_PARAMETER :
+					((TypeVariableBinding) recipient).tagBits |= TagBits.AnnotationResolved;
+					//$FALL-THROUGH$
 				case Binding.TYPE_USE :
-					// deliberately don't set the annotation resolved tagbits, it is not material and also we are working with a dummy static object.
+					// for TYPE_USE we deliberately don't set the annotation resolved tagbits,
+					// it is not material and also we are working with a dummy static object.
 					annotations = new AnnotationBinding[length];
 					break;
 				case Binding.MODULE:
@@ -1157,7 +1161,8 @@ public abstract class ASTNode implements TypeConstants, TypeIds {
 					if (Annotation.isTypeUseCompatible(typeRef, scope)) { // discard hybrid annotations on name qualified types.
 						local.declaration.bits |= HasTypeAnnotations;
 						typeRef.bits |= HasTypeAnnotations;
-						local.type = mergeAnnotationsIntoType(scope, se8Annotations, se8nullBits, se8NullAnnotation, typeRef, local.type);
+						int location = local.isParameter() ? Binding.DefaultLocationParameter : 0 /*no default for locals*/;
+						local.type = mergeAnnotationsIntoType(scope, se8Annotations, se8nullBits, se8NullAnnotation, typeRef, location, local.type);
 						if(scope.environment().usesNullTypeAnnotations()) {
 							local.tagBits &= ~(se8nullBits);
 						}
@@ -1170,7 +1175,8 @@ public abstract class ASTNode implements TypeConstants, TypeIds {
 					if (Annotation.isTypeUseCompatible(fieldDeclaration.type, scope)) { // discard hybrid annotations on name qualified types.
 						fieldDeclaration.bits |= HasTypeAnnotations;
 						fieldDeclaration.type.bits |= HasTypeAnnotations;
-						field.type = mergeAnnotationsIntoType(scope, se8Annotations, se8nullBits, se8NullAnnotation, fieldDeclaration.type, field.type);
+						field.type = mergeAnnotationsIntoType(scope, se8Annotations, se8nullBits, se8NullAnnotation,
+								fieldDeclaration.type, Binding.DefaultLocationField, field.type);
 						if(scope.environment().usesNullTypeAnnotations()) {
 							field.tagBits &= ~(se8nullBits);
 						}
@@ -1182,7 +1188,8 @@ public abstract class ASTNode implements TypeConstants, TypeIds {
 					if (Annotation.isTypeUseCompatible(recordComponent.type, scope)) { // discard hybrid annotations on name qualified types.
 						recordComponent.bits |= HasTypeAnnotations;
 						recordComponent.type.bits |= HasTypeAnnotations;
-						recordComponentBinding.type = mergeAnnotationsIntoType(scope, se8Annotations, se8nullBits, se8NullAnnotation, recordComponent.type, recordComponentBinding.type);
+						recordComponentBinding.type = mergeAnnotationsIntoType(scope, se8Annotations, se8nullBits, se8NullAnnotation, recordComponent.type,
+								Binding.DefaultLocationField, recordComponentBinding.type);
 						if(scope.environment().usesNullTypeAnnotations()) { //TODO Bug 562478
 							recordComponentBinding.tagBits &= ~(se8nullBits);
 						}
@@ -1196,7 +1203,8 @@ public abstract class ASTNode implements TypeConstants, TypeIds {
 						if (Annotation.isTypeUseCompatible(methodDecl.returnType, scope)) {
 							methodDecl.bits |= HasTypeAnnotations;
 							methodDecl.returnType.bits |= HasTypeAnnotations;
-							method.returnType = mergeAnnotationsIntoType(scope, se8Annotations, se8nullBits, se8NullAnnotation, methodDecl.returnType, method.returnType);
+							method.returnType = mergeAnnotationsIntoType(scope, se8Annotations, se8nullBits, se8NullAnnotation,
+									methodDecl.returnType, Binding.DefaultLocationReturnType, method.returnType);
 							if(scope.environment().usesNullTypeAnnotations()) {
 								method.tagBits &= ~(se8nullBits);
 							}
@@ -1278,7 +1286,7 @@ public abstract class ASTNode implements TypeConstants, TypeIds {
 	}
 
 	private static TypeBinding mergeAnnotationsIntoType(BlockScope scope, AnnotationBinding[] se8Annotations, long se8nullBits, Annotation se8NullAnnotation,
-			TypeReference typeRef, TypeBinding existingType)
+			TypeReference typeRef, int location, TypeBinding existingType)
 	{
 		if (existingType == null || !existingType.isValidBinding()) return existingType;
 		TypeReference unionRef = typeRef.isUnionType() ? ((UnionTypeReference) typeRef).typeReferences[0] : null;
@@ -1298,27 +1306,40 @@ public abstract class ASTNode implements TypeConstants, TypeIds {
 			return existingType;
 		}
 
+		if (typeRef.dimensions() > 0) {
+			location = Binding.DefaultLocationArrayContents; // moving from SE7 to SE8 position applies to the array contents!
+		}
+
 		long prevNullBits = oldLeafType.tagBits & TagBits.AnnotationNullMASK;
-		if ((prevNullBits | se8nullBits) == TagBits.AnnotationNullMASK) { // contradiction after merge?
+		if ((prevNullBits | se8nullBits) == TagBits.AnnotationNullMASK && typeRef.hasNullTypeAnnotation(AnnotationPosition.MAIN_TYPE)) {
+			// would merging introduce a contradiction?
 			if (!(oldLeafType instanceof TypeVariableBinding)) { // let type-use annotations override annotations on the type parameter declaration
 				if (prevNullBits != TagBits.AnnotationNullMASK && se8nullBits != TagBits.AnnotationNullMASK) { // conflict caused by the merge?
 					scope.problemReporter().contradictoryNullAnnotations(se8NullAnnotation);
 				}
-				se8Annotations = Binding.NO_ANNOTATIONS;
-				se8nullBits = 0;
+				se8nullBits = TagBits.AnnotationNullMASK;
 			}
 			oldLeafType = oldLeafType.withoutToplevelNullAnnotation();
+		} else if (se8nullBits == TagBits.AnnotationNonNull
+					&& location != Binding.DefaultLocationReturnType // normal return type cases are handled in MethodBinding.fillInDefaultNonNullness18()
+					&& scope.hasDefaultNullnessForType(typeRef.resolvedType, location, typeRef.sourceStart)) {
+			scope.problemReporter().nullAnnotationIsRedundant(typeRef, new Annotation[] { se8NullAnnotation });
 		}
+		if (se8nullBits == TagBits.AnnotationNullMASK) {
+			// withdraw contradicting null annotations
+			se8Annotations = scope.environment().filterNullTypeAnnotations(se8Annotations);
+		}
+		if (se8Annotations.length > 0) {
+			AnnotationBinding [][] goodies = new AnnotationBinding[typeRef.getAnnotatableLevels()][];
+			goodies[0] = se8Annotations;  // @T X.Y.Z local; ==> @T should annotate X
+			TypeBinding newLeafType = scope.environment().createAnnotatedType(oldLeafType, goodies);
 
-		AnnotationBinding [][] goodies = new AnnotationBinding[typeRef.getAnnotatableLevels()][];
-		goodies[0] = se8Annotations;  // @T X.Y.Z local; ==> @T should annotate X
-		TypeBinding newLeafType = scope.environment().createAnnotatedType(oldLeafType, goodies);
-
-		if (unionRef == null) {
-			typeRef.resolvedType = existingType.isArrayType() ? scope.environment().createArrayType(newLeafType, existingType.dimensions(), existingType.getTypeAnnotations()) : newLeafType;
-		} else {
-			unionRef.resolvedType = newLeafType;
-			unionRef.bits |= HasTypeAnnotations;
+			if (unionRef == null) {
+				typeRef.resolvedType = existingType.isArrayType() ? scope.environment().createArrayType(newLeafType, existingType.dimensions(), existingType.getTypeAnnotations()) : newLeafType;
+			} else {
+				unionRef.resolvedType = newLeafType;
+				unionRef.bits |= HasTypeAnnotations;
+			}
 		}
 		return typeRef.resolvedType;
 	}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ArrayQualifiedTypeReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ArrayQualifiedTypeReference.java
@@ -69,6 +69,13 @@ public class ArrayQualifiedTypeReference extends QualifiedTypeReference {
 		this.annotationsOnDimensions = annotationsOnDimensions;
 	}
 
+	@Override
+	public Annotation[] getTopAnnotations() {
+		if (this.annotationsOnDimensions != null)
+			return this.annotationsOnDimensions[0];
+		return new Annotation[0];
+	}
+
 	/**
 	 * @return char[][]
 	 */

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ArrayTypeReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ArrayTypeReference.java
@@ -89,6 +89,14 @@ public class ArrayTypeReference extends SingleTypeReference {
 	public void setAnnotationsOnDimensions(Annotation [][] annotationsOnDimensions) {
 		this.annotationsOnDimensions = annotationsOnDimensions;
 	}
+
+	@Override
+	public Annotation[] getTopAnnotations() {
+		if (this.annotationsOnDimensions != null)
+			return this.annotationsOnDimensions[0];
+		return new Annotation[0];
+	}
+
 	/**
 	 * @return char[][]
 	 */

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypeReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypeReference.java
@@ -681,9 +681,13 @@ protected void resolveAnnotations(Scope scope, int location) {
 					long[] nullTagBitsPerDimension = ((ArrayBinding)this.resolvedType).nullTagBitsPerDimension;
 					if (nullTagBitsPerDimension != null) {
 						for (int i = 0; i < dimensions; i++) { // skip last annotations at [dimensions] (concerns the leaf type)
-							if ((nullTagBitsPerDimension[i] & TagBits.AnnotationNullMASK) == TagBits.AnnotationNullMASK) {
+							long nullTagBits = nullTagBitsPerDimension[i] & TagBits.AnnotationNullMASK;
+							if (nullTagBits == TagBits.AnnotationNullMASK) {
 								scope.problemReporter().contradictoryNullAnnotations(annotationsOnDimensions[i]);
 								nullTagBitsPerDimension[i] = 0;
+							} else if (nullTagBits == TagBits.AnnotationNonNull) {
+								if (scope.hasDefaultNullnessFor(Binding.DefaultLocationArrayContents, this.sourceStart))
+									scope.problemReporter().nullAnnotationIsRedundant(this, annotationsOnDimensions[i]);
 							}
 						}
 					}
@@ -693,21 +697,33 @@ protected void resolveAnnotations(Scope scope, int location) {
 	}
 	if (scope.compilerOptions().isAnnotationBasedNullAnalysisEnabled
 			&& this.resolvedType != null
-			&& (this.resolvedType.tagBits & TagBits.AnnotationNullMASK) == 0
 			&& !this.resolvedType.isTypeVariable()
 			&& !this.resolvedType.isWildcard()
 			&& location != 0
-			&& scope.hasDefaultNullnessFor(location, this.sourceStart))
+			&& scope.hasDefaultNullnessForType(this.resolvedType, location, this.sourceStart))
 	{
-		if (location == Binding.DefaultLocationTypeBound && this.resolvedType.id == TypeIds.T_JavaLangObject) {
-			scope.problemReporter().implicitObjectBoundNoNullDefault(this);
-		} else {
-			LookupEnvironment environment = scope.environment();
-			AnnotationBinding[] annots = new AnnotationBinding[]{environment.getNonNullAnnotation()};
-			this.resolvedType = environment.createAnnotatedType(this.resolvedType, annots);
+		long nullTagBits = this.resolvedType.tagBits & TagBits.AnnotationNullMASK;
+		if (nullTagBits == 0) {
+			if (location == Binding.DefaultLocationTypeBound && this.resolvedType.id == TypeIds.T_JavaLangObject) {
+				scope.problemReporter().implicitObjectBoundNoNullDefault(this);
+			} else {
+				LookupEnvironment environment = scope.environment();
+				AnnotationBinding[] annots = new AnnotationBinding[]{environment.getNonNullAnnotation()};
+				this.resolvedType = environment.createAnnotatedType(this.resolvedType, annots);
+			}
+		} else if (nullTagBits == TagBits.AnnotationNonNull) {
+			if (location != Binding.DefaultLocationParameter) { // parameters are handled in MethodBinding.fillInDefaultNonNullness18()
+				scope.problemReporter().nullAnnotationIsRedundant(this, getTopAnnotations());
+			}
 		}
 	}
 }
+public Annotation[] getTopAnnotations() {
+	if (this.annotations != null)
+		return this.annotations[getAnnotatableLevels()-1];
+	return new Annotation[0];
+}
+
 public int getAnnotatableLevels() {
 	return 1;
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BinaryTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BinaryTypeBinding.java
@@ -1987,7 +1987,7 @@ private void scanFieldForNullAnnotation(IBinaryField field, VariableBinding fiel
 				&& fieldType.acceptsNonNullDefault()) {
 				int nullDefaultFromField = getNullDefaultFrom(field.getAnnotations());
 				if (nullDefaultFromField == Binding.NO_NULL_DEFAULT
-						? hasNonNullDefaultFor(DefaultLocationField, -1)
+						? hasNonNullDefaultForType(fieldType, DefaultLocationField, -1)
 						: (nullDefaultFromField & DefaultLocationField) != 0) {
 					fieldBinding.type = this.environment.createAnnotatedType(fieldType,
 							new AnnotationBinding[] { this.environment.getNonNullAnnotation() });
@@ -2027,7 +2027,7 @@ private void scanFieldForNullAnnotation(IBinaryField field, VariableBinding fiel
 		this.externalAnnotationStatus = ExternalAnnotationStatus.TYPE_IS_ANNOTATED;
 	if (!explicitNullness) {
 		int nullDefaultFromField = getNullDefaultFrom(field.getAnnotations());
-		if (nullDefaultFromField == Binding.NO_NULL_DEFAULT ? hasNonNullDefaultFor(DefaultLocationField, -1)
+		if (nullDefaultFromField == Binding.NO_NULL_DEFAULT ? hasNonNullDefaultForType(fieldBinding.type, DefaultLocationField, -1)
 				: (nullDefaultFromField & DefaultLocationField) != 0) {
 			fieldBinding.tagBits |= TagBits.AnnotationNonNull;
 		}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
@@ -1257,8 +1257,10 @@ public boolean hasMemberTypes() {
  * for 1.8 check if the default is applicable to the given kind of location.
  */
 // pre: null annotation analysis is enabled
-boolean hasNonNullDefaultFor(int location, int sourceStart) {
+boolean hasNonNullDefaultForType(TypeBinding type, int location, int sourceStart) {
 	// Note, STB overrides for correctly handling local types
+	if (type != null && !type.acceptsNonNullDefault())
+		return false;
 	ReferenceBinding currentType = this;
 	while (currentType != null) {
 		int nullDefault = ((ReferenceBinding)currentType.original()).getNullDefault();

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Scope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Scope.java
@@ -5404,6 +5404,12 @@ public abstract class Scope {
 		return this.parent.hasDefaultNullnessFor(location, sourceStart);
 	}
 
+	public boolean hasDefaultNullnessForType(TypeBinding type, int location, int sourceStart) {
+		if (environment().usesNullTypeAnnotations() && type != null && !type.acceptsNonNullDefault())
+			return false;
+		return hasDefaultNullnessFor(location, sourceStart);
+	}
+
 	/*
 	 * helper for hasDefaultNullnessFor(..) which inspects only ranges recorded within this scope.
 	 */

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
@@ -10612,6 +10612,11 @@ public void nullAnnotationIsRedundant(AbstractMethodDeclaration sourceMethod, in
 	if (i == -1) {
 		MethodDeclaration methodDecl = (MethodDeclaration) sourceMethod;
 		Annotation annotation = findAnnotation(methodDecl.annotations, TypeIds.BitNonNullAnnotation);
+		if (annotation == null) {
+			Annotation[] annotationsOnType = methodDecl.returnType.getTopAnnotations();
+			if (annotationsOnType != null)
+				annotation = findAnnotation(annotationsOnType, TypeIds.BitNonNullAnnotation);
+		}
 		sourceStart = annotation != null ? annotation.sourceStart : methodDecl.returnType.sourceStart;
 		sourceEnd = methodDecl.returnType.sourceEnd;
 	} else {
@@ -10626,6 +10631,20 @@ public void nullAnnotationIsRedundant(FieldDeclaration sourceField) {
 	Annotation annotation = findAnnotation(sourceField.annotations, TypeIds.BitNonNullAnnotation);
 	int sourceStart = annotation != null ? annotation.sourceStart : sourceField.type.sourceStart;
 	int sourceEnd = sourceField.type.sourceEnd;
+	this.handle(IProblem.RedundantNullAnnotation, ProblemHandler.NoArgument, ProblemHandler.NoArgument, sourceStart, sourceEnd);
+}
+
+public void nullAnnotationIsRedundant(TypeParameter typeParameter) {
+	Annotation annotation = findAnnotation(typeParameter.annotations, TypeIds.BitNonNullAnnotation);
+	int sourceStart = annotation != null ? annotation.sourceStart : typeParameter.sourceStart;
+	int sourceEnd = typeParameter.sourceEnd;
+	this.handle(IProblem.RedundantNullAnnotation, ProblemHandler.NoArgument, ProblemHandler.NoArgument, sourceStart, sourceEnd);
+}
+
+public void nullAnnotationIsRedundant(TypeReference typeReference, Annotation[] annotations) {
+	Annotation annotation = findAnnotation(annotations, TypeIds.BitNonNullAnnotation);
+	int sourceStart = annotation != null ? annotation.sourceStart : typeReference.sourceStart;
+	int sourceEnd = typeReference.sourceEnd;
 	this.handle(IProblem.RedundantNullAnnotation, ProblemHandler.NoArgument, ProblemHandler.NoArgument, sourceStart, sourceEnd);
 }
 

--- a/org.eclipse.jdt.core.tests.builder/src/org/eclipse/jdt/core/tests/builder/IncrementalTests18.java
+++ b/org.eclipse.jdt.core.tests.builder/src/org/eclipse/jdt/core/tests/builder/IncrementalTests18.java
@@ -735,6 +735,7 @@ public class IncrementalTests18 extends BuilderTests {
 
 	public void testBug483744_remove() throws JavaModelException {
 		IPath projectPath = env.addProject("Project", "1.8");
+		env.getJavaProject(projectPath).setOption(JavaCore.COMPILER_PB_REDUNDANT_NULL_ANNOTATION, JavaCore.IGNORE);
 		env.addExternalJars(projectPath, Util.getJavaClassLibs());
 
 		env.removePackageFragmentRoot(projectPath, "");

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullAnnotationBatchCompilerTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullAnnotationBatchCompilerTest.java
@@ -829,9 +829,14 @@ public class NullAnnotationBatchCompilerTest extends AbstractBatchCompilerTest {
 					"1. WARNING in ---OUTPUT_DIR_PLACEHOLDER---/test1/Test1.java (at line 13)\n" +
 					"	public boolean equals(@NonNull Object other) { return false; }\n" +
 					"	                      ^^^^^^^^^^^^^^^\n" +
+					"The nullness annotation is redundant with a default that applies to this location\n" +
+					"----------\n" +
+					"2. WARNING in ---OUTPUT_DIR_PLACEHOLDER---/test1/Test1.java (at line 13)\n" +
+					"	public boolean equals(@NonNull Object other) { return false; }\n" +
+					"	                      ^^^^^^^^^^^^^^^\n" +
 					"Illegal redefinition of parameter other, inherited method from Object declares this parameter as @Nullable\n" +
 					"----------\n" +
-					"1 problem (1 warning)\n";
+					"2 problems (2 warnings)\n";
 		try {
 			if (isSuccess)
 				this.runConformTest(testFiles, commandLine, "", expectedCompilerMessage, true);
@@ -943,9 +948,14 @@ public class NullAnnotationBatchCompilerTest extends AbstractBatchCompilerTest {
 				"3. WARNING in ---OUTPUT_DIR_PLACEHOLDER---/test1/Test1.java (at line 13)\n" +
 				"	public boolean equals(@NonNull Object other) { return false; }\n" +
 				"	                      ^^^^^^^^^^^^^^^\n" +
+				"The nullness annotation is redundant with a default that applies to this location\n" +
+				"----------\n" +
+				"4. WARNING in ---OUTPUT_DIR_PLACEHOLDER---/test1/Test1.java (at line 13)\n" +
+				"	public boolean equals(@NonNull Object other) { return false; }\n" +
+				"	                      ^^^^^^^^^^^^^^^\n" +
 				"Illegal redefinition of parameter other, inherited method from Object declares this parameter as @Nullable\n" +
 				"----------\n" +
-				"3 problems (3 warnings)\n",
+				"4 problems (4 warnings)\n",
 				true);
 	}
 
@@ -980,9 +990,14 @@ public class NullAnnotationBatchCompilerTest extends AbstractBatchCompilerTest {
 				"3. WARNING in ---OUTPUT_DIR_PLACEHOLDER---/test1/Test1.java (at line 13)\n" +
 				"	public boolean equals(@NonNull Object other) { return false; }\n" +
 				"	                      ^^^^^^^^^^^^^^^\n" +
+				"The nullness annotation is redundant with a default that applies to this location\n" +
+				"----------\n" +
+				"4. WARNING in ---OUTPUT_DIR_PLACEHOLDER---/test1/Test1.java (at line 13)\n" +
+				"	public boolean equals(@NonNull Object other) { return false; }\n" +
+				"	                      ^^^^^^^^^^^^^^^\n" +
 				"Illegal redefinition of parameter other, inherited method from Object declares this parameter as @Nullable\n" +
 				"----------\n" +
-				"3 problems (3 warnings)\n",
+				"4 problems (4 warnings)\n",
 				true);
 	}
 
@@ -1017,9 +1032,14 @@ public class NullAnnotationBatchCompilerTest extends AbstractBatchCompilerTest {
 				"3. WARNING in ---OUTPUT_DIR_PLACEHOLDER---/test1/Test1.java (at line 13)\n" +
 				"	public boolean equals(@NonNull Object other) { return false; }\n" +
 				"	                      ^^^^^^^^^^^^^^^\n" +
+				"The nullness annotation is redundant with a default that applies to this location\n" +
+				"----------\n" +
+				"4. WARNING in ---OUTPUT_DIR_PLACEHOLDER---/test1/Test1.java (at line 13)\n" +
+				"	public boolean equals(@NonNull Object other) { return false; }\n" +
+				"	                      ^^^^^^^^^^^^^^^\n" +
 				"Illegal redefinition of parameter other, inherited method from Object declares this parameter as @Nullable\n" +
 				"----------\n" +
-				"3 problems (3 warnings)\n",
+				"4 problems (4 warnings)\n",
 				true);
 	}
 	public void testBug571055_explicit() throws IOException {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullAnnotationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullAnnotationTest.java
@@ -2806,7 +2806,10 @@ public void test_default_nullness_010() {
 		"----------\n" +
 		"2. WARNING in p2\\Y.java (at line 5)\n" +
 		"	protected @NonNull Object getObject(@NonNull Object o) {\n" +
-		"	                                    ^^^^^^^^^^^^^^^^^\n" +
+		(this.complianceLevel < ClassFileConstants.JDK1_8
+	  ? "	                                    ^^^^^^^^^^^^^^^^^\n"
+	  : "	                                    ^^^^^^^^^^^^^^^\n"
+		) +
 		"The nullness annotation is redundant with a default that applies to this location\n" +
 		"----------\n");
 }
@@ -3489,7 +3492,10 @@ public void test_nonnull_var_in_constrol_structure_1() {
 		"----------\n" +
 		"1. WARNING in X.java (at line 4)\n" +
 		"	void print4(@NonNull String s) {\n" +
-		"	            ^^^^^^^^^^^^^^^^^\n" +
+		(this.complianceLevel < ClassFileConstants.JDK1_8
+	  ? "	            ^^^^^^^^^^^^^^^^^\n"
+	  : "	            ^^^^^^^^^^^^^^^\n"
+		) +
 		"The nullness annotation is redundant with a default that applies to this location\n" +
 		"----------\n" +
 		"2. ERROR in X.java (at line 10)\n" +
@@ -3504,7 +3510,10 @@ public void test_nonnull_var_in_constrol_structure_1() {
 		"----------\n" +
 		"4. WARNING in X.java (at line 17)\n" +
 		"	void print(@NonNull String s) {\n" +
-		"	           ^^^^^^^^^^^^^^^^^\n" +
+		(this.complianceLevel < ClassFileConstants.JDK1_8
+	  ? "	           ^^^^^^^^^^^^^^^^^\n"
+	  : "	           ^^^^^^^^^^^^^^^\n"
+		) +
 		"The nullness annotation is redundant with a default that applies to this location\n" +
 		"----------\n");
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullTypeAnnotationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullTypeAnnotationTest.java
@@ -5236,6 +5236,12 @@ public void testDefault01_bin() {
 				"}\n"
 			},
 			getCompilerOptions(),
+			"----------\n" +
+			"1. WARNING in X.java (at line 10)\n" +
+			"	return new ArrayList<@NonNull Number>();\n" +
+			"	                     ^^^^^^^^^^^^^^^\n" +
+			"The nullness annotation is redundant with a default that applies to this location\n" +
+			"----------\n",
 			"");
 	runNegativeTestWithLibs(
 		new String[] {
@@ -6554,6 +6560,8 @@ public void testBug435399() {
 		"");
 }
 public void testBug435962() {
+	Map options = getCompilerOptions();
+	options.put(JavaCore.COMPILER_PB_REDUNDANT_NULL_ANNOTATION, JavaCore.IGNORE);
 	runConformTestWithLibs(
 		new String[] {
 			"interfaces/CopyableNode.java",
@@ -6617,7 +6625,7 @@ public void testBug435962() {
 			"	}\n" +
 			"}\n"
 		},
-		getCompilerOptions(),
+		options,
 		"");
 }
 public void testBug440462() {
@@ -10812,6 +10820,11 @@ public void testBug485058() {
 		"	                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
 		"Null constraint mismatch: The type \'@Nullable ? extends @NonNull Serializable\' is not a valid substitute for the type parameter \'Q extends @NonNull Serializable\'\n" +
 		"----------\n" +
+		"2. WARNING in test\\Test4.java (at line 25)\n" +
+		"	public static void g(Feature4<@Nullable ? extends @NonNull Serializable> feature) {\n" +
+		"	                                                  ^^^^^^^^^^^^^^^^^^^^^\n" +
+		"The nullness annotation is redundant with a default that applies to this location\n" +
+		"----------\n" +
 		"2. ERROR in test\\Test4.java (at line 25)\n" +
 		"	public static void g(Feature4<@Nullable ? extends @NonNull Serializable> feature) {\n" +
 		"	                                                  ^^^^^^^^\n" +
@@ -13184,6 +13197,12 @@ public void testBug499597simplified() {
 			"",
 		},
 		getCompilerOptions(),
+		"----------\n" +
+		"1. WARNING in Foo2.java (at line 15)\n" +
+		"	return Foo2.<@NonNull String>of(\"\"); // <-- no warning\n" +
+		"	             ^^^^^^^^^^^^^^^\n" +
+		"The nullness annotation is redundant with a default that applies to this location\n" +
+		"----------\n",
 		""
 	);
 }
@@ -13223,13 +13242,23 @@ public void testBug499597original() {
 		"----------\n" +
 		"1. WARNING in Foo.java (at line 12)\n" +
 		"	static <T> Collection<T> of(@NonNull T @NonNull... elements) {\n" +
-		"	                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
+		"	                            ^^^^^^^^^^^^^^^^^^^^^^\n" +
 		"The nullness annotation is redundant with a default that applies to this location\n" +
 		"----------\n" +
-		"2. WARNING in Foo.java (at line 13)\n" +
+		"2. WARNING in Foo.java (at line 12)\n" +
+		"	static <T> Collection<T> of(@NonNull T @NonNull... elements) {\n" +
+		"	                                       ^^^^^^^^^^^\n" +
+		"The nullness annotation is redundant with a default that applies to this location\n" +
+		"----------\n" +
+		"3. WARNING in Foo.java (at line 13)\n" +
 		"	return Collections.singleton(elements[0]);\n" +
 		"	       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
 		"Null type safety (type annotations): The expression of type \'Set<@NonNull T>\' needs unchecked conversion to conform to \'@NonNull Collection<@NonNull T>\', corresponding supertype is \'Collection<@NonNull T>\'\n" +
+		"----------\n" +
+		"4. WARNING in Foo.java (at line 23)\n" +
+		"	return Foo.<String @NonNull []>of(X); // <-- no warning\n" +
+		"	                   ^^^^^^^^^^^\n" +
+		"The nullness annotation is redundant with a default that applies to this location\n" +
 		"----------\n"
 	);
 }
@@ -13533,22 +13562,27 @@ public void testBug484926locals() {
 		},
 		options,
 		"----------\n" +
-		"1. ERROR in test\\NNBDOnLocalOrField.java (at line 16)\n" +
+		"1. WARNING in test\\NNBDOnLocalOrField.java (at line 16)\n" +
+		"	AtomicReference<String> x2 = new AtomicReference<@NonNull String>(), x3=new AtomicReference<@Nullable String>();\n" +
+		"	                                                 ^^^^^^^^^^^^^^^\n" +
+		"The nullness annotation is redundant with a default that applies to this location\n" +
+		"----------\n" +
+		"2. ERROR in test\\NNBDOnLocalOrField.java (at line 16)\n" +
 		"	AtomicReference<String> x2 = new AtomicReference<@NonNull String>(), x3=new AtomicReference<@Nullable String>();\n" +
 		"	                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
 		"Null type mismatch (type annotations): required \'AtomicReference<@NonNull String>\' but this expression has type \'@NonNull AtomicReference<@Nullable String>\'\n" +
 		"----------\n" +
-		"2. ERROR in test\\NNBDOnLocalOrField.java (at line 21)\n" +
+		"3. ERROR in test\\NNBDOnLocalOrField.java (at line 21)\n" +
 		"	x1.set(null);\n" +
 		"	       ^^^^\n" +
 		"Null type mismatch: required \'@NonNull String\' but the provided value is null\n" +
 		"----------\n" +
-		"3. ERROR in test\\NNBDOnLocalOrField.java (at line 22)\n" +
+		"4. ERROR in test\\NNBDOnLocalOrField.java (at line 22)\n" +
 		"	x2.set(null);\n" +
 		"	       ^^^^\n" +
 		"Null type mismatch: required \'@NonNull String\' but the provided value is null\n" +
 		"----------\n" +
-		"4. ERROR in test\\NNBDOnLocalOrField.java (at line 23)\n" +
+		"5. ERROR in test\\NNBDOnLocalOrField.java (at line 23)\n" +
 		"	x3.set(null);\n" +
 		"	       ^^^^\n" +
 		"Null type mismatch: required \'@NonNull String\' but the provided value is null\n" +
@@ -13592,22 +13626,27 @@ public void testBug484926fields() {
 		},
 		options,
 		"----------\n" +
-		"1. ERROR in test\\NNBDOnLocalOrField.java (at line 15)\n" +
+		"1. WARNING in test\\NNBDOnLocalOrField.java (at line 15)\n" +
+		"	AtomicReference<String> x2 = new AtomicReference<@NonNull String>(), x3=new AtomicReference<@Nullable String>();\n" +
+		"	                                                 ^^^^^^^^^^^^^^^\n" +
+		"The nullness annotation is redundant with a default that applies to this location\n" +
+		"----------\n" +
+		"2. ERROR in test\\NNBDOnLocalOrField.java (at line 15)\n" +
 		"	AtomicReference<String> x2 = new AtomicReference<@NonNull String>(), x3=new AtomicReference<@Nullable String>();\n" +
 		"	                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
 		"Null type mismatch (type annotations): required \'@NonNull AtomicReference<@NonNull String>\' but this expression has type \'@NonNull AtomicReference<@Nullable String>\'\n" +
 		"----------\n" +
-		"2. ERROR in test\\NNBDOnLocalOrField.java (at line 21)\n" +
+		"3. ERROR in test\\NNBDOnLocalOrField.java (at line 21)\n" +
 		"	x1.set(null);\n" +
 		"	       ^^^^\n" +
 		"Null type mismatch: required \'@NonNull String\' but the provided value is null\n" +
 		"----------\n" +
-		"3. ERROR in test\\NNBDOnLocalOrField.java (at line 22)\n" +
+		"4. ERROR in test\\NNBDOnLocalOrField.java (at line 22)\n" +
 		"	x2.set(null);\n" +
 		"	       ^^^^\n" +
 		"Null type mismatch: required \'@NonNull String\' but the provided value is null\n" +
 		"----------\n" +
-		"4. ERROR in test\\NNBDOnLocalOrField.java (at line 23)\n" +
+		"5. ERROR in test\\NNBDOnLocalOrField.java (at line 23)\n" +
 		"	x3.set(null);\n" +
 		"	       ^^^^\n" +
 		"Null type mismatch: required \'@NonNull String\' but the provided value is null\n" +
@@ -14321,7 +14360,111 @@ public void testBug508497() {
 		"----------\n"
 	);
 }
-public void testBug509025() {
+public void testBug509025_a() {
+	runConformTestWithLibs(
+		new String[] {
+			"MyAnno.java",
+			"import java.lang.annotation.Retention;\n" +
+			"import java.lang.annotation.RetentionPolicy;\n" +
+			"import org.eclipse.jdt.annotation.DefaultLocation;\n" +
+			"import org.eclipse.jdt.annotation.NonNull;\n" +
+			"import org.eclipse.jdt.annotation.NonNullByDefault;\n" +
+			"\n" +
+			"@Retention(RetentionPolicy.RUNTIME)\n" +
+			"@NonNullByDefault(DefaultLocation.ARRAY_CONTENTS)\n" +
+			"public @interface MyAnno {\n" +
+			"	@NonNull String[] items();\n" +
+			"\n" +
+			"}\n" +
+			"",
+		},
+		getCompilerOptions(),
+		"----------\n" +
+		"1. WARNING in MyAnno.java (at line 10)\n" +
+		"	@NonNull String[] items();\n" +
+		"	^^^^^^^^^^^^^^^^^\n" +
+		"The nullness annotation is redundant with a default that applies to this location\n" +
+		"----------\n",
+		""
+	);
+	runConformTestWithLibs(
+		false /* don't flush */,
+		new String[] {
+			"AnnoLoop.java",
+			"import org.eclipse.jdt.annotation.NonNull;\n" +
+			"import org.eclipse.jdt.annotation.NonNullByDefault;\n" +
+			"import org.eclipse.jdt.annotation.DefaultLocation;\n" +
+			"@NonNullByDefault(DefaultLocation.ARRAY_CONTENTS)\n" +
+			"public class AnnoLoop {\n" +
+			"	@NonNull String[] test(MyAnno anno) {\n" +
+			"		return anno.items();\n" +
+			"	}\n" +
+			"}\n" +
+			"",
+		},
+		getCompilerOptions(),
+		"----------\n" +
+		"1. WARNING in AnnoLoop.java (at line 6)\n" +
+		"	@NonNull String[] test(MyAnno anno) {\n" +
+		"	^^^^^^^^^^^^^^^^^\n" +
+		"The nullness annotation is redundant with a default that applies to this location\n" +
+		"----------\n",
+		""
+	);
+}
+public void testBug509025_b() {
+	runConformTestWithLibs(
+		new String[] {
+			"MyAnno.java",
+			"import java.lang.annotation.Retention;\n" +
+			"import java.lang.annotation.RetentionPolicy;\n" +
+			"\n" +
+			"import org.eclipse.jdt.annotation.NonNull;\n" +
+			"import org.eclipse.jdt.annotation.NonNullByDefault;\n" +
+			"\n" +
+			"@Retention(RetentionPolicy.RUNTIME)\n" +
+			"@NonNullByDefault\n" +
+			"public @interface MyAnno {\n" +
+			"	String @NonNull[] items();\n" +
+			"\n" +
+			"}\n" +
+			"",
+		},
+		getCompilerOptions(),
+		"----------\n" +
+		"1. WARNING in MyAnno.java (at line 10)\n" +
+		"	String @NonNull[] items();\n" +
+		"	       ^^^^^^^^^^\n" +
+		"The nullness annotation is redundant with a default that applies to this location\n" +
+		"----------\n",
+		""
+	);
+	runConformTestWithLibs(
+		false /* don't flush */,
+		new String[] {
+			"AnnoLoop.java",
+			"import org.eclipse.jdt.annotation.NonNull;\n" +
+			"import org.eclipse.jdt.annotation.NonNullByDefault;\n" +
+			"\n" +
+			"@NonNullByDefault\n" +
+			"public class AnnoLoop {\n" +
+			"	String @NonNull[] test(MyAnno anno) {\n" +
+			"		return anno.items();\n" +
+			"	}\n" +
+			"}\n" +
+			"",
+		},
+		getCompilerOptions(),
+		"----------\n" +
+		"1. WARNING in AnnoLoop.java (at line 6)\n" +
+		"	String @NonNull[] test(MyAnno anno) {\n" +
+		"	       ^^^^^^^^^^\n" +
+		"The nullness annotation is redundant with a default that applies to this location\n" +
+		"----------\n",
+		""
+	);
+}
+public void testBug509025_c() {
 	runConformTestWithLibs(
 		new String[] {
 			"MyAnno.java",
@@ -14340,6 +14483,7 @@ public void testBug509025() {
 			"",
 		},
 		getCompilerOptions(),
+		"",
 		""
 	);
 	runConformTestWithLibs(
@@ -14351,14 +14495,14 @@ public void testBug509025() {
 			"\n" +
 			"@NonNullByDefault\n" +
 			"public class AnnoLoop {\n" +
-			"	@NonNull\n" +
-			"	String[] test(MyAnno anno) {\n" +
+			"	@NonNull String[] test(MyAnno anno) {\n" +
 			"		return anno.items();\n" +
 			"	}\n" +
 			"}\n" +
 			"",
 		},
 		getCompilerOptions(),
+		"",
 		""
 	);
 }
@@ -18407,4 +18551,179 @@ public void testRequireNonNull() {
 	runner.runConformTest();
 }
 
+public void testBug522142_redundant1() {
+	Runner runner = new Runner();
+	runner.testFiles =
+		new String[] {
+			"Foo.java",
+			"import static org.eclipse.jdt.annotation.DefaultLocation.*;" +
+			"import org.eclipse.jdt.annotation.*;" +
+			"@NonNullByDefault({PARAMETER, RETURN_TYPE, FIELD, TYPE_PARAMETER, TYPE_BOUND, TYPE_ARGUMENT})\n" +
+			"interface Foo<A> {\n" +
+			"    interface Bar<@NonNull A> extends Iterable<Foo<A>> {\n" +
+			"    }\n" +
+			"}\n"
+		};
+	runner.expectedCompilerLog =
+			"----------\n" +
+			"1. WARNING in Foo.java (at line 3)\n" +
+			"	interface Bar<@NonNull A> extends Iterable<Foo<A>> {\n" +
+			"	              ^^^^^^^^^^\n" +
+			"The nullness annotation is redundant with a default that applies to this location\n" +
+			"----------\n";
+	runner.customOptions = getCompilerOptions();
+	runner.classLibraries = this.LIBS;
+	runner.runWarningTest();
+}
+
+public void testBug522142_redundant2() {
+	// challenge ArrayQualifiedTypeReference:
+	Runner runner = new Runner();
+	runner.testFiles =
+		new String[] {
+			"Foo.java",
+			"import static org.eclipse.jdt.annotation.DefaultLocation.*;" +
+			"import org.eclipse.jdt.annotation.*;" +
+			"@NonNullByDefault({PARAMETER, RETURN_TYPE, FIELD, TYPE_PARAMETER, TYPE_BOUND, TYPE_ARGUMENT})\n" +
+			"class Foo {\n" +
+			"	java.util.List<java.lang.String @NonNull[]> f1 = new java.util.ArrayList<>();\n" +
+			"	java.util.List<java.lang.String @NonNull[][]> f2 = new java.util.ArrayList<>();\n" +
+			"}\n"
+		};
+	runner.expectedCompilerLog =
+			"----------\n" +
+			"1. WARNING in Foo.java (at line 3)\n" +
+			"	java.util.List<java.lang.String @NonNull[]> f1 = new java.util.ArrayList<>();\n" +
+			"	                                ^^^^^^^^^^\n" +
+			"The nullness annotation is redundant with a default that applies to this location\n" +
+			"----------\n" +
+			"2. WARNING in Foo.java (at line 4)\n" +
+			"	java.util.List<java.lang.String @NonNull[][]> f2 = new java.util.ArrayList<>();\n" +
+			"	                                ^^^^^^^^^^^^\n" +
+			"The nullness annotation is redundant with a default that applies to this location\n" +
+			"----------\n";
+	runner.customOptions = getCompilerOptions();
+	runner.classLibraries = this.LIBS;
+	runner.runWarningTest();
+}
+
+public void testBug522142_redundant3() {
+	// challenge ArrayQualifiedTypeReference:
+	Runner runner = new Runner();
+	runner.testFiles =
+		new String[] {
+			"Foo.java",
+			"import static org.eclipse.jdt.annotation.DefaultLocation.*;" +
+			"import org.eclipse.jdt.annotation.*;" +
+			"@NonNullByDefault({PARAMETER, RETURN_TYPE, FIELD, TYPE_PARAMETER, TYPE_BOUND, TYPE_ARGUMENT})\n" +
+			"class Foo {\n" +
+			"	java.util.List<java.lang. @NonNull String> f = new java.util.ArrayList<>();\n" +
+			"}\n"
+		};
+	runner.expectedCompilerLog =
+			"----------\n" +
+			"1. WARNING in Foo.java (at line 3)\n" +
+			"	java.util.List<java.lang. @NonNull String> f = new java.util.ArrayList<>();\n" +
+			"	                          ^^^^^^^^^^^^^^^\n" +
+			"The nullness annotation is redundant with a default that applies to this location\n" +
+			"----------\n";
+	runner.customOptions = getCompilerOptions();
+	runner.classLibraries = this.LIBS;
+	runner.runWarningTest();
+}
+public void testBug522142_bogusError() {
+	Runner runner = new Runner();
+	runner.testFiles =
+		new String[] {
+			"Foo.java",
+			"import static org.eclipse.jdt.annotation.DefaultLocation.*;" +
+			"import org.eclipse.jdt.annotation.*;" +
+			"@NonNullByDefault({PARAMETER, RETURN_TYPE, FIELD, TYPE_PARAMETER, TYPE_BOUND, TYPE_ARGUMENT})\n" +
+			"interface Foo<A> {\n" +
+			"    interface Bar<A> extends Iterable<Foo<A>> {\n" +
+			"    }\n" +
+			"}\n"
+		};
+	runner.expectedCompilerLog =
+			"";
+	runner.customOptions = getCompilerOptions();
+	runner.classLibraries = this.LIBS;
+	runner.runConformTest();
+}
+public void testBug499596() throws Exception {
+	Runner runner = new Runner();
+	runner.testFiles =
+		new String[] {
+			"Foo.java",
+			"import static org.eclipse.jdt.annotation.DefaultLocation.*;\n" +
+			"import org.eclipse.jdt.annotation.*;\n" +
+			"import java.util.*;\n" +
+			"\n" +
+			"@NonNullByDefault({ PARAMETER, RETURN_TYPE, FIELD, TYPE_PARAMETER, TYPE_BOUND, TYPE_ARGUMENT, ARRAY_CONTENTS })\n" +
+			"abstract class Foo {\n" +
+			"	abstract <T> Collection<T> singleton(T t);\n" +
+			"	Collection<String[]> from0(@NonNull String @NonNull [] @NonNull... elements) { // <-- 3 warnings here, ok\n" +
+			"		return singleton(elements[0]);\n" +
+			"	}\n" +
+			"	Collection<String[]> from1(String @NonNull [] @NonNull... elements) { // <-- 2 warnings here, ok\n" +
+			"		return singleton(elements[0]);\n" +
+			"	}\n" +
+			"	Collection<String[]> from2(String [] @NonNull... elements) { // <-- 1 warning here, ok\n" +
+			"		return singleton(elements[0]);\n" +
+			"	}\n" +
+			"	Collection<String[]> from3(String []... elements) {\n" +
+			"		return singleton(elements[0]);\n" +
+			"	}\n" +
+			"	@NonNullByDefault({}) // cancel outer default\n" +
+			"	Collection<@NonNull String @NonNull[]> from4(String []... elements) {\n" +
+			"		return singleton(elements[0]); // <-- should warn\n" +
+			"	}\n" +
+			"}\n"
+		};
+	// Expectations:
+	// from0 .. from3:
+	// 		declarations should show the indicated number of warnings
+	// 		statements are OK, since everything is covered by the outer @NNBD
+	// from4 should flag the statement (only)
+	runner.expectedCompilerLog =
+			"----------\n" +
+			"1. WARNING in Foo.java (at line 8)\n" +
+			"	Collection<String[]> from0(@NonNull String @NonNull [] @NonNull... elements) { // <-- 3 warnings here, ok\n" +
+			"	                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
+			"The nullness annotation is redundant with a default that applies to this location\n" +
+			"----------\n" +
+			"2. WARNING in Foo.java (at line 8)\n" +
+			"	Collection<String[]> from0(@NonNull String @NonNull [] @NonNull... elements) { // <-- 3 warnings here, ok\n" +
+			"	                                           ^^^^^^^^^^^^^^^^^^^^^^^\n" +
+			"The nullness annotation is redundant with a default that applies to this location\n" +
+			"----------\n" +
+			"3. WARNING in Foo.java (at line 8)\n" +
+			"	Collection<String[]> from0(@NonNull String @NonNull [] @NonNull... elements) { // <-- 3 warnings here, ok\n" +
+			"	                                                       ^^^^^^^^^^^\n" +
+			"The nullness annotation is redundant with a default that applies to this location\n" +
+			"----------\n" +
+			"4. WARNING in Foo.java (at line 11)\n" +
+			"	Collection<String[]> from1(String @NonNull [] @NonNull... elements) { // <-- 2 warnings here, ok\n" +
+			"	                                  ^^^^^^^^^^^^^^^^^^^^^^^\n" +
+			"The nullness annotation is redundant with a default that applies to this location\n" +
+			"----------\n" +
+			"5. WARNING in Foo.java (at line 11)\n" +
+			"	Collection<String[]> from1(String @NonNull [] @NonNull... elements) { // <-- 2 warnings here, ok\n" +
+			"	                                              ^^^^^^^^^^^\n" +
+			"The nullness annotation is redundant with a default that applies to this location\n" +
+			"----------\n" +
+			"6. WARNING in Foo.java (at line 14)\n" +
+			"	Collection<String[]> from2(String [] @NonNull... elements) { // <-- 1 warning here, ok\n" +
+			"	                                     ^^^^^^^^^^^\n" +
+			"The nullness annotation is redundant with a default that applies to this location\n" +
+			"----------\n" +
+			"7. WARNING in Foo.java (at line 22)\n" +
+			"	return singleton(elements[0]); // <-- should warn\n" +
+			"	                 ^^^^^^^^^^^\n" +
+			"Null type safety (type annotations): The expression of type \'String[]\' needs unchecked conversion to conform to \'@NonNull String @NonNull[]\'\n" +
+			"----------\n";
+	runner.customOptions = getCompilerOptions();
+	runner.classLibraries = this.LIBS;
+	runner.runWarningTest();
+}
 }

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ExternalAnnotations18Test.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ExternalAnnotations18Test.java
@@ -2039,6 +2039,7 @@ public class ExternalAnnotations18Test extends ModifyingResourceTests {
 			this.root = null; // prepare to get the root from project Test1
 
 			setupJavaProject("Test3b");
+			this.project.setOption(JavaCore.COMPILER_PB_REDUNDANT_NULL_ANNOTATION, JavaCore.IGNORE);
 			Util.createSourceZip(
 				new String[] {
 					"libs/MyFunction.eea",
@@ -2319,6 +2320,7 @@ public class ExternalAnnotations18Test extends ModifyingResourceTests {
 		try {
 			String projectName = "Bug500024";
 			setupJavaProject(projectName, true, true);
+			this.project.setOption(JavaCore.COMPILER_PB_REDUNDANT_NULL_ANNOTATION, JavaCore.IGNORE);
 
 			addEeaToVariableEntry("JCL18_FULL", "/"+projectName+"/annots");
 			IPackageFragment fragment = this.project.getPackageFragmentRoots()[0].createPackageFragment("test1", true, null);
@@ -2358,6 +2360,7 @@ public class ExternalAnnotations18Test extends ModifyingResourceTests {
 		try {
 			String projectName = "Bug500024";
 			setupJavaProject(projectName, true, true);
+			this.project.setOption(JavaCore.COMPILER_PB_REDUNDANT_NULL_ANNOTATION, JavaCore.IGNORE);
 
 			String projectLoc = this.project.getResource().getLocation().toString();
 			String annotsZip = "/annots.zip";
@@ -2583,6 +2586,7 @@ public class ExternalAnnotations18Test extends ModifyingResourceTests {
 	}
 	public void testBug517275() throws Exception {
 		myCreateJavaProject("TestLibs");
+		this.project.setOption(JavaCore.COMPILER_PB_REDUNDANT_NULL_ANNOTATION, JavaCore.IGNORE);
 		String lib1Content =
 				"package libs;\n" +
 				"import java.util.List;\n" +
@@ -2627,6 +2631,7 @@ public class ExternalAnnotations18Test extends ModifyingResourceTests {
 	}
 	public void testBug513880() throws Exception {
 		myCreateJavaProject("TestLibs");
+		this.project.setOption(JavaCore.COMPILER_PB_REDUNDANT_NULL_ANNOTATION, JavaCore.IGNORE);
 		String lib1Content =
 				"package libs;\n" +
 				"import java.util.List;\n" +

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/NullAnnotationModelTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/NullAnnotationModelTests.java
@@ -1072,7 +1072,7 @@ public class NullAnnotationModelTests extends ReconcilerTests {
 					"----------\n" +
 					"1. WARNING in /Bug549764/src/nullAnalysis/Endpoint.java (at line 14)\n" +
 					"	native void format(@NonNull String comment, String arg);\n" +
-					"	                   ^^^^^^^^^^^^^^^^^^^^^^^\n" +
+					"	                   ^^^^^^^^^^^^^^^\n" +
 					"The nullness annotation is redundant with a default that applies to this location\n" +
 					"----------\n"
 					);


### PR DESCRIPTION
+ applying @NNBD to a type parameter needs to know, whether on demand resolving has already happened (to detect explicit null annotations)
  - ASTNode.resolveAnnotations
  - STB.maybeMarkTypeParametersNonNull
+ better distinction if null tag bits result from @NNBD or explicit anno
  - ASTNode.mergeAnnotationsIntoType - may now report redundance
  - fix withdrawal of contradiction null annots after these changes
+ more detection of redundance below @NNBD
  - TypeParameter.resolveAnnotations
  - TypeReference.resolveAnnotations - one focus on annots on dimensions
  - MethodBinding.fillInDefaultNonNullness18 - less reporting here
  - ProblemReporter.nullAnnotationIsRedundant
    - 2 more overloads
    - fine tuning of error positions
+ be careful not to apply @NNBD to typevar (when using TYPE_USE)
  - new methods {Scope,STB}.hasDefaultNullnessForType()
+ expect redundance warning in may more tests
  - NullTypeAnnotationTest
  - NullAnnotationBatchCompilerTest
+ new tests from Bugs [522142](https://bugs.eclipse.org/522142) and [499596](https://bugs.eclipse.org/499596)
