### PR TITLE
Record with exception in constructor results in invalid byte code

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/CompactConstructorDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/CompactConstructorDeclaration.java
@@ -76,7 +76,7 @@ public class CompactConstructorDeclaration extends ConstructorDeclaration {
 			assert flowInfo.isDefinitelyAssigned(field);
 			fieldAssignments.add(assignment);
 		}
-		if (fieldAssignments.isEmpty())
+		if (fieldAssignments.isEmpty() || (flowInfo.tagBits & FlowInfo.UNREACHABLE_OR_DEAD) != 0)
 			return;
 
 		Statement[] fa = fieldAssignments.toArray(new Statement[0]);


### PR DESCRIPTION
The following code results in generating instructions after an `athrow` byte code statement:

```
record X(String s) {
    X {
        throw new RuntimeException();
    }
}
```

This is due to
`CompactConstructorDeclaration.checkAndGenerateFieldAssignment()` appending field assignments after the record constructor body.

This change adjusts `CompactConstructorDeclaration` to not generate field assignments if the execution flow is unreachable or dead after adding the statements from the record constructor. This prevents generating code after an `athrow` statement in the byte code.

Fixes: #487

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
