### PR TITLE
Update build-helper-maven-plugin to 3.3.0

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/pom.xml
+++ b/org.eclipse.jdt.core.compiler.batch/pom.xml
@@ -216,7 +216,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>3.3.0</version>
         <executions>
           <!--
             Replace '\' Windows file separators by '/' in order to expand the new property 'compiler-message-properties'


### PR DESCRIPTION
## What it does
Updates to new plugin version as with Maven 3.9.0 and plugin version 3.2.0 build fails with:
```
[WARNING] The POM for org.codehaus.mojo:build-helper-maven-plugin:jar:3.2.0 is invalid, transitive dependencies (if any) will not be available, enable debug logging for more details
[ERROR] Plugin org.codehaus.mojo:build-helper-maven-plugin:3.2.0 or one of its dependencies could not be resolved: Failed to read artifact descriptor for org.codehaus.mojo:build-helper-maven-plugin:jar:3.2.0: 1 problem was encountered while building the effective model
[ERROR] [FATAL] Non-parseable POM /home/akurtakov/.m2/repository/org/codehaus/mojo/build-helper-maven-plugin/3.2.0/build-helper-maven-plugin-3.2.0.pom: UTF-8 BOM plus xml decl of ISO-8859-1 is incompatible (position: START_DOCUMENT seen <?xml version="1.0" encoding="ISO-8859-1"... @1:42)  @ line 1, column 42
[ERROR] -> [Help 1]
```

## How to test

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
