### PR TITLE
Fix "requires" sort in CompilationParticipants.sortParticipants()

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelManager.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelManager.java
@@ -577,9 +577,9 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 					for (int i = 0, length = requiredElements.length; i < length; i++) {
 						IConfigurationElement required = requiredElements[i];
 						if (id.equals(required.getAttribute("id"))) //$NON-NLS-1$
-							return 1;
+							return -1;
 					}
-					return -1;
+					return 1;
 				}
 			});
 			for (int i = 0; i < size; i++)

--- a/org.eclipse.jdt.core/schema/compilationParticipant.exsd
+++ b/org.eclipse.jdt.core/schema/compilationParticipant.exsd
@@ -97,14 +97,14 @@
    <element name="requires">
       <annotation>
          <documentation>
-            a participant that is required to run this compilation participant
+            a participant that is required to run before this compilation participant
          </documentation>
       </annotation>
       <complexType>
          <attribute name="id" type="string" use="required">
             <annotation>
                <documentation>
-                  the unique identifier of the participant that is required
+                  the unique identifier of the participant that is required to run before
                </documentation>
             </annotation>
          </attribute>


### PR DESCRIPTION
According to original intent
https://bugs.eclipse.org/bugs/show_bug.cgi?id=115658#c12 (emphasis mine):

> `changed the extension point to specify whether the participant
modifies the environment, whether it creates problems, and optionally the list of participants it requires to run **before** itself.`

And extension point says:

> `a participant that is required to run this compilation participant`
> `the unique identifier of the participant that is required`

In my understanding if P1 "requires" P2, it means: P1 requires P2 to run before.

So "P1 requires P2 requires P3" means first P3 is called, then P2, then P1.

However it looks like opposite is the case ?!?

From my POV this is a never detected bug in
`JavaModelManager.CompilationParticipants.sortParticipants()`

Found in context of
https://github.com/eclipse-jdt/eclipse.jdt.core/issues/983

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1000