### PR TITLE
JobManager should not implement Runnable for internal purpose only (#41)

### DIFF
--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/processing/JobManager.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/processing/JobManager.java
@@ -29,7 +29,7 @@ import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jdt.internal.core.util.Messages;
 import org.eclipse.jdt.internal.core.util.Util;
 
-public abstract class JobManager implements Runnable {
+public abstract class JobManager {
 
 	/**
 	 * queue of jobs to execute
@@ -416,7 +416,7 @@ public abstract class JobManager implements Runnable {
 		} else {
 			synchronized (this) {
 				/* initiate background processing */
-				Thread t = new Thread(this, processName());
+				Thread t = new Thread(this::indexerLoop, processName());
 				t.setDaemon(true);
 				// less prioritary by default, priority is raised if clients are actively waiting on it
 				t.setPriority(Thread.NORM_PRIORITY-1);
@@ -428,11 +428,11 @@ public abstract class JobManager implements Runnable {
 			}
 		}
 	}
+
 	/**
 	 * Infinite loop performing resource indexing
 	 */
-	@Override
-	public void run() {
+	void indexerLoop() {
 
 		long idlingStart = -1;
 		activateProcessing();


### PR DESCRIPTION
Exposing "public run()" API is not necessary for any code, run() is used for internal purpose only to start a Thread.

Also renamed run() into indexerLoop() to make clear what the code is actually doing.

See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/41
