### PR TITLE
EncodingTests.test021() fails on win

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/EncodingTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/EncodingTests.java
@@ -455,17 +455,21 @@ public class EncodingTests extends ModifyingResourceTests {
 	 * Verification is done by comparing source with file contents read directly with VM encoding...
 	 */
 	public void test021() throws JavaModelException, CoreException {
+		getWorkspaceRoot().setDefaultCharset(vmEncoding, null);
+		try {
+			// Get class file and compare source
+			IPackageFragmentRoot root = getPackageFragmentRoot("Encoding", "testUTF8.jar");
+			this.utf8Source = root.getPackageFragment("testUTF8").getClassFile("Test.class");
+			assertNotNull(this.utf8Source);
+			String source = this.utf8Source.getSource();
+			assertNotNull(source);
+			String encodedContents = new String (Util.getResourceContentsAsCharArray(this.utf8File, vmEncoding));
+			assertSourceEquals("Encoded UTF-8 source should have been decoded the same way!", source, encodedContents);
 
-		// Get class file and compare source
-		IPackageFragmentRoot root = getPackageFragmentRoot("Encoding", "testUTF8.jar");
-		this.utf8Source = root.getPackageFragment("testUTF8").getClassFile("Test.class");
-		assertNotNull(this.utf8Source);
-		String source = this.utf8Source.getSource();
-		assertNotNull(source);
-		String encodedContents = new String (Util.getResourceContentsAsCharArray(this.utf8File, vmEncoding));
-		assertSourceEquals("Encoded UTF-8 source should have been decoded the same way!", source, encodedContents);
-
-		// Cannot compare bytes array without encoding as we're dependent of linux/windows os for new lines delimiter
+			// Cannot compare bytes array without encoding as we're dependent of linux/windows os for new lines delimiter
+		} finally {
+			getWorkspaceRoot().setDefaultCharset(wkspEncoding, null);
+		}
 	}
 
 	/*


### PR DESCRIPTION
Original test assumed workspace always uses system default encoding and projects follow that if nothing is set explikcitly.

This assumption was not correct anymore after
https://github.com/eclipse-platform/eclipse.platform.resources/pull/51 and https://github.com/eclipse-platform/eclipse.platform.resources/commit/961d08076b4eba7c93d4f7264de88c87c2cc753e

For the concrete test to succeed we should set "system" encoding on the project we use.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/462

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
