### PR TITLE
JDT error logs without stack trace

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AbstractJavaModelTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AbstractJavaModelTests.java
@@ -22,6 +22,7 @@ import java.io.InputStream;
 import java.io.PrintStream;
 import java.net.URI;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Hashtable;
@@ -552,7 +553,26 @@ public abstract class AbstractJavaModelTests extends SuiteOfTestCases {
 	}
 	protected DeltaListener deltaListener = new DeltaListener();
 
-	protected ILogListener logListener;
+	public static class LogListenerWithHistory implements ILogListener {
+		private StringBuffer buffer = new StringBuffer();
+		private List<IStatus> logs = new ArrayList<>();
+
+		public void logging(IStatus status, String plugin) {
+			this.logs.add(status);
+			this.buffer.append(status);
+			this.buffer.append('\n');
+		}
+
+		public String toString() {
+			return this.buffer.toString();
+		}
+
+		public List<IStatus> getLogs() {
+			return this.logs;
+		}
+	}
+
+	protected LogListenerWithHistory logListener;
 	protected ILog log;
 
 	protected static boolean systemConfigReported;
@@ -3900,16 +3920,7 @@ public abstract class AbstractJavaModelTests extends SuiteOfTestCases {
 	protected void startLogListening(ILog logToListen) {
 		stopLogListening(); // cleanup if we forgot to stop listening
 		this.log = logToListen;
-		this.logListener = new ILogListener(){
-			private StringBuffer buffer = new StringBuffer();
-			public void logging(IStatus status, String plugin) {
-				this.buffer.append(status);
-				this.buffer.append('\n');
-			}
-			public String toString() {
-				return this.buffer.toString();
-			}
-		};
+		this.logListener = new LogListenerWithHistory();
 		if (logToListen == null) {
 			Platform.addLogListener(this.logListener);
 		} else {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/UtilTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/UtilTests.java
@@ -13,6 +13,13 @@
  *******************************************************************************/
 package org.eclipse.jdt.core.tests.model;
 
+import java.util.List;
+
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.jdt.core.IJavaModelStatusConstants;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.internal.core.JavaModelManager;
+import org.eclipse.jdt.internal.core.JavaModelStatus;
 import org.eclipse.jdt.internal.core.util.Util;
 
 import junit.framework.Test;
@@ -77,5 +84,26 @@ public class UtilTests extends AbstractJavaModelTests {
 		String[] arguments = new String[] {"foo#test", "bar"};
 		String[] result = Util.getProblemArgumentsFromMarker(Util.getProblemArgumentsForMarker(arguments));
 		assertStringsEqual("Wrong arguments", arguments, result);
+	}
+
+	public void testLogWithStackTrace() {
+		startLogListening();
+		try {
+			Util.log(new JavaModelException(new JavaModelStatus(IJavaModelStatusConstants.ELEMENT_DOES_NOT_EXIST,
+					JavaModelManager.getJavaModelManager().getJavaModel())));
+			List<IStatus> logs = this.logListener.getLogs();
+			while (logs.isEmpty()) {
+				try {
+					Thread.sleep(50);
+				} catch (InterruptedException e) {
+					break;
+				}
+			}
+			assertEquals("More errors as expected", 1, logs.size());
+			IStatus status = logs.get(0);
+			assertNotNull("No exception on logged status", status.getException());
+		} finally {
+			stopLogListening();
+		}
 	}
 }

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/PackageFragmentRoot.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/PackageFragmentRoot.java
@@ -932,7 +932,9 @@ private IModuleDescription getSourceModuleDescription() {
 			}
 		}
 	} catch (JavaModelException e) {
-		Util.log(e);
+		if (!e.isDoesNotExist()) {
+			Util.log(e);
+		}
 	}
 	return null;
 }

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/Util.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/Util.java
@@ -1897,8 +1897,8 @@ public class Util {
 	}
 
 	public static void log(Throwable e) {
-		if (e instanceof CoreException) {
-			log(((CoreException)e).getStatus());
+		if (e instanceof CoreException ce && ce.getStatus().getException() != null) {
+			log(ce.getStatus());
 		} else {
 			log(new Status(IStatus.ERROR, JavaCore.PLUGIN_ID, Messages.internal_error, e));
 		}


### PR DESCRIPTION
- Make sure Util.log(Throwable e) logs errors with stack trace
- Mute getSourceModuleDescription() if element is not found (we don't care if we can't find module description on non existing elements).

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1372