### PR TITLE
Fix problems in lambda exception analysis

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LambdaExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LambdaExpression.java
@@ -560,9 +560,17 @@ public class LambdaExpression extends FunctionalExpression implements IPolyExpre
 		boolean oldAnalyseResources = compilerOptions.analyseResourceLeaks;
 		compilerOptions.analyseResourceLeaks = false;
 		try {
+			int firstLocalLocal = this.scope.outerMostMethodScope().analysisIndex;
+			LocalVariableBinding[] locals = this.scope.locals;
+			if (locals != null) {
+				for (LocalVariableBinding local : locals) {
+					if (local != null && local.isParameter())
+						firstLocalLocal = local.id + 1;
+				}
+			}
 			this.body.analyseCode(this.scope,
 									 ehfc = new ExceptionInferenceFlowContext(null, this, Binding.NO_EXCEPTIONS, null, this.scope, FlowInfo.DEAD_END),
-									 UnconditionalFlowInfo.fakeInitializedFlowInfo(this.scope.outerMostMethodScope().analysisIndex, this.scope.referenceType().maxFieldCount));
+									 UnconditionalFlowInfo.fakeInitializedFlowInfo(firstLocalLocal, this.scope.referenceType().maxFieldCount));
 			this.thrownExceptions = ehfc.extendedExceptions == null ? Collections.emptySet() : new HashSet<TypeBinding>(ehfc.extendedExceptions);
 		} catch (Exception e) {
 			// drop silently.

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LambdaExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LambdaExpression.java
@@ -567,9 +567,6 @@ public class LambdaExpression extends FunctionalExpression implements IPolyExpre
 					if (local != null) {
 						if (local.isParameter()) {
 							firstLocalLocal = local.id + 1;
-						} else {
-							firstLocalLocal = local.id;
-							break;
 						}
 					}
 				}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LambdaExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LambdaExpression.java
@@ -564,8 +564,14 @@ public class LambdaExpression extends FunctionalExpression implements IPolyExpre
 			LocalVariableBinding[] locals = this.scope.locals;
 			if (locals != null) {
 				for (LocalVariableBinding local : locals) {
-					if (local != null && local.isParameter())
-						firstLocalLocal = local.id + 1;
+					if (local != null) {
+						if (local.isParameter()) {
+							firstLocalLocal = local.id + 1;
+						} else {
+							firstLocalLocal = local.id;
+							break;
+						}
+					}
 				}
 			}
 			this.body.analyseCode(this.scope,

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LambdaExpressionsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LambdaExpressionsTest.java
@@ -7951,7 +7951,6 @@ public void testBug511958() {
 			);
 }
 
-
 // https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1060
 // NPE when inspecting scrapbook expression that uses Java 8 features
 public void testGH1060() {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LambdaExpressionsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LambdaExpressionsTest.java
@@ -7951,6 +7951,7 @@ public void testBug511958() {
 			);
 }
 
+<<<<<<< Upstream, based on branch 'master' of git@github.com:srikanth-sankaran/eclipse.jdt.core.git
 // https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1060
 // NPE when inspecting scrapbook expression that uses Java 8 features
 public void testGH1060() {
@@ -8250,6 +8251,8 @@ public void testBug577719_2() {
 			);
 }
 
+=======
+>>>>>>> b8be702 Handle lambdas with no parameters
 // https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1162
 // Eclipse incorrectly requires catch for nested sneaky throws; OpenJDK compiles with no problem
 public void testGH1162() {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LambdaExpressionsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LambdaExpressionsTest.java
@@ -7951,7 +7951,7 @@ public void testBug511958() {
 			);
 }
 
-<<<<<<< Upstream, based on branch 'master' of git@github.com:srikanth-sankaran/eclipse.jdt.core.git
+
 // https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1060
 // NPE when inspecting scrapbook expression that uses Java 8 features
 public void testGH1060() {
@@ -8251,8 +8251,6 @@ public void testBug577719_2() {
 			);
 }
 
-=======
->>>>>>> b8be702 Handle lambdas with no parameters
 // https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1162
 // Eclipse incorrectly requires catch for nested sneaky throws; OpenJDK compiles with no problem
 public void testGH1162() {


### PR DESCRIPTION

## What it does

* The method org.eclipse.jdt.internal.compiler.ast.LambdaExpression.analyzeExceptions() over-reaches into current lambda locals while wanting to flag all outer locals touched by the lambda as being definitely assigned and
   effectively final.

* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1162


## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
