### PR TITLE
Fix NPE in SelectionParser.attachOrphanCompletionNode

### DIFF
--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionParser.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionParser.java
@@ -145,35 +145,6 @@ protected void attachOrphanCompletionNode(){
 			this.currentToken = 0; // given we are not on an eof, we do not want side effects caused by looked-ahead token
 		}
 	}
-	// if casestatement and not orphan, then add switch statement as assist node parent
-	if (this.expressionPtr > 0 && this.assistNodeParent == null) {
-		if (this.astPtr >= 0) {
-			if (this.astStack[this.astPtr] instanceof CaseStatement) {
-				// add switch statement as assistNodeParent
-				Expression expression = this.expressionStack[this.expressionPtr];
-				SwitchStatement switchStatement = new SwitchStatement();
-				switchStatement.expression = this.expressionStack[this.expressionPtr - 1];
-				if (this.astLengthPtr > -1 && this.astPtr > -1) {
-					int length = this.astLengthStack[this.astLengthPtr];
-					int newAstPtr = this.astPtr - length;
-					ASTNode firstNode = this.astStack[newAstPtr + 1];
-					if (length != 0 && switchStatement.expression != null && firstNode.sourceStart > switchStatement.expression.sourceEnd) {
-						switchStatement.statements = new Statement[length + 1];
-						System.arraycopy(this.astStack, newAstPtr + 1, switchStatement.statements, 0, length);
-					}
-
-				}
-				CaseStatement caseStatement = new CaseStatement(expression, expression.sourceStart,
-						expression.sourceEnd);
-				if (switchStatement.statements == null) {
-					switchStatement.statements = new Statement[] { caseStatement };
-				} else {
-					switchStatement.statements[switchStatement.statements.length - 1] = caseStatement;
-				}
-				this.assistNodeParent = switchStatement;
-			}
-		}
-	}
 }
 private void buildMoreCompletionContext(Expression expression) {
 	ASTNode parentNode = null;

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionParser.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionParser.java
@@ -157,7 +157,7 @@ protected void attachOrphanCompletionNode(){
 					int length = this.astLengthStack[this.astLengthPtr];
 					int newAstPtr = this.astPtr - length;
 					ASTNode firstNode = this.astStack[newAstPtr + 1];
-					if (length != 0 && firstNode.sourceStart > switchStatement.expression.sourceEnd) {
+					if (length != 0 && switchStatement.expression != null && firstNode.sourceStart > switchStatement.expression.sourceEnd) {
 						switchStatement.statements = new Statement[length + 1];
 						System.arraycopy(this.astStack, newAstPtr + 1, switchStatement.statements, 0, length);
 					}


### PR DESCRIPTION
- add null check
- fixes #1023

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes NPE caused when searching for broken NLS message in eclipse.jdt.ui.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Run Source -> Find Broken NLS Strings on org.eclipse.jdt.ui plug-in.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
