### PR TITLE
Content assist does not work after switch and lambda

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Scanner.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Scanner.java
@@ -5550,6 +5550,11 @@ protected boolean mayBeAtCaseLabelExpr() {
 				(this.lookBack[0] == TerminalTokens.TokenNamecase || this.lookBack[0] == TerminalTokens.TokenNameCOMMA)
 				: false;
 	}
+	if (this.lookBack[0] == TokenNameBeginLambda) {
+		return JavaFeature.PATTERN_MATCHING_IN_SWITCH.isSupported(this.complianceLevel, this.previewEnabled) ?
+				this.lookBack[1] != TokenNameRPAREN
+				: false;
+	}
 	return true;
 }
 

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchExpressionsYieldTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchExpressionsYieldTest.java
@@ -6167,4 +6167,69 @@ public class SwitchExpressionsYieldTest extends AbstractRegressionTest {
 			"Syntax error, insert \";\" to complete BlockStatements\n" +
 			"----------\n");
 	}
+	/**
+	 * Test for the bug, a switch in a method followed by a lambda in another method,
+	 * followed by an incomplete method definition.
+	 * Instead of seeing only compile errors for the incomplete method definition,
+	 * compile errors are seen for the switch and the lambda too.
+	 * See: https://github.com/eclipse-jdt/eclipse.jdt.core/issues/193
+	 */
+	public void testSwitchAndLambdaGh193_compileErrors() {
+		runNegativeTest(
+				new String[] {
+					"X.java",
+					"public class X {\n"+
+					"\n"+
+					"       void a() {\n"+
+					"               switch (1) {\n"+
+					"                       case 1: {\n"+
+					"                           break;\n"+
+					"                       }\n"+
+					"               };\n"+
+					"       }\n"+
+					"       void b() {\n"+
+					"               Runnable r = () -> {\n"+
+					"               };\n"+
+					"       }\n"+
+					"       private fi\n"+
+					"}\n"
+				},
+				"----------\n"+
+				"1. ERROR in X.java (at line 14)\n"+
+				"	private fi\n"+
+				"	        ^^\n"+
+				"Syntax error, insert \"Identifier (\" to complete MethodHeaderName\n"+
+				"----------\n"+
+				"2. ERROR in X.java (at line 14)\n"+
+				"	private fi\n"+
+				"	        ^^\n"+
+				"Syntax error, insert \")\" to complete MethodDeclaration\n"+
+				"----------\n"+
+				"3. ERROR in X.java (at line 14)\n"+
+				"	private fi\n"+
+				"	        ^^\n"+
+				"Syntax error, insert \";\" to complete MethodDeclaration\n"+
+				"----------\n");
+	}
+	/**
+	 * Extra test for the bug fix, ensure a lambda inside an arrow switch case doesn't cause compile errors.
+	 * See: https://github.com/eclipse-jdt/eclipse.jdt.core/issues/193
+	 */
+	public void testSwitchAndLambdaGh193_nestedLambda() {
+		this.runConformTest(
+				new String[] {
+					"X.java",
+					"public class X {\n"+
+					"	public static void main(String[] args) {\n"+
+					"		java.util.function.Supplier<Runnable> s = switch (1) {\n"+
+					"			case 1 -> () -> () -> System.out.println(\"1\");\n"+
+					"			case 2 -> () -> () -> System.out.println(\"2\");\n"+
+					"			default -> () -> () -> System.out.println(\"default\");\n"+
+					"		};\n"+
+					"		s.get().run();\n"+
+					"	}\n"+
+					"}"
+				},
+				"1");
+	}
 }


### PR DESCRIPTION
The fix for bug 565844 introduces a regression, with a switch and a
lambda in different methods, followed by an incomplete method
definition.

This is due to Scanner.disambiguateArrowWithCaseExpr() including the
switch case statement when scanning the lambda expression. Specifically,
Scanner.caseStartPosition is set in Scanner.updateCase() but is never
set back to -1 once scanning the switch expression is done.

This change adjusts Scanner.mayBeAtCaseLabelExpr() to check
Scanner.lookBack for lambda definition symbols, "-> (". If so, assume no
case label expression. This prevents confusing the lambda for an arrow
case of a switch expression.

Fixes: #193

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
