### PR TITLE
Fix javadoc error about unexpected end tag

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/core/compiler/CompilationParticipant.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/core/compiler/CompilationParticipant.java
@@ -111,14 +111,13 @@ public void cleanStarting(IJavaProject project) {
  * </p><p>
  * For efficiency, participants that are not interested in the
  * given project should return <code>false</code> for that project.
- * </p><p>
+ * </p>
  * Note: In {@link org.eclipse.jdt.core.WorkingCopyOwner#newWorkingCopy(String, org.eclipse.jdt.core.IClasspathEntry[], org.eclipse.core.runtime.IProgressMonitor)
  * special cases}, the project may be closed and not exist. Participants typically return false when the
  * underlying project is closed. I.e. when the following check returns false:
  *  <pre>
  * 	javaProject.getProject().isOpen();
  * </pre>
- * </p>
  * @param project the project to participate in
  * @return whether this participant is active for a given project
  */


### PR DESCRIPTION
```
../../../eclipse.jdt.core/org.eclipse.jdt.core/model/org/eclipse/jdt/core/compiler/CompilationParticipant.java:121:
error: unexpected end tag: </p>
 * </p>
   ^
1 error
```

See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/983
