### PR TITLE
Bug 574111 - Catch TheNotFoundPackage

### DIFF
--- a/org.eclipse.jdt.apt.tests/src-ext/META-INF/services/javax.annotation.processing.Processor
+++ b/org.eclipse.jdt.apt.tests/src-ext/META-INF/services/javax.annotation.processing.Processor
@@ -1,0 +1,1 @@
+org.eclipse.jdt.apt.tests.external.annotations.batch.BatchGenProcessor

--- a/org.eclipse.jdt.apt.tests/src-ext/org/eclipse/jdt/apt/tests/external/annotations/batch/BatchGenProcessor.java
+++ b/org.eclipse.jdt.apt.tests/src-ext/org/eclipse/jdt/apt/tests/external/annotations/batch/BatchGenProcessor.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2005 BEA Systems, Inc and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    Salesforce - extracted and adapted from BatchGenAnnotationFactory
+ *******************************************************************************/
+package org.eclipse.jdt.apt.tests.external.annotations.batch;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Set;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.TypeElement;
+import javax.tools.Diagnostic.Kind;
+import javax.tools.JavaFileObject;
+
+@SupportedAnnotationTypes("org.eclipse.jdt.apt.tests.external.annotations.batch.BatchGen")
+@SupportedSourceVersion(SourceVersion.RELEASE_6)
+public class BatchGenProcessor extends AbstractProcessor {
+
+	private static int ROUND = 0;
+
+	@Override
+	public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+		try {
+			if( ROUND == 0 ){
+				ROUND ++;
+				JavaFileObject builderFile = processingEnv.getFiler().createSourceFile("p1.Class0");
+				try (PrintWriter writer = new PrintWriter(builderFile.openWriter())){
+					writer.print("package p1;\n");
+					writer.print("public class Class0{ X x; }");
+				}
+				builderFile = processingEnv.getFiler().createSourceFile("p1.gen.Class1");
+				try (PrintWriter writer = new PrintWriter(builderFile.openWriter())){
+					writer.print("package p1.gen;\n");
+					writer.print("public class Class1{}");
+				}
+				builderFile = processingEnv.getFiler().createSourceFile("p1.gen.Class2");
+				try (PrintWriter writer = new PrintWriter(builderFile.openWriter())){
+					writer.print("package p1.gen;\n");
+					writer.print("public class Class2{ Class1 class1; }");
+				}
+				return true;
+			}
+			else { // NO-OP
+				return false;
+			}
+		} catch (IOException e) {
+			processingEnv.getMessager().printMessage(Kind.ERROR, e.getMessage());
+		}
+
+		return false;
+	}
+
+}

--- a/org.eclipse.jdt.apt.tests/src/org/eclipse/jdt/apt/tests/AnnotationProcessingCompilerToolTest.java
+++ b/org.eclipse.jdt.apt.tests/src/org/eclipse/jdt/apt/tests/AnnotationProcessingCompilerToolTest.java
@@ -1,0 +1,222 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2022 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Salesforce - copied and adapted from org.eclipse.jdt.core.tests.compiler.regression.BatchCompilerTest
+ *******************************************************************************/
+package org.eclipse.jdt.apt.tests;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+
+import javax.tools.Diagnostic;
+import javax.tools.DiagnosticListener;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaCompiler.CompilationTask;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.ToolProvider;
+
+import org.eclipse.jdt.core.tests.compiler.regression.AbstractBatchCompilerTest;
+import org.eclipse.jdt.internal.compiler.tool.EclipseCompiler;
+
+import junit.framework.Test;
+import junit.framework.TestSuite;
+
+@SuppressWarnings("restriction")
+public class AnnotationProcessingCompilerToolTest extends AbstractBatchCompilerTest {
+
+	public static record JavacArguments(List<Path> classPath, Path classOutput, Path nativeHeaderOutput, List<Path> sourcePath, List<Path> sourceFiles, Path system, List<Path> bootClassPath, List<Path> processorPath, Path sourceOutput) {};
+
+	public static Test suite() {
+		return new TestSuite(AnnotationProcessingCompilerToolTest.class);
+	}
+
+	private File _extJar; // external annotation jar
+
+	public AnnotationProcessingCompilerToolTest(String name) {
+		super(name);
+	}
+
+	@Override
+	protected void setUp() throws Exception {
+		super.setUp();
+
+		_extJar = TestUtil.createAndAddExternalAnnotationJar(null /* no project */);
+	}
+
+	public void test_github844() throws IOException {
+		// @formatter:off
+		runTest(
+			true /* shouldCompileOK */,
+			new String [] { /* sourceFiles */
+				"X.java",
+				"package p1;\n"
+				+ "\n import org.eclipse.jdt.apt.tests.external.annotations.batch.*;"
+				+ "\n import p1.gen.*;"
+				+ "\n@BatchGen\n"
+				+ "public class X {"
+				+ "   Class0 clazz0;\n"
+				+ "   Class1 clazz1;\n"
+				+ "}\n",
+			},
+			null /* standardJavaFileManager */,
+			Arrays.asList(
+					"-d", OUTPUT_DIR,
+			        "-source", "1.6",
+			        "-g", "-preserveAllLocals",
+			        "-cp",  OUTPUT_DIR  + File.pathSeparator + _extJar.getAbsolutePath() ,
+			        "-s", OUTPUT_DIR  +  File.separator + "src-gen",
+			        "-processorpath", _extJar.getAbsolutePath(),
+			        "-XprintProcessorInfo", "-XprintRounds",
+			        "-proceedOnError"
+					) /* options */,
+			new String[] { /* compileFileNames */
+				"X.java"
+			},
+			"Round 1:\n"
+			+ "	input files: {p1.X}\n"
+			+ "	annotations: [org.eclipse.jdt.apt.tests.external.annotations.batch.BatchGen]\n"
+			+ "	last round: false\n"
+			+ "Discovered processor service org.eclipse.jdt.apt.tests.external.annotations.batch.BatchGenProcessor\n"
+			+ "  supporting [org.eclipse.jdt.apt.tests.external.annotations.batch.BatchGen]\n"
+			+ "  in jar:file:"  + _extJar.getCanonicalPath() +"!/\n"
+			+ "Processor org.eclipse.jdt.apt.tests.external.annotations.batch.BatchGenProcessor matches [org.eclipse.jdt.apt.tests.external.annotations.batch.BatchGen] and returns true\n"
+			+ "Round 2:\n"
+			+ "	input files: {p1.gen.Class1,p1.gen.Class2,p1.Class0}\n"
+			+ "	annotations: []\n"
+			+ "	last round: false\n"
+			+ "Processor org.eclipse.jdt.apt.tests.external.annotations.batch.BatchGenProcessor matches [] and returns false\n"
+			+ "Round 3:\n"
+			+ "	input files: {}\n"
+			+ "	annotations: []\n"
+			+ "	last round: true\n" /* expectedOutOutputString */,
+			"" /* expectedErrOutputString */,
+			true /* shouldFlushOutputDirectory */ );
+		// @formatter:on
+	}
+
+	protected static class CompilerInvocationTestsArguments {
+		StandardJavaFileManager standardJavaFileManager;
+		List<String> options;
+		String[] fileNames;
+		public CompilerInvocationTestsArguments(
+				StandardJavaFileManager standardJavaFileManager,
+				List<String> options,
+				String[] fileNames) {
+			this.standardJavaFileManager = standardJavaFileManager;
+			this.options = options;
+			this.fileNames = fileNames;
+		}
+		@Override
+		public String toString() {
+			StringBuffer result = new StringBuffer();
+			for (String option: this.options) {
+				result.append(option);
+				result.append(' ');
+			}
+			return result.toString();
+		}
+	}
+	static class CompilerInvocationDiagnosticListener implements DiagnosticListener<JavaFileObject> {
+		public static final int NONE = 0;
+		public static final int ERROR = 1;
+		public static final int INFO = 2;
+		public static final int WARNING = 4;
+
+		private PrintWriter err;
+		public int kind;
+
+		public CompilerInvocationDiagnosticListener(PrintWriter err) {
+			this.err = err;
+			this.kind = NONE;
+		}
+		@Override
+		public void report(Diagnostic<? extends JavaFileObject> diagnostic) {
+			err.println(diagnostic.getMessage(Locale.getDefault()));
+			if (this.kind == NONE) {
+				switch(diagnostic.getKind()) {
+					case ERROR :
+						this.kind = ERROR;
+						break;
+					case WARNING :
+					case MANDATORY_WARNING :
+						this.kind = WARNING;
+						break;
+					case NOTE :
+					case OTHER :
+						this.kind = INFO;
+				}
+			}
+		}
+	}
+	static EclipseCompiler COMPILER = new EclipseCompiler();
+	static JavaCompiler JAVAC_COMPILER = ToolProvider.getSystemJavaCompiler();
+	@Override
+	protected boolean invokeCompiler(
+			PrintWriter out,
+			PrintWriter err,
+			Object extraArguments,
+			TestCompilationProgress compilationProgress) {
+		CompilerInvocationTestsArguments arguments = (CompilerInvocationTestsArguments) extraArguments;
+		StandardJavaFileManager manager = arguments.standardJavaFileManager;
+		boolean ownsManager = false;
+		if (manager == null) {
+			manager = COMPILER.getStandardFileManager(null, null, null); // will pick defaults up
+			ownsManager = true;
+		}
+		try {
+			List<File> files = new ArrayList<File>();
+			String[] fileNames = arguments.fileNames;
+			for (int i = 0, l = fileNames.length; i < l; i++) {
+				if (fileNames[i].startsWith(OUTPUT_DIR)) {
+					files.add(new File(fileNames[i]));
+				} else {
+					files.add(new File(OUTPUT_DIR + File.separator + fileNames[i]));
+				}
+			}
+			CompilationTask task = COMPILER.getTask(out, arguments.standardJavaFileManager /* carry the null over */, new CompilerInvocationDiagnosticListener(err), arguments.options, null, manager.getJavaFileObjectsFromFiles(files));
+			return task.call();
+		} finally {
+			try {
+				if (ownsManager)
+					manager.close();
+			} catch (IOException e) {
+				// nop
+			}
+		}
+	}
+
+	protected void runTest(
+			boolean shouldCompileOK,
+			String[] sourceFiles,
+			StandardJavaFileManager standardJavaFileManager,
+			List<String> options,
+			String[] compileFileNames,
+			String expectedOutOutputString,
+			String expectedErrOutputString,
+			boolean shouldFlushOutputDirectory) {
+		super.runTest(
+			shouldCompileOK,
+			sourceFiles,
+			new CompilerInvocationTestsArguments(standardJavaFileManager, options, compileFileNames),
+			expectedOutOutputString,
+			expectedErrOutputString,
+			shouldFlushOutputDirectory,
+			null /* progress */);
+	}
+
+}

--- a/org.eclipse.jdt.apt.tests/src/org/eclipse/jdt/apt/tests/TestAll.java
+++ b/org.eclipse.jdt.apt.tests/src/org/eclipse/jdt/apt/tests/TestAll.java
@@ -62,6 +62,7 @@ public class TestAll extends TestCase {
 		suite.addTest(ScannerTests.suite());
 		suite.addTest(DeclarationVisitorTests.suite());
 		suite.addTest(TypeVisitorTests.suite());
+		suite.addTest(AnnotationProcessingCompilerToolTest.suite());
 
 		return suite;
 

--- a/org.eclipse.jdt.apt.tests/src/org/eclipse/jdt/apt/tests/TestUtil.java
+++ b/org.eclipse.jdt.apt.tests/src/org/eclipse/jdt/apt/tests/TestUtil.java
@@ -156,9 +156,10 @@ public class TestUtil
 
 		}
 
-		addLibraryEntry( project, new Path(classesJarPath), null /*srcAttachmentPath*/,
-				null /*srcAttachmentPathRoot*/, true );
-
+		if(project != null) {
+			addLibraryEntry( project, new Path(classesJarPath), null /*srcAttachmentPath*/,
+					null /*srcAttachmentPathRoot*/, true );
+		}
 
 		// This file will be locked until GC takes care of unloading the
 		// annotation processor classes, so we can't delete it ourselves.

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/LookupEnvironment.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/LookupEnvironment.java
@@ -1148,7 +1148,7 @@ public PlainPackageBinding createPlainPackage(char[][] compoundName) {
 				// parent.getPackage0() may have been too shy, so drill into the split:
 				packageBinding = singleParent.getPackage0(compoundName[i]);
 			}
-			if (packageBinding == null) {
+			if (packageBinding == null || packageBinding == TheNotFoundPackage) {
 				packageBinding = this.module.createDeclaredPackage(CharOperation.subarray(compoundName, 0, i + 1), parent);
 				packageBinding = parent.addPackage(packageBinding, this.module);
 			}


### PR DESCRIPTION
The condition must replicate what's possible in the outer condition on line 1126. The package is allowed to be null *and* TheNotFoundPackage.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/844

## What it does
Fixes #844.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
