### PR TITLE
12 compiler fails since Java 20 is used

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullAnnotationTests18.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullAnnotationTests18.java
@@ -130,6 +130,7 @@ public class NullAnnotationTests18 extends AbstractNullAnnotationTest {
 		runner.classLibraries = this.LIBS;
 		Map<String,String> opts = getCompilerOptions();
 		opts.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_20);
+		opts.put(CompilerOptions.OPTION_TargetPlatform, CompilerOptions.VERSION_20);
 		opts.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.ENABLED);
 		opts.put(CompilerOptions.OPTION_ReportPreviewFeatures, CompilerOptions.IGNORE);
 		runner.customOptions = opts;


### PR DESCRIPTION
Set target compilation level to 20 to avoid

`UnsupportedClassVersionError: Main (class file version 63.65535) was compiled with preview features that are unsupported. This version of the Java Runtime only recognizes preview features for class file version 64.65535`.

Not clear however why default seem to be set to 19.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/992
