### PR TITLE
False positive warning: redundant specification of type arguments

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
@@ -1895,15 +1895,8 @@ public class InferenceContext18 {
 		if (targetType != null)
 			invocation.registerResult(targetType, pmb);
 		Expression[] arguments = invocation.arguments();
+		updateInnerDiamonds(pmb, arguments);
 		for (int i = 0, length = arguments == null ? 0 : arguments.length; i < length; i++) {
-			if (arguments[i] instanceof AllocationExpression) {
-				// do we need to suppress "Redundant specification of type arguments" warnings?
-				TypeBinding pmbParam = getParameter(pmb.parameters, i, pmb.isVarargs());
-				TypeBinding origParam = getParameter(pmb.originalMethod.parameters, i, pmb.isVarargs());
-				if (TypeBinding.notEquals(pmbParam, origParam)) {
-					((AllocationExpression) arguments[i]).expectedTypeWasInferred = true;
-				}
-			}
 			Expression [] expressions = arguments[i].getPolyExpressions();
 			for (int j = 0, jLength = expressions.length; j < jLength; j++) {
 				Expression expression = expressions[j];
@@ -1948,6 +1941,19 @@ public class InferenceContext18 {
 				}
 				TypeBinding parameterType = InferenceContext18.getParameter(parameters, i, variableArity);
 				forwardResults(result, polyInvocation, methodSubstitute, parameterType);
+			}
+		}
+	}
+
+	public static void updateInnerDiamonds(ParameterizedMethodBinding pmb, Expression[] arguments) {
+		for (int i = 0, length = arguments == null ? 0 : arguments.length; i < length; i++) {
+			if (arguments[i] instanceof AllocationExpression) {
+				// do we need to suppress "Redundant specification of type arguments" warnings?
+				TypeBinding pmbParam = getParameter(pmb.parameters, i, pmb.isVarargs());
+				TypeBinding origParam = getParameter(pmb.originalMethod.parameters, i, pmb.isVarargs());
+				if (TypeBinding.notEquals(pmbParam, origParam)) {
+					((AllocationExpression) arguments[i]).expectedTypeWasInferred = true;
+				}
 			}
 		}
 	}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedGenericMethodBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedGenericMethodBinding.java
@@ -195,6 +195,9 @@ public class ParameterizedGenericMethodBinding extends ParameterizedMethodBindin
 					break;
 			}
 		}
+		if (invocationSite instanceof Invocation) {
+			InferenceContext18.updateInnerDiamonds(methodSubstitute, ((Invocation) invocationSite).arguments());
+		}
 		// check presence of unchecked argument conversion a posteriori (15.12.2.6)
 		return methodSubstitute;
 	}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_1_7.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_1_7.java
@@ -3155,12 +3155,28 @@ public void testGH1326_alt() {
 		"""
 	};
 	runner.expectedCompilerLog =
+			this.complianceLevel >= ClassFileConstants.JDK1_8
+			?
 			"""
 			----------
 			1. ERROR in Foo.java (at line 8)
 				Outer<Inner<String>> x = new Outer<>(new Inner<String>(), inner).self();
 				                                         ^^^^^
 			Redundant specification of type arguments <String>
+			----------
+			"""
+			: // 1.7 inference is less capable:
+			"""
+			----------
+			1. ERROR in Foo.java (at line 8)
+				Outer<Inner<String>> x = new Outer<>(new Inner<String>(), inner).self();
+				                                         ^^^^^
+			Redundant specification of type arguments <String>
+			----------
+			2. ERROR in Foo.java (at line 9)
+				Outer<Inner<String>> xok = new Outer<>(new Inner<>(), inner).self();
+				                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+			Cannot infer type arguments for Outer<>
 			----------
 			""";
 	runner.runNegativeTest();


### PR DESCRIPTION
fixes #1326 also for compliance 1.7
(same strategy as PR #1378)
