### PR TITLE
Reflection fails due to class file's EnclosingMethod attribute incorrectly pointing to lambda implementation

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/LocalTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/LocalTypeBinding.java
@@ -46,8 +46,8 @@ public LocalTypeBinding(ClassScope scope, SourceTypeBinding enclosingType, CaseS
 	}
 	this.enclosingCase = switchCase;
 	this.sourceStart = typeDeclaration.sourceStart;
-	MethodScope methodScope = scope.enclosingMethodScope();
-	MethodBinding methodBinding = methodScope.referenceMethodBinding();
+	MethodScope methodScope = scope.lexicallyEnclosingMethodScope();
+	MethodBinding methodBinding = methodScope != null ? methodScope.referenceMethodBinding() : null;
 	if (methodBinding != null) {
 		this.enclosingMethod = methodBinding;
 	}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Scope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Scope.java
@@ -1162,6 +1162,18 @@ public abstract class Scope {
 		return null; // may answer null if no method around
 	}
 
+	public final MethodScope lexicallyEnclosingMethodScope() {
+		Scope scope = this;
+		while ((scope = scope.parent) != null) {
+			if (scope instanceof MethodScope) {
+				MethodScope methodScope = (MethodScope) scope;
+				if (methodScope.referenceContext instanceof AbstractMethodDeclaration)
+					return (MethodScope) scope;
+			}
+		}
+		return null; // may answer null if no method around
+	}
+
 	public final MethodScope enclosingLambdaScope() {
 		Scope scope = this;
 		while ((scope = scope.parent) != null) {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LambdaExpressionsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LambdaExpressionsTest.java
@@ -6215,9 +6215,9 @@ public void test476859() {
 			"}"
 		};
 	runner.expectedOutputString =
-		"private static java.lang.reflect.Method Test.lambda$0(java.lang.Void)";
+		"public static void Test.main(java.lang.String[])";
 	runner.expectedJavacOutputString =
-		"private static java.lang.reflect.Method Test.lambda$main$0(java.lang.Void)";
+		"public static void Test.main(java.lang.String[])";
 	runner.runConformTest();
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=476859 enclosing method not found error when EJC compiled, works fine with oracle jdk compiler
@@ -6250,11 +6250,11 @@ public void test476859a() {
 			"}\n"
 		};
 	runner.expectedOutputString =
-		"private static java.lang.reflect.Method Test.lambda$0(java.lang.Void)\n" +
-		"private java.lang.reflect.Method AnotherClass.lambda$0(java.lang.Void)";
+		"public static void Test.main(java.lang.String[])\n" +
+		"void AnotherClass.foo()";
 	runner.expectedJavacOutputString =
-			"private static java.lang.reflect.Method Test.lambda$main$0(java.lang.Void)\n" +
-			"private java.lang.reflect.Method AnotherClass.lambda$foo$0(java.lang.Void)";
+		"public static void Test.main(java.lang.String[])\n" +
+		"void AnotherClass.foo()";
 	runner.runConformTest();
 }
 public void testBug499258() {
@@ -6468,9 +6468,9 @@ public void test509804() {
 			"}\n"
 		};
 	runner.expectedOutputString =
-			"private static java.lang.Object Test.lambda$1()";
+			"null";
 	runner.expectedJavacOutputString =
-			"private static java.lang.Object Test.lambda$static$0()";
+			"null";
 	runner.runConformTest();
 }
 public void testBug514105() {
@@ -7818,6 +7818,46 @@ public void testGHIssue1054_2() {
 				"	}\n" +
 				"}\n"},
 			"NPE as expected"
+			);
+}
+
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/975
+// [Compiler] Reflection returns null for lambda capturing local method type variable
+public void testGHIssue975() {
+	this.runConformTest(
+			new String[] {
+				"Test.java",
+				"import java.lang.reflect.*;\n" +
+				"\n" +
+				"public class Test {\n" +
+				"    static class Capturing<T> {\n" +
+				"        protected Capturing() {\n" +
+				"            ParameterizedType paramT = (ParameterizedType) getClass().getGenericSuperclass();\n" +
+				"            Type t = paramT.getActualTypeArguments()[0];\n" +
+				"\n" +
+				"            if (t instanceof TypeVariable) {\n" +
+				"                System.out.println(\"Found expected type\");\n" +
+				"            } else {\n" +
+				"                throw new AssertionError(\"Unexpected type: \" + t);\n" +
+				"            }\n" +
+				"        }\n" +
+				"    }\n" +
+				"\n" +
+				"    static void run(Runnable r) {\n" +
+				"        r.run();\n" +
+				"    }\n" +
+				"\n" +
+				"    public static <T> void main(String... args) {\n" +
+				"        class Local {\n" +
+				"            <M> void runTest() {\n" +
+				"                run(() -> new Capturing<M>() {});\n" +
+				"            }\n" +
+				"        }\n" +
+				"\n" +
+				"        new Local().runTest();\n" +
+				"    }\n" +
+				"}\n"},
+			"Found expected type"
 			);
 }
 


### PR DESCRIPTION

## What it does
According to JVMS 4.7.7, the EnclosingMethod is supposed to point to the closest lexically enclosing method of the class. ECJ incorrectly mentions the lambda implementation method which doesn't meet the criteria.

With this fix, we reach for and encode the right method. 

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/975

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
