### PR TITLE
Touch bundles affected by the new ecj version

### DIFF
--- a/org.eclipse.jdt.apt.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.apt.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.apt.core; singleton:=true
-Bundle-Version: 3.8.0.qualifier
+Bundle-Version: 3.8.100.qualifier
 Bundle-Localization: plugin
 Export-Package: com.sun.mirror.apt,
  com.sun.mirror.declaration,

--- a/org.eclipse.jdt.apt.core/forceQualifierUpdate.txt
+++ b/org.eclipse.jdt.apt.core/forceQualifierUpdate.txt
@@ -3,3 +3,4 @@ Bug 441790 - AnnotationValue.toString is creating incorrect and truncated text t
 BUg 492759 - update jdtcompiler and eclipserun to RC2 level to produce RC3
 Bug 509973 - Comparator errors in I20170105-0320
 Bug 566471 - I20200828-0150 - Comparator Errors Found
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184

--- a/org.eclipse.jdt.apt.core/pom.xml
+++ b/org.eclipse.jdt.apt.core/pom.xml
@@ -17,6 +17,6 @@
     <version>4.29.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.eclipse.jdt.apt.core</artifactId>
-  <version>3.8.0-SNAPSHOT</version>
+  <version>3.8.100-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.eclipse.jdt.apt.pluggable.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.apt.pluggable.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.apt.pluggable.core;singleton:=true
-Bundle-Version: 1.4.0.qualifier
+Bundle-Version: 1.4.100.qualifier
 Bundle-Activator: org.eclipse.jdt.internal.apt.pluggable.core.Apt6Plugin
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime,

--- a/org.eclipse.jdt.apt.pluggable.core/forceQualifierUpdate.txt
+++ b/org.eclipse.jdt.apt.pluggable.core/forceQualifierUpdate.txt
@@ -1,3 +1,2 @@
 # To force a version qualifier update add the bug here
-Bug 566471 - I20200828-0150 - Comparator Errors Found
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184

--- a/org.eclipse.jdt.apt.pluggable.core/pom.xml
+++ b/org.eclipse.jdt.apt.pluggable.core/pom.xml
@@ -17,6 +17,6 @@
     <version>4.29.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.eclipse.jdt.apt.pluggable.core</artifactId>
-  <version>1.4.0-SNAPSHOT</version>
+  <version>1.4.100-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.eclipse.jdt.apt.pluggable.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.apt.pluggable.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.apt.pluggable.tests;singleton:=true
-Bundle-Version: 3.6.0.qualifier
+Bundle-Version: 3.6.100.qualifier
 Bundle-Activator: org.eclipse.jdt.apt.pluggable.tests.Apt6TestsPlugin
 Bundle-Localization: plugin
 Require-Bundle: org.junit,

--- a/org.eclipse.jdt.apt.pluggable.tests/forceQualifierUpdate.txt
+++ b/org.eclipse.jdt.apt.pluggable.tests/forceQualifierUpdate.txt
@@ -1,3 +1,2 @@
 # To force a version qualifier update add the bug here
-Bug 566471 - I20200828-0150 - Comparator Errors Found
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184

--- a/org.eclipse.jdt.apt.pluggable.tests/pom.xml
+++ b/org.eclipse.jdt.apt.pluggable.tests/pom.xml
@@ -19,7 +19,7 @@
     <relativePath>../tests-pom/</relativePath>
   </parent>
   <artifactId>org.eclipse.jdt.apt.pluggable.tests</artifactId>
-  <version>3.6.0-SNAPSHOT</version>
+  <version>3.6.100-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <properties>
   	<testSuite>${project.artifactId}</testSuite>

--- a/org.eclipse.jdt.apt.tests/forceQualifierUpdate.txt
+++ b/org.eclipse.jdt.apt.tests/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Several bundles changed and need to be touched
 Bug 420446 - APT tests don't run
 Bug 566471 - I20200828-0150 - Comparator Errors Found
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184

--- a/org.eclipse.jdt.apt.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.apt.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.apt.ui; singleton:=true
-Bundle-Version: 3.8.0.qualifier
+Bundle-Version: 3.8.100.qualifier
 Bundle-Activator: org.eclipse.jdt.apt.ui.internal.AptUIPlugin
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.jdt.apt.core;bundle-version="[3.6.0,4.0.0)",

--- a/org.eclipse.jdt.apt.ui/pom.xml
+++ b/org.eclipse.jdt.apt.ui/pom.xml
@@ -17,6 +17,6 @@
     <version>4.29.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.eclipse.jdt.apt.ui</artifactId>
-  <version>3.8.0-SNAPSHOT</version>
+  <version>3.8.100-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.eclipse.jdt.compiler.apt.tests/forceQualifierUpdate.txt
+++ b/org.eclipse.jdt.compiler.apt.tests/forceQualifierUpdate.txt
@@ -1,2 +1,3 @@
 # To force a version qualifier update add the bug here
 Bug 566471 - I20200828-0150 - Comparator Errors Found
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184

--- a/org.eclipse.jdt.compiler.tool.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.compiler.tool.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.compiler.tool.tests
-Bundle-Version: 1.4.0.qualifier
+Bundle-Version: 1.4.100.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/org.eclipse.jdt.compiler.tool.tests/forceQualifierUpdate.txt
+++ b/org.eclipse.jdt.compiler.tool.tests/forceQualifierUpdate.txt
@@ -1,2 +1,3 @@
 # To force a version qualifier update add the bug here
 Bug 566471 - I20200828-0150 - Comparator Errors Found
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184

--- a/org.eclipse.jdt.compiler.tool.tests/pom.xml
+++ b/org.eclipse.jdt.compiler.tool.tests/pom.xml
@@ -19,7 +19,7 @@
     <relativePath>../tests-pom/</relativePath>
   </parent>
   <artifactId>org.eclipse.jdt.compiler.tool.tests</artifactId>
-  <version>1.4.0-SNAPSHOT</version>
+  <version>1.4.100-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <properties>
   	<testSuite>${project.artifactId}</testSuite>

--- a/org.eclipse.jdt.core.tests.builder/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.tests.builder/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.core.tests.builder; singleton:=true
-Bundle-Version: 3.12.0.qualifier
+Bundle-Version: 3.12.100.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jdt.core.tests.builder

--- a/org.eclipse.jdt.core.tests.builder/forceQualifierUpdate.txt
+++ b/org.eclipse.jdt.core.tests.builder/forceQualifierUpdate.txt
@@ -1,2 +1,3 @@
 # To force a version qualifier update, add the bug here
 Bug 480835 - Failures in build due to changes not being picked up by tests
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184

--- a/org.eclipse.jdt.core.tests.builder/pom.xml
+++ b/org.eclipse.jdt.core.tests.builder/pom.xml
@@ -18,7 +18,7 @@
     <relativePath>../tests-pom/</relativePath>
   </parent>
   <artifactId>org.eclipse.jdt.core.tests.builder</artifactId>
-  <version>3.12.0-SNAPSHOT</version>
+  <version>3.12.100-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>

--- a/org.eclipse.jdt.core.tests.model/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.tests.model/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.core.tests.model;singleton:=true
-Bundle-Version: 3.12.50.qualifier
+Bundle-Version: 3.12.100.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jdt.core.tests,

--- a/org.eclipse.jdt.core.tests.model/forceQualifierUpdate.txt
+++ b/org.eclipse.jdt.core.tests.model/forceQualifierUpdate.txt
@@ -1,2 +1,3 @@
 # To force a version qualifier update, add the bug here
 Bug 489604 - should not override <timestampProvider>
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184

--- a/org.eclipse.jdt.core.tests.model/pom.xml
+++ b/org.eclipse.jdt.core.tests.model/pom.xml
@@ -19,7 +19,7 @@
     <relativePath>../tests-pom/</relativePath>
   </parent>
   <artifactId>org.eclipse.jdt.core.tests.model</artifactId>
-  <version>3.12.50-SNAPSHOT</version>
+  <version>3.12.100-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>

--- a/org.eclipse.jdt.core.tests.performance/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.tests.performance/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.core.tests.performance
-Bundle-Version: 3.12.0.qualifier
+Bundle-Version: 3.12.100.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jdt.core.tests.performance,

--- a/org.eclipse.jdt.core.tests.performance/forceQualifierUpdate.txt
+++ b/org.eclipse.jdt.core.tests.performance/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 545608 - [comparator] 4.12 Comparator errors - I20190320-1800
 Bug 561237 - [comparator] Comparator errors I20200318-1800
 Bug 574551 - Comparator errors in Y20210629-0800
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184

--- a/org.eclipse.jdt.core.tests.performance/pom.xml
+++ b/org.eclipse.jdt.core.tests.performance/pom.xml
@@ -19,7 +19,7 @@
     <relativePath>../tests-pom/</relativePath>
   </parent>
   <artifactId>org.eclipse.jdt.core.tests.performance</artifactId>
-  <version>3.12.0-SNAPSHOT</version>
+  <version>3.12.100-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <properties>
   	<testSuite>${project.artifactId}</testSuite>

--- a/org.eclipse.jdt.core/forceQualifierUpdate.txt
+++ b/org.eclipse.jdt.core/forceQualifierUpdate.txt
@@ -10,3 +10,4 @@ Bug 551547 - The library org.eclipse.jdt.core.compiler.batch_*.jar should be sig
 Bug 549687 - Local ecj build has a SHA-256 digest error for org/eclipse/jdt/internal/compiler/apt/model/PackageElementImpl.class
 Bug 566471 - I20200828-0150 - Comparator Errors Found
 Bug 573283 - don't include javax15api.jar in jdt binaries
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184


### PR DESCRIPTION
See https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184