### PR TITLE
ECJ generated code fails at runtime with a LambdaConversionException:

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ReferenceExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ReferenceExpression.java
@@ -143,7 +143,7 @@ public class ReferenceExpression extends FunctionalExpression implements IPolyEx
 		this.sourceEnd = sourceEndPosition;
 	}
 
-	/** 
+	/**
 	 * @return a virgin copy of `this' by reparsing the stashed textual form.
 	 */
 	private ReferenceExpression copy() {
@@ -300,15 +300,26 @@ public class ReferenceExpression extends FunctionalExpression implements IPolyEx
 				}
 			}
 			TypeBinding[] descriptorParams = this.descriptor.parameters;
-			TypeBinding[] origParams = this.binding.original().parameters;
-			TypeBinding[] origDescParams = this.descriptor.original().parameters;
-			int offset = this.receiverPrecedesParameters ? 1 : 0;
-			for (int i = 0; i < descriptorParams.length - offset; i++) {
-				TypeBinding descType = descriptorParams[i + offset];
-				TypeBinding origDescType = origDescParams[i + offset];
-				if (descType.isIntersectionType18() ||
-						(descType.isTypeVariable() && ((TypeVariableBinding) descType).boundsCount() > 1)) {
-					return CharOperation.equals(origDescType.signature(), origParams[i].signature());
+			if (descriptorParams.length > 0) {
+				TypeBinding[] origParams = this.binding.original().parameters;
+				TypeBinding[] origDescParams = this.descriptor.original().parameters;
+				for (int i = 0; i < descriptorParams.length; i++) {
+					TypeBinding descType = descriptorParams[i];
+					TypeBinding origDescType = origDescParams[i];
+					TypeBinding origParam = this.receiverPrecedesParameters
+							? i == 0 ? this.receiverType : origParams[i - 1]
+							: origParams[i];
+					if (descType.isIntersectionType18()
+							|| (descType.isTypeVariable() && ((TypeVariableBinding) descType).boundsCount() > 1)) {
+						if (!CharOperation.equals(origDescType.signature(), origParam.signature()))
+							return false;
+					}
+				}
+			} else if (this.haveReceiver) {
+				 if (this.receiverType.isIntersectionType18()
+						 || (this.receiverType.isTypeVariable() && ((TypeVariableBinding) this.receiverType).boundsCount() > 1)) {
+					 if (!CharOperation.equals(this.binding.original().declaringClass.signature(), this.receiverType.signature()))
+						return false;
 				}
 			}
 		}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LambdaExpressionsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LambdaExpressionsTest.java
@@ -7436,6 +7436,92 @@ public void testIssue756() {
 			);
 }
 
+// https://bugs.eclipse.org/bugs/show_bug.cgi?id=577466
+public void test577466() {
+	this.runConformTest(
+			new String[] {
+				"X.java",
+				"import static java.util.function.Function.identity;\n" +
+				"import java.util.Map;\n" +
+				"import java.util.concurrent.ConcurrentHashMap;\n" +
+				"import java.util.stream.Collectors;\n" +
+				"import java.util.stream.Stream;\n" +
+				"\n" +
+				"public class X {\n" +
+				"\n" +
+				"    private static final Map<Class<?>, Map<String, I>> LOOKUP = new ConcurrentHashMap<>();\n" +
+				"\n" +
+				"    @SuppressWarnings(\"unchecked\")\n" +
+				"    static <E extends Enum<E> & I> E lookupLiteral(Class<E> enumType, String literal) {\n" +
+				"        return (E) LOOKUP.computeIfAbsent(enumType, t ->\n" +
+				"            Stream.of(enumType.getEnumConstants()).collect(Collectors.<E, String, I>toMap(E::getLiteral, identity()))\n" +
+				"        ).get(literal);\n" +
+				"    }\n" +
+				" \n" +
+				"    public static void main(String[] args) {\n" +
+				"        System.out.println(X.lookupLiteral(EN.class, \"a\"));\n" +
+				"    }\n" +
+				"\n" +
+				"    interface I {\n" +
+				"        String getLiteral();\n" +
+				"    }\n" +
+				"\n" +
+				"    enum EN implements I { \n" +
+				"        A(\"a\");\n" +
+				"\n" +
+				"        final String literal;\n" +
+				"\n" +
+				"        EN(String literal) {\n" +
+				"            this.literal = literal;\n" +
+				"        }\n" +
+				"\n" +
+				"        @Override\n" +
+				"        public String getLiteral() {\n" +
+				"            return literal;\n" +
+				"        }\n" +
+				"    }\n" +
+				"}\n"
+
+			},
+			"A"
+			);
+}
+
+// https://bugs.eclipse.org/bugs/show_bug.cgi?id=570511#c2
+public void test570511_comment2() {
+	this.runConformTest(
+			new String[] {
+				"X.java",
+				"import java.util.function.Supplier;\n" +
+				"\n" +
+				"  public class X {\n" +
+				"\n" +
+				"    public static void main(String[] args) {\n" +
+				"        System.out.println(getValue(Size.S));\n" +
+				"    }\n" +
+				"\n" +
+				"    enum Size implements Supplier<String> {\n" +
+				"        S, M, L;\n" +
+				"\n" +
+				"        @Override\n" +
+				"        public String get() {\n" +
+				"            return \"Size: \" + toString();\n" +
+				"        }\n" +
+				"    }\n" +
+				"\n" +
+				"    public static <V extends Enum<?> & Supplier<String>> String getValue(V t) {\n" +
+				"        return valueOf(t::get);\n" +
+				"    }\n" +
+				"\n" +
+				"    public static String valueOf(Supplier<String> id) {\n" +
+				"        return id.get();\n" +
+				"    }\n" +
+				"  }\n"
+			},
+			"Size: S"
+			);
+}
+
 public static Class testClass() {
 	return LambdaExpressionsTest.class;
 }


### PR DESCRIPTION

## What it does
ECJ generated code fails at runtime with LambdaConversionException.

When the method reference receiver is of intersection type, internally fold the reference expression into a lambda

Fixes https://bugs.eclipse.org/bugs/show_bug.cgi?id=577466

## How to test

Contains regression tests

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
