### PR TITLE
Switch Code gen index OOBE

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ClassFile.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ClassFile.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -3846,7 +3846,9 @@ public class ClassFile implements TypeConstants, TypeIds {
 		return localContentsOffset;
 	}
 	private int addBootStrapTypeSwitchEntry(int localContentsOffset, SwitchStatement switchStatement, Map<String, Integer> fPtr) {
-		final int contentsEntries = 10;
+		CaseStatement.ResolvedCase[] constants = switchStatement.otherConstants;
+		int numArgs = constants.length;
+		final int contentsEntries = 10 + (numArgs * 2);
 		int indexFortypeSwitch = fPtr.get(ClassFile.TYPESWITCH_STRING);
 		if (contentsEntries + localContentsOffset >= this.contents.length) {
 			resizeContents(contentsEntries);
@@ -3862,8 +3864,6 @@ public class ClassFile implements TypeConstants, TypeIds {
 
 		// u2 num_bootstrap_arguments
 		int numArgsLocation = localContentsOffset;
-		CaseStatement.ResolvedCase[] constants = switchStatement.otherConstants;
-		int numArgs = constants.length;
 		if (switchStatement.containsNull) --numArgs;
 		this.contents[numArgsLocation++] = (byte) (numArgs >> 8);
 		this.contents[numArgsLocation] = (byte) numArgs;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)

On code analysis, there is a probability of AIOOBE in Switch Code Gen . There is no separate specific test for this, but the safety net need to be increased. In the existing code, there is no provision for a variable number of constants. This pr addresses that issue