### PR TITLE
Call hierarchy has zero results for JARs with module-info

### DIFF
--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/JavaSearchNameEnvironment.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/JavaSearchNameEnvironment.java
@@ -635,4 +635,18 @@ private static boolean isSourceOrExported(PackageFragmentRoot root) {
 	}
 	return isExported;
 }
+
+static boolean isOnModulePath(PackageFragmentRoot root) {
+	boolean isOnModulePath;
+	try {
+		IJavaProject javaProject = root.getJavaProject();
+		IModuleDescription defaultModule = javaProject.getModuleDescription();
+		IModuleDescription moduleForRoot = computeModuleFor(root, defaultModule);
+		isOnModulePath = moduleForRoot != null;
+	} catch (JavaModelException e) {
+		isOnModulePath = true; // if an exception occurs, assume yes
+		Util.log(e, "Error checking whether PackageFragmentRoot is on module path!"); //$NON-NLS-1$
+	}
+	return isOnModulePath;
+}
 }

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/PossibleMatch.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/PossibleMatch.java
@@ -210,9 +210,12 @@ public char[] getModuleName() {
 	if (this.openable instanceof CompilationUnit) {
 		return ((CompilationUnit) this.openable).getModuleName();
 	} else if (this.openable instanceof ClassFile) {
-		IModuleDescription moduleDescription = this.openable.getPackageFragmentRoot().getModuleDescription();
-		if (moduleDescription != null) {
-			return moduleDescription.getElementName().toCharArray();
+		PackageFragmentRoot root = this.openable.getPackageFragmentRoot();
+		if (JavaSearchNameEnvironment.isOnModulePath(root)) {
+			IModuleDescription moduleDescription = root.getModuleDescription();
+			if (moduleDescription != null) {
+				return moduleDescription.getElementName().toCharArray();
+			}
 		}
 	}
 	return null;


### PR DESCRIPTION
With the fix for #675, during a search we no longer add module infos for jars that are not on the module path. This collides with `MatchLocator.skipMatch()`, which checks if a jar has module info based on the package fragment root module info. The search environment doesn't find infos for the module of the jar, so the fix for bug 522606 causes the possible match to be skipped (due to `MatchLocator.skipMatch()`).

Fixes: #935

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
