### PR TITLE
NPE when inspecting scrapbook expression that uses Java 8 features

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LambdaExpressionsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LambdaExpressionsTest.java
@@ -7951,6 +7951,27 @@ public void testBug511958() {
 			);
 }
 
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1060
+// NPE when inspecting scrapbook expression that uses Java 8 features
+public void testGH1060() {
+	this.runConformTest(
+			new String[] {
+				"X.java",
+				"public class X {\n" +
+				"	public static void main(String[] args) {\n" +
+				"		System.out.println(new X().foo());\n" +
+				"	}\n" +
+				"	\n" +
+				"	String foo() {\n" +
+				"		return java.time.format.DateTimeFormatter\n" +
+				"				.ofPattern(\"yyyyMMddHHmmss.SSS000\")\n" +
+				"				.format(java.time.format.DateTimeFormatter.ofPattern(\"dd.MM.yyyy HHmmss\").parse(\"30.03.2021 112430\", java.time.LocalDateTime::from));\n" +
+				"	}\n" +
+				"}\n"},
+			"20210330112430.000000"
+			);
+}
+
 
 public static Class testClass() {
 	return LambdaExpressionsTest.class;

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/eval/CodeSnippetTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/eval/CodeSnippetTest.java
@@ -1046,4 +1046,16 @@ public void testBug571310_SynthVarReciever() {
 			"new Outer().boo().get();"}),
 			"16".toCharArray());
 }
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1060
+// NPE when inspecting scrapbook expression that uses Java 8 features
+public void testGH1060() {
+	if (this.complianceLevel < ClassFileConstants.JDK1_8) {
+		return;
+	}
+	evaluateWithExpectedDisplayString(buildCharArray(new String[] {
+			"return java.time.format.DateTimeFormatter\r\n"
+			+ "				.ofPattern(\"yyyyMMddHHmmss.SSS000\")\r\n"
+			+ "				.format(java.time.format.DateTimeFormatter.ofPattern(\"dd.MM.yyyy HHmmss\").parse(\"30.03.2021 112430\", java.time.LocalDateTime::from));"}),
+			"20210330112430.000000".toCharArray());
+}
 }

--- a/org.eclipse.jdt.core/eval/org/eclipse/jdt/internal/eval/CodeSnippetMessageSend.java
+++ b/org.eclipse.jdt.core/eval/org/eclipse/jdt/internal/eval/CodeSnippetMessageSend.java
@@ -261,8 +261,13 @@ public TypeBinding resolveType(BlockScope scope) {
 			return null;
 		}
 	}
-	findMethodBinding(scope);
 
+	TypeBinding methodType = findMethodBinding(scope);
+	if (methodType != null && methodType.isPolyType()) {
+		this.resolvedType = this.binding.returnType.capture(scope, this.sourceStart, this.sourceEnd);
+		return methodType;
+	}
+	
 	if (!this.binding.isValidBinding()) {
 		if (this.binding instanceof ProblemMethodBinding
 			&& ((ProblemMethodBinding) this.binding).problemId() == ProblemReasons.NotVisible) {


### PR DESCRIPTION

## What it does

Eliminate deviation in behavior between org.eclipse.jdt.internal.eval.CodeSnippetMessageSend.resolveType(BlockScope) and
org.eclipse.jdt.internal.compiler.ast.MessageSend.resolveType(BlockScope)

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1060

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
