### PR TITLE
Use DebugTrace to log debugging information while indexing

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelManager.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelManager.java
@@ -161,6 +161,7 @@ import org.eclipse.jdt.internal.core.util.Util;
 import org.eclipse.jdt.internal.formatter.DefaultCodeFormatter;
 import org.eclipse.osgi.service.debug.DebugOptions;
 import org.eclipse.osgi.service.debug.DebugOptionsListener;
+import org.eclipse.osgi.service.debug.DebugTrace;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.prefs.BackingStoreException;
@@ -417,6 +418,8 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 	static final int PREF_DEFAULT = 1;
 
 	static final Object[][] NO_PARTICIPANTS = new Object[0][];
+
+	private static DebugTrace DEBUG_TRACE;
 
 	public static class CompilationParticipants {
 
@@ -1919,8 +1922,11 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 		Hashtable<String, String> properties = new Hashtable<>(2);
 		properties.put(DebugOptions.LISTENER_SYMBOLICNAME, JavaCore.PLUGIN_ID);
 		DEBUG_REGISTRATION = context.registerService(DebugOptionsListener.class, new DebugOptionsListener() {
+
+
 			@Override
 			public void optionsChanged(DebugOptions options) {
+				DEBUG_TRACE = options.newDebugTrace(JavaCore.PLUGIN_ID, JavaModelManager.class);
 				boolean debug = options.getBooleanOption(DEBUG, false);
 				BufferManager.VERBOSE = debug && options.getBooleanOption(BUFFER_MANAGER_DEBUG, false);
 				JavaBuilder.DEBUG = debug && options.getBooleanOption(BUILDER_DEBUG, false);
@@ -4717,6 +4723,18 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 		String message = MessageFormat.format(pattern, new Object[]{action, length, delta});
 
 		System.out.println(message);
+	}
+
+	public static void trace(String msg) {
+		DEBUG_TRACE.trace(null, msg);
+	}
+
+	public static void trace(String msg, Exception e) {
+		DEBUG_TRACE.trace(null, msg, e);
+	}
+
+	public static void traceDumpStack() {
+		DEBUG_TRACE.traceDumpStack(null);
 	}
 
 	/**

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/AddFolderToIndex.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/AddFolderToIndex.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.core.search.indexing;
 
+import static org.eclipse.jdt.internal.core.JavaModelManager.trace;
+
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
@@ -103,8 +105,7 @@ class AddFolderToIndex extends IndexRequest {
 			}
 		} catch (CoreException e) {
 			if (JobManager.VERBOSE) {
-				Util.verbose("-> failed to add " + this.folderPath + " to index because of the following exception:", System.err); //$NON-NLS-1$ //$NON-NLS-2$
-				e.printStackTrace();
+				trace("-> failed to add " + this.folderPath + " to index because of the following exception:", e); //$NON-NLS-1$ //$NON-NLS-2$
 			}
 			return false;
 		} finally {

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/AddJarFileToIndex.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/AddJarFileToIndex.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.core.search.indexing;
 
+import static org.eclipse.jdt.internal.core.JavaModelManager.trace;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -106,20 +108,20 @@ class AddJarFileToIndex extends BinaryContainer {
 			Index index = this.manager.getIndexForUpdate(this.containerPath, false, /*do not reuse index file*/ false /*do not create if none*/);
 			if (index != null) {
 				if (JobManager.VERBOSE)
-					org.eclipse.jdt.internal.core.util.Util.verbose("-> no indexing required (index already exists) for " + this.containerPath); //$NON-NLS-1$
+					trace("-> no indexing required (index already exists) for " + this.containerPath); //$NON-NLS-1$
 				return true;
 			}
 
 			index = this.manager.getIndexForUpdate(this.containerPath, true, /*reuse index file*/ true /*create if none*/);
 			if (index == null) {
 				if (JobManager.VERBOSE)
-					org.eclipse.jdt.internal.core.util.Util.verbose("-> index could not be created for " + this.containerPath); //$NON-NLS-1$
+					trace("-> index could not be created for " + this.containerPath); //$NON-NLS-1$
 				return true;
 			}
 			ReadWriteMonitor monitor = index.monitor;
 			if (monitor == null) {
 				if (JobManager.VERBOSE)
-					org.eclipse.jdt.internal.core.util.Util.verbose("-> index for " + this.containerPath + " just got deleted"); //$NON-NLS-1$//$NON-NLS-2$
+					trace("-> index for " + this.containerPath + " just got deleted"); //$NON-NLS-1$//$NON-NLS-2$
 				return true; // index got deleted since acquired
 			}
 			index.separator = JAR_SEPARATOR;
@@ -140,13 +142,12 @@ class AddJarFileToIndex extends BinaryContainer {
 						file = org.eclipse.jdt.internal.core.util.Util.toLocalFile(location, progressMonitor);
 					} catch (CoreException e) {
 						if (JobManager.VERBOSE) {
-							org.eclipse.jdt.internal.core.util.Util.verbose("-> failed to index " + location.getPath() + " because of the following exception:"); //$NON-NLS-1$ //$NON-NLS-2$
-							e.printStackTrace();
+							trace("-> failed to index " + location.getPath() + " because of the following exception:", e); //$NON-NLS-1$ //$NON-NLS-2$
 						}
 					}
 					if (file == null) {
 						if (JobManager.VERBOSE)
-							org.eclipse.jdt.internal.core.util.Util.verbose("-> failed to index " + location.getPath() + " because the file could not be fetched"); //$NON-NLS-1$ //$NON-NLS-2$
+							trace("-> failed to index " + location.getPath() + " because the file could not be fetched"); //$NON-NLS-1$ //$NON-NLS-2$
 						return false;
 					}
 					if (JavaModelManager.ZIP_ACCESS_VERBOSE)
@@ -165,12 +166,12 @@ class AddJarFileToIndex extends BinaryContainer {
 
 				if (this.isCancelled) {
 					if (JobManager.VERBOSE)
-						org.eclipse.jdt.internal.core.util.Util.verbose("-> indexing of " + zip.getName() + " has been cancelled"); //$NON-NLS-1$ //$NON-NLS-2$
+						trace("-> indexing of " + zip.getName() + " has been cancelled"); //$NON-NLS-1$ //$NON-NLS-2$
 					return false;
 				}
 
 				if (JobManager.VERBOSE)
-					org.eclipse.jdt.internal.core.util.Util.verbose("-> indexing " + zip.getName()); //$NON-NLS-1$
+					trace("-> indexing " + zip.getName()); //$NON-NLS-1$
 				long initialTime = System.currentTimeMillis();
 
 				String[] paths = index.queryDocumentNames(""); // all file names //$NON-NLS-1$
@@ -205,7 +206,7 @@ class AddJarFileToIndex extends BinaryContainer {
 						}
 						if (!needToReindex) {
 							if (JobManager.VERBOSE)
-								org.eclipse.jdt.internal.core.util.Util.verbose("-> no indexing required (index is consistent with library) for " //$NON-NLS-1$
+								trace("-> no indexing required (index is consistent with library) for " //$NON-NLS-1$
 								+ zip.getName() + " (" //$NON-NLS-1$
 								+ (System.currentTimeMillis() - initialTime) + "ms)"); //$NON-NLS-1$
 							this.manager.saveIndex(index); // to ensure its placed into the saved state
@@ -232,7 +233,7 @@ class AddJarFileToIndex extends BinaryContainer {
 				for (Enumeration e = zip.entries(); e.hasMoreElements();) {
 					if (this.isCancelled) {
 						if (JobManager.VERBOSE)
-							org.eclipse.jdt.internal.core.util.Util.verbose("-> indexing of " + zip.getName() + " has been cancelled"); //$NON-NLS-1$ //$NON-NLS-2$
+							trace("-> indexing of " + zip.getName() + " has been cancelled"); //$NON-NLS-1$ //$NON-NLS-2$
 						return false;
 					}
 
@@ -271,7 +272,7 @@ class AddJarFileToIndex extends BinaryContainer {
 					this.manager.saveIndex(index);
 				}
 				if (JobManager.VERBOSE)
-					org.eclipse.jdt.internal.core.util.Util.verbose("-> done indexing of " //$NON-NLS-1$
+					trace("-> done indexing of " //$NON-NLS-1$
 						+ zip.getName() + " (" //$NON-NLS-1$
 						+ (System.currentTimeMillis() - initialTime) + "ms)"); //$NON-NLS-1$
 			} finally {

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/IndexAllProject.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/IndexAllProject.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.core.search.indexing;
 
+import static org.eclipse.jdt.internal.core.JavaModelManager.trace;
+
 import java.io.IOException;
 import java.net.URI;
 import java.util.HashSet;
@@ -230,8 +232,7 @@ public class IndexAllProject extends IndexRequest {
 			this.manager.request(new SaveIndex(this.containerPath, this.manager));
 		} catch (CoreException | IOException e) {
 			if (JobManager.VERBOSE) {
-				Util.verbose("-> failed to index " + this.project + " because of the following exception:", System.err); //$NON-NLS-1$ //$NON-NLS-2$
-				e.printStackTrace();
+				trace("-> failed to index " + this.project + " because of the following exception:", e); //$NON-NLS-1$ //$NON-NLS-2$
 			}
 			this.manager.removeIndex(this.containerPath);
 			return false;

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/IndexBinaryFolder.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/IndexBinaryFolder.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.core.search.indexing;
 
+import static org.eclipse.jdt.internal.core.JavaModelManager.trace;
+
 import java.io.IOException;
 import java.net.URI;
 
@@ -137,8 +139,7 @@ public class IndexBinaryFolder extends IndexRequest {
 			this.manager.request(new SaveIndex(this.containerPath, this.manager));
 		} catch (CoreException | IOException e) {
 			if (JobManager.VERBOSE) {
-				Util.verbose("-> failed to index " + this.folder + " because of the following exception:", System.err); //$NON-NLS-1$ //$NON-NLS-2$
-				e.printStackTrace();
+				trace("-> failed to index " + this.folder + " because of the following exception:", e); //$NON-NLS-1$ //$NON-NLS-2$
 			}
 			this.manager.removeIndex(this.containerPath);
 			return false;

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/IndexNamesRegistry.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/IndexNamesRegistry.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.core.search.indexing;
 
+import static org.eclipse.jdt.internal.core.JavaModelManager.trace;
+
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
@@ -25,7 +27,6 @@ import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.internal.core.index.DiskIndex;
 import org.eclipse.jdt.internal.core.search.processing.JobManager;
-import org.eclipse.jdt.internal.core.util.Util;
 
 public class IndexNamesRegistry {
 	private final File savedIndexNamesFile;
@@ -83,7 +84,7 @@ public class IndexNamesRegistry {
 			}
 		} catch (IOException ignored) {
 			if (JobManager.VERBOSE)
-				Util.verbose("Failed to read saved index file names"); //$NON-NLS-1$
+				trace("Failed to read saved index file names"); //$NON-NLS-1$
 		}
 		return null;
 	}
@@ -113,7 +114,7 @@ public class IndexNamesRegistry {
 			}
 		} catch (IOException ignored) {
 			if (JobManager.VERBOSE)
-				Util.verbose("Failed to write saved index file names", System.err); //$NON-NLS-1$
+				trace("Failed to write saved index file names"); //$NON-NLS-1$
 		}
 
 		synchronized (this.queueMutex) {

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/RemoveFolderFromIndex.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/RemoveFolderFromIndex.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.core.search.indexing;
 
+import static org.eclipse.jdt.internal.core.JavaModelManager.trace;
+
 import java.io.IOException;
 
 import org.eclipse.core.resources.IProject;
@@ -65,8 +67,7 @@ class RemoveFolderFromIndex extends IndexRequest {
 			}
 		} catch (IOException e) {
 			if (JobManager.VERBOSE) {
-				Util.verbose("-> failed to remove " + this.folderPath + " from index because of the following exception:", System.err); //$NON-NLS-1$ //$NON-NLS-2$
-				e.printStackTrace();
+				trace("-> failed to remove " + this.folderPath + " from index because of the following exception:", e); //$NON-NLS-1$ //$NON-NLS-2$
 			}
 			return false;
 		} finally {

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/SaveIndex.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/SaveIndex.java
@@ -13,13 +13,14 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.core.search.indexing;
 
+import static org.eclipse.jdt.internal.core.JavaModelManager.trace;
+
 import java.io.IOException;
 
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.internal.core.index.Index;
 import org.eclipse.jdt.internal.core.search.processing.JobManager;
-import org.eclipse.jdt.internal.core.util.Util;
 
 /*
  * Save the index of a project.
@@ -44,8 +45,7 @@ public class SaveIndex extends IndexRequest {
 			this.manager.saveIndex(index);
 		} catch (IOException e) {
 			if (JobManager.VERBOSE) {
-				Util.verbose("-> failed to save index " + this.containerPath + " because of the following exception:", System.err); //$NON-NLS-1$ //$NON-NLS-2$
-				e.printStackTrace();
+				trace("-> failed to save index " + this.containerPath + " because of the following exception:", e); //$NON-NLS-1$ //$NON-NLS-2$
 			}
 			return false;
 		} finally {

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/SourceIndexer.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/SourceIndexer.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.core.search.indexing;
 
+import static org.eclipse.jdt.internal.core.JavaModelManager.trace;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.ResourcesPlugin;
@@ -114,7 +115,7 @@ public class SourceIndexer extends AbstractIndexer implements ITypeRequestor, Su
 				this.document.requireIndexingResolvedDocument();
 		} catch (Exception e) {
 			if (JobManager.VERBOSE) {
-				e.printStackTrace();
+				trace("", e); //$NON-NLS-1$
 			}
 		}
 	}
@@ -172,7 +173,7 @@ public class SourceIndexer extends AbstractIndexer implements ITypeRequestor, Su
 			this.cud.resolve();
 		} catch (Exception e) {
 			if (JobManager.VERBOSE) {
-				e.printStackTrace();
+				trace("", e); //$NON-NLS-1$
 			}
 		}
 	}
@@ -260,7 +261,7 @@ public class SourceIndexer extends AbstractIndexer implements ITypeRequestor, Su
 			}
 		} catch (Exception e) {
 			if (JobManager.VERBOSE) {
-				e.printStackTrace();
+				trace("", e); //$NON-NLS-1$
 			}
 		}
 	}

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/SourceIndexerRequestor.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/SourceIndexerRequestor.java
@@ -13,10 +13,14 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.core.search.indexing;
 
+import static org.eclipse.jdt.internal.core.JavaModelManager.traceDumpStack;
+
 import java.util.ArrayList;
 import java.util.List;
+
 import org.eclipse.jdt.core.Signature;
-import org.eclipse.jdt.core.compiler.*;
+import org.eclipse.jdt.core.compiler.CategorizedProblem;
+import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.internal.compiler.ExtraFlags;
 import org.eclipse.jdt.internal.compiler.ISourceElementRequestor;
 import org.eclipse.jdt.internal.compiler.ast.AbstractMethodDeclaration;
@@ -522,11 +526,7 @@ public void popTypeName() {
 		this.enclosingTypeNames[--this.depth] = null;
 	} else if (JobManager.VERBOSE) {
 		// dump a trace so it can be tracked down
-		try {
-			this.enclosingTypeNames[-1] = null;
-		} catch (ArrayIndexOutOfBoundsException e) {
-			e.printStackTrace();
-		}
+		traceDumpStack();
 	}
 }
 public void pushTypeName(char[] typeName) {


### PR DESCRIPTION
## What it does

This PR is has been split from https://github.com/eclipse-jdt/eclipse.jdt.core/pull/1304 (see [comment](https://github.com/eclipse-jdt/eclipse.jdt.core/pull/1304#issuecomment-1717130773))

Add an instance of `DebugTrace` to the `JavaModelManager` and use it to log tracing information in the package `org.eclipse.jdt.internal.core.search.indexing`. All calls to `e.printStackTrace()` in that package are now unnecessary since the trace method accepts a `Throwable` so they have been removed.

Contributes to https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1303


## How to test
Similar to https://github.com/eclipse-jdt/eclipse.jdt.core/pull/1304#issue-1860893048, you need to
* Activate the `VERBOSE` mode in `JobManager`
* (Optional) Use the "small hack" and randomly throw a `RuntimeException`, but log it using `JavaModelManager.getTrace().trace(null, "some message", e)` instead of `Util.log(e)`. The output will be visible in a file in the workspace (**\<WS\>\\.metadata\trace.log**)

## Author checklist

✔️ I have thoroughly tested my changes
✔️ The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
✔️ I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
