### PR TITLE
ASTRewriteFlattener: Check YieldStatement.isImplicit before append `yield`

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter14Test.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter14Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 IBM Corporation and others.
+ * Copyright (c) 2019, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter14Test.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter14Test.java
@@ -37,6 +37,8 @@ import org.eclipse.jdt.core.dom.Type;
 import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
 import org.eclipse.jdt.core.dom.VariableDeclarationStatement;
 import org.eclipse.jdt.core.dom.YieldStatement;
+import org.eclipse.jdt.internal.core.dom.rewrite.ASTRewriteFlattener;
+import org.eclipse.jdt.internal.core.dom.rewrite.RewriteEventStore;
 
 import junit.framework.AssertionFailedError;
 import junit.framework.Test;
@@ -483,4 +485,27 @@ public class ASTConverter14Test extends ConverterTestSetup {
 
 	}
 
+	public void testBugGH949() throws JavaModelException {
+		if (!isJRE14) {
+			System.err.println("Test "+getName()+" requires a JRE 14");
+			return;
+		}
+		String sourceCode =
+				"public class GH949 {" +
+				"public void test(String s){" +
+				"switch (s){" +
+				"case \"1\" ->System.out.println(\"One\");" +
+				"case \"2\" ->System.out.println(\"Two\");" +
+				"case \"3\" ->System.out.println(\"Three\");" +
+				"}" +
+				"}" +
+				"}";
+
+		this.workingCopies = new ICompilationUnit[] {
+				getWorkingCopy("/Converter14/src/GH949.java", sourceCode, true/* resolve */)
+		};
+		CompilationUnit cu = (CompilationUnit) buildAST(this.workingCopies[0]);
+		String flattened = ASTRewriteFlattener.asString(cu, new RewriteEventStore());
+		assertEquals("Flattened AST", sourceCode, flattened);
+	}
 }

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/ASTRewriteFlattener.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/ASTRewriteFlattener.java
@@ -1635,15 +1635,14 @@ public class ASTRewriteFlattener extends ASTVisitor {
 
 	@Override
 	public boolean visit(YieldStatement node) {
-		if (node.getAST().apiLevel() >= JLS14_INTERNAL && node.isImplicit()  && node.getExpression() == null) {
-			return false;
+		if (!node.isImplicit()) {
+			this.result.append("yield"); //$NON-NLS-1$
 		}
-
-		this.result.append("yield"); //$NON-NLS-1$
-
 		ASTNode expression = getChildNode(node, YieldStatement.EXPRESSION_PROPERTY);
-		if (expression != null ) {
-			this.result.append(' ');
+		if (expression != null) {
+			if (!node.isImplicit()) {
+				this.result.append(' ');
+			}
 			expression.accept(this);
 		}
 		this.result.append(';');

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/ASTRewriteFlattener.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/ASTRewriteFlattener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0


### PR DESCRIPTION
## What it does
In ASTRewriteFlattener, check YieldStatement.isImplicit before append `yield`. Fix bug #949.

## How to test
See #949.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
