### PR TITLE
Bug 573552 - Missing warning for diamond operator

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ASTNode.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ASTNode.java
@@ -74,6 +74,7 @@ import org.eclipse.jdt.internal.compiler.lookup.ModuleBinding;
 import org.eclipse.jdt.internal.compiler.lookup.PackageBinding;
 import org.eclipse.jdt.internal.compiler.lookup.ParameterizedGenericMethodBinding;
 import org.eclipse.jdt.internal.compiler.lookup.ParameterizedMethodBinding;
+import org.eclipse.jdt.internal.compiler.lookup.ParameterizedTypeBinding;
 import org.eclipse.jdt.internal.compiler.lookup.ProblemMethodBinding;
 import org.eclipse.jdt.internal.compiler.lookup.ProblemReasons;
 import org.eclipse.jdt.internal.compiler.lookup.RecordComponentBinding;
@@ -354,7 +355,19 @@ public abstract class ASTNode implements TypeConstants, TypeIds {
 	}
 	private static int checkInvocationArgument(BlockScope scope, Expression argument, TypeBinding parameterType, TypeBinding argumentType, TypeBinding originalParameterType) {
 		argument.computeConversion(scope, parameterType, argumentType);
-
+		if (argument instanceof AllocationExpression) {
+			AllocationExpression allocExp = (AllocationExpression) argument;
+			// we need this only when this is met and as a result the error
+			// is not reported in AllocationExpression#checkTypeArgumentRedundancy()
+			if (allocExp.typeExpected == null) {
+				final boolean isDiamond = allocExp.type != null && (allocExp.type.bits & ASTNode.IsDiamond) != 0;
+				allocExp.typeExpected = parameterType;
+				if (!isDiamond && allocExp.resolvedType.isParameterizedTypeWithActualArguments()) {
+					ParameterizedTypeBinding pbinding = (ParameterizedTypeBinding) allocExp.resolvedType;
+					scope.problemReporter().redundantSpecificationOfTypeArguments(allocExp.type, pbinding.arguments);
+				}
+			}
+		}
 		if (argumentType != TypeBinding.NULL && parameterType.kind() == Binding.WILDCARD_TYPE) { // intersection types are tolerated
 			WildcardBinding wildcard = (WildcardBinding) parameterType;
 			if (wildcard.boundKind != Wildcard.SUPER) {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_1_7.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_1_7.java
@@ -2030,37 +2030,47 @@ public void test0052() {
 			"class AX<T>{}\n"
 		},
 		(this.complianceLevel < ClassFileConstants.JDK1_8 ?
-			"----------\n" +
-			"1. ERROR in X.java (at line 6)\n" +
-			"	X<String> x2 = new X<String>(\"SUCCESS\");\n" +
-			"	                   ^\n" +
-			"Redundant specification of type arguments <String>\n" +
-			"----------\n" +
-			"2. ERROR in X.java (at line 7)\n" +
-			"	X<Integer> x3 = new X<Integer>(1);\n" +
-			"	                    ^\n" +
-			"Redundant specification of type arguments <Integer>\n" +
-			"----------\n" +
-			"3. ERROR in X.java (at line 8)\n" +
-			"	X<AX> x4 = new X<AX>(new AX());\n" +
-			"	               ^\n" +
-			"Redundant specification of type arguments <AX>\n" +
-			"----------\n" +
-			"4. ERROR in X.java (at line 9)\n" +
-			"	X<? extends AX> x5 = new X<AX<String>>(new AX<String>());\n" +
-			"	                         ^\n" +
-			"Redundant specification of type arguments <AX<String>>\n" +
-			"----------\n" +
-			"5. ERROR in X.java (at line 10)\n" +
-			"	X<?> x6 = new X<AX<String>>(new AX<String>());\n" +
-			"	              ^\n" +
-			"Redundant specification of type arguments <AX<String>>\n" +
-			"----------\n" +
-			"6. ERROR in X.java (at line 11)\n" +
-			"	X<Class<? extends Object>> x7 = new X<Class<? extends Object>>();\n" +
-			"	                                    ^\n" +
-			"Redundant specification of type arguments <Class<? extends Object>>\n" +
-			"----------\n"
+				"----------\n" +
+				"1. ERROR in X.java (at line 6)\n" +
+				"	X<String> x2 = new X<String>(\"SUCCESS\");\n" +
+				"	                   ^\n" +
+				"Redundant specification of type arguments <String>\n" +
+				"----------\n" +
+				"2. ERROR in X.java (at line 7)\n" +
+				"	X<Integer> x3 = new X<Integer>(1);\n" +
+				"	                    ^\n" +
+				"Redundant specification of type arguments <Integer>\n" +
+				"----------\n" +
+				"3. ERROR in X.java (at line 8)\n" +
+				"	X<AX> x4 = new X<AX>(new AX());\n" +
+				"	               ^\n" +
+				"Redundant specification of type arguments <AX>\n" +
+				"----------\n" +
+				"4. ERROR in X.java (at line 9)\n" +
+				"	X<? extends AX> x5 = new X<AX<String>>(new AX<String>());\n" +
+				"	                         ^\n" +
+				"Redundant specification of type arguments <AX<String>>\n" +
+				"----------\n" +
+				"5. ERROR in X.java (at line 9)\n" +
+				"	X<? extends AX> x5 = new X<AX<String>>(new AX<String>());\n" +
+				"	                                           ^^\n" +
+				"Redundant specification of type arguments <String>\n" +
+				"----------\n" +
+				"6. ERROR in X.java (at line 10)\n" +
+				"	X<?> x6 = new X<AX<String>>(new AX<String>());\n" +
+				"	              ^\n" +
+				"Redundant specification of type arguments <AX<String>>\n" +
+				"----------\n" +
+				"7. ERROR in X.java (at line 10)\n" +
+				"	X<?> x6 = new X<AX<String>>(new AX<String>());\n" +
+				"	                                ^^\n" +
+				"Redundant specification of type arguments <String>\n" +
+				"----------\n" +
+				"8. ERROR in X.java (at line 11)\n" +
+				"	X<Class<? extends Object>> x7 = new X<Class<? extends Object>>();\n" +
+				"	                                    ^\n" +
+				"Redundant specification of type arguments <Class<? extends Object>>\n" +
+				"----------\n"
 		: // additional error at line 5 due to better inference:
 			"----------\n" +
 			"1. ERROR in X.java (at line 5)\n" +
@@ -2088,12 +2098,22 @@ public void test0052() {
 			"	                         ^\n" +
 			"Redundant specification of type arguments <AX<String>>\n" +
 			"----------\n" +
-			"6. ERROR in X.java (at line 10)\n" +
+			"6. ERROR in X.java (at line 9)\n" +
+			"	X<? extends AX> x5 = new X<AX<String>>(new AX<String>());\n" +
+			"	                                           ^^\n" +
+			"Redundant specification of type arguments <String>\n" +
+			"----------\n" +
+			"7. ERROR in X.java (at line 10)\n" +
 			"	X<?> x6 = new X<AX<String>>(new AX<String>());\n" +
 			"	              ^\n" +
 			"Redundant specification of type arguments <AX<String>>\n" +
 			"----------\n" +
-			"7. ERROR in X.java (at line 11)\n" +
+			"8. ERROR in X.java (at line 10)\n" +
+			"	X<?> x6 = new X<AX<String>>(new AX<String>());\n" +
+			"	                                ^^\n" +
+			"Redundant specification of type arguments <String>\n" +
+			"----------\n" +
+			"9. ERROR in X.java (at line 11)\n" +
 			"	X<Class<? extends Object>> x7 = new X<Class<? extends Object>>();\n" +
 			"	                                    ^\n" +
 			"Redundant specification of type arguments <Class<? extends Object>>\n" +
@@ -2150,6 +2170,11 @@ public void test0052b() {
 			"	String s = foo(new X<String>(\"aaa\"));\n" +
 			"	                   ^\n" +
 			"Redundant specification of type arguments <String>\n" +
+			"----------\n" +
+			"5. ERROR in X.java (at line 12)\n" +
+			"	String s2 = foo(new X<String>(1,\"aaa\"));\n" +
+			"	                    ^\n" +
+			"Redundant specification of type arguments <String>\n" +
 			"----------\n"
 		: // additional error at line 7 due to better inference
 			"----------\n" +
@@ -2176,6 +2201,11 @@ public void test0052b() {
 			"5. ERROR in X.java (at line 11)\n" +
 			"	String s = foo(new X<String>(\"aaa\"));\n" +
 			"	                   ^\n" +
+			"Redundant specification of type arguments <String>\n" +
+			"----------\n" +
+			"6. ERROR in X.java (at line 12)\n" +
+			"	String s2 = foo(new X<String>(1,\"aaa\"));\n" +
+			"	                    ^\n" +
 			"Redundant specification of type arguments <String>\n" +
 			"----------\n"
 		),
@@ -2209,7 +2239,12 @@ public void test0052c() {
 		"	                   ^\n" +
 		"Redundant specification of type arguments <Integer>\n" +
 		"----------\n" +
-		"2. ERROR in X.java (at line 8)\n" +
+		"2. ERROR in X.java (at line 5)\n" +
+		"	foo3(new X<Integer>(\"\",\"\"));\n" +
+		"	         ^\n" +
+		"Redundant specification of type arguments <Integer>\n" +
+		"----------\n" +
+		"3. ERROR in X.java (at line 8)\n" +
 		"	return new X<Integer>(\"\",\"\");\n" +
 		"	           ^\n" +
 		"Redundant specification of type arguments <Integer>\n" +


### PR DESCRIPTION
For method invocations, the allocation expression does not get its expected type soon enough. So, we should wait till it's available.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
