### PR TITLE
12 compiler fails since Java 20 is used #992

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TestAll.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TestAll.java
@@ -228,14 +228,11 @@ public static Test suite() {
 	 ArrayList since_18 = new ArrayList();
 	 since_18.add(JavadocTest_18.class);
 
-	 // add 19 specific test here (check duplicates)
-	 ArrayList since_19 = new ArrayList();
-	 since_19.add(NullAnnotationTests18.class);
-
-	 // add 19 specific test here (check duplicates)
+	 // add 20 specific test here (check duplicates)
 	 ArrayList since_20 = new ArrayList();
 	 since_20.add(SwitchPatternTest.class);
 	 since_20.add(RecordPatternTest.class);
+	 since_20.add(NullAnnotationTests18.class);
 
 	 // Build final test suite
 	TestSuite all = new TestSuite(TestAll.class.getName());
@@ -472,7 +469,6 @@ public static Test suite() {
 		tests_19.addAll(since_16);
 		tests_19.addAll(since_17);
 		tests_19.addAll(since_18);
-		tests_19.addAll(since_19);
 		TestCase.resetForgottenFilters(tests_19);
 		all.addTest(AbstractCompilerTest.buildComplianceTestSuite(ClassFileConstants.getComplianceLevelForJavaVersion(ClassFileConstants.MAJOR_VERSION_19), tests_19));
 	}
@@ -493,7 +489,6 @@ public static Test suite() {
 		tests_20.addAll(since_16);
 		tests_20.addAll(since_17);
 		tests_20.addAll(since_18);
-		tests_20.addAll(since_19);
 		tests_20.addAll(since_20);
 		TestCase.resetForgottenFilters(tests_20);
 		all.addTest(AbstractCompilerTest.buildComplianceTestSuite(ClassFileConstants.getComplianceLevelForJavaVersion(ClassFileConstants.MAJOR_VERSION_20), tests_20));


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
