### PR TITLE
Remove unnecessary 'collectAllTypeBindings(...)' call

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SourceTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SourceTypeBinding.java
@@ -1198,13 +1198,12 @@ private void checkPermitsInType() {
 			else if (this.isInterface())
 				this.scope.problemReporter().sealedMissingInterfaceModifier(this, typeDecl, sealedEntry.getValue());
 		}
-		List<SourceTypeBinding> typesInCU = collectAllTypeBindings(typeDecl, this.scope.compilationUnitScope());
-		if (!typeDecl.isRecord() && typeDecl.superclass != null && !checkPermitsAndAdd(this.superclass, typesInCU)) {
+		if (!typeDecl.isRecord() && typeDecl.superclass != null && !checkPermitsAndAdd(this.superclass)) {
 			reportSealedSuperTypeDoesNotPermitProblem(typeDecl.superclass, this.superclass);
 		}
 		for (int i = 0, l = this.superInterfaces.length; i < l; ++i) {
 			ReferenceBinding superInterface = this.superInterfaces[i];
-			if (superInterface != null && !checkPermitsAndAdd(superInterface, typesInCU)) {
+			if (superInterface != null && !checkPermitsAndAdd(superInterface)) {
 				TypeReference superInterfaceRef = typeDecl.superInterfaces[i];
 				reportSealedSuperTypeDoesNotPermitProblem(superInterfaceRef, superInterface);
 			}
@@ -1335,7 +1334,7 @@ public List<SourceTypeBinding> collectAllTypeBindings(TypeDeclaration typeDecl, 
 	return typeCollector.types;
 }
 
-private boolean checkPermitsAndAdd(ReferenceBinding superType, List<SourceTypeBinding> types) {
+private boolean checkPermitsAndAdd(ReferenceBinding superType) {
 	if (superType == null
 			|| superType.equals(this.scope.getJavaLangObject())
 			|| !superType.isSealed())


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. TODO: how to report security issues
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
collectAllTypeBindings(...) is called unnecessarily, as the result is not used anywhere, and it seems, that collectAllTypeBindings doesn't mutate the objects, so it seems unnecessary 

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Trying code with sealed interfaces, etc  

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
