### PR TITLE
Bug 572361 - @NonNullByDefault and records

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SyntheticMethodBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SyntheticMethodBinding.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -660,6 +660,16 @@ public class SyntheticMethodBinding extends MethodBinding {
 	@Override
 	public LambdaExpression sourceLambda() {
 		return this.lambda;
+	}
+
+	@Override
+	public ParameterNonNullDefaultProvider hasNonNullDefaultForParameter(AbstractMethodDeclaration srcMethod) {
+		switch (this.purpose) {
+			case SyntheticMethodBinding.RecordOverrideEquals:
+				return ParameterNonNullDefaultProvider.FALSE_PROVIDER;
+			default:
+				return super.hasNonNullDefaultForParameter(srcMethod);
+		}
 	}
 
 	public void markNonNull(LookupEnvironment environment) {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullAnnotationTests18.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullAnnotationTests18.java
@@ -686,4 +686,17 @@ public class NullAnnotationTests18 extends AbstractNullAnnotationTest {
 				options,
 				"");
 	}
+	public void testBug572361() {
+		runConformTestWithLibs(
+			new String[] {
+				"NonNullByDefaultAndRecords.java",
+				"import org.eclipse.jdt.annotation.NonNullByDefault;\n" +
+				"\n" +
+				"@NonNullByDefault\n" +
+				"public record NonNullByDefaultAndRecords () { }\n"
+			},
+			getCompilerOptions(),
+			"");
+	}
+
 }


### PR DESCRIPTION
## What it does

Fixes https://bugs.eclipse.org/bugs/show_bug.cgi?id=572361
* don't apply `@NNBD` to synthetic `equals(other)` method

