### PR TITLE
AIOOBE when compiling method reference expression

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ReferenceExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ReferenceExpression.java
@@ -306,11 +306,12 @@ public class ReferenceExpression extends FunctionalExpression implements IPolyEx
 				for (int i = 0; i < descriptorParams.length; i++) {
 					TypeBinding descType = descriptorParams[i];
 					TypeBinding origDescType = origDescParams[i];
-					TypeBinding origParam = this.receiverPrecedesParameters
-							? i == 0 ? this.receiverType : origParams[i - 1]
-							: origParams[i];
 					if (descType.isIntersectionType18()
 							|| (descType.isTypeVariable() && ((TypeVariableBinding) descType).boundsCount() > 1)) {
+						boolean varargs = this.binding.original().isVarargs();
+						TypeBinding origParam = this.receiverPrecedesParameters
+								? i == 0 ? this.receiverType : InferenceContext18.getParameter(origParams, i-1, varargs)
+								: InferenceContext18.getParameter(origParams, i, varargs);
 						if (!CharOperation.equals(origDescType.signature(), origParam.signature()))
 							return false;
 					}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LambdaExpressionsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LambdaExpressionsTest.java
@@ -7759,6 +7759,67 @@ public void testGHIssue1048() {
 			"interface java.util.stream.Stream"
 			);
 }
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1054
+// AIOOBE when checking implicit lambda generation requirement
+public void testGHIssue1054() {
+	this.runConformTest(
+			new String[] {
+				"X.java",
+				"import java.lang.invoke.MethodHandle;\n" +
+				"interface FI {\n" +
+				"    Object invokeMethodReference(String s, char c1, char c2) throws Throwable;\n" +
+				"}\n" +
+				"public class X {\n" +
+				"    private static MethodHandle createMethodHandle() {\n" +
+				"    	return null;\n" +
+				"    }\n" +
+				"    public static void run() throws Throwable {\n" +
+				"        MethodHandle ms = createMethodHandle(); \n" +
+				"        FI fi = ms::invoke;\n" +
+				"        fi.invokeMethodReference(\"\", (char)0, (char)0);\n" +
+				"    }\n" +
+				"    public static void main(String [] args) throws Throwable {\n" +
+				"        try { \n" +
+				"            run();\n" +
+				"        } catch(NullPointerException npe) {\n" +
+				"            System.out.println(\"NPE as expected\");\n" +
+				"        }\n" +
+				"    }\n" +
+				"}\n"},
+			"NPE as expected"
+			);
+}
+
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1054
+// AIOOBE when checking implicit lambda generation requirement
+public void testGHIssue1054_2() {
+	this.runConformTest(
+			new String[] {
+				"X.java",
+				"import java.lang.invoke.MethodHandle;\n" +
+				"interface FI {\n" +
+				"    <T extends Object & Runnable> Object invokeMethodReference(Object o, T t2) throws Throwable;\n" +
+				"}\n" +
+				"public class X {\n" +
+				"    private static MethodHandle createMethodHandle() {\n" +
+				"    	return null;\n" +
+				"    }\n" +
+				"    public static void run() throws Throwable {\n" +
+				"        MethodHandle ms = createMethodHandle(); \n" +
+				"        FI fi = ms::invoke;\n" +
+				"        fi.invokeMethodReference(null, ()-> {}); \n" +
+				"    }\n" +
+				"    public static void main(String[] args) throws Throwable {\n" +
+				"    	try {\n" +
+				"    		run();\n" +
+				"    	} catch (NullPointerException npe) {\n" +
+				"    		System.out.println(\"NPE as expected\");\n" +
+				"    	}\n" +
+				"	}\n" +
+				"}\n"},
+			"NPE as expected"
+			);
+}
 
 public static Class testClass() {
 	return LambdaExpressionsTest.class;


### PR DESCRIPTION
## What it does

Fix incorrect handling of variable arity method parameter list. Existing code was completely unprepared to deal with varargs method and accesses parameter list by direct array indexing as though it were a fixed arity method leading to AIOOB. 

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1054

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
