### PR TITLE
Eclipse compiler not inferring lambda parameter type in Eclipse EE 2023-09 M1 #1261

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LambdaExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LambdaExpression.java
@@ -988,6 +988,9 @@ public class LambdaExpression extends FunctionalExpression implements IPolyExpre
 				copy = copy();
 				if (copy == null)
 					throw new CopyFailureException();
+				if (InferenceContext18.DEBUG) {
+					System.out.println("Copy lambda "+this+" for target "+targetType.debugName()); //$NON-NLS-1$ //$NON-NLS-2$
+				}
 
 				copy.setExpressionContext(this.expressionContext);
 				copy.setExpectedType(targetType);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/MessageSend.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/MessageSend.java
@@ -1194,6 +1194,9 @@ public MethodBinding binding() {
 
 @Override
 public void registerInferenceContext(ParameterizedGenericMethodBinding method, InferenceContext18 infCtx18) {
+	if (InferenceContext18.DEBUG) {
+		System.out.println("Register inference context of "+this+" for "+method+":\n"+infCtx18); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+	}
 	if (this.inferenceContexts == null)
 		this.inferenceContexts = new SimpleLookupTable();
 	this.inferenceContexts.put(method, infCtx18);
@@ -1201,6 +1204,10 @@ public void registerInferenceContext(ParameterizedGenericMethodBinding method, I
 
 @Override
 public void registerResult(TypeBinding targetType, MethodBinding method) {
+	if (InferenceContext18.DEBUG) {
+		System.out.println("Register inference result for "+this+" with target "+ //$NON-NLS-1$ //$NON-NLS-2$
+				(targetType == null ? "<no type>" : targetType.debugName())+": "+method); //$NON-NLS-1$ //$NON-NLS-2$
+	}
 	if (this.solutionsPerTargetType == null)
 		this.solutionsPerTargetType = new HashMap<TypeBinding, MethodBinding>();
 	this.solutionsPerTargetType.put(targetType, method);
@@ -1208,9 +1215,13 @@ public void registerResult(TypeBinding targetType, MethodBinding method) {
 
 @Override
 public InferenceContext18 getInferenceContext(ParameterizedMethodBinding method) {
-	if (this.inferenceContexts == null)
-		return null;
-	return (InferenceContext18) this.inferenceContexts.get(method);
+	InferenceContext18 context = null;
+	if (this.inferenceContexts != null)
+		context = (InferenceContext18) this.inferenceContexts.get(method);
+	if (InferenceContext18.DEBUG) {
+		System.out.println("Retrieve inference context of "+this+" for "+method+":\n"+context); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+	}
+	return context;
 }
 @Override
 public void cleanUpInferenceContexts() {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BoundSet.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BoundSet.java
@@ -503,28 +503,33 @@ class BoundSet {
 		if (this.unincorporatedBoundsCount == 0 && this.captures.isEmpty())
 			return true;
 
-		do {
-			TypeBound [] freshBounds;
-			System.arraycopy(this.unincorporatedBounds, 0, freshBounds = new TypeBound[this.unincorporatedBoundsCount], 0, this.unincorporatedBoundsCount);
-			this.unincorporatedBoundsCount = 0;
+		try {
+			do {
+				TypeBound [] freshBounds;
+				System.arraycopy(this.unincorporatedBounds, 0, freshBounds = new TypeBound[this.unincorporatedBoundsCount], 0, this.unincorporatedBoundsCount);
+				this.unincorporatedBoundsCount = 0;
 
-			// Pairwise bidirectional compare all bounds from previous generation with the fresh set.
-			if (!incorporate(context, this.incorporatedBounds, freshBounds))
-				return false;
-			// Pairwise bidirectional compare all fresh bounds.
-			if (!incorporate(context, freshBounds, freshBounds))
-				return false;
+				// Pairwise bidirectional compare all bounds from previous generation with the fresh set.
+				if (!incorporate(context, this.incorporatedBounds, freshBounds))
+					return false;
+				// Pairwise bidirectional compare all fresh bounds.
+				if (!incorporate(context, freshBounds, freshBounds))
+					return false;
 
-			// Merge the bounds into one incorporated generation.
-			final int incorporatedLength = this.incorporatedBounds.length;
-			final int unincorporatedLength = freshBounds.length;
-			TypeBound [] aggregate = new TypeBound[incorporatedLength + unincorporatedLength];
-			System.arraycopy(this.incorporatedBounds, 0, aggregate, 0, incorporatedLength);
-			System.arraycopy(freshBounds, 0, aggregate, incorporatedLength, unincorporatedLength);
-			this.incorporatedBounds = aggregate;
+				// Merge the bounds into one incorporated generation.
+				final int incorporatedLength = this.incorporatedBounds.length;
+				final int unincorporatedLength = freshBounds.length;
+				TypeBound [] aggregate = new TypeBound[incorporatedLength + unincorporatedLength];
+				System.arraycopy(this.incorporatedBounds, 0, aggregate, 0, incorporatedLength);
+				System.arraycopy(freshBounds, 0, aggregate, incorporatedLength, unincorporatedLength);
+				this.incorporatedBounds = aggregate;
 
-		} while (this.unincorporatedBoundsCount > 0);
-
+			} while (this.unincorporatedBoundsCount > 0);
+		} finally {
+			if (InferenceContext18.DEBUG) {
+				System.out.println("Incorporated:\n"+this); //$NON-NLS-1$
+			}
+		}
 		return true;
 	}
 	/**
@@ -983,8 +988,12 @@ class BoundSet {
 	 */
 	public boolean reduceOneConstraint(InferenceContext18 context, ConstraintFormula currentConstraint) throws InferenceFailureException {
 		Object result = currentConstraint.reduce(context);
-		if (result == ReductionResult.FALSE)
+		if (result == ReductionResult.FALSE) {
+			if (InferenceContext18.DEBUG) {
+				System.out.println("Couldn't reduce constraint "+currentConstraint+ " in\n"+context); //$NON-NLS-1$ //$NON-NLS-2$
+			}
 			return false;
+		}
 		if (result == ReductionResult.TRUE)
 			return true;
 		if (result == currentConstraint) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
@@ -175,7 +175,9 @@ public class InferenceContext18 {
 	private boolean directlyAcceptingInnerBounds = false;
 	/** Not per JLS: pushing bounds from inner to outer may have to be deferred till after overload resolution, store here a runnable to perform the push. */
 	private Runnable pushToOuterJob = null;
+	// the following two flags control to what degree we continue with incomplete information:
 	private boolean isInexactVarargsInference = false;
+	boolean prematureOverloadResolution = false;
 
 	public static boolean isSameSite(InvocationSite site1, InvocationSite site2) {
 		if (site1 == site2)
@@ -2203,5 +2205,17 @@ public class InferenceContext18 {
 
 	public void setInexactVarargsInference(boolean isInexactVarargsInference) {
 		this.isInexactVarargsInference = isInexactVarargsInference;
+	}
+
+	public boolean hasPrematureOverloadResolution() {
+		if (this.prematureOverloadResolution)
+			return true;
+		if (this.seenInnerContexts != null) {
+			for (InferenceContext18 inner : this.seenInnerContexts) {
+				if (inner.hasPrematureOverloadResolution())
+					return true;
+			}
+		}
+		return false;
 	}
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
@@ -110,6 +110,8 @@ import org.eclipse.jdt.internal.compiler.util.Sorting;
  */
 public class InferenceContext18 {
 
+	public final static boolean DEBUG = false;
+
 	/** to conform with javac regarding https://bugs.openjdk.java.net/browse/JDK-8026527 */
 	static final boolean SIMULATE_BUG_JDK_8026527 = true;
 
@@ -1086,6 +1088,9 @@ public class InferenceContext18 {
 				return false;
 		}
 		this.initialConstraints = null;
+		if (DEBUG) {
+			System.out.println("reduced to\n"+this); //$NON-NLS-1$
+		}
 		return true;
 	}
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedGenericMethodBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedGenericMethodBinding.java
@@ -331,10 +331,12 @@ public class ParameterizedGenericMethodBinding extends ParameterizedMethodBindin
 						}
 					} finally {
 						infCtx18.setInexactVarargsInference(isInexactVarargsInference);
-						if (invocationSite instanceof Invocation)
-							((Invocation) invocationSite).registerInferenceContext(methodSubstitute, infCtx18); // keep context so we can finish later
-						else if (invocationSite instanceof ReferenceExpression)
-							((ReferenceExpression) invocationSite).registerInferenceContext(methodSubstitute, infCtx18); // keep context so we can finish later
+						if (!infCtx18.hasPrematureOverloadResolution()) {
+							if (invocationSite instanceof Invocation)
+								((Invocation) invocationSite).registerInferenceContext(methodSubstitute, infCtx18); // keep context so we can finish later
+							else if (invocationSite instanceof ReferenceExpression)
+								((ReferenceExpression) invocationSite).registerInferenceContext(methodSubstitute, infCtx18); // keep context so we can finish later
+						}
 					}
 					return methodSubstitute;
 				}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedGenericMethodBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedGenericMethodBinding.java
@@ -247,7 +247,13 @@ public class ParameterizedGenericMethodBinding extends ParameterizedMethodBindin
 			if (arguments.length == parameters.length) {
 				infCtx18.inferenceKind = requireBoxing ? InferenceContext18.CHECK_LOOSE : InferenceContext18.CHECK_STRICT; // engine may still slip into loose mode and adjust level.
 				infCtx18.inferInvocationApplicability(originalMethod, arguments, isDiamond);
+				if (InferenceContext18.DEBUG) {
+					System.out.println("Infer applicability for "+invocationSite+":\n"+infCtx18); //$NON-NLS-1$ //$NON-NLS-2$
+				}
 				result = infCtx18.solve(true);
+				if (InferenceContext18.DEBUG) {
+					System.out.println("Result=\n"+result); //$NON-NLS-1$
+				}
 				isInexactVarargsInference = (result != null && originalMethod.isVarargs() && !allArgumentsAreProper);
 			}
 			if (result == null && originalMethod.isVarargs()) {
@@ -255,7 +261,13 @@ public class ParameterizedGenericMethodBinding extends ParameterizedMethodBindin
 				infCtx18 = invocationSite.freshInferenceContext(scope); // start over
 				infCtx18.inferenceKind = InferenceContext18.CHECK_VARARG;
 				infCtx18.inferInvocationApplicability(originalMethod, arguments, isDiamond);
+				if (InferenceContext18.DEBUG) {
+					System.out.println("Infer varargs applicability for "+invocationSite+":\n"+infCtx18); //$NON-NLS-1$ //$NON-NLS-2$
+				}
 				result = infCtx18.solve(true);
+				if (InferenceContext18.DEBUG) {
+					System.out.println("Result=\n"+result); //$NON-NLS-1$
+				}
 			}
 			if (result == null)
 				return null;
@@ -271,6 +283,11 @@ public class ParameterizedGenericMethodBinding extends ParameterizedMethodBindin
 				// ---- 18.5.2 (Invocation type): ----
 				provisionalResult = result;
 				result = infCtx18.inferInvocationType(expectedType, invocationSite, originalMethod);
+				if (InferenceContext18.DEBUG) {
+					System.out.println("Infer invocation type for "+invocationSite+ " with target " //$NON-NLS-1$ //$NON-NLS-2$
+							+(expectedType == null ? "<no type>" : expectedType.debugName())); //$NON-NLS-1$
+					System.out.println("Result=\n"+result); //$NON-NLS-1$
+				}
 				invocationTypeInferred = infCtx18.stepCompleted == InferenceContext18.TYPE_INFERRED_FINAL;
 				hasReturnProblem |= result == null;
 				if (hasReturnProblem)
@@ -281,12 +298,18 @@ public class ParameterizedGenericMethodBinding extends ParameterizedMethodBindin
 				TypeBinding[] solutions = infCtx18.getSolutions(typeVariables, invocationSite, result);
 				if (solutions != null) {
 					methodSubstitute = scope.environment().createParameterizedGenericMethod(originalMethod, solutions, infCtx18.usesUncheckedConversion, hasReturnProblem, expectedType);
+					if (InferenceContext18.DEBUG) {
+						System.out.println("Method substitute: "+methodSubstitute); //$NON-NLS-1$
+					}
 					if (invocationSite instanceof Invocation && allArgumentsAreProper && (expectedType == null || expectedType.isProperType(true)))
 						infCtx18.forwardResults(result, (Invocation) invocationSite, methodSubstitute, expectedType);
 					try {
 						if (hasReturnProblem) { // illegally working from the provisional result?
 							MethodBinding problemMethod = infCtx18.getReturnProblemMethodIfNeeded(expectedType, methodSubstitute);
 							if (problemMethod instanceof ProblemMethodBinding) {
+								if (InferenceContext18.DEBUG) {
+									System.out.println("Inference reports problem method "+problemMethod); //$NON-NLS-1$
+								}
 								return problemMethod;
 							}
 						}
@@ -295,10 +318,16 @@ public class ParameterizedGenericMethodBinding extends ParameterizedMethodBindin
 								NullAnnotationMatching.checkForContradictions(methodSubstitute, invocationSite, scope);
 							MethodBinding problemMethod = methodSubstitute.boundCheck18(scope, arguments, invocationSite);
 							if (problemMethod != null) {
+								if (InferenceContext18.DEBUG) {
+									System.out.println("Bound check after inference failed: "+problemMethod); //$NON-NLS-1$
+								}
 								return problemMethod;
 							}
 						} else {
 							methodSubstitute = new PolyParameterizedGenericMethodBinding(methodSubstitute);
+							if (InferenceContext18.DEBUG) {
+								System.out.println("PolyParameterizedGenericMethodBinding: "+methodSubstitute); //$NON-NLS-1$
+							}
 						}
 					} finally {
 						infCtx18.setInexactVarargsInference(isInexactVarargsInference);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Scope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Scope.java
@@ -4674,6 +4674,16 @@ public abstract class Scope {
 				return new ProblemMethodBinding(visible[0], visible[0].selector, visible[0].parameters, ProblemReasons.Ambiguous);
 			} else if (count == 1) {
 				MethodBinding candidate = moreSpecific[0];
+				if (visibleSize > 1 && candidate instanceof ParameterizedMethodBinding && invocationSite instanceof MessageSend) {
+					for (TypeBinding typeBinding : argumentTypes) {
+						if (!typeBinding.isProperType(true)) {
+							InferenceContext18 ic18 = ((MessageSend) invocationSite).getInferenceContext((ParameterizedMethodBinding) candidate);
+							if (ic18 != null)
+								ic18.prematureOverloadResolution = true;
+							break;
+						}
+					}
+				}
 				if (candidate != null)
 					compilationUnitScope().recordTypeReferences(candidate.thrownExceptions);
 				return candidate;

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_1_8.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_1_8.java
@@ -10448,4 +10448,51 @@ public void testBug508834_comment0() {
 			}
 		);
 	}
+	public void testGH1261() {
+		runConformTest(
+			new String[] {
+				"GH1261.java",
+				"""
+				import java.io.IOException;
+				import java.util.AbstractMap;
+				import java.util.function.BiConsumer;
+				import java.util.Collections;
+				import java.util.Map;
+
+				class Matcher<T extends Object> {}
+
+				public class GH1261 {
+					private static final Map<String, String> PARAMETER_VALUE_STRINGS_BY_VALUE = Collections.emptyMap();
+
+					public void testParameterAppendValueTo() throws IOException {
+						PARAMETER_VALUE_STRINGS_BY_VALUE.forEach(throwingBiConsumer((value, valueString) -> {
+							assertThat(Parameter.appendValueTo(new StringBuilder(), value).toString(), is(valueString));
+						}));
+					}
+					public static <T, R, X extends Throwable> ThrowingBiConsumer<T, R, X> throwingBiConsumer(
+							final ThrowingBiConsumer<T, R, X> consumer) {
+						return consumer;
+					}
+					public static <T extends java.lang.Object> Matcher<T> is(Matcher<T> m) { return null; }
+					public static <T extends java.lang.Object> Matcher<T> is(T t) { return null; }
+
+					public static <T extends java.lang.Object> void assertThat(T t, Matcher<? super T> m) { }
+					// original has overloads of assertThat, which are not relevant here
+				}
+				interface ThrowingBiConsumer<T, U, X extends Throwable> extends BiConsumer<T, U> {
+					void tryAccept(T t, U u) throws X;
+					default void accept(final T t, final U u) { }
+				}
+				@SuppressWarnings("serial")
+				final class Parameter extends AbstractMap.SimpleImmutableEntry<String, String> {
+					public static <A extends Appendable> A appendValueTo(final A appendable, CharSequence parameterValue) throws IOException {
+						return appendable;
+					}
+					public Parameter(final String name, final String value) {
+						super("", "");
+					}
+				}
+				"""
+			});
+	}
 }


### PR DESCRIPTION
## What it does

Avoid re-using an inference context that was built with information from a premature overload resolution (i.e., overload resolution based on improper argument types).

## How to test

JUnit test is included.
