### PR TITLE
Improve error handling in JRTUtil.getJrtSystem()

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/util/JrtUtilTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/util/JrtUtilTest.java
@@ -58,7 +58,7 @@ public class JrtUtilTest extends TestCase {
 	}
 
 	@Test
-	public void testGetNewJrtFileSystem() {
+	public void testGetNewJrtFileSystem() throws Exception {
 		int majorVersionSegment = getMajorVersionSegment(this.jdkRelease);
 		Object jrtSystem = JRTUtil.getJrtSystem(this.image);
 		Object jrtSystem2 = JRTUtil.getJrtSystem(this.image, String.valueOf(majorVersionSegment));

--- a/org.eclipse.jdt.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core/META-INF/MANIFEST.MF
@@ -47,7 +47,7 @@ Require-Bundle: org.eclipse.core.resources;bundle-version="[3.18.0,4.0.0)",
  org.eclipse.core.filesystem;bundle-version="[1.7.0,2.0.0)",
  org.eclipse.text;bundle-version="[3.6.0,4.0.0)",
  org.eclipse.team.core;bundle-version="[3.1.0,4.0.0)";resolution:=optional,
- org.eclipse.jdt.core.compiler.batch;bundle-version="3.34.0";visibility:=reexport
+ org.eclipse.jdt.core.compiler.batch;bundle-version="3.35.0";visibility:=reexport
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Eclipse-ExtensibleAPI: true
 Bundle-ActivationPolicy: lazy

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JarPackageFragmentRoot.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JarPackageFragmentRoot.java
@@ -30,7 +30,6 @@ import java.util.zip.ZipFile;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.IStatus;
 import org.eclipse.jdt.core.IClasspathAttribute;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaElement;
@@ -177,9 +176,9 @@ public class JarPackageFragmentRoot extends PackageFragmentRoot {
 				children[index++] = getPackageFragment(pkgName);
 			}
 		} catch (CoreException e) {
-			if (e.getCause() instanceof ZipException) {
+			if (e.getCause() instanceof ZipException zipex) {
 				// not a ZIP archive, leave the children empty
-				Util.log(IStatus.ERROR, "Invalid ZIP archive: " + toStringWithAncestors()); //$NON-NLS-1$
+				Util.log(zipex, "Invalid ZIP archive: " + toStringWithAncestors()); //$NON-NLS-1$
 				children = NO_ELEMENTS;
 			} else if (e instanceof JavaModelException) {
 				throw (JavaModelException)e;

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaProject.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaProject.java
@@ -1002,7 +1002,7 @@ public class JavaProject
 				}
 			}, JRTUtil.NOTIFY_MODULES);
 		} catch (IOException e) {
-			Util.log(IStatus.ERROR, "Error reading modules from " + imagePath.toOSString()); //$NON-NLS-1$
+			Util.log(e, "Error reading modules from " + imagePath.toOSString()); //$NON-NLS-1$
 		}
 	}
 

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JrtPackageFragmentRoot.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JrtPackageFragmentRoot.java
@@ -89,7 +89,7 @@ public class JrtPackageFragmentRoot extends JarPackageFragmentRoot implements IM
 				}
 			}, JRTUtil.NOTIFY_ALL);
 		} catch (IOException e) {
-			Util.log(IStatus.ERROR, "Error reading modules" + toStringWithAncestors()); //$NON-NLS-1$
+			Util.log(e, "Error reading modules" + toStringWithAncestors()); //$NON-NLS-1$
 		}
 
 		info.setChildren(createChildren(rawPackageInfo));

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/ClasspathLocation.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/ClasspathLocation.java
@@ -30,6 +30,8 @@ import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
@@ -160,7 +162,12 @@ static ClasspathLocation forLibrary(String libraryPathname,
 public static ClasspathJrt forJrtSystem(String jrtPath, AccessRuleSet accessRuleSet, IPath annotationsPath, String release) throws CoreException {
 	boolean useRelease = release != null && !release.isEmpty();
 	if(useRelease) {
-		String jrtVersion = JRTUtil.getJdkRelease(new File(jrtPath));
+		String jrtVersion;
+		try {
+			jrtVersion = JRTUtil.getJdkRelease(new File(jrtPath));
+		} catch (IOException e) {
+			throw new CoreException(new Status(IStatus.ERROR, ClasspathLocation.class, "Failed to detect JDK release for: " + jrtPath, e)); //$NON-NLS-1$
+		}
 		boolean sameRelease = JavaCore.compareJavaVersions(jrtVersion, release) == 0;
 		if(sameRelease) {
 			useRelease = false;


### PR DESCRIPTION
Try to propagate IOExceptions to caller where possible.

See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1154