### PR TITLE
Improve metaindex update scheduling while indexing. #1203

### DIFF
--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/IndexManager.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/IndexManager.java
@@ -1755,14 +1755,15 @@ private void writeIntoMetaIndex() {
 	boolean hasMoreIndexes = true;
 
 	while (hasMoreIndexes) {
-		synchronized (IndexManager.this.metaIndexUpdates) {
-			Iterator<Index> iterator = IndexManager.this.metaIndexUpdates.iterator();
-			if (iterator.hasNext()) {
-				index = iterator.next();
-				iterator.remove();
-			}
-			metaIndexUpdatesSize = IndexManager.this.metaIndexUpdates.size();
+		// the metaIndexUpdates is already a synchronized collection, so no need to synchronized following operations
+		// since this method is called by the index loop thread.
+		Iterator<Index> iterator = IndexManager.this.metaIndexUpdates.iterator();
+		if (iterator.hasNext()) {
+			index = iterator.next();
+			iterator.remove();
 		}
+		metaIndexUpdatesSize = IndexManager.this.metaIndexUpdates.size();
+
 		if (index == null) {
 			break;
 		}
@@ -1791,9 +1792,7 @@ private void writeIntoMetaIndex() {
 				}
 			}
 		}
-		synchronized (IndexManager.this.metaIndexUpdates) {
-			hasMoreIndexes = !IndexManager.this.metaIndexUpdates.isEmpty();
-		}
+		hasMoreIndexes = !IndexManager.this.metaIndexUpdates.isEmpty();
 	}
 }
 

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/processing/JobManager.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/processing/JobManager.java
@@ -476,6 +476,7 @@ public abstract class JobManager {
 
 						// must check for new job inside this sync block to avoid timing hole
 						if ((job = currentJob()) == null) {
+							onJobQueueEmpty();
 							Job pJob = this.progressJob;
 							if (pJob != null) {
 								pJob.cancel();
@@ -548,6 +549,13 @@ public abstract class JobManager {
 			throw e;
 		}
 	}
+
+	/**
+	 * Notified when the when queue is found to be empty by the indexer loop.
+	 */
+	protected void onJobQueueEmpty() {
+	}
+
 	/**
 	 * Stop background processing, and wait until the current job is completed before returning
 	 */


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
This changeset introduce post event method into JobManager so that IndexManager can use it write all pending meta updates into meta index prior all indexes are saved to disk.


## How to test
Tests mentioned in #1203 and available index manager unit tests.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
