### PR TITLE
Fix VerifyError with nested static templated instance

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/QualifiedNameReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/QualifiedNameReference.java
@@ -776,7 +776,7 @@ public TypeBinding getOtherFieldBindings(BlockScope scope) {
 				fieldReceiverType = fieldReceiverType.getErasureCompatibleType(field.declaringClass);// handle indirect inheritance thru variable secondary bound
 				FieldBinding originalBinding = previousField.original();
 				if (TypeBinding.notEquals(fieldReceiverType, oldReceiverType) || originalBinding.type.leafComponentType().isTypeVariable()) { // record need for explicit cast at codegen
-			    	setGenericCast(index-1,originalBinding.type.genericCast(fieldReceiverType)); // type cannot be base-type even in boxing case
+			    	setGenericCast(place,originalBinding.type.genericCast(fieldReceiverType)); // type cannot be base-type even in boxing case
 				}
 		    }
 			// only last field is actually a write access if any

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest.java
@@ -6770,5 +6770,106 @@ public void testBugGH472_d() {
 		);
 	}
 }
+
+// https://bugs.eclipse.org/bugs/show_bug.cgi?id=540063
+// VerifyError with nested static templated instance
+public void test540063() {
+	this.runConformTest(
+		new String[] {
+			"SomeClass.java",
+			"public class SomeClass {\n" +
+			"  public static void main(String[] args) {\n" +
+			"    String s = Namespace.t.contained.s;\n" +
+			"    System.out.println(s);\n" +
+			"  }\n" +
+			"\n" +
+			"  static class Namespace {\n" +
+			"    static Templated<StringHolder> t = new Templated<StringHolder>(new StringHolder());\n" +
+			"  }\n" +
+			"\n" +
+			"  static class Templated<T> {\n" +
+			"    T contained;\n" +
+			"\n" +
+			"    Templated(T contained) {\n" +
+			"      this.contained = contained;\n" +
+			"    }\n" +
+			"  }\n" +
+			"\n" +
+			"  static class StringHolder {\n" +
+			"    String s = \"some string\";\n" +
+			"  }\n" +
+			"}\n"
+			},
+		"some string"
+	);
+}
+
+// https://bugs.eclipse.org/bugs/show_bug.cgi?id=540063
+// VerifyError with nested static templated instance
+public void test540063_2() {
+	this.runConformTest(
+		new String[] {
+			"SomeClass.java",
+			"public class SomeClass {\n" +
+			"  public static void main(String[] args) {\n" +
+			"    String s = t.contained.s;\n" +
+			"    System.out.println(s);\n" +
+			"  }\n" +
+			"\n" +
+			"  static Templated<StringHolder> t = new Templated<StringHolder>(new StringHolder());\n" +
+			"\n" +
+			"  static class Templated<T> {\n" +
+			"    T contained;\n" +
+			"\n" +
+			"    Templated(T contained) {\n" +
+			"      this.contained = contained;\n" +
+			"    }\n" +
+			"  }\n" +
+			"\n" +
+			"  static class StringHolder {\n" +
+			"    String s = \"some string\";\n" +
+			"  }\n" +
+			"}\n"
+		},
+		"some string"
+	);
+}
+
+// https://bugs.eclipse.org/bugs/show_bug.cgi?id=540063
+// VerifyError with nested static templated instance
+public void test540063_3() {
+	this.runConformTest(
+		new String[] {
+			"SomeClass.java",
+			"public class SomeClass {\n" +
+			"  public static void main(String[] args) {\n" +
+			"    String s = Namespace_O.Namespace_M.Namespace_I.t.contained.s;\n" +
+			"    System.out.println(s);\n" +
+			"  }\n" +
+			"\n" +
+			" static class Namespace_O {\n" +
+			"	static class Namespace_M {\n" +
+			"		static class Namespace_I {\n" +
+			"			static Templated<StringHolder> t = new Templated<StringHolder>(new StringHolder());\n" +
+			"		}\n" +
+			"	}\n" +
+			"  }\n" +
+			"\n" +
+			"  static class Templated<T> {\n" +
+			"    T contained;\n" +
+			"\n" +
+			"    Templated(T contained) {\n" +
+			"      this.contained = contained;\n" +
+			"    }\n" +
+			"  }\n" +
+			"\n" +
+			"  static class StringHolder {\n" +
+			"    String s = \"some string\";\n" +
+			"  }\n" +
+			"}\n"
+		},
+		"some string"
+	);
+}
 }
 

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest.java
@@ -6871,5 +6871,45 @@ public void test540063_3() {
 		"some string"
 	);
 }
+
+// https://bugs.eclipse.org/bugs/show_bug.cgi?id=570022
+// QualifiedNameReference.setGenericCast(...) throws ArrayIndexOutOfBoundsException
+public void test570022() {
+	this.runNegativeTest(
+			new String[] {
+					"p000/aazh.java",
+					"package p000;\n" +
+					"\n" +
+					"public class aazh {\n" +
+					"    public static p000.abyz<p000.aazh.EnumC0166a> f2789a = p000.abyz.m1243c(p000.aazh.EnumC0166a.DISABLED);\n" +
+					"\n" +
+					"    public enum EnumC0166a {\n" +
+					"        DISABLED;\n" +
+					"        \n" +
+					"        public boolean f2796f;\n" +
+					"    }\n" +
+					"}\n",
+					"p000/abam.java",
+					"package p000;\n" +
+					"\n" +
+					"public class abam {\n" +
+					"    public Object mo369h() {\n" +
+					"        return p000.aazh.f2789a.f4668a.f2796f;\n" +
+					"    }\n" +
+					"}\n",
+					"p000/abyz.java",
+					"package p000;\n" +
+					"\n" +
+					"public class abyz<T> {\n" +
+					"    public volatile T f4668a;\n" +
+					"}\n",
+			},
+			"----------\n" +
+			"1. ERROR in p000\\aazh.java (at line 4)\n" +
+			"	public static p000.abyz<p000.aazh.EnumC0166a> f2789a = p000.abyz.m1243c(p000.aazh.EnumC0166a.DISABLED);\n" +
+			"	                                                                 ^^^^^^\n" +
+			"The method m1243c(aazh.EnumC0166a) is undefined for the type abyz\n" +
+			"----------\n");
+}
 }
 


### PR DESCRIPTION
## What it does

When translating _QualifiedNameReference_s ECJ uses incorrect indexing which results in either bad class files being produced that fail verification or in AIOOB while compiling itself.

Correct this behavior.

Fixes https://bugs.eclipse.org/bugs/show_bug.cgi?id=540063


## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
