### PR TITLE
Fail with appropriate assertion in TestingEnvironment

### DIFF
--- a/org.eclipse.jdt.core.tests.builder/src/org/eclipse/jdt/core/tests/builder/TestingEnvironment.java
+++ b/org.eclipse.jdt.core.tests.builder/src/org/eclipse/jdt/core/tests/builder/TestingEnvironment.java
@@ -829,19 +829,50 @@ public void cleanBuild(String projectName) {
 		return getProject(projectPath).getFullPath();
 	}
 
-	void handle(Exception e) {
-		if (e instanceof CoreException) {
-			handleCoreException((CoreException) e);
+	void handle(Throwable e) {
+		if (e instanceof CoreException ce) {
+			handleCoreException(ce);
+		} else if(e instanceof AssertionError ae) {
+			throw ae;
 		} else {
 			e.printStackTrace();
-			Assert.isTrue(false);
+			Assert.isTrue(false, "Unhandled exception: " + e.toString());
 		}
+	}
+
+	/**
+	 * Tries to find and return first exception from a status, if any.
+	 */
+	Throwable getRootCauseFromStatus(CoreException e) {
+		IStatus status = e.getStatus();
+		while(status.getException() instanceof CoreException ce) {
+			status = ce.getStatus();
+		}
+		if(status instanceof MultiStatus ms) {
+			IStatus[] children = ms.getChildren();
+			for (IStatus s : children) {
+				Throwable exception = s.getException();
+				if(exception instanceof CoreException ce) {
+					Throwable t = getRootCauseFromStatus(ce);
+					if(t != null) {
+						return t;
+					}
+				} else if(exception != null){
+					return exception;
+				}
+			}
+		}
+		return status.getException();
 	}
 
 	/**
 	* Handles a core exception thrown during a testing environment operation
 	*/
 	private void handleCoreException(CoreException e) {
+		Throwable throwable = getRootCauseFromStatus(e);
+		if(throwable instanceof AssertionError ae) {
+			throw ae;
+		}
 		e.printStackTrace();
 		IStatus status = e.getStatus();
 		String message = e.getMessage();
@@ -886,11 +917,9 @@ public void cleanBuild(String projectName) {
 		checkAssertion("a workspace must be open", this.isOpen); //$NON-NLS-1$
 		try {
 			getProject(projectPath).build(IncrementalProjectBuilder.INCREMENTAL_BUILD, null);
-		} catch (CoreException e) {
+		} catch (Throwable e) {
 			handle(e);
-		} catch(Throwable e) {
-			e.printStackTrace();
-	}
+		}
 	}
 
 	public boolean isAutoBuilding() {


### PR DESCRIPTION
Tests that throw assertions inside callback classes (like in builders) are failing today with a completely useless `Assert.isTrue(false)` error that also doesn't point to the actual assertion / fail in the test code.

Let inspect the CoreException that probably just wraps some test fail or assertion - and if it is the case, just throw that original error.

Found in context of
https://github.com/eclipse-jdt/eclipse.jdt.core/issues/983