### PR TITLE
Add record component completion. Fix #667

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
@@ -11392,11 +11392,9 @@ protected void consumeRecordComponent(boolean isVarArgs) {
 	}
 	int modifierPositions = this.intStack[this.intPtr--];
 	RecordComponent recordComponent;
-	recordComponent = new RecordComponent(
-			identifierName,
-			namePositions,
-			type,
-			this.intStack[this.intPtr--] & ~ClassFileConstants.AccDeprecated); // modifiers
+	recordComponent = createComponent(identifierName, namePositions, type,
+			this.intStack[this.intPtr--] & ~ClassFileConstants.AccDeprecated // modifiers
+	);
 	recordComponent.declarationSourceStart = modifierPositions;
 	recordComponent.bits |= (type.bits & ASTNode.HasTypeAnnotations);
 	// consume annotations
@@ -11716,6 +11714,10 @@ protected TypeReference augmentTypeWithAdditionalDimensions(TypeReference typeRe
 
 protected FieldDeclaration createFieldDeclaration(char[] fieldDeclarationName, int sourceStart, int sourceEnd) {
 	return new FieldDeclaration(fieldDeclarationName, sourceStart, sourceEnd);
+}
+
+protected RecordComponent createComponent(char[] identifierName, long namePositions, TypeReference type, int modifier) {
+	return new RecordComponent(identifierName, namePositions, type, modifier);
 }
 protected JavadocParser createJavadocParser() {
 	return new JavadocParser(this);

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests14.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests14.java
@@ -518,4 +518,64 @@ public class CompletionTests14 extends AbstractJavaModelCompletionTests {
 						requestor.getResults());
 
 	}
+
+	public void testGH667_CompletionOnRecordComponent_SimpleTypeName() throws JavaModelException {
+		this.workingCopies = new ICompilationUnit[2];
+		this.workingCopies[0] = getWorkingCopy(
+				"/Completion/src/Person.java",
+				"public record Person(Nam) {\n"
+						+ "}\n");
+		this.workingCopies[1] = getWorkingCopy(
+				"/Completion/src/Name.java",
+				"public class Name {\n"
+						+ "}\n");
+		CompletionTestsRequestor2 requestor = new CompletionTestsRequestor2(true, true, true, false);
+		String str = this.workingCopies[0].getSource();
+		String completeBehind = "Nam";
+		int cursorLocation = str.lastIndexOf(completeBehind) + completeBehind.length();
+		this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner);
+		assertResults(
+				"Name[TYPE_REF]{Name, , LName;, null, null, null, null, [21, 24], "
+						+ (R_DEFAULT + R_RESOLVED + R_INTERESTING + R_CASE + R_UNQUALIFIED + R_NON_RESTRICTED) + "}",
+				requestor.getResults());
+	}
+
+	public void testGH667_CompletionOnRecordComponent_QualifiedTypeName() throws JavaModelException {
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy(
+				"/Completion/src/Person.java",
+				"public record Person(pack2.P) {\n"
+						+ "}\n");
+		CompletionTestsRequestor2 requestor = new CompletionTestsRequestor2(true, true, true, false);
+		String str = this.workingCopies[0].getSource();
+		String completeBehind = "pack2.P";
+		int cursorLocation = str.lastIndexOf(completeBehind) + completeBehind.length();
+		this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner);
+		assertResults(
+				"PX[TYPE_REF]{pack2.PX, pack2, Lpack2.PX;, null, null, null, null, [21, 28], "
+						+ (R_DEFAULT + R_RESOLVED + R_INTERESTING + R_CASE + R_QUALIFIED + R_NON_RESTRICTED) + "}",
+				requestor.getResults());
+	}
+
+	public void testGH667_CompletionOnRecordComponent_VariableName() throws JavaModelException {
+		this.workingCopies = new ICompilationUnit[2];
+		this.workingCopies[0] = getWorkingCopy(
+				"/Completion/src/Person.java",
+				"public record Person(Name ) {\n"
+						+ "}\n");
+		this.workingCopies[1] = getWorkingCopy(
+				"/Completion/src/Name.java",
+				"public class Name {\n"
+						+ "}\n");
+		CompletionTestsRequestor2 requestor = new CompletionTestsRequestor2(true, true, true, false);
+		String str = this.workingCopies[0].getSource();
+		String completeBehind = "Name ";
+		int cursorLocation = str.lastIndexOf(completeBehind) + completeBehind.length();
+		this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner);
+		assertResults(
+				"name[VARIABLE_DECLARATION]{name, null, LName;, null, null, name, null, [26, 26], "
+						+ (R_DEFAULT + R_INTERESTING + R_CASE + R_NON_RESTRICTED) + "}",
+				requestor.getResults());
+	}
+
 }

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/CompletionEngine.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/CompletionEngine.java
@@ -110,6 +110,7 @@ import org.eclipse.jdt.internal.codeassist.complete.CompletionOnProvidesInterfac
 import org.eclipse.jdt.internal.codeassist.complete.CompletionOnQualifiedAllocationExpression;
 import org.eclipse.jdt.internal.codeassist.complete.CompletionOnQualifiedNameReference;
 import org.eclipse.jdt.internal.codeassist.complete.CompletionOnQualifiedTypeReference;
+import org.eclipse.jdt.internal.codeassist.complete.CompletionOnRecordComponentName;
 import org.eclipse.jdt.internal.codeassist.complete.CompletionOnReferenceExpressionName;
 import org.eclipse.jdt.internal.codeassist.complete.CompletionOnSingleNameReference;
 import org.eclipse.jdt.internal.codeassist.complete.CompletionOnSingleTypeReference;
@@ -2041,6 +2042,8 @@ public final class CompletionEngine
 			completionOnMethodName(astNode, scope);
 		} else if (astNode instanceof CompletionOnFieldName) {
 			completionOnFieldName(astNode, scope);
+		} else if (astNode instanceof CompletionOnRecordComponentName) {
+			completionOnRecordComponentName(astNode, scope);
 		} else if (astNode instanceof CompletionOnLocalName) {
 			completionOnLocalOrArgumentName(astNode, scope);
 		} else if (astNode instanceof CompletionOnArgumentName) {
@@ -2709,6 +2712,21 @@ public final class CompletionEngine
 										InternalNamingConventions.VK_STATIC_FINAL_FIELD;
 
 			findVariableNames(field.realName, field.type, excludeNames, null, kind);
+		}
+	}
+
+	private void completionOnRecordComponentName(ASTNode astNode, Scope scope) {
+		if (!this.requestor.isIgnored(CompletionProposal.VARIABLE_DECLARATION)) {
+			CompletionOnRecordComponentName component = (CompletionOnRecordComponentName) astNode;
+
+			FieldBinding[] fields = scope.enclosingSourceType().fields();
+			char[][] excludeNames = new char[fields.length][];
+			for (int i = 0; i < fields.length; i++) {
+				excludeNames[i] = fields[i].name;
+			}
+			this.completionToken = component.realName;
+			findVariableNames(component.realName, component.type, excludeNames, null,
+					InternalNamingConventions.VK_INSTANCE_FIELD);
 		}
 	}
 

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnRecordComponentName.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnRecordComponentName.java
@@ -18,7 +18,6 @@ import org.eclipse.jdt.internal.compiler.ast.RecordComponent;
 import org.eclipse.jdt.internal.compiler.ast.TypeReference;
 import org.eclipse.jdt.internal.compiler.lookup.BlockScope;
 
-// copied implementation from org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnFieldName.java
 public class CompletionOnRecordComponentName extends RecordComponent {
 
 	public CompletionOnRecordComponentName(char[] name, long posNom, TypeReference tr, int modifiers) {

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnRecordComponentName.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnRecordComponentName.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Gayan Perera and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Gayan Perera - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.internal.codeassist.complete;
+
+import org.eclipse.jdt.core.compiler.CharOperation;
+import org.eclipse.jdt.internal.compiler.ast.RecordComponent;
+import org.eclipse.jdt.internal.compiler.ast.TypeReference;
+import org.eclipse.jdt.internal.compiler.lookup.BlockScope;
+
+// copied implementation from org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnFieldName.java
+public class CompletionOnRecordComponentName extends RecordComponent {
+
+	public CompletionOnRecordComponentName(char[] name, long posNom, TypeReference tr, int modifiers) {
+		super(CharOperation.concat(name, FAKENAMESUFFIX), posNom, tr, modifiers);
+		this.realName = name;
+	}
+
+	private static final char[] FAKENAMESUFFIX = " ".toCharArray(); //$NON-NLS-1$
+	public char[] realName;
+
+	@Override
+	public StringBuffer printStatement(int tab, StringBuffer output) {
+
+		printIndent(tab, output).append("<CompletionOnRecordComponentName:"); //$NON-NLS-1$
+		if (this.type != null)
+			this.type.print(0, output).append(' ');
+		output.append(this.realName);
+		if (this.initialization != null) {
+			output.append(" = "); //$NON-NLS-1$
+			this.initialization.printExpression(0, output);
+		}
+		return output.append(">;"); //$NON-NLS-1$
+	}
+
+	@Override
+	public void resolve(BlockScope scope) {
+		super.resolve(scope);
+		throw new CompletionNodeFound(this, scope);
+	}
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
Fix record component type and name completions by recovering it as a local field on the recovered type. This follows the strategy of how fields completions are handled by CompletionParser.

## How to test
Completions on record component as described in https://github.com/eclipse-jdt/eclipse.jdt.core/issues/667
## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
