### PR TITLE
Add completion boost for constructor parameters Fix: #1102

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests11.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests11.java
@@ -247,4 +247,41 @@ public void test_members_matching_paramater_name_on_local_variable() throws Java
 									+ R_UNQUALIFIED)
 							+ "}"));
 }
+
+public void test_members_matching_constructors_parameter_name() throws JavaModelException {
+	this.workingCopies = new ICompilationUnit[2];
+	this.workingCopies[0] = getWorkingCopy("/Completion/src/test/Smart.java", """
+			package test;
+			public class Smart {
+				public static void persist(Task task) {\t
+					new SmartObject(task.);
+				}
+				public static class Task {
+					public String getName() {return null;}
+					public boolean isCompleted() {return false;}
+					public String details() {return null;}
+				}
+			}
+			""");
+	this.workingCopies[1] = getWorkingCopy("/Completion/src/test/SmartObject.java", """
+			package test;
+			public class SmartObject {
+				public SmartObject(String name, String details) {}
+			}
+			""");
+
+	CompletionTestsRequestor2 requestor = new CompletionTestsRequestor2(true);
+	requestor.allowAllRequiredProposals();
+	String str = this.workingCopies[0].getSource();
+	String completeBehind = "task.";
+	int cursorLocation = str.lastIndexOf(completeBehind) + completeBehind.length();
+	this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner);
+	assertTrue(requestor.getResults(),
+			requestor.getResults()
+					.contains(
+							"getName[METHOD_REF]{getName(), Ltest.Smart$Task;, ()Ljava.lang.String;, getName, null, "
+									+ (R_DEFAULT + R_INTERESTING + R_EXACT_NAME + R_CASE + R_CASE
+											+ R_EXACT_EXPECTED_TYPE + R_NON_STATIC + R_NON_RESTRICTED + R_RESOLVED)
+									+ "}"));
+}
 }

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/CompletionEngine.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/CompletionEngine.java
@@ -9842,15 +9842,14 @@ public final class CompletionEngine
 					.map(m -> new MethodBinding[] { m }).orElse(new MethodBinding[0]);
 		} else if (this.parser.assistNodeParent instanceof AllocationExpression ae) {
 			arguments = ae.arguments;
-			if (ae.type != null) {
-				ReferenceBinding binding = (ReferenceBinding) ae.type.resolvedType;
-				findConstructors(binding, computeTypes(arguments), scope, ae, false, null, null, null, false,
+			if (ae.type != null && ae.type.resolvedType instanceof ReferenceBinding rb) {
+				findConstructors(rb, computeTypes(arguments), scope, ae, false, null, null, null, false,
 						methodsFound);
 			}
 			candidates = StreamSupport.stream(methodsFound.spliterator(), false).filter(Objects::nonNull)
 					.filter(o -> o instanceof Object[]).map(o -> (Object[]) o).map(o -> o[0])
 					.filter(o -> o instanceof MethodBinding).map(b -> (MethodBinding) b).filter(b -> b.isConstructor())
-					.findFirst().map(m -> new MethodBinding[] { m }).orElse(new MethodBinding[0]);
+					.toArray(MethodBinding[]::new);
 		} else {
 			return parameterName;
 		}

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/CompletionEngine.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/CompletionEngine.java
@@ -7132,7 +7132,7 @@ public final class CompletionEngine
 			}
 		}
 
-		char[] boostMatches = findParameterNameAtLocationFromAssistParent(new ObjectVector());
+		char[] boostMatches = findParameterNameAtLocationFromAssistParent(new ObjectVector(), scope);
 
 		// Inherited fields which are hidden by subclasses are filtered out
 		// No visibility checks can be performed without the scope & invocationSite
@@ -9463,7 +9463,7 @@ public final class CompletionEngine
 		int minArgLength = argTypes == null ? 0 : argTypes.length;
 
 		char[][] boostMatches = new char[0][];
-		char[] parameterName = findParameterNameAtLocationFromAssistParent(new ObjectVector());
+		char[] parameterName = findParameterNameAtLocationFromAssistParent(new ObjectVector(), scope);
 		if(parameterName.length > 0) {
 			char[] nameForMethods = capitalize(parameterName);
 			boostMatches = new char[][] { parameterName, CharOperation.concat(GET, nameForMethods),
@@ -9823,32 +9823,43 @@ public final class CompletionEngine
 		return result;
 	}
 
-	private char[] findParameterNameAtLocationFromAssistParent(ObjectVector methodsFound) {
+	private char[] findParameterNameAtLocationFromAssistParent(ObjectVector methodsFound, Scope scope) {
 		char[] parameterName = new char[0];
 		MethodBinding[] candidates;
-		final MessageSend parent;
-		if (this.parser.assistNodeParent instanceof MessageSend) {
-			parent = (MessageSend) this.parser.assistNodeParent;
-			candidates = Optional.ofNullable(parent.actualReceiverType)
-					.or(() -> Optional.ofNullable(parent.receiver).map(r -> r.resolvedType))
-					.map(t -> t.getMethods(parent.selector)).orElse(new MethodBinding[0]);
-		} else if (this.parser.assistNode instanceof MessageSend) {
-			parent = (MessageSend) this.parser.assistNode;
+		final Expression[] arguments;
+		if (this.parser.assistNodeParent instanceof MessageSend ms) {
+			arguments = ms.arguments;
+			candidates = Optional.ofNullable(ms.actualReceiverType)
+					.or(() -> Optional.ofNullable(ms.receiver).map(r -> r.resolvedType))
+					.map(t -> t.getMethods(ms.selector)).orElse(new MethodBinding[0]);
+		} else if (this.parser.assistNode instanceof MessageSend ms) {
+			arguments = ms.arguments;
 			candidates = StreamSupport.stream(methodsFound.spliterator(), false)
 					.filter(Objects::nonNull)
 					.filter(o -> o instanceof Object[]).map(o -> (Object[]) o)
 					.map(o -> o[0]).filter(o -> o instanceof MethodBinding).map(b -> (MethodBinding) b)
-					.filter(b -> CharOperation.equals(parent.selector, b.selector)).findFirst()
+					.filter(b -> CharOperation.equals(ms.selector, b.selector)).findFirst()
 					.map(m -> new MethodBinding[] { m }).orElse(new MethodBinding[0]);
+		} else if (this.parser.assistNodeParent instanceof AllocationExpression ae) {
+			arguments = ae.arguments;
+			if (ae.type != null) {
+				ReferenceBinding binding = (ReferenceBinding) ae.type.resolvedType;
+				findConstructors(binding, computeTypes(arguments), scope, ae, false, null, null, null, false,
+						methodsFound);
+			}
+			candidates = StreamSupport.stream(methodsFound.spliterator(), false).filter(Objects::nonNull)
+					.filter(o -> o instanceof Object[]).map(o -> (Object[]) o).map(o -> o[0])
+					.filter(o -> o instanceof MethodBinding).map(b -> (MethodBinding) b).filter(b -> b.isConstructor())
+					.findFirst().map(m -> new MethodBinding[] { m }).orElse(new MethodBinding[0]);
 		} else {
 			return parameterName;
 		}
 
-		final int argumentLength = (parent.arguments != null) ? parent.arguments.length : 1;
+		final int argumentLength = (arguments != null) ? arguments.length : 1;
 		for (MethodBinding binding : candidates) {
 			if (binding.parameterNames.length >= argumentLength) {
 				for (int i = 0; i < argumentLength; i++) {
-					if (parent.arguments == null || parent.arguments[i] == this.parser.assistNode) {
+					if (arguments == null || arguments[i] == this.parser.assistNode) {
 						parameterName = binding.parameterNames[i];
 					}
 				}
@@ -13265,7 +13276,7 @@ public final class CompletionEngine
 
 		Scope currentScope = scope;
 
-		char[]	boostMatches = findParameterNameAtLocationFromAssistParent(methodsFound);
+		char[]	boostMatches = findParameterNameAtLocationFromAssistParent(methodsFound, scope);
 
 		if (!this.requestor.isIgnored(CompletionProposal.LOCAL_VARIABLE_REF)) {
 			done1 : while (true) { // done when a COMPILATION_UNIT_SCOPE is found


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
Rank the completions on constructor parameters by considering the parameter type and name at the location based on what was introduced through [#1102](https://github.com/eclipse-jdt/eclipse.jdt.core/pull/779)

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1102

## How to test
Unit test and sample in the issue

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
