### PR TITLE
Also install the batch compiler under the official id in the local repo

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/pom.xml
+++ b/org.eclipse.jdt.core.compiler.batch/pom.xml
@@ -23,6 +23,7 @@
   <properties>
     <defaultSigning-excludeInnerJars>true</defaultSigning-excludeInnerJars>
     <code.ignoredWarnings>-warn:+fieldHiding,-unavoidableGenericProblems</code.ignoredWarnings>
+    <localEcjVersion>${project.version}</localEcjVersion>
   </properties>
 
   <build>
@@ -48,157 +49,32 @@
 			</execution>
 		</executions>
 	  </plugin>
-      <!-- XXX ???
-      <plugin>
-        <artifactId>maven-resources-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>copy-batch-compiler-source</id>
-            <phase>package</phase>
-            <goals>
-              <goal>copy-resources</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>${project.build.directory}/scripts/source</outputDirectory>
-              <resources>
-                <resource>
-                  <directory>${project.basedir}/scripts/source</directory>
-                  <filtering>true</filtering>
-                </resource>
-              </resources>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      -->
-        <!-- XXX ???
-      <plugin>
-        <groupId>org.eclipse.tycho.extras</groupId>
-        <artifactId>tycho-custom-bundle-plugin</artifactId>
-        <version>${tycho.version}</version>
-        <executions>
-          <execution>
-            <id>batch-compiler-src</id>
-            <phase>package</phase>
-            <goals>
-              <goal>custom-bundle</goal>
-            </goals>
-            <configuration>
-				<archive>
-					<addMavenDescriptor>false</addMavenDescriptor>
-				</archive>
-              <bundleLocation>${project.build.directory}/scripts/source</bundleLocation>
-              <classifier>batch-compiler-src</classifier>
-              <fileSets>
-                <fileSet>
-                  <directory>${project.basedir}/batch</directory>
-                  <excludes>
-                    <exclude>org/eclipse/jdt/internal/compiler/batch/messages.properties</exclude>
-                  </excludes>
-                </fileSet>
-                <fileSet>
-                  <directory>${project.build.directory}/classes</directory>
-                  <includes>
-                    <include>org/eclipse/jdt/internal/compiler/batch/messages.properties</include>
-                  </includes>
-                </fileSet>
-                <fileSet>
-                  <directory>${project.basedir}/compiler</directory>
-                </fileSet>
-                <fileSet>
-                  <directory>${project.basedir}/antadapter</directory>
-                  <excludes>
-				    <exclude>org/eclipse/jdt/core/CheckDebugAttributes.java</exclude>
-					<exclude>org/eclipse/jdt/core/BuildJarIndex.java</exclude>
-                  </excludes>
-                </fileSet>
-				<fileSet>
-                  <directory>${project.basedir}/../org.eclipse.jdt.compiler.tool/src</directory>
-                </fileSet>
-				<fileSet>
-                  <directory>${project.basedir}/../org.eclipse.jdt.compiler.apt/src</directory>
-                </fileSet>
-				<fileSet>
-                  <directory>${project.basedir}/scripts</directory>
-                  <includes>
-				    <include>about.html</include>
-					<include>build.xml</include>
-					<include>ecj.1</include>
-                  </includes>
-                </fileSet>
-                <fileSet>
-                  <directory>${project.basedir}</directory>
-                  <includes>
-                    <include>scripts/binary/**</include>
-                  </includes>
-                </fileSet>
-                <fileSet>
-                  <directory>${project.basedir}/../org.eclipse.jdt.compiler.tool/lib</directory>
-                  <includes>
-                    <include>*.jar</include>
-                  </includes>
-                </fileSet>
-              </fileSets>
-            </configuration>
-          </execution>
-          <execution>
-            <id>batch-compiler</id>
-            <phase>package</phase>
-            <goals>
-              <goal>custom-bundle</goal>
-            </goals>
-            <configuration>
-				<archive>
-					<addMavenDescriptor>false</addMavenDescriptor>
-				</archive>
-              <bundleLocation>${project.basedir}/scripts/binary</bundleLocation>
-              <classifier>batch-compiler</classifier>
-              <fileSets>
-                <fileSet>
-                  <directory>${project.build.directory}/jdtCompilerAdapter.jar-classes</directory>
-                  <includes>
-				    <include>META-INF/eclipse.inf</include>
-                  </includes>
-                </fileSet>
-				<fileSet>
-                  <directory>${project.basedir}/scripts</directory>
-                  <includes>
-				    <include>about.html</include>
-				    <include>ecj.1</include>
-                  </includes>
-                </fileSet>
-                <fileSet>
-                  <directory>${project.build.directory}/classes</directory>
-                  <includes>
-                    <include>org/eclipse/jdt/internal/compiler/**</include>
-                    <include>org/eclipse/jdt/core/compiler/**</include>
-                  </includes>
-                  <excludes>
-                    <exclude>**/package.htm*</exclude>
-                    <exclude>org/eclipse/jdt/core/compiler/CompilationParticipant*.class</exclude>
-                    <exclude>org/eclipse/jdt/core/compiler/BuildContext.class</exclude>
-                    <exclude>org/eclipse/jdt/core/compiler/IScanner.class</exclude>
-                    <exclude>org/eclipse/jdt/core/compiler/ITerminalSymbols*.class</exclude>
-                    <exclude>org/eclipse/jdt/core/compiler/ReconcileContext*.class</exclude>
-                    <exclude>org/eclipse/jdt/internal/compiler/DocumentElementParser*.class</exclude>
-                    <exclude>org/eclipse/jdt/internal/compiler/IDocumentElementRequestor.class</exclude>
-                    <exclude>org/eclipse/jdt/internal/compiler/ISourceElementRequestor*.class</exclude>
-                    <exclude>org/eclipse/jdt/internal/compiler/SourceElementParser*.class</exclude>
-                    <exclude>org/eclipse/jdt/internal/compiler/SourceElementRequestorAdapter*.class</exclude>
-                    <exclude>org/eclipse/jdt/internal/compiler/SourceJavadocParser*.class</exclude>
-                    <exclude>org/eclipse/jdt/internal/compiler/parser/SourceTypeConverter*.class</exclude>
-                  </excludes>
-                </fileSet>
-              </fileSets>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-         -->
+		<!-- ECJ is deployed to maven central under a different artifact id, this ensures that in a local build we also deploy the artifact under that artifact id -->
+		<!-- Additionally it allow to specify -DlocalEcjVersion=<my custom version> for pin the version used for local deploy -->
+		<plugin>
+			<groupId>org.apache.maven.plugins</groupId>
+			<artifactId>maven-install-plugin</artifactId>
+			<version>3.1.1</version>
+			<executions>
+				<execution>
+					<id>deploy-ecj</id>
+					<goals>
+						<goal>install-file</goal>
+					</goals>
+					<phase>install</phase>
+					<configuration>
+						<file>${project.build.directory}/${project.build.finalName}.jar</file>
+						<artifactId>ecj</artifactId>
+						<groupId>${project.groupId}</groupId>
+						<version>${localEcjVersion}</version>
+						<packaging>jar</packaging>
+					</configuration>
+				</execution>
+			</executions>
+		</plugin>
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-p2-plugin</artifactId>
-        <version>${tycho.version}</version>
         <configuration>
           <baselineMode>warn</baselineMode>
           <baselineReplace>common</baselineReplace>


### PR DESCRIPTION
Currently running a local build results that the batch compiler is installed under org.eclipse.jdt:org.eclipse.jdt.core.compiler.batch but the "offical" id it is later deployed with to central is org.eclipse.jdt:ecj.

## What it does
This adds an execution of the maven-install plugin bound to the install phase of maven to additionally install the jar under this group id so it can be used as if we where using the right artifactid at the first place.

I also removed the content currently commented out and an obsolete version definition.

## How to test

1. check out the code
2. run `mvn clean install -f org.eclipse.jdt.core.compiler.batch`
3. verify that `<your repository location, usually ~/.m2>/org/eclipse/jdt/ecj/3.35.0-SNAPSHOT/ecj-3.35.0-SNAPSHOT.jar` is present
4. run `mvn clean install -f org.eclipse.jdt.core.compiler.batch -DlocalEcjVersion=99.99`
5. verify that `<your repository location, usually ~/.m2>/org/eclipse/jdt/ecj/99.99/ecj-99.99.jar` is present
6. (optionally) run a build (e.g. aggregator or any eclipse sub project like jdt) with `mvn clean verify -Dcbi-ecj-version=99.99`

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)

FYI @iloveeclipse @stephan-herrmann I think that's the closes possibility we can get here given the mentioned restrictions (no renaming of anything).