### PR TITLE
Create updateRelease.yml

### DIFF
--- a/.github/workflows/updateRelease.yml
+++ b/.github/workflows/updateRelease.yml
@@ -1,0 +1,12 @@
+name: Update to next release
+on:
+  milestone:
+    types: [created]
+
+jobs:
+  update:
+    if: contains(github.event.milestone.description, 'Release')
+    permissions:
+      pull-requests: write
+      contents: write
+    uses: eclipse-platform/eclipse.platform.releng.aggregator/.github/workflows/updateRelease.yml@master


### PR DESCRIPTION
FYI @iloveeclipse @akurtakov 

This adds automatic updates of the poms to the new release once the milestone is created as a new PR, example:
- https://github.com/laeubi/eclipse.jdt.core/pull/4