### PR TITLE
[regression] Record methods are not recognized #1258

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SourceTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SourceTypeBinding.java
@@ -2066,6 +2066,7 @@ void initializeForStaticImports() {
 
 	if (this.superInterfaces == null)
 		this.scope.connectTypeHierarchy();
+	this.scope.buildComponents();
 	this.scope.buildFields();
 	this.scope.buildMethods();
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordsRestrictedClassTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordsRestrictedClassTest.java
@@ -9418,4 +9418,22 @@ public void testBug576719() {
 		// javac options
 		JavacTestOptions.Excuse.EclipseWarningConfiguredAsError /* javac test options */);
 }
+public void testGH1258() {
+	runConformTest(
+		new String[] {
+			"Main.java",
+			"""
+			public class Main {
+				public static void main(String[] args) {
+				MyRecord test = new MyRecord(0, 0);
+				System.out.println(test.field1());
+				}
+			}
+
+			@Deprecated(since = MyRecord.STATIC_VALUE)
+			record MyRecord(int field1, int field2) {
+				public static final String STATIC_VALUE = "test";
+			}
+			"""});
+}
 }


### PR DESCRIPTION
## What it does
Fixes an omission to build record components on one execution path.

The connection to #1077 is simply, that the other PR causes the compiler to take a different - legal - execution path.

## How to test
JUnit test from #1258  is included.
