### PR TITLE
PatterSearchJob: Use custom ForkJoinWorkerThreadFactory

### DIFF
--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/PatternSearchJob.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/PatternSearchJob.java
@@ -185,6 +185,8 @@ private boolean performParallelSearch(Index[] indexes, SubMonitor loopMonitor) {
 	} catch (Exception e) {
 		monitor.setCanceled(true);
 		throw e;
+	} finally {
+		commonPool.shutdown();
 	}
 	return isComplete;
 }


### PR DESCRIPTION
### What it does
In case a SecurityManager is installed, using the defaultForkJoinWorkerThreadFactory would result in worker threads with no permissions, which leads to not working java type search.

Use a custom ForkJoinWorkerThreadFactory implementation to work around this.

The same fix was also applied to org.eclipse.jdt.internal.core.JavaModelManager.java

See also:
https://github.com/eclipse-jdt/eclipse.jdt.core/pull/604
https://github.com/eclipse-platform/eclipse.platform/issues/294
https://github.com/eclipse-platform/eclipse.platform/pull/295

## How to test

1. Have any Eclipse-plugin that installs a SecurityManager. Use attached demo plugin [foo.bar.securitymanager.zip](https://github.com/eclipse-platform/eclipse.platform/files/10208024/foo.bar.securitymanager.zip) (Main Menu SecurityManager -> Install SecurityManager) or the following snippet:
```
Policy.getPolicy(); // init
Policy.setPolicy(new Policy() {
    @Override
    public boolean implies(ProtectionDomain domain, Permission permission) {
        return true;
    }
});
System.setSecurityManager(new SecurityManager());
```
3. Open a Java project and open the type search (CTRL+SHIFT+T)
4. As soon as you start typing a error is shown

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
