### PR TITLE
No search results for inner class constructor with outer type argument

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/ClassFileReader.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/ClassFileReader.java
@@ -1481,4 +1481,14 @@ public IRecordComponent[] getRecordComponents() {
 public URI getURI() {
 	return this.path;
 }
+public boolean isStaticInner(char[] innerTypeName) {
+	if (this.innerInfos != null) {
+		for (InnerClassInfo innerClassInfo : this.innerInfos) {
+			if (Arrays.equals(innerTypeName, innerClassInfo.getName())) {
+				return (innerClassInfo.getModifiers() & ClassFileConstants.AccStatic) != 0;
+			}
+		}
+	}
+	return false;
+}
 }

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/index/DiskIndex.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/index/DiskIndex.java
@@ -53,7 +53,7 @@ private int bufferIndex, bufferEnd; // used when reading from the file into the 
 private int streamEnd; // used when writing data from the streamBuffer to the file
 char separator = Index.DEFAULT_SEPARATOR;
 
-public static final String INDEX_VERSION = "1.133"; //$NON-NLS-1$
+public static final String INDEX_VERSION = "1.134"; //$NON-NLS-1$
 public static final String SIGNATURE = "INDEX VERSION " + INDEX_VERSION; //$NON-NLS-1$
 private static final char[] SIGNATURE_CHARS = SIGNATURE.toCharArray();
 public static boolean DEBUG = false;


### PR DESCRIPTION
Constructors of inner types have a synthetic first argument, if the inner type is not static. Both the search and indexer code have various places where its not checked whether the inner type is static. Instead, the type name of the first argument of the constructor is checked - if it matches the name of the outer type, the first argument is assumed to be synthetic.

This causes issues when searching for references of a static inner type constructor which takes the outer type as the first argument. There is no synthetic argument in the constructor, but the search/index code assumes there is and so constructor invocations are not evaluated as matching (due to an argument count mismatch).

This change adjusts several such places that result in inaccurate searches, as well as adds a test case. The disk index version is also incremented, since existing stored indices are wrong w.r.t. static inner type constructors that take the outer type as their first argument.

Fixes: #401

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
