### PR TITLE
*Field.isRecordComponent() returns false for record component (#1035)

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/parser/AbstractSyntaxTreeTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/parser/AbstractSyntaxTreeTest.java
@@ -481,9 +481,5 @@ public class AbstractSyntaxTreeTest extends AbstractCompilerTest implements IDoc
 
 
 	}
-	@Override
-	public void exitRecordComponent(int declarationEnd, int declarationSourceEnd) {
-
-	}
 
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/parser/TestSourceElementRequestor.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/parser/TestSourceElementRequestor.java
@@ -28,107 +28,131 @@ public TestSourceElementRequestor() {
 /**
  * acceptAnnotationTypeReference method comment.
  */
+@Override
 public void acceptAnnotationTypeReference(char[][] typeName, int sourceStart, int sourceEnd) {}
 /**
  * acceptAnnotationTypeReference method comment.
  */
+@Override
 public void acceptAnnotationTypeReference(char[] typeName, int sourcePosition) {}
 /**
  * acceptConstructorReference method comment.
  */
+@Override
 public void acceptConstructorReference(char[] typeName, int argCount, int sourcePosition) {}
 /**
  * acceptFieldReference method comment.
  */
+@Override
 public void acceptFieldReference(char[] fieldName, int sourcePosition) {}
 /**
  * acceptImport method comment.
  */
+@Override
 public void acceptImport(int declarationStart, int declarationEnd, int nameStart, int nameEnd, char[][] tokens, boolean onDemand, int modifiers) {}
 /**
  * acceptLineSeparatorPositions method comment.
  */
+@Override
 public void acceptLineSeparatorPositions(int[] positions) {}
 /**
  * acceptMethodReference method comment.
  */
+@Override
 public void acceptMethodReference(char[] methodName, int argCount, int sourcePosition) {}
 /**
  * acceptPackage method comment.
  */
+@Override
 public void acceptPackage(ImportReference importReference) {}
 /**
  * acceptProblem method comment.
  */
+@Override
 public void acceptProblem(CategorizedProblem problem) {}
 /**
  * acceptTypeReference method comment.
  */
+@Override
 public void acceptTypeReference(char[][] typeName, int sourceStart, int sourceEnd) {}
 /**
  * acceptTypeReference method comment.
  */
+@Override
 public void acceptTypeReference(char[] typeName, int sourcePosition) {}
 /**
  * acceptUnknownReference method comment.
  */
+@Override
 public void acceptUnknownReference(char[][] name, int sourceStart, int sourceEnd) {}
 /**
  * acceptUnknownReference method comment.
  */
+@Override
 public void acceptUnknownReference(char[] name, int sourcePosition) {}
 /**
  * enterCompilationUnit method comment.
  */
+@Override
 public void enterCompilationUnit() {}
 /**
  * enterConstructor method comment.
  */
+@Override
 public void enterConstructor(MethodInfo methodInfo) {}
 /**
  * enterField method comment.
  */
+@Override
 public void enterField(FieldInfo fieldInfo) {}
 /**
  * enterMethod method comment.
  */
+@Override
 public void enterMethod(MethodInfo methodInfo) {}
 /**
  * enterType method comment.
  */
+@Override
 public void enterType(TypeInfo typeInfo) {}
 /**
  * exitCompilationUnit method comment.
  */
+@Override
 public void exitCompilationUnit(int declarationEnd) {}
 /**
  * exitConstructor method comment.
  */
+@Override
 public void exitConstructor(int declarationEnd) {}
 /**
  * exitField method comment.
  */
+@Override
 public void exitField(int initializationStart, int declarationEnd, int declarationSourceEnd) {}
-public void exitRecordComponent(int declarationEnd, int declarationSourceEnd) {}
 /**
  * exitMethod method comment.
  */
+@Override
 public void exitMethod(int declarationEnd, Expression defaultValue) {}
 
 /**
  * enterInitializer method comment.
  */
+@Override
 public void enterInitializer(int sourceStart, int sourceEnd) {
 }
 
 /**
  * exitInitializer method comment.
  */
+@Override
 public void exitInitializer(int sourceEnd) {
 }
 /**
  * exitType method comment.
  */
+@Override
 public void exitType(int declarationEnd) {}
 
 }

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/RecordsElementTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/RecordsElementTests.java
@@ -159,6 +159,8 @@ public class RecordsElementTests extends AbstractJavaModelTests {
 			assertEquals("Incorret no of fields", 2, fields.length);
 			for (IField field : fields) {
 				assertTrue("Should be record component: " + field, field.isRecordComponent());
+				IField sameField = types[0].getRecordComponent(field.getElementName());
+				assertTrue("Should be record component: " + sameField, sameField.isRecordComponent());
 			}
 
 			IMethod[] methods = types[0].getMethods();
@@ -243,6 +245,8 @@ public class RecordsElementTests extends AbstractJavaModelTests {
 			assertEquals("Incorret no of fields", 2, fields.length);
 			for (IField field : fields) {
 				assertTrue("Should be record component: " + field, field.isRecordComponent());
+				IField sameField = types[0].getRecordComponent(field.getElementName());
+				assertTrue("Should be record component: " + sameField, sameField.isRecordComponent());
 			}
 			IMethod[] methods = types[0].getMethods();
 			assertNotNull("should not be null", methods);
@@ -324,6 +328,8 @@ public class RecordsElementTests extends AbstractJavaModelTests {
 			assertEquals("Incorret no of fields", 2, fields.length);
 			for (IField field : fields) {
 				assertTrue("Should be record component: " + field, field.isRecordComponent());
+				IField sameField = type.getRecordComponent(field.getElementName());
+				assertTrue("Should be record component: " + sameField, sameField.isRecordComponent());
 			}
 
 			IMethod[] methods = type.getMethods();

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/compiler/ISourceElementRequestor.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/compiler/ISourceElementRequestor.java
@@ -231,8 +231,6 @@ public interface ISourceElementRequestor {
 	 */
 	void exitField(int initializationStart, int declarationEnd, int declarationSourceEnd);
 
-	void exitRecordComponent(int declarationEnd, int declarationSourceEnd);
-
 	void exitInitializer(int declarationEnd);
 
 	void exitMethod(int declarationEnd, Expression defaultValue);

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/compiler/SourceElementRequestorAdapter.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/compiler/SourceElementRequestorAdapter.java
@@ -232,10 +232,5 @@ public class SourceElementRequestorAdapter implements ISourceElementRequestor {
 		// default implementation: do nothing
 	}
 
-	@Override
-	public void exitRecordComponent(int declarationEnd, int declarationSourceEnd) {
-		// default implementation: do nothing
-	}
-
 }
 

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/BinaryType.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/BinaryType.java
@@ -337,7 +337,12 @@ private IField[] getFieldsOrComponents(boolean component) throws JavaModelExcept
 public IField getRecordComponent(String compName) {
 	try {
 		if (isRecord())
-			return new BinaryField(this, compName);
+			return new BinaryField(this, compName) {
+				@Override
+				public boolean isRecordComponent() throws JavaModelException {
+					return true;
+				}
+			};
 	} catch (JavaModelException e) {
 		//
 	}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/CompilationUnitStructureRequestor.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/CompilationUnitStructureRequestor.java
@@ -697,6 +697,7 @@ public void exitField(int initializationStart, int declarationEnd, int declarati
 	info.setFlags(fieldInfo.modifiers);
 	char[] typeName = JavaModelManager.getJavaModelManager().intern(fieldInfo.type);
 	info.setTypeName(typeName);
+	info.isRecordComponent = fieldInfo.isRecordComponent;
 	this.newElements.put(handle, info);
 
 	if (fieldInfo.annotations != null) {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/CompilationUnitStructureRequestor.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/CompilationUnitStructureRequestor.java
@@ -730,40 +730,7 @@ public void exitField(int initializationStart, int declarationEnd, int declarati
 		this.unitInfo.annotationNumber = CompilationUnitElementInfo.ANNOTATION_THRESHOLD_FOR_DIET_PARSE;
 	}
 }
-/**
- * @see ISourceElementRequestor
- */
-@Override
-public void exitRecordComponent(int declarationEnd, int declarationSourceEnd) {
-	JavaElement handle = (JavaElement) this.handleStack.peek();
-	FieldInfo compInfo = (FieldInfo) this.infoStack.peek();
-	IJavaElement[] elements = getChildren(compInfo);
-	SourceFieldElementInfo info = elements.length == 0 ? new SourceFieldElementInfo() : new SourceFieldWithChildrenInfo(elements);
-	info.isRecordComponent = true;
-	info.setNameSourceStart(compInfo.nameSourceStart);
-	info.setNameSourceEnd(compInfo.nameSourceEnd);
-	info.setSourceRangeStart(compInfo.declarationStart);
-	info.setFlags(compInfo.modifiers);
-	char[] typeName = JavaModelManager.getJavaModelManager().intern(compInfo.type);
-	info.setTypeName(typeName);
-	this.newElements.put(handle, info);
 
-	if (compInfo.annotations != null) {
-		int length = compInfo.annotations.length;
-		this.unitInfo.annotationNumber += length;
-		for (int i = 0; i < length; i++) {
-			org.eclipse.jdt.internal.compiler.ast.Annotation annotation = compInfo.annotations[i];
-			acceptAnnotation(annotation, info, handle);
-		}
-	}
-	info.setSourceRangeEnd(declarationSourceEnd);
-	this.handleStack.pop();
-	this.infoStack.pop();
-
-	if (compInfo.typeAnnotated) {
-		this.unitInfo.annotationNumber = CompilationUnitElementInfo.ANNOTATION_THRESHOLD_FOR_DIET_PARSE;
-	}
-}
 /**
  * @see ISourceElementRequestor
  */

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SourceMapper.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SourceMapper.java
@@ -1071,21 +1071,6 @@ public class SourceMapper
 				this.memberNameRange[this.typeDepth]);
 		}
 	}
-	/**
-	 * @see ISourceElementRequestor
-	 */
-	@Override
-	public void exitRecordComponent(int declarationEnd, int declarationSourceEnd) {
-		if (this.typeDepth >= 0) {
-			IType currentType = this.types[this.typeDepth];
-			setSourceRange(
-				currentType.getRecordComponent(this.memberName[this.typeDepth]),
-				new SourceRange(
-					this.memberDeclarationStart[this.typeDepth],
-					declarationEnd - this.memberDeclarationStart[this.typeDepth] + 1),
-				this.memberNameRange[this.typeDepth]);
-		}
-	}
 
 	/**
 	 * @see ISourceElementRequestor

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/jdom/SimpleDOMBuilder.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/jdom/SimpleDOMBuilder.java
@@ -208,8 +208,4 @@ protected SourceElementParser getParser(Map<String, String> settings) {
 	return new SourceElementParser(this, new DefaultProblemFactory(), new CompilerOptions(settings), false/*don't report local declarations*/, true/*optimize string literals*/);
 }
 
-@Override
-public void exitRecordComponent(int declarationEnd, int declarationSourceEnd) {
-	// TODO Auto-generated method stub
-}
 }

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/SourceIndexerRequestor.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/SourceIndexerRequestor.java
@@ -457,13 +457,7 @@ public void exitConstructor(int declarationEnd) {
 public void exitField(int initializationStart, int declarationEnd, int declarationSourceEnd) {
 	this.methodDepth--;
 }
-/**
- * @see ISourceElementRequestor#exitRecordComponent(int, int)
- */
-@Override
-public void exitRecordComponent(int declarationEnd, int declarationSourceEnd) {
-	//Nothing by default
-}
+
 /**
  * @see ISourceElementRequestor#exitInitializer(int)
  */


### PR DESCRIPTION
**First commit**
Cleanup after https://github.com/eclipse-jdt/eclipse.jdt.core/commit/7f0b7a275edf8d5988fd058f6d1144e100d714e0

`ISourceElementRequestor.exitRecordComponent()` is not called anymore,
hence this is all dead code and can be removed without affecting
functionality.

**Second commit**
This seem to be regression from bug 565211 / commit 7f0b7a2 that changed
code added for bug 562637 / commit aa930da.

The 7f0b7a2 removed `notifySourceElementRequestor(RecordComponent)` that
called `requestor.exitRecordComponent` where
`SourceFieldElementInfo.isRecordComponent = true;` was set, and the code
uses now only `notifySourceElementRequestor(FieldDeclaration)`. In this
one, the `SourceFieldElementInfo.isRecordComponent` is not changed.

Fix is to update exitField() to transfer also
`fieldInfo.isRecordComponent` value to `SourceFieldElementInfo`.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1035