### PR TITLE
After upgrade to 2023-09, quick fixes throws internal NullPointerException in LookupEnvironment

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/LookupEnvironment.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/LookupEnvironment.java
@@ -148,11 +148,11 @@ public class LookupEnvironment implements ProblemReasons, TypeConstants {
 
 	public String moduleVersion; 	// ROOT_ONLY
 
-	final static int BUILD_FIELDS_AND_METHODS = 4;
 	final static int BUILD_TYPE_HIERARCHY = 1;
 	final static int CHECK_AND_SET_IMPORTS = 2;
 	final static int CONNECT_TYPE_HIERARCHY1 = 3;
-	final static int CONNECT_TYPE_HIERARCHY2 = 4;
+	final static int BUILD_FIELDS_AND_METHODS = 4;
+	final static int CONNECT_TYPE_HIERARCHY2 = 5;
 
 	static final ProblemPackageBinding TheNotFoundPackage = new ProblemPackageBinding(CharOperation.NO_CHAR, NotFound, null/*not perfect*/);
 	static final ProblemReferenceBinding TheNotFoundType = new ProblemReferenceBinding(CharOperation.NO_CHAR_CHAR, null, NotFound);


### PR DESCRIPTION
fixes #1376

## What it does
Fix stupid constant error from #1077 

## How to test
JUnit included.

Actually, on top of what I wrote in #1376 one more ingredient was necessary to reproduce: somehow the supertype chain must contain a binary type, which remains unresolved during `completeTypeHierarchy()` and this must be specifically setup such that bound check needs to resolve it such that at that point we discover a new source type.

This ping pong with source->binary->source references let's me hope, that the bug will not occur for *every* user ...