### PR TITLE
testBug566803 fails since I20230608-1800 on Java 17

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TypeAnnotationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TypeAnnotationTest.java
@@ -7085,7 +7085,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 				"\n" +
 				"    Annotation[] as = s.getAnnotations();\n" +
 				"    for (int i = 0; i < as.length; i++) {\n" +
-				"      System.out.println(i + \" \" + as[i]);\n" +
+				"      System.out.println(i + \" @\" + as[i].annotationType().getCanonicalName() + \"()\");\n" +
 				"    }\n" +
 				"\n" +
 				"    if (1 != as.length) {\n" +


### PR DESCRIPTION

## What it does

* Make the test more resilent by not relying on APIs that are not stable across revisions

* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1138

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
