### PR TITLE
Ecj emits suspect code for try with resources.

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TryStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TryStatement.java
@@ -634,9 +634,6 @@ public void generateCode(BlockScope currentScope, CodeStream codeStream) {
 					elseLabel.place();
 					codeStream.load(this.primaryExceptionVariable);
 					codeStream.load(this.caughtThrowableVariable);
-					codeStream.if_acmpeq(postElseLabel);
-					codeStream.load(this.primaryExceptionVariable);
-					codeStream.load(this.caughtThrowableVariable);
 					codeStream.invokeThrowableAddSuppressed();
 					postElseLabel.place();
 				}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/StackMapAttributeTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/StackMapAttributeTest.java
@@ -7828,10 +7828,10 @@ public class StackMapAttributeTest extends AbstractRegressionTest {
 					"     36  pop\n" +
 					"     37  return\n" +
 					"     38  aload 4 [fis]\n" +
-					"     40  ifnull 86\n" +
+					"     40  ifnull 81\n" +
 					"     43  aload 4 [fis]\n" +
 					"     45  invokevirtual java.io.FileInputStream.close() : void [25]\n" +
-					"     48  goto 86\n" +
+					"     48  goto 81\n" +
 					"     51  astore_2\n" +
 					"     52  aload 4 [fis]\n" +
 					"     54  ifnull 62\n" +
@@ -7844,49 +7844,47 @@ public class StackMapAttributeTest extends AbstractRegressionTest {
 					"     66  ifnonnull 74\n" +
 					"     69  aload_3\n" +
 					"     70  astore_2\n" +
-					"     71  goto 84\n" +
+					"     71  goto 79\n" +
+
 					"     74  aload_2\n" +
 					"     75  aload_3\n" +
-					"     76  if_acmpeq 84\n" +
+					"     76  invokevirtual java.lang.Throwable.addSuppressed(java.lang.Throwable) : void [32]\n" +
 					"     79  aload_2\n" +
-					"     80  aload_3\n" +
-					"     81  invokevirtual java.lang.Throwable.addSuppressed(java.lang.Throwable) : void [32]\n" +
-					"     84  aload_2\n" +
-					"     85  athrow\n" +
-					"     86  iload_1 [i]\n" +
-					"     87  bipush 35\n" +
-					"     89  if_icmpne 122\n" +
-					"     92  aload_0 [this]\n" + 	// return 2
-					"     93  " + xBarCall +
-					"     96  pop\n" +
-					"     97  return\n" +
-					"     98  astore_2 [e]\n" +
+					"     80  athrow\n" +
+					"     81  iload_1 [i]\n" +
+					"     82  bipush 35\n" +
+					"     84  if_icmpne 117\n" +
+					"     87  aload_0 [this]\n" + 	// return 2
+					"     88  " + xBarCall +
+					"     91  pop\n" +
+					"     92  return\n" +
+					"     93  astore_2 [e]\n" +
+					"     94  aload_0 [this]\n" +
+					"     95  " + xBarCall +
+					"     98  pop\n" +
 					"     99  aload_0 [this]\n" +
 					"    100  " + xBarCall +
 					"    103  pop\n" +
-					"    104  aload_0 [this]\n" +
-					"    105  " + xBarCall +
-					"    108  pop\n" +
-					"    109  goto 127\n" +
-					"    112  astore 5\n" +
-					"    114  aload_0 [this]\n" +
-					"    115  " + xBarCall +
-					"    118  pop\n" +
-					"    119  aload 5\n" +
-					"    121  athrow\n" +
-					"    122  aload_0 [this]\n" +
-					"    123  " + xBarCall +
-					"    126  pop\n" +
-					"    127  return\n" +
+					"    104  goto 122\n" +
+					"    107  astore 5\n" +
+					"    109  aload_0 [this]\n" +
+					"    110  " + xBarCall +
+					"    113  pop\n" +
+					"    114  aload 5\n" +
+					"    116  athrow\n" +
+					"    117  aload_0 [this]\n" +
+					"    118  " + xBarCall +
+					"    121  pop\n" +
+					"    122  return\n" +
 					"      Exception Table:\n" +
 					"        [pc: 17, pc: 22] -> 51 when : any\n" +
 					"        [pc: 6, pc: 32] -> 64 when : any\n" +
 					"        [pc: 38, pc: 64] -> 64 when : any\n" +
-					"        [pc: 2, pc: 32] -> 98 when : java.io.IOException\n" +
-					"        [pc: 38, pc: 92] -> 98 when : java.io.IOException\n" +
-					"        [pc: 2, pc: 32] -> 112 when : any\n" +
-					"        [pc: 38, pc: 92] -> 112 when : any\n" +
-					"        [pc: 98, pc: 104] -> 112 when : any\n" +
+					"        [pc: 2, pc: 32] -> 93 when : java.io.IOException\n" +
+					"        [pc: 38, pc: 87] -> 93 when : java.io.IOException\n" +
+					"        [pc: 2, pc: 32] -> 107 when : any\n" +
+					"        [pc: 38, pc: 87] -> 107 when : any\n" +
+					"        [pc: 93, pc: 99] -> 107 when : any\n" +
 					"      Line numbers:\n" +
 					"        [pc: 0, line: 5]\n" +
 					"        [pc: 2, line: 7]\n" +
@@ -7895,22 +7893,22 @@ public class StackMapAttributeTest extends AbstractRegressionTest {
 					"        [pc: 32, line: 15]\n" +
 					"        [pc: 37, line: 8]\n" +
 					"        [pc: 38, line: 9]\n" +
-					"        [pc: 86, line: 10]\n" +
-					"        [pc: 92, line: 15]\n" +
-					"        [pc: 97, line: 11]\n" +
-					"        [pc: 98, line: 12]\n" +
-					"        [pc: 99, line: 13]\n" +
-					"        [pc: 104, line: 15]\n" +
-					"        [pc: 112, line: 14]\n" +
-					"        [pc: 114, line: 15]\n" +
-					"        [pc: 119, line: 16]\n" +
-					"        [pc: 122, line: 15]\n" +
-					"        [pc: 127, line: 17]\n" +
+					"        [pc: 81, line: 10]\n" +
+					"        [pc: 87, line: 15]\n" +
+					"        [pc: 92, line: 11]\n" +
+					"        [pc: 93, line: 12]\n" +
+					"        [pc: 94, line: 13]\n" +
+					"        [pc: 99, line: 15]\n" +
+					"        [pc: 107, line: 14]\n" +
+					"        [pc: 109, line: 15]\n" +
+					"        [pc: 114, line: 16]\n" +
+					"        [pc: 117, line: 15]\n" +
+					"        [pc: 122, line: 17]\n" +
 					"      Local variable table:\n" +
-					"        [pc: 0, pc: 128] local: this index: 0 type: X\n" +
-					"        [pc: 2, pc: 128] local: i index: 1 type: int\n" +
+					"        [pc: 0, pc: 123] local: this index: 0 type: X\n" +
+					"        [pc: 2, pc: 123] local: i index: 1 type: int\n" +
 					"        [pc: 17, pc: 62] local: fis index: 4 type: java.io.FileInputStream\n" +
-					"        [pc: 99, pc: 104] local: e index: 2 type: java.io.IOException\n" +
+					"        [pc: 94, pc: 99] local: e index: 2 type: java.io.IOException\n" +
 					"      Stack map table: number of frames 12\n" +
 					"        [pc: 32, full, stack: {}, locals: {X, int, java.lang.Throwable, java.lang.Throwable, java.io.FileInputStream}]\n" +
 					"        [pc: 38, same]\n" +
@@ -7918,12 +7916,12 @@ public class StackMapAttributeTest extends AbstractRegressionTest {
 					"        [pc: 62, chop 1 local(s)]\n" +
 					"        [pc: 64, same_locals_1_stack_item, stack: {java.lang.Throwable}]\n" +
 					"        [pc: 74, same]\n" +
-					"        [pc: 84, same]\n" +
-					"        [pc: 86, chop 2 local(s)]\n" +
-					"        [pc: 98, same_locals_1_stack_item, stack: {java.io.IOException}]\n" +
-					"        [pc: 112, same_locals_1_stack_item, stack: {java.lang.Throwable}]\n" +
-					"        [pc: 122, same]\n" +
-					"        [pc: 127, same]\n";
+					"        [pc: 79, same]\n" +
+					"        [pc: 81, chop 2 local(s)]\n" +
+					"        [pc: 93, same_locals_1_stack_item, stack: {java.io.IOException}]\n" +
+					"        [pc: 107, same_locals_1_stack_item, stack: {java.lang.Throwable}]\n" +
+					"        [pc: 117, same]\n" +
+					"        [pc: 122, same]\n";
 			int index = actualOutput.indexOf(expectedOutput);
 			if (index == -1 || expectedOutput.length() == 0) {
 				System.out.println(Util.displayString(actualOutput, 2));

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TryWithResourcesStatementTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TryWithResourcesStatementTest.java
@@ -4320,6 +4320,46 @@ public void testBug467230() {
 			"	at Test.main(Test.java:14)\n",
 			null);
 }
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/934
+public void testGHIssue934() {
+	this.runConformTest(
+			true,
+			new String[] {
+				"X.java",
+				"public class X {\n" +
+				"	static class Y implements AutoCloseable {\n" +
+				"		RuntimeException e;\n" +
+				"\n" +
+				"		public Y(RuntimeException e) {\n" +
+				"			this.e = e;\n" +
+				"		}\n" +
+				"\n" +
+				"		@Override\n" +
+				"		public void close() {\n" +
+				"			throw e;\n" +
+				"		}\n" +
+				"	}\n" +
+				"    public static void main(String[] args) {\n" +
+				"        RuntimeException e = new RuntimeException(\"My Exception\");\n" +
+				"        try {\n" +
+				"            try (Y A = new Y(e)) {\n" +
+				"                throw e;\n" +
+				"            }\n" +
+				"        } catch (IllegalArgumentException iae) {\n" +
+				"            if (iae.getCause() == e) \n" +
+				"                System.out.println(\"OK!\");\n" +
+				"        }\n" +
+				"    }\n" +
+				"}\n"
+
+			},
+			null,
+			null,
+			null,
+			"OK!",
+			"",
+			null);
+}
 public static Class testClass() {
 	return TryWithResourcesStatementTest.class;
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TypeAnnotationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TypeAnnotationTest.java
@@ -2238,7 +2238,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"      #85 @A(\n" +
 			"        target type = 0x41 RESOURCE_VARIABLE\n" +
 			"        local variable entries:\n" +
-			"          [pc: 21, pc: 135] index: 3\n" +
+			"          [pc: 21, pc: 130] index: 3\n" +
 			"      )\n";
 		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}


### PR DESCRIPTION
## What it does

ECJ violates the translation scheme for try with resources as outlined in the JLS with pseudo code translations.
This patch aligns ECJ behavior with the JLS.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/934


## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
