### PR TITLE
SecondaryTypes cache refactoring and MT fix for JavaModelManager

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelManager.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelManager.java
@@ -1244,6 +1244,73 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 	 */
 	protected WeakHashMap<AbstractSearchScope, ?> searchScopes = new WeakHashMap<>();
 
+	/**
+	 * Current secondary types cache and temporary indexing cache
+	 *
+	 * @param secondaryTypes
+	 *            the main cache containing known secondary types in a project, can be null to indicate no search were
+	 *            done. Note, the cache might be not complete if the search is still running.
+	 * @param indexingSecondaryCache
+	 *            the temporary structure used while indexing, previously known as INDEXED_SECONDARY_TYPES entry. If it
+	 *            is null, no cache updates are running now
+	 */
+	private static record SecondaryTypesCache(Hashtable<String, Map<String, IType>> secondaryTypes,
+			Map<IFile, Map<String, Map<String, IType>>> indexingSecondaryCache) {
+
+		boolean isIndexingDone() {
+			return this.secondaryTypes != null && this.indexingSecondaryCache == null;
+		}
+	}
+
+	/**
+	 * Secondary types cache management code for a {@link PerProjectInfo}
+	 */
+	private static class SecondaryTypes {
+		private volatile SecondaryTypesCache cache;
+
+		public SecondaryTypes() {
+			this.cache = new SecondaryTypesCache(null, null);
+		}
+
+		SecondaryTypesCache cache() {
+			return this.cache;
+		}
+
+		private synchronized SecondaryTypesCache getOrCreateCache() {
+			Hashtable<String, Map<String, IType>> secondaryTypes = this.cache.secondaryTypes;
+			Map<IFile, Map<String, Map<String, IType>>> indexingSecondaryCache = this.cache.indexingSecondaryCache;
+			if (secondaryTypes != null && indexingSecondaryCache != null) {
+				return this.cache;
+			}
+			if (secondaryTypes == null) {
+				secondaryTypes = new Hashtable<>(3);
+			}
+			if (indexingSecondaryCache == null) {
+				indexingSecondaryCache = Collections.synchronizedMap(new HashMap<>(3));
+			}
+			this.cache = new SecondaryTypesCache(secondaryTypes, indexingSecondaryCache);
+			return this.cache;
+		}
+
+		private synchronized SecondaryTypesCache startIndexing() {
+			this.cache = new SecondaryTypesCache(this.cache.secondaryTypes(), Collections.synchronizedMap(new HashMap<>(3)));
+			return this.cache;
+		}
+
+		private synchronized void indexingDone() {
+			this.cache = new SecondaryTypesCache(this.cache.secondaryTypes(), null);
+		}
+
+		private synchronized SecondaryTypesCache doneSearching(Hashtable<String, Map<String, IType>> newSecondaryTypes) {
+			this.cache = new SecondaryTypesCache(newSecondaryTypes, this.cache.indexingSecondaryCache());
+			return this.cache;
+		}
+
+		private synchronized void clearAllCaches() {
+			this.cache = new SecondaryTypesCache(null, null);
+		}
+	}
+
 	public static class PerProjectInfo {
 		private static final int JAVADOC_CACHE_INITIAL_SIZE = 10;
 
@@ -1266,12 +1333,8 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 
 		public IEclipsePreferences preferences;
 		public Hashtable<String, String> options;
-		public Hashtable<String, Map<String, IType>> secondaryTypes;
-		/**
-		 * The temporary structure used while indexing, previously known as INDEXED_SECONDARY_TYPES entry
-		 */
-		volatile Map<IFile, Map<String, Map<String, IType>>> indexingSecondaryCache;
 
+		private final SecondaryTypes secondaryTypes;
 
 		// NB: PackageFragment#getAttachedJavadoc uses this map differently
 		// and stores String data, not JavadocContents as values
@@ -1283,6 +1346,7 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 			this.savedState = null;
 			this.project = project;
 			this.javadocCache = new LRUCache<>(JAVADOC_CACHE_INITIAL_SIZE);
+			this.secondaryTypes = new SecondaryTypes();
 		}
 
 		public synchronized IClasspathEntry[] getResolvedClasspath() {
@@ -4757,18 +4821,8 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 				try {
 					PerProjectInfo projectInfo = getPerProjectInfoCheckExistence(project);
 					// Get or create map to cache secondary types while indexing (can be not synchronized as indexing insure a non-concurrent usage)
-					Map<IFile, Map<String, Map<String, IType>>> indexedSecondaryTypes;
-					if (projectInfo.secondaryTypes == null) {
-						projectInfo.secondaryTypes = new Hashtable<>(3);
-						indexedSecondaryTypes = Collections.synchronizedMap(new HashMap<>(3));
-						projectInfo.indexingSecondaryCache = indexedSecondaryTypes;
-					} else {
-						indexedSecondaryTypes = projectInfo.indexingSecondaryCache;
-						if (indexedSecondaryTypes == null) {
-							indexedSecondaryTypes = Collections.synchronizedMap(new HashMap<>(3));
-							projectInfo.indexingSecondaryCache = indexedSecondaryTypes;
-						}
-					}
+					SecondaryTypesCache stCache = projectInfo.secondaryTypes.getOrCreateCache();
+					Map<IFile, Map<String, Map<String, IType>>> indexedSecondaryTypes = stCache.indexingSecondaryCache();
 					// Store the secondary type in temporary cache (these are just handles => no problem to create it now...)
 					Map<String, Map<String, IType>> allTypes = indexedSecondaryTypes.get(resource);
 					if (allTypes == null) {
@@ -4792,17 +4846,34 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 					}
 					if (VERBOSE) {
 						Util.verbose("	- indexing cache:"); //$NON-NLS-1$
-						Iterator<Entry<IFile, Map<String, Map<String, IType>>>> entries = indexedSecondaryTypes.entrySet().iterator();
-						while (entries.hasNext()) {
-							Entry<IFile, Map<String, Map<String, IType>>> entry = entries.next();
-							IFile file = entry.getKey();
-							Util.verbose("		+ "+file.getFullPath()+':'+ entry.getValue()); //$NON-NLS-1$
-						}
+						dumpIndexingSecondaryTypes(indexedSecondaryTypes);
 					}
 				}
 				catch (JavaModelException jme) {
 					// do nothing
 				}
+			}
+		}
+	}
+
+	private void dumpIndexingSecondaryTypes(Map<IFile, Map<String, Map<String, IType>>> indexedSecondaryTypes) {
+		synchronized(indexedSecondaryTypes) {
+			Iterator<Entry<IFile, Map<String, Map<String, IType>>>> entries = indexedSecondaryTypes.entrySet().iterator();
+			while (entries.hasNext()) {
+				Entry<IFile, Map<String, Map<String, IType>>> entry = entries.next();
+				IFile file = entry.getKey();
+				Util.verbose("		+ "+file.getFullPath()+':'+ entry.getValue()); //$NON-NLS-1$
+			}
+		}
+	}
+
+	private static void dumpSecondaryTypes(Map<String, Map<String, IType>> secondaryTypes) {
+		synchronized (secondaryTypes) {
+			Iterator<Entry<String, Map<String, IType>>> entries = secondaryTypes.entrySet().iterator();
+			while (entries.hasNext()) {
+				Entry<String, Map<String, IType>> entry = entries.next();
+				String packName = entry.getKey();
+				Util.verbose("		+ " + packName + ':' + entry.getValue()); //$NON-NLS-1$
 			}
 		}
 	}
@@ -4831,22 +4902,20 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 	public Map<String, Map<String, IType>> secondaryTypes(IJavaProject project, boolean waitForIndexes, IProgressMonitor monitor) throws JavaModelException {
 		if (VERBOSE) {
 			StringBuilder buffer = new StringBuilder("JavaModelManager.secondaryTypes("); //$NON-NLS-1$
-			buffer.append(project.getElementName());
-			buffer.append(',');
-			buffer.append(waitForIndexes);
-			buffer.append(')');
+			buffer.append(project.getElementName()).append(',').append(waitForIndexes).append(')');
 			Util.verbose(buffer.toString());
 		}
 
 		// Return cache if not empty and there's no new secondary types created during indexing
 		final PerProjectInfo projectInfo = getPerProjectInfoCheckExistence(project.getProject());
-		Map<IFile, Map<String, Map<String, IType>>> indexingSecondaryCache = projectInfo.secondaryTypes == null ? null : projectInfo.indexingSecondaryCache;
-		if (projectInfo.secondaryTypes != null && indexingSecondaryCache == null) {
-			return projectInfo.secondaryTypes;
+		SecondaryTypesCache secondaryTypesCache = projectInfo.secondaryTypes.cache();
+		Hashtable<String, Map<String, IType>> secondaryTypes = secondaryTypesCache.secondaryTypes();
+		if (secondaryTypesCache.isIndexingDone()) {
+			return secondaryTypes;
 		}
 
 		// Perform search request only if secondary types cache is not initialized yet (this will happen only once!)
-		if (projectInfo.secondaryTypes == null) {
+		if (secondaryTypes == null) {
 			return secondaryTypesSearching(project, waitForIndexes, monitor, projectInfo);
 		}
 
@@ -4856,7 +4925,7 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 		if (indexing) {
 			if (!waitForIndexes)  {
 				// Indexing is running but caller cannot wait => return current cache
-				return projectInfo.secondaryTypes;
+				return secondaryTypes;
 			}
 
 			// Wait for the end of indexing or a cancel
@@ -4889,7 +4958,7 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 
 				}, IJob.WaitUntilReady, monitor);
 			} catch (OperationCanceledException oce) {
-				return projectInfo.secondaryTypes;
+				return secondaryTypes;
 			}
 		}
 
@@ -4897,29 +4966,25 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 		return secondaryTypesMerging(projectInfo);
 	}
 
-	/*
-	 * Return secondary types cache merged with new secondary types created while indexing
-	 * Note that merge result is directly stored in given parameter map.
+	/**
+	 * Return secondary types cache merged with new secondary types created while indexing.
+	 * Note that merge result is directly stored in given {@link PerProjectInfo#secondaryTypes}
+	 * cache and that this method is synchronized on that cache object.
 	 */
-	private Map<String, Map<String, IType>> secondaryTypesMerging(PerProjectInfo projectInfo) {
-		Map<String, Map<String, IType>> secondaryTypes = projectInfo.secondaryTypes;
+	private static Map<String, Map<String, IType>> secondaryTypesMerging(PerProjectInfo projectInfo) {
+		synchronized (projectInfo.secondaryTypes) {
+		// Return current cache if there's no indexing cache (double check, this should not happen)
+		SecondaryTypesCache cache = projectInfo.secondaryTypes.cache();
+		Map<String, Map<String, IType>> secondaryTypes = cache.secondaryTypes();
+		if (cache.isIndexingDone()) {
+			return secondaryTypes;
+		}
 		if (VERBOSE) {
 			Util.verbose("JavaModelManager.getSecondaryTypesMerged()"); //$NON-NLS-1$
 			Util.verbose("	- current cache to merge:"); //$NON-NLS-1$
-			Iterator<Entry<String, Map<String, IType>>> entries = secondaryTypes.entrySet().iterator();
-			while (entries.hasNext()) {
-				Entry<String, Map<String, IType>> entry = entries.next();
-				String packName = entry.getKey();
-				Util.verbose("		+ "+packName+':'+ entry.getValue() ); //$NON-NLS-1$
-			}
+			dumpSecondaryTypes(secondaryTypes);
 		}
-
-		// Return current cache if there's no indexing cache (double check, this should not happen)
-		Map<IFile, Map<String, Map<String, IType>>> indexedSecondaryTypes = projectInfo.indexingSecondaryCache;
-		projectInfo.indexingSecondaryCache = null;
-		if (indexedSecondaryTypes == null) {
-			return secondaryTypes;
-		}
+		Map<IFile, Map<String, Map<String, IType>>> indexedSecondaryTypes = cache.indexingSecondaryCache();
 		Map<IFile, Map<String, Map<String, IType>>> indexedSecondaryTypesCopy;
 		synchronized (indexedSecondaryTypes) {
 			indexedSecondaryTypesCopy = new HashMap<>(indexedSecondaryTypes);
@@ -4956,14 +5021,11 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 		}
 		if (VERBOSE) {
 			Util.verbose("	- secondary types cache merged:"); //$NON-NLS-1$
-			Iterator<Entry<String, Map<String, IType>>> entries2 = secondaryTypes.entrySet().iterator();
-			while (entries.hasNext()) {
-				Entry<String, Map<String, IType>> entry = entries2.next();
-				String packName = entry.getKey();
-				Util.verbose("		+ "+packName+':'+ entry.getValue()); //$NON-NLS-1$
-			}
+			dumpSecondaryTypes(secondaryTypes);
 		}
+		projectInfo.secondaryTypes.indexingDone();
 		return secondaryTypes;
+		}
 	}
 
 	/*
@@ -5028,20 +5090,18 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 		}
 
 		// Store result in per project info cache if still null or there's still an indexing cache (may have been set by another thread...)
-		if (projectInfo.secondaryTypes == null || projectInfo.indexingSecondaryCache != null) {
-			projectInfo.secondaryTypes = secondaryTypes;
-			if (VERBOSE || BasicSearchEngine.VERBOSE) {
-				System.out.print(Thread.currentThread() + "	-> secondary paths stored in cache: ");  //$NON-NLS-1$
-				System.out.println();
-				Iterator<Entry<String, Map<String, IType>>> entries = secondaryTypes.entrySet().iterator();
-				while (entries.hasNext()) {
-					Entry<String, Map<String, IType>> entry = entries.next();
-					String qualifiedName = entry.getKey();
-					Util.verbose("		- "+qualifiedName+'-'+ entry.getValue()); //$NON-NLS-1$
+		synchronized(projectInfo.secondaryTypes) {
+			SecondaryTypesCache stCache = projectInfo.secondaryTypes.cache();
+			if (stCache.secondaryTypes() == null || stCache.indexingSecondaryCache() != null) {
+				stCache = projectInfo.secondaryTypes.doneSearching(secondaryTypes);
+
+				if (VERBOSE || BasicSearchEngine.VERBOSE) {
+					Util.verbose("	-> secondary paths stored in cache: ");  //$NON-NLS-1$
+					dumpSecondaryTypes(secondaryTypes);
 				}
 			}
+			return stCache.secondaryTypes();
 		}
-		return projectInfo.secondaryTypes;
 	}
 
 	/**
@@ -5061,21 +5121,29 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 		}
 		if (file != null) {
 			PerProjectInfo projectInfo = getPerProjectInfo(file.getProject(), false);
-			if (projectInfo != null && projectInfo.secondaryTypes != null) {
+			if (projectInfo == null) {
+				return;
+			}
+			synchronized (projectInfo.secondaryTypes) {
+				SecondaryTypesCache stCache = projectInfo.secondaryTypes.cache();
+				Hashtable<String, Map<String, IType>> secondaryTypes = stCache.secondaryTypes();
+				if (secondaryTypes == null) {
+					return;
+				}
 				if (VERBOSE) {
 					Util.verbose("-> remove file from cache of project: "+file.getProject().getName()); //$NON-NLS-1$
 				}
 
 				// Clean current cache
-				secondaryTypesRemoving(projectInfo.secondaryTypes, file);
+				secondaryTypesRemoving(secondaryTypes, file);
 
 				// Clean indexing cache if necessary
-				Map<IFile, Map<String, Map<String, IType>>> indexingCache = projectInfo.indexingSecondaryCache;
+				Map<IFile, Map<String, Map<String, IType>>> indexingCache = stCache.indexingSecondaryCache();
 				if (!cleanIndexCache) {
 					if (indexingCache == null) {
 						// Need to signify that secondary types indexing will happen before any request happens
 						// see bug https://bugs.eclipse.org/bugs/show_bug.cgi?id=152841
-						projectInfo.indexingSecondaryCache = Collections.synchronizedMap(new HashMap<>());
+						projectInfo.secondaryTypes.startIndexing();
 					}
 					return;
 				}
@@ -5090,19 +5158,12 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 	 * Remove from a given cache map all secondary types belonging to a given file.
 	 * Note that there can have several secondary types per file...
 	 */
-	private void secondaryTypesRemoving(Map<String, Map<String, IType>> secondaryTypesMap, IFile file) {
+	private static void secondaryTypesRemoving(Map<String, Map<String, IType>> secondaryTypesMap, IFile file) {
 		if (VERBOSE) {
 			StringBuilder buffer = new StringBuilder("JavaModelManager.removeSecondaryTypesFromMap("); //$NON-NLS-1$
-			Iterator<Entry<String, Map<String, IType>>> entries = secondaryTypesMap.entrySet().iterator();
-			while (entries.hasNext()) {
-				Entry<String, Map<String, IType>> entry = entries.next();
-				String qualifiedName = entry.getKey();
-				buffer.append(qualifiedName+':'+ entry.getValue());
-			}
-			buffer.append(',');
-			buffer.append(file.getFullPath());
-			buffer.append(')');
+			buffer.append(',').append(file.getFullPath()).append(')');
 			Util.verbose(buffer.toString());
+			dumpSecondaryTypes(secondaryTypesMap);
 		}
 		Set<Entry<String, Map<String, IType>>> packageEntries = secondaryTypesMap.entrySet();
 		int packagesSize = packageEntries.size(), removedPackagesCount = 0;
@@ -5144,12 +5205,7 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 		}
 		if (VERBOSE) {
 			Util.verbose("	- new secondary types map:"); //$NON-NLS-1$
-			Iterator<Entry<String, Map<String, IType>>> entries = secondaryTypesMap.entrySet().iterator();
-			while (entries.hasNext()) {
-				Entry<String, Map<String, IType>> entry = entries.next();
-				String qualifiedName = entry.getKey();
-				Util.verbose("		+ "+qualifiedName+':'+ entry.getValue()); //$NON-NLS-1$
-			}
+			dumpSecondaryTypes(secondaryTypesMap);
 		}
 	}
 
@@ -5586,7 +5642,7 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 			IJavaProject project = projects[i];
 			final PerProjectInfo projectInfo = getPerProjectInfo(project.getProject(), false /* don't create info */);
 			if (projectInfo != null) {
-				projectInfo.secondaryTypes = null;
+				projectInfo.secondaryTypes.clearAllCaches();
 			}
 		}
 	}


### PR DESCRIPTION
Some history research to explain how that code works / evolved.

JavaModelManager got a "secondary types" cache used to store data for the "secondary" types defined in a Java file.

See first implementation
- https://bugs.eclipse.org/bugs/show_bug.cgi?id=36032
- 2d9dc5098273e0e95832d81d735d2d77249738ef

This comment explains the theory of operations:
https://bugs.eclipse.org/bugs/show_bug.cgi?id=36032#c35

Quote (still valid):

> Solution was to use a cache on JavaModelManager per project information. Secondary types are searched the first time using a specific BasicSearchEngine request and corresponding IType stored in the cache. Then, after the consumed time is only to look in maps to retrieve the key.

> Cache size is currently not considered as a potential problem due to the fact that secondary types number should not be too big. Cache is reset each time a secondary type entry is added to the index and type is removed from cache each time its file is deleted.


Big fix for stale cache issue
- https://bugs.eclipse.org/bugs/show_bug.cgi?id=118823
- 04c08732703d5f5e97b66e89468d2f87b7f84cff

Third main change adding secondary types to IJavaProject.findType()
- https://bugs.eclipse.org/bugs/show_bug.cgi?id=118789#c13
- 8aee5680d034dfec291b1e7b2abb4d9d081e8e31

Quote:

> NameLookup findType public internal methods have been modified to consider secondary types or not as well as to wait for indexes or not. For obvious performance potential issues, all JDT/Core tools (eg. code assist, reconciler, etc.) consider secondary types now but do _not_ wait for indexes...

Initially the code wasn't MT safe at all. On bug 118823 the cache was changed to Hashtable (from HashMap) and commented that there were MT issues considered and that depending on indexer state caller may see not all secondary types.

At this point the cache was used by multiple threads but the code wasn't fully MT safe. Later changes added a bit more complexity but the main issue with unsafe MT code remained.

The main problem is that the indexing, updating and querying the cache can happen in parallel, and that while we are searching clients may already query for types or remove types from cache.

The original design managed that by holding a main map for "known secondary types" and second map (originally inside the first map) for "types being re-indexed" and depending on the call entry either of maps (or both) could be used / updated by multiple clients. That made the code extremely complex / error prone.

The main map is known as "secondaryTypes" and temporary map used to update first one is "indexedSecondaryTypes".

The "secondaryTypes" is the main cache for secondary types in the project and is what the clients are supposed to query. The "secondaryTypes" is originally filled in secondaryTypesSearching() (but can be updated later). The "indexedSecondaryTypes" is internal map and is used only for the main cache updates coming from secondaryTypeAdding() and secondaryTypesRemoving().

The second cache is "merged" to the first one secondaryTypesMerging().

An example for MT problems with two maps: the second "indexedSecondaryTypes" map was accessed in parallel on deleting files and while merging latest search results, resulting in https://bugs.eclipse.org/bugs/show_bug.cgi?id=567512 and refactoring in e59811a5cf43566d5300a91fc0b632e557a64348.

The current issue #1235 is coming from another MT problem around secondaryTypesMerging().

secondaryTypes() call was supposed to wait for indexer and merge found new secondary types into the main cache but had a problem that it could be entered by multiple threads in parallel and so the secondaryTypesMerging() code would run amok.

This patch tries to minimize possible MT issues accessing two caches.

- We move cache management into a dedicated SecondaryTypes class and combine two maps in a SecondaryTypesCache structure. This allows to get atomic access to both caches and also to synchronize two caches updates
code.
- The code in secondaryTypesSearching() updates the caches / returns the "known" cache from inside synchronized block.
- The entire work in secondaryTypesMerging() is done inside synchronized block.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1235