### PR TITLE
Bump tests required jdt.core version to require latest jdt.core

### DIFF
--- a/org.eclipse.jdt.compiler.apt.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.compiler.apt.tests/META-INF/MANIFEST.MF
@@ -9,7 +9,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.junit,
  org.eclipse.core.resources,
  org.eclipse.core.runtime,
- org.eclipse.jdt.core.compiler.batch;bundle-version="3.34.0"
+ org.eclipse.jdt.core.compiler.batch;bundle-version="3.35.0"
 Export-Package: org.eclipse.jdt.compiler.apt.tests,
  org.eclipse.jdt.compiler.apt.tests.annotations,
  org.eclipse.jdt.compiler.apt.tests.processors.base,

--- a/org.eclipse.jdt.compiler.tool.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.compiler.tool.tests/META-INF/MANIFEST.MF
@@ -6,7 +6,7 @@ Bundle-Version: 1.4.100.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-17
-Require-Bundle: org.eclipse.jdt.core;bundle-version="3.34.0",
+Require-Bundle: org.eclipse.jdt.core;bundle-version="3.35.0",
  org.junit,
  org.eclipse.core.resources,
  org.eclipse.core.runtime,

--- a/org.eclipse.jdt.core.tests.builder/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.tests.builder/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jdt.core.tests.builder
 Require-Bundle: org.junit;bundle-version="3.8.1",
- org.eclipse.jdt.core;bundle-version="[3.34.0,4.0.0)",
+ org.eclipse.jdt.core;bundle-version="[3.35.0,4.0.0)",
  org.eclipse.jdt.core.tests.compiler;bundle-version="[3.4.0,4.0.0)",
  org.eclipse.core.resources;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",

--- a/org.eclipse.jdt.core.tests.compiler/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.tests.compiler/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.core.tests.compiler;singleton:=true
-Bundle-Version: 3.13.50.qualifier
+Bundle-Version: 3.13.100.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jdt.core.tests.compiler,
@@ -17,7 +17,7 @@ Export-Package: org.eclipse.jdt.core.tests.compiler,
  org.eclipse.jdt.core.tests.util
 Require-Bundle: org.junit;bundle-version="3.8.1",
  org.eclipse.jdt.debug;bundle-version="[3.2.0,4.0.0)",
- org.eclipse.jdt.core;bundle-version="[3.34.0,4.0.0)",
+ org.eclipse.jdt.core;bundle-version="[3.35.0,4.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
  org.eclipse.test.performance;bundle-version="[3.10.0,4.0.0)",
  org.eclipse.core.resources;bundle-version="[3.2.0,4.0.0)",

--- a/org.eclipse.jdt.core.tests.compiler/pom.xml
+++ b/org.eclipse.jdt.core.tests.compiler/pom.xml
@@ -19,7 +19,7 @@
     <relativePath>../tests-pom/</relativePath>
   </parent>
   <artifactId>org.eclipse.jdt.core.tests.compiler</artifactId>
-  <version>3.13.50-SNAPSHOT</version>
+  <version>3.13.100-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>

--- a/org.eclipse.jdt.core.tests.model/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.tests.model/META-INF/MANIFEST.MF
@@ -15,7 +15,7 @@ Export-Package: org.eclipse.jdt.core.tests,
  org.eclipse.jdt.core.tests.rewrite.modifying
 Require-Bundle: org.eclipse.core.resources;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
- org.eclipse.jdt.core;bundle-version="[3.34.0,4.0.0)",
+ org.eclipse.jdt.core;bundle-version="[3.35.0,4.0.0)",
  org.junit;bundle-version="3.8.1",
  org.eclipse.test.performance;bundle-version="[3.1.0,4.0.0)",
  org.eclipse.jdt.core.tests.compiler;bundle-version="[3.4.0,4.0.0)",


### PR DESCRIPTION
See comments on
https://github.com/eclipse-jdt/eclipse.jdt.core/pull/1286
