### PR TITLE
Support cancelation of AptConfig changes

### DIFF
--- a/org.eclipse.jdt.apt.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.apt.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.apt.core; singleton:=true
-Bundle-Version: 3.7.100.qualifier
+Bundle-Version: 3.8.0.qualifier
 Bundle-Localization: plugin
 Export-Package: com.sun.mirror.apt,
  com.sun.mirror.declaration,
@@ -18,7 +18,7 @@ Export-Package: com.sun.mirror.apt,
  org.eclipse.jdt.apt.core.internal.type;x-friends:="org.eclipse.jdt.apt.pluggable.core,org.eclipse.jdt.apt.tests,org.eclipse.jdt.apt.ui,org.eclipse.jdt.apt.pluggable.tests",
  org.eclipse.jdt.apt.core.internal.util;x-friends:="org.eclipse.jdt.apt.pluggable.core,org.eclipse.jdt.apt.tests,org.eclipse.jdt.apt.ui,org.eclipse.jdt.apt.pluggable.tests",
  org.eclipse.jdt.apt.core.util
-Require-Bundle: org.eclipse.jdt.core;bundle-version="[3.33.0,4.0.0)",
+Require-Bundle: org.eclipse.jdt.core;bundle-version="[3,4.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.5.100,4.0.0)",
  org.eclipse.core.resources;bundle-version="[3.6.0,4.0.0)",
  org.apache.ant;bundle-version="1.6.5"

--- a/org.eclipse.jdt.apt.core/pom.xml
+++ b/org.eclipse.jdt.apt.core/pom.xml
@@ -17,6 +17,6 @@
     <version>4.27.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.eclipse.jdt.apt.core</artifactId>
-  <version>3.7.100-SNAPSHOT</version>
+  <version>3.8.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/AptProject.java
+++ b/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/AptProject.java
@@ -16,6 +16,7 @@ package org.eclipse.jdt.apt.core.internal;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.apt.core.internal.generatedfile.GeneratedFileManager;
 import org.eclipse.jdt.apt.core.internal.generatedfile.GeneratedSourceFolderManager;
 import org.eclipse.jdt.apt.core.internal.util.FileSystemUtil;
@@ -76,14 +77,14 @@ public class AptProject {
 	 * certain resource change listeners.
 	 * @param key a preference key such as @see AptPreferenceConstants#APT_ENABLED
 	 */
-	public void preferenceChanged(String key) {
+	public void preferenceChanged(String key, IProgressMonitor monitor) {
 		if (AptPreferenceConstants.APT_GENSRCDIR.equals(key)) {
-			_main_gsfm.folderNamePreferenceChanged();
+			_main_gsfm.folderNamePreferenceChanged(monitor);
 		} else if (AptPreferenceConstants.APT_GENTESTSRCDIR.equals(key)) {
-			_test_gsfm.folderNamePreferenceChanged();
+			_test_gsfm.folderNamePreferenceChanged(monitor);
 		} else if(AptPreferenceConstants.APT_ENABLED.equals(key) ){
-			_main_gsfm.enabledPreferenceChanged();
-			_test_gsfm.enabledPreferenceChanged();
+			_main_gsfm.enabledPreferenceChanged(monitor);
+			_test_gsfm.enabledPreferenceChanged(monitor);
 		}
 	}
 


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
currently AptConfig includes interact with the workspace in a loop and in a join operation, both of them are not cancelable at the moment (except from Thread interruption).

This adds alternative methods that allow to pass a progressmonitor for cancelation checks.

See #689

## How to test
No test required, as the monitor is just passed to standard eclipse API that performs the actual checks as per there API.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
