### PR TITLE
False positive warning: redundant specification of type arguments

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ASTNode.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ASTNode.java
@@ -358,7 +358,7 @@ public abstract class ASTNode implements TypeConstants, TypeIds {
 		if (argument instanceof AllocationExpression) {
 			AllocationExpression allocExp = (AllocationExpression) argument;
 			// we need this only when the error is not reported in AllocationExpression#checkTypeArgumentRedundancy()
-			if (allocExp.typeExpected == null) {
+			if (allocExp.typeExpected == null && !allocExp.expectedTypeWasInferred) {
 				final boolean isDiamond = allocExp.type != null && (allocExp.type.bits & ASTNode.IsDiamond) != 0;
 				allocExp.typeExpected = parameterType;
 				if (!isDiamond && allocExp.resolvedType.isParameterizedTypeWithActualArguments()) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AllocationExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AllocationExpression.java
@@ -91,6 +91,11 @@ public class AllocationExpression extends Expression implements IPolyExpression,
 	public boolean argsContainCast;
 	public TypeBinding[] argumentTypes = Binding.NO_PARAMETERS;
 	public boolean argumentsHaveErrors = false;
+	/**
+	 * This flag avoids "Redundant specification of type arguments" if the target type was inferred in an outer context,
+	 * possibly based on the provided type arguments of this allocation:
+	 */
+	public boolean expectedTypeWasInferred;
 
 @Override
 public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext, FlowInfo flowInfo) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.jdt.core.compiler.CharOperation;
+import org.eclipse.jdt.internal.compiler.ast.AllocationExpression;
 import org.eclipse.jdt.internal.compiler.ast.ConditionalExpression;
 import org.eclipse.jdt.internal.compiler.ast.Expression;
 import org.eclipse.jdt.internal.compiler.ast.FunctionalExpression;
@@ -1895,6 +1896,14 @@ public class InferenceContext18 {
 			invocation.registerResult(targetType, pmb);
 		Expression[] arguments = invocation.arguments();
 		for (int i = 0, length = arguments == null ? 0 : arguments.length; i < length; i++) {
+			if (arguments[i] instanceof AllocationExpression) {
+				// do we need to suppress "Redundant specification of type arguments" warnings?
+				TypeBinding pmbParam = getParameter(pmb.parameters, i, pmb.isVarargs());
+				TypeBinding origParam = getParameter(pmb.originalMethod.parameters, i, pmb.isVarargs());
+				if (TypeBinding.notEquals(pmbParam, origParam)) {
+					((AllocationExpression) arguments[i]).expectedTypeWasInferred = true;
+				}
+			}
 			Expression [] expressions = arguments[i].getPolyExpressions();
 			for (int j = 0, jLength = expressions.length; j < jLength; j++) {
 				Expression expression = expressions[j];

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_1_7.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_1_7.java
@@ -3116,6 +3116,55 @@ public void testBug488649_JDK6791481_ex1() {
 		"Class is a raw type. References to generic type Class<T> should be parameterized\n" +
 		"----------\n");
 }
+public void testGH1326() {
+	Runner runner = new Runner();
+	runner.customOptions = getCompilerOptions();
+	runner.customOptions.put(CompilerOptions.OPTION_ReportRedundantSpecificationOfTypeArguments, CompilerOptions.ERROR);
+	runner.testFiles = new String[] {
+		"Foo.java",
+		"""
+		class Inner<T> {}
+		class Outer<T> {
+			Outer(T t) {}
+			Outer<T> self() { return this; }
+		}
+		public class Foo {
+			Outer<Inner<String>> x = new Outer<>(new Inner<String>()).self();
+		}
+		"""
+	};
+	runner.runConformTest();
+}
+public void testGH1326_alt() {
+	Runner runner = new Runner();
+	runner.customOptions = getCompilerOptions();
+	runner.customOptions.put(CompilerOptions.OPTION_ReportRedundantSpecificationOfTypeArguments, CompilerOptions.ERROR);
+	runner.testFiles = new String[] {
+		"Foo.java",
+		"""
+		class Inner<T> {}
+		class Outer<T> {
+			Outer(Inner<String> t1, T t2) {}
+			Outer<T> self() { return this; }
+		}
+		public class Foo {
+			Inner<String> inner = new Inner<>();
+			Outer<Inner<String>> x = new Outer<>(new Inner<String>(), inner).self();
+			Outer<Inner<String>> xok = new Outer<>(new Inner<>(), inner).self();
+		}
+		"""
+	};
+	runner.expectedCompilerLog =
+			"""
+			----------
+			1. ERROR in Foo.java (at line 8)
+				Outer<Inner<String>> x = new Outer<>(new Inner<String>(), inner).self();
+				                                         ^^^^^
+			Redundant specification of type arguments <String>
+			----------
+			""";
+	runner.runNegativeTest();
+}
 public static Class testClass() {
 	return GenericsRegressionTest_1_7.class;
 }


### PR DESCRIPTION
fixes #1326

## What it does
Creates a little worm-hole between disconnected pieces of resolving:
* at the end of outer inference, `forwardResult()` checks for the following situation:
  * an argument is an `AllocationExpression`
  * the corresponding parameter has been updated from the original method binding to the `ParameterizedGenericMethodBinding` as the result of inference
  * if so, this situation is remembered in a new flag `AllocationExpression.expectedTypeWasInferred`.
* now the code block from [#1036](https://github.com/eclipse-jdt/eclipse.jdt.core/pull/1036) can avoid false positives based on the above flag.

Rationale: the flag signals that the target type for a given inner allocation was indeed determined during outer inference. This _could_ indicate, that without type arguments of the inner, inference might have failed. In the end we _might_ err on the side of keeping silent, if that outer inference got its information from a different source than the inner allocation. The exact answer can only be given by modifying the code and running the compiler. But in such subtle cases, specifying a few potentially redundant type arguments is probably the least bad.

## How to test
JUnit tests included.

In particular `testGH1326_alt` demonstrates that an outer inference alone doesn't set `expectedTypeWasInferred` if the corresponding parameter was not influenced by inference. The test also shows, that in this situation type arguments can indeed safely be omitted.

