### PR TITLE
* Fix improper handling of permits clause

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ClassScope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ClassScope.java
@@ -1688,6 +1688,14 @@ public class ClassScope extends Scope {
 			env.missingClassFileLocation = typeReference;
 			typeReference.aboutToResolve(this); // allows us to trap completion & selection nodes
 			unitScope.recordQualifiedReference(typeReference.getTypeName());
+			if (typeReference.isParameterizedTypeReference()) {
+				for (TypeReference [] typeArguments : typeReference.getTypeArguments()) {
+					if (typeArguments != null && typeArguments.length > 0) {
+						problemReporter().invalidTypeArguments(typeArguments);
+					}
+				}
+			}
+			typeReference.bits |= ASTNode.IgnoreRawTypeCheck;
 			ReferenceBinding permittedType = (ReferenceBinding) typeReference.resolveType(this);
 			return permittedType;
 		} catch (AbortCompilation e) {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SealedTypesTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SealedTypesTests.java
@@ -5762,4 +5762,87 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 				"An interface I3 declared as non-sealed should have a sealed direct superinterface\n" +
 				"----------\n");
 	}
+	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=576378
+	// [compiler] Wrong rawtype warning and wrong compilation of generic type reference in permits clause
+	public void testBug576378() {
+		runNegativeTest(
+				new String[] {
+						"X.java",
+						"sealed interface I permits J {}\r\n" +
+						"record J<T>() implements I {}\n" +
+						"public class X {\n" +
+						"    public static void main(String [] args) {\n" +
+						"        J j; K k;\n" +
+						"    }\n" +
+						"}\n"
+				},
+				"----------\n"
+				+ "1. WARNING in X.java (at line 5)\n"
+				+ "	J j; K k;\n"
+				+ "	^\n"
+				+ "J is a raw type. References to generic type J<T> should be parameterized\n"
+				+ "----------\n"
+				+ "2. ERROR in X.java (at line 5)\n"
+				+ "	J j; K k;\n"
+				+ "	     ^\n"
+				+ "K cannot be resolved to a type\n"
+				+ "----------\n");
+	}
+	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=576378
+	// [compiler] Wrong rawtype warning and wrong compilation of generic type reference in permits clause
+	public void testBug576378_2() {
+		runNegativeTest(
+				new String[] {
+						"X.java",
+						"sealed interface I permits J<Object> {}\r\n" +
+						"record J<T>() implements I {}\n"
+				},
+				"----------\n"
+				+ "1. ERROR in X.java (at line 1)\n"
+				+ "	sealed interface I permits J<Object> {}\n"
+				+ "	                             ^^^^^^\n"
+				+ "Type arguments are not allowed here\n"
+				+ "----------\n");
+	}
+	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=576378
+	// [compiler] Wrong rawtype warning and wrong compilation of generic type reference in permits clause
+	public void testBug576378_3() {
+		runNegativeTest(
+				new String[] {
+						"X.java",
+						"sealed interface I permits J<Object>.K<String> {}\r\n" +
+						"final class J<T> {\n" +
+						"    final class K<P> implements I {}\n" +
+						"}\n"
+				},
+				"----------\n"
+				+ "1. ERROR in X.java (at line 1)\n"
+				+ "	sealed interface I permits J<Object>.K<String> {}\n"
+				+ "	                             ^^^^^^\n"
+				+ "Type arguments are not allowed here\n"
+				+ "----------\n"
+				+ "2. ERROR in X.java (at line 1)\n"
+				+ "	sealed interface I permits J<Object>.K<String> {}\n"
+				+ "	                                       ^^^^^^\n"
+				+ "Type arguments are not allowed here\n"
+				+ "----------\n");
+	}
+	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=576378
+	// [compiler] Wrong rawtype warning and wrong compilation of generic type reference in permits clause
+	public void testBug576378_4() {
+		runNegativeTest(
+				new String[] {
+						"X.java",
+						"sealed interface I permits J.K<String> {}\r\n" +
+						"final class J<T> {\n" +
+						"    final static class K<P> implements I {}\n" +
+						"}\n"
+				},
+				"----------\n"
+				+ "1. ERROR in X.java (at line 1)\n"
+				+ "	sealed interface I permits J.K<String> {}\n"
+				+ "	                               ^^^^^^\n"
+				+ "Type arguments are not allowed here\n"
+				+ "----------\n");
+	}
 }


### PR DESCRIPTION

## What it does

* Inhibit raw type diagnostics while handling permits clause
* Permits clause lists typenames sans type arguments
* Fixes https://bugs.eclipse.org/bugs/show_bug.cgi?id=576378



## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
