### PR TITLE
Bug 571467: [compiler] [performance] .java files are read again for each

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/FunctionalExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/FunctionalExpression.java
@@ -70,6 +70,7 @@ public abstract class FunctionalExpression extends Expression {
 	public boolean hasDescripterProblem;
 	public boolean isSerializable;
 	public int ordinal;
+	public char[] text;  // source representation of the FE - used in virgin copy construction
 
 	public FunctionalExpression(CompilationResult compilationResult) {
 		this.compilationResult = compilationResult;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ReferenceExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ReferenceExpression.java
@@ -58,7 +58,6 @@ import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 import org.eclipse.jdt.internal.compiler.codegen.CodeStream;
 import org.eclipse.jdt.internal.compiler.codegen.ConstantPool;
 import org.eclipse.jdt.internal.compiler.codegen.Opcodes;
-import org.eclipse.jdt.internal.compiler.env.ICompilationUnit;
 import org.eclipse.jdt.internal.compiler.flow.FieldInitsFakingFlowContext;
 import org.eclipse.jdt.internal.compiler.flow.FlowContext;
 import org.eclipse.jdt.internal.compiler.flow.FlowInfo;
@@ -123,7 +122,6 @@ public class ReferenceExpression extends FunctionalExpression implements IPolyEx
 	private MethodBinding[] potentialMethods = Binding.NO_METHODS;
 	protected ReferenceExpression original;
 	private HashMap<TypeBinding, ReferenceExpression> copiesPerTargetType;
-	public char[] text; // source representation of the expression.
 	private HashMap<ParameterizedGenericMethodBinding, InferenceContext18> inferenceContexts;
 
 	// the scanner used when creating this expression, may be a RecoveryScanner (with proper RecoveryScannerData),
@@ -145,16 +143,20 @@ public class ReferenceExpression extends FunctionalExpression implements IPolyEx
 		this.sourceEnd = sourceEndPosition;
 	}
 
+	/** 
+	 * @return a virgin copy of `this' by reparsing the stashed textual form.
+	 */
 	private ReferenceExpression copy() {
 		final Parser parser = new Parser(this.enclosingScope.problemReporter(), false);
-		final ICompilationUnit compilationUnit = this.compilationResult.getCompilationUnit();
-		final char[] source = compilationUnit != null ? compilationUnit.getContents() : this.text;
+		char [] source = new char [this.sourceEnd+1];
+		System.arraycopy(this.text, 0, source, this.sourceStart, this.sourceEnd - this.sourceStart + 1);
 		parser.scanner = this.scanner;
-		ReferenceExpression copy =  (ReferenceExpression) parser.parseExpression(source, compilationUnit != null ? this.sourceStart : 0, this.sourceEnd - this.sourceStart + 1,
+		ReferenceExpression copy =  (ReferenceExpression) parser.parseExpression(source, this.sourceStart, this.sourceEnd - this.sourceStart + 1,
 										this.enclosingScope.referenceCompilationUnit(), false /* record line separators */);
 		copy.original = this;
 		copy.sourceStart = this.sourceStart;
 		copy.sourceEnd = this.sourceEnd;
+		copy.text = this.text;
 		return copy;
 	}
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
@@ -9173,11 +9173,16 @@ protected void consumeLambdaExpression() {
 	}
 	this.referenceContext.compilationResult().hasFunctionalTypes = true;
 	markEnclosingMemberWithLocalOrFunctionalType(LocalTypeKind.LAMBDA);
-	if (lexp.compilationResult.getCompilationUnit() == null) {
-		// unit built out of model. Stash a textual representation of lambda to enable LE.copy().
-		int length = lexp.sourceEnd - lexp.sourceStart + 1;
-		System.arraycopy(this.scanner.getSource(), lexp.sourceStart, lexp.text = new char [length], 0, length);
-	}
+	stashTextualRepresentation(lexp);
+}
+
+/* Stash away a copy of the textual representation of the functional expression to facilitate
+   virgin copy construction by reparse. This deep copy may be replaced by a shallow
+   copy by LE.copy() or RE.copy where feasible.
+*/
+private void stashTextualRepresentation(FunctionalExpression fnExp) {
+	int length = fnExp.sourceEnd - fnExp.sourceStart + 1;
+	System.arraycopy(this.scanner.getSource(), fnExp.sourceStart, fnExp.text = new char [length], 0, length);
 }
 
 protected Argument typeElidedArgument() {
@@ -9369,11 +9374,7 @@ protected void consumeReferenceExpression(ReferenceExpression referenceExpressio
 	if (!this.parsingJava8Plus) {
 		problemReporter().referenceExpressionsNotBelow18(referenceExpression);
 	}
-	if (referenceExpression.compilationResult.getCompilationUnit() == null) {
-		// unit built out of model. Stash a textual representation to enable RE.copy().
-		int length = referenceExpression.sourceEnd - referenceExpression.sourceStart + 1;
-		System.arraycopy(this.scanner.getSource(), referenceExpression.sourceStart, referenceExpression.text = new char [length], 0, length);
-	}
+	stashTextualRepresentation(referenceExpression);
 	this.referenceContext.compilationResult().hasFunctionalTypes = true;
 	markEnclosingMemberWithLocalOrFunctionalType(LocalTypeKind.METHOD_REFERENCE);
 }
@@ -14690,6 +14691,9 @@ protected void updateSourcePosition(Expression exp) {
 
 	exp.sourceEnd = this.intStack[this.intPtr--];
 	exp.sourceStart = this.intStack[this.intPtr--];
+	if (exp instanceof FunctionalExpression) {
+		stashTextualRepresentation((FunctionalExpression) exp);
+	}
 }
 public void copyState(Parser from) {
 


### PR DESCRIPTION
<!--
## What it does

Fix bug 571467: [compiler] [performance] .java files are read again for each lambda inside

Stash a copy of the textual representation of the functional expression to facilitate virgin copy construction without having to trigger a file system access when compiling a large number of files simultaneously

Fixes https://bugs.eclipse.org/bugs/show_bug.cgi?id=571467

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

No new regression test is included. This is a design change. All existing lambda tests validate the new implementation.

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
