### PR TITLE
Don't put Javadoc html block tags on separate lines if requested

### DIFF
--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/core/formatter/DefaultCodeFormatterConstants.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/core/formatter/DefaultCodeFormatterConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -1705,6 +1705,19 @@ public class DefaultCodeFormatterConstants {
 	 * @since 3.6
 	 */
 	public final static String FORMATTER_COMMENT_NEW_LINES_AT_JAVADOC_BOUNDARIES = "org.eclipse.jdt.core.formatter.comment.new_lines_at_javadoc_boundaries"; //$NON-NLS-1$
+
+	/**
+	 * <pre>
+	 * FORMATTER / Option to control whether paragraph tags in javadoc comments are put with the content or on their own line
+	 *     - option id:         "org.eclipse.jdt.core.formatter.comment.javadoc_paragraphs_tags_with_content"
+	 *     - possible values:   { TRUE, FALSE }
+	 *     - default:           FALSE
+	 * </pre>
+	 * @see #TRUE
+	 * @see #FALSE
+	 * @since 3.34
+	 */
+	public final static String FORMATTER_COMMENT_JAVADOC_DO_NOT_SEPARATE_BLOCK_TAGS = "org.eclipse.jdt.core.formatter.comment.javadoc_do_not_separate_block_tags"; //$NON-NLS-1$
 
 	/**
 	 * <pre>

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/CommentsPreparator.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/CommentsPreparator.java
@@ -807,7 +807,7 @@ public class CommentsPreparator extends ASTVisitor {
 				Matcher attrMatcher = HTML_ATTRIBUTE_PATTERN.matcher(attributesText);
 				final int commentStart = this.ctm.get(0).originalStart;
 				while (attrMatcher.find()) {
-					int equalPos = node.getStartPosition() + matcher.start(8) + attrMatcher.start(1);
+					int equalPos = node.getStartPosition() + matcher.start(9) + attrMatcher.start(1);
 					assert this.tm.charAt(equalPos) == '=';
 					this.allowSubstituteWrapping[equalPos - commentStart] = true;
 				}

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/CommentsPreparator.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/CommentsPreparator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2022 Mateusz Matela and others.
+ * Copyright (c) 2014, 2023 Mateusz Matela and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -59,8 +59,9 @@ public class CommentsPreparator extends ASTVisitor {
 	private final static Pattern HTML_ATTRIBUTE_PATTERN;
 	static {
 		String formatCodeTags = "(pre)"; //$NON-NLS-1$
-		String separateLineTags = "(dl|hr|nl|p|ul|ol|table|tr)"; //$NON-NLS-1$
+		String separateLineTags = "(nl|table|tr)"; //$NON-NLS-1$
 		String breakBeforeTags = "(dd|dt|li|td|th|h1|h2|h3|h4|h5|h6|q)"; //$NON-NLS-1$
+		String blockTags = "(p|dl|ul|ol|hr|dir)"; //$NON-NLS-1$
 		String breakAfterTags = "(br)"; //$NON-NLS-1$
 		String noFormatTags = "(code|tt)"; //$NON-NLS-1$
 		String otherTags = "([\\S&&[^<>]]++)"; //$NON-NLS-1$
@@ -68,7 +69,7 @@ public class CommentsPreparator extends ASTVisitor {
 		String attributeValue = "(?>\"[^\"]*\")|(?>\'[^\']*\')|[\\S&&[^/>\"\']]++"; //$NON-NLS-1$
 		String attribute = "(?>" + ws + "+[\\S&&[^=]]+" + ws + "*(=)" + ws + "*(?>" + attributeValue  + "))"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
 		HTML_TAG_PATTERN = Pattern.compile("<(/)?+(?:" //$NON-NLS-1$
-				+ formatCodeTags + '|' + separateLineTags + '|' + breakBeforeTags + '|' + breakAfterTags + '|' + noFormatTags + '|' + otherTags + ')'
+				+ formatCodeTags + '|' + separateLineTags + '|' + breakBeforeTags + '|' + breakAfterTags + '|' + noFormatTags + '|' + blockTags + '|' + otherTags + ')'
 				+ "(" + attribute + "*)" + ws + "*/?>", Pattern.CASE_INSENSITIVE); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 		HTML_ATTRIBUTE_PATTERN = Pattern.compile(attribute);
 	}
@@ -802,7 +803,7 @@ public class CommentsPreparator extends ASTVisitor {
 				}
 
 				// allow wraps around equals sign in attributes
-				String attributesText = matcher.group(8);
+				String attributesText = matcher.group(9);
 				Matcher attrMatcher = HTML_ATTRIBUTE_PATTERN.matcher(attributesText);
 				final int commentStart = this.ctm.get(0).originalStart;
 				while (attrMatcher.find()) {
@@ -836,6 +837,12 @@ public class CommentsPreparator extends ASTVisitor {
 					handleBreakAfterTag(startPos, endPos);
 				} else if (matcher.start(6) < matcher.end(6)) {
 					handleNoFormatTag(startPos, endPos, isOpeningTag);
+				} else if (matcher.start(7) < matcher.end(7)) {
+					if (this.options.comment_javadoc_do_not_separate_block_tags) {
+						handleBreakBeforeTag(startPos, endPos, isOpeningTag);
+					} else {
+						handleSeparateLineTag(startPos, endPos);
+					}
 				}
 			}
 		}
@@ -965,8 +972,13 @@ public class CommentsPreparator extends ASTVisitor {
 			return;
 		}
 
-		// add empty lines before opening and after closing token
-		handleSeparateLineTag(startPos, endPos);
+		if (this.options.comment_javadoc_do_not_separate_block_tags) {
+			handleBreakBeforeTag(startPos, endPos, isOpeningTag);
+		} else {
+			// add empty lines before opening and after closing token
+			handleSeparateLineTag(startPos, endPos);
+		}
+
 		int startIndex = tokenStartingAt(startPos);
 		int endTagIndex = tokenEndingAt(endPos);
 		if (isOpeningTag) {

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/DefaultCodeFormatterOptions.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/DefaultCodeFormatterOptions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -235,6 +235,7 @@ public class DefaultCodeFormatterOptions {
 	public boolean comment_clear_blank_lines_in_block_comment;
 	public boolean comment_new_lines_at_block_boundaries;
 	public boolean comment_new_lines_at_javadoc_boundaries;
+	public boolean comment_javadoc_do_not_separate_block_tags;
 	public boolean comment_format_javadoc_comment;
 	public boolean comment_format_line_comment;
 	public boolean comment_format_line_comment_starting_on_first_column;
@@ -657,6 +658,7 @@ public class DefaultCodeFormatterOptions {
 		options.put(DefaultCodeFormatterConstants.FORMATTER_COMMENT_CLEAR_BLANK_LINES_IN_JAVADOC_COMMENT, this.comment_clear_blank_lines_in_javadoc_comment ? DefaultCodeFormatterConstants.TRUE : DefaultCodeFormatterConstants.FALSE);
 		options.put(DefaultCodeFormatterConstants.FORMATTER_COMMENT_NEW_LINES_AT_BLOCK_BOUNDARIES, this.comment_new_lines_at_block_boundaries ? DefaultCodeFormatterConstants.TRUE : DefaultCodeFormatterConstants.FALSE);
 		options.put(DefaultCodeFormatterConstants.FORMATTER_COMMENT_NEW_LINES_AT_JAVADOC_BOUNDARIES, this.comment_new_lines_at_javadoc_boundaries ? DefaultCodeFormatterConstants.TRUE : DefaultCodeFormatterConstants.FALSE);
+		options.put(DefaultCodeFormatterConstants.FORMATTER_COMMENT_JAVADOC_DO_NOT_SEPARATE_BLOCK_TAGS, this.comment_javadoc_do_not_separate_block_tags ? DefaultCodeFormatterConstants.TRUE : DefaultCodeFormatterConstants.FALSE);
 		options.put(DefaultCodeFormatterConstants.FORMATTER_COMMENT_FORMAT_BLOCK_COMMENT, this.comment_format_block_comment ? DefaultCodeFormatterConstants.TRUE : DefaultCodeFormatterConstants.FALSE);
 		options.put(DefaultCodeFormatterConstants.FORMATTER_COMMENT_FORMAT_HEADER, this.comment_format_header ? DefaultCodeFormatterConstants.TRUE : DefaultCodeFormatterConstants.FALSE);
 		options.put(DefaultCodeFormatterConstants.FORMATTER_COMMENT_FORMAT_HTML, this.comment_format_html ? DefaultCodeFormatterConstants.TRUE : DefaultCodeFormatterConstants.FALSE);
@@ -1634,6 +1636,10 @@ public class DefaultCodeFormatterOptions {
 		final Object commentNewLinesAtJavadocBoundariesOption = settings.get(DefaultCodeFormatterConstants.FORMATTER_COMMENT_NEW_LINES_AT_JAVADOC_BOUNDARIES);
 		if (commentNewLinesAtJavadocBoundariesOption != null) {
 			this.comment_new_lines_at_javadoc_boundaries = DefaultCodeFormatterConstants.TRUE.equals(commentNewLinesAtJavadocBoundariesOption);
+		}
+		final Object commentJavadocDoNotSeparateBlockTags = settings.get(DefaultCodeFormatterConstants.FORMATTER_COMMENT_JAVADOC_DO_NOT_SEPARATE_BLOCK_TAGS);
+		if (commentJavadocDoNotSeparateBlockTags != null) {
+			this.comment_javadoc_do_not_separate_block_tags = DefaultCodeFormatterConstants.TRUE.equals(commentJavadocDoNotSeparateBlockTags);
 		}
 		final Object indentStatementsCompareToBlockOption = settings.get(DefaultCodeFormatterConstants.FORMATTER_INDENT_STATEMENTS_COMPARE_TO_BLOCK);
 		if (indentStatementsCompareToBlockOption != null) {


### PR DESCRIPTION
- add new DefaultCodeFormatterConstants value: FORMATTER_COMMENT_JAVADOC_DO_NOT_SEPARATE_BLOCK_TAGS
- move html block tags in CommentsPreparator to a new category and add a check for the new formatter option in which case if true, treat as break-before, otherwise treat as separate-lines
- add code in handleFormatCodeTag() to use same option to determine if pre tag should have separate lines or treated as break-before
- needed for: #991

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue #991

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
This will require a change to JDT UI to add support for setting the option which is by default false.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
