### PR TITLE
"Missing tag for return type" javadoc error reported for inline return

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/JavadocParser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/JavadocParser.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -877,19 +877,20 @@ public class JavadocParser extends AbstractCommentParser {
 			if (!this.inlineTagStarted) {
 				this.lastBlockTagValue = this.tagValue;
 			}
-			if(this.tagValue == TAG_RETURN_VALUE && this.sourceLevel >= ClassFileConstants.JDK16) {
-				// no checks for @return, which can be both inline / block since Java 16
+			// see bug https://bugs.eclipse.org/bugs/show_bug.cgi?id=267833
+			// Report a problem if a block tag is being used in the context of an inline tag and vice versa.
+			if(this.sourceLevel >= ClassFileConstants.JDK16) {
+				int acceptedTag = this.inlineTagStarted ? TAG_TYPE_INLINE : TAG_TYPE_BLOCK;
+				valid = (JAVADOC_TAG_TYPE_16PLUS[this.tagValue] & acceptedTag) != 0;
 			} else {
-				// see bug https://bugs.eclipse.org/bugs/show_bug.cgi?id=267833
-				// Report a problem if a block tag is being used in the context of an inline tag and vice versa.
-				if ((this.inlineTagStarted ? JAVADOC_TAG_TYPE[this.tagValue] == TAG_TYPE_BLOCK : JAVADOC_TAG_TYPE[this.tagValue] == TAG_TYPE_INLINE)) {
-					valid = false;
-					this.tagValue = TAG_OTHERS_VALUE;
-					this.tagWaitingForDescription = NO_TAG_VALUE;
-					if (this.reportProblems) {
-						this.sourceParser.problemReporter().javadocUnexpectedTag(this.tagSourceStart, this.tagSourceEnd);
-					}
+				valid = (this.inlineTagStarted ? JAVADOC_TAG_TYPE[this.tagValue] == TAG_TYPE_INLINE : JAVADOC_TAG_TYPE[this.tagValue] == TAG_TYPE_BLOCK);
+			}
+			if (!valid) {
+				if (this.reportProblems) {
+					this.sourceParser.problemReporter().javadocUnexpectedTag(this.tagSourceStart, this.tagSourceEnd);
 				}
+				this.tagValue = TAG_OTHERS_VALUE;
+				this.tagWaitingForDescription = NO_TAG_VALUE;
 			}
 		}
 		return valid;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/JavadocParser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/JavadocParser.java
@@ -782,7 +782,7 @@ public class JavadocParser extends AbstractCommentParser {
 			case 'r':
 				if (length == TAG_RETURN_LENGTH && CharOperation.equals(TAG_RETURN, tagName, 0, length)) {
 					this.tagValue = TAG_RETURN_VALUE;
-					if (!this.inlineTagStarted) {
+					if(this.sourceLevel >= ClassFileConstants.JDK16 || !this.inlineTagStarted){
 						valid = parseReturn();
 					}
 				}
@@ -877,14 +877,18 @@ public class JavadocParser extends AbstractCommentParser {
 			if (!this.inlineTagStarted) {
 				this.lastBlockTagValue = this.tagValue;
 			}
-			// see bug https://bugs.eclipse.org/bugs/show_bug.cgi?id=267833
-			// Report a problem if a block tag is being used in the context of an inline tag and vice versa.
-			if ((this.inlineTagStarted ? JAVADOC_TAG_TYPE[this.tagValue] == TAG_TYPE_BLOCK : JAVADOC_TAG_TYPE[this.tagValue] == TAG_TYPE_INLINE)) {
-				valid = false;
-				this.tagValue = TAG_OTHERS_VALUE;
-				this.tagWaitingForDescription = NO_TAG_VALUE;
-				if (this.reportProblems) {
-					this.sourceParser.problemReporter().javadocUnexpectedTag(this.tagSourceStart, this.tagSourceEnd);
+			if(this.tagValue == TAG_RETURN_VALUE && this.sourceLevel >= ClassFileConstants.JDK16) {
+				// no checks for @return, which can be both inline / block since Java 16
+			} else {
+				// see bug https://bugs.eclipse.org/bugs/show_bug.cgi?id=267833
+				// Report a problem if a block tag is being used in the context of an inline tag and vice versa.
+				if ((this.inlineTagStarted ? JAVADOC_TAG_TYPE[this.tagValue] == TAG_TYPE_BLOCK : JAVADOC_TAG_TYPE[this.tagValue] == TAG_TYPE_INLINE)) {
+					valid = false;
+					this.tagValue = TAG_OTHERS_VALUE;
+					this.tagWaitingForDescription = NO_TAG_VALUE;
+					if (this.reportProblems) {
+						this.sourceParser.problemReporter().javadocUnexpectedTag(this.tagSourceStart, this.tagSourceEnd);
+					}
 				}
 			}
 		}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/JavadocTagConstants.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/JavadocTagConstants.java
@@ -261,7 +261,7 @@ public interface JavadocTagConstants {
 		//since 15
 		{},
 		//since 16
-		{},
+		{TAG_RETURN},
 		//since 17
 		{},
 		//since 18
@@ -285,12 +285,52 @@ public interface JavadocTagConstants {
 	public final static short TAG_TYPE_NONE = 0;
 	public final static short TAG_TYPE_INLINE = 1;
 	public final static short TAG_TYPE_BLOCK = 2;
-	public final static short TAG_TYPE_IN_SNIPPET = 3;
+	public final static short TAG_TYPE_IN_SNIPPET = 4;
+	public final static short TAG_TYPE_INLINE_BLOCK = (short) (TAG_TYPE_INLINE | TAG_TYPE_BLOCK);
 	public static final short[] JAVADOC_TAG_TYPE = {
+			TAG_TYPE_NONE, 		// NO_TAG_VALUE = 0;
+			TAG_TYPE_BLOCK,		// TAG_DEPRECATED_VALUE = 1;
+			TAG_TYPE_BLOCK,		// TAG_PARAM_VALUE = 2;
+			TAG_TYPE_BLOCK,		// TAG_RETURN_VALUE = 3;
+			TAG_TYPE_BLOCK,		// TAG_THROWS_VALUE = 4;
+			TAG_TYPE_BLOCK,		// TAG_EXCEPTION_VALUE = 5;
+			TAG_TYPE_BLOCK,		// TAG_SEE_VALUE = 6;
+			TAG_TYPE_INLINE,	// TAG_LINK_VALUE = 7;
+			TAG_TYPE_INLINE,	// TAG_LINKPLAIN_VALUE = 8;
+			TAG_TYPE_INLINE,	// TAG_INHERITDOC_VALUE = 9;
+			TAG_TYPE_INLINE,	// TAG_VALUE_VALUE = 10;
+			TAG_TYPE_BLOCK,		// TAG_CATEGORY_VALUE = 11;
+			TAG_TYPE_BLOCK,		// TAG_AUTHOR_VALUE = 12;
+			TAG_TYPE_BLOCK,		// TAG_SERIAL_VALUE = 13;
+			TAG_TYPE_BLOCK,		// TAG_SERIAL_DATA_VALUE = 14;
+			TAG_TYPE_BLOCK,		// TAG_SERIAL_FIELD_VALUE = 15;
+			TAG_TYPE_BLOCK,		// TAG_SINCE_VALUE = 16;
+			TAG_TYPE_BLOCK,		// TAG_VERSION_VALUE = 17;
+			TAG_TYPE_INLINE,	// TAG_CODE_VALUE = 18;
+			TAG_TYPE_INLINE,	// TAG_LITERAL_VALUE = 19;
+			TAG_TYPE_INLINE,	// TAG_DOC_ROOT_VALUE = 20;
+			TAG_TYPE_INLINE,    // TAG_DOC_SYSTEM_PROPERTY = 21
+			TAG_TYPE_BLOCK,		// TAG_USES_VALUE = 22;
+			TAG_TYPE_BLOCK,		// TAG_PROVIDES_VALUE = 23;
+			TAG_TYPE_BLOCK,		// TAG_HIDDEN_VALUE = 24;
+			TAG_TYPE_INLINE,	// TAG_INDEX_VALUE = 25;
+			TAG_TYPE_INLINE,	// TAG_SUMMARY_VALUE = 26;
+			TAG_TYPE_BLOCK,		// TAG_API_NOTE = 27;
+			TAG_TYPE_BLOCK,		// TAG_IMPL_SPEC = 28;
+			TAG_TYPE_BLOCK,		// TAG_IMPL_NOTE = 29;
+			TAG_TYPE_INLINE,	// TAG_SNIPPET_VALUE = 30;
+			TAG_TYPE_IN_SNIPPET,// TAG_HIGHLIGHT_VALUE = 31;
+			TAG_TYPE_IN_SNIPPET,// TAG_HIGHLIGHT_VALUE = 32;
+	 	};
+	// Same as above with a single difference for TAG_RETURN_VALUE
+	// which can now be both TAG_TYPE_BLOCK and TAG_TYPE_INLINE => TAG_TYPE_INLINE_BLOCK
+	// Should this become complex, meaning multiple JLS levels requiring different support,
+	// we will need a better model to capture that. For now, this should be enough.
+	public static final short[] JAVADOC_TAG_TYPE_16PLUS = {
 		TAG_TYPE_NONE, 		// NO_TAG_VALUE = 0;
 		TAG_TYPE_BLOCK,		// TAG_DEPRECATED_VALUE = 1;
 		TAG_TYPE_BLOCK,		// TAG_PARAM_VALUE = 2;
-		TAG_TYPE_BLOCK,		// TAG_RETURN_VALUE = 3;
+		TAG_TYPE_INLINE_BLOCK,		// TAG_RETURN_VALUE = 3;
 		TAG_TYPE_BLOCK,		// TAG_THROWS_VALUE = 4;
 		TAG_TYPE_BLOCK,		// TAG_EXCEPTION_VALUE = 5;
 		TAG_TYPE_BLOCK,		// TAG_SEE_VALUE = 6;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/JavadocTagConstants.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/JavadocTagConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -224,6 +224,8 @@ public interface JavadocTagConstants {
 		{},
 		// since 19
 		{},
+		// since 20
+		{},
 	};
 	public static final char[][][] INLINE_TAGS = {
 		// since 1.0
@@ -265,7 +267,9 @@ public interface JavadocTagConstants {
 		//since 18
 		{ TAG_SNIPPET },
 		//since 19
-		{}
+		{},
+		// since 20
+		{},
 	};
 	public static final char[][][] IN_SNIPPET_TAGS = {
 		//since 18

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/parser/JavadocCompletionParserTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/parser/JavadocCompletionParserTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -101,6 +101,52 @@ protected Map getCompilerOptions() {
 	options.put(CompilerOptions.OPTION_Source, this.sourceLevel);
 	return options;
 }
+private char[][] getAdditionalTagsPerLevels() {
+	char[][] additionalTags = null;
+	if (this.complianceLevel == ClassFileConstants.JDK1_4) {
+		additionalTags = new char[][] {
+			TAG_INHERITDOC, TAG_LINKPLAIN, TAG_VALUE
+		};
+	} else if (this.complianceLevel > ClassFileConstants.JDK1_4
+			&& this.complianceLevel < ClassFileConstants.JDK9) {
+		additionalTags = new char[][] {
+			TAG_INHERITDOC, TAG_LINKPLAIN, TAG_VALUE,
+			TAG_CODE, TAG_LITERAL
+		};
+	} else if (this.complianceLevel == ClassFileConstants.JDK9) {
+		additionalTags = new char[][] {
+			TAG_INHERITDOC, TAG_LINKPLAIN, TAG_VALUE,
+			TAG_CODE, TAG_LITERAL,
+			TAG_INDEX
+		};
+	} else if (this.complianceLevel >= ClassFileConstants.JDK10
+			&& this.complianceLevel < ClassFileConstants.JDK12) {
+		additionalTags = new char[][] {
+			TAG_INHERITDOC, TAG_LINKPLAIN, TAG_VALUE,
+			TAG_CODE, TAG_LITERAL,
+			TAG_INDEX, TAG_SUMMARY
+		};
+	} else if(this.complianceLevel >= ClassFileConstants.JDK12
+			&& this.complianceLevel < ClassFileConstants.JDK16) {
+		additionalTags = new char[][] {
+			TAG_INHERITDOC, TAG_LINKPLAIN, TAG_VALUE,
+			TAG_CODE, TAG_LITERAL, TAG_INDEX, TAG_SUMMARY, TAG_SYSTEM_PROPERTY
+		};
+	} else if(this.complianceLevel >= ClassFileConstants.JDK16
+			&& this.complianceLevel < ClassFileConstants.JDK18) {
+		additionalTags = new char[][] {
+			TAG_INHERITDOC, TAG_LINKPLAIN, TAG_VALUE,
+			TAG_CODE, TAG_LITERAL, TAG_INDEX, TAG_SUMMARY, TAG_SYSTEM_PROPERTY, TAG_RETURN
+		};
+	} else if(this.complianceLevel >= ClassFileConstants.JDK18) {
+		additionalTags = new char[][] {
+			TAG_INHERITDOC, TAG_LINKPLAIN, TAG_VALUE,
+			TAG_CODE, TAG_LITERAL, TAG_INDEX, TAG_SUMMARY, TAG_SYSTEM_PROPERTY, TAG_RETURN, TAG_SNIPPET
+		};
+	}
+	return additionalTags;
+}
+
 protected void verifyCompletionInJavadoc(String source, String after) {
 	CompilerOptions options = new CompilerOptions(getCompilerOptions());
 	CompletionParser parser = new CompletionParser(new ProblemReporter(DefaultErrorHandlingPolicies.proceedWithAllProblems(),
@@ -190,40 +236,7 @@ protected void verifyAllTagsCompletion() {
 				TAG_LINK,
 				TAG_DOC_ROOT
 			};
-	char[][] additionalTags = null;
-	if(this.complianceLevel == ClassFileConstants.JDK1_4) {
-		additionalTags = new char[][] {
-			TAG_INHERITDOC, TAG_LINKPLAIN, TAG_VALUE
-		};
-	} else if(this.complianceLevel > ClassFileConstants.JDK1_4
-			&& this.complianceLevel < ClassFileConstants.JDK9) {
-		additionalTags = new char[][] {
-			TAG_INHERITDOC, TAG_LINKPLAIN, TAG_VALUE,
-			TAG_CODE, TAG_LITERAL
-		};
-	} else if (this.complianceLevel == ClassFileConstants.JDK9) {
-		additionalTags = new char[][] {
-			TAG_INHERITDOC, TAG_LINKPLAIN, TAG_VALUE,
-			TAG_CODE, TAG_LITERAL, TAG_INDEX
-		};
-	} else if (this.complianceLevel > ClassFileConstants.JDK9
-			&& this.complianceLevel < ClassFileConstants.JDK12) {
-		additionalTags = new char[][] {
-			TAG_INHERITDOC, TAG_LINKPLAIN, TAG_VALUE,
-			TAG_CODE, TAG_LITERAL, TAG_INDEX, TAG_SUMMARY
-		};
-	} else if(this.complianceLevel >= ClassFileConstants.JDK12
-			&& this.complianceLevel < ClassFileConstants.JDK18) {
-		additionalTags = new char[][] {
-			TAG_INHERITDOC, TAG_LINKPLAIN, TAG_VALUE,
-			TAG_CODE, TAG_LITERAL, TAG_INDEX, TAG_SUMMARY, TAG_SYSTEM_PROPERTY
-		};
-	} else if(this.complianceLevel >= ClassFileConstants.JDK18) {
-		additionalTags = new char[][] {
-			TAG_INHERITDOC, TAG_LINKPLAIN, TAG_VALUE,
-			TAG_CODE, TAG_LITERAL, TAG_INDEX, TAG_SUMMARY, TAG_SYSTEM_PROPERTY, TAG_SNIPPET
-		};
-	}
+	char[][] additionalTags = getAdditionalTagsPerLevels();
 	allTagsFinal = this.complianceLevel > ClassFileConstants.JDK1_8 ? allTagsJava9Plus  :  this.complianceLevel == ClassFileConstants.JDK1_8 ? allTagsJava8 : allTags  ;
 	if (additionalTags != null) {
 		int length = allTagsFinal.length;
@@ -309,42 +322,7 @@ public void test006() {
 		TAG_LINK,
 		TAG_DOC_ROOT,
 	};
-	char[][] additionalTags = null;
-	if (this.complianceLevel == ClassFileConstants.JDK1_4) {
-		additionalTags = new char[][] {
-			TAG_INHERITDOC, TAG_LINKPLAIN, TAG_VALUE
-		};
-	} else if (this.complianceLevel > ClassFileConstants.JDK1_4
-			&& this.complianceLevel < ClassFileConstants.JDK9) {
-		additionalTags = new char[][] {
-			TAG_INHERITDOC, TAG_LINKPLAIN, TAG_VALUE,
-			TAG_CODE, TAG_LITERAL
-		};
-	} else if (this.complianceLevel == ClassFileConstants.JDK9) {
-		additionalTags = new char[][] {
-			TAG_INHERITDOC, TAG_LINKPLAIN, TAG_VALUE,
-			TAG_CODE, TAG_LITERAL,
-			TAG_INDEX
-		};
-	} else if (this.complianceLevel >= ClassFileConstants.JDK10
-			&& this.complianceLevel < ClassFileConstants.JDK12) {
-		additionalTags = new char[][] {
-			TAG_INHERITDOC, TAG_LINKPLAIN, TAG_VALUE,
-			TAG_CODE, TAG_LITERAL,
-			TAG_INDEX, TAG_SUMMARY
-		};
-	} else if(this.complianceLevel >= ClassFileConstants.JDK12
-			&& this.complianceLevel < ClassFileConstants.JDK18) {
-		additionalTags = new char[][] {
-			TAG_INHERITDOC, TAG_LINKPLAIN, TAG_VALUE,
-			TAG_CODE, TAG_LITERAL, TAG_INDEX, TAG_SUMMARY, TAG_SYSTEM_PROPERTY
-		};
-	} else if(this.complianceLevel >= ClassFileConstants.JDK18) {
-		additionalTags = new char[][] {
-			TAG_INHERITDOC, TAG_LINKPLAIN, TAG_VALUE,
-			TAG_CODE, TAG_LITERAL, TAG_INDEX, TAG_SUMMARY, TAG_SYSTEM_PROPERTY, TAG_SNIPPET
-		};
-	}
+	char[][] additionalTags = getAdditionalTagsPerLevels();
 	if (additionalTags != null) {
 		int length = allTags.length;
 		int add = additionalTags.length;
@@ -573,44 +551,7 @@ public void test025() {
 		TAG_LINK,
 		TAG_DOC_ROOT,
 	};
-	char[][] additionalTags = null;
-	if (this.complianceLevel == ClassFileConstants.JDK1_4) {
-		additionalTags = new char[][] {
-			TAG_INHERITDOC, TAG_LINKPLAIN, TAG_VALUE
-		};
-	} else if (this.complianceLevel > ClassFileConstants.JDK1_4
-			&& this.complianceLevel < ClassFileConstants.JDK9) {
-		additionalTags = new char[][] {
-			TAG_INHERITDOC, TAG_LINKPLAIN, TAG_VALUE,
-			TAG_CODE, TAG_LITERAL
-		};
-	} else if (this.complianceLevel == ClassFileConstants.JDK9) {
-		additionalTags = new char[][] {
-			TAG_INHERITDOC, TAG_LINKPLAIN, TAG_VALUE,
-			TAG_CODE, TAG_LITERAL,
-			TAG_INDEX
-		};
-	} else if (this.complianceLevel > ClassFileConstants.JDK9
-			&& this.complianceLevel < ClassFileConstants.JDK12) {
-		additionalTags = new char[][] {
-			TAG_INHERITDOC, TAG_LINKPLAIN, TAG_VALUE,
-			TAG_CODE, TAG_LITERAL,
-			TAG_INDEX, TAG_SUMMARY
-		};
-	} else if(this.complianceLevel >= ClassFileConstants.JDK12
-			&& this.complianceLevel < ClassFileConstants.JDK18) {
-		additionalTags = new char[][] {
-			TAG_INHERITDOC, TAG_LINKPLAIN, TAG_VALUE,
-			TAG_CODE, TAG_LITERAL,
-			TAG_INDEX, TAG_SUMMARY, TAG_SYSTEM_PROPERTY
-		};
-	} else if (this.complianceLevel >= ClassFileConstants.JDK18) {
-		additionalTags = new char[][] {
-			TAG_INHERITDOC, TAG_LINKPLAIN, TAG_VALUE,
-			TAG_CODE, TAG_LITERAL,
-			TAG_INDEX, TAG_SUMMARY, TAG_SYSTEM_PROPERTY, TAG_SNIPPET
-		};
-	}
+	char[][] additionalTags = getAdditionalTagsPerLevels();
 	if (additionalTags != null) {
 		int length = allTags.length;
 		int add = additionalTags.length;
@@ -673,45 +614,7 @@ public void test028() {
 		TAG_LINK,
 		TAG_DOC_ROOT,
 	};
-	char[][] additionalTags = null;
-	if (this.complianceLevel == ClassFileConstants.JDK1_4) {
-		additionalTags = new char[][] {
-			TAG_INHERITDOC, TAG_LINKPLAIN, TAG_VALUE
-		};
-	} else if (this.complianceLevel > ClassFileConstants.JDK1_4
-			&& this.complianceLevel < ClassFileConstants.JDK9) {
-		additionalTags = new char[][] {
-			TAG_INHERITDOC, TAG_LINKPLAIN, TAG_VALUE,
-			TAG_CODE, TAG_LITERAL
-		};
-	} else if (this.complianceLevel == ClassFileConstants.JDK9) {
-		additionalTags = new char[][] {
-			TAG_INHERITDOC, TAG_LINKPLAIN, TAG_VALUE,
-			TAG_CODE, TAG_LITERAL,
-			TAG_INDEX
-		};
-	} else if (this.complianceLevel > ClassFileConstants.JDK9
-			&& this.complianceLevel < ClassFileConstants.JDK12) {
-		additionalTags = new char[][] {
-			TAG_INHERITDOC, TAG_LINKPLAIN, TAG_VALUE,
-			TAG_CODE, TAG_LITERAL,
-			TAG_INDEX, TAG_SUMMARY
-		};
-	} else if(this.complianceLevel >= ClassFileConstants.JDK12
-			&& this.complianceLevel < ClassFileConstants.JDK18) {
-		additionalTags = new char[][] {
-			TAG_INHERITDOC, TAG_LINKPLAIN, TAG_VALUE,
-			TAG_CODE, TAG_LITERAL,
-			TAG_INDEX, TAG_SUMMARY, TAG_SYSTEM_PROPERTY
-		};
-	} else if(this.complianceLevel >= ClassFileConstants.JDK18) {
-		additionalTags = new char[][] {
-			TAG_INHERITDOC, TAG_LINKPLAIN, TAG_VALUE,
-			TAG_CODE, TAG_LITERAL,
-			TAG_INDEX, TAG_SUMMARY, TAG_SYSTEM_PROPERTY,
-			TAG_SNIPPET
-		};
-	}
+	char[][] additionalTags = getAdditionalTagsPerLevels();
 	if (additionalTags != null) {
 		int length = allTags.length;
 		int add = additionalTags.length;

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocBugsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocBugsTest.java
@@ -8518,6 +8518,9 @@ public void testBug267833_2() {
  * @test Ensure that a warning is raised when block tags are used as inline tags.
  */
 public void testBug267833_3() {
+	if(this.complianceLevel >= ClassFileConstants.JDK16) {
+		return;
+	}
 	runNegativeTest(
 		new String[] {
 			"X.java",
@@ -8604,6 +8607,105 @@ public void testBug267833_3() {
 			"	* and more {@since 1.0}, {@serial 0L}, {@serialData data}, {@serialField field}\n" +
 			"	                                                             ^^^^^^^^^^^\n" +
 			"Javadoc: Unexpected tag\n" +
+			"----------\n");
+}
+/**
+ * Additional test for bug 267833 and https://github.com/eclipse-jdt/eclipse.jdt.core/issues/795
+ * For java 16+:
+ * 1) Ensure that a warning is raised when block tags are used as inline tags.
+ * 2) Ensure there is no error reported for return tag used inline
+ * 3) TODO: ensure  there is no error reported for duplicated return tag if it is used inline and as block
+ */
+public void testBug267833_3a() {
+	if(this.complianceLevel < ClassFileConstants.JDK16) {
+		return;
+	}
+	runNegativeTest(
+			new String[] {
+					"X.java",
+					"public class X {\n" +
+							"/** \n" +
+							"* Description {@see String} , {@return int}, {@since 1.0}, {@param i}, {@throws NullPointerException}\n" +
+							"* and more {@author jay}, {@category cat}, {@deprecated}, {@exception NullPointerException}, {@version 1.1}\n" +
+							"* and more {@since 1.0}, {@serial 0L}, {@serialData data}, {@serialField field}\n" +
+							"* @param i\n" +
+							"* @return value\n" +
+							"* @throws NullPointerException \n" +
+							"*/\n" +
+							"public int foo(int i) {\n" +
+							"	return 0;\n" +
+							"}\n" +
+			"}\n" },
+			"----------\n" +
+					"1. ERROR in X.java (at line 3)\n" +
+					"	* Description {@see String} , {@return int}, {@since 1.0}, {@param i}, {@throws NullPointerException}\n" +
+					"	                ^^^\n" +
+					"Javadoc: Unexpected tag\n" +
+					"----------\n" +
+					"2. ERROR in X.java (at line 3)\n" +
+					"	* Description {@see String} , {@return int}, {@since 1.0}, {@param i}, {@throws NullPointerException}\n" +
+					"	                                               ^^^^^\n" +
+					"Javadoc: Unexpected tag\n" +
+					"----------\n" +
+					"3. ERROR in X.java (at line 3)\n" +
+					"	* Description {@see String} , {@return int}, {@since 1.0}, {@param i}, {@throws NullPointerException}\n" +
+					"	                                                             ^^^^^\n" +
+					"Javadoc: Unexpected tag\n" +
+					"----------\n" +
+					"4. ERROR in X.java (at line 3)\n" +
+					"	* Description {@see String} , {@return int}, {@since 1.0}, {@param i}, {@throws NullPointerException}\n" +
+					"	                                                                         ^^^^^^\n" +
+					"Javadoc: Unexpected tag\n" +
+					"----------\n" +
+					"5. ERROR in X.java (at line 4)\n" +
+					"	* and more {@author jay}, {@category cat}, {@deprecated}, {@exception NullPointerException}, {@version 1.1}\n" +
+					"	             ^^^^^^\n" +
+					"Javadoc: Unexpected tag\n" +
+					"----------\n" +
+					"6. ERROR in X.java (at line 4)\n" +
+					"	* and more {@author jay}, {@category cat}, {@deprecated}, {@exception NullPointerException}, {@version 1.1}\n" +
+					"	                            ^^^^^^^^\n" +
+					"Javadoc: Unexpected tag\n" +
+					"----------\n" +
+					"7. ERROR in X.java (at line 4)\n" +
+					"	* and more {@author jay}, {@category cat}, {@deprecated}, {@exception NullPointerException}, {@version 1.1}\n" +
+					"	                                             ^^^^^^^^^^\n" +
+					"Javadoc: Unexpected tag\n" +
+					"----------\n" +
+					"8. ERROR in X.java (at line 4)\n" +
+					"	* and more {@author jay}, {@category cat}, {@deprecated}, {@exception NullPointerException}, {@version 1.1}\n" +
+					"	                                                            ^^^^^^^^^\n" +
+					"Javadoc: Unexpected tag\n" +
+					"----------\n" +
+					"9. ERROR in X.java (at line 4)\n" +
+					"	* and more {@author jay}, {@category cat}, {@deprecated}, {@exception NullPointerException}, {@version 1.1}\n" +
+					"	                                                                                               ^^^^^^^\n" +
+					"Javadoc: Unexpected tag\n" +
+					"----------\n" +
+					"10. ERROR in X.java (at line 5)\n" +
+					"	* and more {@since 1.0}, {@serial 0L}, {@serialData data}, {@serialField field}\n" +
+					"	             ^^^^^\n" +
+					"Javadoc: Unexpected tag\n" +
+					"----------\n" +
+					"11. ERROR in X.java (at line 5)\n" +
+					"	* and more {@since 1.0}, {@serial 0L}, {@serialData data}, {@serialField field}\n" +
+					"	                           ^^^^^^\n" +
+					"Javadoc: Unexpected tag\n" +
+					"----------\n" +
+					"12. ERROR in X.java (at line 5)\n" +
+					"	* and more {@since 1.0}, {@serial 0L}, {@serialData data}, {@serialField field}\n" +
+					"	                                         ^^^^^^^^^^\n" +
+					"Javadoc: Unexpected tag\n" +
+					"----------\n" +
+					"13. ERROR in X.java (at line 5)\n" +
+					"	* and more {@since 1.0}, {@serial 0L}, {@serialData data}, {@serialField field}\n" +
+					"	                                                             ^^^^^^^^^^^\n" +
+					"Javadoc: Unexpected tag\n" +
+					"----------\n" +
+					"14. ERROR in X.java (at line 7)\n" + // XXX should be WARNING
+					"	* @return value\n" +
+					"	   ^^^^^^\n" +
+					"Javadoc: Duplicate tag for return type\n" + // XXX change to: "Javadoc: @return has already been specified"
 			"----------\n");
 }
 

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocBugsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocBugsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -8486,7 +8486,8 @@ public void testBug267833_2() {
 				int length = JavadocTagConstants.BLOCK_TAGS[i].length;
 				for (int j=0; j < length; j++) {
 					if (tagName == JavadocTagConstants.BLOCK_TAGS[i][j]) {
-						assertEquals(JavadocTagConstants.JAVADOC_TAG_TYPE[index], JavadocTagConstants.TAG_TYPE_BLOCK);
+						int tagType = JavadocTagConstants.JAVADOC_TAG_TYPE[index];
+						assertTrue((tagType & JavadocTagConstants.TAG_TYPE_BLOCK) != 0);
 						continue nextTag;
 					}
 				}
@@ -8495,7 +8496,8 @@ public void testBug267833_2() {
 				int length = JavadocTagConstants.INLINE_TAGS[i].length;
 				for (int j=0; j < length; j++) {
 					if (tagName == JavadocTagConstants.INLINE_TAGS[i][j]) {
-						assertEquals(JavadocTagConstants.JAVADOC_TAG_TYPE[index], JavadocTagConstants.TAG_TYPE_INLINE);
+						int tagType = JavadocTagConstants.JAVADOC_TAG_TYPE[index];
+						assertTrue((tagType & JavadocTagConstants.TAG_TYPE_INLINE) != 0);
 						continue nextTag;
 					}
 				}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocTest_16.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocTest_16.java
@@ -1,0 +1,206 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Andrey Loskutov (loskutov@gmx.de) and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Andrey Loskutov (loskutov@gmx.de) - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.core.tests.compiler.regression;
+
+import java.util.Map;
+
+import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
+import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
+
+import junit.framework.Test;
+
+
+@SuppressWarnings({ "unchecked", "rawtypes" })
+public class JavadocTest_16 extends JavadocTest {
+
+	String docCommentSupport = CompilerOptions.ENABLED;
+	String reportInvalidJavadoc = CompilerOptions.ERROR;
+	String reportMissingJavadocDescription = CompilerOptions.RETURN_TAG;
+	String reportInvalidJavadocVisibility = CompilerOptions.PRIVATE;
+	String reportMissingJavadocTags = CompilerOptions.ERROR;
+	String reportMissingJavadocComments = null;
+	String reportMissingJavadocCommentsVisibility = null;
+	String reportDeprecation = CompilerOptions.ERROR;
+	String reportJavadocDeprecation = null;
+	String processAnnotations = null;
+
+public JavadocTest_16(String name) {
+	super(name);
+}
+
+public static Class javadocTestClass() {
+	return JavadocTest_16.class;
+}
+
+// Use this static initializer to specify subset for tests
+// All specified tests which does not belong to the class are skipped...
+static {
+
+}
+
+public static Test suite() {
+	return buildMinimalComplianceTestSuite(javadocTestClass(), F_16);
+}
+
+@Override
+protected Map getCompilerOptions() {
+	Map options = super.getCompilerOptions();
+	options.put(CompilerOptions.OPTION_DocCommentSupport, this.docCommentSupport);
+	options.put(CompilerOptions.OPTION_ReportInvalidJavadoc, this.reportInvalidJavadoc);
+	if (!CompilerOptions.IGNORE.equals(this.reportInvalidJavadoc)) {
+		options.put(CompilerOptions.OPTION_ReportInvalidJavadocTagsVisibility, this.reportInvalidJavadocVisibility);
+	}
+	if (this.reportJavadocDeprecation != null) {
+		options.put(CompilerOptions.OPTION_ReportInvalidJavadocTagsDeprecatedRef, this.reportJavadocDeprecation);
+	}
+	if (this.reportMissingJavadocComments != null) {
+		options.put(CompilerOptions.OPTION_ReportMissingJavadocComments, this.reportMissingJavadocComments);
+		options.put(CompilerOptions.OPTION_ReportMissingJavadocCommentsOverriding, CompilerOptions.ENABLED);
+		if (this.reportMissingJavadocCommentsVisibility != null) {
+			options.put(CompilerOptions.OPTION_ReportMissingJavadocCommentsVisibility, this.reportMissingJavadocCommentsVisibility);
+		}
+	} else {
+		options.put(CompilerOptions.OPTION_ReportMissingJavadocComments, this.reportInvalidJavadoc);
+	}
+	if (this.reportMissingJavadocTags != null) {
+		options.put(CompilerOptions.OPTION_ReportMissingJavadocTags, this.reportMissingJavadocTags);
+		options.put(CompilerOptions.OPTION_ReportMissingJavadocTagsOverriding, CompilerOptions.ENABLED);
+	} else {
+		options.put(CompilerOptions.OPTION_ReportMissingJavadocTags, this.reportInvalidJavadoc);
+	}
+	if (this.reportMissingJavadocDescription != null) {
+		options.put(CompilerOptions.OPTION_ReportMissingJavadocTagDescription, this.reportMissingJavadocDescription);
+	}
+	if (this.processAnnotations != null) {
+		options.put(CompilerOptions.OPTION_Process_Annotations, this.processAnnotations);
+	}
+	options.put(CompilerOptions.OPTION_ReportFieldHiding, CompilerOptions.IGNORE);
+	options.put(CompilerOptions.OPTION_ReportSyntheticAccessEmulation, CompilerOptions.IGNORE);
+	options.put(CompilerOptions.OPTION_ReportDeprecation, this.reportDeprecation);
+	options.put(CompilerOptions.OPTION_ReportUnusedImport, CompilerOptions.ERROR);
+	options.put(CompilerOptions.OPTION_ReportRawTypeReference, CompilerOptions.IGNORE);
+	options.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.IGNORE);
+	return options;
+}
+
+@Override
+protected void setUp() throws Exception {
+	super.setUp();
+	this.docCommentSupport = CompilerOptions.ENABLED;
+	this.reportInvalidJavadoc = CompilerOptions.ERROR;
+	this.reportInvalidJavadocVisibility = CompilerOptions.PRIVATE;
+	this.reportMissingJavadocTags = CompilerOptions.IGNORE;
+	this.reportMissingJavadocComments = CompilerOptions.IGNORE;
+	this.reportMissingJavadocCommentsVisibility = CompilerOptions.PUBLIC;
+	this.reportDeprecation = CompilerOptions.ERROR;
+	this.reportInvalidJavadoc = CompilerOptions.ERROR;
+}
+
+
+public void testInlineReturn1() {
+	if(this.complianceLevel < ClassFileConstants.JDK16) {
+		return;
+	}
+	this.runConformTest(
+		new String[] {
+			"X.java",
+			"""
+			public class X {
+				/** {@return 42} */
+				public int sample() {
+					return 42;
+				}
+			}
+			""",
+		}
+	);
+}
+public void testInlineReturn2() {
+	if(this.complianceLevel < ClassFileConstants.JDK16) {
+		return;
+	}
+	this.runConformTest(
+		new String[] {
+			"X.java",
+			"""
+			public class X {
+				/** {@return some lengthy description} */
+				public int sample() {
+					return 42;
+				}
+			}
+			""",
+		}
+	);
+}
+
+public void testInlineReturn_broken1() {
+	if(this.complianceLevel < ClassFileConstants.JDK16) {
+		return;
+	}
+	this.runNegativeTest(
+		new String[] {
+			"X.java",
+			"""
+			public class X {
+				/** {@return with unbalanced brace{} */
+				public int sample() {
+					return 42;
+				}
+			}
+			""",
+		},
+
+		"""
+		----------
+		1. ERROR in X.java (at line 2)
+			/** {@return with unbalanced brace{} */
+			    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+		Javadoc: Missing closing brace for inline tag
+		----------
+		""",
+		JavacTestOptions.Excuse.EclipseWarningConfiguredAsError
+	);
+}
+
+public void testInlineReturn_broken2() {
+	if(this.complianceLevel < ClassFileConstants.JDK16) {
+		return;
+	}
+	this.runNegativeTest(
+			new String[] {
+					"X.java",
+			"""
+			public class X
+				/** {@return with unbalanced brace}} */
+				public int sample() {
+					return 42;
+				}
+			}
+			""",
+			},
+
+		"""
+		----------
+		1. ERROR in X.java (at line 1)
+			public class X
+			             ^
+		Syntax error on token "X", { expected after this token
+		----------
+		""",
+		JavacTestOptions.Excuse.EclipseWarningConfiguredAsError
+			);
+}
+}
+

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TestAll.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TestAll.java
@@ -217,6 +217,7 @@ public static Test suite() {
 	 since_16.add(PatternMatching16Test.class);
 	 since_16.add(RecordsRestrictedClassTest.class);
 	 since_16.add(JavadocTestForRecord.class);
+	 since_16.add(JavadocTest_16.class);
 
 	 // add 17 specific test here (check duplicates)
 	 ArrayList since_17 = new ArrayList();


### PR DESCRIPTION
- Updated JavadocParser code to allow return tags to be "inlined".
- Relaxed the error check for inline/block return tags mismatch added via  https://bugs.eclipse.org/bugs/show_bug.cgi?id=267833
- added regression tests

Note: because of the JLS change, JavadocTagConstants.JAVADOC_TAG_TYPE array doesn't work anymore as intended, because there are now tags that can be tags that support *both* block or inline style.

See https://docs.oracle.com/en/java/javase/17/docs/specs/javadoc/doc-comment-spec.html#return

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/795