### PR TITLE
ContentAssist / CompletionScanner running into deadlock

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests17.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests17.java
@@ -654,4 +654,34 @@ public class CompletionTests17 extends AbstractJavaModelCompletionTests {
 				requestor.getResults());
 
 	}
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1100
+	// ContentAssist / CompletionScanner running into deadlock
+	public void testGH1100() throws JavaModelException {
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy(
+				"/Completion/src/X.java",
+				"import java.lang.StackWalker.Option;\n" +
+				"public class X {\n" +
+				"	private void test() {\n" +
+				"		Option opt = Option.RETAIN_CLASS_REFERENCE;\n" +
+				"		boolean testswitch (opt) { // <- remove pipe and press CTRL+Space\n" +
+				"			case RETAIN_CLASS_REFERENCE -> {\n" +
+				"			}\n" +
+				"			case SHOW_HIDDEN_FRAMES -> {\n" +
+				"			}\n" +
+				"			case SHOW_REFLECT_FRAMES -> throw new UnsupportedOperationException(\"Unimplemented case: \");\n" +
+				"		}\n" +
+				"	}\n" +
+				"}\n"
+				);
+		CompletionTestsRequestor2 requestor = new CompletionTestsRequestor2(true);
+		requestor.allowAllRequiredProposals();
+		String str = this.workingCopies[0].getSource();
+		String completeBehind = "test";
+		int cursorLocation = str.lastIndexOf(completeBehind) + completeBehind.length();
+		this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner);
+		assertResults("",
+				requestor.getResults());
+
+	}
 }


### PR DESCRIPTION
## What it does

* Ensure that attempts to nudge recovery along don't stuck reducing empty statements

* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1100

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
