### PR TITLE
Call hierarchy incomplete for method of private nested type

### DIFF
--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/MatchLocator.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/MatchLocator.java
@@ -984,6 +984,10 @@ public MethodBinding getMethodBinding(MethodPattern methodPattern) {
     	return methodBinding; // known to be valid.
     // special handling for methods of anonymous/local types. Since these cannot be looked up in the environment the usual way ...
     if (methodPattern.focus instanceof SourceMethod) {
+    	MethodBinding binding = getClosestMatchMethodBinding(methodPattern);
+    	if (binding != null) {
+    		return binding;
+    	}
     	char[] typeName = PatternLocator.qualifiedPattern(methodPattern.declaringSimpleName, methodPattern.declaringQualification);
     	if (typeName != null) {
     		IType type = methodPattern.declaringType;
@@ -1012,24 +1016,22 @@ public MethodBinding getMethodBinding(MethodPattern methodPattern) {
     } else if (methodPattern.focus instanceof BinaryMethod &&
     		methodPattern.declaringType instanceof BinaryType &&
     		this.unitScopeTypeBinding instanceof ProblemReferenceBinding) {//Get binding from unit scope for non-visible member of binary type
-    	char[] typeName = PatternLocator.qualifiedPattern(methodPattern.declaringSimpleName, methodPattern.declaringQualification);
-    	if (typeName != null) {
-    		IType type = methodPattern.declaringType;
-    		IType enclosingType = type.getDeclaringType();
-    		while (enclosingType != null) {
-    			type = enclosingType;
-    			enclosingType = type.getDeclaringType();
-    		}
-    		typeName = type.getFullyQualifiedName().toCharArray();
-    		TypeBinding typeBinding = this.unitScopeTypeBinding;
-    		if (typeBinding instanceof ProblemReferenceBinding) {
-    			ProblemReferenceBinding problemReferenceBinding = (ProblemReferenceBinding) this.unitScopeTypeBinding;
-    			ReferenceBinding closestMatch = (problemReferenceBinding.problemId() == ProblemReasons.NotVisible) ?
-    					problemReferenceBinding.closestReferenceMatch() : null;
-    					return closestMatch != null ?  getMethodBinding(methodPattern, closestMatch) : null;
-    		}
-    	}
+    	return getClosestMatchMethodBinding(methodPattern);
     }
+	return null;
+}
+
+private MethodBinding getClosestMatchMethodBinding(MethodPattern methodPattern) {
+	TypeBinding typeBinding = this.unitScopeTypeBinding;
+	if (typeBinding instanceof ProblemReferenceBinding) {
+		ProblemReferenceBinding problemReferenceBinding = (ProblemReferenceBinding) this.unitScopeTypeBinding;
+		if (problemReferenceBinding.problemId() == ProblemReasons.NotVisible) {
+			ReferenceBinding closestMatch = problemReferenceBinding.closestReferenceMatch();
+			if (closestMatch != null) {
+				return getMethodBinding(methodPattern, closestMatch);
+			}
+		}
+	}
 	return null;
 }
 


### PR DESCRIPTION
An incomplete call hierarchy is computed given the following conditions:

1. A private nested class implements an interface.
2. The interface has a method with a nested type.
3. The call hierarchy starts at the private nested class level.

This is a regression from the fix for:
https://bugs.eclipse.org/bugs/show_bug.cgi?id=431357

In particular the fix uses `MethodBinding.parameters`, which is empty for the callee method in the described scenario.

A `MethodBinding` with empty `parameters` is computed due to the following sequence:

1. The method caller is not able to see the private private nested class with the callee method, resulting in creating a `ProblemReferenceBinding` for the nested private class.
2. `MatchLocator.getMethodBinding(MethodPattern)` fails to retrieve a `MethodBinding` via `MatchLocator.getMethodBinding0(MethodPattern)`, due to the `ProblemReferenceBinding`.
3. `getMethodBinding()` resorts to parsing source code, but retrieves a `MethodBinding` with unresolved parameters.

This change adjusts the part of `getMethodBinding()` which resorts to reading a source file, so that method parameters are resolved if they are not resolved yet.

Fixes: #821

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
