### PR TITLE
Guard the new CompletionOnRecordComponentName.#757

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
@@ -11394,7 +11394,7 @@ protected void consumeRecordComponent(boolean isVarArgs) {
 	RecordComponent recordComponent;
 	recordComponent = createComponent(identifierName, namePositions, type,
 			this.intStack[this.intPtr--] & ~ClassFileConstants.AccDeprecated // modifiers
-	);
+			, modifierPositions);
 	recordComponent.declarationSourceStart = modifierPositions;
 	recordComponent.bits |= (type.bits & ASTNode.HasTypeAnnotations);
 	// consume annotations
@@ -11716,7 +11716,8 @@ protected FieldDeclaration createFieldDeclaration(char[] fieldDeclarationName, i
 	return new FieldDeclaration(fieldDeclarationName, sourceStart, sourceEnd);
 }
 
-protected RecordComponent createComponent(char[] identifierName, long namePositions, TypeReference type, int modifier) {
+protected RecordComponent createComponent(char[] identifierName, long namePositions, TypeReference type, int modifier,
+		int declStart) {
 	return new RecordComponent(identifierName, namePositions, type, modifier);
 }
 protected JavadocParser createJavadocParser() {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests14.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests14.java
@@ -578,4 +578,28 @@ public class CompletionTests14 extends AbstractJavaModelCompletionTests {
 				requestor.getResults());
 	}
 
+	public void testGH757_CompletionOnTypeNameAboveRecordDeclaration() throws JavaModelException {
+		this.workingCopies = new ICompilationUnit[2];
+		this.workingCopies[0] = getWorkingCopy(
+				"/Completion/src/Person.java",
+				"public class Person {\n"
+						+ "private Name name = new Name \n"
+						+ "record Age(int value){};"
+						+ "}\n");
+		this.workingCopies[1] = getWorkingCopy(
+				"/Completion/src/Name.java",
+				"public class Name {\n"
+						+ "}\n");
+		CompletionTestsRequestor2 requestor = new CompletionTestsRequestor2(true, true, true, false);
+		String str = this.workingCopies[0].getSource();
+		String completeBehind = "new Name";
+		int cursorLocation = str.lastIndexOf(completeBehind) + completeBehind.length();
+		this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner);
+		assertResults(
+				"Name[TYPE_REF]{Name, , LName;, null, null, null, null, [46, 50], "
+						+ (R_DEFAULT + R_RESOLVED + R_INTERESTING + R_CASE + R_UNQUALIFIED + R_NON_RESTRICTED
+								+ R_EXACT_NAME + R_EXACT_EXPECTED_TYPE)
+						+ "}",
+				requestor.getResults());
+	}
 }

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionParser.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionParser.java
@@ -6327,12 +6327,13 @@ protected FieldDeclaration createFieldDeclaration(char[] assistName, int sourceS
 }
 
 @Override
-protected RecordComponent createComponent(char[] identifierName, long namePositions, TypeReference type, int modifier) {
+protected RecordComponent createComponent(char[] identifierName, long namePositions, TypeReference type, int modifier,
+		int declStart) {
 	int endPos = (int) namePositions;
-	if (this.cursorLocation <= endPos) {
+	if (this.cursorLocation > declStart && this.cursorLocation <= endPos) {
 		return new CompletionOnRecordComponentName(identifierName, namePositions, type, modifier);
 	}
-	return super.createComponent(identifierName, namePositions, type, modifier);
+	return super.createComponent(identifierName, namePositions, type, modifier, declStart);
 }
 
 /*


### PR DESCRIPTION
## What it does
Add proper guard condition for CompletionOnRecordComponentName so that it is created only if the cursor location is in-between the record declaration start and name end position.

## How to test
Use test cases in #757 

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
