### PR TITLE
ECJ accepts illegal modifiers in classic instanceof expression

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
@@ -4605,8 +4605,11 @@ protected void consumeInstanceOfExpression() {
  				new InstanceOfExpression(
  					this.expressionStack[this.expressionPtr],
  					typeRef);
-		this.intPtr--; // skip modifierSourceStart
-		this.intPtr--; // lose the fake modifier if any
+		int anyModifiersourceStart = this.intStack[this.intPtr--];
+		int anyModifiers =  this.intStack[this.intPtr--];
+		if (anyModifiers != 0) {
+			problemReporter().illegalModifiers(anyModifiersourceStart, typeRef.sourceStart - 2);
+		}
 	}
 
 	if (exp.sourceEnd == 0) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
@@ -4608,7 +4608,7 @@ protected void consumeInstanceOfExpression() {
 		int anyModifiersourceStart = this.intStack[this.intPtr--];
 		int anyModifiers =  this.intStack[this.intPtr--];
 		if (anyModifiers != 0) {
-			problemReporter().illegalModifiers(anyModifiersourceStart, typeRef.sourceStart - 2);
+			problemReporter().illegalModifiers(anyModifiersourceStart, typeRef.sourceEnd);
 		}
 	}
 

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/InstanceofPrimaryPatternTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/InstanceofPrimaryPatternTest.java
@@ -278,4 +278,25 @@ public class InstanceofPrimaryPatternTest extends AbstractRegressionTest {
 			"s1 cannot be resolved to a variable\n" +
 			"----------\n");
 	}
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1076
+	// ECJ accepts invalid Java code instanceof final Type
+	public void testGH1076() {
+		runNegativeTest(
+			new String[] {
+				"X.java",
+				"class Test {\n" +
+				"    void check() {\n" +
+				"        Number n = Integer.valueOf(1);\n" +
+				"        if (n instanceof final Integer) {}\n" +
+				"        if (n instanceof final Integer x) {}\n" +
+				"    }\n" +
+				"}\n",
+			},
+			"----------\n" +
+			"1. ERROR in X.java (at line 4)\n" +
+			"	if (n instanceof final Integer) {}\n" +
+			"	                 ^^^^^\n" +
+			"Syntax error, modifiers are not allowed here\n" +
+			"----------\n");
+	}
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/InstanceofPrimaryPatternTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/InstanceofPrimaryPatternTest.java
@@ -295,7 +295,7 @@ public class InstanceofPrimaryPatternTest extends AbstractRegressionTest {
 			"----------\n" +
 			"1. ERROR in X.java (at line 4)\n" +
 			"	if (n instanceof final Integer) {}\n" +
-			"	                 ^^^^^\n" +
+			"	                 ^^^^^^^^^^^^^\n" +
 			"Syntax error, modifiers are not allowed here\n" +
 			"----------\n");
 	}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/compiler/DocumentElementParser.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/compiler/DocumentElementParser.java
@@ -806,13 +806,13 @@ protected void consumeFormalParameter(boolean isVarArgs) {
 }
 @Override
 protected void consumeInstanceOfExpression() {
-	super.consumeInstanceOfExpression();
 	this.intPtr--; // skip declarationSourceStart of modifiers
+	super.consumeInstanceOfExpression();
 }
 @Override
 protected void consumeInstanceOfExpressionWithName() {
-	super.consumeInstanceOfExpressionWithName();
 	this.intPtr--; // skip declarationSourceStart of modifiers
+	super.consumeInstanceOfExpressionWithName();
 }
 /*
  *


### PR DESCRIPTION
## What it does

Fix ECJ's incorrect behavior in accepting modifiers in classic instanceof expression while still allowing them in pattern declarations

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1076

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
