### PR TITLE
Additional module-info in a second source folder breaks project

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ModuleBuilderTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ModuleBuilderTests.java
@@ -2217,7 +2217,6 @@ public class ModuleBuilderTests extends ModifyingResourceTests {
 				"othersrc/module-info.java",
 				"module com.greetings1 {\n" +
 				"	requires org.astro;\n" +
-				"	exports com.greetings;\n" +
 				"}",
 				"othersrc/com/greetings/AnotherWorld.java",
 				"package com.greetings;\n" +
@@ -2231,11 +2230,13 @@ public class ModuleBuilderTests extends ModifyingResourceTests {
 			IClasspathEntry dep = JavaCore.newContainerEntry(new Path(JavaCore.MODULE_PATH_CONTAINER_ID));
 			IJavaProject p2 = setupModuleProject("com.greetings", new String[]{"src", "othersrc"}, src, new IClasspathEntry[] { dep });
 			p2.getProject().getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, null);
-			IMarker[] markers = p2.getProject().findMarkers(IJavaModelMarker.JAVA_MODEL_PROBLEM_MARKER, true, IResource.DEPTH_ZERO);
+
+			String duplicatedModuleFile = new Path("othersrc").append(TypeConstants.MODULE_INFO_FILE_NAME_STRING).toOSString();
+			IMarker[] markers = p2.getProject().getFile(duplicatedModuleFile).findMarkers(IJavaModelMarker.JAVA_MODEL_PROBLEM_MARKER, true, IResource.DEPTH_ZERO);
 			assertEquals(1, markers.length);
 			String msg = markers[0].getAttribute(IMarker.MESSAGE, "");
-			String expected = Messages.bind(Messages.classpath_duplicateEntryPath, TypeConstants.MODULE_INFO_FILE_NAME_STRING, p2.getElementName());
-			assertTrue("Unexpected result", msg.indexOf(expected) != -1);
+			String expected = Messages.build_duplicateModuleInfo;
+			assertEquals("Unexpected problem reported", expected, msg);
 		} finally {
 			deleteProject("org.astro");
 			deleteProject("com.greetings");
@@ -2265,15 +2266,15 @@ public class ModuleBuilderTests extends ModifyingResourceTests {
 			IJavaProject p1 = setupModuleProject("org.astro", new String[]{"src", "othersrc"}, sources, null);
 			this.createFile("org.astro/othersrc/module-info.java",
 					"module org.astro1 {\n" +
-					"	exports org.astro;\n" +
 					"}");
 			waitForAutoBuild();
 			p1.getProject().getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, null);
-			IMarker[] markers = p1.getProject().findMarkers(IJavaModelMarker.JAVA_MODEL_PROBLEM_MARKER, true, IResource.DEPTH_ZERO);
+			String duplicatedModuleFile = new Path("othersrc").append(TypeConstants.MODULE_INFO_FILE_NAME_STRING).toOSString();
+			IMarker[] markers = p1.getProject().getFile(duplicatedModuleFile).findMarkers(IJavaModelMarker.JAVA_MODEL_PROBLEM_MARKER, true, IResource.DEPTH_ZERO);
 			assertEquals(1, markers.length);
 			String msg = markers[0].getAttribute(IMarker.MESSAGE, "");
-			String expected = Messages.bind(Messages.classpath_duplicateEntryPath, TypeConstants.MODULE_INFO_FILE_NAME_STRING, p1.getElementName());
-			assertTrue("Unexpected result", msg.indexOf(expected) != -1);
+			String expected = Messages.build_duplicateModuleInfo;
+			assertEquals("Unexpected problem reported", expected, msg);
 		} finally {
 			deleteProject("org.astro");
 		}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaProject.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaProject.java
@@ -545,8 +545,8 @@ public class JavaProject
 			module = root.getModuleDescription();
 			if (module != null) {
 				if (current != null) {
-					throw new JavaModelException(new Status(IStatus.ERROR, JavaCore.PLUGIN_ID,
-							Messages.bind(Messages.classpath_duplicateEntryPath, TypeConstants.MODULE_INFO_FILE_NAME_STRING, getElementName())));
+					// Error will be reported by the compiler
+					return false;
 				}
 				current = module;
 				JavaModelManager.getModulePathManager().addEntry(module, this);

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/AbstractImageBuilder.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/AbstractImageBuilder.java
@@ -184,7 +184,11 @@ public void acceptResult(CompilationResult result) {
 						String simpleName = qualifiedTypeName.substring(qualifiedTypeName.lastIndexOf('/')+1);
 						type = mainType == null ? null : mainType.getCompilationUnit().getType(simpleName);
 					}
-					createProblemFor(compilationUnit.resource, type, Messages.bind(Messages.build_duplicateClassFile, new String(typeName)), JavaCore.ERROR);
+					if(TypeConstants.MODULE_INFO_NAME_STRING.equals(qualifiedTypeName)) {
+						createProblemFor(compilationUnit.resource, type, Messages.build_duplicateModuleInfo, JavaCore.ERROR);
+					} else {
+						createProblemFor(compilationUnit.resource, type, Messages.bind(Messages.build_duplicateClassFile, new String(typeName)), JavaCore.ERROR);
+					}
 					continue;
 				}
 				this.newState.recordLocatorForType(qualifiedTypeName, typeLocator);
@@ -432,7 +436,9 @@ protected void createProblemFor(IResource resource, IMember javaElement, String 
 				if (e.getJavaModelStatus().getCode() != IJavaModelStatusConstants.ELEMENT_DOES_NOT_EXIST) {
 					throw e;
 				}
-				if (!CharOperation.equals(javaElement.getElementName().toCharArray(), TypeConstants.PACKAGE_INFO_NAME)) {
+				char[] elementName = javaElement.getElementName().toCharArray();
+				if (!CharOperation.equals(elementName, TypeConstants.PACKAGE_INFO_NAME)
+						&& !CharOperation.equals(elementName, TypeConstants.MODULE_INFO_NAME)) {
 					throw e;
 				}
 				// else silently swallow the exception as the synthetic interface type package-info has no

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/Messages.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/Messages.java
@@ -107,6 +107,7 @@ public final class Messages extends NLS {
 	public static String build_serializationError;
 	public static String build_classFileCollision;
 	public static String build_duplicateClassFile;
+	public static String build_duplicateModuleInfo;
 	public static String build_duplicateResource;
 	public static String build_inconsistentClassFile;
 	public static String build_inconsistentProject;

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/messages.properties
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/messages.properties
@@ -99,6 +99,7 @@ build_serializationError = Builder serialization error
 ### build inconsistencies
 build_classFileCollision = Class file collision: {0}
 build_duplicateClassFile = The type {0} is already defined
+build_duplicateModuleInfo = The module-info is already defined in the project
 build_duplicateResource = The resource is a duplicate of {0} and was not copied to the output folder
 build_inconsistentClassFile = A class file was not written. The project may be inconsistent, if so try refreshing this project and building it
 build_inconsistentProject = The project was not built due to "{0}". Fix the problem, then try refreshing this project and building it since it may be inconsistent


### PR DESCRIPTION
- Don't throw in JavaProject.buildStructure() if we find more then one module-info file -this breaks entire project infrastructure and user can't even fix the problem. Instead, just return false as proposed by API.
- don't re-throw exception reported in createProblemFor() while resolving the name range of (duplicated) "module-info", just continue as we do for package-info already.
- Slightly adopted message reported by the builder.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1050
