### PR TITLE
LambdaConversionException due to invalid instantiated method 

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/CaptureBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/CaptureBinding.java
@@ -263,6 +263,12 @@ public class CaptureBinding extends TypeVariableBinding {
 			case Wildcard.UNBOUND :
 				this.setSuperClass(substitutedVariableSuperclass);
 				this.setSuperInterfaces(substitutedVariableInterfaces);
+				if (substitutedVariableSuperclass != null && substitutedVariableInterfaces != null) {
+					if (substitutedVariableSuperclass.id == TypeIds.T_JavaLangObject
+							&& substitutedVariableInterfaces.length > 0) {
+						this.setFirstBound(substitutedVariableInterfaces[0]);
+					}
+				}
 				this.tagBits &= ~TagBits.HasTypeVariable;
 				break;
 			case Wildcard.SUPER :
@@ -587,19 +593,6 @@ public class CaptureBinding extends TypeVariableBinding {
 		return super.toString();
 	}
 
-	@Override
-	public char[] constantPoolName() {
-		// What is the right thing here? Can we do better than defaulting to
-		// org.eclipse.jdt.internal.compiler.lookup.TypeVariableBinding.constantPoolName()
-		return super.constantPoolName();
-	}
-
-	@Override
-	public TypeBinding erasure() {
-		// What is the right thing here? Can we do better than defaulting to
-		// org.eclipse.jdt.internal.compiler.lookup.TypeVariableBinding.erasure()??
-		return super.erasure();
-	}
 
 	@Override
 	public char[] signature() /* Ljava/lang/Object; */ {
@@ -609,8 +602,7 @@ public class CaptureBinding extends TypeVariableBinding {
 		if (this.firstBound instanceof ArrayBinding) {
 			this.signature = constantPoolName();
 		} else {
-			char[] poolName = this.wildcard != null ? this.wildcard.constantPoolName() : constantPoolName();
-			this.signature = CharOperation.concat('L', poolName, ';');
+			this.signature = CharOperation.concat('L', constantPoolName(), ';');
 		}
 		return this.signature;
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/CaptureBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/CaptureBinding.java
@@ -587,6 +587,19 @@ public class CaptureBinding extends TypeVariableBinding {
 		return super.toString();
 	}
 
+	@Override
+	public char[] constantPoolName() {
+		// What is the right thing here? Can we do better than defaulting to
+		// org.eclipse.jdt.internal.compiler.lookup.TypeVariableBinding.constantPoolName()
+		return super.constantPoolName();
+	}
+
+	@Override
+	public TypeBinding erasure() {
+		// What is the right thing here? Can we do better than defaulting to
+		// org.eclipse.jdt.internal.compiler.lookup.TypeVariableBinding.erasure()??
+		return super.erasure();
+	}
 
 	@Override
 	public char[] signature() /* Ljava/lang/Object; */ {
@@ -596,7 +609,8 @@ public class CaptureBinding extends TypeVariableBinding {
 		if (this.firstBound instanceof ArrayBinding) {
 			this.signature = constantPoolName();
 		} else {
-			this.signature = CharOperation.concat('L', constantPoolName(), ';');
+			char[] poolName = this.wildcard != null ? this.wildcard.constantPoolName() : constantPoolName();
+			this.signature = CharOperation.concat('L', poolName, ';');
 		}
 		return this.signature;
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/CaptureBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/CaptureBinding.java
@@ -609,18 +609,7 @@ public class CaptureBinding extends TypeVariableBinding {
 		if (this.firstBound instanceof ArrayBinding) {
 			this.signature = constantPoolName();
 		} else {
-			char [] poolName;
-			if (this.wildcard == null) {
-				if (!(this instanceof CaptureBinding18)) {
-					throw new AssertionError("Unexpected absence of wildcard in capture"); //$NON-NLS-1$
-				}
-				poolName = constantPoolName();
-			} else {
-				if (this instanceof CaptureBinding18) {
-					throw new AssertionError("Unexpected wildcard in capture18"); //$NON-NLS-1$
-				}
-				poolName = this.wildcard.constantPoolName();
-			}
+			char[] poolName = this.wildcard != null ? this.wildcard.constantPoolName() : constantPoolName();
 			this.signature = CharOperation.concat('L', poolName, ';');
 		}
 		return this.signature;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/CaptureBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/CaptureBinding.java
@@ -609,7 +609,18 @@ public class CaptureBinding extends TypeVariableBinding {
 		if (this.firstBound instanceof ArrayBinding) {
 			this.signature = constantPoolName();
 		} else {
-			char[] poolName = this.wildcard != null ? this.wildcard.constantPoolName() : constantPoolName();
+			char [] poolName;
+			if (this.wildcard == null) {
+				if (!(this instanceof CaptureBinding18)) {
+					throw new AssertionError("Unexpected absence of wildcard in capture"); //$NON-NLS-1$
+				}
+				poolName = constantPoolName();
+			} else {
+				if (this instanceof CaptureBinding18) {
+					throw new AssertionError("Unexpected wildcard in capture18"); //$NON-NLS-1$
+				}
+				poolName = this.wildcard.constantPoolName();
+			}
 			this.signature = CharOperation.concat('L', poolName, ';');
 		}
 		return this.signature;

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_1_8.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_1_8.java
@@ -537,7 +537,12 @@ public void testBug424710() {
 			"				.forEach(System.out::println);\n" +
 			"    }\n" +
 			"}\n"
-		});
+		},
+		"abc\n" +
+		"a\n" +
+		"123\n" +
+		"1"
+		);
 }
 
 public void testBug424075() {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LambdaExpressionsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LambdaExpressionsTest.java
@@ -7972,6 +7972,207 @@ public void testGH1060() {
 			);
 }
 
+//https://bugs.eclipse.org/bugs/show_bug.cgi?id=546161
+//LambdaConversionException due to invalid instantiated method type argument to LambdaMetafactory::metafactory
+public void testBug546161() {
+	this.runConformTest(
+			new String[] {
+				"Main.java",
+				"public class Main {\n" +
+				"    public static void main(String[] args) {\n" +
+				"    	((Widget<?>) new Widget<>()).addListener(evt -> {});\n" +
+				"    }\n" +
+				"}\n" +
+				"\n" +
+				"class Widget<E extends CharSequence> {\n" +
+				"    void addListener(Listener<? super E> listener) {}\n" +
+				"}\n" +
+				"\n" +
+				"interface Listener<E extends CharSequence> {\n" +
+				"    void m(E event);\n" +
+				"}\n"},
+			""
+			);
+}
+
+//https://bugs.eclipse.org/bugs/show_bug.cgi?id=546161
+//LambdaConversionException due to invalid instantiated method type argument to LambdaMetafactory::metafactory
+public void testBug546161_2() {
+	this.runConformTest(
+			new String[] {
+				"Main.java",
+				"public class Main {\n" +
+				"    public static void main(String[] args) {\n" +
+				"    	new Widget<>().addListener(evt -> {});\n" +
+				"    }\n" +
+				"}\n" +
+				"class Widget<E extends CharSequence> {\n" +
+				"    void addListener(Listener<? super E> listener) {}\n" +
+				"}\n" +
+				"interface Listener<E extends CharSequence> {\n" +
+				"    void m(E event);\n" +
+				"}\n"},
+			""
+			);
+}
+
+//https://bugs.eclipse.org/bugs/show_bug.cgi?id=574269
+//java.lang.invoke.LambdaConversionException: Invalid receiver type class java.lang.Object
+public void testBug574269() {
+	this.runConformTest(
+			new String[] {
+				"Test.java",
+				"import java.util.List;\n" +
+				"\n" +
+				"public class Test {\n" +
+				"\n" +
+				"	public static void main(String[] args) {\n" +
+				"		System.out.println(\"Testing with explicit type\");\n" +
+				"		MyGroup group = new MyGroup();\n" +
+				"\n" +
+				"		System.out.println(\"  Testing lambda\");\n" +
+				"		if (group.getPersons().stream().anyMatch(p -> p.isFoo())) {}\n" +
+				"		System.out.println(\"  Lambda is good\");\n" +
+				"		\n" +
+				"		System.out.println(\"  Testing method reference\");\n" +
+				"		if (group.getPersons().stream().anyMatch(Test.Person::isFoo)) {}\n" +
+				"		System.out.println(\"  Method reference is good\");\n" +
+				"\n" +
+				"		System.out.println(\"Testing with wildcard\");\n" +
+				"		Group<?> group2 = new MyGroup();\n" +
+				"\n" +
+				"		System.out.println(\"  Testing lambda\");\n" +
+				"		if (group2.getPersons().stream().anyMatch(p -> p.isFoo())) {}\n" +
+				"		System.out.println(\"  Lambda is good\");\n" +
+				"		\n" +
+				"		System.out.println(\"  Testing method reference\");\n" +
+				"		if (group2.getPersons().stream().anyMatch(Test.Person::isFoo)) {}\n" +
+				"		System.out.println(\"  Method reference is good\");\n" +
+				"	}\n" +
+				"\n" +
+				"	interface Group<T extends Person> {\n" +
+				"		List<T> getPersons();\n" +
+				"	}\n" +
+				"\n" +
+				"	interface Person {\n" +
+				"		boolean isFoo();\n" +
+				"	}\n" +
+				"\n" +
+				"	static class MyGroup implements Group<MyPerson> {\n" +
+				"\n" +
+				"		@Override\n" +
+				"		public List<MyPerson> getPersons() {\n" +
+				"			return List.of();\n" +
+				"		}\n" +
+				"	}\n" +
+				"\n" +
+				"	static class MyPerson implements Person {\n" +
+				"\n" +
+				"		@Override\n" +
+				"		public boolean isFoo() {\n" +
+				"			return true;\n" +
+				"		}\n" +
+				"	}\n" +
+				"}\n"},
+			"Testing with explicit type\n" +
+			"  Testing lambda\n" +
+			"  Lambda is good\n" +
+			"  Testing method reference\n" +
+			"  Method reference is good\n" +
+			"Testing with wildcard\n" +
+			"  Testing lambda\n" +
+			"  Lambda is good\n" +
+			"  Testing method reference\n" +
+			"  Method reference is good"
+			);
+}
+
+//https://bugs.eclipse.org/bugs/show_bug.cgi?id=574269
+//java.lang.invoke.LambdaConversionException: Invalid receiver type class java.lang.Object
+public void testBug574269_2() {
+	this.runConformTest(
+			new String[] {
+				"TestX.java",
+				"import java.util.List;\n" +
+				"\n" +
+				"public class TestX {\n" +
+				"\n" +
+				"	public static void main(String[] args) {\n" +
+				"		Group<MyPerson> group1 = new MyGroup();\n" +
+				"		group1.getPersons().stream().anyMatch(TestX.Person::isFoo);\n" +
+				"		System.out.println(\"Method reference is good\");\n" +
+				"		\n" +
+				"		Group<?> group2 = new MyGroup();\n" +
+				"		group2.getPersons().stream().anyMatch(TestX.Person::isFoo);\n" +
+				"		System.out.println(\"Method reference is not bad\");\n" +
+				"	}\n" +
+				"\n" +
+				"	interface Group<T extends Person> {\n" +
+				"		List<T> getPersons();\n" +
+				"	}\n" +
+				"\n" +
+				"	interface Person {\n" +
+				"		boolean isFoo();\n" +
+				"	}\n" +
+				"\n" +
+				"	static class MyGroup implements Group<MyPerson> {\n" +
+				"		@Override\n" +
+				"		public List<MyPerson> getPersons() {\n" +
+				"			return List.of();\n" +
+				"		}\n" +
+				"	}\n" +
+				"\n" +
+				"	static class MyPerson implements Person {\n" +
+				"		@Override\n" +
+				"		public boolean isFoo() {\n" +
+				"			return true;\n" +
+				"		}\n" +
+				"	}\n" +
+				"}\n"},
+			"Method reference is good\n" +
+			"Method reference is not bad"
+			);
+}
+
+//https://bugs.eclipse.org/bugs/show_bug.cgi?id=570511
+//java.lang.BootstrapMethodError in Eclipse compiled code that doesn't happen with javac
+public void testBug570511() {
+	this.runConformTest(
+			new String[] {
+				"T.java",
+				"// ---------------------------------------------------------------\n" +
+				"import java.util.function.Consumer;\n" +
+				"\n" +
+				"public class T {\n" +
+				"    public static void main(String[] args) {\n" +
+				"        new T().test(new X());\n" +
+				"    }\n" +
+				"\n" +
+				"    void test(I<?> i) {\n" +
+				"        i.m(\"a\", \"b\", this::m);\n" +
+				"    }\n" +
+				"\n" +
+				"    void m(I<?> i) {\n" +
+				"        System.out.println(\"T.m\");\n" +
+				"    }\n" +
+				"}\n" +
+				"\n" +
+				"interface I<C extends I<C>> {\n" +
+				"    C m(Object key, Object value, Consumer<? super C> consumer);\n" +
+				"}\n" +
+				"\n" +
+				"class X implements I<X> {\n" +
+				"    @Override\n" +
+				"    public X m(Object key, Object value, Consumer<? super X> consumer) {\n" +
+				"        consumer.accept(this);\n" +
+				"        System.out.println(\"X.m\");\n" +
+				"        return null;\n" +
+				"    }\n" +
+				"}\n"},
+			"T.m\n" +
+			"X.m"
+			);
+}
 
 public static Class testClass() {
 	return LambdaExpressionsTest.class;

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LambdaExpressionsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LambdaExpressionsTest.java
@@ -8174,6 +8174,82 @@ public void testBug570511() {
 			);
 }
 
+// https://bugs.eclipse.org/bugs/show_bug.cgi?id=577719
+// BootstrapMethodError: call site initialization exception
+public void testBug577719() {
+	this.runConformTest(
+			new String[] {
+				"WeirdCleanupAndCallSiteInitializationException.java",
+				"import java.util.stream.Stream;\n" +
+				"\n" +
+				"public class WeirdCleanupAndCallSiteInitializationException {\n" +
+				"	public static void main(String[] args) {\n" +
+				"		B b = () -> new A() {\n" +
+				"		};\n" +
+				"		A a = get();\n" +
+				"		System.out.println(\"done\");\n" +
+				"	}\n" +
+				"\n" +
+				"	public static A get(B<?>... sources) {\n" +
+				"		return Stream.of(sources) //\n" +
+				"				.map(B::getT) //\n" +
+				"				.filter(A::exists_testOpen) //\n" +
+				"				.findFirst() //\n" +
+				"				.orElse(null);\n" +
+				"	}\n" +
+				"\n" +
+				"	public interface B<T extends A> extends A {\n" +
+				"		T getT();\n" +
+				"	}\n" +
+				"\n" +
+				"	public interface A {\n" +
+				"		default boolean exists_testOpen() {\n" +
+				"			return true;\n" +
+				"		}\n" +
+				"	}\n" +
+				"}\n"},
+			"done"
+			);
+}
+
+// https://bugs.eclipse.org/bugs/show_bug.cgi?id=577719
+// BootstrapMethodError: call site initialization exception
+public void testBug577719_2() {
+	this.runConformTest(
+			new String[] {
+				"WeirdCleanupAndCallSiteInitializationException.java",
+				"import java.util.stream.Stream;\n" +
+				"\n" +
+				"public class WeirdCleanupAndCallSiteInitializationException {\n" +
+				"	public static void main(String[] args) {\n" +
+				"		B b = () -> new A() {\n" +
+				"		};\n" +
+				"		A a = get();\n" +
+				"		System.out.println(\"done\");\n" +
+				"	}\n" +
+				"\n" +
+				"	public static A get(B<?>... sources) {\n" +
+				"		return Stream.of(sources) //\n" +
+				"				.map(B::getT) //\n" +
+				"				.filter(x -> x.exists_testOpen()) //\n" +
+				"				.findFirst() //\n" +
+				"				.orElse(null);\n" +
+				"	}\n" +
+				"\n" +
+				"	public interface B<T extends A> extends A {\n" +
+				"		T getT();\n" +
+				"	}\n" +
+				"\n" +
+				"	public interface A {\n" +
+				"		default boolean exists_testOpen() {\n" +
+				"			return true;\n" +
+				"		}\n" +
+				"	}\n" +
+				"}\n"},
+			"done"
+			);
+}
+
 public static Class testClass() {
 	return LambdaExpressionsTest.class;
 }

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests_1_5.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests_1_5.java
@@ -11488,7 +11488,7 @@ public void test0356() throws JavaModelException {
 
 	assertResults(
 			"getClass[METHOD_REF]{getClass(), Ljava.lang.Object;, ()Ljava.lang.Class<+Ljava.lang.Object;>;, getClass, null, " + (R_DEFAULT + R_RESOLVED + R_INTERESTING + R_CASE + R_NON_STATIC + R_NON_RESTRICTED) + "}\n" +
-			"get[METHOD_REF]{get(), Ltest.util.List<Ljava.lang.Object;>;, (I)Ljava.lang.Object;, get, (i), " + (R_DEFAULT + R_RESOLVED + R_INTERESTING + R_CASE + R_EXACT_NAME + R_NON_STATIC + R_NON_RESTRICTED) + "}",
+			"get[METHOD_REF]{get(), Ltest.util.List<Ltest.util.List<TT;>;>;, (I)Ltest.util.List<TT;>;, get, (i), " + (R_DEFAULT + R_RESOLVED + R_INTERESTING + R_CASE + R_EXACT_NAME + R_NON_STATIC + R_NON_RESTRICTED) + "}",
 			requestor.getResults());
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=96604


### PR DESCRIPTION

## What it does

Fix CaptureBinding#signature()'s incorrect fall back on its super implementation.
Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1031




## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
