### PR TITLE
Log exceptions that occurred while indexing using Util.log(...)

### DIFF
--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/AbstractIndexer.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/AbstractIndexer.java
@@ -25,6 +25,7 @@ import org.eclipse.jdt.internal.core.search.matching.MethodPattern;
 import org.eclipse.jdt.internal.core.search.matching.ModulePattern;
 import org.eclipse.jdt.internal.core.search.matching.SuperTypeReferencePattern;
 import org.eclipse.jdt.internal.core.search.matching.TypeDeclarationPattern;
+import org.eclipse.jdt.internal.core.util.Util;
 
 public abstract class AbstractIndexer implements IIndexConstants {
 
@@ -209,7 +210,7 @@ public abstract class AbstractIndexer implements IIndexConstants {
 							typeModifiers,
 							extraFlags));
 		} catch (Exception e) {
-			e.printStackTrace();
+			Util.log(e);
 		}
 	}
 


### PR DESCRIPTION
## What it does
Log exceptions in package `org.eclipse.jdt.internal.core.search.indexing` using `Util.log(...)` instead of `printStackTrace`. In most cases, the logging will only take place if `JobManager.VERBOSE == true` which makes these changes _opt-in_.

Contributes to https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1303

## How to test

### Activate the `VERBOSE`-mode int `JobManager` 
* Add this to the *VM-Args* of the _Run/Debug Configuration_ of **sdk.product**: `-Dosgi.debug`
* Create/Edit `<ECLIPSE_ROOT>\.options` and add: 
```properties
# Turn on debugging
# This needs to be "true" in order to enable other DEBUG/VERBOSE flags below
org.eclipse.jdt.core/debug=true

#JobManager.VERBOSE
org.eclipse.jdt.core/debug/indexmanager=true
```

## A small hack to test it: randomly throw a `RuntimeException`
* Add this at the bottom of `org.eclipse.jdt.internal.core.search.indexing.SourceIndexer.indexDocument()` :
```java
@Override
public void indexDocument() {
	...
	
	try {
		// Add this line
		if (Math.random() > 0.5) throw new RuntimeException("This should be logged into the log file");
		
		...
	} catch (Exception e) {
		if (JobManager.VERBOSE) {
			Util.log(e);
		}
	}
}
```
* Run **sdk.product**.
* Open/Create a java project.
* Create/Edit some class, save it, repeat.

You should start seeing errors like this one in the log file:
```java
!ENTRY org.eclipse.jdt.core 4 0 2023-08-22 10:10:03.886
!MESSAGE Unexpected internal error
!STACK 0
java.lang.RuntimeException: This should be logged into the log file
	at org.eclipse.jdt.internal.core.search.indexing.SourceIndexer.indexDocument(SourceIndexer.java:116)
	at org.eclipse.jdt.internal.core.search.JavaSearchParticipant.indexDocument(JavaSearchParticipant.java:83)
	at org.eclipse.jdt.internal.core.search.indexing.IndexManager.indexDocument(IndexManager.java:674)
	at org.eclipse.jdt.internal.core.search.indexing.IndexManager$2.execute(IndexManager.java:1287)
	at org.eclipse.jdt.internal.core.search.processing.JobManager.indexerLoop(JobManager.java:527)
	at java.base/java.lang.Thread.run(Thread.java:833)
```

... and also entries like this one in the **Error Log** view:
![image](https://github.com/eclipse-jdt/eclipse.jdt.core/assets/2205684/9260c3fb-9f7f-4c0c-97f3-0518b36ed09a)



## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
