### PR TITLE
LambdaConversionException due to invalid instantiated method

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LambdaExpressionsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LambdaExpressionsTest.java
@@ -7917,8 +7917,48 @@ public void testBug551882() {
 			""
 			);
 }
-
-public static Class testClass() {
+//https://bugs.eclipse.org/bugs/show_bug.cgi?id=546161
+//LambdaConversionException due to invalid instantiated method type argument to LambdaMetafactory::metafactory
+public void testBug546161() {
+	this.runConformTest(
+			new String[] {
+				"Main.java",
+				"public class Main {\n" +
+				"    public static void main(String[] args) {\n" +
+				"    	((Widget<?>) new Widget<>()).addListener(evt -> {});\n" +
+				"    }\n" +
+				"}\n" +
+				"\n" +
+				"class Widget<E extends CharSequence> {\n" +
+				"    void addListener(Listener<? super E> listener) {}\n" +
+				"}\n" +
+				"\n" +
+				"interface Listener<E extends CharSequence> {\n" +
+				"    void m(E event);\n" +
+				"}\n"},
+			""
+			);
+}
+//https://bugs.eclipse.org/bugs/show_bug.cgi?id=546161
+//LambdaConversionException due to invalid instantiated method type argument to LambdaMetafactory::metafactory
+public void testBug546161_2() {
+	this.runConformTest(
+			new String[] {
+				"Main.java",
+				"public class Main {\n" +
+				"    public static void main(String[] args) {\n" +
+				"    	new Widget<>().addListener(evt -> {});\n" +
+				"    }\n" +
+				"}\n" +
+				"class Widget<E extends CharSequence> {\n" +
+				"    void addListener(Listener<? super E> listener) {}\n" +
+				"}\n" +
+				"interface Listener<E extends CharSequence> {\n" +
+				"    void m(E event);\n" +
+				"}\n"},
+			""
+			);
+}public static Class testClass() {
 	return LambdaExpressionsTest.class;
 }
 }


### PR DESCRIPTION
LambdaConversionException due to invalid instantiated method type argument to LambdaMetafactory::metafactory

Fixes #1031 

Steps to reproduce:

- create the following class
```
public class Main {    
    public static void main(String[] args) {
		getHasValue().addValueChangeListener(evt -> {System.out.println("hello");});		
    }

    public static HasValue<?, ?> getHasValue() { 
        return new HasValue<HasValue.ValueChangeEvent<String>, String>() { 
			@Override
			public void addValueChangeListener(
					HasValue.ValueChangeListener<? super HasValue.ValueChangeEvent<String>> listener) {
				listener.valueChanged(null);
			}
		};

    }    
}

interface HasValue<E extends HasValue.ValueChangeEvent<V>,V> {    
    public static interface ValueChangeEvent<V> {}    
    public static interface ValueChangeListener<E extends HasValue.ValueChangeEvent<?>> {
        void valueChanged(E event);
    }    
    void addValueChangeListener(HasValue.ValueChangeListener<? super E> listener);
}
```
- try to run it
The issue can't be reproduced with JDK.

Related issues:
- https://bugs.eclipse.org/bugs/show_bug.cgi?id=546161
- https://github.com/eclipse/eclipse.jdt.ls/issues/2631
