### PR TITLE
Improve completions on varargs. Fix #960

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AbstractJavaModelCompletionTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AbstractJavaModelCompletionTests.java
@@ -220,11 +220,9 @@ protected void assertResults(String expected, String actual) {
 
 protected void assertContains(String message, String expected, String containsIn) {
 	if (!containsIn.contains(expected)) {
-		StringBuffer formatted;
+		StringBuilder formatted = new StringBuilder();
 		if (message != null) {
-			formatted = new StringBuffer(message).append('.');
-		} else {
-			formatted = new StringBuffer();
+			formatted.append(message).append('.');
 		}
 		final String expectedWithLineSeparators = showLineSeparators(expected);
 		final String actualWithLineSeparators = showLineSeparators(containsIn);

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AbstractJavaModelCompletionTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AbstractJavaModelCompletionTests.java
@@ -217,4 +217,27 @@ protected void assertResults(String expected, String actual) {
 		throw c;
 	}
 }
+
+protected void assertContains(String message, String expected, String containsIn) {
+	if (!containsIn.contains(expected)) {
+		StringBuffer formatted;
+		if (message != null) {
+			formatted = new StringBuffer(message).append('.');
+		} else {
+			formatted = new StringBuffer();
+		}
+		final String expectedWithLineSeparators = showLineSeparators(expected);
+		final String actualWithLineSeparators = showLineSeparators(containsIn);
+		formatted.append("\n----------- Expected to contain ------------\n"); //$NON-NLS-1$
+		formatted.append(expectedWithLineSeparators);
+		formatted.append("\n------------ but was ------------\n"); //$NON-NLS-1$
+		formatted.append(actualWithLineSeparators);
+		formatted.append("\n--------- Difference is ----------\n"); //$NON-NLS-1$
+		throw new ComparisonFailure(formatted.toString(), expectedWithLineSeparators, actualWithLineSeparators);
+	}
+}
+
+protected void assertContains(String expected, String containsIn) {
+	assertContains(null, expected, containsIn);
+}
 }

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests.java
@@ -26448,11 +26448,11 @@ public void testBug574982() throws JavaModelException {
 	int cursorLocation = str.lastIndexOf(completeBehind) + completeBehind.length();
 	this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner);
 	assertResults(
-			"ABC[TYPE_REF]{p1.ABC, p1, Lp1.ABC;, null, null, 49}\n" +
-			"ABC[TYPE_REF]{p2.ABC, p2, Lp2.ABC;, null, null, 49}\n" +
-			"A3[TYPE_REF]{A3, , LA3;, null, null, 52}\n" +
-			"ArrayTest[TYPE_REF]{ArrayTest, , LArrayTest;, null, null, 52}\n" +
-			"A[TYPE_REF]{A, , LA;, null, null, 56}",
+			"ABC[TYPE_REF]{p1.ABC, p1, Lp1.ABC;, null, null, 69}\n" +
+			"ABC[TYPE_REF]{p2.ABC, p2, Lp2.ABC;, null, null, 69}\n" +
+			"A3[TYPE_REF]{A3, , LA3;, null, null, 72}\n" +
+			"ArrayTest[TYPE_REF]{ArrayTest, , LArrayTest;, null, null, 72}\n" +
+			"A[TYPE_REF]{A, , LA;, null, null, 76}",
 			requestor.getResults());
 }
 /**

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests18.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests18.java
@@ -6804,13 +6804,17 @@ public void testGH960_onVarargArgument_expectCompletionsMatchingElementType() th
 	this.workingCopies = new ICompilationUnit[1];
 	this.workingCopies[0] = getWorkingCopy("/Completion/src/GH960.java", """
 			public class GH960 {
-				public void foo(Thread.State... states) {
+				public void foo(GH960.State... states) {
 				}
 
 				public void boo() {
-				   Thread.State currentState = Thread.State.BLOCKED;
+					GH960.State currentState = GH960.State.BLOCKED;
 
-				   foo()
+					foo()
+				}
+
+				public static enum State {
+					BLOCKED, RUNNABLE;
 				}
 			}
 			""");
@@ -6825,21 +6829,13 @@ public void testGH960_onVarargArgument_expectCompletionsMatchingElementType() th
 
 	String result = requestor.getResults();
 	assertResults(
-			"BLOCKED[FIELD_REF]{State.BLOCKED, Ljava.lang.Thread$State;, Ljava.lang.Thread$State;, BLOCKED, null, "
+			"BLOCKED[FIELD_REF]{State.BLOCKED, LGH960$State;, LGH960$State;, BLOCKED, null, "
 					+ (R_DEFAULT + R_RESOLVED + R_INTERESTING + R_CASE + R_UNQUALIFIED) + "}\n"
-					+ "NEW[FIELD_REF]{State.NEW, Ljava.lang.Thread$State;, Ljava.lang.Thread$State;, NEW, null, "
+					+ "RUNNABLE[FIELD_REF]{State.RUNNABLE, LGH960$State;, LGH960$State;, RUNNABLE, null, "
 					+ (R_DEFAULT + R_RESOLVED + R_INTERESTING + R_CASE + R_UNQUALIFIED) + "}\n"
-					+ "RUNNABLE[FIELD_REF]{State.RUNNABLE, Ljava.lang.Thread$State;, Ljava.lang.Thread$State;, RUNNABLE, null, "
-					+ (R_DEFAULT + R_RESOLVED + R_INTERESTING + R_CASE + R_UNQUALIFIED) + "}\n"
-					+ "TERMINATED[FIELD_REF]{State.TERMINATED, Ljava.lang.Thread$State;, Ljava.lang.Thread$State;, TERMINATED, null, "
-					+ (R_DEFAULT + R_RESOLVED + R_INTERESTING + R_CASE + R_UNQUALIFIED) + "}\n"
-					+ "TIMED_WAITING[FIELD_REF]{State.TIMED_WAITING, Ljava.lang.Thread$State;, Ljava.lang.Thread$State;, TIMED_WAITING, null, "
-					+ (R_DEFAULT + R_RESOLVED + R_INTERESTING + R_CASE + R_UNQUALIFIED) + "}\n"
-					+ "WAITING[FIELD_REF]{State.WAITING, Ljava.lang.Thread$State;, Ljava.lang.Thread$State;, WAITING, null, "
-					+ (R_DEFAULT + R_RESOLVED + R_INTERESTING + R_CASE + R_UNQUALIFIED) + "}\n"
-					+ "currentState[LOCAL_VARIABLE_REF]{currentState, null, Ljava.lang.Thread$State;, currentState, null, "
+					+ "currentState[LOCAL_VARIABLE_REF]{currentState, null, LGH960$State;, currentState, null, "
 					+ (R_DEFAULT + R_RESOLVED + R_INTERESTING + R_CASE + R_UNQUALIFIED + R_NON_RESTRICTED) + "}\n"
-					+ "foo[METHOD_REF]{, LGH960;, ([Ljava.lang.Thread$State;)V, foo, (states), " + (R_DEFAULT
+					+ "foo[METHOD_REF]{, LGH960;, ([LGH960$State;)V, foo, (states), " + (R_DEFAULT
 							+ R_RESOLVED + R_INTERESTING + R_CASE + R_EXACT_NAME + R_UNQUALIFIED + R_NON_RESTRICTED)
 					+ "}",
 			result);
@@ -6849,13 +6845,17 @@ public void testGH960_onVarargArguments_expectCompletionsMatchingElementType() t
 	this.workingCopies = new ICompilationUnit[1];
 	this.workingCopies[0] = getWorkingCopy("/Completion/src/GH960.java", """
 			public class GH960 {
-				public void foo(Thread.State... states) {
+				public void foo(GH960.State... states) {
 				}
 
 				public void boo() {
-				   Thread.State currentState = Thread.State.BLOCKED;
+					GH960.State currentState = GH960.State.BLOCKED;
 
-				   foo(State.BLOCKED, )
+					foo(State.BLOCKED, )
+				}
+
+				public static enum State {
+					BLOCKED, RUNNABLE;
 				}
 			}
 			""");
@@ -6872,21 +6872,13 @@ public void testGH960_onVarargArguments_expectCompletionsMatchingElementType() t
 	int relevanceExpectedTypes = R_DEFAULT + R_RESOLVED + R_INTERESTING + R_CASE + R_UNQUALIFIED
 			+ R_EXACT_EXPECTED_TYPE;
 	assertContains("Enums",
-			"BLOCKED[FIELD_REF]{State.BLOCKED, Ljava.lang.Thread$State;, Ljava.lang.Thread$State;, BLOCKED, null, "
+			"BLOCKED[FIELD_REF]{State.BLOCKED, LGH960$State;, LGH960$State;, BLOCKED, null, "
 					+ relevanceExpectedTypes + "}\n"
-					+ "NEW[FIELD_REF]{State.NEW, Ljava.lang.Thread$State;, Ljava.lang.Thread$State;, NEW, null, "
-					+ relevanceExpectedTypes + "}\n"
-					+ "RUNNABLE[FIELD_REF]{State.RUNNABLE, Ljava.lang.Thread$State;, Ljava.lang.Thread$State;, RUNNABLE, null, "
-					+ relevanceExpectedTypes + "}\n"
-					+ "TERMINATED[FIELD_REF]{State.TERMINATED, Ljava.lang.Thread$State;, Ljava.lang.Thread$State;, TERMINATED, null, "
-					+ relevanceExpectedTypes + "}\n"
-					+ "TIMED_WAITING[FIELD_REF]{State.TIMED_WAITING, Ljava.lang.Thread$State;, Ljava.lang.Thread$State;, TIMED_WAITING, null, "
-					+ relevanceExpectedTypes + "}\n"
-					+ "WAITING[FIELD_REF]{State.WAITING, Ljava.lang.Thread$State;, Ljava.lang.Thread$State;, WAITING, null, "
-					+ relevanceExpectedTypes + "}\n",
+					+ "RUNNABLE[FIELD_REF]{State.RUNNABLE, LGH960$State;, LGH960$State;, RUNNABLE, null, "
+					+ relevanceExpectedTypes + "}",
 			result);
 	assertContains("Variables",
-			"currentState[LOCAL_VARIABLE_REF]{currentState, null, Ljava.lang.Thread$State;, currentState, null, "
+			"currentState[LOCAL_VARIABLE_REF]{currentState, null, LGH960$State;, currentState, null, "
 					+ (R_DEFAULT + R_RESOLVED + R_INTERESTING + R_CASE + R_UNQUALIFIED + R_NON_RESTRICTED
 							+ R_EXACT_EXPECTED_TYPE)
 					+ "}",

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/CompletionEngine.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/CompletionEngine.java
@@ -3334,8 +3334,7 @@ public final class CompletionEngine
 		findCompletionsForArgumentPosition(methodsFound, argTypes != null ? argTypes.length : 0, scope);
 	}
 
-	private void findCompletionsForArgumentPosition(ObjectVector methodsFound, int completedArgumentLength,
-			Scope scope) {
+	private void findCompletionsForArgumentPosition(ObjectVector methodsFound, int completedArgumentLength, Scope scope) {
 		pushExpectedTypesForArgumentPosition(methodsFound, completedArgumentLength, scope);
 		this.strictMatchForExtepectedType = true;
 		int filter = this.expectedTypesFilter;
@@ -3344,8 +3343,7 @@ public final class CompletionEngine
 		int tStart = this.tokenStart, tEnd = this.tokenEnd;
 		try {
 			this.startPosition = this.endPosition = this.tokenStart = this.tokenEnd = this.actualCompletionPosition + 1;
-			findVariablesAndMethods(CharOperation.NO_CHAR, scope, FakeInvocationSite, scope, false, false, false,
-					methodsFound);
+			findVariablesAndMethods(CharOperation.NO_CHAR, scope, FakeInvocationSite, scope, false, false, false, methodsFound);
 		} finally {
 			this.startPosition = start;
 			this.endPosition = end;
@@ -3363,11 +3361,12 @@ public final class CompletionEngine
 		}
 		for (int i = 0; i < methodsToSearchOn.size; i++) {
 			MethodBinding method = (MethodBinding) ((Object[]) methodsToSearchOn.elementAt(i))[0];
-			if (method.parameters.length <= completedArgumentLength && !method.isVarargs()) {
+			boolean onOrAfterLastParam = method.parameters.length <= completedArgumentLength;
+			if (onOrAfterLastParam && !method.isVarargs()) {
 				continue;
 			}
 
-			int index = (method.parameters.length <= completedArgumentLength)
+			int index = onOrAfterLastParam
 					? method.parameters.length - 1
 					: completedArgumentLength;
 

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/CompletionEngine.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/CompletionEngine.java
@@ -30,6 +30,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import org.eclipse.core.runtime.CoreException;
@@ -3333,20 +3334,9 @@ public final class CompletionEngine
 		findCompletionsForArgumentPosition(methodsFound, argTypes != null ? argTypes.length : 0, scope);
 	}
 
-	private void findCompletionsForArgumentPosition(ObjectVector methodsFound, int completedArgumentLength, Scope scope) {
-		if(methodsFound.size == 0) {
-			return;
-		}
-
-		for(int i = 0; i < methodsFound.size; i++) {
-			MethodBinding method = (MethodBinding) ((Object[])methodsFound.elementAt(i))[0];
-			if(method.parameters.length <= completedArgumentLength) {
-				continue;
-			}
-
-			TypeBinding paramType = method.parameters[completedArgumentLength];
-			addExpectedType(paramType, scope);
-		}
+	private void findCompletionsForArgumentPosition(ObjectVector methodsFound, int completedArgumentLength,
+			Scope scope) {
+		pushExpectedTypesForArgumentPosition(methodsFound, completedArgumentLength, scope);
 		this.strictMatchForExtepectedType = true;
 		int filter = this.expectedTypesFilter;
 		this.expectedTypesFilter = SUBTYPE;
@@ -3354,7 +3344,8 @@ public final class CompletionEngine
 		int tStart = this.tokenStart, tEnd = this.tokenEnd;
 		try {
 			this.startPosition = this.endPosition = this.tokenStart = this.tokenEnd = this.actualCompletionPosition + 1;
-			findVariablesAndMethods(CharOperation.NO_CHAR, scope, FakeInvocationSite, scope, false, false, false, methodsFound);
+			findVariablesAndMethods(CharOperation.NO_CHAR, scope, FakeInvocationSite, scope, false, false, false,
+					methodsFound);
 		} finally {
 			this.startPosition = start;
 			this.endPosition = end;
@@ -3362,6 +3353,30 @@ public final class CompletionEngine
 			this.tokenEnd = tEnd;
 			this.strictMatchForExtepectedType = false;
 			this.expectedTypesFilter = filter;
+		}
+	}
+
+	private void pushExpectedTypesForArgumentPosition(ObjectVector methodsToSearchOn, int completedArgumentLength,
+			Scope scope) {
+		if (methodsToSearchOn.size == 0) {
+			return;
+		}
+		for (int i = 0; i < methodsToSearchOn.size; i++) {
+			MethodBinding method = (MethodBinding) ((Object[]) methodsToSearchOn.elementAt(i))[0];
+			if (method.parameters.length <= completedArgumentLength && !method.isVarargs()) {
+				continue;
+			}
+
+			int index = (method.parameters.length <= completedArgumentLength)
+					? method.parameters.length - 1
+					: completedArgumentLength;
+
+			TypeBinding paramType = method.parameters[index];
+			addExpectedType(paramType, scope);
+			if (method.isVarargs() && paramType.isArrayType()
+					&& index == (method.parameters.length - 1)) {
+				addExpectedType(((ArrayBinding) paramType).elementsType(), scope);
+			}
 		}
 	}
 
@@ -3983,13 +3998,31 @@ public final class CompletionEngine
 
 			checkCancel();
 
-			findVariablesAndMethods(
-				this.completionToken,
-				scope,
-				singleNameReference,
-				scope,
-				insideTypeAnnotation,
-				singleNameReference.isInsideAnnotationAttribute);
+			// see if we can find argument type at position incase if we are at a vararg.
+			if (astNodeParent instanceof MessageSend m && this.expectedTypesPtr == -1) {
+				final ObjectVector methodsToSearchOn = new ObjectVector();
+				final CompletionRequestor actual = this.requestor;
+				this.requestor = new CompletionRequestor(true) {
+
+					@Override
+					public void accept(CompletionProposal proposal) {
+						// do nothing
+					}
+				};
+				this.requestor.setIgnored(CompletionProposal.METHOD_REF, false);
+				try {
+					// this will help to find the actual resolved method we are at since current MessageSend is not
+					// properly resolved. We use the same strategy we have at completionOnMessageSend
+					findVariablesAndMethods(m.selector, scope, m, scope, false, false, true, methodsToSearchOn);
+				} finally {
+					this.requestor = actual;
+				}
+
+				pushExpectedTypesForArgumentPosition(methodsToSearchOn,
+						(int) Stream.of(m.argumentTypes).filter(Objects::nonNull).count(), scope);
+			}
+			findVariablesAndMethods(this.completionToken, scope, singleNameReference, scope, insideTypeAnnotation,
+					singleNameReference.isInsideAnnotationAttribute, true, new ObjectVector());
 
 			checkCancel();
 


### PR DESCRIPTION
## What it does
This improvement consider the element type of a var-arg argument currently at completion position as a expected type to suggest completions based on that expected type.

## How to test
Use example in #960

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
