### PR TITLE
Fix duplication annotation emission for record component accessors and components

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ClassFile.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ClassFile.java
@@ -655,7 +655,7 @@ public class ClassFile implements TypeConstants, TypeIds {
 			if ((this.produceAttributes & ClassFileConstants.ATTR_TYPE_ANNOTATION) != 0) {
 				List<AnnotationContext> allTypeAnnotationContexts = new ArrayList<>();
 				if (annotations != null && (recordComponent.bits & ASTNode.HasTypeAnnotations) != 0) {
-					recordComponent.getAllAnnotationContexts(AnnotationTargetTypeConstants.FIELD, allTypeAnnotationContexts);
+					recordComponent.getAllAnnotationContexts(AnnotationTargetTypeConstants.RECORD_COMPONENT, allTypeAnnotationContexts);
 				}
 				TypeReference recordComponentType = recordComponent.type;
 				if (recordComponentType != null && ((recordComponentType.bits & ASTNode.HasTypeAnnotations) != 0)) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/RecordComponent.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/RecordComponent.java
@@ -81,7 +81,10 @@ public class RecordComponent extends AbstractVariableDeclaration {
 
 	public void getAllAnnotationContexts(int targetType, List<AnnotationContext> allAnnotationContexts) {
 		AnnotationCollector collector = new AnnotationCollector(this, targetType, allAnnotationContexts);
-		this.traverse(collector, (BlockScope) null);
+		for (int i = 0, max = this.annotations.length; i < max; i++) {
+			Annotation annotation = this.annotations[i];
+			annotation.traverse(collector, (BlockScope) null);
+		}
 	}
 
 	public boolean isVarArgs() {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypeReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypeReference.java
@@ -56,7 +56,6 @@ import org.eclipse.jdt.internal.compiler.lookup.ArrayBinding;
 import org.eclipse.jdt.internal.compiler.lookup.Binding;
 import org.eclipse.jdt.internal.compiler.lookup.BlockScope;
 import org.eclipse.jdt.internal.compiler.lookup.ClassScope;
-import org.eclipse.jdt.internal.compiler.lookup.RecordComponentBinding;
 import org.eclipse.jdt.internal.compiler.lookup.LocalVariableBinding;
 import org.eclipse.jdt.internal.compiler.lookup.LookupEnvironment;
 import org.eclipse.jdt.internal.compiler.lookup.ProblemReasons;
@@ -100,7 +99,6 @@ static class AnnotationCollector extends ASTVisitor {
 	Annotation[][] annotationsOnDimensions;
 	int dimensions;
 	Wildcard currentWildcard;
-	RecordComponentBinding recordComponentBinding;
 
 	public AnnotationCollector(
 			TypeParameter typeParameter,
@@ -189,7 +187,6 @@ static class AnnotationCollector extends ASTVisitor {
 		this.annotationContexts = annotationContexts;
 		this.typeReference = recordComponent.type;
 		this.targetType = targetType;
-		this.recordComponentBinding = recordComponent.binding;
 	}
 
 	private boolean internalVisit(Annotation annotation) {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordsRestrictedClassTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordsRestrictedClassTest.java
@@ -9267,4 +9267,128 @@ public void testRecordConstructorWithExceptionGh487() throws Exception {
 			""";
 	RecordsRestrictedClassTest.verifyClassFile(expectedOutput, "X.class", ClassFileBytesDisassembler.SYSTEM);
 }
+
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1092
+// Duplicate Annotation Error for Records
+public void testGH1092() throws Exception {
+	runConformTest(
+			new String[] {
+					"X.java",
+					"import java.lang.annotation.*;\n" +
+					"import java.lang.annotation.Target;\n" +
+					"import java.util.List;\n" +
+					"import java.lang.reflect.AnnotatedParameterizedType;\n" +
+					"\n" +
+					"@Target(ElementType.TYPE_USE)\n" +
+					"@Retention(RetentionPolicy.RUNTIME)\n" +
+					"@interface Ann {\n" +
+					"}\n" +
+					"\n" +
+					"record Record(\n" +
+					"    @Ann\n" +
+					"    List<@Ann String> list\n" +
+					") {\n" +
+					"}\n" +
+					"\n" +
+					"public class X {\n" +
+					"\n" +
+					"	static void assertDoesNotThrow(Runnable exe, String message) {\n" +
+					"		exe.run();\n" +
+					"	}\n" +
+					"	\n" +
+					"    public static void main(String [] args) throws Exception {\n" +
+					"        AnnotatedParameterizedType listField = (AnnotatedParameterizedType) Record.class.getDeclaredMethod(\"list\").getAnnotatedReturnType();\n" +
+					"        assertDoesNotThrow(listField::getAnnotatedActualTypeArguments, \"Should not throw duplicate annotation exception.\");\n" +
+					"    }\n" +
+					"}\n"
+				},
+		"");
+
+	// verify annotations on field
+	String expectedOutput =
+			"  // Field descriptor #6 Ljava/util/List;\n" +
+			"  // Signature: Ljava/util/List<Ljava/lang/String;>;\n" +
+			"  private final java.util.List list;\n" +
+			"    RuntimeVisibleTypeAnnotations: \n" +
+			"      #10 @Ann(\n" +
+			"        target type = 0x13 FIELD\n" +
+			"      )\n" +
+			"      #10 @Ann(\n" +
+			"        target type = 0x13 FIELD\n" +
+			"        location = [TYPE_ARGUMENT(0)]\n" +
+			"      )\n" +
+			"  \n";
+	RecordsRestrictedClassTest.verifyClassFile(expectedOutput, "Record.class", ClassFileBytesDisassembler.SYSTEM);
+
+	// verify annotations on constructor
+	expectedOutput =
+			"  // Method descriptor #12 (Ljava/util/List;)V\n" +
+			"  // Signature: (Ljava/util/List<Ljava/lang/String;>;)V\n" +
+			"  // Stack: 2, Locals: 2\n" +
+			"  Record(java.util.List list);\n" +
+			"     0  aload_0 [this]\n" +
+			"     1  invokespecial java.lang.Record() [15]\n" +
+			"     4  aload_0 [this]\n" +
+			"     5  aload_1 [list]\n" +
+			"     6  putfield Record.list : java.util.List [18]\n" +
+			"     9  return\n" +
+			"      Line numbers:\n" +
+			"        [pc: 0, line: 11]\n" +
+			"      Local variable table:\n" +
+			"        [pc: 0, pc: 10] local: this index: 0 type: Record\n" +
+			"        [pc: 0, pc: 10] local: list index: 1 type: java.util.List\n" +
+			"      Local variable type table:\n" +
+			"        [pc: 0, pc: 10] local: list index: 1 type: java.util.List<java.lang.String>\n" +
+			"      Method Parameters:\n" +
+			"        list\n" +
+			"    RuntimeVisibleTypeAnnotations: \n" +
+			"      #10 @Ann(\n" +
+			"        target type = 0x16 METHOD_FORMAL_PARAMETER\n" +
+			"        method parameter index = 0\n" +
+			"      )\n" +
+			"      #10 @Ann(\n" +
+			"        target type = 0x16 METHOD_FORMAL_PARAMETER\n" +
+			"        method parameter index = 0\n" +
+			"        location = [TYPE_ARGUMENT(0)]\n" +
+			"      )\n" +
+			"  \n" ;
+	RecordsRestrictedClassTest.verifyClassFile(expectedOutput, "Record.class", ClassFileBytesDisassembler.SYSTEM);
+
+	// verify annotations on accessor
+	expectedOutput =
+			"  // Method descriptor #26 ()Ljava/util/List;\n" +
+			"  // Signature: ()Ljava/util/List<Ljava/lang/String;>;\n" +
+			"  // Stack: 1, Locals: 1\n" +
+			"  public java.util.List list();\n" +
+			"    0  aload_0 [this]\n" +
+			"    1  getfield Record.list : java.util.List [18]\n" +
+			"    4  areturn\n" +
+			"      Line numbers:\n" +
+			"        [pc: 0, line: 13]\n" +
+			"    RuntimeVisibleTypeAnnotations: \n" +
+			"      #10 @Ann(\n" +
+			"        target type = 0x14 METHOD_RETURN\n" +
+			"      )\n" +
+			"      #10 @Ann(\n" +
+			"        target type = 0x14 METHOD_RETURN\n" +
+			"        location = [TYPE_ARGUMENT(0)]\n" +
+			"      )\n" +
+			"  \n";
+	RecordsRestrictedClassTest.verifyClassFile(expectedOutput, "Record.class", ClassFileBytesDisassembler.SYSTEM);
+
+	// verify annotations on record component
+	expectedOutput =
+			"// Component descriptor #6 Ljava/util/List;\n" +
+			"// Signature: Ljava/util/List<Ljava/lang/String;>;\n" +
+			"java.util.List list;\n" +
+			"  RuntimeVisibleTypeAnnotations: \n" +
+			"    #10 @Ann(\n" +
+			"      target type = 0x13 FIELD\n" +
+			"    )\n" +
+			"    #10 @Ann(\n" +
+			"      target type = 0x13 FIELD\n" +
+			"      location = [TYPE_ARGUMENT(0)]\n" +
+			"    )\n";
+	RecordsRestrictedClassTest.verifyClassFile(expectedOutput, "Record.class", ClassFileBytesDisassembler.SYSTEM);
+}
 }


### PR DESCRIPTION
## What it does

Double traversal results in duplicate annotations being emitted. Fixed it.

Fixes: https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1092

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
