### PR TITLE
Exception thrown during auto complete for Optional

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/IntersectionTypeBinding18.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/IntersectionTypeBinding18.java
@@ -39,6 +39,8 @@ import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
  */
 public class IntersectionTypeBinding18 extends ReferenceBinding {
 
+	private static final char[] INTERSECTION_PACKAGE_NAME = "<package intersection>".toCharArray(); //$NON-NLS-1$
+
 	public ReferenceBinding [] intersectingTypes;
 	private ReferenceBinding javaLangObject;
 	int length;
@@ -253,6 +255,11 @@ public class IntersectionTypeBinding18 extends ReferenceBinding {
 		if (classIdx > -1 && classIdx < Integer.MAX_VALUE)
 			return this.intersectingTypes[classIdx].erasure();
 		return this;
+	}
+
+	@Override
+	public char[] qualifiedPackageName() {
+		return INTERSECTION_PACKAGE_NAME;
 	}
 
 	@Override

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests18.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests18.java
@@ -6776,4 +6776,27 @@ public void testGH767() throws JavaModelException {
 	assertTrue(String.format("Result doesn't contain expected method (%s)", result),
 			result.contains("length[METHOD_REF]{length(), Ljava.lang.String;, ()I, length, null, 60}\n"));
 }
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/831
+public void testIntersection18GH831() throws Exception {
+	this.workingCopies = new ICompilationUnit[1];
+	this.workingCopies[0] = getWorkingCopy(
+			"/Completion/src/Foo.java",
+			"public class Foo {\n"
+			+ "    public void foo() {\n"
+			+ "			java.util.Optional.of(true ? 0 : \"\")."
+			+ "    }\n"
+			+ "}");
+
+	CompletionTestsRequestor2 requestor = new CompletionTestsRequestor2(true);
+	requestor.allowAllRequiredProposals();
+
+	String str = this.workingCopies[0].getSource();
+	String completeBehind = "of(true ? 0 : \"\").";
+	int cursorLocation = str.lastIndexOf(completeBehind) + completeBehind.length();
+	this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner, new NullProgressMonitor());
+
+	String result = requestor.getResults();
+	assertTrue(String.format("Result doesn't contain expected method (%s)", result),
+	result.contains("get[METHOD_REF]{get(), Ljava.util.Optional<Ljava.io.Serializable;>;, ()Ljava.io.Serializable;, get, null, 60}\n"));
+}
 }


### PR DESCRIPTION
Add an override `IntersectionTypeBinding18.qualifiedPackageName()` to prevent exceptions in `IntersectionTypeBinding18.getPackage()`, when trying to retrieve the package name of a type intersection.

The new override is similar to the override for `qualifiedSourceName()`.

Fixes: #831

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
