### PR TITLE
[21][record patterns] Fixing the synthetic default instrumentation triggered stack verify

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
@@ -8,6 +8,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Stephan Herrmann - Contributions for
@@ -626,7 +630,16 @@ public class SwitchStatement extends Expression {
 							&& this.expression.resolvedType instanceof ReferenceBinding
 							&& ((ReferenceBinding) this.expression.resolvedType).isSealed();
 
-			if (isEnumSwitchWithoutDefaultCase || isPatternSwitchSealedWithoutDefaultCase) {
+			boolean isRecordPatternSwitchWithoutDefault = this.defaultCase == null
+					&& compilerOptions != null
+					&& this.containsPatterns
+					&& JavaFeature.RECORD_PATTERNS.isSupported(compilerOptions)
+					&& JavaFeature.PATTERN_MATCHING_IN_SWITCH.isSupported(compilerOptions)
+					&& this.expression.resolvedType instanceof ReferenceBinding
+					&& this.expression.resolvedType.isRecord();
+			if (isEnumSwitchWithoutDefaultCase
+					|| isPatternSwitchSealedWithoutDefaultCase
+					|| isRecordPatternSwitchWithoutDefault) {
 				// we want to force an line number entry to get an end position after the switch statement
 				if (this.preSwitchInitStateIndex != -1) {
 					codeStream.removeNotDefinitelyAssignedVariables(currentScope, this.preSwitchInitStateIndex);
@@ -665,7 +678,9 @@ public class SwitchStatement extends Expression {
 			}
 			// place the trailing labels (for break and default case)
 			this.breakLabel.place();
-			if (this.defaultCase == null && !(enumInSwitchExpression || isPatternSwitchSealedWithoutDefaultCase)) {
+			if (this.defaultCase == null && !(enumInSwitchExpression
+					|| isPatternSwitchSealedWithoutDefaultCase
+					|| isRecordPatternSwitchWithoutDefault)) {
 				// we want to force an line number entry to get an end position after the switch statement
 				codeStream.recordPositionsFrom(codeStream.position, this.sourceEnd, true);
 				defaultLabel.place();

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordPatternTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordPatternTest.java
@@ -2884,7 +2884,7 @@ public class RecordPatternTest extends AbstractRegressionTest9 {
 	}
 	// Fails with VerifyError since we allow the switch now but don't
 	// generate a label/action for implicit default.
-	public void _testIssue1224_8() {
+	public void testIssue1224_8() {
 		runConformTest(new String[] {
 			"X.java",
 			"record Record(int a) {}\n"


### PR DESCRIPTION
error

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
