### PR TITLE
Call Hierarchy and references search don't see obvious references

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AbstractJavaSearchTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AbstractJavaSearchTests.java
@@ -1242,6 +1242,29 @@ protected JavaSearchResultCollector resultCollector;
 	protected void searchDeclarationsOfSentMessages(IJavaElement enclosingElement, SearchRequestor requestor) throws JavaModelException {
 		new SearchEngine().searchDeclarationsOfSentMessages(enclosingElement, requestor, null);
 	}
+	protected void buildAndExpectNoProblems(IJavaProject... javaProjects) throws CoreException {
+		List<IProject> projects = new ArrayList<>();
+		if (javaProjects != null) {
+			Arrays.stream(javaProjects).forEach(jp -> projects.add(jp.getProject()));
+		}
+		for (IProject project : projects) {
+			project.build(IncrementalProjectBuilder.AUTO_BUILD, new NullProgressMonitor());
+		}
+		waitForAutoBuild();
+		waitUntilIndexesReady();
+
+		for (IProject project : projects) {
+			assertProblemMarkers("Expected no build problems on project: " + project, "", project);
+		}
+	}
+	protected void buildAndExpectProblems(IJavaProject javaProject, String expectedMarkers) throws CoreException {
+		IProject project = javaProject.getProject();
+		project.build(IncrementalProjectBuilder.AUTO_BUILD, new NullProgressMonitor());
+		waitForAutoBuild();
+		waitUntilIndexesReady();
+		assertProblemMarkers("Expected build problems on project due to undefined type",
+				expectedMarkers, project);
+	}
 	@Override
 	protected void setUp () throws Exception {
 		this.indexDisabledForTest = false;

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchBugsTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchBugsTests.java
@@ -21,7 +21,6 @@ import static org.eclipse.jdt.core.search.IJavaSearchScope.SYSTEM_LIBRARIES;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -15472,31 +15471,6 @@ public void testModuleConflictForClasspathProjectsBugGh675() throws Exception {
 				"src/test/Test.java void test.Test.testMethod() [testField] EXACT_MATCH");
 	} finally {
 		deleteProject(projectName);
-	}
-}
-
-private void buildAndExpectProblems(IJavaProject javaProject, String expectedMarkers) throws CoreException {
-	IProject project = javaProject.getProject();
-	project.build(IncrementalProjectBuilder.AUTO_BUILD, new NullProgressMonitor());
-	waitForAutoBuild();
-	waitUntilIndexesReady();
-	assertProblemMarkers("Expected build problems on project due to undefined type",
-			expectedMarkers, project);
-}
-
-private void buildAndExpectNoProblems(IJavaProject... javaProjects) throws CoreException {
-	List<IProject> projects = new ArrayList<>();
-	if (javaProjects != null) {
-		Arrays.stream(javaProjects).forEach(jp -> projects.add(jp.getProject()));
-	}
-	for (IProject project : projects) {
-		project.build(IncrementalProjectBuilder.AUTO_BUILD, new NullProgressMonitor());
-	}
-	waitForAutoBuild();
-	waitUntilIndexesReady();
-
-	for (IProject project : projects) {
-		assertProblemMarkers("Expected no build problems on project: " + project, "", project);
 	}
 }
 


### PR DESCRIPTION
The fix for #675 neglects the fact that a classpath JRE 9+ is on the module path despite not having a classpath entry to indicate this. This change disables the change for classpath container entries.

Fixes: https://github.com/eclipse-jdt/eclipse.jdt.core/issues/740
Signed-off-by: Simeon Andreev <simeon.danailov.andreev@gmail.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
