### PR TITLE
Don't put package or import statements ahead of header comments

### DIFF
--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/imports/ImportRewriteAnalyzer.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/imports/ImportRewriteAnalyzer.java
@@ -316,13 +316,15 @@ public final class ImportRewriteAnalyzer {
 			}
 			else {
 				surroundingStart = 0;
-				ASTNode topNode = nodesTreeMap.firstEntry().getValue();
-				if (topNode instanceof Comment) {
-					for (ASTNode node : nodesTreeMap.values()) {
-						if (!(node instanceof Comment)) {
-							break;
-						} else {
-							surroundingStart = node.getStartPosition() + node.getLength();
+				if (!nodesTreeMap.isEmpty()) {
+					ASTNode topNode = nodesTreeMap.firstEntry().getValue();
+					if (topNode instanceof Comment) {
+						for (ASTNode node : nodesTreeMap.values()) {
+							if (!(node instanceof Comment)) {
+								break;
+							} else {
+								surroundingStart = node.getStartPosition() + node.getLength();
+							}
 						}
 					}
 				}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/imports/ImportRewriteAnalyzer.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/imports/ImportRewriteAnalyzer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2013, 2014, 2015 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -28,6 +28,7 @@ import java.util.Map.Entry;
 import java.util.NavigableMap;
 import java.util.Set;
 import java.util.TreeMap;
+
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
@@ -315,6 +316,16 @@ public final class ImportRewriteAnalyzer {
 			}
 			else {
 				surroundingStart = 0;
+				ASTNode topNode = nodesTreeMap.firstEntry().getValue();
+				if (topNode instanceof Comment) {
+					for (ASTNode node : nodesTreeMap.values()) {
+						if (!(node instanceof Comment)) {
+							break;
+						} else {
+							surroundingStart = node.getStartPosition() + node.getLength();
+						}
+					}
+				}
 			}
 
 			positionAfterImports = surroundingStart;


### PR DESCRIPTION
- modify CopyResourceElementsOperation.updatePackageStatement() to add any header comments to package statement if no package statement existed previously and delete the original comments so there aren't duplicates
- modify ImportRewriteAnalyzer.determineSurroundingRegion() to calculate start of imports to be after any header comments if no package statement currently exists
- for #649

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes organize imports and move resource to preserve header comments when adding imports to a class that is in the default package or moving a class from the default package to another package that will end up adding package statement.  See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See examples in issue.  Tests will be added to jdt.ui once this patch is merged.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
