### PR TITLE
Compile JDT with current compiler

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,1 @@
+-Pbuild-individual-bundles

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,10 +29,13 @@ pipeline {
 					# via configuration/argLine property in pom.xml
 					# export MAVEN_OPTS="-Xmx2G"
 					
+					mvn clean install -f org.eclipse.jdt.core.compiler.batch -DlocalEcjVersion=99.99
+					
 					mvn -U clean verify --batch-mode --fail-at-end -Dmaven.repo.local=$WORKSPACE/.m2/repository \
-					-Pbuild-individual-bundles -Ptest-on-javase-20 -Pbree-libs -Papi-check \
+					-Ptest-on-javase-20 -Pbree-libs -Papi-check \
 					-Djava.io.tmpdir=$WORKSPACE/tmp -Dproject.build.sourceEncoding=UTF-8 \
-					-Dtycho.surefire.argLine="--add-modules ALL-SYSTEM -Dcompliance=1.8,11,17,20 -Djdt.performance.asserts=disabled"
+					-Dtycho.surefire.argLine="--add-modules ALL-SYSTEM -Dcompliance=1.8,11,17,20 -Djdt.performance.asserts=disabled" \
+					-Dcbi-ecj-version=99.99
 					"""
 			}
 			post {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
This adds the required steps to use the current build compiler as the compiler of the maven run.

## How to test
Jenkins should suceed, afterwards one might test this by creating a PR that makes the compiler fail compilation always.

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)

FYI @iloveeclipse @stephan-herrmann 
