### PR TITLE
[20] Internal error "info cannot be null" for nested generic record patterns (preview feature) #900

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/InstanceOfExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/InstanceOfExpression.java
@@ -313,13 +313,12 @@ public TypeBinding resolveType(BlockScope scope) {
 	this.constant = Constant.NotAConstant;
 	if (this.elementVariable != null || this.pattern != null)
 		addSecretInstanceOfPatternExpressionValue(scope);
-//	resolvePatternVariable(scope);
+	resolvePatternVariable(scope);
 	TypeBinding checkedType = this.type.resolveType(scope, true /* check bounds*/);
 	if (this.expression instanceof CastExpression) {
 		((CastExpression) this.expression).setInstanceofType(checkedType); // for cast expression we need to know instanceof type to not tag unnecessary when needed
 	}
 	TypeBinding expressionType = this.expression.resolveType(scope);
-	resolvePatternVariable(scope);
 	if (this.pattern != null) {
 		this.pattern.resolveWithExpression(scope, this.expression);
 	}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/RecordPattern.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/RecordPattern.java
@@ -176,7 +176,6 @@ public class RecordPattern extends TypePattern {
 					MethodBinding[] methods = this.resolvedType.getMethods(componentBinding.name);
 					if (methods != null && methods.length > 0) {
 						p.accessorMethod = methods[0];
-//						p.resolvedType = p.accessorMethod.returnType;
 					}
 				}
 			}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/RecordPattern.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/RecordPattern.java
@@ -132,6 +132,11 @@ public class RecordPattern extends TypePattern {
 			this.type.bits |= ASTNode.IgnoreRawTypeCheck;
 			this.resolvedType = this.type.resolveType(scope);
 		}
+		if (this.resolvedType == null) {
+			// Probably called during collectPatternVariablesToScope()
+			// and probably due to an error, this is unresolved.
+			return null;
+		}
 		if (!this.resolvedType.isValidBinding())
 			return this.resolvedType;
 
@@ -144,10 +149,6 @@ public class RecordPattern extends TypePattern {
 			scope.problemReporter().unexpectedTypeinRecordPattern(this.resolvedType, this.type);
 			return this.resolvedType;
 		}
-		if (shouldInitiateRecordTypeInference()) {
-			return this.resolvedType; // do the actual stuff in resolveWithExpression
-		}
-
 		setAccessorsPlusInfuseInferredType(scope);
 		return this.resolvedType;
 	}
@@ -175,6 +176,7 @@ public class RecordPattern extends TypePattern {
 					MethodBinding[] methods = this.resolvedType.getMethods(componentBinding.name);
 					if (methods != null && methods.length > 0) {
 						p.accessorMethod = methods[0];
+//						p.resolvedType = p.accessorMethod.returnType;
 					}
 				}
 			}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypePattern.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypePattern.java
@@ -206,8 +206,8 @@ public class TypePattern extends Pattern {
 					ReferenceBinding recType = (ReferenceBinding) enclosingPattern.resolvedType;
 					if (recType != null) {
 						RecordComponentBinding[] components = recType.components();
-						RecordComponentBinding rcb = components[this.index];
-						if (rcb != null) {
+						if (components.length > this.index) {
+							RecordComponentBinding rcb = components[this.index];
 							TypeVariableBinding[] mentionedTypeVariables = findSyntheticTypeVariables(rcb.type);
 							if  (mentionedTypeVariables != null && mentionedTypeVariables.length > 0) {
 								this.local.type.resolvedType = recType.upwardsProjection(scope, mentionedTypeVariables);


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
