### PR TITLE
Eclipse JDT produces bytecode that can't be indexed by Jandex

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/IntersectionTypeBinding18.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/IntersectionTypeBinding18.java
@@ -380,4 +380,9 @@ public class IntersectionTypeBinding18 extends ReferenceBinding {
 			this.tagBits |= intersectingType.updateTagBits();
 		return super.updateTagBits();
 	}
+
+	@Override
+	public boolean isNonDenotable() {
+		return true;
+	}
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/IntersectionTypeBinding18.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/IntersectionTypeBinding18.java
@@ -382,7 +382,7 @@ public class IntersectionTypeBinding18 extends ReferenceBinding {
 	}
 
 	@Override
-	public boolean isNonDenotable() {
-		return true;
+	public char[] genericTypeSignature(boolean approximateToDenotable) {
+    	return approximateToDenotable ? erasure().genericTypeSignature() : genericTypeSignature();
 	}
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MethodBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MethodBinding.java
@@ -603,6 +603,9 @@ public MethodBinding findOriginalInheritedMethod(MethodBinding inheritedMethod) 
  */
 public char[] genericSignature() {
 	if ((this.modifiers & ExtraCompilerModifiers.AccGenericSignature) == 0) return null;
+	// Synthetic methods may have non-denotable inferred types in their signatures,
+	// fold them into approximate denotable forms so class file parsers don't choke
+	boolean approximateToDenotable = (this.modifiers & ClassFileConstants.AccSynthetic) != 0;
 	StringBuilder sig = new StringBuilder(10);
 	if (this.typeVariables != Binding.NO_TYPE_VARIABLES) {
 		sig.append('<');
@@ -613,11 +616,11 @@ public char[] genericSignature() {
 	}
 	sig.append('(');
 	for (int i = 0, length = this.parameters.length; i < length; i++) {
-		sig.append(this.parameters[i].genericTypeSignature());
+		sig.append(this.parameters[i].genericTypeSignature(approximateToDenotable));
 	}
 	sig.append(')');
 	if (this.returnType != null)
-		sig.append(this.returnType.genericTypeSignature());
+		sig.append(this.returnType.genericTypeSignature(approximateToDenotable));
 
 	// only append thrown exceptions if any is generic/parameterized
 	boolean needExceptionSignatures = false;
@@ -631,7 +634,7 @@ public char[] genericSignature() {
 	if (needExceptionSignatures) {
 		for (int i = 0; i < length; i++) {
 			sig.append('^');
-			sig.append(this.thrownExceptions[i].genericTypeSignature());
+			sig.append(this.thrownExceptions[i].genericTypeSignature(approximateToDenotable));
 		}
 	}
 	int sigLength = sig.length();

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SyntheticMethodBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SyntheticMethodBinding.java
@@ -390,6 +390,9 @@ public class SyntheticMethodBinding extends MethodBinding {
 		this.tagBits |= (TagBits.AnnotationResolved | TagBits.DeprecatedAnnotationResolved) | (lambda.binding.tagBits & TagBits.HasParameterAnnotations);
 	    this.returnType = lambda.binding.returnType;
 	    this.parameters = lambda.binding.parameters;
+        if (this.returnType.isNonDenotable() || Stream.of(this.parameters).anyMatch(p -> p.isNonDenotable())) {
+        	this.modifiers &= ~ExtraCompilerModifiers.AccGenericSignature;
+        }
 	    TypeVariableBinding[] vars = Stream.of(this.parameters).filter(param -> param.isTypeVariable()).toArray(TypeVariableBinding[]::new);
 	    if (vars != null && vars.length > 0)
 	    	this.typeVariables = vars;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SyntheticMethodBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SyntheticMethodBinding.java
@@ -390,9 +390,6 @@ public class SyntheticMethodBinding extends MethodBinding {
 		this.tagBits |= (TagBits.AnnotationResolved | TagBits.DeprecatedAnnotationResolved) | (lambda.binding.tagBits & TagBits.HasParameterAnnotations);
 	    this.returnType = lambda.binding.returnType;
 	    this.parameters = lambda.binding.parameters;
-        if (this.returnType.isNonDenotable() || Stream.of(this.parameters).anyMatch(p -> p.isNonDenotable())) {
-        	this.modifiers &= ~ExtraCompilerModifiers.AccGenericSignature;
-        }
 	    TypeVariableBinding[] vars = Stream.of(this.parameters).filter(param -> param.isTypeVariable()).toArray(TypeVariableBinding[]::new);
 	    if (vars != null && vars.length > 0)
 	    	this.typeVariables = vars;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeBinding.java
@@ -1767,4 +1767,12 @@ public long updateTagBits() {
 public boolean isFreeTypeVariable() {
 	return false;
 }
+
+/**
+ * Does this type lack a class file representation on its own ?
+ */
+public boolean isNonDenotable() {
+	return false;
+}
+
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeBinding.java
@@ -527,6 +527,15 @@ public char[] genericTypeSignature() {
 }
 
 /**
+ * Answer the receiver classfile signature, folding any non-denotable types
+ * to a denotable approximation by using erasure.
+ * NOTE: This method should only be used during/after code gen.
+ */
+public char[] genericTypeSignature(boolean approximateToDenotable) {
+	return genericTypeSignature();
+}
+
+/**
  * Return the supertype which would erase as a subtype of a given declaring class.
  * If the receiver is already erasure compatible, then it will returned. If not, then will return the alternate lowest
  * upper bound compatible with declaring class.
@@ -1767,12 +1776,4 @@ public long updateTagBits() {
 public boolean isFreeTypeVariable() {
 	return false;
 }
-
-/**
- * Does this type lack a class file representation on its own ?
- */
-public boolean isNonDenotable() {
-	return false;
-}
-
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/WildcardBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/WildcardBinding.java
@@ -1087,4 +1087,9 @@ public class WildcardBinding extends ReferenceBinding {
 		}
 		return super.updateTagBits();
 	}
+
+	@Override
+	public boolean isNonDenotable() {
+		return true;
+	}
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/WildcardBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/WildcardBinding.java
@@ -614,6 +614,11 @@ public class WildcardBinding extends ReferenceBinding {
         return this.genericSignature;
     }
 
+    @Override
+    public char[] genericTypeSignature(boolean approximateToDenotable) {
+    	return approximateToDenotable ? erasure().genericTypeSignature() : genericTypeSignature();
+    }
+
 	@Override
 	public int hashCode() {
 		return this.genericType.hashCode();
@@ -1086,10 +1091,5 @@ public class WildcardBinding extends ReferenceBinding {
 			}
 		}
 		return super.updateTagBits();
-	}
-
-	@Override
-	public boolean isNonDenotable() {
-		return true;
 	}
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LambdaExpressionsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LambdaExpressionsTest.java
@@ -7399,6 +7399,43 @@ public void testBug529197_003() {
 			"SUCCESS.run"
 			);
 }
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/756
+public void testIssue756() {
+	this.runConformTest(
+			new String[] {
+				"X.java",
+				"import java.lang.reflect.GenericSignatureFormatError;\n" +
+				"import java.lang.reflect.Method;\n" +
+				"import java.util.function.Supplier;\n" +
+				"\n" +
+				"public class X<T> {\n" +
+				"    public X(T... elements) {\n" +
+				"    	System.out.println();\n" +
+				"    }\n" +
+				"\n" +
+				"    public static Supplier<? extends X<Object>> supplier() {\n" +
+				"        return X<Object>::new;\n" +
+				"    }\n" +
+				"\n" +
+				"    public static void main(String[] args) {\n" +
+				"		boolean OK = true;\n" +
+				"    	for (Method m : X.class.getDeclaredMethods()) {\n" +
+				"			try {\n" +
+				"				m.getGenericReturnType();\n" +
+				"			} catch (GenericSignatureFormatError e) {\n" +
+				"				System.out.println(\"Oops, bad signature in class file\");\n" +
+				"				OK = false;\n" +
+				"			}\n" +
+				"		}\n" +
+				"    	if (OK)\n" +
+				"    		System.out.println(\"All clear!\");\n" +
+				"	}\n" +
+				"}\n"
+			},
+			"All clear!"
+			);
+}
+
 public static Class testClass() {
 	return LambdaExpressionsTest.class;
 }


### PR DESCRIPTION
Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/756

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

Generic signatures emitted for the synthetic lambda implementation methods may occasionally contain non-denotable types resulting from type inference. This will cause grief for class file parsers, reflection utilities and such. Given that javac does not emit generic signatures for lambda methods at all, a safe approach is to suppress the emission of this attribute if we encounter any non-denotable types.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
The included regression test shows how reflection utilities may be used to test
## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
