### PR TITLE
Fix regression from #683

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ASTNode.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ASTNode.java
@@ -1322,6 +1322,7 @@ public abstract class ASTNode implements TypeConstants, TypeIds {
 			oldLeafType = oldLeafType.withoutToplevelNullAnnotation();
 		} else if (se8nullBits == TagBits.AnnotationNonNull
 					&& location != Binding.DefaultLocationReturnType // normal return type cases are handled in MethodBinding.fillInDefaultNonNullness18()
+					&& location != Binding.DefaultLocationField      // normal field type cases are handled in FieldBinding.fillInDefaultNonNullness()
 					&& scope.hasDefaultNullnessForType(typeRef.resolvedType, location, typeRef.sourceStart)) {
 			scope.problemReporter().nullAnnotationIsRedundant(typeRef, new Annotation[] { se8NullAnnotation });
 		}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullTypeAnnotationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullTypeAnnotationTest.java
@@ -18726,4 +18726,26 @@ public void testBug499596() throws Exception {
 	runner.classLibraries = this.LIBS;
 	runner.runWarningTest();
 }
+public void testRedundantNonNull_field() {
+	Runner runner = new Runner();
+	runner.testFiles =
+		new String[] {
+			"test1/Foo.java",
+			"package test1;\n" +
+			"import org.eclipse.jdt.annotation.*;\n" +
+			"@NonNullByDefault\n" +
+			"public class Foo {\n" +
+			"    @NonNull Object f=new Object();\n" +
+			"}\n"
+		};
+	runner.expectedCompilerLog =
+			"----------\n" +
+			"1. WARNING in test1\\Foo.java (at line 5)\n" +
+			"	@NonNull Object f=new Object();\n" +
+			"	^^^^^^^^^^^^^^^\n" +
+			"The nullness annotation is redundant with a default that applies to this location\n" +
+			"----------\n";
+	runner.classLibraries = this.LIBS;
+	runner.runWarningTest();
+}
 }


### PR DESCRIPTION
This should fix eclipse-jdt/eclipse.jdt.ui#423

Unfortunately, JDT/Core tests are unable to detect the situation of duplicate problem messages.

I have a draft improving our test infra in this direction, which, however, reveals that approx. 9 other tests are affected by this problem, which needs to be looked into separately.