### PR TITLE
"The parameter <xyz> should not be assigned" diagnostic is useless on compact constructors

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SingleNameReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SingleNameReference.java
@@ -172,8 +172,10 @@ public FlowInfo analyseAssignment(BlockScope currentScope, FlowContext flowConte
 					currentScope.problemReporter().cannotAssignToFinalOuterLocal(localBinding, this);
 				}
 			}
-			else /* avoid double diagnostic */ if ((localBinding.tagBits & TagBits.IsArgument) != 0 && !localBinding.getEnclosingMethod().isCompactConstructor()) {
-				currentScope.problemReporter().parameterAssignment(localBinding, this);
+			else /* avoid double diagnostic */ if ((localBinding.tagBits & TagBits.IsArgument) != 0) {
+				MethodBinding owner = localBinding.getEnclosingMethod();
+				if (owner == null /*lambda */ || !owner.isCompactConstructor())
+					currentScope.problemReporter().parameterAssignment(localBinding, this);
 			}
 			flowInfo.markAsDefinitelyAssigned(localBinding);
 	}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SingleNameReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SingleNameReference.java
@@ -172,7 +172,7 @@ public FlowInfo analyseAssignment(BlockScope currentScope, FlowContext flowConte
 					currentScope.problemReporter().cannotAssignToFinalOuterLocal(localBinding, this);
 				}
 			}
-			else /* avoid double diagnostic */ if ((localBinding.tagBits & TagBits.IsArgument) != 0) {
+			else /* avoid double diagnostic */ if ((localBinding.tagBits & TagBits.IsArgument) != 0 && !localBinding.getEnclosingMethod().isCompactConstructor()) {
 				currentScope.problemReporter().parameterAssignment(localBinding, this);
 			}
 			flowInfo.markAsDefinitelyAssigned(localBinding);


### PR DESCRIPTION

## What it does

"The parameter <xyz> should not be assigned" diagnostic is useless on compact constructors

* Fixes https://bugs.eclipse.org/bugs/show_bug.cgi?id=576719

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
