### PR TITLE
Fix unknown ref for metaindex Fix:#902

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchBugs9Tests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchBugs9Tests.java
@@ -4800,6 +4800,32 @@ public void testMethodReferenceForTypeFromJREModuleBugGh740() throws Exception {
 		deleteProject(projectName);
 	}
 }
+public void testGH902_whenTypeReferenceIsUnknown_expectToBeFound() throws CoreException {
+	try {
+		IJavaProject project = createJava9Project("JavaSearchBugs9");
+		project.open(null);
+		createFile("JavaSearchBugs9/src/GH902.java",
+		"""
+			public class GH902 {
+				public static void foo() {
+					StackWalker.getInstance().forEach(s -> System.out.println(s));
+				}
+			}
+		""");
 
+		// sync
+		project.close();
+		project.open(null);
+
+		IType type = project.findType("java.lang.StackWalker");
+		assertNotNull("type should not be null", type);
+		search(type, REFERENCES, EXACT_RULE, SearchEngine.createWorkspaceScope());
+		assertTrue("Actual: ".concat(this.resultCollector.toString()), this.resultCollector.toString()
+				.contains("src/GH902.java void GH902.foo() [StackWalker] EXACT_MATCH"));
+	}
+	finally {
+		deleteProject("JavaSearchBugs9");
+	}
+}
 // Add more tests here
 }

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/core/search/SearchPattern.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/core/search/SearchPattern.java
@@ -2234,9 +2234,8 @@ public static SearchPattern createPattern(IJavaElement element, int limitTo, int
 			break;
 		case IJavaElement.TYPE :
 			IType type = (IType)element;
-			char[] simpleName = type.getElementName().toCharArray();
-			searchPattern = 	createTypePattern(
-					simpleName,
+			searchPattern = createTypePattern(
+						type.getElementName().toCharArray(),
 						type.getPackageFragment().getElementName().toCharArray(),
 						ignoreDeclaringType ? null : enclosingTypeNames(type),
 						null,
@@ -2246,6 +2245,9 @@ public static SearchPattern createPattern(IJavaElement element, int limitTo, int
 			if ((maskedLimitTo == IJavaSearchConstants.DECLARATIONS) ||
 					(maskedLimitTo == IJavaSearchConstants.REFERENCES)) {
 				char[] qualifiedName = type.getFullyQualifiedName().toCharArray();
+				// for java.lang type refs the element name is qualified with the java.lang, but at indexing time we only
+				// have the simple name. So we should make sure we search for the simple name as well.
+				char[] simpleName = CharOperation.lastSegment(type.getElementName().toCharArray(), '.');
 				qualifiedName = CharOperation.equals(simpleName, qualifiedName) ? CharOperation.NO_CHAR : qualifiedName;
 				MatchLocator.setIndexQualifierQuery(searchPattern, QualifierQuery.encodeQuery(new QueryCategory[] {
 						QueryCategory.REF

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/core/search/SearchPattern.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/core/search/SearchPattern.java
@@ -2234,8 +2234,9 @@ public static SearchPattern createPattern(IJavaElement element, int limitTo, int
 			break;
 		case IJavaElement.TYPE :
 			IType type = (IType)element;
-			searchPattern = createTypePattern(
-						type.getElementName().toCharArray(),
+			char[] simpleName = type.getElementName().toCharArray();
+			searchPattern = 	createTypePattern(
+					simpleName,
 						type.getPackageFragment().getElementName().toCharArray(),
 						ignoreDeclaringType ? null : enclosingTypeNames(type),
 						null,
@@ -2245,9 +2246,6 @@ public static SearchPattern createPattern(IJavaElement element, int limitTo, int
 			if ((maskedLimitTo == IJavaSearchConstants.DECLARATIONS) ||
 					(maskedLimitTo == IJavaSearchConstants.REFERENCES)) {
 				char[] qualifiedName = type.getFullyQualifiedName().toCharArray();
-				// for java.lang type refs the element name is qualified with the java.lang, but at indexing time we only
-				// have the simple name. So we should make sure we search for the simple name as well.
-				char[] simpleName = CharOperation.lastSegment(type.getElementName().toCharArray(), '.');
 				qualifiedName = CharOperation.equals(simpleName, qualifiedName) ? CharOperation.NO_CHAR : qualifiedName;
 				MatchLocator.setIndexQualifierQuery(searchPattern, QualifierQuery.encodeQuery(new QueryCategory[] {
 						QueryCategory.REF

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/index/DiskIndex.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/index/DiskIndex.java
@@ -53,7 +53,7 @@ private int bufferIndex, bufferEnd; // used when reading from the file into the 
 private int streamEnd; // used when writing data from the streamBuffer to the file
 char separator = Index.DEFAULT_SEPARATOR;
 
-public static final String INDEX_VERSION = "1.132"; //$NON-NLS-1$
+public static final String INDEX_VERSION = "1.133"; //$NON-NLS-1$
 public static final String SIGNATURE = "INDEX VERSION " + INDEX_VERSION; //$NON-NLS-1$
 private static final char[] SIGNATURE_CHARS = SIGNATURE.toCharArray();
 public static boolean DEBUG = false;

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/SourceIndexerRequestor.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/SourceIndexerRequestor.java
@@ -149,6 +149,7 @@ public void acceptUnknownReference(char[][] name, int sourceStart, int sourceEnd
 @Override
 public void acceptUnknownReference(char[] name, int sourcePosition) {
 	this.indexer.addNameReference(name);
+	this.indexer.addIndexMetaQualification(name, false);
 }
 
 private void addDefaultConstructorIfNecessary(TypeInfo typeInfo) {


### PR DESCRIPTION
## What it does
When updating metaindex, now the unknown references from SourceIndexerRequestor is creating meta index qualifications. In addition to this an uncovered method declaration now adds meta index qualifications as well.

The SearchPattern only to use the computed simple name for meta index qualification query.
Fix:#902

## How to test
Check #902

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
