### PR TITLE
ECJ fails to generate canonical constructor from model

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ReconcilerTests16.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ReconcilerTests16.java
@@ -379,4 +379,127 @@ public void testGH612_002() throws Exception {
 		deleteProject(p);
 	}
 }
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1085
+// Canonical constructor of generic record not found if other constructor is present
+public void testGHIssue1085() throws Exception {
+	if (!isJRE16)
+		return;
+	IJavaProject p = createJava16Project("p");
+	try {
+		createFile("p/src/GenericRecord.java",
+				"public record GenericRecord<A>(int parameter) {\n" +
+				"    public GenericRecord() {\n" +
+				"        this(0);\n" +
+				"    }\n" +
+				"}\n");
+
+		createFile("p/src/Test.java",
+				"public class Test {\n" +
+				"    public void test() {\n" +
+				"        new GenericRecord<String>(0);\n" +
+				"    }\n" +
+				"}\n");
+
+		p.getProject().build(IncrementalProjectBuilder.FULL_BUILD, null);
+		IMarker[] markers = p.getProject().findMarkers(null, true, IResource.DEPTH_INFINITE);
+		assertMarkers("markers in p",
+				"",
+				markers);
+
+		this.workingCopy = getCompilationUnit("p/src/Test.java").getWorkingCopy(this.wcOwner, null);
+		this.problemRequestor.initialize(this.workingCopy.getSource().toCharArray());
+		this.workingCopy.reconcile(JLS_LATEST, true, this.wcOwner, null);
+		assertProblems("Expecting no problems",
+				"----------\n" +
+				"----------\n",
+				this.problemRequestor);
+		this.workingCopy.discardWorkingCopy();
+	} finally {
+		deleteProject(p);
+	}
+}
+
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1085
+// Canonical constructor of generic record not found if other constructor is present
+public void testGHIssue1085_2() throws Exception {
+	if (!isJRE16)
+		return;
+	IJavaProject p = createJava16Project("p");
+	try {
+		createFile("p/src/GenericRecord.java",
+				"public record GenericRecord<A>(int parameter) {\n" +
+				"    public GenericRecord() {\n" +
+				"        this(0);\n" +
+				"    }\n" +
+				"    public GenericRecord(int parameter) {\n" +
+				"        this.parameter = parameter;\n" +
+				"    }\n" +
+				"}\n");
+
+		createFile("p/src/Test.java",
+				"public class Test {\n" +
+				"    public void test() {\n" +
+				"        new GenericRecord<String>(0);\n" +
+				"    }\n" +
+				"}\n");
+
+		p.getProject().build(IncrementalProjectBuilder.FULL_BUILD, null);
+		IMarker[] markers = p.getProject().findMarkers(null, true, IResource.DEPTH_INFINITE);
+		assertMarkers("markers in p",
+				"",
+				markers);
+
+		this.workingCopy = getCompilationUnit("p/src/Test.java").getWorkingCopy(this.wcOwner, null);
+		this.problemRequestor.initialize(this.workingCopy.getSource().toCharArray());
+		this.workingCopy.reconcile(JLS_LATEST, true, this.wcOwner, null);
+		assertProblems("Expecting no problems",
+				"----------\n" +
+				"----------\n",
+				this.problemRequestor);
+		this.workingCopy.discardWorkingCopy();
+	} finally {
+		deleteProject(p);
+	}
+}
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1085
+// Canonical constructor of generic record not found if other constructor is present
+public void testGHIssue1085_3() throws Exception {
+	if (!isJRE16)
+		return;
+	IJavaProject p = createJava16Project("p");
+	try {
+		createFile("p/src/GenericRecord.java",
+				"public record GenericRecord<A>(int parameter) {\n" +
+				"    public GenericRecord() {\n" +
+				"        this(0);\n" +
+				"    }\n" +
+				"    public GenericRecord {\n" +
+				"    }\n" +
+				"}\n");
+
+		createFile("p/src/Test.java",
+				"public class Test {\n" +
+				"    public void test() {\n" +
+				"        new GenericRecord<String>(0);\n" +
+				"    }\n" +
+				"}\n");
+
+		p.getProject().build(IncrementalProjectBuilder.FULL_BUILD, null);
+		IMarker[] markers = p.getProject().findMarkers(null, true, IResource.DEPTH_INFINITE);
+		assertMarkers("markers in p",
+				"",
+				markers);
+
+		this.workingCopy = getCompilationUnit("p/src/Test.java").getWorkingCopy(this.wcOwner, null);
+		this.problemRequestor.initialize(this.workingCopy.getSource().toCharArray());
+		this.workingCopy.reconcile(JLS_LATEST, true, this.wcOwner, null);
+		assertProblems("Expecting no problems",
+				"----------\n" +
+				"----------\n",
+				this.problemRequestor);
+		this.workingCopy.discardWorkingCopy();
+	} finally {
+		deleteProject(p);
+	}
+}
 }

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ReconcilerTests16.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ReconcilerTests16.java
@@ -513,8 +513,7 @@ public void test578080() throws Exception {
 				"public record Diamond<T> (T value) {\n" +
 				"	public Diamond {	\n" +
 				"	}\n" +
-				"}\n"
-						);
+				"}\n");
 
 		createFile("p/src/DiamondTest.java",
 				"public class DiamondTest {\n" +
@@ -538,6 +537,62 @@ public void test578080() throws Exception {
 				markers);
 
 		this.workingCopy = getCompilationUnit("p/src/DiamondTest.java").getWorkingCopy(this.wcOwner, null);
+		this.problemRequestor.initialize(this.workingCopy.getSource().toCharArray());
+		this.workingCopy.reconcile(JLS_LATEST, true, this.wcOwner, null);
+		assertProblems("Expecting no problems",
+				"----------\n" +
+				"----------\n",
+				this.problemRequestor);
+		this.workingCopy.discardWorkingCopy();
+	} finally {
+		deleteProject(p);
+	}
+}
+// https://bugs.eclipse.org/bugs/show_bug.cgi?id=577351
+// inference with diamond error in records in two files
+public void test577351() throws Exception {
+	if (!isJRE16)
+		return;
+	IJavaProject p = createJava16Project("p");
+	try {
+
+		createFile("p/src/TimeSeries.java",
+				"import java.util.Objects;\n" +
+				"\n" +
+				"public final class TimeSeries<T> {\n" +
+				"  public record Data<T>(long timestamp, T element) {\n" +
+				"    public Data {\n" +
+				"      Objects.requireNonNull(element);\n" +
+				"    }\n" +
+				"    @Override\n" +
+				"    public String toString() {\n" +
+				"      return timestamp + \" | \" + element;\n" +
+				"    }\n" +
+				"  }\n" +
+				"}\n");
+
+		createFile("p/src/TimeSeriesTest.java",
+				"public class TimeSeriesTest {\n" +
+				"	public interface Executable {\n" +
+				"		void execute() throws Throwable;\n" +
+				"	}\n" +
+				"\n" +
+				"	public void test() {\n" +
+				"		assertThrows(NullPointerException.class, () -> new TimeSeries.Data<>(0, null));\n" +
+				"	}\n" +
+				"\n" +
+				"	private void assertThrows(Class<NullPointerException> class1, Executable ex) {\n" +
+				"	}\n" +
+				"}\n"
+				);
+
+		p.getProject().build(IncrementalProjectBuilder.FULL_BUILD, null);
+		IMarker[] markers = p.getProject().findMarkers(null, true, IResource.DEPTH_INFINITE);
+		assertMarkers("markers in p",
+				"",
+				markers);
+
+		this.workingCopy = getCompilationUnit("p/src/TimeSeriesTest.java").getWorkingCopy(this.wcOwner, null);
 		this.problemRequestor.initialize(this.workingCopy.getSource().toCharArray());
 		this.workingCopy.reconcile(JLS_LATEST, true, this.wcOwner, null);
 		assertProblems("Expecting no problems",

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/compiler/parser/SourceTypeConverter.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/compiler/parser/SourceTypeConverter.java
@@ -644,7 +644,8 @@ public class SourceTypeConverter extends TypeConverter {
 				for (int i = 0; i < sourceMethodCount; i++) {
 					if (sourceMethods[i].isConstructor()) {
 						if (needConstructor) {
-							extraConstructor = 0; // Does not need the extra constructor since one constructor already exists.
+							if (!type.isRecord())     // Records need a canonical constructor - clashes with express ones handled elsewhere
+								extraConstructor = 0; // Does not need the extra constructor since one constructor already exists.
 							methodCount++;
 						}
 					} else if (needMethod) {


### PR DESCRIPTION

## What it does

When a record type declaration is generated from model, ensure that canonical constructors are generated even when other constructors may be present. Any clashes with expressly supplied constructors will be weeded out later.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1085

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
