### PR TITLE
Bad selection for method call with nested instanceof argument

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/parser/SelectionTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/parser/SelectionTest.java
@@ -2515,4 +2515,55 @@ public void _test56() {
 		expectedReplacedSource,
 		testName);
 }
+/*
+ * Test that an {@code instanceof} expression for an object field
+ * doesn't result in a bad selection when nested in a method invocation.
+ * See: https://github.com/eclipse-jdt/eclipse.jdt.core/issues/848
+ */
+public void testInstanceOfFieldGh848() {
+	String str =
+		"public class X {                     \n" +
+		"    public Object o = new Object();\n" +
+		"    public static void bar() {\n" +
+		"        Test x = new Test();\n" +
+		"        foo(x.o instanceof Object);\n" +
+		"    }\n" +
+		"    private static void foo(boolean b) {\n" +
+		"    }" +
+		"}								     \n";
+
+	String selection = "foo";
+
+	String expectedCompletionNodeToString = "<SelectOnMessageSend:foo((x.o instanceof Object))>";
+
+	String completionIdentifier = "foo";
+	String expectedUnitDisplayString =
+			"public class X {\n" +
+			"  public Object o;\n" +
+			"  public X() {\n" +
+			"  }\n" +
+			"  public static void bar() {\n" +
+			"    Test x;\n" +
+			"    <SelectOnMessageSend:foo((x.o instanceof Object))>;\n" +
+			"  }\n" +
+			"  private static void foo(boolean b) {\n" +
+			"  }\n" +
+			"}\n";
+	String expectedReplacedSource = "foo(x.o instanceof Object)";
+	String testName = "<select inside instanceof statement>";
+
+	int selectionStart = str.indexOf(selection);
+	int selectionEnd = str.indexOf(selection) + selection.length() - 1;
+
+	this.checkMethodParse(
+		str.toCharArray(),
+		selectionStart,
+		selectionEnd,
+		expectedCompletionNodeToString,
+		expectedUnitDisplayString,
+		completionIdentifier,
+		expectedReplacedSource,
+		testName);
+}
+
 }

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionParser.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionParser.java
@@ -819,7 +819,7 @@ protected void consumeInsideCastExpressionWithQualifiedGenerics() {
 }
 @Override
 protected void consumeInstanceOfExpression() {
-	if (indexOfAssistIdentifier() < 0) {
+	if (indexOfAssistIdentifier() < 0 || this.genericsIdentifiersLengthPtr < 0) {
 		super.consumeInstanceOfExpression();
 	} else {
 		getTypeReference(this.intStack[this.intPtr--]);


### PR DESCRIPTION
Selecting a method with a call as follows results in an AIOOBE:

```
foo(x.y instanceof Object);
```

This change adjusts `SelectionParser.consumeInstanceOfExpression()` to not try to parse a type reference if there are no generic identifiers. This prevents an AIOOBE in the method.

Fixes: #848

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
