### PR TITLE
org.eclipse.jdt.core.dom.AST class is not updated for jdk20 #953

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTTest.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
 
@@ -9556,7 +9557,8 @@ public class ASTTest extends org.eclipse.jdt.core.tests.junit.extension.TestCase
 
 	@SuppressWarnings("deprecation")
 	public void testASTLevels() throws Exception {
-		int[] apilLevels = {AST.JLS2, AST.JLS3, AST.JLS4, AST.JLS8, AST.JLS9, AST.JLS10, AST.JLS11, AST.JLS12, AST.JLS13, AST.JLS14, AST.JLS15, AST.JLS16, AST.JLS17,AST.JLS18, AST.JLS19, AST.JLS20};
+		int[] apilLevels = {AST.JLS2, AST.JLS3, AST.JLS4, AST.JLS8, AST.JLS9, AST.JLS10, AST.JLS11,
+				AST.JLS12, AST.JLS13, AST.JLS14, AST.JLS15, AST.JLS16, AST.JLS17,AST.JLS18, AST.JLS19, AST.JLS20};
 		for (int level : apilLevels) {
 			try {
 				DOMASTUtil.checkASTLevel(level);
@@ -9564,6 +9566,12 @@ public class ASTTest extends org.eclipse.jdt.core.tests.junit.extension.TestCase
 				throw new AssertionFailedError("missing support for AST level: " + level);
 			}
 		}
+		Hashtable<String, String> options = JavaCore.getDefaultOptions();
+		options.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.latestSupportedJavaVersion());
+		options.put(JavaCore.COMPILER_SOURCE, JavaCore.latestSupportedJavaVersion());
+		options.put(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, JavaCore.latestSupportedJavaVersion());
+		AST a = new AST(options);
+		assertEquals("Incorrect ast mapping", a.apiLevel(), AST.getJLSLatest());
 	}
 }
 

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/AST.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/AST.java
@@ -1218,6 +1218,7 @@ public final class AST {
         t.put(JavaCore.VERSION_17, ClassFileConstants.JDK17);
         t.put(JavaCore.VERSION_18, ClassFileConstants.JDK18);
         t.put(JavaCore.VERSION_19, ClassFileConstants.JDK19);
+        t.put(JavaCore.VERSION_20, ClassFileConstants.JDK20);
         return Collections.unmodifiableMap(t);
 	}
 	private static Map<String, Integer> getApiLevelMapTable() {
@@ -1241,6 +1242,7 @@ public final class AST {
         t.put(JavaCore.VERSION_17, JLS17_INTERNAL);
         t.put(JavaCore.VERSION_18, JLS18_INTERNAL);
         t.put(JavaCore.VERSION_19, JLS19_INTERNAL);
+        t.put(JavaCore.VERSION_20, JLS20_INTERNAL);
         return Collections.unmodifiableMap(t);
 	}
 	/**


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
