### PR TITLE
Improve array completions Fixes #1021

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests.java
@@ -26522,4 +26522,28 @@ public void testGH504PrimitiveArrayTypeRecieverExpectArrayCompletion() throws Ja
 					+ "}",
 			requestor.getResults());
 }
+public void testGH1021OnSourceTypeArrayExpectArrayCompletion() throws JavaModelException {
+	this.workingCopies = new ICompilationUnit[1];
+	this.workingCopies[0] = getWorkingCopy("Completion/src/ArrayTest.java", """
+			public class ArrayTest {
+			  public void test() {
+			 		ArrayTest[] arr = new\s
+			  }
+			}
+			""");
+
+	CompletionTestsRequestor2 requestor = new CompletionTestsRequestor2(true);
+	requestor.allowAllRequiredProposals();
+	String str = this.workingCopies[0].getSource();
+	String completeBehind = "new ";
+	int cursorLocation = str.lastIndexOf(completeBehind) + completeBehind.length();
+	this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner);
+	assertResults(
+			"ArrayTest[TYPE_REF]{ArrayTest, , LArrayTest;, null, null, "
+					+ (R_DEFAULT + R_RESOLVED + R_INTERESTING + R_CASE + R_UNQUALIFIED + R_NON_RESTRICTED) + "}\n"
+					+ "ArrayTest[TYPE_REF<ARRAY>]{ArrayTest, , LArrayTest;, null, null, " + (R_DEFAULT + R_RESOLVED
+							+ R_INTERESTING + R_CASE + R_NON_RESTRICTED + R_EXACT_EXPECTED_TYPE + R_UNQUALIFIED)
+					+ "}",
+			requestor.getResults());
+}
 }

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests.java
@@ -26538,10 +26538,7 @@ public void testGH1021OnSourceTypeArrayExpectArrayCompletion() throws JavaModelE
 	String completeBehind = "new ";
 	int cursorLocation = str.lastIndexOf(completeBehind) + completeBehind.length();
 	this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner);
-	assertResults(
-			"ArrayTest[TYPE_REF]{ArrayTest, , LArrayTest;, null, null, "
-					+ (R_DEFAULT + R_RESOLVED + R_INTERESTING + R_CASE + R_UNQUALIFIED + R_NON_RESTRICTED) + "}\n"
-					+ "ArrayTest[TYPE_REF<ARRAY>]{ArrayTest, , LArrayTest;, null, null, " + (R_DEFAULT + R_RESOLVED
+	assertResults("ArrayTest[TYPE_REF<ARRAY>]{ArrayTest, , LArrayTest;, null, null, " + (R_DEFAULT + R_RESOLVED
 							+ R_INTERESTING + R_CASE + R_NON_RESTRICTED + R_EXACT_EXPECTED_TYPE + R_UNQUALIFIED)
 					+ "}",
 			requestor.getResults());

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/CompletionEngine.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/CompletionEngine.java
@@ -11812,14 +11812,18 @@ public final class CompletionEngine
 			}
 		}
 
-		checkCancel();
 		if (proposeConstructor && !isEmptyPrefix) {
+
+			checkCancel();
+
 			findTypesFromImports(token, scope, proposeType, typesFound);
 		} else if(proposeType) {
+
+			checkCancel();
+
 			findTypesFromStaticImports(token, scope, proposeAllMemberTypes, typesFound);
 		}
 
-		checkCancel();
 		if (isEmptyPrefix && !this.assistNodeIsAnnotation) {
 			if (proposeConstructor) {
 				findConstructorsFromSubTypes(scope, typesFound);


### PR DESCRIPTION
## What it does
The current fix avoid skipping current type from completions processing if the original expected type is an Array. And for primitives types remove unwanted conditions `!this.assistNodeIsConstructor || !allowingLongComputationProposals` which proves it is not needed for correct completions for primitive arrays.

For enclosing type array expected types, already found enclosing type proposal is carried forward into expected type evaluation and if such proposal is found, that proposal is updated with array dimension and relevance instead of creating similar TYPE-REF completion.

## How to test
Unit Tests

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
