### PR TITLE
Call Hierarchy identifies incompatible methods with same signature

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchBugsTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchBugsTests.java
@@ -13141,7 +13141,7 @@ public void testBug345807() throws CoreException {
 	}
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=355605
-public void testBug355605() throws CoreException {
+public void testBug355605_1() throws CoreException {
 	try {
 	createJavaProject("P");
 
@@ -13163,6 +13163,44 @@ public void testBug355605() throws CoreException {
 			+ "   };\n"
 			+ "}\n"
 			+ "}\n" ;
+		createFile("/P/X.java", fileContent);
+
+		waitUntilIndexesReady();
+		this.resultCollector = new TestCollector();
+		this.resultCollector.showAccuracy(true);
+		ICompilationUnit unit = getCompilationUnit("/P/X.java");
+		IMethod method = selectMethod(unit, "myMethod", 1);
+		IJavaSearchScope hierarchyScope = SearchEngine.createHierarchyScope((IType)method.getParent());
+		search(method, IMPLEMENTORS, EXACT_RULE, hierarchyScope, this.resultCollector);
+		assertSearchResults("Unexpected search results!", "X.java void X$R.t:<anonymous>#1.s:<anonymous>#1.myMethod() [myMethod] EXACT_MATCH", this.resultCollector);
+
+	} finally {
+		deleteProject("P");
+	}
+}
+public void testBug355605_2() throws CoreException {
+	try {
+		createJavaProject("P");
+
+		String fileContent =
+				"public class X { \n"
+						+ "class R {\n"
+						+ "   class S {\n"
+						+ "     S(String s) {}\n"
+						+ "   	void setInfo(String x) {\n"
+						+ "   	}\n"
+						+ "   }\n"
+						+ "   class T {\n"
+						+ "   }\n"
+						+ "	T t = new T()  {\n"
+						+ "		S s = new S(\"test\") {\n"
+						+ "           void myMethod() {\n"
+						+ "               setInfo(\"a\");\n"
+						+ "           }\n"
+						+ "      };// S ends\n"
+						+ "   };\n"
+						+ "}\n"
+						+ "}\n" ;
 		createFile("/P/X.java", fileContent);
 
 		waitUntilIndexesReady();

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/core/search/SearchPattern.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/core/search/SearchPattern.java
@@ -2453,10 +2453,19 @@ private static char[][] enclosingTypeNames(IType type) {
 		case IJavaElement.FIELD:
 		case IJavaElement.INITIALIZER:
 		case IJavaElement.METHOD:
+			char[] typeName = IIndexConstants.ONE_STAR;
+			try {
+				String superclassName = type.getSuperclassName();
+				if (superclassName != null) {
+					typeName = (type.getOccurrenceCount() + ".new " + superclassName + "(){}").toCharArray(); //$NON-NLS-1$ //$NON-NLS-2$
+				}
+			} catch (JavaModelException e) {
+				// fall back to using '*'
+			}
 			IType declaringClass = ((IMember) parent).getDeclaringType();
 			return CharOperation.arrayConcat(
 				enclosingTypeNames(declaringClass),
-				new char[][] {declaringClass.getElementName().toCharArray(), IIndexConstants.ONE_STAR});
+				new char[][] {declaringClass.getElementName().toCharArray(), typeName});
 		case IJavaElement.TYPE:
 			return CharOperation.arrayConcat(
 				enclosingTypeNames((IType)parent),


### PR DESCRIPTION
Given an anonymous type defined in a method, the call hierarchy of a
method in the anonymous type can contain wrong entries. This is due to
`SearchPattern.enclosingTypeNames()` adding `*` symbols to a part of the
search pattern, for anonymous types defined in a method. The `*` symbol
then matches more inner types than actual matches.

This change replaces the `*` symbol with type names, when possible. This
ensures no unexpected matches are seen in the call hierarchy.

Fixes: #856

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
