### PR TITLE
Field assignment to anonymous type breaks selection

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ResolveTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ResolveTests.java
@@ -2733,4 +2733,39 @@ public void testConstantInLocal() throws JavaModelException {
 			"CONSTANT [in Local [in main(String[]) [in X [in [Working copy] Test2.java [in <default> [in src [in Resolve]]]]]]]",
 			elements);
 }
+/*
+ * Test that assigning a anonymous inner class definition to a field
+ * doesn't result in a bad selections within the inner class.
+ * See: https://github.com/eclipse-jdt/eclipse.jdt.core/issues/860
+ */
+public void testAssignAnonymousClassToFieldGh860() throws Exception {
+	this.workingCopies = new ICompilationUnit[2];
+	this.workingCopies[0] = getWorkingCopy(
+			"/Resolve/src/X.java",
+			"public class X {\n" +
+			"	public static class S {\n" +
+			"		public void testMethod() {}\n" +
+			"	}\n" +
+			"	Object o;\n" +
+			"	public void foo(){\n" +
+			"	    o = new Object(){\n" +
+			"	        public void m(){\n" +
+			"	            S s = new S();\n" +
+			"	            s.testMethod();\n" +
+			"	        }\n" +
+			"	    };\n" +
+			"	}\n" +
+			"}\n");
+
+	String str = this.workingCopies[0].getSource();
+	String selection = "s.testMethod";
+	int start = str.indexOf(selection);
+	int length = selection.length();
+	IJavaElement[] elements = this.workingCopies[0].codeSelect(start, length, this.wcOwner);
+
+	assertElementsEqual(
+			"Unexpected elements after selecting method in anonymous class assigned to a field",
+			"testMethod() [in S [in X [in [Working copy] X.java [in <default> [in src [in Resolve]]]]]]",
+			elements);
+}
 }

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/impl/AssistParser.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/impl/AssistParser.java
@@ -31,6 +31,7 @@ import org.eclipse.jdt.internal.compiler.ast.ASTNode;
 import org.eclipse.jdt.internal.compiler.ast.AbstractMethodDeclaration;
 import org.eclipse.jdt.internal.compiler.ast.AbstractVariableDeclaration;
 import org.eclipse.jdt.internal.compiler.ast.Annotation;
+import org.eclipse.jdt.internal.compiler.ast.Assignment;
 import org.eclipse.jdt.internal.compiler.ast.Block;
 import org.eclipse.jdt.internal.compiler.ast.CaseStatement;
 import org.eclipse.jdt.internal.compiler.ast.CompilationUnitDeclaration;
@@ -50,6 +51,7 @@ import org.eclipse.jdt.internal.compiler.ast.ModuleDeclaration;
 import org.eclipse.jdt.internal.compiler.ast.ModuleReference;
 import org.eclipse.jdt.internal.compiler.ast.NameReference;
 import org.eclipse.jdt.internal.compiler.ast.RecordPattern;
+import org.eclipse.jdt.internal.compiler.ast.QualifiedAllocationExpression;
 import org.eclipse.jdt.internal.compiler.ast.RequiresStatement;
 import org.eclipse.jdt.internal.compiler.ast.Statement;
 import org.eclipse.jdt.internal.compiler.ast.SuperReference;
@@ -437,6 +439,16 @@ public RecoveredElement buildInitialRecoveryState(){
 			LocalDeclaration local = pattern.elementVariable;
 			if (local != null)
 				element = element.add(local, 0);
+			continue;
+		}
+		if (node instanceof Assignment) {
+			Assignment assignment = (Assignment) node;
+			if (assignment.expression instanceof QualifiedAllocationExpression) {
+				QualifiedAllocationExpression expression = (QualifiedAllocationExpression) assignment.expression;
+				if (expression.anonymousType != null) {
+					element.add(assignment, 0);
+				}
+			}
 			continue;
 		}
 	}


### PR DESCRIPTION
Assigning an anonymous inner class to a class field results in a
dysfunctional selection (e.g. open declaration doesn't work). Normally,
`AssistParser.buildInitialRecoveryState()` will ensure completeness of the
code block in which the selection is evaluated.

An assignment expression is not handled in `buildInitialRecoveryState()`,
and so the context in which the selection is evaluated is incomplete.
This can lead to the dysfunctional selection.

This change adjusts `buildInitialRecoveryState()` to handle assignment
expressions, so that selections work as expected.

Fixes: #860

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
