### PR TITLE
Unexpected cast compile error for generic type argument

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
@@ -1488,6 +1488,8 @@ private boolean isCompatibleWith0(TypeBinding otherType, /*@Nullable*/ Scope cap
 	// bound
 	if (isEquivalentTo(otherType))
 		return true;
+	if (kind() == Binding.WILDCARD_TYPE  && ((WildcardBinding) this).boundCheck(otherType))
+		return true;
 	switch (otherType.kind()) {
 		case Binding.WILDCARD_TYPE :
 		case Binding.INTERSECTION_TYPE:

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_1_8.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_1_8.java
@@ -10379,4 +10379,19 @@ public void testBug508834_comment0() {
 				"}\n"
 			});
 	}
+	public void testBugGh837() {
+		if (this.complianceLevel < ClassFileConstants.JDK1_5) return; // uses parameterized types
+		runConformTest(
+			new String[] {
+				"X.java",
+				"import java.util.Collections;\n" +
+				"import java.util.List;\n" +
+				"public class X {\n" +
+				"	public static <Z extends Comparable<? super Z>> String test(List<Z> in) {\n" +
+				"		List<String> x = (List<String>) in;\n" +
+				"		return x.get(0);\n" +
+				"	}\n" +
+				"}\n"
+			});
+	}
 }


### PR DESCRIPTION
Given a generic type defined as `<Z extends Comparable<? super Z>>`, the compiler fails to cast `List<Z>` to e.g. `List<String>`. Despite `String` fulfilling the bound requirements for `Z` (due to `String implements Comparable<String>`).

For this particular case, the bug occurs due to:

For the `? super Z` bound, `TypeBinding.isTypeArgumentContainedBy()` calls `isCompatibleWith()` on `String`, with argument the lower bound `?`. Then in `ReferenceBinding.isCompatibleWith0()` the equivalence check fails, since `String` doesn't evaluate to being equivalent to `?` - `String` is not a parameterized type.

This change adds an extra equivalence check, ensuring `?` is tested for equivalence to `String` (or any other type that would fit the generic argument bounds).

Fixes: #837

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
