### PR TITLE
Improve OSGi metadata about dependency to javax.inject/annotations

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.tests.compiler/META-INF/MANIFEST.MF
@@ -22,9 +22,9 @@ Require-Bundle: org.junit;bundle-version="3.8.1",
  org.eclipse.test.performance;bundle-version="[3.10.0,4.0.0)",
  org.eclipse.core.resources;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.jdt.annotation;bundle-version="[1.1.0,2.0.0)";resolution:=optional,
- org.eclipse.jdt.annotation;bundle-version="[2.0.0,3.0.0)";resolution:=optional,
- javax.annotation
-Import-Package: org.eclipse.jdt.internal.compiler.apt.dispatch
+ org.eclipse.jdt.annotation;bundle-version="[2.0.0,3.0.0)";resolution:=optional
+Import-Package: javax.annotation;version="[1.3.0,2.0.0)",
+ org.eclipse.jdt.internal.compiler.apt.dispatch
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Eclipse-BundleShape: dir
 Bundle-Activator: org.eclipse.jdt.core.tests.compiler.Activator

--- a/org.eclipse.jdt.tests.latestBREE/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.tests.latestBREE/META-INF/MANIFEST.MF
@@ -13,8 +13,7 @@ Require-Bundle: org.junit;bundle-version="3.8.1",
  org.eclipse.jdt.annotation;bundle-version="[1.1.0,2.0.0)";resolution:=optional,
  org.eclipse.jdt.annotation;bundle-version="[2.0.0,3.0.0)";resolution:=optional,
  org.eclipse.jdt.core.tests.model;bundle-version="[3.10.0,4.0.0)",
- org.eclipse.jdt.core.tests.compiler;bundle-version="[3.10.0,4.0.0)",
- javax.annotation
+ org.eclipse.jdt.core.tests.compiler;bundle-version="[3.10.0,4.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-15
 Automatic-Module-Name: org.eclipse.jdt.tests.latestBREE
 Bundle-ActivationPolicy: lazy


### PR DESCRIPTION
## What it does

- Only use Import-Package to for javax.annotation
- Always use closed version ranges [1.X,2) with a minor lower bound
- Remove unused dependencies

Part of https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1056

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
