### PR TITLE
False type mismatch on array initializer with null annotations (regression 2023-03)

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
@@ -60,7 +60,6 @@ import org.eclipse.jdt.core.compiler.InvalidInputException;
 import org.eclipse.jdt.internal.compiler.ast.LambdaExpression;
 import org.eclipse.jdt.internal.compiler.ast.MethodDeclaration;
 import org.eclipse.jdt.internal.compiler.ast.NullAnnotationMatching;
-import org.eclipse.jdt.internal.compiler.ast.TypeReference;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jdt.internal.compiler.impl.JavaFeature;
@@ -1353,27 +1352,6 @@ public boolean implementsInterface(ReferenceBinding anInterface, boolean searchH
 				for (int b = 0; b < nextPosition; b++)
 					if (TypeBinding.equalsEquals(next, interfacesToVisit[b])) continue nextInterface;
 				interfacesToVisit[nextPosition++] = next;
-			}
-		}
-	}
-	// see https://github.com/eclipse-jdt/eclipse.jdt.core/issues/629
-	if (nextPosition == 0 && this instanceof SourceTypeBinding) {
-		SourceTypeBinding sourceType = (SourceTypeBinding) this;
-		if (sourceType.scope != null && sourceType.scope.referenceContext != null && sourceType.scope.compilerOptions().isAnnotationBasedNullAnalysisEnabled) {
-			TypeReference[] references = sourceType.scope.referenceContext.superInterfaces;
-			if (references == null || references.length == 0) {
-				return false;
-			}
-			for (TypeReference reference: references) {
-				if (!(reference.resolvedType instanceof ReferenceBinding)) {
-					reference.resolveType(sourceType.scope);
-				}
-				if (reference.resolvedType instanceof ReferenceBinding) {
-					ReferenceBinding binding = (ReferenceBinding) reference.resolvedType;
-					if (binding.isEquivalentTo(anInterface)) {
-						return true;
-					}
-				}
 			}
 		}
 	}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
@@ -2003,7 +2003,7 @@ String deprecatedSinceValue(Supplier<AnnotationBinding[]> annotations) {
 		ReferenceContext contextSave = this.referenceContext;
 		try {
 			for (AnnotationBinding annotationBinding : annotations.get()) {
-				if (annotationBinding.getAnnotationType().id == TypeIds.T_JavaLangDeprecated) {
+				if (annotationBinding != null && annotationBinding.getAnnotationType().id == TypeIds.T_JavaLangDeprecated) {
 					for (ElementValuePair elementValuePair : annotationBinding.getElementValuePairs()) {
 						if (CharOperation.equals(elementValuePair.getName(), TypeConstants.SINCE) && elementValuePair.value instanceof StringConstant)
 							return ((StringConstant) elementValuePair.value).stringValue();

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullTypeAnnotationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullTypeAnnotationTest.java
@@ -18748,4 +18748,119 @@ public void testRedundantNonNull_field() {
 	runner.classLibraries = this.LIBS;
 	runner.runWarningTest();
 }
+public void testGH1007_srikanth() {
+	Runner runner = new Runner();
+	runner.testFiles =
+		new String[] {
+			"SubClass.java",
+			"// ECJ error in next line: Type mismatch: cannot convert from Class<SubClass> to Class<? extends SuperClass>[]\n" +
+			"@AnnotationWithArrayInitializer(annotationArgument = SubClass.class)\n" +
+			"class AnnotatedClass2 extends AnnotatedSuperClass {}\n" +
+			"\n" +
+			"//ECJ error in next line: Type mismatch: cannot convert from Class<SubClass> to Class<? extends SuperClass>\n" +
+			"@AnnotationWithArrayInitializer(annotationArgument = {SubClass.class})\n" +
+			"class AnnotatedClass extends AnnotatedSuperClass {}\n" +
+			"\n" +
+			"\n" +
+			"class AnnotatedSuperClass {}\n" +
+			"\n" +
+			"@interface AnnotationWithArrayInitializer {\n" +
+			"    Class<? extends SuperClass>[] annotationArgument();\n" +
+			"}\n" +
+			"\n" +
+			"class SubClass extends SuperClass {}\n" +
+			"abstract class SuperClass {}"
+		};
+	runner.runConformTest();
+}
+public void testGH854() {
+	Runner runner = new Runner();
+	runner.testFiles =
+		new String[] {
+			"Annot.java",
+			"public @interface Annot {\n" +
+			"    Class<? extends Init<? extends Configuration>>[] inits(); \n" +
+			"}\n",
+			"Configuration.java",
+			"public interface Configuration {\n" +
+			"}\n",
+			"Init.java",
+			"public interface Init<C extends Configuration> {\n" +
+			"}\n",
+			"App.java",
+			"interface I<T> {}\n" +
+			"class IImpl<T> implements I<String>, Init<Configuration> {}\n" +
+			"@Annot(inits = {App.MyInit.class})\n" +
+			"public class App {\n" +
+			"	static class MyInit extends IImpl<Configuration> {}\n" +
+			"}\n"
+		};
+	runner.runConformTest();
+}
+public void testVSCodeIssue3076() {
+	Runner runner = new Runner();
+	runner.testFiles =
+		new String[] {
+			"demo/cache/AbstractCache.java",
+			"package demo.cache;\n" +
+			"\n" +
+			"public abstract class AbstractCache {\n" +
+			"    public enum Expiry {\n" +
+			"        ONE, TWO, THREE\n" +
+			"    }\n" +
+			"\n" +
+			"    protected abstract void cacheThis(int param1, Expiry param2);\n" +
+			"}\n",
+			"demo/Annot.java",
+			"package demo;\n" +
+			"public @interface Annot {\n" +
+			"	String defaultProperty();\n" +
+			"}\n",
+			"demo/cache/MyCache.java",
+			"package demo.cache;\n" +
+			"\n" +
+			"import demo.Annot;\n" +
+			"\n" +
+			"/**\n" +
+			" * This annotation is what causes the confusion around the nested Expiry type.\n" +
+			" *\n" +
+			" * If you comment out this annotation the language server has no problem\n" +
+			" * figuring it out.\n" +
+			" *\n" +
+			" * It can be *any* annotation.\n" +
+			" * So it would seem that referring to your own class outside of the\n" +
+			" * class definition is what triggers this particular bug.\n" +
+			" */\n" +
+			"@Annot(defaultProperty = MyCache.DEFAULT_PROPERTY_NAME)\n" +
+			"public class MyCache extends AbstractCache {\n" +
+			"    public static final String DEFAULT_PROPERTY_NAME = \"WHATEVER\";\n" +
+			"\n" +
+			"    @Override\n" +
+			"    protected void cacheThis(int param1, Expiry param2) {\n" +
+			"        throw new UnsupportedOperationException(\"Unimplemented method 'doSomethingElse'\");\n" +
+			"    }\n" +
+			"}\n"
+		};
+	runner.runConformTest();
+}
+public void testGH969() {
+	Runner runner = new Runner();
+	runner.testFiles =
+		new String[] {
+			"mypackage/Example.java",
+			"package mypackage;\n" +
+			"\n" +
+			"import java.io.Serializable;\n" +
+			"\n" +
+			"@Deprecated(since = Example.SINCE)\n" +
+			"public class Example<T> implements Serializable {\n" +
+			"	\n" +
+			"	static final String SINCE = \"...\";\n" +
+			"\n" +
+			"	private T target;\n" +
+			"\n" +
+			"}"
+		};
+	runner.runConformTest();
+}
 }


### PR DESCRIPTION
fixes #1007

Here I removed one code block from #630 and made resolving on one particular call path deferrable.

This breaks the following unfortunate chain:

1. A type's hierarchy was being connected
2. ClassScope.findSupertype() triggered initializing the null default 
(since [#630](https://github.com/eclipse-jdt/eclipse.jdt.core/pull/630), still needed and retained)
4. This triggered resolving annotations
5. An annotation had member value pairs, where values were type checked against the annotation's attributes
6. The value type contained a type that did not yet have super types connected
7. This triggered ahead of time  resolving
( [#630](https://github.com/eclipse-jdt/eclipse.jdt.core/pull/630), now removed)
9. That ahead of time resolving caused havoc in  [#1007](https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1007)

Starting at (4) different test cases had different ways to cause havoc (different ways to trigger undesired ahead-of-time side-effects). So that point offered itself as a suitable location for severing the unfortunate chain and start deferring instead.

The complex part is making the set of deferred tasks as narrow as possible (see new method `Annotation.shouldDeferResolvingDetails()`).

I merged the solution into prior art around `ClassScope#deferredBoundChecks`, which works fine. Only the name `ClassScope.checkParameterizedTypeBounds()` is no longer accurate (I simply forgot to change it).
