### PR TITLE
[21] Pattern variable not reported as final when dereferenced

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/GuardedPattern.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/GuardedPattern.java
@@ -140,15 +140,13 @@ public class GuardedPattern extends Pattern {
 		if (cst.typeID() == TypeIds.T_boolean && cst.booleanValue() == false) {
 			scope.problemReporter().falseLiteralInGuard(this.condition);
 		}
-		LocalDeclaration PatternVar = this.primaryPattern.getPatternVariable();
-		LocalVariableBinding lvb = PatternVar == null ? null : PatternVar.binding;
 		this.condition.traverse(new ASTVisitor() {
 			@Override
 			public boolean visit(
 					SingleNameReference ref,
 					BlockScope skope) {
 				LocalVariableBinding local = ref.localVariableBinding();
-				if (local != null && local != lvb) {
+				if (local != null) {
 					ref.bits |= ASTNode.IsUsedInPatternGuard;
 				}
 				return false;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
@@ -1268,7 +1268,7 @@ public class SwitchStatement extends Expression {
 											if (type.isBaseType()) {
 												type = this.scope.environment().computeBoxingType(type);
 											}
-											if (p1.primary().coversType(type))
+											if (p1.coversType(type))
 												this.scope.problemReporter().patternDominatedByAnother(c.e);
 										}
 									}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchPatternTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchPatternTest.java
@@ -3595,11 +3595,6 @@ public class SwitchPatternTest extends AbstractRegressionTest9 {
 				"	return switch (o) {\n" +
 				"	               ^\n" +
 				"A Switch expression should cover all possible values\n" +
-				"----------\n" +
-				"2. ERROR in X.java (at line 5)\n" +
-				"	case Red -> \"Red\";\n" +
-				"	     ^^^\n" +
-				"This case label is dominated by one of the preceding case labels\n" +
 				"----------\n");
 	}
 	public void testBug575047_14() {
@@ -3623,11 +3618,6 @@ public class SwitchPatternTest extends AbstractRegressionTest9 {
 				"	return switch (o) {\n" +
 				"	               ^\n" +
 				"A Switch expression should cover all possible values\n" +
-				"----------\n" +
-				"2. ERROR in X.java (at line 5)\n" +
-				"	case Red -> \"Red\";\n" +
-				"	     ^^^\n" +
-				"This case label is dominated by one of the preceding case labels\n" +
 				"----------\n");
 	}
 	public void testBug575047_15() {
@@ -6407,5 +6397,104 @@ public class SwitchPatternTest extends AbstractRegressionTest9 {
 				+ "const B0\n"
 				+ "B1\n"
 				+ "default");
+	}
+	public void testIssue1351_1() {
+		this.runNegativeTest(
+				new String[] {
+						"X.java",
+						"public class X {\n"
+								+ "	public static void foo() {\n"
+								+ "		Object o = new String(\"\");\n"
+								+ "		int len = 2;\n"
+								+ "		switch (o) {\n"
+								+ "		case String o1 when ((String) o).length() == o1.length() :\n"
+								+ "			o = null;\n"
+								+ "			o1 = null;\n"
+								+ "			break;\n"
+								+ "		default:\n"
+								+ "			break;\n"
+								+ "		}\n"
+								+ "	}\n"
+								+ "} ",
+				},
+				"----------\n" +
+				"1. ERROR in X.java (at line 6)\n" +
+				"	case String o1 when ((String) o).length() == o1.length() :\n" +
+				"	                              ^\n" +
+				"Local variable o referenced from a guard must be final or effectively final\n" +
+				"----------\n");
+	}
+	public void testIssue1351_2() {
+		this.runNegativeTest(
+				new String[] {
+						"X.java",
+						"public class X {\n"
+								+ "	public static void foo() {\n"
+								+ "		Object o = new String(\"\");\n"
+								+ "		int len = 2;\n"
+								+ "		switch (o) {\n"
+								+ "		case String o1 when o1.length() == ((String) o).length():\n"
+								+ "			o = null;\n"
+								+ "			o1 = null;\n"
+								+ "			break;\n"
+								+ "		default:\n"
+								+ "			break;\n"
+								+ "		}\n"
+								+ "	}\n"
+								+ "} ",
+				},
+				"----------\n" +
+				"1. ERROR in X.java (at line 6)\n" +
+				"	case String o1 when o1.length() == ((String) o).length():\n" +
+				"	                    ^^\n" +
+				"Local variable o1 referenced from a guard must be final or effectively final\n" +
+				"----------\n");
+	}
+	public void testIssue1351_3() {
+		this.runNegativeTest(
+				new String[] {
+						"X.java",
+						"public class X {\n"
+								+ "	public static void foo() {\n"
+								+ "		Integer in = 0;\n"
+								+ "		switch (in) {\n"
+								+ "		    case Integer i ->\n"
+								+ "		        System.out.println(\"Boxed\");\n"
+								+ "		    case 95 ->\n"
+								+ "		        System.out.println(\"Literal!\");\n"
+								+ "		}\n"
+								+ "	}\n"
+								+ "} ",
+				},
+				"----------\n" +
+				"1. ERROR in X.java (at line 7)\n" +
+				"	case 95 ->\n" +
+				"	     ^^\n" +
+				"This case label is dominated by one of the preceding case labels\n" +
+				"----------\n");
+	}
+	public void testIssue1351_4() {
+		runNegativeTest(
+				new String[] {
+					"X.java",
+					"public class X {\n"+
+					"	static String foo(Color o) {\n" +
+					"		return switch (o) {\n" +
+					"	     case Color s when true  -> s.toString();\n" +
+					"	     case Red -> \"Red\";\n" +
+					"	     case null -> \"\";\n" +
+					"	   };\n" +
+					"	}\n" +
+					"} \n" +
+					"enum Color {\n" +
+					"	Red; \n" +
+					"}",
+				},
+				"----------\n" +
+				"1. ERROR in X.java (at line 5)\n" +
+				"	case Red -> \"Red\";\n" +
+				"	     ^^^\n" +
+				"This case label is dominated by one of the preceding case labels\n" +
+				"----------\n");
 	}
 }


### PR DESCRIPTION
#1351

Fix the domination rule that ignores the guard - We should only ignore if the guard is always true.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
Fixes #1351 

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
