### PR TITLE
fix IllegalArgumentException in InfixExpression on LHS #316

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.compiler.batch/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Main-Class: org.eclipse.jdt.internal.compiler.batch.Main
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse Compiler for Java(TM)
 Bundle-SymbolicName: org.eclipse.jdt.core.compiler.batch
-Bundle-Version: 3.35.0.qualifier
+Bundle-Version: 3.35.100.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: Eclipse.org
 Automatic-Module-Name: org.eclipse.jdt.core.compiler.batch

--- a/org.eclipse.jdt.core.compiler.batch/forceQualifierUpdate.txt
+++ b/org.eclipse.jdt.core.compiler.batch/forceQualifierUpdate.txt
@@ -1,1 +1,2 @@
 Comparator errors in I20230607-0720
+Build error

--- a/org.eclipse.jdt.core.compiler.batch/pom.xml
+++ b/org.eclipse.jdt.core.compiler.batch/pom.xml
@@ -17,7 +17,7 @@
     <version>4.29.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.eclipse.jdt.core.compiler.batch</artifactId>
-  <version>3.35.0-SNAPSHOT</version>
+  <version>3.35.100-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ASTNode.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ASTNode.java
@@ -108,7 +108,7 @@ public abstract class ASTNode implements TypeConstants, TypeIds {
 	public final static int Bit11 = 0x400;				// depth (name ref, msg) | operator (operator) | is member type (type decl)
 	public final static int Bit12 = 0x800;				// depth (name ref, msg) | operator (operator) | has abstract methods (type decl)
 	public final static int Bit13 = 0x1000;			// depth (name ref, msg) | operator (operator) | is secondary type (type decl)
-	public final static int Bit14 = 0x2000;			// strictly assigned (reference lhs) | operator (operator) | discard enclosing instance (explicit constr call) | hasBeenGenerated (type decl)
+	public final static int Bit14 = 0x2000;			// strictly assigned (reference lhs) | discard enclosing instance (explicit constr call) | hasBeenGenerated (type decl)
 	public final static int Bit15 = 0x4000;			// is unnecessary cast (expression) | is varargs (type ref) | isSubRoutineEscaping (try statement) | superAccess (javadoc allocation expression/javadoc message send/javadoc return statement)
 	public final static int Bit16 = 0x8000;			// in javadoc comment (name ref, type ref, msg)
 	public final static int Bit17 = 0x10000;			// compound assigned (reference lhs) | unchecked (msg, alloc, explicit constr call)
@@ -167,7 +167,7 @@ public abstract class ASTNode implements TypeConstants, TypeIds {
 	// for operators
 	public static final int ReturnTypeIDMASK = Bit1|Bit2|Bit3|Bit4;
 	public static final int OperatorSHIFT = 8;	// Bit9 -> Bit14
-	public static final int OperatorMASK = Bit9|Bit10|Bit11|Bit12|Bit13|Bit14; // 6 bits for operator ID
+	public static final int OperatorMASK = Bit9|Bit10|Bit11|Bit12|Bit13; // 5 bits for operator ID - see org.eclipse.jdt.internal.compiler.ast.OperatorIds
 
 	// for binary expressions
 	public static final int IsReturnedValue = Bit5;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/OperatorIds.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/OperatorIds.java
@@ -36,11 +36,11 @@ public interface OperatorIds {
 	public static final int UNSIGNED_RIGHT_SHIFT= 19;
 	public static final int NumberOfTables = 20;
 
-	public static final int QUESTIONCOLON = 23;
+	public static final int QUESTIONCOLON = 21;
 
-	public static final int NOT_EQUAL = 29;
-	public static final int EQUAL = 30;
-	public static final int INSTANCEOF = 31;
-	public static final int PLUS_PLUS = 32;
-	public static final int MINUS_MINUS = 33;
+	public static final int NOT_EQUAL = 22;
+	public static final int EQUAL = 23;
+	public static final int INSTANCEOF = 24;
+	public static final int PLUS_PLUS = 25;
+	public static final int MINUS_MINUS = 26;
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/BatchCompilerTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/BatchCompilerTest.java
@@ -13469,4 +13469,53 @@ public void testIssue89_5() {
 				"error: warnings found and -failOnWarning specified\n",
 				true);
 }
+
+public void testGitHub316(){
+	this.runNegativeTest(
+		new String[] {
+			"X.java",
+			"public class X {\n" +
+					"void m() { (1+2) = 3; }"+// was IllegalArgumentException in InfixExpression#setOperator
+			"}"},
+        "\"" + OUTPUT_DIR +  File.separator +
+        	"X.java\"",
+		"",
+		"----------\n"
+		+ "1. ERROR in ---OUTPUT_DIR_PLACEHOLDER---/X.java (at line 2)\n"
+		+ "	void m() { (1+2) = 3; }}\n"
+		+ "	           ^^^^^\n"
+		+ "The left-hand side of an assignment must be a variable\n"
+		+ "----------\n"
+		+ "1 problem (1 error)\n"
+		+ "",
+		true);
+}
+public void testGitHub1122(){
+	this.runNegativeTest(
+		new String[] {
+			"X.java",
+			"public class X {\n" +
+					"void m() {"
+					+ ".a() >0);"// was IllegalArgumentException in InfixExpression#setOperator
+					+ " }"+
+			"}"},
+        "\"" + OUTPUT_DIR +  File.separator +
+        	"X.java\"",
+		"",
+		"----------\n"
+		+ "1. ERROR in ---OUTPUT_DIR_PLACEHOLDER---/X.java (at line 2)\n"
+		+ "	void m() {.a() >0); }}\n"
+		+ "	          ^\n"
+		+ "Syntax error on token \".\", invalid (\n"
+		+ "----------\n"
+		+ "2. ERROR in ---OUTPUT_DIR_PLACEHOLDER---/X.java (at line 2)\n"
+		+ "	void m() {.a() >0); }}\n"
+		+ "	                 ^\n"
+		// XXX ASTParser instead reports "The left-hand side of an assignment must be a variable":
+		+ "Syntax error, insert \"AssignmentOperator Expression\" to complete Expression\n"
+		+ "----------\n"
+		+ "2 problems (2 errors)\n"
+		+ "",
+		true);
+}
 }

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ASTConverter.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ASTConverter.java
@@ -4801,8 +4801,14 @@ class ASTConverter {
 				return InfixExpression.Operator.GREATER;
 			case org.eclipse.jdt.internal.compiler.ast.OperatorIds.LESS :
 				return InfixExpression.Operator.LESS;
+			case org.eclipse.jdt.internal.compiler.ast.OperatorIds.NumberOfTables :
+			case org.eclipse.jdt.internal.compiler.ast.OperatorIds.QUESTIONCOLON :
+			case org.eclipse.jdt.internal.compiler.ast.OperatorIds.INSTANCEOF :
+			case org.eclipse.jdt.internal.compiler.ast.OperatorIds.PLUS_PLUS :
+			case org.eclipse.jdt.internal.compiler.ast.OperatorIds.MINUS_MINUS :
+				throw new IllegalArgumentException("Not an InfixExpression: operatorID="+operatorID+ " MINUS_MINUS="+org.eclipse.jdt.internal.compiler.ast.OperatorIds.MINUS_MINUS ); //$NON-NLS-1$ //$NON-NLS-2$
 		}
-		return null;
+		throw new IllegalArgumentException("unknown operatorID="+operatorID+ " MINUS_MINUS="+org.eclipse.jdt.internal.compiler.ast.OperatorIds.MINUS_MINUS ); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
 	protected PrimitiveType.Code getPrimitiveTypeCode(char[] name) {


### PR DESCRIPTION
A "+" Operator (OperatorId 14) was using
OperatorID 14+32 (+ the IsStrictlyAssigned Bit)

https://github.com/eclipse-jdt/eclipse.jdt.core/issues/316
