### PR TITLE
Errors running builder 'Java Builder' on project 'org.eclipse.tycho.core.shared'.

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchExpression.java
@@ -452,7 +452,8 @@ public class SwitchExpression extends SwitchStatement implements IPolyExpression
 				for (int i = 0; i < resultExpressionsCount; i++) {
 					Expression resultExpr = this.resultExpressions.get(i);
 					TypeBinding origType = this.originalTypeMap.get(resultExpr);
-					if (origType == null || origType.kind() == Binding.POLY_TYPE) {
+					// NB: if origType == null we assume that initial resolving failed hard, rendering re-resolving impossible
+					if (origType != null &&  origType.kind() == Binding.POLY_TYPE) {
 						this.finalValueResultExpressionTypes[i] = this.originalValueResultExpressionTypes[i] =
 							resultExpr.resolveTypeExpecting(upperScope, this.expectedType);
 					}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchExpressionsYieldTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchExpressionsYieldTest.java
@@ -6296,4 +6296,36 @@ public class SwitchExpressionsYieldTest extends AbstractRegressionTest {
 				"Continue out of switch expressions not permitted\n" +
 				"----------\n");
 	}
+
+	public void testGH520() throws Exception {
+		runNegativeTest(
+			new String[] {
+				"X.java",
+				"public class X {\n" +
+				"	void test(int i) {\n" +
+				"		foo(switch (i) {\n" +
+				"			case 0 -> m.call();\n" +
+				"			default -> null;\n" +
+				"		});\n" +
+				"	}\n" +
+				"	<T> void foo(T t) { }\n" +
+				"}\n"
+			},
+			"----------\n" +
+			"1. ERROR in X.java (at line 3)\n" +
+			"	foo(switch (i) {\n" +
+			"	^^^\n" +
+			"The method foo(T) in the type X is not applicable for the arguments (switch (i) {\n" +
+			"case 0 ->\n" +
+			" m.call();\n" +
+			"default ->\n" +
+			" null;\n" +
+			"})\n" +
+			"----------\n" +
+			"2. ERROR in X.java (at line 4)\n" +
+			"	case 0 -> m.call();\n" +
+			"	          ^\n" +
+			"m cannot be resolved\n" +
+			"----------\n");
+	}
 }


### PR DESCRIPTION
fixes #520

## What it does
Avoid re-resolving a `MessageSend` that already failed hard (here: due to unresolvable receiver) during the first attempt.

## How to test
Test case throws NPE like #520 without the code change.
