### PR TITLE
Don't try to persist null classpath entries or attributes

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelManager.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelManager.java
@@ -4543,20 +4543,43 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 
 		private void saveAttributes(IClasspathAttribute[] attributes)
 				throws IOException {
-			int count = attributes == null ? 0 : attributes.length;
+			int count = 0;
+			if (attributes != null) {
+				for (IClasspathAttribute attr : attributes) {
+					if (attr != null) {
+						count ++;
+					}
+				}
+			}
 
 			saveInt(count);
-			for (int i = 0; i < count; ++i)
-				saveAttribute(attributes[i]);
+
+			for (IClasspathAttribute attribute : attributes) {
+				if (attribute != null) {
+					saveAttribute(attribute);
+				}
+			}
 		}
 
 		private void saveClasspathEntries(IClasspathEntry[] entries)
 				throws IOException {
-			int count = entries == null ? 0 : entries.length;
+
+			int count = 0;
+			if (entries != null) {
+				for (IClasspathEntry entry : entries) {
+					if (entry != null) {
+						count ++;
+					}
+				}
+			}
 
 			saveInt(count);
-			for (int i = 0; i < count; ++i)
-				saveClasspathEntry(entries[i]);
+
+			for (IClasspathEntry entry : entries) {
+				if (entry != null) {
+					saveClasspathEntry(entry);
+				}
+			}
 		}
 
 		private void saveClasspathEntry(IClasspathEntry entry)


### PR DESCRIPTION
... by not doing so we break workspace save.

The problem with containers is that they can be contributed by 3rd party or computed dynamically and we can't control what they return if something breaks like in
https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/702.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1284
