### PR TITLE
Get rid of separate stacks for managing patterns during parsing

### DIFF
--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionParser.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionParser.java
@@ -801,7 +801,7 @@ protected void consumeCaseLabelElement(CaseLabelKind kind) {
 	super.consumeCaseLabelElement(kind);
 	switch (kind) {
 		case CASE_PATTERN: {
-			ASTNode[] ps = this.patternStack;
+			ASTNode[] ps = this.astStack;
 			if (ps[0] instanceof RecordPattern) {
 				pushLocalVariableFromRecordPatternOnAstStack((RecordPattern) ps[0]);
 			}
@@ -833,10 +833,9 @@ private void pushLocalVariableFromRecordPatternOnAstStack(RecordPattern rp) {
 
 @Override
 protected void consumeInstanceOfExpressionWithName() {
-	int length = this.patternLengthPtr >= 0 ?
-			this.patternLengthStack[this.patternLengthPtr--] : 0;
+	int length = this.astLengthStack[this.astLengthPtr--];
 	if (length > 0) {
-		Pattern pattern = (Pattern) this.patternStack[this.patternPtr--];
+		Pattern pattern = (Pattern) this.astStack[this.astPtr--];
 		pushOnExpressionStack(getUnspecifiedReferenceOptimized());
 		if (this.expressionStack[this.expressionPtr] != this.assistNode) {
 			// Push only when the selection node is not the expression of this

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionParser.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionParser.java
@@ -833,8 +833,9 @@ private void pushLocalVariableFromRecordPatternOnAstStack(RecordPattern rp) {
 
 @Override
 protected void consumeInstanceOfExpressionWithName() {
-	int length = this.astLengthStack[this.astLengthPtr--];
+	int length = this.astLengthStack[this.astLengthPtr];
 	if (length > 0) {
+		this.astLengthPtr--;
 		Pattern pattern = (Pattern) this.astStack[this.astPtr--];
 		pushOnExpressionStack(getUnspecifiedReferenceOptimized());
 		if (this.expressionStack[this.expressionPtr] != this.assistNode) {


### PR DESCRIPTION

## What it does

Get rid of separate stacks for managing patterns during parsing

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
