### PR TITLE
OPTION_JdtDebugCompileMode has surprising effects on imports

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ImportReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ImportReference.java
@@ -64,6 +64,10 @@ public class ImportReference extends ASTNode {
 		ModuleBinding module = scope.module();
 		PackageBinding visiblePackage = module.getVisiblePackage(this.tokens);
 		if (visiblePackage instanceof SplitPackageBinding) {
+			// attempt normalization (filter out packages w/o compilation units, optionally ignore named<->unnamed conflict):
+			visiblePackage = visiblePackage.getVisibleFor(module, false);
+		}
+		if (visiblePackage instanceof SplitPackageBinding) {
 			Set<ModuleBinding> declaringMods = new HashSet<>();
 			for (PackageBinding incarnation : ((SplitPackageBinding) visiblePackage).incarnations) {
 				if (incarnation.enclosingModule != module && module.canAccess(incarnation))

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ImportReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ImportReference.java
@@ -18,7 +18,6 @@ import java.util.Set;
 
 import org.eclipse.jdt.internal.compiler.ASTVisitor;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
-import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jdt.internal.compiler.lookup.*;
 
 public class ImportReference extends ASTNode {
@@ -71,11 +70,7 @@ public class ImportReference extends ASTNode {
 					declaringMods.add(incarnation.enclosingModule);
 			}
 			if (!declaringMods.isEmpty()) {
-				CompilerOptions compilerOptions = scope.compilerOptions();
-				boolean inJdtDebugCompileMode = compilerOptions.enableJdtDebugCompileMode;
-				if (!inJdtDebugCompileMode) {
-					scope.problemReporter().conflictingPackagesFromOtherModules(this, declaringMods);
-				}
+				scope.problemReporter().conflictingPackagesFromOtherModules(this, declaringMods);
 			}
 		}
 	}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ModuleDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ModuleDeclaration.java
@@ -29,7 +29,6 @@ import org.eclipse.jdt.internal.compiler.ASTVisitor;
 import org.eclipse.jdt.internal.compiler.ClassFile;
 import org.eclipse.jdt.internal.compiler.CompilationResult;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
-import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jdt.internal.compiler.impl.ReferenceContext;
 import org.eclipse.jdt.internal.compiler.lookup.CompilationUnitScope;
 import org.eclipse.jdt.internal.compiler.lookup.ExtraCompilerModifiers;
@@ -347,11 +346,7 @@ public class ModuleDeclaration extends ASTNode implements ReferenceContext {
 		for (PlainPackageBinding pack : requiredModule.getExports()) {
 			Set<ModuleBinding> mods = pack2mods.get(String.valueOf(pack.readableName()));
 			if (mods != null && mods.size() > 1) {
-				CompilerOptions compilerOptions = skope.compilerOptions();
-				boolean inJdtDebugCompileMode = compilerOptions.enableJdtDebugCompileMode;
-				if (!inJdtDebugCompileMode) {
-					skope.problemReporter().conflictingPackagesFromModules(pack, mods, requiresStat.sourceStart, requiresStat.sourceEnd);
-				}
+				skope.problemReporter().conflictingPackagesFromModules(pack, mods, requiresStat.sourceStart, requiresStat.sourceEnd);
 			}
 		}
 	}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/QualifiedTypeReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/QualifiedTypeReference.java
@@ -15,7 +15,6 @@ package org.eclipse.jdt.internal.compiler.ast;
 
 import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.internal.compiler.ASTVisitor;
-import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jdt.internal.compiler.lookup.*;
 import org.eclipse.jdt.internal.compiler.problem.AbortCompilation;
 
@@ -126,14 +125,10 @@ public class QualifiedTypeReference extends TypeReference {
 	    if (packageBinding != null) {
 	    	PackageBinding uniquePackage = packageBinding.getVisibleFor(scope.module(), false);
 	    	if (uniquePackage instanceof SplitPackageBinding) {
-	    		CompilerOptions compilerOptions = scope.compilerOptions();
-	    		boolean inJdtDebugCompileMode = compilerOptions.enableJdtDebugCompileMode;
-	    		if (!inJdtDebugCompileMode) {
-	    			SplitPackageBinding splitPackage = (SplitPackageBinding) uniquePackage;
-	    			scope.problemReporter().conflictingPackagesFromModules(splitPackage, scope.module(), this.sourceStart, (int)this.sourcePositions[typeStart-1]);
-	    			this.resolvedType = new ProblemReferenceBinding(this.tokens, null, ProblemReasons.Ambiguous);
-	    			return null;
-	    		}
+	    		SplitPackageBinding splitPackage = (SplitPackageBinding) uniquePackage;
+    			scope.problemReporter().conflictingPackagesFromModules(splitPackage, scope.module(), this.sourceStart, (int)this.sourcePositions[typeStart-1]);
+    			this.resolvedType = new ProblemReferenceBinding(this.tokens, null, ProblemReasons.Ambiguous);
+    			return null;
 	    	}
 	    }
 	    rejectAnnotationsOnPackageQualifiers(scope, packageBinding);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/impl/CompilerOptions.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/impl/CompilerOptions.java
@@ -208,9 +208,6 @@ public class CompilerOptions {
 
 	public static final String OPTION_ReportSuppressWarningNotFullyAnalysed = "org.eclipse.jdt.core.compiler.problem.suppressWarningsNotFullyAnalysed";  //$NON-NLS-1$
 
-	// Internally used option to allow debug framework compile evaluation snippets in context of modules, see bug 543604
-	public static final String OPTION_JdtDebugCompileMode = "org.eclipse.jdt.internal.debug.compile.mode"; //$NON-NLS-1$
-
 	public static final String OPTION_IgnoreUnnamedModuleForSplitPackage = "org.eclipse.jdt.core.compiler.ignoreUnnamedModuleForSplitPackage"; //$NON-NLS-1$
 
 	public static final String OPTION_UseStringConcatFactory = "org.eclipse.jdt.core.compiler.codegen.useStringConcatFactory"; //$NON-NLS-1$
@@ -547,9 +544,6 @@ public class CompilerOptions {
 
 	/** Master flag to enabled/disable all preview features */
 	public boolean enablePreviewFeatures;
-
-	/** Enable a less restrictive compile mode for JDT debug. */
-	public boolean enableJdtDebugCompileMode;
 
 	/** Should the compiler ignore the unnamed module when a package is defined in both a named module and the unnamed module? */
 	public boolean ignoreUnnamedModuleForSplitPackage;
@@ -1606,7 +1600,6 @@ public class CompilerOptions {
 		this.complainOnUninternedIdentityComparison = false;
 		this.enablePreviewFeatures = false;
 
-		this.enableJdtDebugCompileMode = false;
 		this.ignoreUnnamedModuleForSplitPackage = false;
 		this.useStringConcatFactory = true;
 	}
@@ -2134,14 +2127,6 @@ public class CompilerOptions {
 			updateSeverity(PreviewFeatureUsed, optionValue);
 		if ((optionValue = optionsMap.get(OPTION_ReportSuppressWarningNotFullyAnalysed)) != null)
 			updateSeverity(SuppressWarningsNotAnalysed, optionValue);
-
-		if ((optionValue = optionsMap.get(OPTION_JdtDebugCompileMode)) != null) {
-			if (ENABLED.equals(optionValue)) {
-				this.enableJdtDebugCompileMode = true;
-			} else if (DISABLED.equals(optionValue)) {
-				this.enableJdtDebugCompileMode = false;
-			}
-		}
 
 		if ((optionValue = optionsMap.get(OPTION_IgnoreUnnamedModuleForSplitPackage)) != null) {
 			if (ENABLED.equals(optionValue)) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/CompilationUnitScope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/CompilationUnitScope.java
@@ -451,7 +451,6 @@ void faultInImports() {
 	this.importPtr = 1;
 
 	CompilerOptions compilerOptions = compilerOptions();
-	boolean inJdtDebugCompileMode = compilerOptions.enableJdtDebugCompileMode;
 
 	// keep static imports with normal imports until there is a reason to split them up
 	// on demand imports continue to be packages & types. need to check on demand type imports for fields/methods
@@ -478,7 +477,7 @@ void faultInImports() {
 			}
 			if (importBinding instanceof PackageBinding) {
 				PackageBinding uniquePackage = ((PackageBinding)importBinding).getVisibleFor(module(), false);
-				if (uniquePackage instanceof SplitPackageBinding && !inJdtDebugCompileMode) {
+				if (uniquePackage instanceof SplitPackageBinding) {
 					SplitPackageBinding splitPackage = (SplitPackageBinding) uniquePackage;
 					problemReporter().conflictingPackagesFromModules(splitPackage, module(), importReference.sourceStart, importReference.sourceEnd);
 					continue nextImport;
@@ -491,7 +490,7 @@ void faultInImports() {
 			recordImportBinding(new ImportBinding(compoundName, true, importBinding, importReference));
 		} else {
 			Binding importBinding = findSingleImport(compoundName, Binding.TYPE | Binding.FIELD | Binding.METHOD, importReference.isStatic());
-			if (importBinding instanceof SplitPackageBinding && !inJdtDebugCompileMode) {
+			if (importBinding instanceof SplitPackageBinding) {
 				SplitPackageBinding splitPackage = (SplitPackageBinding) importBinding;
 				int sourceEnd = (int)(importReference.sourcePositions[splitPackage.compoundName.length-1] & 0xFFFF);
 				problemReporter().conflictingPackagesFromModules((SplitPackageBinding) importBinding, module(), importReference.sourceStart, sourceEnd);
@@ -522,7 +521,7 @@ void faultInImports() {
 					importedPackage = (PackageBinding) findImport(importedPackage.compoundName, false, true);
 					if (importedPackage != null)
 						importedPackage = importedPackage.getVisibleFor(module(), true);
-					if (importedPackage instanceof SplitPackageBinding && !inJdtDebugCompileMode) {
+					if (importedPackage instanceof SplitPackageBinding) {
 						SplitPackageBinding splitPackage = (SplitPackageBinding) importedPackage;
 						int sourceEnd = (int) importReference.sourcePositions[splitPackage.compoundName.length-1];
 						problemReporter().conflictingPackagesFromModules(splitPackage, module(), importReference.sourceStart, sourceEnd);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/LookupEnvironment.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/LookupEnvironment.java
@@ -1502,7 +1502,7 @@ private boolean flaggedJavaBaseTypeErrors(ReferenceBinding result, char[][] comp
 					ModuleBinding visibleModule = currentPack != null ? currentPack.enclosingModule : null;
 					if (visibleModule != null && visibleModule != javaBaseModule()) {
 						// A type from java.base is not visible
-						if (!this.globalOptions.enableJdtDebugCompileMode) {
+						if (!this.globalOptions.ignoreUnnamedModuleForSplitPackage) {
 							this.problemReporter.conflictingPackageInModules(compoundName, this.root.unitBeingCompleted, this.missingClassFileLocation,
 									readableName, TypeConstants.JAVA_BASE, visibleModule.readableName());
 							return true;

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ModuleBuilderTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ModuleBuilderTests.java
@@ -3449,6 +3449,7 @@ public class ModuleBuilderTests extends ModifyingResourceTests {
 			IJavaProject p1= setupModuleProject("debugger_project", sources, new IClasspathEntry[]{dep});
 			p1.getProject().getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, null);
 			IMarker[] markers = p1.getProject().findMarkers(null, true, IResource.DEPTH_INFINITE);
+			sortMarkers(markers);
 			assertMarkers("unexpected markers",
 					"The package java.util conflicts with a package accessible from another module: java.base\n" +
 					"The package java.util is accessible from more than one module: <unnamed>, java.base\n" +

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ModuleBuilderTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ModuleBuilderTests.java
@@ -3407,7 +3407,7 @@ public class ModuleBuilderTests extends ModifyingResourceTests {
 		Hashtable<String, String> javaCoreOptions = JavaCore.getOptions();
 		try {
 			Hashtable<String, String> newOptions=new Hashtable<>(javaCoreOptions);
-			newOptions.put(CompilerOptions.OPTION_JdtDebugCompileMode, JavaCore.ENABLED);
+			newOptions.put(CompilerOptions.OPTION_IgnoreUnnamedModuleForSplitPackage, JavaCore.ENABLED);
 			JavaCore.setOptions(newOptions);
 			String[] sources = new String[] {
 					"src/java/util/Map___.java",
@@ -3425,43 +3425,9 @@ public class ModuleBuilderTests extends ModifyingResourceTests {
 			IJavaProject p1= setupModuleProject("debugger_project", sources, new IClasspathEntry[]{dep});
 			p1.getProject().getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, null);
 			assertNoErrors();
-
-			assertNull("Option should not be stored", JavaCore.getOption(CompilerOptions.OPTION_JdtDebugCompileMode));
 		} finally {
 			deleteProject("debugger_project");
 			JavaCore.setOptions(javaCoreOptions);
-		}
-	}
-
-	// test that the special OPTION_JdtDebugCompileMode cannot be persisted on a project
-	public void test_no_conflicting_packages_for_debugger_project() throws CoreException {
-		try {
-			String[] sources = new String[] {
-					"src/java/util/Map___.java",
-					"package java.util;\n" +
-					"abstract class Map___ implements java.util.Map {\n" +
-					"  Map___() {\n" +
-					"    super();\n" +
-					"  }\n" +
-					"  Object[] ___run() throws Throwable {\n" +
-					"    return entrySet().toArray();\n" +
-					"  }\n" +
-					"}"
-			};
-			IClasspathEntry dep = JavaCore.newContainerEntry(new Path(JavaCore.MODULE_PATH_CONTAINER_ID));
-			IJavaProject p1= setupModuleProject("debugger_project", sources, new IClasspathEntry[]{dep});
-			p1.setOption(CompilerOptions.OPTION_JdtDebugCompileMode, JavaCore.ENABLED);
-			assertNull("Option should not be stored", p1.getOption(CompilerOptions.OPTION_JdtDebugCompileMode, false));
-			p1.getProject().getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, null);
-			IMarker[] markers = p1.getProject().findMarkers(null, true, IResource.DEPTH_INFINITE);
-			sortMarkers(markers);
-			assertMarkers("Unexpected markers",
-					"The package java.util conflicts with a package accessible from another module: java.base\n" +
-					"The package java.util is accessible from more than one module: <unnamed>, java.base\n" +
-					"The method entrySet() is undefined for the type Map___",
-					markers);
-		} finally {
-			deleteProject("debugger_project");
 		}
 	}
 


### PR DESCRIPTION
Replace OPTION_JdtDebugCompileMode with
OPTION_IgnoreUnnamedModuleForSplitPackage, to avoid unexpected effects from the first.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
