### PR TITLE
Enhance the BuildContext with the produced output class

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/core/compiler/BuildContext.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/core/compiler/BuildContext.java
@@ -64,9 +64,15 @@ public boolean hasAnnotations() {
  * Returns whether the compilation unit contained any annotations with a given type when it was compiled.
  *
  * NOTE: This is only valid during {@link CompilationParticipant#processAnnotations(BuildContext[])}.
+<<<<<<< Upstream, based on master
  * @param fqn the fully qualified name of the annotation to check for presence
  * @return whether the compilation unit contained any annotations of the given type when it was compiled
  * @since 3.35
+=======
+ * @param fqn the fully qualified name of the annotation to check for precence
+ * @return whether the compilation unit contained any annotations of the given type when it was compiled
+ * @since 3.34
+>>>>>>> ea801ca Enhance the BuildContext with the discovered annotations
  */
 public boolean hasAnnotations(String fqn) {
 	return false; // default overridden by concrete implementation

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/core/compiler/BuildContext.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/core/compiler/BuildContext.java
@@ -41,6 +41,20 @@ public char[] getContents() {
 }
 
 /**
+ * Returns the compiled results of the compilation unit
+ *
+ * NOTE: This is only valid during {@link CompilationParticipant#processClasses(BuildContext[])} and
+ * {@link CompilationParticipant#processAnnotations(BuildContext[])}.
+ *
+ * @return an array of results or an empty arry if no results where produced (yet).
+ *
+ * @since 3.35
+ */
+public IClassContent[] getClassContent() {
+	return new IClassContent[0]; // default overridden by concrete implementation
+}
+
+/**
  * Returns the <code>IFile</code> representing the compilation unit.
  *
  * @return the <code>IFile</code> representing the compilation unit
@@ -64,15 +78,9 @@ public boolean hasAnnotations() {
  * Returns whether the compilation unit contained any annotations with a given type when it was compiled.
  *
  * NOTE: This is only valid during {@link CompilationParticipant#processAnnotations(BuildContext[])}.
-<<<<<<< Upstream, based on master
  * @param fqn the fully qualified name of the annotation to check for presence
  * @return whether the compilation unit contained any annotations of the given type when it was compiled
  * @since 3.35
-=======
- * @param fqn the fully qualified name of the annotation to check for precence
- * @return whether the compilation unit contained any annotations of the given type when it was compiled
- * @since 3.34
->>>>>>> ea801ca Enhance the BuildContext with the discovered annotations
  */
 public boolean hasAnnotations(String fqn) {
 	return false; // default overridden by concrete implementation

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/core/compiler/CompilationParticipant.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/core/compiler/CompilationParticipant.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2019 IBM Corporation and others.
+ * Copyright (c) 2005, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -12,6 +12,7 @@
  *    mkaufman@bea.com - initial API as ICompilationParticipant
  *    IBM - changed from interface ICompilationParticipant to abstract class CompilationParticipant
  *    IBM - rewrote specification
+ *    Christoph Läubrich - add methods for classfile processing
  *
  *******************************************************************************/
 
@@ -142,6 +143,23 @@ public boolean isAnnotationProcessor() {
 }
 
 /**
+ * Returns whether this participant is interested in the generated classes.
+ * <p>
+ * Returning <code>true</code> enables the callback {@link #processClasses(BuildContext[])}, where this
+ * participant can inspect build results.
+ * </p>
+ * <p>
+ * Default is to return <code>false</code>.
+ * </p>
+ *
+ * @return whether this participant is interested in class files
+ * @since 3.35
+ */
+public boolean isClassProcessor() {
+	return false;
+}
+
+/**
  * Notifies this participant that a compile operation has found source files using Annotations.
  * Only sent to participants interested in the current build project that answer true to {@link #isAnnotationProcessor()}.
  * Each BuildContext was informed whether its source file currently hasAnnotations().
@@ -149,6 +167,17 @@ public boolean isAnnotationProcessor() {
  * @param files is an array of BuildContext
   */
 public void processAnnotations(BuildContext[] files) {
+	// do nothing by default
+}
+
+/**
+ * Notifies this participant that a compile operation has completed.
+ * Only sent to participants interested in the current build project that answer true to {@link #isAnnotationProcessor()}.
+ *
+ * @param files is an array of BuildContext
+ * @since 3.35
+  */
+public void processClasses(BuildContext[] files) {
 	// do nothing by default
 }
 

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/core/compiler/IClassContent.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/core/compiler/IClassContent.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Christoph Läubrich and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.core.compiler;
+
+import org.eclipse.core.runtime.CoreException;
+
+/**
+ * Encapsulates the produced class of the compile operation
+ * @since 3.35
+ * @noimplement This interface is not intended to be implemented by clients.
+ */
+public interface IClassContent {
+
+	/**
+	 * Provides access to the raw class bytes of this class content.
+	 *
+	 * @see #setBytes(byte[]) for how to update the class bytes
+	 * @return the class bytes of this class content or <code>null</code> if no content is avaiable
+	 * @throws CoreException
+	 *             if gathering the bytes failed
+	 */
+	byte[] getBytes() throws CoreException;
+
+	/**
+	 * Set the class bytes to the provided array
+	 *
+	 * @see #getBytes() for gathering the current class bytes
+	 * @param classBytes
+	 * @throws CoreException
+	 */
+	void setBytes(byte[] classBytes) throws CoreException;
+
+	/**
+	 * Describe the relative filename of the class that could be used to store the contetn for example in a jar file or on disk.
+	 *
+	 * @return the filename of the class as represented for example in a jar file
+	 */
+	String getFileName();
+}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/ClassContent.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/ClassContent.java
@@ -1,0 +1,104 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Christoph Läubrich and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.internal.core.builder;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.ref.SoftReference;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IAdaptable;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.jdt.core.compiler.IClassContent;
+
+class ClassContent implements IClassContent, IAdaptable{
+
+	private String fileName;
+	private IFile file;
+	private SoftReference<byte[]> bytes;
+
+	@Override
+	public byte[] getBytes() throws CoreException {
+		if (this.bytes == null) {
+			return new byte[0];
+		}
+		byte[] bs = this.bytes.get();
+		if (bs == null) {
+			// cache was cleared out recover from underlying file...
+			IFile f = getFile();
+			if (f == null) {
+				return new byte[0];
+			}
+			try {
+				bs = f.getContents().readAllBytes();
+			} catch (IOException e) {
+				throw new CoreException(Status.error("reading bytes failed", e)); //$NON-NLS-1$
+			}
+			this.bytes = new SoftReference<byte[]>(bs);
+		}
+		return bs.clone();
+	}
+
+	@Override
+	public void setBytes(byte[] classBytes) throws CoreException {
+		InputStream input = new ByteArrayInputStream(classBytes);
+		IFile f = getFile();
+		if (f.exists()) {
+			// Deal with shared output folders... last one wins... no collision cases detected
+			if (JavaBuilder.DEBUG)
+				System.out.println("Writing changed class file " + f.getName());//$NON-NLS-1$
+			if (!f.isDerived())
+				f.setDerived(true, null);
+			f.setContents(input, true, false, null);
+		} else {
+			if (JavaBuilder.DEBUG)
+				System.out.println("Writing new class file " + f.getName());//$NON-NLS-1$
+			f.create(input, IResource.FORCE | IResource.DERIVED, null);
+		}
+		setBytesInternal(classBytes);
+	}
+
+	public IFile getFile() {
+		return this.file;
+	}
+
+	@Override
+	public String getFileName() {
+		return this.fileName;
+	}
+
+	void setFile(IFile file) {
+		this.file = file;
+	}
+
+	void setFileName(String fileName) {
+		this.fileName = fileName;
+	}
+
+	void setBytesInternal(byte[] direct) {
+		this.bytes = new SoftReference<byte[]>(direct);
+	}
+
+	@Override
+	public <T> T getAdapter(Class<T> adapter) {
+		if (adapter.isInstance(this.file)) {
+			return adapter.cast(this.file);
+		}
+		return null;
+	}
+
+}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/CompilationParticipantResult.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/CompilationParticipantResult.java
@@ -28,6 +28,7 @@ public class CompilationParticipantResult extends BuildContext {
 	protected CategorizedProblem[] problems; // new problems to report against this compilationUnit
 	protected String[] dependencies; // fully-qualified type names of any new dependencies, each name is of the form 'p1.p2.A.B'
 	private boolean isTestCode;
+	private ClassContent[] classfiles;
 
 protected CompilationParticipantResult(SourceFile sourceFile, boolean isTestCode) {
 	this.sourceFile = sourceFile;
@@ -47,6 +48,14 @@ protected CompilationParticipantResult(SourceFile sourceFile, boolean isTestCode
 @Override
 public char[] getContents() {
 	return this.sourceFile.getContents();
+}
+
+@Override
+public IClassContent[] getClassContent() {
+	if (this.classfiles == null) {
+		return super.getClassContent();
+	}
+	return this.classfiles.clone();
 }
 
 /**
@@ -171,6 +180,10 @@ void reset(AnnotationBinding[] newAnnotations) {
 	this.deletedFiles = null;
 	this.problems = null;
 	this.dependencies = null;
+}
+
+void setClassFiles(ClassContent[] classfiles) {
+	this.classfiles = classfiles;
 }
 
 @Override


### PR DESCRIPTION
## What it does
Currently a CompilationParticipant can't get the produced class files to
further process them.

This adds new method to access the generated classfiles name, location
and bytes.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
A new test method has been added.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
