### PR TITLE
continue without label is incorrectly handled in a switch expression

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/BreakStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/BreakStatement.java
@@ -36,17 +36,15 @@ public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext, Fl
 		? flowContext.getTargetContextForDefaultBreak()
 		: flowContext.getTargetContextForBreakLabel(this.label);
 
-		// JLS 13 14.15
-		if (targetContext instanceof SwitchFlowContext &&
-				targetContext.associatedNode instanceof SwitchExpression) {
-			currentScope.problemReporter().switchExpressionBreakNotAllowed(this);
-		}
 	if (targetContext == null) {
 		if (this.label == null) {
 			currentScope.problemReporter().invalidBreak(this);
 		} else {
 			currentScope.problemReporter().undefinedLabel(this);
 		}
+		return flowInfo; // pretend it did not break since no actual target
+	} else if (targetContext == FlowContext.NonLocalGotoThroughSwitchContext) { // JLS 13 14.15
+		currentScope.problemReporter().switchExpressionsBreakOutOfSwitchExpression(this);
 		return flowInfo; // pretend it did not break since no actual target
 	}
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ContinueStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ContinueStatement.java
@@ -43,6 +43,9 @@ public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext, Fl
 			currentScope.problemReporter().undefinedLabel(this);
 		}
 		return flowInfo; // pretend it did not continue since no actual target
+	} else if (targetContext == FlowContext.NonLocalGotoThroughSwitchContext) {
+		currentScope.problemReporter().switchExpressionsContinueOutOfSwitchExpression(this);
+		return flowInfo; // pretend it did not continue since no actual target
 	}
 
 	targetContext.recordAbruptExit();

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ReturnStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ReturnStatement.java
@@ -153,6 +153,9 @@ public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext, Fl
 		} else if (traversedContext instanceof InitializationFlowContext) {
 				currentScope.problemReporter().cannotReturnInInitializer(this);
 				return FlowInfo.DEAD_END;
+		} else if (traversedContext.associatedNode instanceof SwitchExpression) {
+				currentScope.problemReporter().switchExpressionsReturnWithinSwitchExpression(this);
+				return FlowInfo.DEAD_END;
 		}
 	} while ((traversedContext = traversedContext.getLocalParent()) != null);
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchExpression.java
@@ -18,7 +18,6 @@ import static org.eclipse.jdt.internal.compiler.ast.ExpressionContext.VANILLA_CO
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.EmptyStackException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -386,74 +385,7 @@ public class SwitchExpression extends SwitchStatement implements IPolyExpression
 		}
 		return true;
 	}
-	static class OOBLFlagger extends ASTVisitor {
-		Set<String> labelDecls;
-		Set<BreakStatement> referencedBreakLabels;
-		Set<ContinueStatement> referencedContinueLabels;
-		public OOBLFlagger(SwitchExpression se) {
-			this.labelDecls = new HashSet<>();
-			this.referencedBreakLabels = new HashSet<>();
-			this.referencedContinueLabels = new HashSet<>();
-		}
-		@Override
-		public boolean visit(SwitchExpression switchExpression, BlockScope blockScope) {
-			return true;
-		}
-		private void checkForOutofBoundLabels(BlockScope blockScope) {
-			try {
-				for (BreakStatement bs : this.referencedBreakLabels) {
-					if (bs.label == null || bs.label.length == 0)
-						continue;
-					if (!this.labelDecls.contains(new String(bs.label)))
-						blockScope.problemReporter().switchExpressionsBreakOutOfSwitchExpression(bs);
-				}
-				for (ContinueStatement cs : this.referencedContinueLabels) {
-					if (cs.label == null || cs.label.length == 0)
-						continue;
-					if (!this.labelDecls.contains(new String(cs.label)))
-						blockScope.problemReporter().switchExpressionsContinueOutOfSwitchExpression(cs);
-				}
-			} catch (EmptyStackException e) {
-				// ignore
-			}
-		}
 
-		@Override
-		public void endVisit(SwitchExpression switchExpression,	BlockScope blockScope) {
-			checkForOutofBoundLabels(blockScope);
-		}
-		@Override
-		public boolean visit(BreakStatement breakStatement, BlockScope blockScope) {
-			if (breakStatement.label != null && breakStatement.label.length != 0)
-				this.referencedBreakLabels.add(breakStatement);
-			return true;
-		}
-		@Override
-		public boolean visit(ContinueStatement continueStatement, BlockScope blockScope) {
-			if (continueStatement.label != null && continueStatement.label.length != 0)
-				this.referencedContinueLabels.add(continueStatement);
-			return true;
-		}
-		@Override
-		public boolean visit(LambdaExpression lambdaExpression, BlockScope blockScope) {
-			return false;
-		}
-		@Override
-		public boolean visit(LabeledStatement stmt, BlockScope blockScope) {
-			if (stmt.label != null && stmt.label.length != 0)
-				this.labelDecls.add(new String(stmt.label));
-			return true;
-		}
-		@Override
-		public boolean visit(ReturnStatement stmt, BlockScope blockScope) {
-			blockScope.problemReporter().switchExpressionsReturnWithinSwitchExpression(stmt);
-			return false;
-		}
-		@Override
-		public boolean visit(TypeDeclaration stmt, BlockScope blockScope) {
-			return false;
-		}
-	}
 	@Override
 	public void collectPatternVariablesToScope(LocalVariableBinding[] variables, BlockScope skope) {
 		// Do nothing. This will be called later during resolveType()
@@ -496,7 +428,6 @@ public class SwitchExpression extends SwitchStatement implements IPolyExpression
 					upperScope.problemReporter().switchExpressionNoResultExpressions(this);
 					return null;
 				}
-				this.traverse(new OOBLFlagger(this), upperScope);
 
 				if (this.originalValueResultExpressionTypes == null) {
 					this.originalValueResultExpressionTypes = new TypeBinding[resultExpressionsCount];

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/YieldStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/YieldStatement.java
@@ -49,8 +49,7 @@ public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext, Fl
 	// doesn't occur since it immediately follow '->' and hence identical to default break - ie the
 	// immediate breakable context is guaranteed to be the one intended;
 	// while explicit yield should move up the parent to the switch expression.
-	FlowContext targetContext = this.isImplicit ? flowContext.getTargetContextForDefaultBreak() :
-		flowContext.getTargetContextForDefaultYield();
+	FlowContext targetContext = flowContext.getTargetContextForYield(!this.isImplicit);
 
 	flowInfo = this.expression.analyseCode(currentScope, flowContext, flowInfo);
 	this.expression.checkNPEbyUnboxing(currentScope, flowContext, flowInfo);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
@@ -11666,6 +11666,7 @@ public void switchExpressionMixedCase(ASTNode statement) {
 		statement.sourceStart,
 		statement.sourceEnd);
 }
+// Is this redundant ?? See switchExpressionsBreakOutOfSwitchExpression
 public void switchExpressionBreakNotAllowed(ASTNode statement) {
 	this.handle(
 		IProblem.SwitchExpressionsYieldBreakNotAllowed,

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullAnnotationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullAnnotationTest.java
@@ -10701,13 +10701,22 @@ public void testBug548418_001a() {
 			"	}\n"+
 			"}\n"
 				},
-		"----------\n" +
-		"1. ERROR in X.java (at line 13)\n" +
-		"	break x;\n" +
-		"	^^^^^^^^\n" +
-		"Breaking out of switch expressions not permitted\n" +
-		"----------\n"
-	);
+			"----------\n" +
+			"1. ERROR in X.java (at line 12)\n" +
+			"	x = null;\n" +
+			"	    ^^^^\n" +
+			"Null type mismatch: required '@NonNull X' but the provided value is null\n" +
+			"----------\n" +
+			"2. ERROR in X.java (at line 13)\n" +
+			"	break x;\n" +
+			"	^^^^^^^^\n" +
+			"Breaking out of switch expressions not permitted\n" +
+			"----------\n" +
+			"3. ERROR in X.java (at line 15)\n" +
+			"	default -> null;\n" +
+			"	           ^^^^\n" +
+			"Null type mismatch: required '@NonNull X' but the provided value is null\n" +
+			"----------\n");
 }
 public void testBug548418_001b() {
 	if (this.complianceLevel < ClassFileConstants.JDK14) return;

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchExpressionsYieldTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchExpressionsYieldTest.java
@@ -1185,7 +1185,7 @@ public class SwitchExpressionsYieldTest extends AbstractRegressionTest {
 			"1. ERROR in X.java (at line 10)\n" +
 			"	break;\n" +
 			"	^^^^^^\n" +
-			"break out of switch expression not allowed\n" +
+			"Breaking out of switch expressions not permitted\n" +
 			"----------\n");
 	}
 	public void testBug544073_036() {
@@ -2145,6 +2145,11 @@ public class SwitchExpressionsYieldTest extends AbstractRegressionTest {
 			"1. ERROR in X.java (at line 11)\n" +
 			"	continue;\n" +
 			"	^^^^^^^^^\n" +
+			"Continue out of switch expressions not permitted\n" +
+			"----------\n" +
+			"2. ERROR in X.java (at line 11)\n" +
+			"	continue;\n" +
+			"	^^^^^^^^^\n" +
 			"'continue' or 'return' cannot be the last statement in a Switch expression case body\n" +
 			"----------\n");
 	}
@@ -2178,6 +2183,11 @@ public class SwitchExpressionsYieldTest extends AbstractRegressionTest {
 			"	return 2;\n" +
 			"	^^^^^^^^^\n" +
 			"Return within switch expressions not permitted\n" +
+			"----------\n" +
+			"2. ERROR in X.java (at line 11)\n" +
+			"	return 2;\n" +
+			"	^^^^^^^^^\n" +
+			"'continue' or 'return' cannot be the last statement in a Switch expression case body\n" +
 			"----------\n");
 	}
 	public void testBug544073_078() {
@@ -3399,12 +3409,23 @@ public class SwitchExpressionsYieldTest extends AbstractRegressionTest {
 				"        new X().foo(0, 1);\n"+
 				"     }\n"+
 				"}\n"
-			},	"----------\n" +
-			"1. ERROR in X.java (at line 7)\n" +
-			"	break LABEL; // NO error flagged\n" +
-			"	^^^^^^^^^^^^\n" +
-			"Breaking out of switch expressions not permitted\n" +
-			"----------\n");
+			},
+				"----------\n" +
+				"1. WARNING in X.java (at line 3)\n" +
+				"	LABEL: while (i == 0) {\n" +
+				"	^^^^^\n" +
+				"The label LABEL is never explicitly referenced\n" +
+				"----------\n" +
+				"2. ERROR in X.java (at line 7)\n" +
+				"	break LABEL; // NO error flagged\n" +
+				"	^^^^^^^^^^^^\n" +
+				"Breaking out of switch expressions not permitted\n" +
+				"----------\n" +
+				"3. ERROR in X.java (at line 9)\n" +
+				"	yield 1;\n" +
+				"	^^^^^^^^\n" +
+				"Unreachable code\n" +
+				"----------\n");
 	}
 	public void testBug558067_002() {
 		this.runNegativeTest(
@@ -3435,17 +3456,33 @@ public class SwitchExpressionsYieldTest extends AbstractRegressionTest {
 				"        new X().foo(0, 1);\n"+
 				"     }\n"+
 				"} \n"
-			},	"----------\n" +
-			"1. ERROR in X.java (at line 10)\n" +
-			"	break LABEL;\n" +
-			"	^^^^^^^^^^^^\n" +
-			"Breaking out of switch expressions not permitted\n" +
-			"----------\n" +
-			"2. ERROR in X.java (at line 17)\n" +
-			"	case 2: for(;;) break TOP;\n" +
-			"	                ^^^^^^^^^^\n" +
-			"Breaking out of switch expressions not permitted\n" +
-			"----------\n");
+			},
+				"----------\n" +
+				"1. WARNING in X.java (at line 3)\n" +
+				"	TOP:System.out.println(\"hello\");\n" +
+				"	^^^\n" +
+				"The label TOP is never explicitly referenced\n" +
+				"----------\n" +
+				"2. WARNING in X.java (at line 6)\n" +
+				"	LABEL: while (i == 0) {\n" +
+				"	^^^^^\n" +
+				"The label LABEL is never explicitly referenced\n" +
+				"----------\n" +
+				"3. ERROR in X.java (at line 10)\n" +
+				"	break LABEL;\n" +
+				"	^^^^^^^^^^^^\n" +
+				"Breaking out of switch expressions not permitted\n" +
+				"----------\n" +
+				"4. ERROR in X.java (at line 12)\n" +
+				"	yield 1;\n" +
+				"	^^^^^^^^\n" +
+				"Unreachable code\n" +
+				"----------\n" +
+				"5. ERROR in X.java (at line 17)\n" +
+				"	case 2: for(;;) break TOP;\n" +
+				"	                ^^^^^^^^^^\n" +
+				"Breaking out of switch expressions not permitted\n" +
+				"----------\n");
 	}
 	public void testBug558067_003() {
 		this.runNegativeTest(
@@ -3470,12 +3507,23 @@ public class SwitchExpressionsYieldTest extends AbstractRegressionTest {
 				"        new X().foo(0, 1);\n"+
 				"     }\n"+
 				"}\n"
-			},	"----------\n" +
-			"1. ERROR in X.java (at line 7)\n" +
-			"	continue LABEL;\n" +
-			"	^^^^^^^^^^^^^^^\n" +
-			"Continue out of switch expressions not permitted\n" +
-			"----------\n");
+			},
+				"----------\n" +
+				"1. WARNING in X.java (at line 3)\n" +
+				"	LABEL: while (i == 0) {\n" +
+				"	^^^^^\n" +
+				"The label LABEL is never explicitly referenced\n" +
+				"----------\n" +
+				"2. ERROR in X.java (at line 7)\n" +
+				"	continue LABEL;\n" +
+				"	^^^^^^^^^^^^^^^\n" +
+				"Continue out of switch expressions not permitted\n" +
+				"----------\n" +
+				"3. ERROR in X.java (at line 9)\n" +
+				"	yield 1;\n" +
+				"	^^^^^^^^\n" +
+				"Unreachable code\n" +
+				"----------\n");
 	}
 	public void testBug558067_004() {
 		this.runNegativeTest(
@@ -3502,12 +3550,18 @@ public class SwitchExpressionsYieldTest extends AbstractRegressionTest {
 				"        new X().foo(0, 1);\n"+
 				"     }\n"+
 				"}\n"
-			},	"----------\n" +
-			"1. ERROR in X.java (at line 8)\n" +
-			"	break LABEL;\n" +
-			"	^^^^^^^^^^^^\n" +
-			"Breaking out of switch expressions not permitted\n" +
-			"----------\n");
+			},
+				"----------\n" +
+				"1. WARNING in X.java (at line 3)\n" +
+				"	LABEL: while (i == 0) {\n" +
+				"	^^^^^\n" +
+				"The label LABEL is never explicitly referenced\n" +
+				"----------\n" +
+				"2. ERROR in X.java (at line 8)\n" +
+				"	break LABEL;\n" +
+				"	^^^^^^^^^^^^\n" +
+				"Breaking out of switch expressions not permitted\n" +
+				"----------\n");
 	}
 	public void testBug558067_005() {
 		this.runNegativeTest(
@@ -3534,12 +3588,18 @@ public class SwitchExpressionsYieldTest extends AbstractRegressionTest {
 				"        new X().foo(0, 1);\n"+
 				"     }\n"+
 				"}\n"
-			},	"----------\n" +
-			"1. ERROR in X.java (at line 8)\n" +
-			"	continue LABEL;\n" +
-			"	^^^^^^^^^^^^^^^\n" +
-			"Continue out of switch expressions not permitted\n" +
-			"----------\n");
+			},
+				"----------\n" +
+				"1. WARNING in X.java (at line 3)\n" +
+				"	LABEL: while (i == 0) {\n" +
+				"	^^^^^\n" +
+				"The label LABEL is never explicitly referenced\n" +
+				"----------\n" +
+				"2. ERROR in X.java (at line 8)\n" +
+				"	continue LABEL;\n" +
+				"	^^^^^^^^^^^^^^^\n" +
+				"Continue out of switch expressions not permitted\n" +
+				"----------\n");
 	}
 		public void testConversion1() {
 		runConformTest(
@@ -6183,5 +6243,57 @@ public class SwitchExpressionsYieldTest extends AbstractRegressionTest {
 				"}"
 				},
 				"PASS");
+	}
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/53
+	// continue without label is incorrectly handled in a switch expression
+	public void testGHIssue53() {
+		runNegativeTest(
+			new String[] {
+				"X.java",
+				"public class X {\n" +
+				"	interface I {\n" +
+				"		void foo();\n" +
+				"	}\n" +
+				"	public static String string = \"a\";\n" +
+				"\n" +
+				"	public static void main(String[] args) {\n" +
+				"		loop: for (;;) {\n" +
+				"			System.out.println(\"In loop before switch\");\n" +
+				"			\n" +
+				"			int result = 123 + switch (string) {\n" +
+				"			case \"a\" -> {\n" +
+				"				if (string == null)\n" +
+				"					continue; // incorrectly compiles in JDT\n" +
+				"				else \n" +
+				"					continue loop; // correctly flagged as error (\"Continue out of switch\n" +
+				"				// expressions not permitted\")\n" +
+				"				// javac (correctly) outputs \"error: attempt to continue out of a switch\n" +
+				"				// expression\" for both continue statements\n" +
+				"				yield 789;\n" +
+				"			}\n" +
+				"			default -> 456;\n" +
+				"			};\n" +
+				"			System.out.println(\"After switch. result: \" + result);\n" +
+				"		}\n" +
+				"	}\n" +
+				"}\n"
+
+				},
+				"----------\n" +
+				"1. WARNING in X.java (at line 8)\n" +
+				"	loop: for (;;) {\n" +
+				"	^^^^\n" +
+				"The label loop is never explicitly referenced\n" +
+				"----------\n" +
+				"2. ERROR in X.java (at line 14)\n" +
+				"	continue; // incorrectly compiles in JDT\n" +
+				"	^^^^^^^^^\n" +
+				"Continue out of switch expressions not permitted\n" +
+				"----------\n" +
+				"3. ERROR in X.java (at line 16)\n" +
+				"	continue loop; // correctly flagged as error (\"Continue out of switch\n" +
+				"	^^^^^^^^^^^^^^\n" +
+				"Continue out of switch expressions not permitted\n" +
+				"----------\n");
 	}
 }


### PR DESCRIPTION



## What it does
Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/53

Get rid of the abstraction SwitchExpression.OOBLFlagger altogether and integrate flow analysis of SwitchExpressions into the canonical flow analysis infrastructure.

## How to test

This is work in progress, not fully tested or polished yet. The PR is to trigger automated tests.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
