### PR TITLE
Improve the constructor expected type fix #979

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests18.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests18.java
@@ -6955,4 +6955,31 @@ public void testGH979_on1stConstructorArgument_expectCompletionsMatchinType() th
 					+ (R_DEFAULT + R_RESOLVED + R_INTERESTING + R_CASE + R_UNQUALIFIED + R_NON_RESTRICTED) + "}",
 			result);
 }
+
+public void testGH979_onAnonClassConstructorWith_expectOnlyAnonClassCompletion() throws JavaModelException {
+	this.workingCopies = new ICompilationUnit[1];
+	this.workingCopies[0] = getWorkingCopy("/Completion/src/GH979.java", """
+		import java.io.Serializable;
+		public class GH979 {
+				public GH979() {}
+
+				public void foo() {
+					Serializable run= new Serializable() {
+					};
+				}
+			}
+			""");
+
+	CompletionTestsRequestor2 requestor = new CompletionTestsRequestor2(true);
+	requestor.allowAllRequiredProposals();
+
+	String str = this.workingCopies[0].getSource();
+	String completeBehind = "Serializable run= new Serializable(";
+	int cursorLocation = str.lastIndexOf(completeBehind) + completeBehind.length();
+	this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner, new NullProgressMonitor());
+
+	String result = requestor.getResults();
+	assertResults("Serializable[ANONYMOUS_CLASS_DECLARATION]{, Ljava.io.Serializable;, ()V, null, null, "
+			+ (R_DEFAULT + R_INTERESTING + R_RESOLVED + R_NON_RESTRICTED) + "}", result);
+}
 }

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests18.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests18.java
@@ -6957,15 +6957,23 @@ public void testGH979_on1stConstructorArgument_expectCompletionsMatchinType() th
 }
 
 public void testGH979_onAnonClassConstructorWith_expectOnlyAnonClassCompletion() throws JavaModelException {
-	this.workingCopies = new ICompilationUnit[1];
+	this.workingCopies = new ICompilationUnit[2];
+	this.workingCopies[1] = getWorkingCopy("/Completion/src/Serial.java", """
+			public interface Serial {
+
+			}
+			""");
 	this.workingCopies[0] = getWorkingCopy("/Completion/src/GH979.java", """
-		import java.io.Serializable;
 		public class GH979 {
 				public GH979() {}
 
 				public void foo() {
-					Serializable run= new Serializable() {
+					Serial run= new Serial() {
 					};
+				}
+
+				public Serial toString1() {
+					return null;
 				}
 			}
 			""");
@@ -6974,12 +6982,12 @@ public void testGH979_onAnonClassConstructorWith_expectOnlyAnonClassCompletion()
 	requestor.allowAllRequiredProposals();
 
 	String str = this.workingCopies[0].getSource();
-	String completeBehind = "Serializable run= new Serializable(";
+	String completeBehind = "Serial run= new Serial(";
 	int cursorLocation = str.lastIndexOf(completeBehind) + completeBehind.length();
 	this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner, new NullProgressMonitor());
 
 	String result = requestor.getResults();
-	assertResults("Serializable[ANONYMOUS_CLASS_DECLARATION]{, Ljava.io.Serializable;, ()V, null, null, "
+	assertResults("Serial[ANONYMOUS_CLASS_DECLARATION]{, LSerial;, ()V, null, null, "
 			+ (R_DEFAULT + R_INTERESTING + R_RESOLVED + R_NON_RESTRICTED) + "}", result);
 }
 }

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/CompletionEngine.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/CompletionEngine.java
@@ -3339,6 +3339,9 @@ public final class CompletionEngine
 	}
 
 	private void findCompletionsForArgumentPosition(ObjectVector methodsFound, int completedArgumentLength, Scope scope) {
+		if (methodsFound.size() == 0) {
+			return;
+		}
 		pushExpectedTypesForArgumentPosition(methodsFound, completedArgumentLength, scope);
 		this.strictMatchForExtepectedType = true;
 		int filter = this.expectedTypesFilter;


### PR DESCRIPTION
## What it does
The original fix didn't exit when there are no constructors found which results in suggesting visible symbols in current enclosing scope.

Now the fix is improved so that if we don't find constructors we will not continue to look for visible symbols that could match the argument type at the current position.

## How to test
Unit Test in jdt.core and jdt.ui.text

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
