### PR TITLE
Adjust class file generation so that reflection APIs don't fail with NPE

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/IntersectionTypeBinding18.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/IntersectionTypeBinding18.java
@@ -382,7 +382,7 @@ public class IntersectionTypeBinding18 extends ReferenceBinding {
 	}
 
 	@Override
-	public char[] genericTypeSignature(boolean approximateToDenotable) {
-    	return approximateToDenotable ? erasure().genericTypeSignature() : genericTypeSignature();
+	public boolean isNonDenotable() {
+		return true;
 	}
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MethodBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MethodBinding.java
@@ -603,9 +603,6 @@ public MethodBinding findOriginalInheritedMethod(MethodBinding inheritedMethod) 
  */
 public char[] genericSignature() {
 	if ((this.modifiers & ExtraCompilerModifiers.AccGenericSignature) == 0) return null;
-	// Synthetic methods may have non-denotable inferred types in their signatures,
-	// fold them into approximate denotable forms so class file parsers don't choke
-	boolean approximateToDenotable = (this.modifiers & ClassFileConstants.AccSynthetic) != 0;
 	StringBuilder sig = new StringBuilder(10);
 	if (this.typeVariables != Binding.NO_TYPE_VARIABLES) {
 		sig.append('<');
@@ -616,11 +613,11 @@ public char[] genericSignature() {
 	}
 	sig.append('(');
 	for (int i = 0, length = this.parameters.length; i < length; i++) {
-		sig.append(this.parameters[i].genericTypeSignature(approximateToDenotable));
+		sig.append(this.parameters[i].genericTypeSignature());
 	}
 	sig.append(')');
 	if (this.returnType != null)
-		sig.append(this.returnType.genericTypeSignature(approximateToDenotable));
+		sig.append(this.returnType.genericTypeSignature());
 
 	// only append thrown exceptions if any is generic/parameterized
 	boolean needExceptionSignatures = false;
@@ -634,7 +631,7 @@ public char[] genericSignature() {
 	if (needExceptionSignatures) {
 		for (int i = 0; i < length; i++) {
 			sig.append('^');
-			sig.append(this.thrownExceptions[i].genericTypeSignature(approximateToDenotable));
+			sig.append(this.thrownExceptions[i].genericTypeSignature());
 		}
 	}
 	int sigLength = sig.length();

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SyntheticMethodBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SyntheticMethodBinding.java
@@ -390,6 +390,9 @@ public class SyntheticMethodBinding extends MethodBinding {
 		this.tagBits |= (TagBits.AnnotationResolved | TagBits.DeprecatedAnnotationResolved) | (lambda.binding.tagBits & TagBits.HasParameterAnnotations);
 	    this.returnType = lambda.binding.returnType;
 	    this.parameters = lambda.binding.parameters;
+        if (this.returnType.isNonDenotable() || Stream.of(this.parameters).anyMatch(p -> p.isNonDenotable())) {
+        	this.modifiers &= ~ExtraCompilerModifiers.AccGenericSignature;
+        }
 	    TypeVariableBinding[] vars = Stream.of(this.parameters).filter(param -> param.isTypeVariable()).toArray(TypeVariableBinding[]::new);
 	    if (vars != null && vars.length > 0)
 	    	this.typeVariables = vars;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeBinding.java
@@ -527,15 +527,6 @@ public char[] genericTypeSignature() {
 }
 
 /**
- * Answer the receiver classfile signature, folding any non-denotable types
- * to a denotable approximation by using erasure.
- * NOTE: This method should only be used during/after code gen.
- */
-public char[] genericTypeSignature(boolean approximateToDenotable) {
-	return genericTypeSignature();
-}
-
-/**
  * Return the supertype which would erase as a subtype of a given declaring class.
  * If the receiver is already erasure compatible, then it will returned. If not, then will return the alternate lowest
  * upper bound compatible with declaring class.
@@ -1776,4 +1767,12 @@ public long updateTagBits() {
 public boolean isFreeTypeVariable() {
 	return false;
 }
+
+/**
+ * Does this type lack a class file representation on its own ?
+ */
+public boolean isNonDenotable() {
+	return false;
+}
+
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/WildcardBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/WildcardBinding.java
@@ -614,11 +614,6 @@ public class WildcardBinding extends ReferenceBinding {
         return this.genericSignature;
     }
 
-    @Override
-    public char[] genericTypeSignature(boolean approximateToDenotable) {
-    	return approximateToDenotable ? erasure().genericTypeSignature() : genericTypeSignature();
-    }
-
 	@Override
 	public int hashCode() {
 		return this.genericType.hashCode();
@@ -1091,5 +1086,10 @@ public class WildcardBinding extends ReferenceBinding {
 			}
 		}
 		return super.updateTagBits();
+	}
+
+	@Override
+	public boolean isNonDenotable() {
+		return true;
 	}
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LambdaExpressionsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LambdaExpressionsTest.java
@@ -7724,6 +7724,42 @@ public void test483219_comment_3() {
 			);
 }
 
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1048
+// Reflection APIs fail with NPE processing class file produced by JDT compiler
+public void testGHIssue1048() {
+	this.runConformTest(
+			new String[] {
+				"Reproducer.java",
+				"import java.io.IOException;\n" +
+				"import java.io.Serializable;\n" +
+				"import java.lang.reflect.Method;\n" +
+				"import java.util.Optional;\n" +
+				"import java.util.stream.Stream;\n" +
+				"public class Reproducer {\n" +
+				"    public static void main(String[] args) {\n" +
+				"        try {\n" +
+				"            new Reproducer().testClassWithStreamAndOptional2();\n" +
+				"        } catch (IOException e) {\n" +
+				"            e.printStackTrace();\n" +
+				"        }\n" +
+				"    }\n" +
+				"    private void testClassWithStreamAndOptional2() throws IOException {\n" +
+				"        Class<?> c = this.getClass();\n" +
+				"        for (Method m : c.getDeclaredMethods()) {\n" +
+				"            if (m.isSynthetic())\n" +
+				"                System.out.println(m.getGenericReturnType());\n" +
+				"        }\n" +
+				"    }\n" +
+				"    private Stream<Serializable> doMyStuff() {\n" +
+				"        Stream<Serializable> s = Stream.empty(); \n" +
+				"        return Optional.ofNullable(s).orElseGet(Stream::of);\n" +
+				"    }\n" +
+				"}\n"
+			},
+			"interface java.util.stream.Stream"
+			);
+}
+
 public static Class testClass() {
 	return LambdaExpressionsTest.class;
 }


### PR DESCRIPTION
## What it does

As of the fix https://github.com/eclipse-jdt/eclipse.jdt.core/issues/756, ECJ employs an approximate-by-erasure strategy when having to encode non-denotable types in generic signatures. As this approach has its own share of problems, it has been decided to simply not emit generic signatures for synthetic methods if non-denotable types are involved. 

See discussion originating in https://github.com/eclipse-jdt/eclipse.jdt.core/pull/414#issuecomment-1550974879 onwards

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1048

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
