### PR TITLE
2623 test fails in jdt.core.tests.model in I20230823-1800

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AbstractJavaModelCompletionTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AbstractJavaModelCompletionTests.java
@@ -181,7 +181,9 @@ protected void setUp() throws Exception {
 }
 @Override
 public void tearDownSuite() throws Exception {
-	JavaCore.setOptions(this.oldOptions);
+	if (this.oldOptions != null) {
+		JavaCore.setOptions(this.oldOptions);
+	}
 	this.oldOptions = null;
 	if (COMPLETION_SUITES == null) {
 		deleteProject("Completion");

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AbstractJavaModelTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AbstractJavaModelTests.java
@@ -2057,6 +2057,10 @@ public abstract class AbstractJavaModelTests extends SuiteOfTestCases {
 		final IJavaProject[] result = new IJavaProject[1];
 		IWorkspaceRunnable create = new IWorkspaceRunnable() {
 			public void run(IProgressMonitor monitor) throws CoreException {
+
+				// Always delete first, in case there is a leftover from some broken test
+				deleteProject(projectName);
+
 				// create project
 				if (locationURI != null)
 					createExternalProject(projectName, locationURI);

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/NamingConventionTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/NamingConventionTests.java
@@ -53,7 +53,9 @@ public void setUp() throws Exception {
  */
 @Override
 public void tearDown() throws Exception {
-	JavaCore.setOptions(this.oldOptions);
+	if (this.oldOptions != null) {
+		JavaCore.setOptions(this.oldOptions);
+	}
 
 	this.deleteProject("P"); //$NON-NLS-1$
 

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/rewrite/modifying/ASTRewritingModifyingTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/rewrite/modifying/ASTRewritingModifyingTest.java
@@ -92,9 +92,14 @@ public abstract class ASTRewritingModifyingTest extends AbstractJavaModelTests {
 
 	@Override
 	public void tearDownSuite() throws Exception {
-		deleteProject("P");
-		JavaCore.setOptions(this.oldOptions);
-		super.tearDownSuite();
+		try {
+			deleteProject("P");
+		} finally {
+			if (this.oldOptions != null) {
+				JavaCore.setOptions(this.oldOptions);
+			}
+			super.tearDownSuite();
+		}
 	}
 
 	@Override


### PR DESCRIPTION
Try to delete (possible existing) project before creating new one - it could be left over from previous failed test that didn't properly run cleanup.

Also don't pass "null oldOptions" to JavaCore.setOptions() on teardown - in case setup was not successful, we might don't restor options as expected

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1307
