### PR TITLE
Further improve restricted identifier when disambiguation

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Scanner.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Scanner.java
@@ -5089,12 +5089,11 @@ protected boolean mayBeAtGuard(int token) {
 	/*
 	 * A simple elimination optimization for some common possible cases. According to the JLS 19 including
 	 * patterns-switch and record-patterns Section 14.30.1, a guard may only be preceded by either right parentheses or
-	 * an identifier. However, we may still encounter comments, whitespace or the not-a-token token.
+	 * an identifier. However, we may still encounter comments or whitespace, but those are not pushed to the lookBack.
 	 */
 	switch (this.lookBack[1]) {
 		case TokenNameRPAREN:
 		case TokenNameIdentifier:
-		case TokenNameNotAToken: // TODO is this useful? Some tests start scanning at "when", but this makes no sense as a Pattern is required by the JLS
 			return true;
 	}
 	return false;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Scanner.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Scanner.java
@@ -1411,6 +1411,7 @@ public int getNextToken() throws InvalidInputException {
 	if (this.nextToken != TokenNameNotAToken) {
 		token = this.nextToken;
 		this.nextToken = TokenNameNotAToken;
+		addTokenToLookBack(token);
 		return token; // presumed to be unambiguous.
 	}
 	if (this.scanContext == null) { // init lazily, since isInModuleDeclaration needs the parser to be known
@@ -4735,6 +4736,7 @@ private static final class VanguardScanner extends Scanner {
 		if (this.nextToken != TokenNameNotAToken) {
 			token = this.nextToken;
 			this.nextToken = TokenNameNotAToken;
+			this.addTokenToLookBack(token);
 			return token; // presumed to be unambiguous.
 		}
 		if (this.scanContext == null) { // init lazily, since isInModuleDeclaration may need the parser to be known

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Scanner.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Scanner.java
@@ -5093,8 +5093,27 @@ protected boolean mayBeAtGuard(int token) {
 	 */
 	switch (this.lookBack[1]) {
 		case TokenNameRPAREN:
+			// This must be a record pattern, so check for suffixes of: ReferenceType "(" [ Pattern { , Pattern } ]
+			switch (this.lookBack[0]) {
+				case TokenNameLPAREN: // record pattern with no record components, e.g., Record()
+				case TokenNameRPAREN: // nested record patterns, e.g., Rec1(Rec2(Rec3(...)))
+				case TokenNameIdentifier: // type pattern in record pattern, e.g., Record(int x)
+					return true;
+				default:
+					return false;
+			}
 		case TokenNameIdentifier:
-			return true;
+			// This must be a type pattern, so check for suffixes of: UnannReferenceType
+			switch (this.lookBack[0]) {
+				case TokenNameRBRACKET: // array type , e.g., int[] a
+				case TokenNameGREATER: // 1-level generic type, e.g., List<Long> a
+				case TokenNameRIGHT_SHIFT: // 2-level generic type, e.g., List<Set<Long>> a
+				case TokenNameUNSIGNED_RIGHT_SHIFT: // 3-level generic type, e.g., List<List<Set<Long>>> a
+				case TokenNameIdentifier: // "regular" type, e.g., String s
+					return true;
+				default:
+					return false;
+			}
 	}
 	return false;
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ScannerTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ScannerTest.java
@@ -1790,15 +1790,18 @@ public class ScannerTest extends AbstractRegressionTest {
 			assertTrue(false);
 		}
 	}
+	@SuppressWarnings("deprecation")
 	public void testWhenOK() {
 		String source = ("public void foo(Object obj) {\n switch(obj) {\n case String s when s.length() > 0 -> {}\n}\n}");
 		IScanner scanner = ToolFactory.createScanner(false, true, false, "19", "19", true);
 		scanner.setSource(source.toCharArray());
-		scanner.resetTo(source.indexOf("when")-1, source.length() - 1); // start directly at "when"
+		scanner.resetTo(source.indexOf("case")-1, source.length() - 1); // start directly at "case"
 		try {
 			int token;
 			while ((token = scanner.getNextToken()) != ITerminalSymbols.TokenNameEOF) {
 				switch (token) {
+					case ITerminalSymbols.TokenNamecase:
+					case ITerminalSymbols.TokenNameIdentifier:
 					case ITerminalSymbols.TokenNameWHITESPACE:
 						break;
 					case ITerminalSymbols.TokenNameRestrictedIdentifierWhen:
@@ -1807,7 +1810,7 @@ public class ScannerTest extends AbstractRegressionTest {
 						fail("Unexpected token "+token);
 				}
 			}
-			fail("TokenNameRestrictedIdentifierYield was not detected");
+			fail("TokenNameRestrictedIdentifierWhen was not detected");
 		} catch (InvalidInputException e) {
 			assertTrue(false);
 		}
@@ -1831,7 +1834,7 @@ public class ScannerTest extends AbstractRegressionTest {
 						fail("Unexpected token "+token);
 				}
 			}
-			fail("TokenNameRestrictedIdentifierYield was not detected");
+			fail("TokenNameRestrictedIdentifierWhen was not detected");
 		} catch (InvalidInputException e) {
 			assertTrue(false);
 		}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchPatternTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchPatternTest.java
@@ -6224,4 +6224,23 @@ public class SwitchPatternTest extends AbstractRegressionTest9 {
 				"1\n" +
 				"0");
 	}
+	public void testIssue456a() {
+		runConformTest(
+				new String[] {
+					"when.java",
+					"public class when {\n"+
+					"	static int when(Object o) {\n"+
+					"		return switch (o) {\n"+
+					"			case when when when when(null) < 1 -> 1;\n"+
+					"			case null, default -> 0;\n"+
+					"		};\n"+
+					"	}\n"+
+					"	public static void main(String[] args) {\n"+
+					"		when(new when());"+
+					"		System.out.println(when(new when()));\n"+
+					"	}\n"+
+					"}",
+				},
+				"1");
+	}
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
This (mostly) fixes #456 and fixes #609 (relates to revelc/formatter-maven-plugin#712, revelc/formatter-maven-plugin#758).

Currently, the current implementation still has flaws, mainly casts before unary methods named `when` (e.g., `(Object) when(true)`). Most problems have arisen from the use of Mockito's `when` at the beginning of method bodies. This should be fixed, and casting the result of `Mockito.when` is very unlikely.

Still, it would be best to follow up with a refined implementation that matches the specification (JLS 20 Prview / JLS 21).
As explained in great detail in #456, this requires more than just the look back.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
- See if the automatic tests are good and sufficient (TODO still missing)
- Review the token logic regarding the JLS 20 Preview / JLS 21 

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
