### PR TITLE
ASTRewriteFlattener inserts unnecessary semicolon

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter_16Test.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter_16Test.java
@@ -31,6 +31,7 @@ import org.eclipse.jdt.core.dom.ASTVisitor;
 import org.eclipse.jdt.core.dom.AbstractTypeDeclaration;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.Expression;
+import org.eclipse.jdt.core.dom.FieldDeclaration;
 import org.eclipse.jdt.core.dom.IBinding;
 import org.eclipse.jdt.core.dom.IMethodBinding;
 import org.eclipse.jdt.core.dom.ITypeBinding;
@@ -69,7 +70,6 @@ public class ASTConverter_16Test extends ConverterTestSetup {
 	public ASTConverter_16Test(String name) {
 		super(name);
 	}
-
 	public static Test suite() {
 		return buildModelTestSuite(ASTConverter_16Test.class);
 	}
@@ -814,5 +814,37 @@ public class ASTConverter_16Test extends ConverterTestSetup {
 	        return super.visit(node);
 	      }
 	    });
+	}
+	@SuppressWarnings("rawtypes")
+	public void test_RecordSemicolon() throws JavaModelException {
+		if (!isJRE16) {
+			System.err.println("Test "+getName()+" requires a JRE 16");
+			return;
+		}
+		String contents =
+		        "record Point(int x, int y) {\n" +
+		        "    private static final int staticField = 16;\n"+
+		        "}";
+		    this.workingCopy = getWorkingCopy("/Converter_16/src/ASTtree.java", true/*resolve*/);
+		    ASTNode node = buildAST(
+		    		contents,
+		    		this.workingCopy);
+		    assertEquals("Not a compilation unit", ASTNode.COMPILATION_UNIT, node.getNodeType());
+		    CompilationUnit unit = (CompilationUnit) node;
+		    assertProblemsSize(unit, 0);
+		    node = getASTNode(unit, 0);
+		    assertEquals("Not a record declaration", ASTNode.RECORD_DECLARATION, node.getNodeType());
+		    RecordDeclaration recordDeclaration = (RecordDeclaration) node;
+		    final List bodyDeclarations = recordDeclaration.bodyDeclarations();
+		    assertEquals("Wrong size", 1, bodyDeclarations.size());
+		    FieldDeclaration fieldDeclaration = (FieldDeclaration) bodyDeclarations.get(0);
+		    final List fragments = fieldDeclaration.fragments();
+		    assertEquals("Wrong size", 1, fragments.size());
+		    VariableDeclarationFragment fragment = (VariableDeclarationFragment)fragments.get(0);
+		    final Expression initializer = fragment.getInitializer();
+		    assertEquals("Not a number literal", ASTNode.NUMBER_LITERAL, initializer.getNodeType());
+		    checkSourceRange(initializer, "16", contents);
+
+
 	}
 }

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/ASTRewriteFlattener.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/ASTRewriteFlattener.java
@@ -919,7 +919,7 @@ public class ASTRewriteFlattener extends ASTVisitor {
 		visitList(node, RecordDeclaration.SUPER_INTERFACE_TYPES_PROPERTY, String.valueOf(','), "implements ", Util.EMPTY_STRING); //$NON-NLS-1$
 
 		this.result.append('{');
-		visitList(node, RecordDeclaration.BODY_DECLARATIONS_PROPERTY, Util.EMPTY_STRING, String.valueOf(';'), Util.EMPTY_STRING);
+		visitList(node, RecordDeclaration.BODY_DECLARATIONS_PROPERTY, Util.EMPTY_STRING);
 		this.result.append('}');
 		return false;
 	}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
Removed the unnecessary semicolon that was added to the start of the body declaration block while creating a record  manually and adding it to AST.
Fixes: https://github.com/eclipse-jdt/eclipse.jdt.core/issues/434

Please Review @mpalat 

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
