### PR TITLE
Fix record canonical constructor signature not generating when there is another constructor

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SourceTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SourceTypeBinding.java
@@ -1426,6 +1426,9 @@ public RecordComponentBinding[] components() {
 				if (smb.purpose == SyntheticMethodBinding.RecordCanonicalConstructor) {
 					for (int i = 0, l = smb.parameters.length; i < l; ++i) {
 						smb.parameters[i] = this.components[i].type;
+						if (smb.parameters[i] != null && smb.parameters[i].isParameterizedTypeWithActualArguments()) {
+							smb.modifiers |= ExtraCompilerModifiers.AccGenericSignature;
+						}
 					}
 					if (this.isVarArgs == true) {
 						smb.modifiers |= ClassFileConstants.AccVarargs;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SourceTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SourceTypeBinding.java
@@ -1426,7 +1426,7 @@ public RecordComponentBinding[] components() {
 				if (smb.purpose == SyntheticMethodBinding.RecordCanonicalConstructor) {
 					for (int i = 0, l = smb.parameters.length; i < l; ++i) {
 						smb.parameters[i] = this.components[i].type;
-						if (smb.parameters[i] != null && smb.parameters[i].isParameterizedTypeWithActualArguments()) {
+						if (smb.parameters[i] != null && smb.parameters[i].isParameterizedType()) {
 							smb.modifiers |= ExtraCompilerModifiers.AccGenericSignature;
 						}
 					}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
Fixes canonical constructors in records not including a signature when compiled when there is another constructor

## How to test
Add this class to a project and use `javap` on the compiled class file
```java
package test1;

import java.time.Instant;
import java.util.Date;
import java.util.function.Function;

public record GenericRecord(Function<Instant, Date> function) {
	public GenericRecord() {
		this(null);
	}
}
```
or after adding that class to a project add this class to a seperate project with a dependency on the first project and check if the second project compiles
```java
package test;

import java.util.Date;

import test1.GenericRecord;

public class Test {	
	public GenericRecord get() {
		return new GenericRecord(Date::from);
	}
}
```

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
