### PR TITLE
Fix: NPE when adding files without file extension to the classpath

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModel.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModel.java
@@ -398,10 +398,7 @@ public static boolean isJimage(File file) {
 }
 public static boolean isJmod(File file) {
 	IPath path = Path.fromOSString(file.getPath());
-	if (path.getFileExtension().equalsIgnoreCase(SuffixConstants.EXTENSION_jmod)) {
-		return true;
-	}
-	return false;
+	return SuffixConstants.EXTENSION_jmod.equalsIgnoreCase(path.getFileExtension());
 }
 
 /**


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

Swap the operands of the file-extension check so that the constant is on the left side.
Resolves #720

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Create a new Java project and add a file without file extension (e.g. `.jar`) to the classpath. Without this fix, the builder should then stop due to an uncaught NullPointerException.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
