### PR TITLE
 [20] Guarded patterns with constant true should be considered for  dominance check eclipse-jdt #742

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/GuardedPattern.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/GuardedPattern.java
@@ -100,7 +100,8 @@ public class GuardedPattern extends Pattern {
 
 	@Override
 	public boolean dominates(Pattern p) {
-		// Guarded pattern can never dominate another, even if the guards are identical
+		if (isAlwaysTrue())
+			return this.primaryPattern.dominates(p);
 		return false;
 	}
 

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchPatternTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchPatternTest.java
@@ -5823,4 +5823,62 @@ public class SwitchPatternTest extends AbstractRegressionTest9 {
 				"This case label is dominated by one of the preceding case label\n" +
 				"----------\n");
 	}
+	public void testIssue742_1() {
+		runNegativeTest(
+				new String[] {
+					"X.java",
+					"import java.util.*;\n" +
+					"public class X {\n" +
+					"@SuppressWarnings(\"preview\")\n"
+					+ "public static void foo(Integer n) {\n"
+					+ "  switch (n) {\n"
+					+ "    case Integer i when true -> // Allowed but why write this?\n"
+					+ "        System.out.println(\"An integer\"); \n"
+					+ "    case Integer i ->                     // Error - dominated case label\n"
+					+ "        System.out.println(\"An integer\"); \n"
+					+ "  }\n"
+					+ "}\n" +
+					"}",
+				},
+				"----------\n" +
+				"1. ERROR in X.java (at line 8)\n" +
+				"	case Integer i ->                     // Error - dominated case label\n" +
+				"	     ^^^^^^^^^\n" +
+				"The switch statement cannot have more than one unconditional pattern\n" +
+				"----------\n" +
+				"2. ERROR in X.java (at line 8)\n" +
+				"	case Integer i ->                     // Error - dominated case label\n" +
+				"	     ^^^^^^^^^\n" +
+				"This case label is dominated by one of the preceding case label\n" +
+				"----------\n");
+	}
+	public void testIssue742_2() {
+		runNegativeTest(
+				new String[] {
+					"X.java",
+					"import java.util.*;\n" +
+					"public class X {\n" +
+					"@SuppressWarnings(\"preview\")\n"
+					+ "public static void foo(Integer n) {\n"
+					+ "  switch (n) {\n"
+					+ "    case Integer i -> // Allowed but why write this?\n"
+					+ "        System.out.println(\"An integer\"); \n"
+					+ "    case Integer i when true ->                     // Error - dominated case label\n"
+					+ "        System.out.println(\"An integer\"); \n"
+					+ "  }\n"
+					+ "}\n" +
+					"}",
+				},
+				"----------\n" +
+				"1. ERROR in X.java (at line 8)\n" +
+				"	case Integer i when true ->                     // Error - dominated case label\n" +
+				"	     ^^^^^^^^^^^^^^^^^^^\n" +
+				"The switch statement cannot have more than one unconditional pattern\n" +
+				"----------\n" +
+				"2. ERROR in X.java (at line 8)\n" +
+				"	case Integer i when true ->                     // Error - dominated case label\n" +
+				"	     ^^^^^^^^^^^^^^^^^^^\n" +
+				"This case label is dominated by one of the preceding case label\n" +
+				"----------\n");
+	}
 }


### PR DESCRIPTION
dominance check #742

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
