### PR TITLE
Indexer: more robust

### DIFF
--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/IndexManager.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/IndexManager.java
@@ -832,8 +832,8 @@ protected synchronized void moveToNextJob() {
  * No more job awaiting.
  */
 @Override
-protected void notifyIdle(long idlingTime){
-	if (idlingTime > INDEX_MANAGER_NOTIFY_IDLE_WAIT && this.needToSave) saveIndexes();
+protected void notifyIdle(long idlingMilliSeconds){
+	if (idlingMilliSeconds > INDEX_MANAGER_NOTIFY_IDLE_WAIT && this.needToSave) saveIndexes();
 }
 /**
  * Name of the background process
@@ -1738,13 +1738,9 @@ public Optional<MetaIndex> getMetaIndex() {
 
 void scheduleForMetaIndexUpdate(Index index) {
 	synchronized(this.metaIndexUpdates){
-		if (this.metaIndexUpdates.contains(index)) {
-			if (VERBOSE) {
-				Util.verbose("-> already waiting for meta-index update for " + index); //$NON-NLS-1$
-			}
-			return;
+		if (!this.metaIndexUpdates.add(index) && VERBOSE) {
+			Util.verbose("-> already waiting for meta-index update for " + index); //$NON-NLS-1$
 		}
-		this.metaIndexUpdates.add(index);
 	}
 	requestIfNotWaiting(new MetaIndexUpdateRequest());
 }


### PR DESCRIPTION
* use monotonic nanotime
* avoid deadlock if notifyIdle() requested new job

