### PR TITLE
Avoid potential Threadlocal.set(null) memory leak

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/DeltaProcessingState.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/DeltaProcessingState.java
@@ -502,7 +502,7 @@ public class DeltaProcessingState implements IResourceChangeListener {
 		} finally {
 			// TODO (jerome) see 47631, may want to get rid of following so as to reuse delta processor ?
 			if (event.getType() == IResourceChangeEvent.POST_CHANGE) {
-				this.deltaProcessors.set(null);
+				this.deltaProcessors.remove();
 			} else {
 				// If we are going to reuse the delta processor of this thread, don't hang on to state
 				// that isn't meant to be reused. https://bugs.eclipse.org/bugs/show_bug.cgi?id=273385


### PR DESCRIPTION
Threadlocal.set(null) keeps a reference to ThreadLocal.this 
see https://rules.sonarsource.com/java/RSPEC-5164
