### PR TITLE
Store declaring type arguments info when creating constructor completion

### DIFF
--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/CompletionEngine.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/CompletionEngine.java
@@ -14158,9 +14158,20 @@ public final class CompletionEngine
 		relevance += computeRelevanceForInterestingProposal();
 		relevance += computeRelevanceForRestrictions(accessibility);
 		relevance += computeRelevanceForCaseMatching(this.completionToken, simpleTypeName);
-		relevance += computeRelevanceForExpectingType(typeBinding);
+		int relevanceForExpected = computeRelevanceForExpectingType(typeBinding);
+		relevance += relevanceForExpected;
 		relevance += computeRelevanceForQualification(isQualified);
 		relevance += computeRelevanceForConstructor();
+
+		boolean isCompatibleType = this.expectedTypesPtr < 0 || relevanceForExpected >= R_EXPECTED_TYPE;
+		char[][] typeVariables = null;
+		if (typeBinding != null && typeBinding.typeVariables() != null) {
+			TypeVariableBinding[] variableBindings = typeBinding.erasure().typeVariables();
+			typeVariables = new char[variableBindings.length][];
+			for (int i = 0; i < typeVariables.length; i++) {
+				typeVariables[i] = variableBindings[i].sourceName;
+			}
+		}
 
 		boolean isInterface = false;
 		int kind = typeModifiers & (ClassFileConstants.AccInterface | ClassFileConstants.AccEnum | ClassFileConstants.AccAnnotation);
@@ -14205,6 +14216,8 @@ public final class CompletionEngine
 		typeProposal.setReplaceRange(this.startPosition - this.offset, this.endPosition - this.offset);
 		typeProposal.setTokenRange(this.startPosition - this.offset, this.endPosition - this.offset);
 		typeProposal.setRelevance(relevance);
+		typeProposal.setDeclarationTypeVariables(typeVariables);
+		typeProposal.setCompatibleProposal(isCompatibleType);
 
 		switch (parameterCount) {
 			case -1: // default constructor
@@ -14233,6 +14246,8 @@ public final class CompletionEngine
 						proposal.setReplaceRange(this.endPosition - this.offset, this.endPosition - this.offset);
 						proposal.setTokenRange(this.tokenStart - this.offset, this.tokenEnd - this.offset);
 						proposal.setRelevance(relevance);
+						proposal.setDeclarationTypeVariables(typeVariables);
+						proposal.setCompatibleProposal(isCompatibleType);
 						this.requestor.accept(proposal);
 						if(DEBUG) {
 							this.printDebug(proposal);
@@ -14257,6 +14272,8 @@ public final class CompletionEngine
 						proposal.setReplaceRange(this.endPosition - this.offset, this.endPosition - this.offset);
 						proposal.setTokenRange(this.tokenStart - this.offset, this.tokenEnd - this.offset);
 						proposal.setRelevance(relevance);
+						proposal.setDeclarationTypeVariables(typeVariables);
+						proposal.setCompatibleProposal(isCompatibleType);
 						this.requestor.accept(proposal);
 						if(DEBUG) {
 							this.printDebug(proposal);
@@ -14286,6 +14303,8 @@ public final class CompletionEngine
 						proposal.setReplaceRange(this.endPosition - this.offset, this.endPosition - this.offset);
 						proposal.setTokenRange(this.tokenStart - this.offset, this.tokenEnd - this.offset);
 						proposal.setRelevance(relevance);
+						proposal.setDeclarationTypeVariables(typeVariables);
+						proposal.setCompatibleProposal(isCompatibleType);
 						this.requestor.accept(proposal);
 						if(DEBUG) {
 							this.printDebug(proposal);
@@ -14310,6 +14329,8 @@ public final class CompletionEngine
 						proposal.setReplaceRange(this.endPosition - this.offset, this.endPosition - this.offset);
 						proposal.setTokenRange(this.tokenStart - this.offset, this.tokenEnd - this.offset);
 						proposal.setRelevance(relevance);
+						proposal.setDeclarationTypeVariables(typeVariables);
+						proposal.setCompatibleProposal(isCompatibleType);
 						this.requestor.accept(proposal);
 						if(DEBUG) {
 							this.printDebug(proposal);
@@ -14355,6 +14376,8 @@ public final class CompletionEngine
 						proposal.setReplaceRange(this.endPosition - this.offset, this.endPosition - this.offset);
 						proposal.setTokenRange(this.tokenStart - this.offset, this.tokenEnd - this.offset);
 						proposal.setRelevance(relevance);
+						proposal.setDeclarationTypeVariables(typeVariables);
+						proposal.setCompatibleProposal(isCompatibleType);
 						this.requestor.accept(proposal);
 						if(DEBUG) {
 							this.printDebug(proposal);
@@ -14383,6 +14406,8 @@ public final class CompletionEngine
 						proposal.setReplaceRange(this.endPosition - this.offset, this.endPosition - this.offset);
 						proposal.setTokenRange(this.tokenStart - this.offset, this.tokenEnd - this.offset);
 						proposal.setRelevance(relevance);
+						proposal.setDeclarationTypeVariables(typeVariables);
+						proposal.setCompatibleProposal(isCompatibleType);
 						this.requestor.accept(proposal);
 						if(DEBUG) {
 							this.printDebug(proposal);

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/InternalCompletionProposal.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/InternalCompletionProposal.java
@@ -130,6 +130,20 @@ public class InternalCompletionProposal extends CompletionProposal {
 	 */
 	private char[] declarationKey = null;
 
+ 	/**
+	 * Type variable names of the relevant type declaration
+	 * in the context.
+	 *
+	 * Defaults to null if not set.
+	 *
+	 */
+	private char[][] declarationTypeVariables = null;
+
+	/**
+	 * Indicates whether the proposal is a context-compatible proposal.
+	 */
+	private boolean isCompatibleProposal = true;
+
 	/**
 	 * Simple name of the method, field,
 	 * member, or variable relevant in the context, or
@@ -1202,6 +1216,9 @@ public class InternalCompletionProposal extends CompletionProposal {
 			for (int i= 0; i < types.length; i++) {
 				paramTypeNames[i]= new String(Signature.toCharArray(types[i]));
 			}
+			if (this.declarationTypeVariables != null) {
+				return internalCompletionContext.extendedContext.canUseDiamond(paramTypeNames, this.declarationTypeVariables);
+			}
 			return internalCompletionContext.extendedContext.canUseDiamond(paramTypeNames,declarationType);
 		}
 		else {
@@ -1216,5 +1233,31 @@ public class InternalCompletionProposal extends CompletionProposal {
 
 	public void setArrayDimensions(int dimensions) {
 		this.arrayDimensions = dimensions;
+	}
+
+	/**
+	 * Returns the type variables of the declaring type corresponding to this proposal.
+	 *
+	 * If not set, defaults to null.
+	 *
+	 * @return the type variable names
+	 */
+	public char[][] getDeclarationTypeVariables() {
+		return this.declarationTypeVariables;
+	}
+
+	public void setDeclarationTypeVariables(char[][] declarationTypeVariables) {
+		this.declarationTypeVariables = declarationTypeVariables;
+	}
+
+	/**
+	 * Returns whether the completion proposal is a context-compatible proposal.
+	 */
+	public boolean isCompatibleProposal() {
+		return this.isCompatibleProposal;
+	}
+
+	public void setCompatibleProposal(boolean isCompatibleProposal) {
+		this.isCompatibleProposal = isCompatibleProposal;
 	}
 }

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/InternalExtendedCompletionContext.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/InternalExtendedCompletionContext.java
@@ -945,6 +945,28 @@ public class InternalExtendedCompletionContext {
 		return false;
 	}
 
+	public boolean canUseDiamond(String[] parameterTypes, char[][] typeVariables) {
+		Scope scope = this.assistScope;
+		if (scope.compilerOptions().sourceLevel < ClassFileConstants.JDK1_7)
+			return false;
+		// If no LHS or return type expected, then we can safely use diamond
+		char[][] expectedTypekeys = this.completionContext.getExpectedTypesKeys();
+		if (expectedTypekeys == null || expectedTypekeys.length == 0)
+			return true;
+		// Next, find out whether any of the constructor parameters are the same as one of the
+		// class type variables. If yes, diamond cannot be used.
+		if (typeVariables != null) {
+			for (int i = 0; i < parameterTypes.length; i++) {
+				for (int j = 0; j < typeVariables.length; j++) {
+					if (CharOperation.equals(parameterTypes[i].toCharArray(), typeVariables[j]))
+						return false;
+				}
+			}
+		}
+
+		return true;
+	}
+
 	/**
 	 * @see InternalCompletionContext#getCompletionNode()
 	 */


### PR DESCRIPTION
Rebased Gerrit change https://git.eclipse.org/r/c/jdt/eclipse.jdt.core/+/191217 
Author: jinbwan@microsoft.com

Related issues:
- https://github.com/eclipse/eclipse.jdt.ls/pull/2535#issuecomment-1493803864
- https://bugs.eclipse.org/bugs/show_bug.cgi?id=578969

It's cheap to get the type variable names and the compatibility info when creating constructor completion proposal in CompletionEngine. This can be used in the later completion processing to quick check if the diamond operator is needed.
In addition to storing type arguments, I also save isCompatibleProposal in CompletionProposal. See
LazyGenericTypeProposal#computeTypeArgumentProposals(), if proposed type does not inherit from expected type, it doesn't add any type arguments. The compatibility info can be reused later to quickly skip those incompatible proposals in computeTypeArgumentProposals().
