### PR TITLE
Fix GH-954: module binding error message not rendering correctly.

### DIFF
--- a/org.eclipse.jdt.compiler.tool.tests/src/org/eclipse/jdt/compiler/tool/tests/CompilerToolTests.java
+++ b/org.eclipse.jdt.compiler.tool.tests/src/org/eclipse/jdt/compiler/tool/tests/CompilerToolTests.java
@@ -1416,6 +1416,30 @@ static final String[] FAKE_ZERO_ARG_OPTIONS = new String[] {
 				);
 	}
 
+	/**
+	 * See: https://github.com/eclipse-jdt/eclipse.jdt.core/issues/954
+	 */
+	public void testModuleCannotBeResolvedErrorMessageGh955() throws Exception {
+		suppressTest(
+				"module-info.java",
+				"""
+				module testmodule {
+					requires aaa;
+				}
+				""",
+				"ERROR 2: aaa cannot be resolved to a module",
+				"""
+				----------
+				1. ERROR in /tmp/module-info.java (at line 2)
+					requires aaa;
+					         ^^^
+				aaa cannot be resolved to a module
+				----------
+				1 problem (1 error)
+				"""
+				);
+	}
+
 	public void testSupportedCompilerVersions() throws IOException {
 		Set<SourceVersion> sourceVersions = compiler.getSourceVersions();
 		SourceVersion[] values = SourceVersion.values();

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
@@ -75,6 +75,8 @@
  *								bug 527554 - [18.3] Compiler support for JEP 286 Local-Variable Type
  *     Ulrich Grave <ulrich.grave@gmx.de> - Contributions for
  *                              bug 386692 - Missing "unused" warning on "autowired" fields
+ *     Ashley Scopes - Contributions for
+ * 								GH-954 	   - Module binding error renders incorrectly for diagnostics
  ********************************************************************************/
 package org.eclipse.jdt.internal.compiler.problem;
 
@@ -11446,9 +11448,8 @@ public void invalidTypeArguments(TypeReference[] typeReference) {
 			typeReference[typeReference.length - 1].sourceEnd);
 }
 public void invalidModule(ModuleReference ref) {
-	this.handle(IProblem.UndefinedModule,
-		NoArgument, new String[] { CharOperation.charToString(ref.moduleName) },
-		ref.sourceStart, ref.sourceEnd);
+	String[] args = new String[] { CharOperation.charToString(ref.moduleName) };
+	this.handle(IProblem.UndefinedModule, args, args, ref.sourceStart, ref.sourceEnd);
 }
 public void missingModuleAddReads(char[] requiredModuleName) {
 	String[] args = new String[] { new String(requiredModuleName) };


### PR DESCRIPTION
## What it does
Fixes GH-954: a message rendering issue for module resolution issues.

## How to test
Right now, I am integrating with the compiler from a project of mine, and I am coming across
the following diagnostic being output:

```
8389908 - Cannot bind message for problem (id: 1300) "{0} cannot be resolved to a module" with arguments: {}
```

I am still looking for the actual trigger of this error in my code, but it appears that the
log message is misconfigured.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
