### PR TITLE
AIOOBE during search for references

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/compiler/parser/TypeConverter.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/compiler/parser/TypeConverter.java
@@ -482,14 +482,21 @@ public abstract class TypeConverter {
 			/* rebuild identifiers and dimensions */
 			if (identCount == 1) { // simple type reference
 				if (dim == 0) {
+					int n = typeName.length;
+					boolean hasDiamond = n > 2 && typeName[n - 2] == '<' && typeName[n - 1] == '>';
 					char[] nameFragment;
-					if (nameFragmentStart != 0 || nameFragmentEnd >= 0) {
-						int nameFragmentLength = nameFragmentEnd - nameFragmentStart + 1;
+					int nameFragmentLength = nameFragmentEnd - nameFragmentStart + 1;
+					boolean hasEmptyFragment = nameFragmentLength == 0 && hasDiamond;
+					if ((nameFragmentStart != 0 || nameFragmentEnd >= 0) && !hasEmptyFragment) {
 						System.arraycopy(typeName, nameFragmentStart, nameFragment = new char[nameFragmentLength], 0, nameFragmentLength);
 					} else {
 						nameFragment = typeName;
 					}
-					return new SingleTypeReference(nameFragment, ((long) start << 32) + end);
+					SingleTypeReference singleTypeReference = new SingleTypeReference(nameFragment, ((long) start << 32) + end);
+					if (hasDiamond) {
+						singleTypeReference.bits |= ASTNode.IsDiamond;
+					}
+					return singleTypeReference;
 				} else {
 					int nameFragmentLength = nameFragmentEnd - nameFragmentStart + 1;
 					char[] nameFragment = new char[nameFragmentLength];


### PR DESCRIPTION
AIOOBE during search for references

Prevent creating a type argument for a type reference with empty type
arguments. I.e. for a type reference "MyType<>" don't create a type
argument, to prevent an AIOOBE later on during a search.

Fixes: #825

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
