### PR TITLE
Handle JRE container when adding module class path info in Java search

### DIFF
--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/JavaSearchNameEnvironment.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/JavaSearchNameEnvironment.java
@@ -578,13 +578,10 @@ private static boolean isOnModulePath(JavaProject javaProject, PackageFragmentRo
 			 * so we cannot rely on the attribute.
 			 */
 			isOnModulePath = isModularProject(javaProject);
-		} else if (classpathEntry.getEntryKind() == IClasspathEntry.CPE_CONTAINER) {
+		} else if (hasSystemModule(root)) {
 			/*
 			 * The JRE 9+ container is on the module path without the 'module' classpath attribute being set.
-			 * So for any container with modules, we assume its on the module path. Since its difficult to know
-			 * whether we have the JRE container or not.
-			 * We want to improve this check with https://github.com/eclipse-jdt/eclipse.jdt.core/issues/748,
-			 * so that only module path containers have their module infos added.
+			 * We detected the JRE container by checking the container for system modules.
 			 */
 			isOnModulePath = true;
 		} else {
@@ -601,5 +598,13 @@ private static boolean isModularProject(IJavaProject project) throws JavaModelEx
 	IModuleDescription module = project.getModuleDescription();
 	String modName = module == null ? null : module.getElementName();
 	return modName != null && modName.length() > 0;
+}
+
+private static boolean hasSystemModule(PackageFragmentRoot fragmentRoot) {
+	IModuleDescription module = fragmentRoot.getModuleDescription();
+	if (module != null && module.isSystemModule()) {
+		return true;
+	}
+	return false;
 }
 }


### PR DESCRIPTION
The JRE container on a projects classpath doesn't always have the module attribute set, despite being on the module path. Due to not considering this, the fix for #675 introduces a bug - types in the JRE modules are not resolved correctly.

The fix for #740 disables the fix for #675 for classpath containers to prevent this bug from occurring.

This change ensures classpath containers with system modules (such as the JRE container) have their classpath module info attached, while the module info is not attached for other containers without the module classpath attribute. This ensures the bug in #675 is fixed also for containers on the classpath.

Fixes: https://github.com/eclipse-jdt/eclipse.jdt.core/issues/748

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
