### PR TITLE
Do not refer to ID_RES_NAV

### DIFF
--- a/org.eclipse.jdt.core.tests.model/workspace/Converter/src/test0501/JavaEditor.java
+++ b/org.eclipse.jdt.core.tests.model/workspace/Converter/src/test0501/JavaEditor.java
@@ -1923,7 +1923,7 @@ public abstract class JavaEditor extends ExtendedTextEditor implements IViewPart
 		if (required == IShowInTargetList.class) {
 			return new IShowInTargetList() {
 				public String[] getShowInTargetIds() {
-					return new String[] { JavaUI.ID_PACKAGES, IPageLayout.ID_OUTLINE, IPageLayout.ID_RES_NAV };
+					return new String[] { JavaUI.ID_PACKAGES, IPageLayout.ID_OUTLINE };
 				}
 
 			};


### PR DESCRIPTION
## What it does
Removes references in tests code to deprecated and scheduled for removal Navigator view.

## How to test
Automated tests continue to work

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
