### PR TITLE
[21] ECJ accepts code that has a boolean false constant in the pattern guard

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/core/compiler/IProblem.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/core/compiler/IProblem.java
@@ -8,6 +8,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     IBM Corporation - added the following constants
@@ -2538,8 +2542,14 @@ void setSourceStart(int sourceStart);
 	/**
 	 * @since 3.32
 	 * @noreference preview feature
+	 * @deprecated
 	 */
 	int RawTypeInRecordPattern =  PreviewRelated + 1915;
+	/**
+	 * @since 3.35
+	 * @noreference preview feature
+	 */
+	int FalseConstantInGuard =  PreviewRelated + 1916;
 	/**
 	 * @since 3.34
 	 * @noreference preview feature

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/GuardedPattern.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/GuardedPattern.java
@@ -108,7 +108,7 @@ public class GuardedPattern extends Pattern {
 	}
 	@Override
 	public boolean coversType(TypeBinding type) {
-		return this.primaryPattern.coversType(type);
+		return this.primaryPattern.coversType(type) && isAlwaysTrue();
 	}
 	@Override
 	public Pattern primary() {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/GuardedPattern.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/GuardedPattern.java
@@ -26,6 +26,7 @@ import org.eclipse.jdt.internal.compiler.impl.Constant;
 import org.eclipse.jdt.internal.compiler.lookup.BlockScope;
 import org.eclipse.jdt.internal.compiler.lookup.LocalVariableBinding;
 import org.eclipse.jdt.internal.compiler.lookup.TypeBinding;
+import org.eclipse.jdt.internal.compiler.lookup.TypeIds;
 
 public class GuardedPattern extends Pattern {
 
@@ -78,7 +79,6 @@ public class GuardedPattern extends Pattern {
 				this.thenTarget,
 				null,
 				cst == Constant.NotAConstant);
-//		codeStream.goto_(this.elseTarget);
 		if (this.thenInitStateIndex2 != -1) {
 			codeStream.removeNotDefinitelyAssignedVariables(currentScope, this.thenInitStateIndex2);
 			codeStream.addDefinitelyAssignedVariables(currentScope, this.thenInitStateIndex2);
@@ -108,7 +108,7 @@ public class GuardedPattern extends Pattern {
 	}
 	@Override
 	public boolean coversType(TypeBinding type) {
-		return this.primaryPattern.coversType(type) && isAlwaysTrue();
+		return this.primaryPattern.coversType(type);
 	}
 	@Override
 	public Pattern primary() {
@@ -136,6 +136,10 @@ public class GuardedPattern extends Pattern {
 		// the implicitConversion code is set properly and thus the correct
 		// unboxing calls are generated.
 		this.condition.resolveTypeExpecting(scope, TypeBinding.BOOLEAN);
+		Constant cst = this.condition.optimizedBooleanConstant();
+		if (cst.typeID() == TypeIds.T_boolean && cst.booleanValue() == false) {
+			scope.problemReporter().falseLiteralInGuard(this.condition);
+		}
 		LocalDeclaration PatternVar = this.primaryPattern.getPatternVariable();
 		LocalVariableBinding lvb = PatternVar == null ? null : PatternVar.binding;
 		this.condition.traverse(new ASTVisitor() {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
@@ -1293,12 +1293,9 @@ public class SwitchStatement extends Expression {
 								} else {
 									if (!c.isPattern() && check.test(j)) {
 										if (this.isNonTraditional) {
-											boolean reportDup = true;
-											if (c.e instanceof NullLiteral || this.otherConstants[j].e instanceof NullLiteral) {
-												reportDup = c.e instanceof NullLiteral && this.otherConstants[j].e instanceof NullLiteral;
+											if (c.e instanceof NullLiteral && this.otherConstants[j].e instanceof NullLiteral) {
+												reportDuplicateCase(c.e, this.otherConstants[j].e, length);
 											}
-											if (reportDup)
-											reportDuplicateCase(c.e, this.otherConstants[j].e, length);
 										} else {
 											reportDuplicateCase(caseStmt, this.cases[caseIndex[j]], length);
 										}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
@@ -8,6 +8,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Benjamin Muskalla - Contribution for bug 239066
@@ -12465,5 +12469,13 @@ public void cannotInferRecordPatternTypes(RecordPattern pattern) {
 			arguments,
 			pattern.sourceStart,
 			pattern.sourceEnd);
+}
+public void falseLiteralInGuard(Expression exp) {
+	this.handle(
+			IProblem.FalseConstantInGuard,
+			NoArgument,
+			NoArgument,
+			exp.sourceStart,
+			exp.sourceEnd);
 }
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/messages.properties
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/messages.properties
@@ -1134,7 +1134,7 @@
 1866 = Sealed type {2} and sub type {0} in an unnamed module should be declared in the same package {1}
 1867 = Sealed type {1} cannot be super type of {0} as it is from a different package or split package or module
 
-# Switch Patterns - Java 20 - JEP 432 - preview
+# Switch Patterns - Java 21
 1900 = Local variable {0} referenced from a guard must be final or effectively final
 1901 = Constant case label elements and pattern case label elements cannot be present in a switch label
 1902 = Illegal fall-through to a pattern
@@ -1151,10 +1151,11 @@
 1921 = A 'default' can occur after 'case' only as a second case label expression and that too only if 'null' precedes  in 'case null, default' 
 1922 = Illegal fall-through from a case label pattern
 
-# Record patterns = Java 19 JEP 405 preview
+# Record patterns = Java 21
 1912 = Only record types are permitted in a record pattern
 1913 = Record pattern should match the signature of the record declaration
 1914 = Pattern of type {0} is not compatible with type {1}
+1916 = A case label guard cannot have a constant expression with value as 'false'
 1940 = Cannot infer record pattern types for {0}
 
 1990 = Access to {1}({2}) from the type {0} is emulated by a synthetic accessor method

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/CompilerInvocationTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/CompilerInvocationTests.java
@@ -1321,6 +1321,7 @@ public void test011_problem_categories() {
 	    expectedProblemAttributes.put("RecordPatternMismatch", new ProblemAttributes(true));
 	    expectedProblemAttributes.put("PatternTypeMismatch", new ProblemAttributes(true));
 	    expectedProblemAttributes.put("RawTypeInRecordPattern", new ProblemAttributes(true));
+	    expectedProblemAttributes.put("FalseConstantInGuard", new ProblemAttributes(true));
 	    expectedProblemAttributes.put("CannotInferRecordPatternTypes", new ProblemAttributes(true));
 	    expectedProblemAttributes.put("ClassExtendFinalRecord", new ProblemAttributes(CategorizedProblem.CAT_TYPE));
 	    expectedProblemAttributes.put("RecordErasureIncompatibilityInCanonicalConstructor", new ProblemAttributes(CategorizedProblem.CAT_TYPE));
@@ -2419,6 +2420,7 @@ public void test012_compiler_problems_tuning() {
 	    expectedProblemAttributes.put("RecordPatternMismatch", SKIP);
 	    expectedProblemAttributes.put("PatternTypeMismatch", SKIP);
 	    expectedProblemAttributes.put("RawTypeInRecordPattern", SKIP);
+	    expectedProblemAttributes.put("FalseConstantInGuard", SKIP);
 	    expectedProblemAttributes.put("CannotInferRecordPatternTypes", SKIP);
 	    expectedProblemAttributes.put("ClassExtendFinalRecord", SKIP);
 	    expectedProblemAttributes.put("RecordErasureIncompatibilityInCanonicalConstructor", SKIP);

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordPatternTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordPatternTest.java
@@ -3454,4 +3454,52 @@ public class RecordPatternTest extends AbstractRegressionTest9 {
 			"An enhanced switch statement should be exhaustive; a default label expected\n" +
 			"----------\n");
 	}
+	public void testIssue1328() {
+		runNegativeTest(
+				new String[] {
+					"X.java",
+					"public class X {\n"+
+					"    public int foo(Object o) {\n"+
+					"        return switch (o) {\n"+
+					"            case String s when false -> 1;\n"+
+					"            case String s when true != true -> 2;\n"+
+					"            case String s when false == true -> 3;\n"+
+					"            case String s when 0 != 0 -> 3;\n"+
+					"            default -> 0;\n"+
+					"        };\n"+
+					"    }\n"+
+					"}",
+				},
+				"----------\n" +
+				"1. ERROR in X.java (at line 4)\n" +
+				"	case String s when false -> 1;\n" +
+				"	                   ^^^^^\n" +
+				"A case label guard cannot have a constant expression with value as \'false\'\n" +
+				"----------\n" +
+				"2. WARNING in X.java (at line 5)\n" +
+				"	case String s when true != true -> 2;\n" +
+				"	                   ^^^^^^^^^^^^\n" +
+				"Comparing identical expressions\n" +
+				"----------\n" +
+				"3. ERROR in X.java (at line 5)\n" +
+				"	case String s when true != true -> 2;\n" +
+				"	                   ^^^^^^^^^^^^\n" +
+				"A case label guard cannot have a constant expression with value as \'false\'\n" +
+				"----------\n" +
+				"4. ERROR in X.java (at line 6)\n" +
+				"	case String s when false == true -> 3;\n" +
+				"	                   ^^^^^^^^^^^^^\n" +
+				"A case label guard cannot have a constant expression with value as \'false\'\n" +
+				"----------\n" +
+				"5. WARNING in X.java (at line 7)\n" +
+				"	case String s when 0 != 0 -> 3;\n" +
+				"	                   ^^^^^^\n" +
+				"Comparing identical expressions\n" +
+				"----------\n" +
+				"6. ERROR in X.java (at line 7)\n" +
+				"	case String s when 0 != 0 -> 3;\n" +
+				"	                   ^^^^^^\n" +
+				"A case label guard cannot have a constant expression with value as \'false\'\n" +
+				"----------\n");
+	}
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordPatternTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordPatternTest.java
@@ -3454,7 +3454,7 @@ public class RecordPatternTest extends AbstractRegressionTest9 {
 			"An enhanced switch statement should be exhaustive; a default label expected\n" +
 			"----------\n");
 	}
-	public void testIssue1328() {
+	public void testIssue1328_1() {
 		runNegativeTest(
 				new String[] {
 					"X.java",
@@ -3500,6 +3500,29 @@ public class RecordPatternTest extends AbstractRegressionTest9 {
 				"	case String s when 0 != 0 -> 3;\n" +
 				"	                   ^^^^^^\n" +
 				"A case label guard cannot have a constant expression with value as \'false\'\n" +
+				"----------\n");
+	}
+	public void testIssue1328_2() {
+		runNegativeTest(
+				new String[] {
+					"X.java",
+					"public class X {\n"
+					+ "    public int foo(Character c) {\n"
+					+ "        int result = 0;\n"
+					+ "        switch (c) {\n"
+					+ "            case Character p when p.equals(\"c\") -> {\n"
+					+ "                result = 6;\n"
+					+ "            }\n"
+					+ "        };\n"
+					+ "        return result;\n"
+					+ "    }\n"
+					+ "}",
+				},
+				"----------\n" +
+				"1. ERROR in X.java (at line 4)\n" +
+				"	switch (c) {\n" +
+				"	        ^\n" +
+				"An enhanced switch statement should be exhaustive; a default label expected\n" +
 				"----------\n");
 	}
 }


### PR DESCRIPTION

#1328

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
Fixes Issue #1328 

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
