### PR TITLE
ClasspathEntry.full*PatternChars() methods are not thread safe (#1043)

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ClasspathEntry.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ClasspathEntry.java
@@ -162,9 +162,9 @@ public class ClasspathEntry implements IClasspathEntry {
 	 * Patterns allowing to include/exclude portions of the resource tree denoted by this entry path.
 	 */
 	private IPath[] inclusionPatterns;
-	private char[][] fullInclusionPatternChars;
+	private volatile char[][] fullInclusionPatternChars;
 	private IPath[] exclusionPatterns;
-	private char[][] fullExclusionPatternChars;
+	private volatile char[][] fullExclusionPatternChars;
 	private final static char[][] UNINIT_PATTERNS = new char[][] { "Non-initialized yet".toCharArray() }; //$NON-NLS-1$
 	public final static ClasspathEntry[] NO_ENTRIES = new ClasspathEntry[0];
 	private final static IPath[] NO_PATHS = new IPath[0];
@@ -552,12 +552,12 @@ public class ClasspathEntry implements IClasspathEntry {
 
 		if (this.fullExclusionPatternChars == UNINIT_PATTERNS) {
 			int length = this.exclusionPatterns.length;
-			this.fullExclusionPatternChars = new char[length][];
+			char[][] chars = new char[length][];
 			IPath prefixPath = this.path.removeTrailingSeparator();
 			for (int i = 0; i < length; i++) {
-				this.fullExclusionPatternChars[i] =
-					prefixPath.append(this.exclusionPatterns[i]).toString().toCharArray();
+				chars[i] = prefixPath.append(this.exclusionPatterns[i]).toString().toCharArray();
 			}
+			this.fullExclusionPatternChars = chars;
 		}
 		return this.fullExclusionPatternChars;
 	}
@@ -569,12 +569,12 @@ public class ClasspathEntry implements IClasspathEntry {
 
 		if (this.fullInclusionPatternChars == UNINIT_PATTERNS) {
 			int length = this.inclusionPatterns.length;
-			this.fullInclusionPatternChars = new char[length][];
+			char[][] chars = new char[length][];
 			IPath prefixPath = this.path.removeTrailingSeparator();
 			for (int i = 0; i < length; i++) {
-				this.fullInclusionPatternChars[i] =
-					prefixPath.append(this.inclusionPatterns[i]).toString().toCharArray();
+				chars[i] = prefixPath.append(this.inclusionPatterns[i]).toString().toCharArray();
 			}
+			this.fullInclusionPatternChars = chars;
 		}
 		return this.fullInclusionPatternChars;
 	}


### PR DESCRIPTION
Don't expose partially initialized arrays.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1043