### PR TITLE
Fix completions on constructor with inner message send. Fix #969

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests_1_5.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests_1_5.java
@@ -14723,4 +14723,108 @@ public void testBug573279() throws Exception {
 			"wait[METHOD_REF]{wait(), Ljava.lang.Object;, (JI)V, null, null, wait, (millis, nanos), replace[289, 318], token[289, 292], "+relevance+"}",
 			requestor.getResults());
 }
+public void testGH969_completeOnFirstArgumentPosition_noToken() throws Exception {
+	this.workingCopies = new ICompilationUnit[2];
+	this.workingCopies[0] = getWorkingCopy("/Completion/src/GH969.java", """
+			public class GH969 {
+				public static void main(String[] args) {
+					foo("1", new PersonDetails("1", GH969List.empty(), 0));
+				}
+				private static void foo(String name, PersonDetails per) {}
+
+				public static class PersonDetails {
+					public PersonDetails(String id, GH969List<String> address, int age){}
+				}
+			}
+			""");
+	this.workingCopies[1] = getWorkingCopy("/Completion/src/GH969List.java", """
+			public class GH969List<T> {
+				public static <T> GH969List<T> empty() {
+					return new GH969List<>();
+				}
+			}
+			""");
+
+	CompletionTestsRequestor2 requestor = new CompletionTestsRequestor2(true, true, true, true, true, true);
+	requestor.allowAllRequiredProposals();
+	String str = this.workingCopies[0].getSource();
+	String completeBehind = "foo(\"1\", new PersonDetails(";
+	int cursorLocation = str.lastIndexOf(completeBehind) + completeBehind.length();
+	this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner);
+	int relevance = R_DEFAULT + R_INTERESTING + R_RESOLVED + R_NON_RESTRICTED;
+	assertEquals(
+			"GH969.PersonDetails[ANONYMOUS_CLASS_DECLARATION]{, LGH969$PersonDetails;, (Ljava.lang.String;LGH969List<Ljava.lang.String;>;I)V, LGH969$PersonDetails;, LGH969$PersonDetails;.(Ljava/lang/String;LGH969List<Ljava/lang/String;>;I)V, null, (id, address, age), replace[118, 118], token[118, 118], "
+					+ relevance + "}\n"
+					+ "PersonDetails[METHOD_REF<CONSTRUCTOR>]{, LGH969$PersonDetails;, (Ljava.lang.String;LGH969List<Ljava.lang.String;>;I)V, null, null, PersonDetails, (id, address, age), replace[118, 118], token[74, 118], "
+					+ relevance + "}",
+			requestor.getResults());
+}
+public void testGH969_completeOnFirstArgumentPosition_WithToken() throws Exception {
+	this.workingCopies = new ICompilationUnit[2];
+	this.workingCopies[0] = getWorkingCopy("/Completion/src/GH969.java", """
+			public class GH969 {
+				public static void main(String[] args) {
+					foo("1", new PersonDetails(first, GH969List.empty(), 0));
+				}
+				private static void foo(String name, PersonDetails per) {}
+				private static String firstName() { return ""; }
+				public static class PersonDetails {
+					public PersonDetails(String id, GH969List<String> address, int age){}
+				}
+			}
+			""");
+	this.workingCopies[1] = getWorkingCopy("/Completion/src/GH969List.java", """
+			public class GH969List<T> {
+				public static <T> GH969List<T> empty() {
+					return new GH969List<>();
+				}
+			}
+			""");
+
+	CompletionTestsRequestor2 requestor = new CompletionTestsRequestor2(true, true, true, true, true, true);
+	requestor.allowAllRequiredProposals();
+	String str = this.workingCopies[0].getSource();
+	String completeBehind = "PersonDetails(first";
+	int cursorLocation = str.lastIndexOf(completeBehind) + completeBehind.length();
+	this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner);
+	int relevance = R_DEFAULT + R_INTERESTING + R_RESOLVED + R_NON_RESTRICTED + R_CASE + R_UNQUALIFIED;
+	assertEquals(
+			"firstName[METHOD_REF]{firstName(), LGH969;, ()Ljava.lang.String;, null, null, firstName, null, replace[92, 97], token[92, 97], "
+					+ relevance + "}",
+			requestor.getResults());
+}
+public void testGH969_completeOnArgumentPosition_WithToken() throws Exception {
+	this.workingCopies = new ICompilationUnit[2];
+	this.workingCopies[0] = getWorkingCopy("/Completion/src/GH969.java", """
+			public class GH969 {
+				public static void main(String[] args) {
+					foo("1", new PersonDetails("1", empty, 0));
+				}
+				private static void foo(String name, PersonDetails per) {}
+				private static <T> GH969List emptyList(){ retutn null; }
+				public static class PersonDetails {
+					public PersonDetails(String id, GH969List<String> address, int age){}
+				}
+			}
+			""");
+	this.workingCopies[1] = getWorkingCopy("/Completion/src/GH969List.java", """
+			public class GH969List<T> {
+				public static <T> GH969List<T> empty() {
+					return new GH969List<>();
+				}
+			}
+			""");
+
+	CompletionTestsRequestor2 requestor = new CompletionTestsRequestor2(true, true, true, true, true, true);
+	requestor.allowAllRequiredProposals();
+	String str = this.workingCopies[0].getSource();
+	String completeBehind = ", empty";
+	int cursorLocation = str.lastIndexOf(completeBehind) + completeBehind.length();
+	this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner);
+	int relevance = R_DEFAULT + R_INTERESTING + R_RESOLVED + R_NON_RESTRICTED + R_CASE + R_UNQUALIFIED;
+	assertEquals(
+			"emptyList[METHOD_REF]{emptyList(), LGH969;, <T:Ljava.lang.Object;>()LGH969List;, null, null, emptyList, null, replace[97, 102], token[97, 102], "
+					+ relevance + "}",
+			requestor.getResults());
+}
 }

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests_1_5.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests_1_5.java
@@ -14867,4 +14867,43 @@ public void testGH969_completeOnArgumentPosition_onMethodWithReceiver() throws E
 					+ relevance + "}",
 			requestor.getResults());
 }
+public void testGH969_completeOnArgumentPosition_onMethodInvocation() throws Exception {
+	this.workingCopies = new ICompilationUnit[2];
+	this.workingCopies[0] = getWorkingCopy("/Completion/src/GH969.java", """
+			public class GH969 {
+				public static void main(String[] args) {
+					instance().foo(new PersonDetails(emptyList(), 0));
+				}
+				public static GH969 instance() {
+					return new GH969();
+				}
+				public void foo(PersonDetails per) {}
+				private static <T> GH969List<T> emptyList(){ return null; }
+				public static class PersonDetails {
+					public PersonDetails(GH969List<String> address, int age){}
+				}
+			}
+			""");
+	this.workingCopies[1] = getWorkingCopy("/Completion/src/GH969List.java", """
+			public class GH969List<T> {
+				public static <T> GH969List<T> empty() {
+					return new GH969List<>();
+				}
+			}
+			""");
+
+	CompletionTestsRequestor2 requestor = new CompletionTestsRequestor2(true, true, true, true, true, true);
+	requestor.allowAllRequiredProposals();
+	String str = this.workingCopies[0].getSource();
+	String completeBehind = "new PersonDetails(";
+	int cursorLocation = str.lastIndexOf(completeBehind) + completeBehind.length();
+	this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner);
+	int relevance = R_DEFAULT + R_INTERESTING + R_RESOLVED + R_NON_RESTRICTED;
+	assertEquals(
+			"GH969.PersonDetails[ANONYMOUS_CLASS_DECLARATION]{, LGH969$PersonDetails;, (LGH969List<Ljava.lang.String;>;I)V, LGH969$PersonDetails;, LGH969$PersonDetails;.(LGH969List<Ljava/lang/String;>;I)V, null, (address, age), replace[113, 113], token[113, 113], "
+					+ relevance + "}\n"
+					+ "PersonDetails[METHOD_REF<CONSTRUCTOR>]{, LGH969$PersonDetails;, (LGH969List<Ljava.lang.String;>;I)V, null, null, PersonDetails, (address, age), replace[113, 113], token[80, 113], "
+					+ relevance + "}",
+			requestor.getResults());
+}
 }

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/CompletionEngine.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/CompletionEngine.java
@@ -6085,7 +6085,9 @@ public final class CompletionEngine
 						continue next;
 					for (int a = minArgLength; --a >= 0;)
 						if (argTypes[a] != null) { // can be null if it could not be resolved properly
-							if (!argTypes[a].isCompatibleWith(constructor.parameters[a]))
+							if (!argTypes[a].isCompatibleWith(constructor.parameters[a])
+								// check if this type pair is parameterized types and their erasure types matches
+									&& !argTypes[a].erasure().isCompatibleWith(constructor.parameters[a].erasure()))
 								continue next;
 						}
 

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionParser.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionParser.java
@@ -5812,13 +5812,17 @@ private boolean checkIfAtFirstArgumentOfConstructor() {
 	}
 	// We try to handle the situation where lParenPos represents a argument MessageSend's left paren in the AllocationExpression like
 	// Foo(|null, Collections.empty(), null). Here we try to calculate the constructor's left paren and match it with the 
-	// assistNode position.
+	// assistNode position if the assistNode is a CompletionOnSingleNameReference or CompletionOnMessageSendName.
+	
+	// following int literals represents
+	// 1 -> '('
+	// 3 -> 'new'
+	int startPos = this.intStack[this.intPtr] + this.identifierStack[this.identifierPtr].length + 1 + 3;
+
 	if (this.assistNode instanceof CompletionOnSingleNameReference) {
-		// following int literals represents
-		// 1 -> '('
-		// 3 -> 'new'
-		int startPos = this.intStack[this.intPtr] + this.identifierStack[this.identifierPtr].length + 1 + 3;
 		return startPos == this.assistNode.sourceEnd;
+	} else if (this.assistNode instanceof CompletionOnMessageSendName ms) {
+		return startPos == ms.sourceStart - 1;
 	}
 	return false;
 }

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionParser.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionParser.java
@@ -5509,8 +5509,12 @@ protected NameReference getUnspecifiedReference(boolean rejectTypeAnnotations) {
 		char[] token = this.identifierStack[this.identifierPtr];
 		long position = this.identifierPositionStack[this.identifierPtr--];
 		int start = (int) (position >>> 32), end = (int) position;
-		if (this.assistNode == null && start <= this.cursorLocation && end >= this.cursorLocation) {
+		// in expression like new Foo(<completion>Collection.emptyList(), 1), the token becomes empty, 
+		// but the positions represents the static type name identifier.
+		int adjustedStart = ((token.length == 0) ? start - 1 : start);
+		if (this.assistNode == null && adjustedStart <= this.cursorLocation && end >= this.cursorLocation) {
 			ref = new CompletionOnSingleNameReference(token, position, isInsideAttributeValue());
+			ref.sourceEnd = (token.length == 0) ? adjustedStart : ref.sourceEnd;
 			this.assistNode = ref;
 		} else {
 			ref = new SingleNameReference(token, position);
@@ -5803,14 +5807,17 @@ protected AllocationExpression newAllocationExpression(boolean isQualified) {
 }
 private boolean checkIfAtFirstArgumentOfConstructor() {
 	// See if we are in a simple constructure like Foo(|) or Foo(|null, null)
-	if(this.lParenPos == this.assistNode.sourceEnd) {
+	if (this.lParenPos == this.assistNode.sourceEnd) {
 		return true;
 	}
 	// We try to handle the situation where lParenPos represents a argument MessageSend's left paren in the AllocationExpression like
 	// Foo(|null, Collections.empty(), null). Here we try to calculate the constructor's left paren and match it with the 
 	// assistNode position.
-	if(this.assistNode instanceof CompletionOnSingleNameReference) {
-		int startPos = this.intStack[this.intPtr] + this.identifierStack[this.identifierPtr].length + 1 /*(*/ + 3 /*new*/;
+	if (this.assistNode instanceof CompletionOnSingleNameReference) {
+		// following int literals represents
+		// 1 -> '('
+		// 3 -> 'new'
+		int startPos = this.intStack[this.intPtr] + this.identifierStack[this.identifierPtr].length + 1 + 3;
 		return startPos == this.assistNode.sourceEnd;
 	}
 	return false;

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionParser.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionParser.java
@@ -5794,12 +5794,26 @@ private MessageSend internalNewMessageSend() {
 }
 @Override
 protected AllocationExpression newAllocationExpression(boolean isQualified) {
-	if (this.assistNode != null && this.lParenPos == this.assistNode.sourceEnd) {
+	if (this.assistNode != null && checkIfAtFirstArgumentOfConstructor()) {
 		CompletionOnQualifiedAllocationExpression allocation = new CompletionOnQualifiedAllocationExpression();
 		this.assistNode = allocation;
 		return allocation;
 	}
 	return super.newAllocationExpression(isQualified);
+}
+private boolean checkIfAtFirstArgumentOfConstructor() {
+	// See if we are in a simple constructure like Foo(|) or Foo(|null, null)
+	if(this.lParenPos == this.assistNode.sourceEnd) {
+		return true;
+	}
+	// We try to handle the situation where lParenPos represents a argument MessageSend's left paren in the AllocationExpression like
+	// Foo(|null, Collections.empty(), null). Here we try to calculate the constructor's left paren and match it with the 
+	// assistNode position.
+	if(this.assistNode instanceof CompletionOnSingleNameReference) {
+		int startPos = this.intStack[this.intPtr] + this.identifierStack[this.identifierPtr].length + 1 /*(*/ + 3 /*new*/;
+		return startPos == this.assistNode.sourceEnd;
+	}
+	return false;
 }
 public CompilationUnitDeclaration parse(ICompilationUnit sourceUnit, CompilationResult compilationResult, int cursorLoc) {
 


### PR DESCRIPTION
## What it does
The fix tries to resolve the constructor completion which is used for parameter information when there are messagesend as arguments. It is done by trying to calculate the constructor's left paren position and see if the assist node is next to it. Once the constructor is resolved, still the argument resolution might not be valid for parameterized types. Therefore the CompletionEngine's constructor search logic is enhanced to also check the erasure type of those parameterized types.

Fixes: #969 

## How to test
Tests in the linked issue and unit tests.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
