### PR TITLE
Use StringBuilder instead of StringBuffer for ASTNode.print*()

### DIFF
--- a/org.eclipse.jdt.apt.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.apt.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.apt.core; singleton:=true
-Bundle-Version: 3.8.200.qualifier
+Bundle-Version: 3.8.300.qualifier
 Bundle-Localization: plugin
 Export-Package: com.sun.mirror.apt,
  com.sun.mirror.declaration,

--- a/org.eclipse.jdt.apt.core/pom.xml
+++ b/org.eclipse.jdt.apt.core/pom.xml
@@ -17,6 +17,6 @@
     <version>4.31.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.eclipse.jdt.apt.core</artifactId>
-  <version>3.8.200-SNAPSHOT</version>
+  <version>3.8.300-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/AptPlugin.java
+++ b/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/AptPlugin.java
@@ -195,7 +195,7 @@ public class AptPlugin extends Plugin implements DebugOptionsListener {
 
 	public static void trace(final String msg){
 		if (DEBUG) {
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			sb.append('[');
 			// SimpleDateFormat is not thread-safe, according to javadoc
 			synchronized(TRACE_DATE_FORMAT) {

--- a/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/declaration/AnnotationValueImpl.java
+++ b/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/declaration/AnnotationValueImpl.java
@@ -206,7 +206,7 @@ public class AnnotationValueImpl implements EclipseMirrorObject, AnnotationValue
 			return "null"; //$NON-NLS-1$
 		} else if (_value instanceof String) {
 			String value = (String) _value;
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			sb.append('"');
 			for (int i = 0; i < value.length(); i++) {
 				Util.appendEscapedChar(sb, value.charAt(i), true);
@@ -214,7 +214,7 @@ public class AnnotationValueImpl implements EclipseMirrorObject, AnnotationValue
 			sb.append('"');
 			return sb.toString();
 		} else if (_value instanceof Character) {
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			sb.append('\'');
 			Util.appendEscapedChar(sb, ((Character) _value).charValue(), false);
 			sb.append('\'');

--- a/org.eclipse.jdt.apt.pluggable.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.apt.pluggable.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.apt.pluggable.core;singleton:=true
-Bundle-Version: 1.4.200.qualifier
+Bundle-Version: 1.4.300.qualifier
 Bundle-Activator: org.eclipse.jdt.internal.apt.pluggable.core.Apt6Plugin
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime,

--- a/org.eclipse.jdt.apt.pluggable.core/pom.xml
+++ b/org.eclipse.jdt.apt.pluggable.core/pom.xml
@@ -17,6 +17,6 @@
     <version>4.31.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.eclipse.jdt.apt.pluggable.core</artifactId>
-  <version>1.4.200-SNAPSHOT</version>
+  <version>1.4.300-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.eclipse.jdt.apt.pluggable.core/src/org/eclipse/jdt/internal/apt/pluggable/core/Apt6Plugin.java
+++ b/org.eclipse.jdt.apt.pluggable.core/src/org/eclipse/jdt/internal/apt/pluggable/core/Apt6Plugin.java
@@ -129,7 +129,7 @@ public class Apt6Plugin extends Plugin implements DebugOptionsListener {
 
 	public static void trace(final String msg) {
 		if (DEBUG) {
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			sb.append('[');
 			// SimpleDateFormat is not thread-safe, according to javadoc
 			synchronized (TRACE_DATE_FORMAT) {

--- a/org.eclipse.jdt.apt.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.apt.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.apt.tests; singleton:=true
-Bundle-Version: 3.6.200.qualifier
+Bundle-Version: 3.6.300.qualifier
 Bundle-ClassPath: apt.jar,
  aptext.jar,
  .

--- a/org.eclipse.jdt.apt.tests/pom.xml
+++ b/org.eclipse.jdt.apt.tests/pom.xml
@@ -19,7 +19,7 @@
     <relativePath>../tests-pom/</relativePath>
   </parent>
   <artifactId>org.eclipse.jdt.apt.tests</artifactId>
-  <version>3.6.200-SNAPSHOT</version>
+  <version>3.6.300-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   
   <build>

--- a/org.eclipse.jdt.apt.tests/src/org/eclipse/jdt/apt/tests/AnnotationProcessingCompilerToolTest.java
+++ b/org.eclipse.jdt.apt.tests/src/org/eclipse/jdt/apt/tests/AnnotationProcessingCompilerToolTest.java
@@ -123,7 +123,7 @@ public class AnnotationProcessingCompilerToolTest extends AbstractBatchCompilerT
 		}
 		@Override
 		public String toString() {
-			StringBuffer result = new StringBuffer();
+			StringBuilder result = new StringBuilder();
 			for (String option: this.options) {
 				result.append(option);
 				result.append(' ');

--- a/org.eclipse.jdt.compiler.apt.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.compiler.apt.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.compiler.apt.tests;singleton:=true
-Bundle-Version: 1.3.200.qualifier
+Bundle-Version: 1.3.300.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/org.eclipse.jdt.compiler.apt.tests/pom.xml
+++ b/org.eclipse.jdt.compiler.apt.tests/pom.xml
@@ -19,7 +19,7 @@
     <relativePath>../tests-pom/</relativePath>
   </parent>
   <artifactId>org.eclipse.jdt.compiler.apt.tests</artifactId>
-  <version>1.3.200-SNAPSHOT</version>
+  <version>1.3.300-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>

--- a/org.eclipse.jdt.compiler.apt.tests/processors/org/eclipse/jdt/compiler/apt/tests/processors/AnnotationProcessorTests/Bug340635Proc.java
+++ b/org.eclipse.jdt.compiler.apt.tests/processors/org/eclipse/jdt/compiler/apt/tests/processors/AnnotationProcessorTests/Bug340635Proc.java
@@ -52,7 +52,7 @@ public class Bug340635Proc extends AbstractProcessor {
 					DeclaredType genericType = element.asType().accept(new GenericTypeVisitor(types), null);
 					DeclaredType erasedType = (DeclaredType) types.erasure(genericType);
 
-					StringBuffer message = new StringBuffer();
+					StringBuilder message = new StringBuilder();
 					message.append("Erased type: " + erasedType);
 					message.append(" - type arguments: ");
 					for (TypeMirror typeArgument : erasedType.getTypeArguments()) {

--- a/org.eclipse.jdt.compiler.apt.tests/processors/org/eclipse/jdt/compiler/apt/tests/processors/base/XMLConverter.java
+++ b/org.eclipse.jdt.compiler.apt.tests/processors/org/eclipse/jdt/compiler/apt/tests/processors/base/XMLConverter.java
@@ -85,7 +85,7 @@ public class XMLConverter extends ElementScanner6<Void, Node> implements IXMLNam
 	public static String xmlToCutAndPasteString(Document model, int indent, boolean shift) {
 		String modelAsString = xmlToString(model);
 	    int length = modelAsString.length();
-	    StringBuffer buffer = new StringBuffer(length);
+	    StringBuilder buffer = new StringBuilder(length);
 	    java.util.StringTokenizer tokenizer = new java.util.StringTokenizer(modelAsString, "\n\r", true);
 	    for (int i = 0; i < indent; i++) buffer.append("\t");
 	    if (shift) indent++;
@@ -101,7 +101,7 @@ public class XMLConverter extends ElementScanner6<Void, Node> implements IXMLNam
 	            }
 	            continue;
 	        }
-	        StringBuffer tokenBuffer = new StringBuffer();
+	        StringBuilder tokenBuffer = new StringBuilder();
 	        for (int i = 0; i < token.length(); i++){
 	            char c = token.charAt(i);
 	            switch (c) {

--- a/org.eclipse.jdt.compiler.apt.tests/processors8/org/eclipse/jdt/compiler/apt/tests/processors/elements/BaseElementProcessor.java
+++ b/org.eclipse.jdt.compiler.apt.tests/processors8/org/eclipse/jdt/compiler/apt/tests/processors/elements/BaseElementProcessor.java
@@ -125,7 +125,7 @@ abstract class BaseElementProcessor extends BaseProcessor {
 		throw new AssertionFailedError(msg + " (Binary mode= " + isBinaryMode + ")");
 	}
 	protected String getExceptionStackTrace(Throwable t) {
-		StringBuffer buf = new StringBuffer(t.getMessage());
+		StringBuilder buf = new StringBuilder(t.getMessage());
 		StackTraceElement[] traces = t.getStackTrace();
 		for (int i = 0; i < traces.length; i++) {
 			StackTraceElement trace = traces[i];
@@ -217,7 +217,7 @@ abstract class BaseElementProcessor extends BaseProcessor {
 
 	public void assertEquals(String msg, int expected, int actual) {
 		if (expected != actual) {
-			StringBuffer buf = new StringBuffer();
+			StringBuilder buf = new StringBuilder();
 			buf.append(msg);
 			buf.append(", expected " + expected + " but was " + actual);
 			reportError(buf.toString());
@@ -235,7 +235,7 @@ abstract class BaseElementProcessor extends BaseProcessor {
 	protected String getAnnotationString(AnnotationMirror annot) {
 		DeclaredType annotType = annot.getAnnotationType();
 		TypeElement type = (TypeElement) annotType.asElement();
-		StringBuffer buf = new StringBuffer("@" + type.getSimpleName());
+		StringBuilder buf = new StringBuilder("@" + type.getSimpleName());
 		Map<? extends ExecutableElement, ? extends AnnotationValue> values = annot.getElementValues();
 		Set<? extends ExecutableElement> keys = values.keySet();
 		buf.append('(');

--- a/org.eclipse.jdt.compiler.apt.tests/processors8/org/eclipse/jdt/compiler/apt/tests/processors/elements/Java11ElementProcessor.java
+++ b/org.eclipse.jdt.compiler.apt.tests/processors8/org/eclipse/jdt/compiler/apt/tests/processors/elements/Java11ElementProcessor.java
@@ -152,7 +152,7 @@ public class Java11ElementProcessor extends BaseProcessor {
 		throw new AssertionFailedError(msg);
 	}
 	private String getExceptionStackTrace(Throwable t) {
-		StringBuffer buf = new StringBuffer(t.getMessage());
+		StringBuilder buf = new StringBuilder(t.getMessage());
 		StackTraceElement[] traces = t.getStackTrace();
 		for (int i = 0; i < traces.length; i++) {
 			StackTraceElement trace = traces[i];
@@ -227,7 +227,7 @@ public class Java11ElementProcessor extends BaseProcessor {
 
 	public void assertEquals(String msg, int expected, int actual) {
 		if (expected != actual) {
-			StringBuffer buf = new StringBuffer();
+			StringBuilder buf = new StringBuilder();
 			buf.append(msg);
 			buf.append(", expected " + expected + " but was " + actual);
 			reportError(buf.toString());

--- a/org.eclipse.jdt.compiler.apt.tests/processors8/org/eclipse/jdt/compiler/apt/tests/processors/elements/Java12ElementProcessor.java
+++ b/org.eclipse.jdt.compiler.apt.tests/processors8/org/eclipse/jdt/compiler/apt/tests/processors/elements/Java12ElementProcessor.java
@@ -346,7 +346,7 @@ public class Java12ElementProcessor extends BaseProcessor {
 		throw new AssertionFailedError(msg);
 	}
 	private String getExceptionStackTrace(Throwable t) {
-		StringBuffer buf = new StringBuffer(t.getMessage());
+		StringBuilder buf = new StringBuilder(t.getMessage());
 		StackTraceElement[] traces = t.getStackTrace();
 		for (int i = 0; i < traces.length; i++) {
 			StackTraceElement trace = traces[i];
@@ -438,7 +438,7 @@ public class Java12ElementProcessor extends BaseProcessor {
 
 	public void assertEquals(String msg, int expected, int actual) {
 		if (expected != actual) {
-			StringBuffer buf = new StringBuffer();
+			StringBuilder buf = new StringBuilder();
 			buf.append(msg);
 			buf.append(", expected " + expected + " but was " + actual);
 			reportError(buf.toString());

--- a/org.eclipse.jdt.compiler.apt.tests/processors8/org/eclipse/jdt/compiler/apt/tests/processors/elements/Java13ElementProcessor.java
+++ b/org.eclipse.jdt.compiler.apt.tests/processors8/org/eclipse/jdt/compiler/apt/tests/processors/elements/Java13ElementProcessor.java
@@ -141,7 +141,7 @@ public class Java13ElementProcessor extends BaseProcessor {
 		throw new AssertionFailedError(msg);
 	}
 	private String getExceptionStackTrace(Throwable t) {
-		StringBuffer buf = new StringBuffer(t.getMessage());
+		StringBuilder buf = new StringBuilder(t.getMessage());
 		StackTraceElement[] traces = t.getStackTrace();
 		for (int i = 0; i < traces.length; i++) {
 			StackTraceElement trace = traces[i];
@@ -233,7 +233,7 @@ public class Java13ElementProcessor extends BaseProcessor {
 
 	public void assertEquals(String msg, int expected, int actual) {
 		if (expected != actual) {
-			StringBuffer buf = new StringBuffer();
+			StringBuilder buf = new StringBuilder();
 			buf.append(msg);
 			buf.append(", expected " + expected + " but was " + actual);
 			reportError(buf.toString());

--- a/org.eclipse.jdt.compiler.apt.tests/processors8/org/eclipse/jdt/compiler/apt/tests/processors/elements/Java8ElementProcessor.java
+++ b/org.eclipse.jdt.compiler.apt.tests/processors8/org/eclipse/jdt/compiler/apt/tests/processors/elements/Java8ElementProcessor.java
@@ -1115,7 +1115,7 @@ public class Java8ElementProcessor extends BaseProcessor {
 	}
 
 	private String getExceptionStackTrace(Throwable t) {
-		StringBuffer buf = new StringBuffer(t.getMessage());
+		StringBuilder buf = new StringBuilder(t.getMessage());
 		StackTraceElement[] traces = t.getStackTrace();
 		for (int i = 0; i < traces.length; i++) {
 			StackTraceElement trace = traces[i];
@@ -1147,7 +1147,7 @@ public class Java8ElementProcessor extends BaseProcessor {
 	private String getAnnotationString(AnnotationMirror annot) {
 		DeclaredType annotType = annot.getAnnotationType();
 		TypeElement type = (TypeElement) annotType.asElement();
-		StringBuffer buf = new StringBuffer("@" + type.getSimpleName());
+		StringBuilder buf = new StringBuilder("@" + type.getSimpleName());
 		Map<? extends ExecutableElement, ? extends AnnotationValue> values = annot.getElementValues();
 		Set<? extends ExecutableElement> keys = values.keySet();
 		buf.append('(');
@@ -1244,7 +1244,7 @@ public class Java8ElementProcessor extends BaseProcessor {
 
 	public void assertEquals(String msg, int expected, int actual) {
 		if (expected != actual) {
-			StringBuffer buf = new StringBuffer();
+			StringBuilder buf = new StringBuilder();
 			buf.append(msg);
 			buf.append(", expected " + expected + " but was " + actual);
 			reportError(buf.toString());

--- a/org.eclipse.jdt.compiler.apt.tests/processors8/org/eclipse/jdt/compiler/apt/tests/processors/elements/Java9ElementProcessor.java
+++ b/org.eclipse.jdt.compiler.apt.tests/processors8/org/eclipse/jdt/compiler/apt/tests/processors/elements/Java9ElementProcessor.java
@@ -1229,7 +1229,7 @@ public class Java9ElementProcessor extends BaseProcessor {
 		throw new AssertionFailedError(msg);
 	}
 	protected String getExceptionStackTrace(Throwable t) {
-		StringBuffer buf = new StringBuffer(t.getMessage());
+		StringBuilder buf = new StringBuilder(t.getMessage());
 		StackTraceElement[] traces = t.getStackTrace();
 		for (int i = 0; i < traces.length; i++) {
 			StackTraceElement trace = traces[i];
@@ -1310,7 +1310,7 @@ public class Java9ElementProcessor extends BaseProcessor {
 
 	public void assertEquals(String msg, int expected, int actual) {
 		if (expected != actual) {
-			StringBuffer buf = new StringBuffer();
+			StringBuilder buf = new StringBuilder();
 			buf.append(msg);
 			buf.append(", expected " + expected + " but was " + actual);
 			reportError(buf.toString());
@@ -1333,7 +1333,7 @@ public class Java9ElementProcessor extends BaseProcessor {
 	private String getAnnotationString(AnnotationMirror annot) {
 		DeclaredType annotType = annot.getAnnotationType();
 		TypeElement type = (TypeElement) annotType.asElement();
-		StringBuffer buf = new StringBuffer("@" + type.getQualifiedName());
+		StringBuilder buf = new StringBuilder("@" + type.getQualifiedName());
 		Map<? extends ExecutableElement, ? extends AnnotationValue> values = annot.getElementValues();
 		Set<? extends ExecutableElement> keys = values.keySet();
 		buf.append('(');

--- a/org.eclipse.jdt.compiler.apt.tests/processors8/org/eclipse/jdt/compiler/apt/tests/processors/elements/Java9ModuleProcessor.java
+++ b/org.eclipse.jdt.compiler.apt.tests/processors8/org/eclipse/jdt/compiler/apt/tests/processors/elements/Java9ModuleProcessor.java
@@ -117,7 +117,7 @@ public class Java9ModuleProcessor extends BaseProcessor {
 		throw new AssertionFailedError(msg);
 	}
 	private String getExceptionStackTrace(Throwable t) {
-		StringBuffer buf = new StringBuffer(t.getMessage());
+		StringBuilder buf = new StringBuilder(t.getMessage());
 		StackTraceElement[] traces = t.getStackTrace();
 		for (int i = 0; i < traces.length; i++) {
 			StackTraceElement trace = traces[i];

--- a/org.eclipse.jdt.compiler.apt.tests/src/org/eclipse/jdt/compiler/apt/tests/AnnotationProcessorTests.java
+++ b/org.eclipse.jdt.compiler.apt.tests/src/org/eclipse/jdt/compiler/apt/tests/AnnotationProcessorTests.java
@@ -32,11 +32,11 @@ public class AnnotationProcessorTests extends TestCase {
 
 	public final class DiagnosticReport<S> implements DiagnosticListener<S> {
 		public int count;
-		public StringBuffer buffer;
+		public StringBuilder buffer;
 		private final List<Diagnostic<? extends S>> warnings = new ArrayList<>();
 		DiagnosticReport() {
 			this.count = 0;
-			this.buffer = new StringBuffer();
+			this.buffer = new StringBuilder();
 		}
 		@Override
 		public void report(Diagnostic<? extends S> diagnostic) {
@@ -61,7 +61,7 @@ public class AnnotationProcessorTests extends TestCase {
 		}
 		public void clear() {
 			this.count = 0;
-			this.buffer = new StringBuffer();
+			this.buffer = new StringBuilder();
 		}
 	}
 

--- a/org.eclipse.jdt.compiler.apt.tests/src/org/eclipse/jdt/compiler/apt/tests/BatchTestUtils.java
+++ b/org.eclipse.jdt.compiler.apt.tests/src/org/eclipse/jdt/compiler/apt/tests/BatchTestUtils.java
@@ -75,10 +75,10 @@ public class BatchTestUtils {
 	private static File _tmpGenDir;
 
 	public static final class DiagnosticReport<S> implements DiagnosticListener<S> {
-		public StringBuffer buffer;
+		public StringBuilder buffer;
 		private final List<Diagnostic<? extends S>> diagnostics = new ArrayList<>();
 		DiagnosticReport() {
-			this.buffer = new StringBuffer();
+			this.buffer = new StringBuilder();
 		}
 		public void report(Diagnostic<? extends S> diagnostic) {
 			diagnostics.add(diagnostic);

--- a/org.eclipse.jdt.compiler.apt.tests/src/org/eclipse/jdt/compiler/apt/tests/ModelTests.java
+++ b/org.eclipse.jdt.compiler.apt.tests/src/org/eclipse/jdt/compiler/apt/tests/ModelTests.java
@@ -168,7 +168,7 @@ public class ModelTests extends TestCase {
 
 		List<String> options = new ArrayList<String>();
 		options.add("-A" + processorClass);
-		final StringBuffer reported = new StringBuffer();
+		final StringBuilder reported = new StringBuilder();
 		BatchTestUtils.compileTree(compiler, options, targetFolder, new DiagnosticListener () {
 			@Override
 			public void report(Diagnostic diag) {

--- a/org.eclipse.jdt.compiler.apt.tests/src/org/eclipse/jdt/compiler/apt/tests/TestUtils.java
+++ b/org.eclipse.jdt.compiler.apt.tests/src/org/eclipse/jdt/compiler/apt/tests/TestUtils.java
@@ -39,7 +39,7 @@ public class TestUtils {
 
 	public static String convertToIndependentLineDelimiter(String source) {
 		if (source.indexOf('\n') == -1 && source.indexOf('\r') == -1) return source;
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		for (int i = 0, length = source.length(); i < length; i++) {
 			char car = source.charAt(i);
 			if (car == '\r') {

--- a/org.eclipse.jdt.compiler.tool.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.compiler.tool.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.compiler.tool.tests
-Bundle-Version: 1.4.200.qualifier
+Bundle-Version: 1.4.300.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/org.eclipse.jdt.compiler.tool.tests/pom.xml
+++ b/org.eclipse.jdt.compiler.tool.tests/pom.xml
@@ -19,7 +19,7 @@
     <relativePath>../tests-pom/</relativePath>
   </parent>
   <artifactId>org.eclipse.jdt.compiler.tool.tests</artifactId>
-  <version>1.4.200-SNAPSHOT</version>
+  <version>1.4.300-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <properties>
   	<testSuite>${project.artifactId}</testSuite>

--- a/org.eclipse.jdt.compiler.tool.tests/src/org/eclipse/jdt/compiler/tool/tests/AbstractCompilerToolTest.java
+++ b/org.eclipse.jdt.compiler.tool.tests/src/org/eclipse/jdt/compiler/tool/tests/AbstractCompilerToolTest.java
@@ -49,7 +49,7 @@ public class AbstractCompilerToolTest extends BatchCompilerTest {
 		}
 		@Override
 		public String toString() {
-			StringBuffer result = new StringBuffer();
+			StringBuilder result = new StringBuilder();
 			for (String option: this.options) {
 				result.append(option);
 				result.append(' ');

--- a/org.eclipse.jdt.compiler.tool.tests/src/org/eclipse/jdt/compiler/tool/tests/CompilerToolJava9Tests.java
+++ b/org.eclipse.jdt.compiler.tool.tests/src/org/eclipse/jdt/compiler/tool/tests/CompilerToolJava9Tests.java
@@ -1226,7 +1226,7 @@ public class CompilerToolJava9Tests extends TestCase {
 
 	public static String convertToIndependentLineDelimiter(String source) {
 		if (source.indexOf('\n') == -1 && source.indexOf('\r') == -1) return source;
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		for (int i = 0, length = source.length(); i < length; i++) {
 			char car = source.charAt(i);
 			if (car == '\r') {

--- a/org.eclipse.jdt.compiler.tool.tests/src/org/eclipse/jdt/compiler/tool/tests/CompilerToolTests.java
+++ b/org.eclipse.jdt.compiler.tool.tests/src/org/eclipse/jdt/compiler/tool/tests/CompilerToolTests.java
@@ -1354,7 +1354,7 @@ static final String[] FAKE_ZERO_ARG_OPTIONS = new String[] {
 	public static String convertToIndependantLineDelimiter(String source) {
 		if (source == null) return "";
 	    if (source.indexOf('\n') == -1 && source.indexOf('\r') == -1) return source;
-	    StringBuffer buffer = new StringBuffer();
+	    StringBuilder buffer = new StringBuilder();
 	    for (int i = 0, length = source.length(); i < length; i++) {
 	        char car = source.charAt(i);
 	        if (car == '\r') {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/apt/model/AnnotationValueImpl.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/apt/model/AnnotationValueImpl.java
@@ -266,7 +266,7 @@ public class AnnotationValueImpl implements AnnotationValue, TypeIds {
 			return "null"; //$NON-NLS-1$
 		} else if (this._value instanceof String) {
 			String value = (String) this._value;
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			sb.append('"');
 			for (int i = 0; i < value.length(); i++) {
 				Util.appendEscapedChar(sb, value.charAt(i), true);
@@ -274,7 +274,7 @@ public class AnnotationValueImpl implements AnnotationValue, TypeIds {
 			sb.append('"');
 			return sb.toString();
 		} else if (this._value instanceof Character) {
-			StringBuffer sb = new StringBuffer();
+			StringBuilder sb = new StringBuilder();
 			sb.append('\'');
 			Util.appendEscapedChar(sb, ((Character) this._value).charValue(), false);
 			sb.append('\'');

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ASTNode.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ASTNode.java
@@ -663,9 +663,9 @@ public abstract class ASTNode implements TypeConstants, TypeIds {
 		return false;
 	}
 
-	public abstract StringBuffer print(int indent, StringBuffer output);
+	public abstract StringBuilder print(int indent, StringBuilder output);
 
-	public static StringBuffer printAnnotations(Annotation[] annotations, StringBuffer output) {
+	public static StringBuilder printAnnotations(Annotation[] annotations, StringBuilder output) {
 		int length = annotations.length;
 		for (int i = 0; i < length; i++) {
 			if (i > 0) {
@@ -681,13 +681,13 @@ public abstract class ASTNode implements TypeConstants, TypeIds {
 		return output;
 	}
 
-	public static StringBuffer printIndent(int indent, StringBuffer output) {
+	public static StringBuilder printIndent(int indent, StringBuilder output) {
 
 		for (int i = indent; i > 0; i--) output.append("  "); //$NON-NLS-1$
 		return output;
 	}
 
-	public static StringBuffer printModifiers(int modifiers, StringBuffer output) {
+	public static StringBuilder printModifiers(int modifiers, StringBuilder output) {
 
 		if ((modifiers & ClassFileConstants.AccPublic) != 0)
 			output.append("public "); //$NON-NLS-1$
@@ -1496,7 +1496,7 @@ public static void resolveDeprecatedAnnotations(BlockScope scope, Annotation[] a
 	@Override
 	public String toString() {
 
-		return print(0, new StringBuffer(30)).toString();
+		return print(0, new StringBuilder(30)).toString();
 	}
 
 	public void traverse(ASTVisitor visitor, BlockScope scope) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AbstractMethodDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AbstractMethodDeclaration.java
@@ -489,7 +489,7 @@ public abstract class AbstractMethodDeclaration
 	public abstract void parseStatements(Parser parser, CompilationUnitDeclaration unit);
 
 	@Override
-	public StringBuffer print(int tab, StringBuffer output) {
+	public StringBuilder print(int tab, StringBuilder output) {
 
 		if (this.javadoc != null) {
 			this.javadoc.print(tab, output);
@@ -535,7 +535,7 @@ public abstract class AbstractMethodDeclaration
 		return output;
 	}
 
-	public StringBuffer printBody(int indent, StringBuffer output) {
+	public StringBuilder printBody(int indent, StringBuilder output) {
 
 		if (isAbstract() || (this.modifiers & ExtraCompilerModifiers.AccSemicolonBody) != 0)
 			return output.append(';');
@@ -552,7 +552,7 @@ public abstract class AbstractMethodDeclaration
 		return output;
 	}
 
-	public StringBuffer printReturnType(int indent, StringBuffer output) {
+	public StringBuilder printReturnType(int indent, StringBuilder output) {
 
 		return output;
 	}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AbstractVariableDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AbstractVariableDeclaration.java
@@ -87,7 +87,7 @@ public abstract class AbstractVariableDeclaration extends Statement implements I
 	}
 
 	@Override
-	public StringBuffer printStatement(int indent, StringBuffer output) {
+	public StringBuilder printStatement(int indent, StringBuilder output) {
 		printAsExpression(indent, output);
 		switch(getKind()) {
 			case ENUM_CONSTANT:
@@ -97,7 +97,7 @@ public abstract class AbstractVariableDeclaration extends Statement implements I
 		}
 	}
 
-	public StringBuffer printAsExpression(int indent, StringBuffer output) {
+	public StringBuilder printAsExpression(int indent, StringBuilder output) {
 		printIndent(indent, output);
 		printModifiers(this.modifiers, output);
 		if (this.annotations != null) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AllocationExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AllocationExpression.java
@@ -318,7 +318,7 @@ public void manageSyntheticAccessIfNecessary(BlockScope currentScope, FlowInfo f
 }
 
 @Override
-public StringBuffer printExpression(int indent, StringBuffer output) {
+public StringBuilder printExpression(int indent, StringBuilder output) {
 	if (this.type != null) { // type null for enum constant initializations
 		output.append("new "); //$NON-NLS-1$
 	}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Annotation.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Annotation.java
@@ -208,7 +208,7 @@ public abstract class Annotation extends Expression {
 
 			@Override
 			public String toString() {
-				StringBuffer buffer = new StringBuffer();
+				StringBuilder buffer = new StringBuilder();
 				buffer
 					.append("search location for ") //$NON-NLS-1$
 					.append(this.searchedAnnotation)
@@ -679,7 +679,7 @@ public abstract class Annotation extends Expression {
 
 		if ((containerAnnotationTypeTargets & ~targets) != 0) {
 			class MissingTargetBuilder {
-				StringBuffer targetBuffer = new StringBuffer();
+				StringBuilder targetBuffer = new StringBuilder();
 				void check(long targetMask, char[] targetName) {
 					if ((containerAnnotationTypeTargets & targetMask & ~targets) != 0) {
 						 // if targetMask equals TagBits.AnnotationForType implies
@@ -814,7 +814,7 @@ public abstract class Annotation extends Expression {
 	public abstract MemberValuePair[] memberValuePairs();
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output) {
+	public StringBuilder printExpression(int indent, StringBuilder output) {
 		output.append('@');
 		this.type.printExpression(0, output);
 		return output;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AnnotationMethodDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AnnotationMethodDeclaration.java
@@ -59,7 +59,7 @@ public class AnnotationMethodDeclaration extends MethodDeclaration {
 	}
 
 	@Override
-	public StringBuffer print(int tab, StringBuffer output) {
+	public StringBuilder print(int tab, StringBuilder output) {
 
 		printIndent(tab, output);
 		printModifiers(this.modifiers, output);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Argument.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Argument.java
@@ -179,7 +179,7 @@ public class Argument extends LocalDeclaration {
 	}
 
 	@Override
-	public StringBuffer print(int indent, StringBuffer output) {
+	public StringBuilder print(int indent, StringBuilder output) {
 
 		printIndent(indent, output);
 		printModifiers(this.modifiers, output);
@@ -197,7 +197,7 @@ public class Argument extends LocalDeclaration {
 	}
 
 	@Override
-	public StringBuffer printStatement(int indent, StringBuffer output) {
+	public StringBuilder printStatement(int indent, StringBuilder output) {
 
 		return print(indent, output).append(';');
 	}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ArrayAllocationExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ArrayAllocationExpression.java
@@ -97,7 +97,7 @@ public class ArrayAllocationExpression extends Expression {
 
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output) {
+	public StringBuilder printExpression(int indent, StringBuilder output) {
 		output.append("new "); //$NON-NLS-1$
 		this.type.print(0, output);
 		for (int i = 0; i < this.dimensions.length; i++) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ArrayInitializer.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ArrayInitializer.java
@@ -142,7 +142,7 @@ public class ArrayInitializer extends Expression {
 	}
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output) {
+	public StringBuilder printExpression(int indent, StringBuilder output) {
 
 		output.append('{');
 		if (this.expressions != null) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ArrayQualifiedTypeReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ArrayQualifiedTypeReference.java
@@ -128,7 +128,7 @@ public class ArrayQualifiedTypeReference extends QualifiedTypeReference {
 	}
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output){
+	public StringBuilder printExpression(int indent, StringBuilder output){
 
 		super.printExpression(indent, output);
 		if ((this.bits & IsVarArgs) != 0) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ArrayReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ArrayReference.java
@@ -196,7 +196,7 @@ public void generatePostIncrement(BlockScope currentScope, CodeStream codeStream
 }
 
 @Override
-public StringBuffer printExpression(int indent, StringBuffer output) {
+public StringBuilder printExpression(int indent, StringBuilder output) {
 	this.receiver.printExpression(0, output).append('[');
 	return this.position.printExpression(0, output).append(']');
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ArrayTypeReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ArrayTypeReference.java
@@ -126,7 +126,7 @@ public class ArrayTypeReference extends SingleTypeReference {
 	}
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output){
+	public StringBuilder printExpression(int indent, StringBuilder output){
 
 		super.printExpression(indent, output);
 		if ((this.bits & IsVarArgs) != 0) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AssertStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AssertStatement.java
@@ -211,7 +211,7 @@ public void manageSyntheticAccessIfNecessary(BlockScope currentScope, FlowInfo f
 }
 
 @Override
-public StringBuffer printStatement(int tab, StringBuffer output) {
+public StringBuilder printStatement(int tab, StringBuilder output) {
 	printIndent(tab, output);
 	output.append("assert "); //$NON-NLS-1$
 	this.assertExpression.printExpression(0, output);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Assignment.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Assignment.java
@@ -170,25 +170,25 @@ public int nullStatus(FlowInfo flowInfo, FlowContext flowContext) {
 }
 
 @Override
-public StringBuffer print(int indent, StringBuffer output) {
+public StringBuilder print(int indent, StringBuilder output) {
 	//no () when used as a statement
 	printIndent(indent, output);
 	return printExpressionNoParenthesis(indent, output);
 }
 @Override
-public StringBuffer printExpression(int indent, StringBuffer output) {
+public StringBuilder printExpression(int indent, StringBuilder output) {
 	//subclass redefine printExpressionNoParenthesis()
 	output.append('(');
 	return printExpressionNoParenthesis(0, output).append(')');
 }
 
-public StringBuffer printExpressionNoParenthesis(int indent, StringBuffer output) {
+public StringBuilder printExpressionNoParenthesis(int indent, StringBuilder output) {
 	this.lhs.printExpression(indent, output).append(" = "); //$NON-NLS-1$
 	return this.expression.printExpression(0, output);
 }
 
 @Override
-public StringBuffer printStatement(int indent, StringBuffer output) {
+public StringBuilder printStatement(int indent, StringBuilder output) {
 	//no () when used as a statement
 	return print(indent, output).append(';');
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/BinaryExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/BinaryExpression.java
@@ -1819,7 +1819,7 @@ public void optimizedBooleanConstant(int leftId, int operator, int rightId) {
 }
 
 @Override
-public StringBuffer printExpressionNoParenthesis(int indent, StringBuffer output) {
+public StringBuilder printExpressionNoParenthesis(int indent, StringBuilder output) {
 	// keep implementation in sync with
 	// CombinedBinaryExpression#printExpressionNoParenthesis
 	this.left.printExpression(indent, output).append(' ').append(operatorToString()).append(' ');

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Block.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Block.java
@@ -99,7 +99,7 @@ public boolean isEmptyBlock() {
 	return this.statements == null;
 }
 
-public StringBuffer printBody(int indent, StringBuffer output) {
+public StringBuilder printBody(int indent, StringBuilder output) {
 	if (this.statements == null) return output;
 	for (int i = 0; i < this.statements.length; i++) {
 		this.statements[i].printStatement(indent + 1, output);
@@ -109,7 +109,7 @@ public StringBuffer printBody(int indent, StringBuffer output) {
 }
 
 @Override
-public StringBuffer printStatement(int indent, StringBuffer output) {
+public StringBuilder printStatement(int indent, StringBuilder output) {
 	printIndent(indent, output);
 	output.append("{\n"); //$NON-NLS-1$
 	printBody(indent, output);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/BreakStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/BreakStatement.java
@@ -94,7 +94,7 @@ public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext, Fl
 }
 
 @Override
-public StringBuffer printStatement(int tab, StringBuffer output) {
+public StringBuilder printStatement(int tab, StringBuilder output) {
 	printIndent(tab, output).append("break"); //$NON-NLS-1$
 	if (this.label != null) output.append(' ').append(this.label);
 	return output.append(';');

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/CaseStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/CaseStatement.java
@@ -132,7 +132,7 @@ public boolean containsPatternVariable() {
 	return false;
 }
 @Override
-public StringBuffer printStatement(int tab, StringBuffer output) {
+public StringBuilder printStatement(int tab, StringBuilder output) {
 	printIndent(tab, output);
 	if (this.constantExpressions == null) {
 		output.append("default "); //$NON-NLS-1$

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/CastExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/CastExpression.java
@@ -593,7 +593,7 @@ public Constant optimizedBooleanConstant() {
 }
 
 @Override
-public StringBuffer printExpression(int indent, StringBuffer output) {
+public StringBuilder printExpression(int indent, StringBuilder output) {
 	int parenthesesCount = (this.bits & ASTNode.ParenthesizedMASK) >> ASTNode.ParenthesizedSHIFT;
 	String suffix = ""; //$NON-NLS-1$
 	for(int i = 0; i < parenthesesCount; i++) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ClassLiteralAccess.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ClassLiteralAccess.java
@@ -73,7 +73,7 @@ public class ClassLiteralAccess extends Expression {
 	}
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output) {
+	public StringBuilder printExpression(int indent, StringBuilder output) {
 
 		return this.type.print(0, output).append(".class"); //$NON-NLS-1$
 	}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Clinit.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Clinit.java
@@ -383,7 +383,7 @@ public class Clinit extends AbstractMethodDeclaration {
 	}
 
 	@Override
-	public StringBuffer print(int tab, StringBuffer output) {
+	public StringBuilder print(int tab, StringBuilder output) {
 
 		printIndent(tab, output).append("<clinit>()"); //$NON-NLS-1$
 		printBody(tab + 1, output);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/CombinedBinaryExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/CombinedBinaryExpression.java
@@ -366,8 +366,8 @@ private void initArity(Expression expression, int value) {
 }
 
 @Override
-public StringBuffer printExpressionNoParenthesis(int indent,
-		StringBuffer output) {
+public StringBuilder printExpressionNoParenthesis(int indent,
+		StringBuilder output) {
 	// keep implementation in sync with
 	// BinaryExpression#printExpressionNoParenthesis and
 	// OperatorExpression#printExpression

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/CompilationUnitDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/CompilationUnitDeclaration.java
@@ -488,7 +488,7 @@ public boolean hasErrors() {
 }
 
 @Override
-public StringBuffer print(int indent, StringBuffer output) {
+public StringBuilder print(int indent, StringBuilder output) {
 	if (this.currentPackage != null) {
 		printIndent(indent, output).append("package "); //$NON-NLS-1$
 		this.currentPackage.print(0, output, false).append(";\n"); //$NON-NLS-1$

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/CompoundAssignment.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/CompoundAssignment.java
@@ -121,7 +121,7 @@ public int nullStatus(FlowInfo flowInfo, FlowContext flowContext) {
 	}
 
 	@Override
-	public StringBuffer printExpressionNoParenthesis(int indent, StringBuffer output) {
+	public StringBuilder printExpressionNoParenthesis(int indent, StringBuilder output) {
 
 		this.lhs.printExpression(indent, output).append(' ').append(operatorToString()).append(' ');
 		return this.expression.printExpression(0, output) ;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ConditionalExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ConditionalExpression.java
@@ -456,7 +456,7 @@ public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext,
 	}
 
 	@Override
-	public StringBuffer printExpressionNoParenthesis(int indent, StringBuffer output) {
+	public StringBuilder printExpressionNoParenthesis(int indent, StringBuilder output) {
 
 		this.condition.printExpression(indent, output).append(" ? "); //$NON-NLS-1$
 		this.valueIfTrue.printExpression(0, output).append(" : "); //$NON-NLS-1$

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ConstructorDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ConstructorDeclaration.java
@@ -600,7 +600,7 @@ public void parseStatements(Parser parser, CompilationUnitDeclaration unit) {
 }
 
 @Override
-public StringBuffer printBody(int indent, StringBuffer output) {
+public StringBuilder printBody(int indent, StringBuilder output) {
 	output.append(" {"); //$NON-NLS-1$
 	if (this.constructorCall != null) {
 		output.append('\n');

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ContinueStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ContinueStatement.java
@@ -97,7 +97,7 @@ public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext, Fl
 }
 
 @Override
-public StringBuffer printStatement(int tab, StringBuffer output) {
+public StringBuilder printStatement(int tab, StringBuilder output) {
 	printIndent(tab, output).append("continue "); //$NON-NLS-1$
 	if (this.label != null) output.append(this.label);
 	return output.append(';');

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/DoStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/DoStatement.java
@@ -212,7 +212,7 @@ public void generateCode(BlockScope currentScope, CodeStream codeStream) {
 }
 
 @Override
-public StringBuffer printStatement(int indent, StringBuffer output) {
+public StringBuilder printStatement(int indent, StringBuilder output) {
 	printIndent(indent, output).append("do"); //$NON-NLS-1$
 	if (this.action == null)
 		output.append(" ;\n"); //$NON-NLS-1$

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/EmptyStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/EmptyStatement.java
@@ -49,7 +49,7 @@ public class EmptyStatement extends Statement {
 	}
 
 	@Override
-	public StringBuffer printStatement(int tab, StringBuffer output) {
+	public StringBuilder printStatement(int tab, StringBuilder output) {
 		return printIndent(tab, output).append(';');
 	}
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ExplicitConstructorCall.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ExplicitConstructorCall.java
@@ -270,7 +270,7 @@ public class ExplicitConstructorCall extends Statement implements Invocation {
 	}
 
 	@Override
-	public StringBuffer printStatement(int indent, StringBuffer output) {
+	public StringBuilder printStatement(int indent, StringBuilder output) {
 		printIndent(indent, output);
 		if (this.qualification != null) this.qualification.printExpression(0, output).append('.');
 		if (this.typeArguments != null) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ExportsStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ExportsStatement.java
@@ -24,7 +24,7 @@ public class ExportsStatement extends PackageVisibilityStatement {
 	}
 
 	@Override
-	public StringBuffer print(int indent, StringBuffer output) {
+	public StringBuilder print(int indent, StringBuilder output) {
 		printIndent(indent, output);
 		output.append("exports "); //$NON-NLS-1$
 		super.print(0, output);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Expression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Expression.java
@@ -1139,15 +1139,15 @@ public TypeBinding postConversionType(Scope scope) {
 }
 
 @Override
-public StringBuffer print(int indent, StringBuffer output) {
+public StringBuilder print(int indent, StringBuilder output) {
 	printIndent(indent, output);
 	return printExpression(indent, output);
 }
 
-public abstract StringBuffer printExpression(int indent, StringBuffer output);
+public abstract StringBuilder printExpression(int indent, StringBuilder output);
 
 @Override
-public StringBuffer printStatement(int indent, StringBuffer output) {
+public StringBuilder printStatement(int indent, StringBuilder output) {
 	return print(indent, output).append(";"); //$NON-NLS-1$
 }
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ExtendedStringLiteral.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ExtendedStringLiteral.java
@@ -72,7 +72,7 @@ public class ExtendedStringLiteral extends StringLiteral {
 	}
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output) {
+	public StringBuilder printExpression(int indent, StringBuilder output) {
 
 		return output.append("ExtendedStringLiteral{").append(this.source).append('}'); //$NON-NLS-1$
 	}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/FieldDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/FieldDeclaration.java
@@ -182,14 +182,14 @@ public boolean isFinal() {
 	return (this.modifiers & ClassFileConstants.AccFinal) != 0;
 }
 @Override
-public StringBuffer print(int indent, StringBuffer output) {
+public StringBuilder print(int indent, StringBuilder output) {
 	if (this.isARecordComponent)
 		output.append("/* Implicit */"); //$NON-NLS-1$
 	return super.print(indent, output);
 }
 
 @Override
-public StringBuffer printStatement(int indent, StringBuffer output) {
+public StringBuilder printStatement(int indent, StringBuilder output) {
 	if (this.javadoc != null) {
 		this.javadoc.print(indent, output);
 	}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/FieldReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/FieldReference.java
@@ -645,7 +645,7 @@ public TypeBinding postConversionType(Scope scope) {
 }
 
 @Override
-public StringBuffer printExpression(int indent, StringBuffer output) {
+public StringBuilder printExpression(int indent, StringBuilder output) {
 	return this.receiver.printExpression(0, output).append('.').append(this.token);
 }
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ForStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ForStatement.java
@@ -373,7 +373,7 @@ public class ForStatement extends Statement {
 	}
 
 	@Override
-	public StringBuffer printStatement(int tab, StringBuffer output) {
+	public StringBuilder printStatement(int tab, StringBuilder output) {
 
 		printIndent(tab, output).append("for ("); //$NON-NLS-1$
 		//inits

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ForeachStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ForeachStatement.java
@@ -465,7 +465,7 @@ public class ForeachStatement extends Statement {
 	}
 
 	@Override
-	public StringBuffer printStatement(int indent, StringBuffer output) {
+	public StringBuilder printStatement(int indent, StringBuilder output) {
 
 		printIndent(indent, output).append("for ("); //$NON-NLS-1$
 		if (this.pattern != null) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/GuardedPattern.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/GuardedPattern.java
@@ -172,7 +172,7 @@ public class GuardedPattern extends Pattern {
 	}
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output) {
+	public StringBuilder printExpression(int indent, StringBuilder output) {
 		this.primaryPattern.print(indent, output).append(" when "); //$NON-NLS-1$
 		return this.condition.print(indent, output);
 	}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/IfStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/IfStatement.java
@@ -272,7 +272,7 @@ public void generateCode(BlockScope currentScope, CodeStream codeStream) {
 
 
 @Override
-public StringBuffer printStatement(int indent, StringBuffer output) {
+public StringBuilder printStatement(int indent, StringBuilder output) {
 	printIndent(indent, output).append("if ("); //$NON-NLS-1$
 	this.condition.printExpression(0, output).append(")\n");	//$NON-NLS-1$
 	this.thenStatement.printStatement(indent + 2, output);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ImportReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ImportReference.java
@@ -81,12 +81,12 @@ public class ImportReference extends ASTNode {
 	}
 
 	@Override
-	public StringBuffer print(int indent, StringBuffer output) {
+	public StringBuilder print(int indent, StringBuilder output) {
 
 		return print(indent, output, true);
 	}
 
-	public StringBuffer print(int tab, StringBuffer output, boolean withOnDemand) {
+	public StringBuilder print(int tab, StringBuilder output, boolean withOnDemand) {
 
 		/* when withOnDemand is false, only the name is printed */
 		for (int i = 0; i < this.tokens.length; i++) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Initializer.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Initializer.java
@@ -95,7 +95,7 @@ public class Initializer extends FieldDeclaration {
 	}
 
 	@Override
-	public StringBuffer printStatement(int indent, StringBuffer output) {
+	public StringBuilder printStatement(int indent, StringBuilder output) {
 
 		if (this.modifiers != 0) {
 			printIndent(indent, output);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/InstanceOfExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/InstanceOfExpression.java
@@ -250,7 +250,7 @@ private void addAssignment(BlockScope currentScope, CodeStream codeStream, Local
 }
 
 @Override
-public StringBuffer printExpressionNoParenthesis(int indent, StringBuffer output) {
+public StringBuilder printExpressionNoParenthesis(int indent, StringBuilder output) {
 	this.expression.printExpression(indent, output).append(" instanceof "); //$NON-NLS-1$
 	return this.pattern == null ? this.type.print(0, output) : this.pattern.printExpression(0, output);
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/IntersectionCastTypeReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/IntersectionCastTypeReference.java
@@ -181,7 +181,7 @@ public class IntersectionCastTypeReference extends TypeReference {
 	}
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output) {
+	public StringBuilder printExpression(int indent, StringBuilder output) {
 		int length = this.typeReferences == null ? 0 : this.typeReferences.length;
 		printIndent(indent, output);
 		for (int i = 0; i < length; i++) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Javadoc.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Javadoc.java
@@ -177,7 +177,7 @@ public class Javadoc extends ASTNode {
 	 * @see org.eclipse.jdt.internal.compiler.ast.ASTNode#print(int, java.lang.StringBuffer)
 	 */
 	@Override
-	public StringBuffer print(int indent, StringBuffer output) {
+	public StringBuilder print(int indent, StringBuilder output) {
 		printIndent(indent, output).append("/**\n"); //$NON-NLS-1$
 		if (this.paramReferences != null) {
 			for (int i = 0, length = this.paramReferences.length; i < length; i++) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/JavadocArgumentExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/JavadocArgumentExpression.java
@@ -82,7 +82,7 @@ public class JavadocArgumentExpression extends Expression {
 	}
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output) {
+	public StringBuilder printExpression(int indent, StringBuilder output) {
 		if (this.argument == null) {
 			if (this.token != null) {
 				output.append(this.token);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/JavadocFieldReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/JavadocFieldReference.java
@@ -120,7 +120,7 @@ public class JavadocFieldReference extends FieldReference {
 	}
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output) {
+	public StringBuilder printExpression(int indent, StringBuilder output) {
 
 		if (this.receiver != null) {
 			this.receiver.printExpression(0, output);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/JavadocImplicitTypeReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/JavadocImplicitTypeReference.java
@@ -139,7 +139,7 @@ public class JavadocImplicitTypeReference extends TypeReference {
 	}
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output) {
-		return new StringBuffer();
+	public StringBuilder printExpression(int indent, StringBuilder output) {
+		return new StringBuilder();
 	}
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/JavadocMessageSend.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/JavadocMessageSend.java
@@ -185,7 +185,7 @@ public class JavadocMessageSend extends MessageSend {
 	}
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output){
+	public StringBuilder printExpression(int indent, StringBuilder output){
 
 		if (this.receiver != null) {
 			this.receiver.printExpression(0, output);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/JavadocModuleReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/JavadocModuleReference.java
@@ -91,7 +91,7 @@ public class JavadocModuleReference extends Expression implements IJavadocTypeRe
 	}
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output) {
+	public StringBuilder printExpression(int indent, StringBuilder output) {
 		if (this.moduleReference != null) {
 			output.append(this.moduleReference.moduleName);
 		}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/JavadocReturnStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/JavadocReturnStatement.java
@@ -42,7 +42,7 @@ public class JavadocReturnStatement extends ReturnStatement {
 	}
 
 	@Override
-	public StringBuffer printStatement(int tab, StringBuffer output) {
+	public StringBuilder printStatement(int tab, StringBuilder output) {
 		printIndent(tab, output).append("return"); //$NON-NLS-1$
 		if ((this.bits & ASTNode.Empty) == 0)
 			output.append(' ').append(" <not empty>"); //$NON-NLS-1$

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LabeledStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LabeledStatement.java
@@ -120,7 +120,7 @@ public class LabeledStatement extends Statement {
 	}
 
 	@Override
-	public StringBuffer printStatement(int tab, StringBuffer output) {
+	public StringBuilder printStatement(int tab, StringBuilder output) {
 
 		printIndent(tab, output).append(this.label).append(": "); //$NON-NLS-1$
 		if (this.statement == null)

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LambdaExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LambdaExpression.java
@@ -759,11 +759,11 @@ public class LambdaExpression extends FunctionalExpression implements IPolyExpre
 	}
 
 	@Override
-	public StringBuffer printExpression(int tab, StringBuffer output) {
+	public StringBuilder printExpression(int tab, StringBuilder output) {
 		return printExpression(tab, output, false);
 	}
 
-	public StringBuffer printExpression(int tab, StringBuffer output, boolean makeShort) {
+	public StringBuilder printExpression(int tab, StringBuilder output, boolean makeShort) {
 		int parenthesesCount = (this.bits & ASTNode.ParenthesizedMASK) >> ASTNode.ParenthesizedSHIFT;
 		String suffix = ""; //$NON-NLS-1$
 		for(int i = 0; i < parenthesesCount; i++) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Literal.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Literal.java
@@ -40,7 +40,7 @@ public abstract class Literal extends Expression {
 	public abstract TypeBinding literalType(BlockScope scope);
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output){
+	public StringBuilder printExpression(int indent, StringBuilder output){
 
 		return output.append(source());
 	 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/MemberValuePair.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/MemberValuePair.java
@@ -52,7 +52,7 @@ public class MemberValuePair extends ASTNode {
 	}
 
 	@Override
-	public StringBuffer print(int indent, StringBuffer output) {
+	public StringBuilder print(int indent, StringBuilder output) {
 		output
 			.append(this.name)
 			.append(" = "); //$NON-NLS-1$

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/MessageSend.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/MessageSend.java
@@ -701,7 +701,7 @@ public TypeBinding postConversionType(Scope scope) {
 }
 
 @Override
-public StringBuffer printExpression(int indent, StringBuffer output){
+public StringBuilder printExpression(int indent, StringBuilder output){
 
 	if (!this.receiver.isImplicitThis()) this.receiver.printExpression(0, output).append('.');
 	if (this.typeArguments != null) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/MethodDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/MethodDeclaration.java
@@ -253,7 +253,7 @@ public class MethodDeclaration extends AbstractMethodDeclaration {
 	}
 
 	@Override
-	public StringBuffer printReturnType(int indent, StringBuffer output) {
+	public StringBuilder printReturnType(int indent, StringBuilder output) {
 		if (this.returnType == null) return output;
 		return this.returnType.printExpression(0, output).append(' ');
 	}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ModuleDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ModuleDeclaration.java
@@ -360,7 +360,7 @@ public class ModuleDeclaration extends ASTNode implements ReferenceContext {
 		visitor.visit(this, unitScope);
 	}
 
-	public StringBuffer printHeader(int indent, StringBuffer output) {
+	public StringBuilder printHeader(int indent, StringBuilder output) {
 		if (this.annotations != null) {
 			for (int i = 0; i < this.annotations.length; i++) {
 				this.annotations[i].print(indent, output);
@@ -376,7 +376,7 @@ public class ModuleDeclaration extends ASTNode implements ReferenceContext {
 		output.append(CharOperation.charToString(this.moduleName));
 		return output;
 	}
-	public StringBuffer printBody(int indent, StringBuffer output) {
+	public StringBuilder printBody(int indent, StringBuilder output) {
 		output.append(" {"); //$NON-NLS-1$
 		if (this.requires != null) {
 			for(int i = 0; i < this.requiresCount; i++) {
@@ -414,7 +414,7 @@ public class ModuleDeclaration extends ASTNode implements ReferenceContext {
 	}
 
 	@Override
-	public StringBuffer print(int indent, StringBuffer output) {
+	public StringBuilder print(int indent, StringBuilder output) {
 		//
 		printIndent(indent, output);
 		printHeader(0, output);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ModuleReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ModuleReference.java
@@ -33,7 +33,7 @@ public class ModuleReference extends ASTNode {
 	}
 
 	@Override
-	public StringBuffer print(int indent, StringBuffer output) {
+	public StringBuilder print(int indent, StringBuilder output) {
 		for (int i = 0; i < this.tokens.length; i++) {
 			if (i > 0) output.append('.');
 			output.append(this.tokens[i]);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/NormalAnnotation.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/NormalAnnotation.java
@@ -49,7 +49,7 @@ public class NormalAnnotation extends Annotation {
 		return this.memberValuePairs == null ? NoValuePairs : this.memberValuePairs;
 	}
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output) {
+	public StringBuilder printExpression(int indent, StringBuilder output) {
 		super.printExpression(indent, output);
 		output.append('(');
 		if (this.memberValuePairs != null) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/OpensStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/OpensStatement.java
@@ -34,7 +34,7 @@ public class OpensStatement extends PackageVisibilityStatement {
 		}
 	}
 	@Override
-	public StringBuffer print(int indent, StringBuffer output) {
+	public StringBuilder print(int indent, StringBuilder output) {
 		printIndent(indent, output);
 		output.append("opens "); //$NON-NLS-1$
 		super.print(0, output);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/OperatorExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/OperatorExpression.java
@@ -1568,11 +1568,11 @@ public abstract class OperatorExpression extends Expression implements OperatorI
 	}
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output){
+	public StringBuilder printExpression(int indent, StringBuilder output){
 
 		output.append('(');
 		return printExpressionNoParenthesis(0, output).append(')');
 	}
 
-	public abstract StringBuffer printExpressionNoParenthesis(int indent, StringBuffer output);
+	public abstract StringBuilder printExpressionNoParenthesis(int indent, StringBuilder output);
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/PackageVisibilityStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/PackageVisibilityStatement.java
@@ -71,7 +71,7 @@ public abstract class PackageVisibilityStatement extends ModuleStatement {
 	}
 
 	@Override
-	public StringBuffer print(int indent, StringBuffer output) {
+	public StringBuilder print(int indent, StringBuilder output) {
 		this.pkgRef.print(indent, output);
 		if (this.isQualified()) {
 			output.append(" to "); //$NON-NLS-1$

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ParameterizedQualifiedTypeReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ParameterizedQualifiedTypeReference.java
@@ -389,7 +389,7 @@ public class ParameterizedQualifiedTypeReference extends ArrayQualifiedTypeRefer
 	}
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output) {
+	public StringBuilder printExpression(int indent, StringBuilder output) {
 		int length = this.tokens.length;
 		for (int i = 0; i < length - 1; i++) {
 			if (this.annotations != null && this.annotations[i] != null) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ParameterizedSingleTypeReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ParameterizedSingleTypeReference.java
@@ -339,7 +339,7 @@ public class ParameterizedSingleTypeReference extends ArrayTypeReference {
 	}
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output){
+	public StringBuilder printExpression(int indent, StringBuilder output){
 		if (this.annotations != null && this.annotations[0] != null) {
 			printAnnotations(this.annotations[0], output);
 			output.append(' ');

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Pattern.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Pattern.java
@@ -132,7 +132,7 @@ public abstract class Pattern extends Expression {
 	}
 
 	@Override
-	public StringBuffer print(int indent, StringBuffer output) {
+	public StringBuilder print(int indent, StringBuilder output) {
 		return this.printExpression(indent, output);
 	}
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/PostfixExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/PostfixExpression.java
@@ -61,7 +61,7 @@ public String operatorToString() {
 }
 
 @Override
-public StringBuffer printExpressionNoParenthesis(int indent, StringBuffer output) {
+public StringBuilder printExpressionNoParenthesis(int indent, StringBuilder output) {
 	return this.lhs.printExpression(indent, output).append(' ').append(operatorToString());
 }
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/PrefixExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/PrefixExpression.java
@@ -45,7 +45,7 @@ public String operatorToString() {
 }
 
 @Override
-public StringBuffer printExpressionNoParenthesis(int indent, StringBuffer output) {
+public StringBuilder printExpressionNoParenthesis(int indent, StringBuilder output) {
 
 	output.append(operatorToString()).append(' ');
 	return this.lhs.printExpression(0, output);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ProvidesStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ProvidesStatement.java
@@ -118,7 +118,7 @@ public class ProvidesStatement extends ModuleStatement {
 	}
 
 	@Override
-	public StringBuffer print(int indent, StringBuffer output) {
+	public StringBuilder print(int indent, StringBuilder output) {
 		printIndent(indent, output);
 		output.append("provides "); //$NON-NLS-1$
 		this.serviceInterface.print(0, output);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/QualifiedAllocationExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/QualifiedAllocationExpression.java
@@ -285,7 +285,7 @@ public class QualifiedAllocationExpression extends AllocationExpression {
 	}
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output) {
+	public StringBuilder printExpression(int indent, StringBuilder output) {
 		if (this.enclosingInstance != null)
 			this.enclosingInstance.printExpression(0, output).append('.');
 		super.printExpression(0, output);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/QualifiedNameReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/QualifiedNameReference.java
@@ -993,7 +993,7 @@ public TypeBinding postConversionType(Scope scope) {
 }
 
 @Override
-public StringBuffer printExpression(int indent, StringBuffer output) {
+public StringBuilder printExpression(int indent, StringBuilder output) {
 	for (int i = 0; i < this.tokens.length; i++) {
 		if (i > 0) output.append('.');
 		output.append(this.tokens[i]);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/QualifiedSuperReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/QualifiedSuperReference.java
@@ -49,7 +49,7 @@ public boolean isThis() {
 }
 
 @Override
-public StringBuffer printExpression(int indent, StringBuffer output) {
+public StringBuilder printExpression(int indent, StringBuilder output) {
 	return this.qualification.print(0, output).append(".super"); //$NON-NLS-1$
 }
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/QualifiedThisReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/QualifiedThisReference.java
@@ -151,7 +151,7 @@ public class QualifiedThisReference extends ThisReference {
 	}
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output) {
+	public StringBuilder printExpression(int indent, StringBuilder output) {
 
 		return this.qualification.print(0, output).append(".this"); //$NON-NLS-1$
 	}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/QualifiedTypeReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/QualifiedTypeReference.java
@@ -203,7 +203,7 @@ public class QualifiedTypeReference extends TypeReference {
 	}
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output) {
+	public StringBuilder printExpression(int indent, StringBuilder output) {
 		for (int i = 0; i < this.tokens.length; i++) {
 			if (i > 0) output.append('.');
 			if (this.annotations != null && this.annotations[i] != null) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Receiver.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Receiver.java
@@ -26,7 +26,7 @@ public class Receiver extends Argument {
 	}
 
 	@Override
-	public StringBuffer print(int indent, StringBuffer output) {
+	public StringBuilder print(int indent, StringBuilder output) {
 
 		printIndent(indent, output);
 		printModifiers(this.modifiers, output);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/RecordComponent.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/RecordComponent.java
@@ -130,7 +130,7 @@ public class RecordComponent extends AbstractVariableDeclaration {
 	}
 
 	@Override
-	public StringBuffer print(int indent, StringBuffer output) {
+	public StringBuilder print(int indent, StringBuilder output) {
 
 		printIndent(indent, output);
 		printModifiers(this.modifiers, output);
@@ -148,7 +148,7 @@ public class RecordComponent extends AbstractVariableDeclaration {
 	}
 
 	@Override
-	public StringBuffer printStatement(int indent, StringBuffer output) {
+	public StringBuilder printStatement(int indent, StringBuilder output) {
 
 		return print(indent, output).append(';');
 	}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/RecordPattern.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/RecordPattern.java
@@ -423,7 +423,7 @@ public class RecordPattern extends TypePattern {
 	}
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output) {
+	public StringBuilder printExpression(int indent, StringBuilder output) {
 		output.append(this.type).append('(');
 		if (this.patterns != null) {
 			for (int i = 0; i < this.patterns.length; i++) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ReferenceExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ReferenceExpression.java
@@ -1106,7 +1106,7 @@ public class ReferenceExpression extends FunctionalExpression implements IPolyEx
 	}
 
 	@Override
-	public StringBuffer printExpression(int tab, StringBuffer output) {
+	public StringBuilder printExpression(int tab, StringBuilder output) {
 
 		this.lhs.print(0, output);
 		output.append("::"); //$NON-NLS-1$

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/RequiresStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/RequiresStatement.java
@@ -35,7 +35,7 @@ public class RequiresStatement extends ModuleStatement {
 		return (this.modifiers & ClassFileConstants.ACC_STATIC_PHASE) != 0;
 	}
 	@Override
-	public StringBuffer print(int indent, StringBuffer output) {
+	public StringBuilder print(int indent, StringBuilder output) {
 		output.append("requires "); //$NON-NLS-1$
 		if (isTransitive())
 			output.append("transitive "); //$NON-NLS-1$

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ReturnStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ReturnStatement.java
@@ -281,7 +281,7 @@ public void prepareSaveValueLocation(TryStatement targetTryStatement){
 }
 
 @Override
-public StringBuffer printStatement(int tab, StringBuffer output){
+public StringBuilder printStatement(int tab, StringBuilder output){
 	printIndent(tab, output).append("return "); //$NON-NLS-1$
 	if (this.expression != null )
 		this.expression.printExpression(0, output) ;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SingleMemberAnnotation.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SingleMemberAnnotation.java
@@ -56,7 +56,7 @@ public class SingleMemberAnnotation extends Annotation {
 	}
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output) {
+	public StringBuilder printExpression(int indent, StringBuilder output) {
 		super.printExpression(indent, output);
 		output.append('(');
 		this.memberValue.printExpression(indent, output);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SingleNameReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SingleNameReference.java
@@ -995,7 +995,7 @@ public TypeBinding postConversionType(Scope scope) {
 }
 
 @Override
-public StringBuffer printExpression(int indent, StringBuffer output){
+public StringBuilder printExpression(int indent, StringBuilder output){
 	return output.append(this.token);
 }
 public TypeBinding reportError(BlockScope scope) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SingleTypeReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SingleTypeReference.java
@@ -98,7 +98,7 @@ public class SingleTypeReference extends TypeReference {
 	}
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output){
+	public StringBuilder printExpression(int indent, StringBuilder output){
 		if (this.annotations != null && this.annotations[0] != null) {
 			printAnnotations(this.annotations[0], output);
 			output.append(' ');

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Statement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Statement.java
@@ -478,11 +478,11 @@ public boolean isValidJavaStatement() {
 }
 
 @Override
-public StringBuffer print(int indent, StringBuffer output) {
+public StringBuilder print(int indent, StringBuilder output) {
 	return printStatement(indent, output);
 }
 
-public abstract StringBuffer printStatement(int indent, StringBuffer output);
+public abstract StringBuilder printStatement(int indent, StringBuilder output);
 
 public abstract void resolve(BlockScope scope);
 public LocalVariableBinding[] getPatternVariablesWhenTrue() {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/StringLiteral.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/StringLiteral.java
@@ -80,7 +80,7 @@ public class StringLiteral extends Literal {
 	}
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output) {
+	public StringBuilder printExpression(int indent, StringBuilder output) {
 
 		// handle some special char.....
 		output.append('\"');

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/StringLiteralConcatenation.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/StringLiteralConcatenation.java
@@ -60,7 +60,7 @@ public class StringLiteralConcatenation extends StringLiteral {
 	}
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output) {
+	public StringBuilder printExpression(int indent, StringBuilder output) {
 		output.append("StringLiteralConcatenation{"); //$NON-NLS-1$
 		for (int i = 0, max = this.counter; i < max; i++) {
 			this.literals[i].printExpression(indent, output);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SuperReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SuperReference.java
@@ -57,7 +57,7 @@ public class SuperReference extends ThisReference {
 	}
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output){
+	public StringBuilder printExpression(int indent, StringBuilder output){
 
 		return output.append("super"); //$NON-NLS-1$
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
@@ -1052,7 +1052,7 @@ public class SwitchStatement extends Expression {
 		generateCode(currentScope, codeStream); // redirecting to statement part
 	}
 	@Override
-	public StringBuffer printStatement(int indent, StringBuffer output) {
+	public StringBuilder printStatement(int indent, StringBuilder output) {
 
 		printIndent(indent, output).append("switch ("); //$NON-NLS-1$
 		this.expression.printExpression(0, output).append(") {"); //$NON-NLS-1$
@@ -1740,7 +1740,7 @@ public class SwitchStatement extends Expression {
 	}
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output) {
+	public StringBuilder printExpression(int indent, StringBuilder output) {
 		return printStatement(indent, output);
 	}
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SynchronizedStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SynchronizedStatement.java
@@ -216,7 +216,7 @@ public void resolve(BlockScope upperScope) {
 }
 
 @Override
-public StringBuffer printStatement(int indent, StringBuffer output) {
+public StringBuilder printStatement(int indent, StringBuilder output) {
 	printIndent(indent, output);
 	output.append("synchronized ("); //$NON-NLS-1$
 	this.expression.printExpression(0, output).append(')');

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ThisReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ThisReference.java
@@ -121,7 +121,7 @@ public class ThisReference extends Reference {
 	}
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output){
+	public StringBuilder printExpression(int indent, StringBuilder output){
 
 		if (isImplicitThis()) return output;
 		return output.append("this"); //$NON-NLS-1$

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ThrowStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ThrowStatement.java
@@ -66,7 +66,7 @@ public void generateCode(BlockScope currentScope, CodeStream codeStream) {
 }
 
 @Override
-public StringBuffer printStatement(int indent, StringBuffer output) {
+public StringBuilder printStatement(int indent, StringBuilder output) {
 	printIndent(indent, output).append("throw "); //$NON-NLS-1$
 	this.exception.printExpression(0, output);
 	return output.append(';');

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TryStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TryStatement.java
@@ -1078,7 +1078,7 @@ public boolean isSubRoutineEscaping() {
 }
 
 @Override
-public StringBuffer printStatement(int indent, StringBuffer output) {
+public StringBuilder printStatement(int indent, StringBuilder output) {
 	int length = this.resources.length;
 	printIndent(indent, output).append("try" + (length == 0 ? "\n" : " (")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 	for (int i = 0; i < length; i++) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypeDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypeDeclaration.java
@@ -1159,7 +1159,7 @@ public void parseMethods(Parser parser, CompilationUnitDeclaration unit) {
 }
 
 @Override
-public StringBuffer print(int indent, StringBuffer output) {
+public StringBuilder print(int indent, StringBuilder output) {
 	if (this.javadoc != null) {
 		this.javadoc.print(indent, output);
 	}
@@ -1170,7 +1170,7 @@ public StringBuffer print(int indent, StringBuffer output) {
 	return printBody(indent, output);
 }
 
-public StringBuffer printBody(int indent, StringBuffer output) {
+public StringBuilder printBody(int indent, StringBuilder output) {
 	output.append(" {"); //$NON-NLS-1$
 	if (this.memberTypes != null) {
 		for (int i = 0; i < this.memberTypes.length; i++) {
@@ -1200,7 +1200,7 @@ public StringBuffer printBody(int indent, StringBuffer output) {
 	return printIndent(indent, output).append('}');
 }
 
-public StringBuffer printHeader(int indent, StringBuffer output) {
+public StringBuilder printHeader(int indent, StringBuilder output) {
 	printModifiers(this.modifiers, output);
 	if (this.annotations != null) {
 		printAnnotations(this.annotations, output);
@@ -1278,7 +1278,7 @@ public StringBuffer printHeader(int indent, StringBuffer output) {
 }
 
 @Override
-public StringBuffer printStatement(int tab, StringBuffer output) {
+public StringBuilder printStatement(int tab, StringBuilder output) {
 	return print(tab, output);
 }
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypeParameter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypeParameter.java
@@ -180,7 +180,7 @@ public class TypeParameter extends AbstractVariableDeclaration {
 	}
 
 	@Override
-	public StringBuffer printStatement(int indent, StringBuffer output) {
+	public StringBuilder printStatement(int indent, StringBuilder output) {
 		if (this.annotations != null) {
 			printAnnotations(this.annotations, output);
 			output.append(' ');

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypePattern.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypePattern.java
@@ -284,7 +284,7 @@ public class TypePattern extends Pattern {
 	}
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output) {
+	public StringBuilder printExpression(int indent, StringBuilder output) {
 		return this.local != null ? this.local.printAsExpression(indent, output) : output;
 	}
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/UnaryExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/UnaryExpression.java
@@ -219,7 +219,7 @@ public class UnaryExpression extends OperatorExpression {
 	}
 
 	@Override
-	public StringBuffer printExpressionNoParenthesis(int indent, StringBuffer output) {
+	public StringBuilder printExpressionNoParenthesis(int indent, StringBuilder output) {
 
 		output.append(operatorToString()).append(' ');
 		return this.expression.printExpression(0, output);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/UnionTypeReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/UnionTypeReference.java
@@ -131,7 +131,7 @@ public class UnionTypeReference extends TypeReference {
 	}
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output) {
+	public StringBuilder printExpression(int indent, StringBuilder output) {
 		int length = this.typeReferences == null ? 0 : this.typeReferences.length;
 		printIndent(indent, output);
 		for (int i = 0; i < length; i++) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/UsesStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/UsesStatement.java
@@ -21,7 +21,7 @@ public class UsesStatement extends ModuleStatement {
 		this.serviceInterface = serviceInterface;
 	}
 	@Override
-	public StringBuffer print(int indent, StringBuffer output) {
+	public StringBuilder print(int indent, StringBuilder output) {
 		printIndent(indent, output);
 		output.append("uses "); //$NON-NLS-1$
 		this.serviceInterface.print(0, output);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/WhileStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/WhileStatement.java
@@ -302,7 +302,7 @@ public class WhileStatement extends Statement {
 	}
 
 	@Override
-	public StringBuffer printStatement(int tab, StringBuffer output) {
+	public StringBuilder printStatement(int tab, StringBuilder output) {
 
 		printIndent(tab, output).append("while ("); //$NON-NLS-1$
 		this.condition.printExpression(0, output).append(')');

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Wildcard.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Wildcard.java
@@ -88,7 +88,7 @@ public class Wildcard extends SingleTypeReference {
 	}
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output){
+	public StringBuilder printExpression(int indent, StringBuilder output){
 		if (this.annotations != null && this.annotations[0] != null) {
 			printAnnotations(this.annotations[0], output);
 			output.append(' ');

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/YieldStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/YieldStatement.java
@@ -255,7 +255,7 @@ public TypeBinding resolveExpressionType(BlockScope scope1) {
 }
 
 @Override
-public StringBuffer printStatement(int tab, StringBuffer output) {
+public StringBuilder printStatement(int tab, StringBuilder output) {
 	if (!this.isImplicit)
 		printIndent(tab, output).append("yield"); //$NON-NLS-1$
 	if (this.expression != null) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/BasicModule.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/BasicModule.java
@@ -209,11 +209,11 @@ public class BasicModule implements ISourceModule {
 	}
 	@Override
 	public String toString() {
-		StringBuffer buffer = new StringBuffer(getClass().getName());
+		StringBuilder buffer = new StringBuilder(getClass().getName());
 		toStringContent(buffer);
 		return buffer.toString();
 	}
-	protected void toStringContent(StringBuffer buffer) {
+	protected void toStringContent(StringBuilder buffer) {
 		buffer.append("\nmodule "); //$NON-NLS-1$
 		buffer.append(this.name).append(' ');
 		buffer.append('{').append('\n');

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/Main.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/Main.java
@@ -46,7 +46,6 @@ import java.io.LineNumberReader;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.StringReader;
-import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
@@ -571,12 +570,7 @@ public class Main implements ProblemSeverities, SuffixConstants {
 		 * @param e the given exception to log
 		 */
 		public void logException(Exception e) {
-			StringWriter writer = new StringWriter();
-			PrintWriter printWriter = new PrintWriter(writer);
-			e.printStackTrace(printWriter);
-			printWriter.flush();
-			printWriter.close();
-			final String stackTrace = writer.toString();
+			final String stackTrace = Util.getStackTrace(e).toString();
 			if ((this.tagBits & Logger.XML) != 0) {
 				LineNumberReader reader = new LineNumberReader(new StringReader(stackTrace));
 				String line;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/Main.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/Main.java
@@ -404,7 +404,7 @@ public class Main implements ProblemSeverities, SuffixConstants {
 			while ((c = unitSource[end]) == ' ' || c == '\t') end--;
 
 			// copy source
-			StringBuffer buffer = new StringBuffer();
+			StringBuilder buffer = new StringBuilder();
 			buffer.append(unitSource, begin, end - begin + 1);
 			HashMap<String, Object> parameters = new HashMap<>();
 			parameters.put(Logger.VALUE, String.valueOf(buffer));
@@ -3240,7 +3240,7 @@ private static String getAllEncodings(Set<String> encodings) {
 	String[] allEncodings = new String[size];
 	encodings.toArray(allEncodings);
 	Arrays.sort(allEncodings);
-	StringBuffer buffer = new StringBuffer();
+	StringBuilder buffer = new StringBuilder();
 	for (int i = 0; i < size; i++) {
 		if (i > 0) {
 			buffer.append(", "); //$NON-NLS-1$

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/BinaryTypeFormatter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/BinaryTypeFormatter.java
@@ -75,12 +75,12 @@ public class BinaryTypeFormatter {
 	}
 
 	public static String methodToString(IBinaryMethod method) {
-		StringBuffer result = new StringBuffer();
+		StringBuilder result = new StringBuilder();
 		methodToStringContent(result, method);
 		return result.toString();
 	}
 
-	public static void methodToStringContent(StringBuffer buffer, IBinaryMethod method) {
+	public static void methodToStringContent(StringBuilder buffer, IBinaryMethod method) {
 		int modifiers = method.getModifiers();
 		char[] desc = method.getGenericSignature();
 		if (desc == null)

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/ClassFileReader.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/ClassFileReader.java
@@ -677,7 +677,7 @@ public char[] getEnclosingMethod() {
 	}
 	if (this.enclosingMethod == null) {
 		// read the name
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 
 		int nameAndTypeOffset = this.constantPoolOffsets[this.enclosingNameAndTypeIndex];
 		int utf8Offset = this.constantPoolOffsets[u2At(nameAndTypeOffset + 1)];

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/ComponentInfoWithAnnotation.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/ComponentInfoWithAnnotation.java
@@ -46,7 +46,7 @@ protected void reset() {
 }
 @Override
 public String toString() {
-	StringBuffer buffer = new StringBuffer(getClass().getName());
+	StringBuilder buffer = new StringBuilder(getClass().getName());
 	if (this.annotations != null) {
 		buffer.append('\n');
 		for (int i = 0; i < this.annotations.length; i++) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/ComponentInfoWithTypeAnnotation.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/ComponentInfoWithTypeAnnotation.java
@@ -40,7 +40,7 @@ protected void reset() {
 }
 @Override
 public String toString() {
-	StringBuffer buffer = new StringBuffer(getClass().getName());
+	StringBuilder buffer = new StringBuilder(getClass().getName());
 	if (this.typeAnnotations != null) {
 		buffer.append('\n');
 		buffer.append("type annotations:"); //$NON-NLS-1$

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/FieldInfo.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/FieldInfo.java
@@ -425,11 +425,11 @@ public void throwFormatException() throws ClassFormatException {
 }
 @Override
 public String toString() {
-	StringBuffer buffer = new StringBuffer(getClass().getName());
+	StringBuilder buffer = new StringBuilder(getClass().getName());
 	toStringContent(buffer);
 	return buffer.toString();
 }
-protected void toStringContent(StringBuffer buffer) {
+protected void toStringContent(StringBuilder buffer) {
 	int modifiers = getModifiers();
 	buffer
 		.append('{')

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/FieldInfoWithAnnotation.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/FieldInfoWithAnnotation.java
@@ -52,7 +52,7 @@ protected void reset() {
 }
 @Override
 public String toString() {
-	StringBuffer buffer = new StringBuffer(getClass().getName());
+	StringBuilder buffer = new StringBuilder(getClass().getName());
 	if (this.annotations != null) {
 		buffer.append('\n');
 		for (int i = 0; i < this.annotations.length; i++) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/FieldInfoWithTypeAnnotation.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/FieldInfoWithTypeAnnotation.java
@@ -42,7 +42,7 @@ protected void reset() {
 }
 @Override
 public String toString() {
-	StringBuffer buffer = new StringBuffer(getClass().getName());
+	StringBuilder buffer = new StringBuilder(getClass().getName());
 	if (this.typeAnnotations != null) {
 		buffer.append('\n');
 		buffer.append("type annotations:"); //$NON-NLS-1$

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/MethodInfo.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/MethodInfo.java
@@ -450,15 +450,15 @@ public int sizeInBytes() {
 
 @Override
 public String toString() {
-	StringBuffer buffer = new StringBuffer();
+	StringBuilder buffer = new StringBuilder();
 	toString(buffer);
 	return buffer.toString();
 }
-void toString(StringBuffer buffer) {
+void toString(StringBuilder buffer) {
 	buffer.append(getClass().getName());
 	toStringContent(buffer);
 }
-protected void toStringContent(StringBuffer buffer) {
+protected void toStringContent(StringBuilder buffer) {
 	BinaryTypeFormatter.methodToStringContent(buffer, this);
 }
 private synchronized void readCodeAttribute() {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/ModuleInfo.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/ModuleInfo.java
@@ -316,11 +316,11 @@ public class ModuleInfo extends ClassFileStruct implements IBinaryModule {
 		}
 		@Override
 		public String toString() {
-			StringBuffer buffer = new StringBuffer();
+			StringBuilder buffer = new StringBuilder();
 			toStringContent(buffer);
 			return buffer.toString();
 		}
-		protected void toStringContent(StringBuffer buffer) {
+		protected void toStringContent(StringBuilder buffer) {
 			buffer.append(this.packageName);
 			if (this.exportedToCount > 0) {
 				buffer.append(" to "); //$NON-NLS-1$
@@ -367,11 +367,11 @@ public class ModuleInfo extends ClassFileStruct implements IBinaryModule {
 	}
 	@Override
 	public String toString() {
-		StringBuffer buffer = new StringBuffer(getClass().getName());
+		StringBuilder buffer = new StringBuilder(getClass().getName());
 		toStringContent(buffer);
 		return buffer.toString();
 	}
-	protected void toStringContent(StringBuffer buffer) {
+	protected void toStringContent(StringBuilder buffer) {
 		buffer.append("\nmodule "); //$NON-NLS-1$
 		buffer.append(this.name).append(' ');
 		buffer.append('{').append('\n');

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/RecordComponentInfo.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/RecordComponentInfo.java
@@ -253,11 +253,11 @@ public void throwFormatException() throws ClassFormatException {
 }
 @Override
 public String toString() {
-	StringBuffer buffer = new StringBuffer(getClass().getName());
+	StringBuilder buffer = new StringBuilder(getClass().getName());
 	toStringContent(buffer);
 	return buffer.toString();
 }
-protected void toStringContent(StringBuffer buffer) {
+protected void toStringContent(StringBuilder buffer) {
 	buffer
 		.append('{')
 		.append(getTypeName())

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/StackMapFrame.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/StackMapFrame.java
@@ -323,12 +323,12 @@ public class StackMapFrame {
 
 	@Override
 	public String toString() {
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		printFrame(buffer, this);
 		return String.valueOf(buffer);
 	}
 
-	private void printFrame(StringBuffer buffer, StackMapFrame frame) {
+	private void printFrame(StringBuilder buffer, StackMapFrame frame) {
 		String pattern = "[pc : {0} locals: {1} stack items: {2}\nlocals: {3}\nstack: {4}\n]"; //$NON-NLS-1$
 		int localsLength = frame.locals == null ? 0 : frame.locals.length;
 		buffer.append(MessageFormat.format(pattern,
@@ -338,7 +338,7 @@ public class StackMapFrame {
 	}
 
 	private String print(VerificationTypeInfo[] infos, int length) {
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append('[');
 		if (infos != null) {
 			for (int i = 0; i < length; i++) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/StackMapFrameCodeStream.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/StackMapFrameCodeStream.java
@@ -72,7 +72,7 @@ public class StackMapFrameCodeStream extends CodeStream {
 
 		@Override
 		public String toString() {
-			StringBuffer buffer = new StringBuffer();
+			StringBuilder buffer = new StringBuilder();
 			buffer.append('(').append(this.pc).append(',').append(this.binding.constantPoolName()).append(')');
 			return String.valueOf(buffer);
 		}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/VerificationTypeInfo.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/VerificationTypeInfo.java
@@ -152,7 +152,7 @@ public class VerificationTypeInfo {
 
 	@Override
 	public String toString() {
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		switch (this.tag) {
 			case VerificationTypeInfo.ITEM_UNINITIALIZED_THIS:
 				buffer.append("uninitialized_this(").append(readableName()).append(")"); //$NON-NLS-1$//$NON-NLS-2$

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/CaptureBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/CaptureBinding.java
@@ -440,7 +440,7 @@ public class CaptureBinding extends TypeVariableBinding {
 
 	@Override
 	public char[] nullAnnotatedReadableName(CompilerOptions options, boolean shortNames) {
-	    StringBuffer nameBuffer = new StringBuffer(10);
+	    StringBuilder nameBuffer = new StringBuilder(10);
 		appendNullAnnotation(nameBuffer, options);
 		nameBuffer.append(this.sourceName());
 		if (!this.inRecursiveFunction) { // CaptureBinding18 can be recursive indeed

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ConstraintExceptionFormula.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ConstraintExceptionFormula.java
@@ -158,7 +158,7 @@ public class ConstraintExceptionFormula extends ConstraintFormula {
 
 	@Override
 	public String toString() {
-		StringBuffer buf = new StringBuffer().append(LEFT_ANGLE_BRACKET);
+		StringBuilder buf = new StringBuilder().append(LEFT_ANGLE_BRACKET);
 		this.left.printExpression(4, buf);
 		buf.append(" \u2286throws "); //$NON-NLS-1$
 		appendTypeName(buf, this.right);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ConstraintExpressionFormula.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ConstraintExpressionFormula.java
@@ -557,7 +557,7 @@ class ConstraintExpressionFormula extends ConstraintFormula {
 	// debugging:
 	@Override
 	public String toString() {
-		StringBuffer buf = new StringBuffer().append(LEFT_ANGLE_BRACKET);
+		StringBuilder buf = new StringBuilder().append(LEFT_ANGLE_BRACKET);
 		this.left.printExpression(4, buf);
 		buf.append(relationToString(this.relation));
 		appendTypeName(buf, this.right);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ConstraintFormula.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ConstraintFormula.java
@@ -59,7 +59,7 @@ abstract class ConstraintFormula extends ReductionResult {
 	}
 
 	// for debug toString():
-	protected void appendTypeName(StringBuffer buf, TypeBinding type) {
+	protected void appendTypeName(StringBuilder buf, TypeBinding type) {
 		if (type instanceof CaptureBinding18)
 			buf.append(type.toString()); // contains more info than readable name
 		else

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ConstraintTypeFormula.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ConstraintTypeFormula.java
@@ -424,7 +424,7 @@ class ConstraintTypeFormula extends ConstraintFormula {
 	// debugging
 	@Override
 	public String toString() {
-		StringBuffer buf = new StringBuffer("Type Constraint:\n"); //$NON-NLS-1$
+		StringBuilder buf = new StringBuilder("Type Constraint:\n"); //$NON-NLS-1$
 		buf.append('\t').append(LEFT_ANGLE_BRACKET);
 		appendTypeName(buf, this.left);
 		buf.append(relationToString(this.relation));

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
@@ -1972,7 +1972,7 @@ public class InferenceContext18 {
 			return null; // should not happen.
 		// 1.If T is not downcast convertible (5.5) to the raw type R, inference fails.
 		Expression synthExpr = new Expression() {
-			@Override public StringBuffer printExpression(int indent, StringBuffer output) {
+			@Override public StringBuilder printExpression(int indent, StringBuilder output) {
 				return output;
 			}
 		};

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/LocalVariableBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/LocalVariableBinding.java
@@ -101,7 +101,7 @@ public class LocalVariableBinding extends VariableBinding {
 	 */
 	@Override
 	public char[] computeUniqueKey(boolean isLeaf) {
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 
 		// declaring method or type
 		BlockScope scope = this.declaringScope;
@@ -212,7 +212,7 @@ public class LocalVariableBinding extends VariableBinding {
 		return sourceType.retrieveAnnotations(this);
 	}
 
-	private void getScopeKey(BlockScope scope, StringBuffer buffer) {
+	private void getScopeKey(BlockScope scope, StringBuilder buffer) {
 		int scopeIndex = scope.scopeIndex();
 		if (scopeIndex != -1) {
 			getScopeKey((BlockScope)scope.parent, buffer);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MethodBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MethodBinding.java
@@ -1308,7 +1308,7 @@ public MethodBinding tiebreakMethod() {
 }
 @Override
 public String toString() {
-	StringBuffer output = new StringBuffer(10);
+	StringBuilder output = new StringBuilder(10);
 	if ((this.modifiers & ExtraCompilerModifiers.AccUnresolved) != 0) {
 		output.append("[unresolved] "); //$NON-NLS-1$
 	}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedTypeBinding.java
@@ -1384,7 +1384,7 @@ public class ParameterizedTypeBinding extends ReferenceBinding implements Substi
 
 	@Override
 	char[] nullAnnotatedReadableName(CompilerOptions options) {
-	    StringBuffer nameBuffer = new StringBuffer(10);
+	    StringBuilder nameBuffer = new StringBuilder(10);
 		if (isMemberType()) {
 			nameBuffer.append(enclosingType().nullAnnotatedReadableName(options, false));
 			nameBuffer.append('.');
@@ -1423,7 +1423,7 @@ public class ParameterizedTypeBinding extends ReferenceBinding implements Substi
 
 	@Override
 	char[] nullAnnotatedShortReadableName(CompilerOptions options) {
-	    StringBuffer nameBuffer = new StringBuffer(10);
+	    StringBuilder nameBuffer = new StringBuilder(10);
 		if (isMemberType()) {
 			nameBuffer.append(enclosingType().nullAnnotatedReadableName(options, true));
 			nameBuffer.append('.');

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/PolyTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/PolyTypeBinding.java
@@ -70,13 +70,13 @@ public class PolyTypeBinding extends TypeBinding {
 
 	@Override
 	public char[] readableName() {
-		return this.expression.printExpression(0,  new StringBuffer()).toString().toCharArray();
+		return this.expression.printExpression(0,  new StringBuilder()).toString().toCharArray();
 	}
 
 	@Override
 	public char[] shortReadableName() {
 		return this.expression instanceof LambdaExpression ?
-				((LambdaExpression) this.expression).printExpression(0, new StringBuffer(), true).toString().toCharArray() : readableName();
+				((LambdaExpression) this.expression).printExpression(0, new StringBuilder(), true).toString().toCharArray() : readableName();
 	}
 
 	@Override
@@ -86,7 +86,7 @@ public class PolyTypeBinding extends TypeBinding {
 
 	@Override
 	public String toString() {
-		StringBuffer buffer = new StringBuffer("PolyTypeBinding for: "); //$NON-NLS-1$
+		StringBuilder buffer = new StringBuilder("PolyTypeBinding for: "); //$NON-NLS-1$
 		return this.expression.printExpression(0,  buffer).toString();
 	}
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
@@ -1866,7 +1866,7 @@ public char[] readableName(boolean showGenerics) /*java.lang.Object,  p.X<T> */ 
 	return readableName;
 }
 
-protected void appendNullAnnotation(StringBuffer nameBuffer, CompilerOptions options) {
+protected void appendNullAnnotation(StringBuilder nameBuffer, CompilerOptions options) {
 	if (options.isAnnotationBasedNullAnalysisEnabled) {
 		if (options.usesNullTypeAnnotations()) {
 			for (AnnotationBinding annotation : this.typeAnnotations) {
@@ -1921,7 +1921,7 @@ public char[] nullAnnotatedReadableName(CompilerOptions options, boolean shortNa
 }
 
 char[] nullAnnotatedReadableName(CompilerOptions options) {
-    StringBuffer nameBuffer = new StringBuffer(10);
+    StringBuilder nameBuffer = new StringBuilder(10);
 	if (isMemberType()) {
 		nameBuffer.append(enclosingType().nullAnnotatedReadableName(options, false));
 		nameBuffer.append('.');
@@ -1960,7 +1960,7 @@ char[] nullAnnotatedReadableName(CompilerOptions options) {
 }
 
 char[] nullAnnotatedShortReadableName(CompilerOptions options) {
-    StringBuffer nameBuffer = new StringBuffer(10);
+    StringBuilder nameBuffer = new StringBuilder(10);
 	if (isMemberType()) {
 		nameBuffer.append(enclosingType().nullAnnotatedReadableName(options, true));
 		nameBuffer.append('.');

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SyntheticMethodBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SyntheticMethodBinding.java
@@ -329,7 +329,7 @@ public class SyntheticMethodBinding extends MethodBinding {
 	public SyntheticMethodBinding(SourceTypeBinding declaringEnum, int startIndex, int endIndex) {
 		this.declaringClass = declaringEnum;
 		this.index = nextSmbIndex();
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append(TypeConstants.SYNTHETIC_ENUM_CONSTANT_INITIALIZATION_METHOD_PREFIX).append(this.index);
 		this.selector = String.valueOf(buffer).toCharArray();
 		this.modifiers = ClassFileConstants.AccPrivate | ClassFileConstants.AccStatic;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeVariableBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeVariableBinding.java
@@ -901,7 +901,7 @@ public class TypeVariableBinding extends ReferenceBinding {
 
 	@Override
 	public char[] nullAnnotatedReadableName(CompilerOptions options, boolean shortNames) {
-	    StringBuffer nameBuffer = new StringBuffer(10);
+	    StringBuilder nameBuffer = new StringBuilder(10);
 		appendNullAnnotation(nameBuffer, options);
 		nameBuffer.append(this.sourceName());
 		if (!this.inRecursiveFunction) {
@@ -932,7 +932,7 @@ public class TypeVariableBinding extends ReferenceBinding {
 	}
 
 	@Override
-	protected void appendNullAnnotation(StringBuffer nameBuffer, CompilerOptions options) {
+	protected void appendNullAnnotation(StringBuilder nameBuffer, CompilerOptions options) {
 		int oldSize = nameBuffer.length();
 		super.appendNullAnnotation(nameBuffer, options);
 		if (oldSize == nameBuffer.length()) { // nothing appended in super.appendNullAnnotation()?

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/VariableBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/VariableBinding.java
@@ -94,7 +94,7 @@ public abstract class VariableBinding extends Binding {
 	}
 	@Override
 	public String toString() {
-		StringBuffer output = new StringBuffer(10);
+		StringBuilder output = new StringBuilder(10);
 		ASTNode.printModifiers(this.modifiers, output);
 		if ((this.modifiers & ExtraCompilerModifiers.AccUnresolved) != 0) {
 			output.append("[unresolved] "); //$NON-NLS-1$

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/WildcardBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/WildcardBinding.java
@@ -799,7 +799,7 @@ public class WildcardBinding extends ReferenceBinding {
 
     @Override
 	public char[] nullAnnotatedReadableName(CompilerOptions options, boolean shortNames) {
-    	StringBuffer buffer = new StringBuffer(10);
+    	StringBuilder buffer = new StringBuilder(10);
     	appendNullAnnotation(buffer, options);
         switch (this.boundKind) {
             case Wildcard.UNBOUND :

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
@@ -338,7 +338,7 @@ public class Parser implements TerminalTokens, ParserBasicInformation, Conflicte
 		for (int i = 0; i < tokens.length; i = i + 3) {
 			if("1".equals(tokens[i])) { //$NON-NLS-1$
 				int index = newNonTerminalIndex[newLhs[Integer.parseInt(tokens[i + 1])]];
-				StringBuffer buffer = new StringBuffer();
+				StringBuilder buffer = new StringBuilder();
 				if(!alreadyAdded[index]) {
 					alreadyAdded[index] = true;
 					buffer.append(newName[index]);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/RecoveredAnnotation.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/RecoveredAnnotation.java
@@ -216,7 +216,7 @@ public class RecoveredAnnotation extends RecoveredElement {
 	@Override
 	public String toString(int tab) {
 		if (this.annotation != null) {
-			return tabString(tab) + "Recovered annotation:\n" + this.annotation.print(tab + 1, new StringBuffer(10)); //$NON-NLS-1$
+			return tabString(tab) + "Recovered annotation:\n" + this.annotation.print(tab + 1, new StringBuilder(10)); //$NON-NLS-1$
 		} else {
 			return tabString(tab) + "Recovered annotation: identiferPtr=" + this.identifierPtr + " identiferlengthPtr=" + this.identifierLengthPtr + "\n"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 		}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/RecoveredBlock.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/RecoveredBlock.java
@@ -289,7 +289,7 @@ public void resetPendingModifiers() {
 }
 @Override
 public String toString(int tab) {
-	StringBuffer result = new StringBuffer(tabString(tab));
+	StringBuilder result = new StringBuilder(tabString(tab));
 	result.append("Recovered block:\n"); //$NON-NLS-1$
 	this.blockDeclaration.print(tab + 1, result);
 	if (this.statements != null) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/RecoveredField.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/RecoveredField.java
@@ -181,7 +181,7 @@ public int sourceEnd(){
 }
 @Override
 public String toString(int tab){
-	StringBuffer buffer = new StringBuffer(tabString(tab));
+	StringBuilder buffer = new StringBuilder(tabString(tab));
 	buffer.append("Recovered field:\n"); //$NON-NLS-1$
 	this.fieldDeclaration.print(tab + 1, buffer);
 	if (this.annotations != null) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/RecoveredInitializer.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/RecoveredInitializer.java
@@ -266,7 +266,7 @@ public void resetPendingModifiers() {
 }
 @Override
 public String toString(int tab) {
-	StringBuffer result = new StringBuffer(tabString(tab));
+	StringBuilder result = new StringBuilder(tabString(tab));
 	result.append("Recovered initializer:\n"); //$NON-NLS-1$
 	this.fieldDeclaration.print(tab + 1, result);
 	if (this.annotations != null) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/RecoveredLocalVariable.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/RecoveredLocalVariable.java
@@ -97,7 +97,7 @@ public int sourceEnd(){
 }
 @Override
 public String toString(int tab) {
-	return tabString(tab) + "Recovered local variable:\n" + this.localDeclaration.print(tab + 1, new StringBuffer(10)); //$NON-NLS-1$
+	return tabString(tab) + "Recovered local variable:\n" + this.localDeclaration.print(tab + 1, new StringBuilder(10)); //$NON-NLS-1$
 }
 @Override
 public Statement updatedStatement(int depth, Set knownTypes){

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/RecoveredMethod.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/RecoveredMethod.java
@@ -325,7 +325,7 @@ public int sourceEnd(){
 }
 @Override
 public String toString(int tab) {
-	StringBuffer result = new StringBuffer(tabString(tab));
+	StringBuilder result = new StringBuilder(tabString(tab));
 	result.append("Recovered method:\n"); //$NON-NLS-1$
 	this.methodDeclaration.print(tab + 1, result);
 	if (this.annotations != null) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/RecoveredStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/RecoveredStatement.java
@@ -51,7 +51,7 @@ public int sourceEnd(){
 }
 @Override
 public String toString(int tab){
-	return tabString(tab) + "Recovered statement:\n" + this.statement.print(tab + 1, new StringBuffer(10)); //$NON-NLS-1$
+	return tabString(tab) + "Recovered statement:\n" + this.statement.print(tab + 1, new StringBuilder(10)); //$NON-NLS-1$
 }
 public Statement updatedStatement(int depth, Set<TypeDeclaration> knownTypes){
 	if (this.nestedBlock != null) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/RecoveredType.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/RecoveredType.java
@@ -452,7 +452,7 @@ public int sourceEnd(){
 }
 @Override
 public String toString(int tab) {
-	StringBuffer result = new StringBuffer(tabString(tab));
+	StringBuilder result = new StringBuilder(tabString(tab));
 	result.append("Recovered type:\n"); //$NON-NLS-1$
 	if ((this.typeDeclaration.bits & ASTNode.IsAnonymousType) != 0) {
 		result.append(tabString(tab));

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/RecoveredUnit.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/RecoveredUnit.java
@@ -251,7 +251,7 @@ public int getLastStart() {
 }
 @Override
 public String toString(int tab) {
-	StringBuffer result = new StringBuffer(tabString(tab));
+	StringBuilder result = new StringBuilder(tabString(tab));
 	result.append("Recovered unit: [\n"); //$NON-NLS-1$
 	this.unitDeclaration.print(tab + 1, result);
 	result.append(tabString(tab + 1));

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/diagnose/DiagnoseParser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/diagnose/DiagnoseParser.java
@@ -453,7 +453,7 @@ public class DiagnoseParser implements ParserBasicInformation, TerminalTokens, C
 	}
 
 	private static char[] displayEscapeCharacters(char[] tokenSource, int start, int end) {
-		StringBuffer tokenSourceBuffer = new StringBuffer();
+		StringBuilder tokenSourceBuffer = new StringBuilder();
 		for (int i = 0; i < start; i++) {
 			tokenSourceBuffer.append(tokenSource[i]);
 		}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/AbortCompilation.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/AbortCompilation.java
@@ -61,7 +61,7 @@ public class AbortCompilation extends RuntimeException {
 	@Override
 	public String getMessage() {
 		String message = super.getMessage();
-		StringBuffer buffer = new StringBuffer(message == null ? Util.EMPTY_STRING : message);
+		StringBuilder buffer = new StringBuilder(message == null ? Util.EMPTY_STRING : message);
 		if (this.problem != null) {
 			buffer.append(this.problem);
 		} else if (this.exception != null) {
@@ -94,7 +94,7 @@ public class AbortCompilation extends RuntimeException {
 	}
 
 	public String getKey() {
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		if (this.problem != null) {
 			buffer.append(this.problem);
 		}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
@@ -81,13 +81,11 @@
 package org.eclipse.jdt.internal.compiler.problem;
 
 import java.io.CharConversionException;
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Set;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -1454,18 +1452,10 @@ public void cannotReadSource(CompilationUnitDeclaration unit, AbortCompilationUn
 				0);
 		return;
 	}
-	StringWriter stringWriter = new StringWriter();
-	PrintWriter writer = new PrintWriter(stringWriter);
 	if (verbose) {
-		abortException.exception.printStackTrace(writer);
-		System.err.println(stringWriter.toString());
-		stringWriter = new StringWriter();
-		writer = new PrintWriter(stringWriter);
+		System.err.println(Util.getStackTrace(abortException.exception));
 	}
-	writer.print(abortException.exception.getClass().getName());
-	writer.print(':');
-	writer.print(abortException.exception.getMessage());
-	String exceptionTrace = stringWriter.toString();
+	String exceptionTrace = abortException.exception.getClass().getName() + ':' + abortException.exception.getMessage();
 	String[] arguments = new String[]{ fileName, exceptionTrace };
 	this.handle(
 			IProblem.CannotReadSource,

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
@@ -3216,7 +3216,7 @@ public void illegalStaticModifierForMemberType(SourceTypeBinding type) {
 		type.sourceEnd());
 }
 public void illegalUsageOfQualifiedTypeReference(QualifiedTypeReference qualifiedTypeReference) {
-	StringBuffer buffer = new StringBuffer();
+	StringBuilder buffer = new StringBuilder();
 	char[][] tokens = qualifiedTypeReference.tokens;
 	for (int i = 0; i < tokens.length; i++) {
 		if (i > 0) buffer.append('.');
@@ -10548,11 +10548,11 @@ public void referenceExpressionArgumentNullityMismatch(ReferenceExpression locat
 }
 public void illegalReturnRedefinition(ASTNode location, MethodBinding descriptorMethod,
 			boolean isUnchecked, TypeBinding providedType) {
-	StringBuffer methodSignature = new StringBuffer()
+	StringBuilder methodSignature = new StringBuilder()
 		.append(descriptorMethod.declaringClass.readableName())
 		.append('.')
 		.append(descriptorMethod.readableName());
-	StringBuffer shortSignature = new StringBuffer()
+	StringBuilder shortSignature = new StringBuilder()
 		.append(descriptorMethod.declaringClass.shortReadableName())
 		.append('.')
 		.append(descriptorMethod.shortReadableName());

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/tool/Util.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/tool/Util.java
@@ -57,7 +57,7 @@ public final class Util {
 				|| unitSource.length == 0)
 				return "No source available"; //$NON-NLS-1$
 
-			StringBuffer errorBuffer = new StringBuffer();
+			StringBuilder errorBuffer = new StringBuilder();
 			errorBuffer.append('\t');
 
 			char c;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/util/GenericXMLWriter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/util/GenericXMLWriter.java
@@ -25,7 +25,7 @@ import java.util.Map;
 public class GenericXMLWriter extends PrintWriter {
 	/* constants */
 	private static final String XML_VERSION= "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"; //$NON-NLS-1$
-	private static void appendEscapedChar(StringBuffer buffer, char c) {
+	private static void appendEscapedChar(StringBuilder buffer, char c) {
 		String replacement= getReplacement(c);
 		if (replacement != null) {
 			buffer.append('&');
@@ -36,7 +36,7 @@ public class GenericXMLWriter extends PrintWriter {
 		}
 	}
 	private static String getEscaped(String s) {
-		StringBuffer result= new StringBuffer(s.length() + 10);
+		StringBuilder result= new StringBuilder(s.length() + 10);
 		for (int i= 0; i < s.length(); ++i)
 			appendEscapedChar(result, s.charAt(i));
 		return result.toString();

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/util/HashtableOfObjectToIntArray.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/util/HashtableOfObjectToIntArray.java
@@ -150,7 +150,7 @@ public final class HashtableOfObjectToIntArray implements Cloneable {
 
 	@Override
 	public String toString() {
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		Object key;
 		for (int i = 0, length = this.keyTable.length; i < length; i++) {
 			if ((key = this.keyTable[i]) != null) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/util/ManifestAnalyzer.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/util/ManifestAnalyzer.java
@@ -56,7 +56,7 @@ public class ManifestAnalyzer {
 	 */
 	public boolean analyzeManifestContents(char[] chars) {
 		int state = START, substate = 0;
-		StringBuffer currentJarToken = new StringBuffer();
+		StringBuilder currentJarToken = new StringBuilder();
 		int currentChar;
 		this.classpathSectionsCount = 0;
 		this.calledFilesNames = null;
@@ -177,7 +177,7 @@ public class ManifestAnalyzer {
 	}
 
 	// >>>>>>>>>>>>>>>> Method Extracted from analyzeManifestContents in the READING_JAR Block
-	private boolean addCurrentTokenJarWhenNecessary(StringBuffer currentJarToken) {
+	private boolean addCurrentTokenJarWhenNecessary(StringBuilder currentJarToken) {
 		if (currentJarToken != null && currentJarToken.length() > 0) {
 			if (this.calledFilesNames == null) {
 				this.calledFilesNames = new ArrayList();

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/util/Util.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/util/Util.java
@@ -23,7 +23,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
-import java.io.StringWriter;
+import java.io.Writer;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
@@ -557,9 +557,7 @@ public class Util implements SuffixConstants {
 	 * @return one line summary for an exception
 	 */
 	public static String getExceptionSummary(Throwable exception) {
-		StringWriter stringWriter = new StringWriter();
-		exception.printStackTrace(new PrintWriter(stringWriter));
-		StringBuffer buffer = stringWriter.getBuffer();
+		CharSequence buffer = getStackTrace(exception);
 		StringBuffer exceptionBuffer = new StringBuffer(50);
 		exceptionBuffer.append(exception.toString());
 		// only keep leading frame portion of the trace (i.e. line no. 2 from the stacktrace)
@@ -568,7 +566,7 @@ public class Util implements SuffixConstants {
 				case '\n':
 				case '\r' :
 					if (line2Start > 0) {
-						exceptionBuffer.append(' ').append(buffer.substring(line2Start, i));
+						exceptionBuffer.append(' ').append(buffer.subSequence(line2Start, i));
 						break lookupLine2;
 					}
 					lineSep++;
@@ -585,6 +583,30 @@ public class Util implements SuffixConstants {
 			}
 		}
 		return exceptionBuffer.toString();
+	}
+
+	public static CharSequence getStackTrace(Throwable exception) {
+		StringBuilder builder = new StringBuilder();
+		exception.printStackTrace(new PrintWriter(new Writer() {
+			@Override
+			public void write(char[] cbuf, int off, int len) throws IOException {
+				builder.append(cbuf, off, len);
+			}
+
+			@Override
+			public void write(String str, int off, int len) throws IOException {
+				builder.append(str, off, len);
+			}
+
+			@Override
+			public void flush() throws IOException { // nothing to do
+			}
+
+			@Override
+			public void close() throws IOException { // nothing to do
+			}
+		}));
+		return builder;
 	}
 
 	public static int getLineNumber(int position, int[] lineEnds, int g, int d) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/util/Util.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/util/Util.java
@@ -558,7 +558,7 @@ public class Util implements SuffixConstants {
 	 */
 	public static String getExceptionSummary(Throwable exception) {
 		CharSequence buffer = getStackTrace(exception);
-		StringBuffer exceptionBuffer = new StringBuffer(50);
+		StringBuilder exceptionBuffer = new StringBuilder(50);
 		exceptionBuffer.append(exception.toString());
 		// only keep leading frame portion of the trace (i.e. line no. 2 from the stacktrace)
 		lookupLine2: for (int i = 0, lineSep = 0, max = buffer.length(), line2Start = 0; i < max; i++) {
@@ -1636,7 +1636,7 @@ public class Util implements SuffixConstants {
 		return true;
 	}
 
-	public static void appendEscapedChar(StringBuffer buffer, char c, boolean stringLiteral) {
+	public static void appendEscapedChar(StringBuilder buffer, char c, boolean stringLiteral) {
 		switch (c) {
 			case '\b' :
 				buffer.append("\\b"); //$NON-NLS-1$

--- a/org.eclipse.jdt.core.internal.tools/src/org/eclipse/jdt/core/internal/tools/unicode/CodePointsBuilder.java
+++ b/org.eclipse.jdt.core.internal.tools/src/org/eclipse/jdt/core/internal/tools/unicode/CodePointsBuilder.java
@@ -85,7 +85,7 @@ public class CodePointsBuilder {
 	private static void printRange(int counter, int bound, int increment, int totalCounter, int length,
 			int numberOfFiguresForRange, int numberOfFiguresForCounters) {
 		if (counter != 0) {
-			StringBuffer buffer = new StringBuffer();
+			StringBuilder buffer = new StringBuilder();
 			int low = bound - increment;
 			if (low != 0) {
 				low++;
@@ -105,7 +105,7 @@ public class CodePointsBuilder {
 		if ((value % 10) == 0) {
 			numberOfFigures = (int) (Math.log(value + 1) / Math.log(10));
 		}
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		switch (radix) {
 		case 10:
 			while (numberOfFigures < numberOfFiguresForRange) {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/parser/SelectionJavadocTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/parser/SelectionJavadocTest.java
@@ -48,7 +48,7 @@ public class SelectionJavadocTest extends AbstractSelectionTest {
 
 	String source;
 	ICompilationUnit unit;
-	StringBuffer result;
+	StringBuilder result;
 
 	public SelectionJavadocTest(String testName) {
 		super(testName);
@@ -134,7 +134,7 @@ public class SelectionJavadocTest extends AbstractSelectionTest {
 	void setUnit(String name, String source) {
 		this.source = source;
 		this.unit = new CompilationUnit(source.toCharArray(), name, null);
-		this.result = new StringBuffer();
+		this.result = new StringBuilder();
 	}
 
 	/*

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/parser/TypeAnnotationSyntaxTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/parser/TypeAnnotationSyntaxTest.java
@@ -128,7 +128,7 @@ public class TypeAnnotationSyntaxTest extends AbstractSyntaxTreeTest {
 				return;
 			}
 
-			StringBuffer buffer = new StringBuffer("[");
+			StringBuilder buffer = new StringBuilder("[");
 			for (int i = 0, max = tab.length; i < max; i += 2) {
 				if (i > 0) {
 					buffer.append(", ");

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ASTImplTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ASTImplTests.java
@@ -887,7 +887,7 @@ public void test0019() {
 
 // Helper classes: define visitors leveraged by some tests
 class ASTCollector extends ASTVisitor {
-	StringBuffer collector = new StringBuffer();
+	StringBuilder collector = new StringBuilder();
 public String result() {
 	return this.collector.toString();
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractBatchCompilerTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractBatchCompilerTest.java
@@ -96,7 +96,7 @@ public abstract class AbstractBatchCompilerTest extends AbstractRegressionTest {
 	protected static class TestCompilationProgress extends CompilationProgress {
 		boolean isCanceled = false;
 		int workedSoFar = 0;
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		public void begin(int remainingWork) {
 			this.buffer.append("----------\n[worked: 0 - remaining: ").append(remainingWork).append("]\n");
 		}
@@ -438,7 +438,7 @@ public abstract class AbstractBatchCompilerTest extends AbstractRegressionTest {
 
 	protected String getLibraryClassesAsQuotedString() {
 		String[] paths = Util.getJavaClassLibs();
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append('"');
 		for (int i = 0, max = paths.length; i < max; i++) {
 			if (i != 0) {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractRegressionTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractRegressionTest.java
@@ -559,10 +559,10 @@ static class JavacCompiler {
 	}
 	// returns 0L if everything went fine; else the lower word contains the
 	// exit value and the upper word is non-zero iff the error log has contents
-	long compile(File directory, String options, String[] sourceFileNames, StringBuffer log) throws IOException, InterruptedException {
+	long compile(File directory, String options, String[] sourceFileNames, StringBuilder log) throws IOException, InterruptedException {
 		return compile(directory, options, sourceFileNames, log, true);
 	}
-	long compile(File directory, String options, String[] sourceFileNames, StringBuffer log, boolean extendCommandLine) throws IOException, InterruptedException {
+	long compile(File directory, String options, String[] sourceFileNames, StringBuilder log, boolean extendCommandLine) throws IOException, InterruptedException {
 		Process compileProcess = null;
 		long result = 0L;
 		// WORK classpath should depend on the compiler, not on the default runtime
@@ -589,7 +589,7 @@ static class JavacCompiler {
 			}
 			compileProcess = Runtime.getRuntime().exec(cmdLineAsString, env, directory);
 			Logger errorLogger = new Logger(compileProcess.getErrorStream(),
-					"ERROR", log == null ? new StringBuffer() : log);
+					"ERROR", log == null ? new StringBuilder() : log);
 			errorLogger.start();
 			int compilerResult = compileProcess.waitFor();
 			result |= compilerResult; // caveat: may never terminate under specific conditions
@@ -643,7 +643,7 @@ static class JavaRuntime {
 		this.minor = minor;
 	}
 	// returns 0 if everything went fine
-	int execute(File directory, String options, String className, StringBuffer stdout, StringBuffer stderr) throws IOException, InterruptedException {
+	int execute(File directory, String options, String className, StringBuilder stdout, StringBuilder stderr) throws IOException, InterruptedException {
 		Process executionProcess = null;
 		try {
 			StringBuilder cmdLine = new StringBuilder(this.javaPathName);
@@ -656,10 +656,10 @@ static class JavaRuntime {
 			cmdLine.append(className);
 			executionProcess = Runtime.getRuntime().exec(cmdLine.toString(), env, directory);
 			Logger outputLogger = new Logger(executionProcess.getInputStream(),
-					"RUNTIME OUTPUT", stdout == null ? new StringBuffer() : stdout);
+					"RUNTIME OUTPUT", stdout == null ? new StringBuilder() : stdout);
 			outputLogger.start();
 			Logger errorLogger = new Logger(executionProcess.getErrorStream(),
-					"RUNTIME ERROR", stderr == null ? new StringBuffer() : stderr);
+					"RUNTIME ERROR", stderr == null ? new StringBuilder() : stderr);
 			errorLogger.start();
 			int result = executionProcess.waitFor(); // caveat: may never terminate under specific conditions
 			outputLogger.join(); // make sure we get the whole output
@@ -1238,15 +1238,15 @@ protected static class JavacTestOptions {
 //            documented in Process); however, we could have a single worker
 //            take care of this
 	static class Logger extends Thread {
-		StringBuffer buffer;
+		StringBuilder buffer;
 		InputStream inputStream;
 		String type;
 		Logger(InputStream inputStream, String type) {
 			this.inputStream = inputStream;
 			this.type = type;
-			this.buffer = new StringBuffer();
+			this.buffer = new StringBuilder();
 		}
-		Logger(InputStream inputStream, String type, StringBuffer buffer) {
+		Logger(InputStream inputStream, String type, StringBuilder buffer) {
 			this.inputStream = inputStream;
 			this.type = type;
 			this.buffer = buffer;
@@ -1473,7 +1473,7 @@ protected static class JavacTestOptions {
 			e.printStackTrace();
 			return;
 		}
-		StringBuffer buffer = new StringBuffer()
+		StringBuilder buffer = new StringBuilder()
 			.append("\"")
 			.append(fileName)
 			.append("\" -d \"")
@@ -2550,7 +2550,7 @@ protected void runJavac(
 			//      complianceLevel is not set); consider accepting the compiler
 			//      in such case and see what happens
 			JavacTestOptions.Excuse excuse = options.excuseFor(compiler);
-			StringBuffer compilerLog = new StringBuffer();
+			StringBuilder compilerLog = new StringBuilder();
 			File javacOutputDirectory = null;
 			int mismatch = 0;
 			String sourceFileNames[] = null;
@@ -2637,13 +2637,13 @@ protected void runJavac(
 						!javacTestErrorFlag && mismatch == 0 && sourceFileNames != null &&
 						!className.endsWith(PACKAGE_INFO_NAME) && !className.endsWith(MODULE_INFO_NAME)) {
 					JavaRuntime runtime = JavaRuntime.fromCurrentVM();
-					StringBuffer stderr = new StringBuffer();
-					StringBuffer stdout = new StringBuffer();
+					StringBuilder stderr = new StringBuilder();
+					StringBuilder stdout = new StringBuilder();
 					String vmOptions = "";
 					if (vmArguments != null) {
 						int l = vmArguments.length;
 						if (l > 0) {
-							StringBuffer buffer = new StringBuffer(vmArguments[0]);
+							StringBuilder buffer = new StringBuilder(vmArguments[0]);
 							for (int i = 1; i < l; i++) {
 								buffer.append(' ');
 								buffer.append(vmArguments[i]);
@@ -2722,7 +2722,7 @@ protected String expandFileNameForJavac(String fileName) {
 	return fileName;
 }
 void handleMismatch(JavacCompiler compiler, String testName, String[] testFiles, String expectedCompilerLog,
-		String expectedOutputString, String expectedErrorString, StringBuffer compilerLog, String output, String err,
+		String expectedOutputString, String expectedErrorString, StringBuilder compilerLog, String output, String err,
 		JavacTestOptions.Excuse excuse, int mismatch) {
 	if (mismatch != 0) {
 		if (excuse != null && excuse.clears(mismatch)) {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ClasspathJmodTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ClasspathJmodTests.java
@@ -74,7 +74,7 @@ public class ClasspathJmodTests extends ModuleCompilationTests {
 						"		return null;\n" +
 						"	}\n" +
 						"}");
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" --module-path \"")
@@ -107,7 +107,7 @@ public class ClasspathJmodTests extends ModuleCompilationTests {
 						"		return null;\n" +
 						"	}\n" +
 						"}");
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" --module-path \"")
@@ -151,7 +151,7 @@ public class ClasspathJmodTests extends ModuleCompilationTests {
 						"		return null;\n" +
 						"	}\n" +
 						"}");
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -195,7 +195,7 @@ public class ClasspathJmodTests extends ModuleCompilationTests {
 						"		return null;\n" +
 						"	}\n" +
 						"}");
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" --module-path \"")
@@ -249,7 +249,7 @@ public class ClasspathJmodTests extends ModuleCompilationTests {
 						"   public static java.sql.Connection con = null;\n" +
 						"}");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" --module-path \"")

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/CompilerInvocationTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/CompilerInvocationTests.java
@@ -1328,8 +1328,8 @@ public void test011_problem_categories() {
 	    expectedProblemAttributes.put("ClassExtendFinalRecord", new ProblemAttributes(CategorizedProblem.CAT_TYPE));
 	    expectedProblemAttributes.put("RecordErasureIncompatibilityInCanonicalConstructor", new ProblemAttributes(CategorizedProblem.CAT_TYPE));
 	    expectedProblemAttributes.put("JavadocInvalidModule", new ProblemAttributes(CategorizedProblem.CAT_INTERNAL));
-	    StringBuffer failures = new StringBuffer();
-		StringBuffer correctResult = new StringBuffer(70000);
+	    StringBuilder failures = new StringBuilder();
+		StringBuilder correctResult = new StringBuilder(70000);
 		Field[] fields = (iProblemClass = IProblem.class).getFields();
 		Arrays.sort(fields, new Comparator() {
 			@Override
@@ -2440,8 +2440,8 @@ public void test012_compiler_problems_tuning() {
 				}
 			}
 			fields = IProblem.class.getFields();
-			StringBuffer failures = new StringBuffer();
-			StringBuffer correctResult = new StringBuffer(70000);
+			StringBuilder failures = new StringBuilder();
+			StringBuilder correctResult = new StringBuilder(70000);
 			Arrays.sort(fields, new Comparator() {
 				@Override
 				public int compare(Object o1, Object o2) {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericTypeSignatureTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericTypeSignatureTest.java
@@ -43,13 +43,13 @@ import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 @SuppressWarnings({ "rawtypes" })
 public class GenericTypeSignatureTest extends AbstractRegressionTest {
 	static class Logger extends Thread {
-		StringBuffer buffer;
+		StringBuilder buffer;
 		InputStream inputStream;
 		String type;
 		Logger(InputStream inputStream, String type) {
 			this.inputStream = inputStream;
 			this.type = type;
-			this.buffer = new StringBuffer();
+			this.buffer = new StringBuilder();
 		}
 
 		@Override

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocTestForModule.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocTestForModule.java
@@ -82,7 +82,7 @@ public class JavadocTestForModule extends AbstractBatchCompilerTest {
 	}
 
 	class Runner extends AbstractRegressionTest.Runner {
-		StringBuffer commandLine = new StringBuffer();
+		StringBuilder commandLine = new StringBuilder();
 		String outputDir = OUTPUT_DIR + File.separator + "javac";
 		List<String> fileNames = new ArrayList<>();
 		/** will replace any -8, -9 ... option for javac */
@@ -115,7 +115,7 @@ public class JavadocTestForModule extends AbstractBatchCompilerTest {
 		}
 	}
 
-	void runConformModuleTest(List<String> testFileNames, StringBuffer commandLine,
+	void runConformModuleTest(List<String> testFileNames, StringBuilder commandLine,
 			String expectedFailureOutOutputString, String expectedFailureErrOutputString,
 			boolean shouldFlushOutputDirectory)
 	{
@@ -123,7 +123,7 @@ public class JavadocTestForModule extends AbstractBatchCompilerTest {
 				expectedFailureOutOutputString, expectedFailureErrOutputString, shouldFlushOutputDirectory, OUTPUT_DIR + File.separator + "javac");
 	}
 
-	void runConformModuleTest(List<String> testFileNames, StringBuffer commandLine,
+	void runConformModuleTest(List<String> testFileNames, StringBuilder commandLine,
 			String expectedFailureOutOutputString, String expectedFailureErrOutputString,
 			boolean shouldFlushOutputDirectory, String output)
 	{
@@ -165,7 +165,7 @@ public class JavadocTestForModule extends AbstractBatchCompilerTest {
 					System.err.println("Skip testing javac in "+testName());
 					continue;
 				}
-				StringBuffer log = new StringBuffer();
+				StringBuilder log = new StringBuilder();
 				try {
 					long compileResult = javacCompiler.compile(
 											outputDir, /* directory */
@@ -191,21 +191,21 @@ public class JavadocTestForModule extends AbstractBatchCompilerTest {
 		return null;
 	}
 
-	void runNegativeModuleTest(List<String> testFileNames, StringBuffer commandLine,
+	void runNegativeModuleTest(List<String> testFileNames, StringBuilder commandLine,
 			String expectedFailureOutOutputString, String expectedFailureErrOutputString,
 			boolean shouldFlushOutputDirectory, String javacErrorMatch) {
 		runNegativeModuleTest(testFileNames, commandLine, expectedFailureOutOutputString,
 				expectedFailureErrOutputString, shouldFlushOutputDirectory, javacErrorMatch, OUTPUT_DIR + File.separator + "javac");
 	}
 
-	void runNegativeModuleTest(List<String> testFileNames, StringBuffer commandLine,
+	void runNegativeModuleTest(List<String> testFileNames, StringBuilder commandLine,
 			String expectedFailureOutOutputString, String expectedFailureErrOutputString,
 			boolean shouldFlushOutputDirectory, String javacErrorMatch, String output)
 	{
 		runNegativeModuleTest(testFileNames, commandLine, expectedFailureOutOutputString, expectedFailureErrOutputString,
 				shouldFlushOutputDirectory, javacErrorMatch, output, JavacTestOptions.DEFAULT);
 	}
-	void runNegativeModuleTest(List<String> testFileNames, StringBuffer commandLine,
+	void runNegativeModuleTest(List<String> testFileNames, StringBuilder commandLine,
 			String expectedFailureOutOutputString, String expectedFailureErrOutputString,
 			boolean shouldFlushOutputDirectory, String javacErrorMatch, String output, JavacTestOptions options)
 	{
@@ -241,7 +241,7 @@ public class JavadocTestForModule extends AbstractBatchCompilerTest {
 				JavacTestOptions.Excuse excuse = options.excuseFor(javacCompiler);
 
 				commandLine = adjustForJavac(commandLine, null);
-				StringBuffer log = new StringBuffer();
+				StringBuilder log = new StringBuilder();
 				int mismatch = 0;
 				try {
 					long compileResult = javacCompiler.compile(
@@ -616,7 +616,7 @@ public class JavadocTestForModule extends AbstractBatchCompilerTest {
 				"	public int foo() { return 0; }\n" +
 				"}");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -enableJavadoc ")

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ModuleCompilationTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ModuleCompilationTests.java
@@ -92,7 +92,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 	}
 
 	class Runner extends AbstractRegressionTest.Runner {
-		StringBuffer commandLine = new StringBuffer();
+		StringBuilder commandLine = new StringBuilder();
 		String outputDir = OUTPUT_DIR + File.separator + "javac";
 		List<String> fileNames = new ArrayList<>();
 		/** will replace any -8, -9 ... option for javac */
@@ -125,7 +125,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 		}
 	}
 
-	void runConformModuleTest(List<String> testFileNames, StringBuffer commandLine,
+	void runConformModuleTest(List<String> testFileNames, StringBuilder commandLine,
 			String expectedFailureOutOutputString, String expectedFailureErrOutputString,
 			boolean shouldFlushOutputDirectory)
 	{
@@ -133,7 +133,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 				expectedFailureOutOutputString, expectedFailureErrOutputString, shouldFlushOutputDirectory, OUTPUT_DIR + File.separator + "javac");
 	}
 
-	void runConformModuleTest(List<String> testFileNames, StringBuffer commandLine,
+	void runConformModuleTest(List<String> testFileNames, StringBuilder commandLine,
 			String expectedFailureOutOutputString, String expectedFailureErrOutputString,
 			boolean shouldFlushOutputDirectory, String output)
 	{
@@ -175,7 +175,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 					System.err.println("Skip testing javac in "+testName());
 					continue;
 				}
-				StringBuffer log = new StringBuffer();
+				StringBuilder log = new StringBuilder();
 				try {
 					long compileResult = javacCompiler.compile(
 											outputDir, /* directory */
@@ -201,21 +201,21 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 		return null;
 	}
 
-	void runNegativeModuleTest(List<String> testFileNames, StringBuffer commandLine,
+	void runNegativeModuleTest(List<String> testFileNames, StringBuilder commandLine,
 			String expectedFailureOutOutputString, String expectedFailureErrOutputString,
 			boolean shouldFlushOutputDirectory, String javacErrorMatch) {
 		runNegativeModuleTest(testFileNames, commandLine, expectedFailureOutOutputString,
 				expectedFailureErrOutputString, shouldFlushOutputDirectory, javacErrorMatch, OUTPUT_DIR + File.separator + "javac");
 	}
 
-	void runNegativeModuleTest(List<String> testFileNames, StringBuffer commandLine,
+	void runNegativeModuleTest(List<String> testFileNames, StringBuilder commandLine,
 			String expectedFailureOutOutputString, String expectedFailureErrOutputString,
 			boolean shouldFlushOutputDirectory, String javacErrorMatch, String output)
 	{
 		runNegativeModuleTest(testFileNames, commandLine, expectedFailureOutOutputString, expectedFailureErrOutputString,
 				shouldFlushOutputDirectory, javacErrorMatch, output, JavacTestOptions.DEFAULT);
 	}
-	void runNegativeModuleTest(List<String> testFileNames, StringBuffer commandLine,
+	void runNegativeModuleTest(List<String> testFileNames, StringBuilder commandLine,
 			String expectedFailureOutOutputString, String expectedFailureErrOutputString,
 			boolean shouldFlushOutputDirectory, String javacErrorMatch, String output, JavacTestOptions options)
 	{
@@ -251,7 +251,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 				JavacTestOptions.Excuse excuse = options.excuseFor(javacCompiler);
 
 				commandLine = adjustForJavac(commandLine, null);
-				StringBuffer log = new StringBuffer();
+				StringBuilder log = new StringBuilder();
 				int mismatch = 0;
 				try {
 					long compileResult = javacCompiler.compile(
@@ -506,7 +506,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 						"   java.awt.Image image;\n" +
 						"}");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -546,7 +546,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 						"   java.sql.Connection con = p.X.getConnection();\n" +
 						"}");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -599,7 +599,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 						"   public static java.sql.Connection con = null;\n" +
 						"}");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -649,7 +649,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 		String systemDirectory = OUTPUT_DIR+File.separator+"system";
 		writeFile(systemDirectory, "readme.txt", "Not a valid system");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append("--system ").append(systemDirectory)
@@ -697,7 +697,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 						"   java.sql.Connection con = p.X.getConnection();\n" +
 						"}");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" --module-source-path " + "\"" + directory + "\"");
@@ -824,7 +824,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 						"	q.Y y = null;\n" +
 						"}");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 			buffer.append("-d " + outDir )
 			.append(" -9 ")
 			.append(" -p \"")
@@ -879,7 +879,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 						"public class Z extends Object {\n" +
 						"}");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 			buffer.append("-d " + outDir )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -925,7 +925,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 						"	q.Y y = null;\n" +
 						"}");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 			buffer.append("-d " + outDir )
 			.append(" -9")
 			.append(" -classpath \"")
@@ -1026,7 +1026,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 						"   java.sql.Connection con = p.X.getConnection();\n" +
 						"}");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -1072,7 +1072,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 						"   java.sql.Connection con = p.X.getConnection();\n" +
 						"}");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -1125,7 +1125,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 						"   java.sql.Connection con = p.X.getConnection();\n" +
 						"}");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -1171,7 +1171,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 						"   java.sql.Connection con = p.X.getConnection();\n" +
 						"}");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -1236,7 +1236,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 						"}");
 
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -1308,7 +1308,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 						"	s.t.Tester t;\n" +
 						"}");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -1352,7 +1352,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 						"public abstract class X {\n" +
 						"}");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -1396,7 +1396,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 						"	}\n" +
 						"}");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -1460,7 +1460,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 						"	}\n" +
 						"}");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -1496,7 +1496,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 						"	}\n" +
 						"}");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -1532,7 +1532,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 						"	}\n" +
 						"}");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -1562,7 +1562,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 						"	requires transitive java.sql;\n" +
 						"}");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -1591,7 +1591,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 						"	requires transitive java.sql;\n" +
 						"}");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -1620,7 +1620,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 						"	requires transitive java.sql;\n" +
 						"}");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -1680,7 +1680,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 						"	p1.X1 x1 = null;\n" +
 						"}");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + outDir )
 		.append(" -9 ")
 		.append(" -p \"")
@@ -1733,7 +1733,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 						"   java.sql.Connection con = p.X.getConnection();\n" +
 						"}");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -1793,7 +1793,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 						"   Connection con = null;\n" +
 						"}");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -1854,7 +1854,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 						"   Connection con = null;\n" +
 						"}");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -1901,7 +1901,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 						"	}\n" +
 						"}");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -1952,7 +1952,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 						"public class X extends a.A {\n" +
 						"}");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -2009,7 +2009,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 						"public class X extends a.A {\n" +
 						"}");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -2068,7 +2068,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 						"public class X extends a.A {\n" +
 						"}");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -2120,7 +2120,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 						"    }\n" +
 						"}\n");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -2176,7 +2176,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 						"    }\n" +
 						"}\n");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -2251,7 +2251,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 						"    }\n" +
 						"}\n");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -2344,7 +2344,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 						"	requires transitive mod.y;\n" +
 						"}");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -2431,7 +2431,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 						"	 p2.sub.C4 f4;\n" + // no conflict mod.one/p2 <-> mod.two/p2.sub
 						"}\n");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -2501,7 +2501,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 						"public class C3 {\n" +
 						"}\n");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -2551,7 +2551,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 						"public class C1 {\n" +
 						"}\n");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -2569,7 +2569,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 		writeFileCollecting(files, directory + File.separator + "p", "X.java",
 						"public class X extends pm.C1 { \n" +
 						"}");
-		buffer = new StringBuffer();
+		buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -2611,7 +2611,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 						"public class C1 {\n" +
 						"}\n");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -2629,7 +2629,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 		writeFileCollecting(files, directory + File.separator + "p", "X.java",
 						"public class X extends pm.C1 { \n" +
 						"}");
-		buffer = new StringBuffer();
+		buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -2677,7 +2677,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 						"public class C1 {\n" +
 						"}\n");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -2695,7 +2695,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 		writeFileCollecting(files, directory + File.separator + "p", "X.java",
 						"public class X extends pm.C1 { \n" +
 						"}");
-		buffer = new StringBuffer();
+		buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -2709,7 +2709,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 				"The package pm is accessible from more than one module: mod.y, mod.x\n",
 				false,
 				"reads package pm from both");
-		buffer = new StringBuffer();
+		buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -2752,7 +2752,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 						"public class C1 {\n" +
 						"}\n");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -2770,7 +2770,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 		writeFileCollecting(files, directory + File.separator + "p", "X.java",
 						"public class X extends pm.C1 { \n" +
 						"}");
-		buffer = new StringBuffer();
+		buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -2819,7 +2819,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 						"public class C1 {\n" +
 						"}\n");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -2837,7 +2837,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 		writeFileCollecting(files, directory + File.separator + "p", "X.java",
 						"public class X { \n" +
 						"}");
-		buffer = new StringBuffer();
+		buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -2890,7 +2890,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 						"	 p1.p2.t3.t4 f;\n" + // no conflict mod.one/p1.p2.t3 <-> mod.two/p1.p2.t3
 						"}\n");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -2918,7 +2918,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 						"public class Test implements org.eclipse.SomeInterface {\n" +
 						"}\n");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -2951,7 +2951,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 						"	exports p.q;\n" +
 						"}");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -3004,7 +3004,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 						"public class C2 {\n" +
 						"}\n");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -3065,7 +3065,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 						"	public C0[] f2;\n" +
 						"}\n");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -3118,7 +3118,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 						"	public C0[] f2;\n" +
 						"}\n");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -3157,7 +3157,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 						"	public C3.C4 f2;\n" +
 						"}\n");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -3226,7 +3226,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 						"	public void m2(p.exp2.C2 arg) {}\n" +
 						"}\n");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -3273,7 +3273,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 						"	public @ANN String test(@ANN String arg, @ANN C0 c) { return \"\"; }\n" +
 						"}\n");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -3319,7 +3319,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 						"	X, Y, Z;\n" +
 						"}\n");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -3349,7 +3349,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 						"	List<?> l;\n" +
 						"}\n");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -3438,7 +3438,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 						"	requires mod.two;\n" +
 						"}");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + outDir )
 		.append(" -9 ")
 		.append(" -p \"")
@@ -3470,7 +3470,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 						"public class X {\n" +
 						"}");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -3518,7 +3518,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 						"	p.a.X f;\n" +
 						"}");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -3554,7 +3554,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 						"	requires mod.two;\n" +
 						"}");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + outDir )
 		.append(" -9 ")
 		.append(" -p \"")
@@ -3588,7 +3588,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 						"	requires mod.two;\n" +
 						"}");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + outDir )
 		.append(" -9 ")
 		.append(" -p \"")
@@ -3619,7 +3619,7 @@ public void testBug521362_emptyFile() {
 		writeFileCollecting(files, moduleLoc + File.separator + "p1", "X.java",
 						"");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -3655,7 +3655,7 @@ public void testBug521362_emptyFile() {
 		writeFileCollecting(files, moduleLoc + File.separator + "p1", "X.java",
 						"package q;\n");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -3696,7 +3696,7 @@ public void testBug521362_emptyFile() {
 				"package q2;\n");
 		writeFileCollecting(files, moduleLoc + File.separator + "p3", "X.java",
 				"package p3;\n");
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -3742,7 +3742,7 @@ public void testBug521362_emptyFile() {
 				"package q2;\n");
 		writeFileCollecting(files, moduleLoc + File.separator + "p3" + File.separator + "p4" + File.separator + "p5", "X.java",
 				"package p3.p4.p5;\n");
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -3816,7 +3816,7 @@ public void testBug521362_emptyFile() {
 						"module mod.one { \n" +
 						"	requires java.sql;\n" +
 						"}");
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -8")
 			.append(" -classpath \"")
@@ -3883,7 +3883,7 @@ public void testBug521362_emptyFile() {
 				"X.java",
 				"package x.y.z;\n" +
 				"public class X {}\n");
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -3914,7 +3914,7 @@ public void testBug521362_emptyFile() {
 				"@SuppressWarnings(\"unused\")\n" +
 				"public class Main {"
 				+ "}");
-		buffer = new StringBuffer();
+		buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -4476,7 +4476,7 @@ public void testBug521362_emptyFile() {
 						"}\n");
 
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -4515,7 +4515,7 @@ public void testBug521362_emptyFile() {
 						"}\n");
 
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -4553,7 +4553,7 @@ public void testBug521362_emptyFile() {
 						"}\n");
 
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -4581,7 +4581,7 @@ public void testBug521362_emptyFile() {
 						"}");
 
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + outDir )
 			.append(" -9 ")
 			.append(" --module-path \"")
@@ -4610,7 +4610,7 @@ public void testBug521362_emptyFile() {
 						"}");
 
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + outDir )
 			.append(" -9 ")
 			.append(" --module-path \"")
@@ -4693,7 +4693,7 @@ public void testBug521362_emptyFile() {
 						"package pack1;\n" +
 						"public class X11 {\n" +
 						"}");
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -4919,7 +4919,7 @@ public void testBug521362_emptyFile() {
 			"		return \"\";\n" +
 			"	}\n" +
 			"}");
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + outDir )
 			.append(" -source 9 ")
 			.append(" --module-source-path " + "\"" + srcDir + "\" ");
@@ -4954,7 +4954,7 @@ public void testBug521362_emptyFile() {
 			"		return \"\";\n" +
 			"	}\n" +
 			"}");
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + outDir )
 			.append(" -source 9 ")
 			.append(" --module-source-path " + "\"" + srcDir + "\" ")
@@ -4991,7 +4991,7 @@ public void testBug521362_emptyFile() {
 			"		return \"\";\n" +
 			"	}\n" +
 			"}");
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + outDir )
 			.append(" -source 9 ")
 			.append(" --module-source-path " + "\"" + srcDir + "\" ")
@@ -5032,7 +5032,7 @@ public void testBug521362_emptyFile() {
 						"public class C1 {\n" +
 						"}\n");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -5058,7 +5058,7 @@ public void testBug521362_emptyFile() {
 						"public class X extends px.C1 { \n" +
 						"	py.C1 c = null;\n" +
 						"}");
-		buffer = new StringBuffer();
+		buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -5345,7 +5345,7 @@ public void testBug521362_emptyFile() {
 				"public class X {\n" +
 				"}");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		String binDir = OUTPUT_DIR + File.separator + out;
 		buffer.append("-d " + binDir )
 			.append(" -9 ")
@@ -5388,7 +5388,7 @@ public void testBug521362_emptyFile() {
 				"public class X {\n" +
 				"}");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		String binDir = OUTPUT_DIR + File.separator + out;
 		buffer.append("-d " + binDir )
 			.append(" -9 ")
@@ -5432,7 +5432,7 @@ public void testBug521362_emptyFile() {
 						"public class t4 {\n" +
 						"}\n");
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -5468,7 +5468,7 @@ public void testBug521362_emptyFile() {
 						"}");
 
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + outDir )
 			.append(" -9 ")
 			.append(" --module-path \"")
@@ -5660,7 +5660,7 @@ public void testBug521362_emptyFile() {
 				"A.java",
 				"package a.b.c;\n" +
 				"public class A {}");
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -5689,7 +5689,7 @@ public void testBug521362_emptyFile() {
 				"import x.y.z.*;\n" +
 				"public class Main {"
 				+ "}");
-		buffer = new StringBuffer();
+		buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -5749,7 +5749,7 @@ public void testBug521362_emptyFile() {
 		writeFileCollecting(files, moduleLoc + File.separator + "x" + File.separator + "y" + File.separator + "z",
 				"X.java",
 				"package x.y.z;\n");
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -5779,7 +5779,7 @@ public void testBug521362_emptyFile() {
 				"import x.y.z.*;\n" +
 				"public class Main {"
 				+ "}");
-		buffer = new StringBuffer();
+		buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")
@@ -5841,7 +5841,7 @@ public void testBug521362_emptyFile() {
 		writeFileCollecting(files, moduleLoc + File.separator + "x" + File.separator + "y" + File.separator + "z",
 				"X.java",
 				"package x.y.z;\n");
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
 			.append(" -9 ")
 			.append(" -classpath \"")

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullReferenceImplTransformations.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullReferenceImplTransformations.java
@@ -1684,20 +1684,20 @@ void printTruthTables(File outputDirectory) {
 					((State) transitionsSet.getValue()).printableBitsField.charAt(bit);
 			}
 		}
-		StringBuffer line;
-		line = new StringBuffer(140);
+		StringBuilder line;
+		line = new StringBuilder(140);
 		line.append("         ");
 		for (int i = 1; i <= State.stateWidth; i++) {
 			line.append(i);
 			line.append(' ');
 		}
 		out.println(line);
-		line = new StringBuffer(140);
+		line = new StringBuilder(140);
 		line.append("       ---------------------");
 		out.println(line);
 		for (row = 0; row < State.statesNb; row++) {
 			if (keepRow[row]) {
-				line = new StringBuffer(140);
+				line = new StringBuilder(140);
 				line.append(truthTableRowNames[row]);
 				line.append(" | ");
 				for (int i = 0; i < State.stateWidth; i++) {
@@ -2357,9 +2357,9 @@ void printTruthTables(File outputDirectory) {
 					keepColumn[row] = true;
 				}
 			}
-			StringBuffer line;
+			StringBuilder line;
 			for (int i = 0; i < State.stateWidth; i++) {
-				line = new StringBuffer(140);
+				line = new StringBuilder(140);
 				line.append("         ");
 				for (column = 0; column < State.statesNb; column++) {
 					if (keepColumn[column]) {
@@ -2369,7 +2369,7 @@ void printTruthTables(File outputDirectory) {
 				}
 				out.println(line);
 			}
-			line = new StringBuffer(140);
+			line = new StringBuilder(140);
 			line.append("       --");
 			for (column = 0; column < State.statesNb; column++) {
 				if (keepColumn[column]) {
@@ -2380,7 +2380,7 @@ void printTruthTables(File outputDirectory) {
 			out.println(line);
 			for (row = 0; row < State.statesNb; row++) {
 				if (keepRow[row]) {
-					line = new StringBuffer(140);
+					line = new StringBuilder(140);
 					line.append(truthTableRowNames[row]);
 					line.append(" | ");
 					for (column = 0; column < State.statesNb; column++) {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ScannerTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ScannerTest.java
@@ -549,7 +549,7 @@ public class ScannerTest extends AbstractRegressionTest {
 		scanner.resetTo(0, source.length - 1);
 		try {
 			int token;
-			StringBuffer buffer = new StringBuffer();
+			StringBuilder buffer = new StringBuilder();
 			while ((token = scanner.getNextToken()) != TerminalTokens.TokenNameEOF) {
 				try {
 					switch(token) {
@@ -578,7 +578,7 @@ public class ScannerTest extends AbstractRegressionTest {
 		scanner.resetTo(0, source.length - 1);
 		try {
 			int token;
-			StringBuffer buffer = new StringBuffer();
+			StringBuilder buffer = new StringBuilder();
 			while ((token = scanner.getNextToken()) != TerminalTokens.TokenNameEOF) {
 				try {
 					switch(token) {
@@ -610,7 +610,7 @@ public class ScannerTest extends AbstractRegressionTest {
 		scanner.resetTo(0, source.length - 1);
 		try {
 			int token;
-			StringBuffer buffer = new StringBuffer();
+			StringBuilder buffer = new StringBuilder();
 			while ((token = scanner.getNextToken()) != TerminalTokens.TokenNameEOF) {
 				try {
 					switch(token) {
@@ -864,7 +864,7 @@ public class ScannerTest extends AbstractRegressionTest {
 		IScanner scanner = ToolFactory.createScanner(true, true, true, "1.5", "1.5");
 		final char[] source = "\"a\\u000D\"".toCharArray();
 		scanner.setSource(source);
-		final StringBuffer buffer = new StringBuffer();
+		final StringBuilder buffer = new StringBuilder();
 		try {
 			int token;
 			while ((token = scanner.getNextToken()) != ITerminalSymbols.TokenNameEOF) {
@@ -893,7 +893,7 @@ public class ScannerTest extends AbstractRegressionTest {
 		IScanner scanner = ToolFactory.createScanner(true, true, true, "1.5", "1.5");
 		final char[] source = "\"\\u004Ca\\u000D\"".toCharArray();
 		scanner.setSource(source);
-		final StringBuffer buffer = new StringBuffer();
+		final StringBuilder buffer = new StringBuilder();
 		try {
 			int token;
 			while ((token = scanner.getNextToken()) != ITerminalSymbols.TokenNameEOF) {
@@ -921,7 +921,7 @@ public class ScannerTest extends AbstractRegressionTest {
 		IScanner scanner = ToolFactory.createScanner(true, true, true, "1.5", "1.5");
 		final char[] source = "\"\\u004Ca\\u000D\\u0022".toCharArray();
 		scanner.setSource(source);
-		final StringBuffer buffer = new StringBuffer();
+		final StringBuilder buffer = new StringBuilder();
 		try {
 			int token;
 			while ((token = scanner.getNextToken()) != ITerminalSymbols.TokenNameEOF) {
@@ -1483,7 +1483,7 @@ public class ScannerTest extends AbstractRegressionTest {
 		scanner.resetTo(0, source.length - 1);
 		try {
 			int token;
-			StringBuffer buffer = new StringBuffer();
+			StringBuilder buffer = new StringBuilder();
 			while ((token = scanner.getNextToken()) != TerminalTokens.TokenNameEOF) {
 				try {
 					switch(token) {
@@ -1516,7 +1516,7 @@ public class ScannerTest extends AbstractRegressionTest {
 		scanner.resetTo(0, source.length - 1);
 		try {
 			int token;
-			StringBuffer buffer = new StringBuffer();
+			StringBuilder buffer = new StringBuilder();
 			while ((token = scanner.getNextToken()) != TerminalTokens.TokenNameEOF) {
 				try {
 					switch(token) {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/UtilTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/UtilTest.java
@@ -25,7 +25,7 @@ import junit.framework.Test;
 @SuppressWarnings({ "rawtypes" })
 public class UtilTest extends AbstractRegressionTest {
 
-StringBuffer camelCaseErrors;
+StringBuilder camelCaseErrors;
 
 public UtilTest(String name) {
 	super(name);
@@ -50,7 +50,7 @@ void assertCamelCase(String pattern, String name, boolean match) {
 void assertCamelCase(String pattern, String name, boolean prefixMatch, boolean match) {
 	boolean camelCase = CharOperation.camelCaseMatch(pattern==null?null:pattern.toCharArray(), name==null?null:name.toCharArray(), prefixMatch);
 	if (match != camelCase) {
-		StringBuffer line = new StringBuffer("'");
+		StringBuilder line = new StringBuilder("'");
 		line.append(name);
 		line.append("' SHOULD");
 		if (!match) line.append(" NOT");
@@ -72,7 +72,7 @@ void assertCamelCase(String pattern, String name, boolean prefixMatch, boolean m
 @Override
 protected void setUp() throws Exception {
 	super.setUp();
-	this.camelCaseErrors = new StringBuffer();
+	this.camelCaseErrors = new StringBuilder();
 }
 
 public boolean checkPathMatch(char[] pattern, char[] path, boolean isCaseSensitive) {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/eval/EvaluationContextWrapperTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/eval/EvaluationContextWrapperTest.java
@@ -179,7 +179,7 @@ public class EvaluationContextWrapperTest extends EvaluationTest {
 			e.printStackTrace();
 			return result;
 		}
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer
 			.append("\"")
 			.append(fileName)

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/junit/extension/TestCase.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/junit/extension/TestCase.java
@@ -104,7 +104,7 @@ public class TestCase extends PerformanceTestCase {
 						try {
 							// https://bugs.eclipse.org/bugs/show_bug.cgi?id=384531
 							// compiler.version is a timestamp since the the above fix (of the format: v20120725-181921)
-							StringBuffer buffer = new StringBuffer();
+							StringBuilder buffer = new StringBuilder();
 							for (int i = 0; i < version.length(); i++) {
 								if (Character.isDigit(version.charAt(i))) {
 									buffer.append(version.charAt(i));
@@ -249,11 +249,11 @@ public static void assertStringEquals(String message, String expected, String ac
 		return;
 	if (expected != null && expected.equals(actual))
 		return;
-	final StringBuffer formatted;
+	final StringBuilder formatted;
 	if (message != null) {
-		formatted = new StringBuffer(message).append('.');
+		formatted = new StringBuilder(message).append('.');
 	} else {
-		formatted = new StringBuffer();
+		formatted = new StringBuilder();
 	}
 	if (showLineSeparators) {
 		expected = showLineSeparators(expected);
@@ -960,7 +960,7 @@ static public void assertSame(String message, int expected, int actual) {
 	failNotSame(message, expected, actual);
 }
 static public void failNotSame(String message, int expected, int actual) {
-	StringBuffer formatted= new StringBuffer();
+	StringBuilder formatted= new StringBuilder();
 	if (message != null) {
 		formatted.append(message).append(' ');
 	}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/runtime/StandardVMLauncher.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/runtime/StandardVMLauncher.java
@@ -95,7 +95,7 @@ public String[] getCommandLine() {
 	List<String> commandLine = new ArrayList<>();
 
 	// VM binary
-	StringBuffer vmLocation = new StringBuffer(this.vmPath);
+	StringBuilder vmLocation = new StringBuilder(this.vmPath);
 	vmLocation
 		.append(this.vmPath.endsWith(File.separator) ? "" : File.separator)
 		.append("bin")

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/util/TestVerifier.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/util/TestVerifier.java
@@ -33,8 +33,8 @@ public class TestVerifier {
 	boolean reuseVM = true;
 	String[] classpathCache;
 	LocalVirtualMachine vm;
-	StringBuffer outputBuffer;
-	StringBuffer errorBuffer;
+	StringBuilder outputBuffer;
+	StringBuilder errorBuffer;
 	Socket socket;
 public TestVerifier(boolean reuseVM) {
 	this.reuseVM = reuseVM;
@@ -114,14 +114,14 @@ private void compileVerifyTests(String verifierDir) {
 	BatchCompiler.compile("\"" + fileName + "\" -d \"" + verifierDir + "\" -warn:-resource -classpath \"" + Util.getJavaClassLibsAsString() + "\"", new PrintWriter(System.out), new PrintWriter(System.err), null/*progress*/);
 }
 public void execute(String className, String[] classpaths) {
-	this.outputBuffer = new StringBuffer();
-	this.errorBuffer = new StringBuffer();
+	this.outputBuffer = new StringBuilder();
+	this.errorBuffer = new StringBuilder();
 
 	launchAndRun(className, classpaths, null, null);
 }
 public void execute(String className, String[] classpaths, String[] programArguments, String[] vmArguments) {
-	this.outputBuffer = new StringBuffer();
-	this.errorBuffer = new StringBuffer();
+	this.outputBuffer = new StringBuilder();
+	this.errorBuffer = new StringBuilder();
 
 	launchAndRun(className, classpaths, programArguments, vmArguments);
 }
@@ -645,8 +645,8 @@ public boolean verifyClassFiles(String sourceFilePath, String className, String 
 }
 public boolean verifyClassFiles(String sourceFilePath, String className, String expectedOutputString,
 		String expectedErrorStringStart, String[] classpaths, String[] programArguments, String[] vmArguments) {
-	this.outputBuffer = new StringBuffer();
-	this.errorBuffer = new StringBuffer();
+	this.outputBuffer = new StringBuilder();
+	this.errorBuffer = new StringBuilder();
 	if (this.reuseVM && programArguments == null) {
 		launchVerifyTestsIfNeeded(classpaths, vmArguments);
 		loadAndRun(className, classpaths);

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/util/Util.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/util/Util.java
@@ -163,7 +163,7 @@ public class Util {
 		OUTPUT_DIRECTORY = pathDir;
    }
 
-public static void appendProblem(StringBuffer problems, IProblem problem, char[] source, int problemCount) {
+public static void appendProblem(StringBuilder problems, IProblem problem, char[] source, int problemCount) {
     problems.append(problemCount + (problem.isError() ? ". ERROR" : problem.isWarning() ? ". WARNING" : ". INFO"));
     problems.append(" in " + new String(problem.getOriginatingFileName()));
     if (source != null) {

--- a/org.eclipse.jdt.core.tests.model/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.tests.model/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.core.tests.model;singleton:=true
-Bundle-Version: 3.12.200.qualifier
+Bundle-Version: 3.12.300.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jdt.core.tests,

--- a/org.eclipse.jdt.core.tests.model/pom.xml
+++ b/org.eclipse.jdt.core.tests.model/pom.xml
@@ -19,7 +19,7 @@
     <relativePath>../tests-pom/</relativePath>
   </parent>
   <artifactId>org.eclipse.jdt.core.tests.model</artifactId>
-  <version>3.12.200-SNAPSHOT</version>
+  <version>3.12.300-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter15JLS4Test.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter15JLS4Test.java
@@ -7544,7 +7544,7 @@ public class ASTConverter15JLS4Test extends ConverterTestSetup {
 		IBinding[] bindings= parser.createBindings(new IJavaElement[] { type }, null);
 		if (bindings.length == 1 && bindings[0] instanceof ITypeBinding) {
 			ITypeBinding typeBinding= (ITypeBinding) bindings[0];
-			StringBuffer buffer = new StringBuffer();
+			StringBuilder buffer = new StringBuilder();
 			while (typeBinding != null) {
 				buffer.append(typeBinding.getAnnotations().length);
 				typeBinding= typeBinding.getSuperclass();
@@ -7571,7 +7571,7 @@ public class ASTConverter15JLS4Test extends ConverterTestSetup {
 		List types = unit.types();
 		TypeDeclaration typeDeclaration = (TypeDeclaration) types.get(0);
 		ITypeBinding typeBinding = typeDeclaration.resolveBinding();
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		while (typeBinding != null) {
 			buffer.append(typeBinding.getAnnotations().length);
 			typeBinding= typeBinding.getSuperclass();

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter15JLS8Test.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter15JLS8Test.java
@@ -7532,7 +7532,7 @@ public class ASTConverter15JLS8Test extends ConverterTestSetup {
 		IBinding[] bindings= parser.createBindings(new IJavaElement[] { type }, null);
 		if (bindings.length == 1 && bindings[0] instanceof ITypeBinding) {
 			ITypeBinding typeBinding= (ITypeBinding) bindings[0];
-			StringBuffer buffer = new StringBuffer();
+			StringBuilder buffer = new StringBuilder();
 			while (typeBinding != null) {
 				buffer.append(typeBinding.getAnnotations().length);
 				typeBinding= typeBinding.getSuperclass();
@@ -7559,7 +7559,7 @@ public class ASTConverter15JLS8Test extends ConverterTestSetup {
 		List types = unit.types();
 		TypeDeclaration typeDeclaration = (TypeDeclaration) types.get(0);
 		ITypeBinding typeBinding = typeDeclaration.resolveBinding();
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		while (typeBinding != null) {
 			buffer.append(typeBinding.getAnnotations().length);
 			typeBinding= typeBinding.getSuperclass();

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter15Test.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter15Test.java
@@ -7555,7 +7555,7 @@ public class ASTConverter15Test extends ConverterTestSetup {
 		IBinding[] bindings= parser.createBindings(new IJavaElement[] { type }, null);
 		if (bindings.length == 1 && bindings[0] instanceof ITypeBinding) {
 			ITypeBinding typeBinding= (ITypeBinding) bindings[0];
-			StringBuffer buffer = new StringBuffer();
+			StringBuilder buffer = new StringBuilder();
 			while (typeBinding != null) {
 				buffer.append(typeBinding.getAnnotations().length);
 				typeBinding= typeBinding.getSuperclass();
@@ -7582,7 +7582,7 @@ public class ASTConverter15Test extends ConverterTestSetup {
 		List types = unit.types();
 		TypeDeclaration typeDeclaration = (TypeDeclaration) types.get(0);
 		ITypeBinding typeBinding = typeDeclaration.resolveBinding();
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		while (typeBinding != null) {
 			buffer.append(typeBinding.getAnnotations().length);
 			typeBinding= typeBinding.getSuperclass();

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter17Test.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter17Test.java
@@ -737,7 +737,7 @@ public class ASTConverter17Test extends ConverterTestSetup {
 		CompilationUnit unit = (CompilationUnit) node;
 		assertProblemsSize(unit, 0);
 		class InferredTypeFromExpectedVisitor extends ASTVisitor {
-			StringBuffer buf = new StringBuffer();
+			StringBuilder buf = new StringBuilder();
 			public boolean visit(ClassInstanceCreation creation) {
 				this.buf.append(creation.isResolvedTypeInferredFromExpectedType());
 				return false;

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterBindingsTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterBindingsTest.java
@@ -529,7 +529,7 @@ public class ASTConverterBindingsTest extends ConverterTestSetup {
 			if (DEBUG) {
 				if (unit.types().size() > 0 ) {
 					AbstractTypeDeclaration typeDeclaration = (AbstractTypeDeclaration) unit.types().get(0);
-					StringBuffer buffer = new StringBuffer();
+					StringBuilder buffer = new StringBuilder();
 					PackageDeclaration packageDeclaration = unit.getPackage();
 					if (packageDeclaration != null) {
 						buffer.append(unit.getPackage().getName()).append(".").append(typeDeclaration.getName());

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterJavadocFlattener.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterJavadocFlattener.java
@@ -25,7 +25,7 @@ public class ASTConverterJavadocFlattener extends ASTVisitor {
 	 * The string buffer into which the serialized representation of the AST is
 	 * written.
 	 */
-	private final StringBuffer buffer;
+	private final StringBuilder buffer;
 	private final int indent = 0;
 	private final String comment;
 
@@ -33,7 +33,7 @@ public class ASTConverterJavadocFlattener extends ASTVisitor {
  * Creates a new AST printer.
  */
 ASTConverterJavadocFlattener(String comment) {
-	this.buffer = new StringBuffer();
+	this.buffer = new StringBuilder();
 	this.comment = comment;
 }
 

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterJavadocTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterJavadocTest.java
@@ -135,7 +135,7 @@ public class ASTConverterJavadocTest extends ConverterTestSetup {
 	// Debug
 	protected String prefix = "";
 	protected boolean debug = false;
-	protected StringBuffer problems;
+	protected StringBuilder problems;
 	protected String compilerOption = JavaCore.IGNORE;
 	protected List failures;
 	protected boolean stopOnFailure = true;
@@ -231,7 +231,7 @@ public class ASTConverterJavadocTest extends ConverterTestSetup {
 		super.setUp();
 		TEST_COUNTERS[0]++;
 		this.failures = new ArrayList();
-		this.problems = new StringBuffer();
+		this.problems = new StringBuilder();
 		this.workingCopies = null;
 		this.savedLevel = this.astLevel;
 	}
@@ -1386,7 +1386,7 @@ public class ASTConverterJavadocTest extends ConverterTestSetup {
 	 * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=47396"
 	 */
 	public void test011() throws JavaModelException {
-		this.problems = new StringBuffer();
+		this.problems = new StringBuilder();
 		this.sourceUnit = getCompilationUnit("Converter" , "src", "javadoc.test011", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		ASTNode result = runConversion(this.sourceUnit, true);
 		assumeNotNull("No compilation unit", result);

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterJavadocTest_15.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterJavadocTest_15.java
@@ -116,7 +116,7 @@ public class ASTConverterJavadocTest_15 extends ConverterTestSetup {
 	// Debug
 	protected String prefix = "";
 	protected boolean debug = false;
-	protected StringBuffer problems;
+	protected StringBuilder problems;
 	protected String compilerOption = JavaCore.IGNORE;
 	protected List failures;
 	protected boolean stopOnFailure = true;
@@ -215,7 +215,7 @@ public class ASTConverterJavadocTest_15 extends ConverterTestSetup {
 		super.setUp();
 		TEST_COUNTERS[0]++;
 		this.failures = new ArrayList();
-		this.problems = new StringBuffer();
+		this.problems = new StringBuilder();
 		this.workingCopies = null;
 		this.savedLevel = this.astLevel;
 	}

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterJavadocTest_18.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterJavadocTest_18.java
@@ -101,7 +101,7 @@ public class ASTConverterJavadocTest_18 extends ConverterTestSetup {
 	// Debug
 	protected String prefix = "";
 	protected boolean debug = false;
-	protected StringBuffer problems;
+	protected StringBuilder problems;
 	protected String compilerOption = JavaCore.IGNORE;
 	protected List failures;
 	protected boolean stopOnFailure = true;
@@ -157,7 +157,7 @@ public class ASTConverterJavadocTest_18 extends ConverterTestSetup {
 		super.setUp();
 		TEST_COUNTERS[0]++;
 		this.failures = new ArrayList();
-		this.problems = new StringBuffer();
+		this.problems = new StringBuilder();
 		this.workingCopies = null;
 		this.savedLevel = this.astLevel;
 	}

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterTest2.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterTest2.java
@@ -5259,7 +5259,7 @@ public class ASTConverterTest2 extends ConverterTestSetup {
 			IOrdinaryClassFile classFile = getClassFile("P", "/P/test0571.jar", "", "X$Y.class");
 			CompilationUnit unit = (CompilationUnit) runConversion(getJLS3(), classFile, 0, true);
 			IProblem[] problems = unit.getProblems();
-			StringBuffer buffer = new StringBuffer();
+			StringBuilder buffer = new StringBuilder();
 			for (int i = 0, length = problems.length; i < length; i++)
 				Util.appendProblem(buffer, problems[i], source.toCharArray(), i);
 			assertEquals("Unexpected problems", "", buffer.toString());

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTMatcherTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTMatcherTest.java
@@ -114,7 +114,7 @@ public class ASTMatcherTest extends org.eclipse.jdt.core.tests.junit.extension.T
 	EnumConstantDeclaration EC2;
 	Type T3;
 	Type T4;
-	final StringBuffer b = new StringBuffer();
+	final StringBuilder b = new StringBuilder();
 
 	int API_LEVEL;
 

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTVisitorTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTVisitorTest.java
@@ -131,7 +131,7 @@ public class ASTVisitorTest extends org.eclipse.jdt.core.tests.junit.extension.T
 	Type T4;
 	String T4S;
 
-	final StringBuffer b = new StringBuffer();
+	final StringBuilder b = new StringBuilder();
 
 	int API_LEVEL;
 

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/AbstractASTTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/AbstractASTTests.java
@@ -337,7 +337,7 @@ public class AbstractASTTests extends ModifyingResourceTests implements DefaultM
 		CompilationUnit unit = (CompilationUnit) parser.createAST(null);
 
 		if (reportErrors) {
-			StringBuffer buffer = new StringBuffer();
+			StringBuilder buffer = new StringBuilder();
 			IProblem[] problems = unit.getProblems();
 			for (int i = 0, length = problems.length; i < length; i++)
 				Util.appendProblem(buffer, problems[i], markerInfo.source.toCharArray(), i+1);
@@ -418,7 +418,7 @@ public class AbstractASTTests extends ModifyingResourceTests implements DefaultM
 		}
 
 		if ((flags & ICompilationUnit.FORCE_PROBLEM_DETECTION) != 0) {
-			StringBuffer buffer = new StringBuffer();
+			StringBuilder buffer = new StringBuilder();
 			IProblem[] problems = unit.getProblems();
 			for (int i = 0, length = problems.length; i < length; i++)
 				Util.appendProblem(buffer, problems[i], newContents.toCharArray(), i+1);
@@ -476,7 +476,7 @@ public class AbstractASTTests extends ModifyingResourceTests implements DefaultM
 		}
 
 		if (reportErrors) {
-			StringBuffer buffer = new StringBuffer();
+			StringBuilder buffer = new StringBuilder();
 			IProblem[] problems = unit.getProblems();
 			for (int i = 0, length = problems.length; i < length; i++)
 				Util.appendProblem(buffer, problems[i], newContents.toCharArray(), i+1);

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ConverterTestSetup.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ConverterTestSetup.java
@@ -864,7 +864,7 @@ public abstract class ConverterTestSetup extends AbstractASTTests {
 	private void checkProblemMessages(String expectedOutput, final IProblem[] problems, final int length) {
 		if (length != 0) {
 			if (expectedOutput != null) {
-				StringBuffer buffer = new StringBuffer();
+				StringBuilder buffer = new StringBuilder();
 				for (int i = 0; i < length; i++) {
 					buffer.append(problems[i].getMessage());
 					if (i < length - 1) {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/MarkedASTFlattener.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/MarkedASTFlattener.java
@@ -55,7 +55,7 @@ public class MarkedASTFlattener extends NaiveASTFlattener {
 			this.options = options;
 		}
 
-		private void appendBinding(ASTNode node, StringBuffer buffer) {
+		private void appendBinding(ASTNode node, StringBuilder buffer) {
 			buffer.append('[');
 			try {
 				IBinding binding = resolveBinding(node);
@@ -89,7 +89,7 @@ public class MarkedASTFlattener extends NaiveASTFlattener {
 			buffer.append(']');
 		}
 
-		private void appendBindingFlags(IBinding binding, StringBuffer buffer) {
+		private void appendBindingFlags(IBinding binding, StringBuilder buffer) {
 			boolean firstFlag = true;
 			if (binding.isDeprecated()) {
 				if (!firstFlag) buffer.append('|');
@@ -111,11 +111,11 @@ public class MarkedASTFlattener extends NaiveASTFlattener {
 			}
 		}
 
-		private void appendBindingKey(IBinding binding, StringBuffer buffer) {
+		private void appendBindingKey(IBinding binding, StringBuilder buffer) {
 			buffer.append(binding.getKey());
 		}
 
-		private void appendBindingKind(IBinding binding, StringBuffer buffer) {
+		private void appendBindingKind(IBinding binding, StringBuilder buffer) {
 			switch (binding.getKind()) {
 				case IBinding.ANNOTATION:
 					buffer.append("ANNOTATION");break;
@@ -134,7 +134,7 @@ public class MarkedASTFlattener extends NaiveASTFlattener {
 			}
 		}
 
-		private void appendFlags(ASTNode node, StringBuffer buffer) {
+		private void appendFlags(ASTNode node, StringBuilder buffer) {
 			boolean firstFlag = true;
 			int flags = node.getFlags();
 			if ((flags & ASTNode.MALFORMED) != 0) {
@@ -165,7 +165,7 @@ public class MarkedASTFlattener extends NaiveASTFlattener {
 			}
 		}
 
-		private void appendNodeExtendedPosition(ASTNode node, StringBuffer buffer) {
+		private void appendNodeExtendedPosition(ASTNode node, StringBuilder buffer) {
 			ASTNode root = node.getRoot();
 
 			if (root.getNodeType() == ASTNode.COMPILATION_UNIT) {
@@ -188,7 +188,7 @@ public class MarkedASTFlattener extends NaiveASTFlattener {
 
 		}
 
-		private void appendNodePosition(ASTNode node, StringBuffer buffer) {
+		private void appendNodePosition(ASTNode node, StringBuilder buffer) {
 			buffer.append('[');
 			buffer.append(node.getStartPosition());
 			buffer.append(',');
@@ -196,7 +196,7 @@ public class MarkedASTFlattener extends NaiveASTFlattener {
 			buffer.append(']');
 		}
 
-		private void appendNodeType(ASTNode node, StringBuffer buffer) {
+		private void appendNodeType(ASTNode node, StringBuilder buffer) {
 			switch (node.getNodeType()) {
 				case ASTNode.ANNOTATION_TYPE_DECLARATION :
 					buffer.append("ANNOTATION_TYPE_DECLARATION");break;
@@ -383,7 +383,7 @@ public class MarkedASTFlattener extends NaiveASTFlattener {
 
 		@Override
 		public String getText(ASTNode node) {
-			StringBuffer buffer = new StringBuffer();
+			StringBuilder buffer = new StringBuilder();
 
 			boolean first = true;
 
@@ -495,7 +495,7 @@ public class MarkedASTFlattener extends NaiveASTFlattener {
 	private Map markerPositonInBuffer;
 
 	private boolean[] foundNodeFromMarker;
-	private final StringBuffer markedNodesBuffer;
+	private final StringBuilder markedNodesBuffer;
 
 	private final MarkedNodeLabelProvider labelProvider;
 
@@ -507,12 +507,12 @@ public class MarkedASTFlattener extends NaiveASTFlattener {
 		this.reportAST = reportAST;
 		this.reportProblems = reportProblems;
 
-		this.markedNodesBuffer = new StringBuffer();
+		this.markedNodesBuffer = new StringBuilder();
 		this.labelProvider = labelProvider;
 	}
 
 	public String getResult() {
-		StringBuffer resultBuffer = new StringBuffer();
+		StringBuilder resultBuffer = new StringBuilder();
 
 		if (this.reportAST) {
 			resultBuffer.append(AST_DELIMITER);
@@ -529,7 +529,7 @@ public class MarkedASTFlattener extends NaiveASTFlattener {
 			resultBuffer.append(PROBLEMS_DELIMITER);
 			resultBuffer.append('\n');
 
-			StringBuffer problemBuffer = new StringBuffer();
+			StringBuilder problemBuffer = new StringBuilder();
 			IProblem[] problems = this.unit.getProblems();
 			int problemCount = problems.length;
 			if (problemCount != 0) {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ProfilingASTConvertionTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ProfilingASTConvertionTest.java
@@ -90,7 +90,7 @@ public class ProfilingASTConvertionTest extends AbstractJavaModelTests {
 		if ((value % 10) == 0) {
 			numberOfFigures = (int) (Math.log(value + 1)/ Math.log(10));
 		}
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		while(numberOfFigures < numberOfFiguresForRange) {
 			buffer.append(" ");
 			numberOfFigures++;
@@ -130,7 +130,7 @@ public class ProfilingASTConvertionTest extends AbstractJavaModelTests {
 
 	private void printRange(int counter, int bound, int increment, int totalCounter, int length, int numberOfFiguresForRange, int numberOfFiguresForCounters) {
 		if (counter != 0) {
-			StringBuffer buffer = new StringBuffer();
+			StringBuilder buffer = new StringBuilder();
 			int low = bound - increment;
 			if (low != 0) {
 				low++;
@@ -253,7 +253,7 @@ public class ProfilingASTConvertionTest extends AbstractJavaModelTests {
 				CompilationUnit unit = (CompilationUnit) node;
 				assertEquals("Has problem", 0, unit.getProblems().length);
 				TypeDeclaration typeDeclaration = (TypeDeclaration) unit.types().get(0);
-				StringBuffer buffer = new StringBuffer();
+				StringBuilder buffer = new StringBuilder();
 				buffer.append(unit.getPackage().getName()).append(".").append(typeDeclaration.getName());
 				IResource resource = this.compilationUnits[i].getResource();
 				if (resource instanceof IFile) {
@@ -291,7 +291,7 @@ public class ProfilingASTConvertionTest extends AbstractJavaModelTests {
 				CompilationUnit unit = (CompilationUnit) node;
 				assertEquals("Has problem", 0, unit.getProblems().length);
 				TypeDeclaration typeDeclaration = (TypeDeclaration) unit.types().get(0);
-				StringBuffer buffer = new StringBuffer();
+				StringBuilder buffer = new StringBuilder();
 				buffer.append(unit.getPackage().getName()).append(".").append(typeDeclaration.getName());
 				IResource resource = this.compilationUnits[i].getResource();
 				if (resource instanceof IFile) {
@@ -330,7 +330,7 @@ public class ProfilingASTConvertionTest extends AbstractJavaModelTests {
 				CompilationUnit unit = (CompilationUnit) node;
 				assertEquals("Has problem", 0, unit.getProblems().length);
 				TypeDeclaration typeDeclaration = (TypeDeclaration) unit.types().get(0);
-				StringBuffer buffer = new StringBuffer();
+				StringBuilder buffer = new StringBuilder();
 				buffer.append(unit.getPackage().getName()).append(".").append(typeDeclaration.getName());
 				IResource resource = this.compilationUnits[i].getResource();
 				if (resource instanceof IFile) {
@@ -370,7 +370,7 @@ public class ProfilingASTConvertionTest extends AbstractJavaModelTests {
 				CompilationUnit unit = (CompilationUnit) node;
 				assertEquals("Has problem", 0, unit.getProblems().length);
 				TypeDeclaration typeDeclaration = (TypeDeclaration) unit.types().get(0);
-				StringBuffer buffer = new StringBuffer();
+				StringBuilder buffer = new StringBuilder();
 				buffer.append(unit.getPackage().getName()).append(".").append(typeDeclaration.getName());
 				IResource resource = this.compilationUnits[i].getResource();
 				if (resource instanceof IFile) {
@@ -410,7 +410,7 @@ public class ProfilingASTConvertionTest extends AbstractJavaModelTests {
 				CompilationUnit unit = (CompilationUnit) node;
 				assertEquals("Has problem", 0, unit.getProblems().length);
 				TypeDeclaration typeDeclaration = (TypeDeclaration) unit.types().get(0);
-				StringBuffer buffer = new StringBuffer();
+				StringBuilder buffer = new StringBuilder();
 				buffer.append(unit.getPackage().getName()).append(".").append(typeDeclaration.getName());
 				IResource resource = this.compilationUnits[i].getResource();
 				if (resource instanceof IFile) {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/formatter/FormatterMassiveRegressionTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/formatter/FormatterMassiveRegressionTests.java
@@ -834,7 +834,7 @@ private static void setProfilesDir(int profiles, List subDirs) {
 	}
 }
 
-private static void appendProfiles(int profiles, StringBuffer buffer) {
+private static void appendProfiles(int profiles, StringBuilder buffer) {
 	String joinLines = null;
 	boolean first = true;
 	switch (profiles & PROFILE_JOIN_LINES_MASK) {
@@ -1187,7 +1187,7 @@ public void setUpSuite() throws Exception {
 
 private void print() {
 
-	StringBuffer buffer = new StringBuffer();
+	StringBuilder buffer = new StringBuilder();
 
 	// Log version info
 	buffer.append("Version   : ");

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/formatter/comment/CommentFormatterUtil.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/formatter/comment/CommentFormatterUtil.java
@@ -115,7 +115,7 @@ public class CommentFormatterUtil {
 	 * @since 3.1
 	 */
 	private static int inferIndentationLevel(String reference, int tabSize) {
-		StringBuffer expanded= expandTabs(reference, tabSize);
+		StringBuilder expanded= expandTabs(reference, tabSize);
 
 		int spaceWidth, referenceWidth;
 		spaceWidth= 1;
@@ -135,8 +135,8 @@ public class CommentFormatterUtil {
 	 * @return the expanded string
 	 * @since 3.1
 	 */
-	private static StringBuffer expandTabs(String string, int tabSize) {
-		StringBuffer expanded= new StringBuffer();
+	private static StringBuilder expandTabs(String string, int tabSize) {
+		StringBuilder expanded= new StringBuilder();
 		for (int i= 0, n= string.length(), chars= 0; i < n; i++) {
 			char ch= string.charAt(i);
 			if (ch == '\t') {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AbstractJavaModelTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AbstractJavaModelTests.java
@@ -314,7 +314,7 @@ public abstract class AbstractJavaModelTests extends SuiteOfTestCases {
 	}
 
 	public static class ProblemRequestor implements IProblemRequestor {
-		public StringBuffer problems;
+		public StringBuilder problems;
 		public int problemCount;
 		protected char[] unitSource;
 		public boolean isActive = true;
@@ -340,7 +340,7 @@ public abstract class AbstractJavaModelTests extends SuiteOfTestCases {
 			this.unitSource = source;
 		}
 		public void reset() {
-			this.problems = new StringBuffer();
+			this.problems = new StringBuilder();
 			this.problemCount = 0;
 		}
 	}
@@ -561,7 +561,7 @@ public abstract class AbstractJavaModelTests extends SuiteOfTestCases {
 	protected DeltaListener deltaListener = new DeltaListener();
 
 	public static class LogListenerWithHistory implements ILogListener {
-		private final StringBuffer buffer = new StringBuffer();
+		private final StringBuilder buffer = new StringBuilder();
 		private final List<IStatus> logs = new ArrayList<>();
 
 		public void logging(IStatus status, String plugin) {
@@ -976,7 +976,7 @@ public abstract class AbstractJavaModelTests extends SuiteOfTestCases {
 
 	protected void assertResourceTreeEquals(String message, String expected, Object[] resources) throws CoreException {
 		sortResources(resources);
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		for (int i = 0, length = resources.length; i < length; i++) {
 			printResourceTree(resources[i], buffer, 0);
 			if (i != length-1) buffer.append("\n");
@@ -992,7 +992,7 @@ public abstract class AbstractJavaModelTests extends SuiteOfTestCases {
 		);
 	}
 
-	private void printResourceTree(Object resource, StringBuffer buffer, int indent) throws CoreException {
+	private void printResourceTree(Object resource, StringBuilder buffer, int indent) throws CoreException {
 		for (int i = 0; i < indent; i++)
 			buffer.append("  ");
 		if (resource instanceof IResource) {
@@ -1130,7 +1130,7 @@ public abstract class AbstractJavaModelTests extends SuiteOfTestCases {
 	}
 
 	protected void assertMemberValuePairEquals(String expected, IMemberValuePair member) throws JavaModelException {
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		appendAnnotationMember(buffer, member);
 		String actual = buffer.toString();
 		if (!expected.equals(actual)) {
@@ -1187,7 +1187,7 @@ public abstract class AbstractJavaModelTests extends SuiteOfTestCases {
 		assertEquals(message, expected, actual);
 	}
 	protected void assertAnnotationsEqual(String expected, IAnnotation[] annotations) throws JavaModelException {
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		for (int i = 0; i < annotations.length; i++) {
 			IAnnotation annotation = annotations[i];
 			appendAnnotation(buffer, annotation);
@@ -1200,7 +1200,7 @@ public abstract class AbstractJavaModelTests extends SuiteOfTestCases {
 		assertEquals("Unexpected annotations", expected, actual);
 	}
 
-	protected void appendAnnotation(StringBuffer buffer, IAnnotation annotation) throws JavaModelException {
+	protected void appendAnnotation(StringBuilder buffer, IAnnotation annotation) throws JavaModelException {
 		buffer.append('@');
 		buffer.append(annotation.getElementName());
 		IMemberValuePair[] members = annotation.getMemberValuePairs();
@@ -1216,7 +1216,7 @@ public abstract class AbstractJavaModelTests extends SuiteOfTestCases {
 		}
 	}
 
-	private void appendAnnotationMember(StringBuffer buffer, IMemberValuePair member) throws JavaModelException {
+	private void appendAnnotationMember(StringBuilder buffer, IMemberValuePair member) throws JavaModelException {
 		if (member == null) {
 			buffer.append("<null>");
 			return;
@@ -1244,7 +1244,7 @@ public abstract class AbstractJavaModelTests extends SuiteOfTestCases {
 		}
 	}
 
-	private void appendAnnotationMemberValue(StringBuffer buffer, Object value, int kind) throws JavaModelException {
+	private void appendAnnotationMemberValue(StringBuilder buffer, Object value, int kind) throws JavaModelException {
 		if (value == null) {
 			buffer.append("<null>");
 			return;

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AbstractJavaSearchGenericTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AbstractJavaSearchGenericTests.java
@@ -43,7 +43,7 @@ public class AbstractJavaSearchGenericTests extends JavaSearchTests {
 	/*
 	 * Add given line to given buffer.
 	 */
-	void addResultLine(StringBuffer buffer, char[] line) {
+	void addResultLine(StringBuilder buffer, char[] line) {
 		if (buffer.length() > 0) buffer.append('\n');
 		buffer.append(line);
 	}
@@ -53,7 +53,7 @@ public class AbstractJavaSearchGenericTests extends JavaSearchTests {
 	 */
 	final String cleanResults(String expected) {
 		char[][] lines = CharOperation.splitOn('\n', expected.toCharArray());
-		StringBuffer buffer = new StringBuffer(expected.length());
+		StringBuilder buffer = new StringBuilder(expected.length());
 		for (int i=0, n=lines.length; i<n; i++) {
 			addResultLine(buffer, lines[i]);
 		}

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AbstractJavaSearchTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AbstractJavaSearchTests.java
@@ -158,7 +158,7 @@ public class AbstractJavaSearchTests extends ModifyingResourceTests implements I
 		}
 	}
 
-	static void checkAndAddtoBuffer(StringBuffer buffer, char[] precond, char c) {
+	static void checkAndAddtoBuffer(StringBuilder buffer, char[] precond, char c) {
 		if (precond == null || precond.length == 0) return;
 		buffer.append(precond);
 		buffer.append(c);
@@ -183,7 +183,7 @@ public class AbstractJavaSearchTests extends ModifyingResourceTests implements I
 				AccessRestriction access,
 				int methodIndex) {
 
-			StringBuffer buffer = new StringBuffer();
+			StringBuilder buffer = new StringBuilder();
 			char c = '.';
 			char[] noname = new String("<NONAME>").toCharArray();
 			buffer.append(path);
@@ -280,7 +280,7 @@ public class AbstractJavaSearchTests extends ModifyingResourceTests implements I
 	public static class JavaSearchResultCollector extends SearchRequestor {
 		int flags = SHOW_POTENTIAL; // default
 		protected SearchMatch match;
-		public StringBuffer results = new StringBuffer(), line;
+		public StringBuilder results = new StringBuilder(), line;
 		public int showFlavors = 0;
 		public int count = 0;
 		List lines = new ArrayList();
@@ -306,7 +306,7 @@ public class AbstractJavaSearchTests extends ModifyingResourceTests implements I
 			try {
 				IResource resource = this.match.getResource();
 				IJavaElement element = getElement(this.match);
-				this.line = new StringBuffer();
+				this.line = new StringBuilder();
 				if ((this.flags & SHOW_MATCH_KIND) != 0) {
 					String matchClassName = this.match.getClass().getName();
 					this.line.append(matchClassName.substring(matchClassName.lastIndexOf('.')+1));

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ClassFileTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ClassFileTests.java
@@ -546,7 +546,7 @@ public void testAnnotations26() throws JavaModelException {
 			"@java.lang.Deprecated\n" +
 			"@test342757.Annot\n" +
 			"@java.lang.Deprecated\n";
-	StringBuffer buffer = new StringBuffer();
+	StringBuilder buffer = new StringBuilder();
 	for (int i = 0, max = methods.length; i < max; i++) {
 		ILocalVariable[] parameters = methods[i].getParameters();
 		for (int j = 0, max2 = parameters.length; j < max2; j++) {
@@ -1452,7 +1452,7 @@ public void testWorkingCopy08() throws CoreException {
 			"  }\n" +
 			"}"
 		);
-		problemRequestor.problems = new StringBuffer();
+		problemRequestor.problems = new StringBuilder();
 		problemRequestor.problemCount = 0;
 		copy.reconcile(ICompilationUnit.NO_AST, false/*don't force problems*/, owner, null/*no progress*/);
 		assertProblems(
@@ -1486,7 +1486,7 @@ public void testWorkingCopy09() throws CoreException {
 			"  workingcopy.X x;\n" +
 			"}"
 		);
-		problemRequestor.problems = new StringBuffer();
+		problemRequestor.problems = new StringBuilder();
 		problemRequestor.problemCount = 0;
 		copy.reconcile(ICompilationUnit.NO_AST, false/*don't force problems*/, owner, null/*no progress*/);
 		assertProblems(

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ClasspathInitializerTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ClasspathInitializerTests.java
@@ -641,7 +641,7 @@ public void testContainerInitializer12() throws CoreException {
  */
 public void testContainerInitializer13() throws CoreException {
 	IResourceChangeListener listener = new IResourceChangeListener() {
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		public void resourceChanged(IResourceChangeEvent event) {
 			this.buffer.append(event.getDelta().findMember(new Path("/P1")));
 		}
@@ -775,7 +775,7 @@ public void testContainerInitializer16() throws CoreException {
  */
 public void testContainerInitializer17() throws CoreException {
 	IResourceChangeListener listener = new IResourceChangeListener() {
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		public void resourceChanged(IResourceChangeEvent event) {
 			this.buffer.append(event.getDelta().findMember(new Path("/P2")));
 		}

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ClasspathTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ClasspathTests.java
@@ -5027,7 +5027,7 @@ public void testNoResourceChange05() throws CoreException {
  */
 public void testNoResourceChange06() throws CoreException {
 	ILogListener listener = new ILogListener(){
-		private final StringBuffer buffer = new StringBuffer();
+		private final StringBuilder buffer = new StringBuilder();
 		public void logging(IStatus status, String plugin) {
 			this.buffer.append(status);
 			this.buffer.append('\n');

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTestsRequestor2.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTestsRequestor2.java
@@ -318,7 +318,7 @@ public class CompletionTestsRequestor2 extends CompletionRequestor {
 	 */
 	public String getResultsWithoutSorting() {
 		if(this.proposalsPtr < 0) return "";
-		StringBuffer buffer = printProposal(this.proposals[0]);
+		StringBuilder buffer = printProposal(this.proposals[0]);
 		for(int i = 1; i <=this.proposalsPtr; i++) {
 			if(i > 0) buffer.append('\n');
 			buffer.append(printProposal(this.proposals[i]));
@@ -336,12 +336,12 @@ public class CompletionTestsRequestor2 extends CompletionRequestor {
 		return strings;
 	}
 
-	protected StringBuffer printProposal(CompletionProposal proposal) {
-		StringBuffer buffer = new StringBuffer();
+	protected StringBuilder printProposal(CompletionProposal proposal) {
+		StringBuilder buffer = new StringBuilder();
 		return printProposal(proposal, 0, buffer);
 	}
 
-	protected StringBuffer printProposal(CompletionProposal proposal, int tab, StringBuffer buffer) {
+	protected StringBuilder printProposal(CompletionProposal proposal, int tab, StringBuilder buffer) {
 		for (int i = 0; i < tab; i++) {
 			buffer.append("   "); //$NON-NLS-1$
 		}

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/DefaultJavaElementComparator.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/DefaultJavaElementComparator.java
@@ -257,7 +257,7 @@ class DefaultJavaElementComparator implements Comparator {
 		switch(node.getNodeType()) {
 			case ASTNode.METHOD_DECLARATION :
 				MethodDeclaration methodDeclaration = (MethodDeclaration) node;
-				StringBuffer buffer = new StringBuffer();
+				StringBuilder buffer = new StringBuilder();
 				buffer.append(methodDeclaration.getName().getIdentifier());
 				final List parameters = methodDeclaration.parameters();
 				int length1 = parameters.size();

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchGenericConstructorEquivalentTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchGenericConstructorEquivalentTests.java
@@ -43,7 +43,7 @@ public class JavaSearchGenericConstructorEquivalentTests extends JavaSearchGener
 	 * Add line to result only if it is not an erasure match rule.
 	 */
 	@Override
-	void addResultLine(StringBuffer buffer, char[] line) {
+	void addResultLine(StringBuilder buffer, char[] line) {
 		if (!CharOperation.match(RESULT_ERASURE_MATCH, line, true)) {
 			super.addResultLine(buffer, line);
 		}

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchGenericConstructorExactTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchGenericConstructorExactTests.java
@@ -43,7 +43,7 @@ public class JavaSearchGenericConstructorExactTests extends JavaSearchGenericCon
 	 * Do not add line if this is not an exact match rule.
 	 */
 	@Override
-	void addResultLine(StringBuffer buffer, char[] line) {
+	void addResultLine(StringBuilder buffer, char[] line) {
 		if (CharOperation.match(RESULT_EXACT_MATCH, line, true)) {
 			super.addResultLine(buffer, line);
 		}

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchGenericConstructorTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchGenericConstructorTests.java
@@ -70,7 +70,7 @@ public class JavaSearchGenericConstructorTests extends AbstractJavaSearchGeneric
 	}
 
 	@Override
-	void addResultLine(StringBuffer buffer, char[] line) {
+	void addResultLine(StringBuilder buffer, char[] line) {
 		long positions = removeFirstTypeArgument(line);
 		if (buffer.length() > 0) buffer.append('\n');
 		if (positions != -1) {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchGenericMethodEquivalentTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchGenericMethodEquivalentTests.java
@@ -44,7 +44,7 @@ public class JavaSearchGenericMethodEquivalentTests extends JavaSearchGenericMet
 	 * Add line to result only if it is not an erasure match rule.
 	 */
 	@Override
-	void addResultLine(StringBuffer buffer, char[] line) {
+	void addResultLine(StringBuilder buffer, char[] line) {
 		if (!CharOperation.match(RESULT_ERASURE_MATCH, line, true) &&
 			!CharOperation.match(RESULT_POTENTIAL_MATCH, line, true)) {
 			super.addResultLine(buffer, line);

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchGenericMethodExactTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchGenericMethodExactTests.java
@@ -43,7 +43,7 @@ public class JavaSearchGenericMethodExactTests extends JavaSearchGenericMethodTe
 	 * Do not add line if this is not an exact match rule.
 	 */
 	@Override
-	void addResultLine(StringBuffer buffer, char[] line) {
+	void addResultLine(StringBuilder buffer, char[] line) {
 		if (CharOperation.match(RESULT_EXACT_MATCH, line, true)) {
 			super.addResultLine(buffer, line);
 		}

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchGenericMethodTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchGenericMethodTests.java
@@ -70,7 +70,7 @@ public class JavaSearchGenericMethodTests extends AbstractJavaSearchGenericTests
 	}
 
 	@Override
-	void addResultLine(StringBuffer buffer, char[] line) {
+	void addResultLine(StringBuilder buffer, char[] line) {
 		long positions = removeFirstTypeArgument(line);
 		if (buffer.length() > 0) buffer.append('\n');
 		if (positions != -1) {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchGenericTypeEquivalentTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchGenericTypeEquivalentTests.java
@@ -45,7 +45,7 @@ public class JavaSearchGenericTypeEquivalentTests extends JavaSearchGenericTypeT
 	 * Add line to result only if it is not an erasure match rule.
 	 */
 	@Override
-	void addResultLine(StringBuffer buffer, char[] line) {
+	void addResultLine(StringBuilder buffer, char[] line) {
 		if (!CharOperation.match(RESULT_ERASURE_MATCH, line, true)) {
 			super.addResultLine(buffer, line);
 		}

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchGenericTypeExactTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchGenericTypeExactTests.java
@@ -52,7 +52,7 @@ public class JavaSearchGenericTypeExactTests extends JavaSearchGenericTypeTests 
 	 * Do not add line if this is not an exact match rule.
 	 */
 	@Override
-	void addResultLine(StringBuffer buffer, char[] line) {
+	void addResultLine(StringBuilder buffer, char[] line) {
 		if (CharOperation.match(RESULT_EXACT_MATCH, line, true)) {
 			super.addResultLine(buffer, line);
 		}

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchGenericTypeTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchGenericTypeTests.java
@@ -87,7 +87,7 @@ public class JavaSearchGenericTypeTests extends AbstractJavaSearchGenericTests {
 	}
 
 	@Override
-	void addResultLine(StringBuffer buffer, char[] line) {
+	void addResultLine(StringBuilder buffer, char[] line) {
 		int[] positions = removeLastTypeArgument(line);
 		if (buffer.length() > 0) buffer.append('\n');
 		if (positions != null) {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ModifyingResourceTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ModifyingResourceTests.java
@@ -234,11 +234,11 @@ protected IFile editFile(String path, String content) throws CoreException {
  * of the tree.
  */
 protected String expandAll(IJavaElement element) throws CoreException {
-	StringBuffer buffer = new StringBuffer();
+	StringBuilder buffer = new StringBuilder();
 	this.expandAll(element, 0, buffer);
 	return buffer.toString();
 }
-private void expandAll(IJavaElement element, int tab, StringBuffer buffer) throws CoreException {
+private void expandAll(IJavaElement element, int tab, StringBuilder buffer) throws CoreException {
 	IJavaElement[] children = null;
 	// force opening of element by getting its children
 	if (element instanceof IParent) {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/RootManipulationsTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/RootManipulationsTests.java
@@ -33,7 +33,7 @@ public RootManipulationsTests(String name) {
 	super(name);
 }
 protected void assertJavaProject(String expected, IJavaProject project) throws CoreException {
-	StringBuffer buffer = new StringBuffer();
+	StringBuilder buffer = new StringBuilder();
 	populate(buffer, project, 0);
 
 	String actual = buffer.toString();
@@ -79,7 +79,7 @@ protected void move(IPackageFragmentRoot root, IPath destination, IClasspathEntr
 		sibling,
 		null);
 }
-protected void populate(StringBuffer buffer, IJavaElement element, int indent) throws CoreException {
+protected void populate(StringBuilder buffer, IJavaElement element, int indent) throws CoreException {
 	if (!(element instanceof IParent) || !(element instanceof IOpenable)) return;
 
 	if (buffer.length() != 0) {
@@ -117,7 +117,7 @@ protected void populate(StringBuffer buffer, IJavaElement element, int indent) t
 		}
 	}
 }
-protected void populate(StringBuffer buffer, Object nonJavaResource, int indent) {
+protected void populate(StringBuilder buffer, Object nonJavaResource, int indent) {
 	if (buffer.length() != 0) {
 		buffer.append("\n");
 	}

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/SearchTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/SearchTests.java
@@ -94,7 +94,7 @@ public class SearchTests extends ModifyingResourceTests implements IJavaSearchCo
 				int modifiers,
 				String path,
 				int methodIndex) {
-			StringBuffer buffer = new StringBuffer();
+			StringBuilder buffer = new StringBuilder();
 			char c = '.';
 			char[] noname = new String("<NONAME>").toCharArray();
 			buffer.append(path);
@@ -138,7 +138,7 @@ public class SearchTests extends ModifyingResourceTests implements IJavaSearchCo
 			buffer.append(')');
 			this.results.add(buffer.toString());
 		}
-		static void checkAndAddtoBuffer(StringBuffer buffer, char[] precond, char c) {
+		static void checkAndAddtoBuffer(StringBuilder buffer, char[] precond, char c) {
 			if (precond == null || precond.length == 0) return;
 			buffer.append(precond);
 			buffer.append(c);

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/TypeResolveTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/TypeResolveTests.java
@@ -442,7 +442,7 @@ public void testParamAnnotations3() throws CoreException {
 		assertEquals(annotationString2, iAnnotation.toString());
 		IMemberValuePair[] memberValuePairs = iAnnotation.getMemberValuePairs();
 		assertEquals("Wrong number of pairs", 1, memberValuePairs.length);
-		StringBuffer output = new StringBuffer();
+		StringBuilder output = new StringBuilder();
 		output.append(memberValuePairs[0].getMemberName());
 		output.append(' ');
 		output.append(memberValuePairs[0].getValue());
@@ -496,7 +496,7 @@ public void testParamAnnotations4() throws CoreException, IOException {
 		assertEquals("@p.Marker [in Test(int, java.lang.String, int) [in X [in X.class [in p [in lib334783_2.jar [in P]]]]]]", annotation.toString());
 		IMemberValuePair[] memberValuePairs = annotation.getMemberValuePairs();
 		assertEquals("Wrong number of pairs", 1, memberValuePairs.length);
-		StringBuffer output = new StringBuffer();
+		StringBuilder output = new StringBuilder();
 		output.append(memberValuePairs[0].getMemberName());
 		output.append(' ');
 		output.append(memberValuePairs[0].getValue());
@@ -515,7 +515,7 @@ public void testParamAnnotations4() throws CoreException, IOException {
 		assertEquals(annotationString2, annotation.toString());
 		memberValuePairs = annotation.getMemberValuePairs();
 		assertEquals("Wrong number of pairs", 1, memberValuePairs.length);
-		output = new StringBuffer();
+		output = new StringBuilder();
 		output.append(memberValuePairs[0].getMemberName());
 		output.append(' ');
 		output.append(memberValuePairs[0].getValue());
@@ -571,7 +571,7 @@ public void testParamAnnotations5() throws CoreException, IOException {
 		assertEquals("@p.Marker [in Test(int, java.lang.String, int) [in X [in X.class [in p [in lib334783_3.jar [in P]]]]]]", annotation.toString());
 		IMemberValuePair[] memberValuePairs = annotation.getMemberValuePairs();
 		assertEquals("Wrong number of pairs", 1, memberValuePairs.length);
-		StringBuffer output = new StringBuffer();
+		StringBuilder output = new StringBuilder();
 		output.append(memberValuePairs[0].getMemberName());
 		output.append(' ');
 		output.append(memberValuePairs[0].getValue());
@@ -583,7 +583,7 @@ public void testParamAnnotations5() throws CoreException, IOException {
 		assertEquals(annotationString2, annotation.toString());
 		memberValuePairs = annotation.getMemberValuePairs();
 		assertEquals("Wrong number of pairs", 1, memberValuePairs.length);
-		output = new StringBuffer();
+		output = new StringBuilder();
 		output.append(memberValuePairs[0].getMemberName());
 		output.append(' ');
 		output.append(memberValuePairs[0].getValue());
@@ -692,7 +692,7 @@ public void testParamAnnotations8() throws CoreException, IOException {
 		assertEquals("@p.Marker [in X(int, java.lang.String, int) [in X [in X.class [in p [in lib334783_3.jar [in P]]]]]]", annotation.toString());
 		IMemberValuePair[] memberValuePairs = annotation.getMemberValuePairs();
 		assertEquals("Wrong number of pairs", 1, memberValuePairs.length);
-		StringBuffer output = new StringBuffer();
+		StringBuilder output = new StringBuilder();
 		output.append(memberValuePairs[0].getMemberName());
 		output.append(' ');
 		output.append(memberValuePairs[0].getValue());
@@ -704,7 +704,7 @@ public void testParamAnnotations8() throws CoreException, IOException {
 		assertEquals(annotationString2, annotation.toString());
 		memberValuePairs = annotation.getMemberValuePairs();
 		assertEquals("Wrong number of pairs", 1, memberValuePairs.length);
-		output = new StringBuffer();
+		output = new StringBuilder();
 		output.append(memberValuePairs[0].getMemberName());
 		output.append(' ');
 		output.append(memberValuePairs[0].getValue());

--- a/org.eclipse.jdt.core.tests.performance/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.tests.performance/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.core.tests.performance
-Bundle-Version: 3.12.200.qualifier
+Bundle-Version: 3.12.300.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jdt.core.tests.performance,

--- a/org.eclipse.jdt.core.tests.performance/pom.xml
+++ b/org.eclipse.jdt.core.tests.performance/pom.xml
@@ -19,7 +19,7 @@
     <relativePath>../tests-pom/</relativePath>
   </parent>
   <artifactId>org.eclipse.jdt.core.tests.performance</artifactId>
-  <version>3.12.200-SNAPSHOT</version>
+  <version>3.12.300-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <properties>
   	<testSuite>${project.artifactId}</testSuite>

--- a/org.eclipse.jdt.core.tests.performance/src/org/eclipse/jdt/core/tests/performance/AllPerformanceTests.java
+++ b/org.eclipse.jdt.core.tests.performance/src/org/eclipse/jdt/core/tests/performance/AllPerformanceTests.java
@@ -72,9 +72,9 @@ public class AllPerformanceTests extends junit.framework.TestCase {
 
 		// Display warning if one of subset static fields is not null
 		// (this may modify tests run order and make stored results invalid)
-		StringBuffer buffer = null;
+		StringBuilder buffer = null;
 		if (TestCase.TESTS_NAMES != null) {
-			buffer = new StringBuffer("WARNING: Performance tests results may be invalid !!!\n");
+			buffer = new StringBuilder("WARNING: Performance tests results may be invalid !!!\n");
 			buffer.append("	- following subset is still defined and may alter tests order:\n");
 			buffer.append("		+ TESTS_NAMES = new String[] { ");
 			int length = TestCase.TESTS_NAMES.length;
@@ -88,7 +88,7 @@ public class AllPerformanceTests extends junit.framework.TestCase {
 		}
 		if (TestCase.TESTS_PREFIX != null) {
 			if (buffer == null) {
-				buffer = new StringBuffer("WARNING: Performance tests results may be invalid !!!\n");
+				buffer = new StringBuilder("WARNING: Performance tests results may be invalid !!!\n");
 				buffer.append("	- following subset is still defined and may alter tests order:\n");
 			}
 			buffer.append("		+ TESTS_PREFIX = ");
@@ -99,7 +99,7 @@ public class AllPerformanceTests extends junit.framework.TestCase {
 		}
 		if (TestCase.TESTS_NUMBERS != null) {
 			if (buffer == null) {
-				buffer = new StringBuffer("WARNING: Performance tests results may be invalid !!!\n");
+				buffer = new StringBuilder("WARNING: Performance tests results may be invalid !!!\n");
 				buffer.append("	- following subset is still defined and may alter tests order:\n");
 			}
 			buffer.append("		+ TESTS_NUMBERS = new int[] { ");
@@ -112,7 +112,7 @@ public class AllPerformanceTests extends junit.framework.TestCase {
 		}
 		if (TestCase.TESTS_RANGE != null) {
 			if (buffer == null) {
-				buffer = new StringBuffer("WARNING: Performance tests results may be invalid !!!\n");
+				buffer = new StringBuilder("WARNING: Performance tests results may be invalid !!!\n");
 				buffer.append("	- following subset is still defined and may alter tests order:\n");
 			}
 			buffer.append("		+ TESTS_RANGE = new int[] { ");
@@ -128,7 +128,7 @@ public class AllPerformanceTests extends junit.framework.TestCase {
 		long maxMem = Runtime.getRuntime().maxMemory(); // -Xmx
 		boolean tooMuch = false;
 		if (maxMem < (MAX_MEM*0.98) || (tooMuch = maxMem > (MAX_MEM*1.02))) {
-			if (buffer == null) buffer = new StringBuffer("WARNING: Performance tests results may be invalid !!!\n");
+			if (buffer == null) buffer = new StringBuilder("WARNING: Performance tests results may be invalid !!!\n");
 			buffer.append("	- ");
 			buffer.append(tooMuch ? "too much " : "not enough ");
 			buffer.append("max memory allocated (");
@@ -141,7 +141,7 @@ public class AllPerformanceTests extends junit.framework.TestCase {
 		long totalMem = Runtime.getRuntime().totalMemory(); // -Xms
 		tooMuch = false;
 		if (totalMem < (TOTAL_MEM*0.98)|| (tooMuch = totalMem > (TOTAL_MEM*1.02))) {
-			if (buffer == null) buffer = new StringBuffer("WARNING: Performance tests results may be invalid !!!\n");
+			if (buffer == null) buffer = new StringBuilder("WARNING: Performance tests results may be invalid !!!\n");
 			buffer.append("	- ");
 			buffer.append(tooMuch ? "too much " : "not enough ");
 			buffer.append("total memory allocated (");

--- a/org.eclipse.jdt.core.tests.performance/src/org/eclipse/jdt/core/tests/performance/FullSourceWorkspaceASTTests.java
+++ b/org.eclipse.jdt.core.tests.performance/src/org/eclipse/jdt/core/tests/performance/FullSourceWorkspaceASTTests.java
@@ -787,7 +787,7 @@ public class FullSourceWorkspaceASTTests extends FullSourceWorkspaceTests {
 					IProblem[] problems = ast.getProblems();
 					int length = problems.length;
 					if (length > 0) {
-						StringBuffer buffer = new StringBuffer();
+						StringBuilder buffer = new StringBuilder();
 						for (int i=0; i<length; i++) {
 							buffer.append(problems[i].getMessage());
 							buffer.append('\n');

--- a/org.eclipse.jdt.core.tests.performance/src/org/eclipse/jdt/core/tests/performance/FullSourceWorkspaceBuildTests.java
+++ b/org.eclipse.jdt.core.tests.performance/src/org/eclipse/jdt/core/tests/performance/FullSourceWorkspaceBuildTests.java
@@ -209,7 +209,7 @@ public class FullSourceWorkspaceBuildTests extends FullSourceWorkspaceTests {
 		// Assert result
 		int size = messages.size();
 		if (size > 0) {
-			StringBuffer debugBuffer = new StringBuffer();
+			StringBuilder debugBuffer = new StringBuilder();
 			for (int i=0; i<size; i++) {
 				debugBuffer.append(resources.get(i));
 				debugBuffer.append(":\n\t");
@@ -232,7 +232,7 @@ public class FullSourceWorkspaceBuildTests extends FullSourceWorkspaceTests {
 			System.out.println("\t- "+warnings+" warnings found while performing build.");
 		}
 		if (this.scenarioComment == null) {
-			this.scenarioComment = new StringBuffer("["+TEST_POSITION+"]");
+			this.scenarioComment = new StringBuilder("["+TEST_POSITION+"]");
 		} else {
 			this.scenarioComment.append(' ');
 		}
@@ -348,7 +348,7 @@ public class FullSourceWorkspaceBuildTests extends FullSourceWorkspaceTests {
 			System.out.println("\t- "+warnings+" warnings found while performing batch compilation.");
 		}
 		if (this.scenarioComment == null) {
-			this.scenarioComment = new StringBuffer("["+TEST_POSITION+"]");
+			this.scenarioComment = new StringBuilder("["+TEST_POSITION+"]");
 		} else {
 			this.scenarioComment.append(' ');
 		}

--- a/org.eclipse.jdt.core.tests.performance/src/org/eclipse/jdt/core/tests/performance/FullSourceWorkspaceCompleteSearchTests.java
+++ b/org.eclipse.jdt.core.tests.performance/src/org/eclipse/jdt/core/tests/performance/FullSourceWorkspaceCompleteSearchTests.java
@@ -81,13 +81,13 @@ private static Class testClass() {
  * Verify VM arguments when full tests are run (should be -Xmx512M)
  */
 private static void verifyVmArguments() {
-	StringBuffer buffer = null;
+	StringBuilder buffer = null;
 	NumberFormat floatFormat = NumberFormat.getNumberInstance();
 	floatFormat.setMaximumFractionDigits(1);
 	long maxMem = Runtime.getRuntime().maxMemory(); // -Xmx
 	boolean tooMuch = false;
 	if (maxMem < (MAX_MEM*0.98) || (tooMuch = maxMem > (MAX_MEM*1.02))) {
-		if (buffer == null) buffer = new StringBuffer("WARNING: Performance tests results may be invalid !!!\n");
+		if (buffer == null) buffer = new StringBuilder("WARNING: Performance tests results may be invalid !!!\n");
 		buffer.append("	- ");
 		buffer.append(tooMuch ? "too much " : "not enough ");
 		buffer.append("max memory allocated (");

--- a/org.eclipse.jdt.core.tests.performance/src/org/eclipse/jdt/core/tests/performance/FullSourceWorkspaceModelTests.java
+++ b/org.eclipse.jdt.core.tests.performance/src/org/eclipse/jdt/core/tests/performance/FullSourceWorkspaceModelTests.java
@@ -337,7 +337,7 @@ protected void assertElementsEqual(String message, String expected, IJavaElement
  * @see org.eclipse.jdt.core.tests.model.AbstractJavaModelTests#assertElementsEqual(String, String, IJavaElement[], boolean)
  */
 protected void assertElementsEqual(String message, String expected, IJavaElement[] elements, boolean showResolvedInfo) {
-	StringBuffer buffer = new StringBuffer();
+	StringBuilder buffer = new StringBuilder();
 	if (elements != null) {
 		for (int i = 0, length = elements.length; i < length; i++){
 			JavaElement element = (JavaElement)elements[i];
@@ -760,7 +760,7 @@ public void testPerfReconcileBigFileWithSyntaxError() throws JavaModelException 
 		"	 \"}\\n\"" +
 		"  );\n" +
 		"}\n";
-	StringBuffer bigContents = new StringBuffer();
+	StringBuilder bigContents = new StringBuilder();
 	bigContents.append("public class BigCU {\n");
 	int fooIndex = 0;
 	while (fooIndex < 2000) { // add 2000 methods (so that source is close to 1MB)
@@ -811,7 +811,7 @@ public void testReconcileDuplicates() throws JavaModelException {
 	tagAsSummary("Reconcile editor change on file with lots of duplicates", false); // do NOT put in fingerprint
 
 	// build big file contents
-	StringBuffer contents = new StringBuffer();
+	StringBuilder contents = new StringBuilder();
 	contents.append("public class CUWithDuplicates {\n");
 	int fooIndex = 0;
 	while (fooIndex < 2000) { // add 2000 duplicate methods
@@ -861,7 +861,7 @@ public void testPerfDeleteLotsOfMembersAndReconcile() throws JavaModelException 
 	tagAsSummary("Reconcile editor change after deleting lots of members", false); // do NOT put in fingerprint
 
 	// build big file contents
-	StringBuffer contents = new StringBuffer();
+	StringBuilder contents = new StringBuilder();
 	contents.append("public class LotsOfMembers {\n");
 	int fooIndex = 0;
 	while (fooIndex < 15000) { // add 15000 methods

--- a/org.eclipse.jdt.core.tests.performance/src/org/eclipse/jdt/core/tests/performance/FullSourceWorkspaceTests.java
+++ b/org.eclipse.jdt.core.tests.performance/src/org/eclipse/jdt/core/tests/performance/FullSourceWorkspaceTests.java
@@ -218,7 +218,7 @@ public abstract class FullSourceWorkspaceTests extends TestCase {
 
 	// Scenario information
 	String scenarioReadableName, scenarioShortName;
-	StringBuffer scenarioComment;
+	StringBuilder scenarioComment;
 	static Map SCENARII_COMMENT = new HashMap();
 
 	// Time measuring
@@ -510,15 +510,15 @@ public abstract class FullSourceWorkspaceTests extends TestCase {
 		}
 
 		// Update comment buffers
-		StringBuffer[] scenarioComments = (StringBuffer[]) SCENARII_COMMENT.get(getClass());
+		StringBuilder[] scenarioComments = (StringBuilder[]) SCENARII_COMMENT.get(getClass());
 		if (scenarioComments == null) {
-			scenarioComments = new StringBuffer[length];
+			scenarioComments = new StringBuilder[length];
 			SCENARII_COMMENT.put(getClass(), scenarioComments);
 		}
 		for (int i=0; i<length; i++) {
 			if (this.scenarioComment != null || comments[i] != null) {
 				if (scenarioComments[i] == null) {
-					scenarioComments[i] = new StringBuffer();
+					scenarioComments[i] = new StringBuilder();
 				} else {
 					scenarioComments[i].append(' ');
 				}

--- a/org.eclipse.jdt.core.tests.performance/src/org/eclipse/jdt/core/tests/performance/util/Statistics.java
+++ b/org.eclipse.jdt.core.tests.performance/src/org/eclipse/jdt/core/tests/performance/util/Statistics.java
@@ -65,7 +65,7 @@ public Statistics(DataPoint[] dataPoints) {
 
 @Override
 public String toString() {
-	StringBuffer buffer = new StringBuffer();
+	StringBuilder buffer = new StringBuilder();
 	int length = DIMENSIONS.length;
 	for (int idx=0; idx<length; idx++) {
 		dimToString(idx, buffer);
@@ -74,18 +74,18 @@ public String toString() {
 }
 
 public String toString(int dimIndex) {
-	StringBuffer buffer = new StringBuffer();
+	StringBuilder buffer = new StringBuilder();
 	dimToString(dimIndex, buffer);
 	return buffer.toString();
 }
 
 public String elapsedProcessToString() {
-	StringBuffer buffer = new StringBuffer();
+	StringBuilder buffer = new StringBuilder();
 	dimToString(1, buffer);
 	return buffer.toString();
 }
 
-void dimToString(int idx, StringBuffer buffer) {
+void dimToString(int idx, StringBuilder buffer) {
 	Dim dim = DIMENSIONS[idx];
 	buffer.append(dim.getName());
 	buffer.append(": n=");

--- a/org.eclipse.jdt.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.core; singleton:=true
-Bundle-Version: 3.36.0.qualifier
+Bundle-Version: 3.36.100.qualifier
 Bundle-Activator: org.eclipse.jdt.core.JavaCore
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/CompletionEngine.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/CompletionEngine.java
@@ -5279,7 +5279,7 @@ public final class CompletionEngine
 		return CharOperation.concat(result, IMPORT_END);
 	}
 
-	private void createMethod(MethodBinding method, char[][] parameterPackageNames, char[][] parameterTypeNames, char[][] parameterNames, Scope scope, StringBuffer completion) {
+	private void createMethod(MethodBinding method, char[][] parameterPackageNames, char[][] parameterTypeNames, char[][] parameterNames, Scope scope, StringBuilder completion) {
 		//// Modifiers
 		// flush uninteresting modifiers
 		int insertedModifiers = method.modifiers & ~(ClassFileConstants.AccNative | ClassFileConstants.AccAbstract);
@@ -5392,7 +5392,7 @@ public final class CompletionEngine
 		return proposal;
 	}
 
-	private void createType(TypeBinding type, Scope scope, StringBuffer completion) {
+	private void createType(TypeBinding type, Scope scope, StringBuilder completion) {
 		switch (type.kind()) {
 			case Binding.BASE_TYPE :
 				completion.append(type.sourceName());
@@ -5635,7 +5635,7 @@ public final class CompletionEngine
 			}
 		}
 	}
-	private void createTypeVariable(TypeVariableBinding typeVariable, Scope scope, StringBuffer completion) {
+	private void createTypeVariable(TypeVariableBinding typeVariable, Scope scope, StringBuilder completion) {
 		completion.append(typeVariable.sourceName);
 
 		if (typeVariable.superclass != null && TypeBinding.equalsEquals(typeVariable.firstBound, typeVariable.superclass)) {
@@ -5660,7 +5660,7 @@ public final class CompletionEngine
 		   }
 		}
 	}
-	private void createVargsType(TypeBinding type, Scope scope, StringBuffer completion) {
+	private void createVargsType(TypeBinding type, Scope scope, StringBuilder completion) {
 		if (type.isArrayType()) {
 			createType(type.leafComponentType(), scope, completion);
 			int dim = type.dimensions() - 1;
@@ -6278,7 +6278,7 @@ public final class CompletionEngine
 								receiver = modRef.typeReference;
 							}
 							if (receiver != null) {
-								StringBuffer javadocCompletion = new StringBuffer();
+								StringBuilder javadocCompletion = new StringBuilder();
 								if (receiver.isThis()) {
 									selector = (((JavadocImplicitTypeReference)receiver).token);
 									if ((this.assistNodeInJavadoc & CompletionOnJavadoc.TEXT) != 0) {
@@ -9404,7 +9404,7 @@ public final class CompletionEngine
 				}
 			}
 
-			StringBuffer completion = new StringBuffer(10);
+			StringBuilder completion = new StringBuilder(10);
 			if (!exactMatch) {
 				createMethod(method, parameterPackageNames, parameterFullTypeNames, parameterNames, scope, completion);
 			}
@@ -9617,7 +9617,7 @@ public final class CompletionEngine
 					receiver = fieldRef.receiver;
 				}
 				if (receiver != null) {
-					StringBuffer javadocCompletion = new StringBuffer();
+					StringBuilder javadocCompletion = new StringBuilder();
 					if (receiver.isThis()) {
 						if ((this.assistNodeInJavadoc & CompletionOnJavadoc.TEXT) != 0) {
 							javadocCompletion.append('#');
@@ -13944,7 +13944,7 @@ public final class CompletionEngine
 		return true;
 	}
 	private Initializer parseSnippeInitializer(char[] snippet, int position, char[][] localVariableTypeNames, char[][] localVariableNames, int[] localVariableModifiers, boolean isStatic){
-		StringBuffer prefix = new StringBuffer();
+		StringBuilder prefix = new StringBuilder();
 		prefix.append("public class FakeType {\n "); //$NON-NLS-1$
 		if(isStatic) {
 			prefix.append("static "); //$NON-NLS-1$
@@ -13985,12 +13985,12 @@ public final class CompletionEngine
 		}
 	}
 	protected void printDebug(CompletionProposal proposal){
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		printDebug(proposal, 0, buffer);
 		trace(buffer.toString());
 	}
 
-	private void printDebug(CompletionProposal proposal, int tab, StringBuffer buffer){
+	private void printDebug(CompletionProposal proposal, int tab, StringBuilder buffer){
 		printDebugTab(tab, buffer);
 		buffer.append("COMPLETION - "); //$NON-NLS-1$
 		switch(proposal.getKind()) {
@@ -14129,7 +14129,7 @@ public final class CompletionEngine
 		buffer.append("}\n");//$NON-NLS-1$
 	}
 
-	private void printDebugTab(int tab, StringBuffer buffer) {
+	private void printDebugTab(int tab, StringBuilder buffer) {
 		for (int i = 0; i < tab; i++) {
 			buffer.append('\t');
 		}

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/AssistNodeParentAnnotationArrayInitializer.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/AssistNodeParentAnnotationArrayInitializer.java
@@ -25,7 +25,7 @@ public class AssistNodeParentAnnotationArrayInitializer extends ASTNode {
 	}
 
 	@Override
-	public StringBuffer print(int indent, StringBuffer output) {
+	public StringBuilder print(int indent, StringBuilder output) {
 		output.append("<AssistNodeParentAnnotationArrayInitializer:"); //$NON-NLS-1$
 		output.append('@');
 		this.type.printExpression(0, output);

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionJavadoc.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionJavadoc.java
@@ -105,7 +105,7 @@ public class CompletionJavadoc extends Javadoc {
 	 * @see org.eclipse.jdt.internal.compiler.ast.ASTNode#print(int, java.lang.StringBuffer)
 	 */
 	@Override
-	public StringBuffer print(int indent, StringBuffer output) {
+	public StringBuilder print(int indent, StringBuilder output) {
 		printIndent(indent, output).append("/**\n"); //$NON-NLS-1$
 		boolean nodePrinted = false;
 		if (this.paramReferences != null) {

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnAnnotationMemberValuePair.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnAnnotationMemberValuePair.java
@@ -43,7 +43,7 @@ public class CompletionOnAnnotationMemberValuePair extends NormalAnnotation impl
 	}
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output) {
+	public StringBuilder printExpression(int indent, StringBuilder output) {
 		output.append('@');
 		this.type.printExpression(0, output);
 		output.append('(');

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnAnnotationOfType.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnAnnotationOfType.java
@@ -33,7 +33,7 @@ public class CompletionOnAnnotationOfType extends TypeDeclaration implements Com
 	}
 
 	@Override
-	public StringBuffer print(int indent, StringBuffer output) {
+	public StringBuilder print(int indent, StringBuilder output) {
 		return this.annotations[0].print(indent, output);
 	}
 }

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnArgumentName.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnArgumentName.java
@@ -48,7 +48,7 @@ public class CompletionOnArgumentName extends Argument implements CompletionNode
 	}
 
 	@Override
-	public StringBuffer print(int indent, StringBuffer output) {
+	public StringBuilder print(int indent, StringBuilder output) {
 
 		printIndent(indent, output);
 		output.append("<CompleteOnArgumentName:"); //$NON-NLS-1$

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnBreakStatement.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnBreakStatement.java
@@ -39,7 +39,7 @@ public class CompletionOnBreakStatement extends BreakStatement implements Comple
 		throw new CompletionNodeFound(this, scope);
 	}
 	@Override
-	public StringBuffer printStatement(int indent, StringBuffer output) {
+	public StringBuilder printStatement(int indent, StringBuilder output) {
 		printIndent(indent, output);
 		output.append("break "); //$NON-NLS-1$
 		output.append("<CompleteOnLabel:"); //$NON-NLS-1$

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnClassLiteralAccess.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnClassLiteralAccess.java
@@ -49,7 +49,7 @@ public class CompletionOnClassLiteralAccess extends ClassLiteralAccess implement
 	}
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output) {
+	public StringBuilder printExpression(int indent, StringBuilder output) {
 
 		output.append("<CompleteOnClassLiteralAccess:"); //$NON-NLS-1$
 		return this.type.print(0, output).append('.').append(this.completionIdentifier).append('>');

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnContinueStatement.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnContinueStatement.java
@@ -39,7 +39,7 @@ public class CompletionOnContinueStatement extends ContinueStatement implements 
 		throw new CompletionNodeFound(this, scope);
 	}
 	@Override
-	public StringBuffer printStatement(int indent, StringBuffer output) {
+	public StringBuilder printStatement(int indent, StringBuilder output) {
 		printIndent(indent, output);
 		output.append("continue "); //$NON-NLS-1$
 		output.append("<CompleteOnLabel:"); //$NON-NLS-1$

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnExplicitConstructorCall.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnExplicitConstructorCall.java
@@ -45,7 +45,7 @@ public class CompletionOnExplicitConstructorCall extends ExplicitConstructorCall
 	}
 
 	@Override
-	public StringBuffer printStatement(int tab, StringBuffer output) {
+	public StringBuilder printStatement(int tab, StringBuilder output) {
 
 		printIndent(tab, output);
 		output.append("<CompleteOnExplicitConstructorCall:"); //$NON-NLS-1$

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnExportReference.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnExportReference.java
@@ -41,7 +41,7 @@ public class CompletionOnExportReference extends ExportsStatement implements Com
 		super(ref, null);
 	}
 	@Override
-	public StringBuffer print(int indent, StringBuffer output) {
+	public StringBuilder print(int indent, StringBuilder output) {
 
 		printIndent(indent, output).append("<CompleteOnExport:"); //$NON-NLS-1$
 		output.append(this.pkgName);

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnFieldName.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnFieldName.java
@@ -26,7 +26,7 @@ public class CompletionOnFieldName extends FieldDeclaration implements Completio
 	}
 
 	@Override
-	public StringBuffer printStatement(int tab, StringBuffer output) {
+	public StringBuilder printStatement(int tab, StringBuilder output) {
 
 		printIndent(tab, output).append("<CompleteOnFieldName:"); //$NON-NLS-1$
 		if (this.type != null) this.type.print(0, output).append(' ');

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnFieldType.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnFieldType.java
@@ -53,7 +53,7 @@ public CompletionOnFieldType(TypeReference type, boolean isLocalVariable){
 }
 
 @Override
-public StringBuffer printStatement(int tab, StringBuffer output) {
+public StringBuilder printStatement(int tab, StringBuilder output) {
 	return this.type.print(tab, output).append(';');
 }
 }

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnImportReference.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnImportReference.java
@@ -43,7 +43,7 @@ public CompletionOnImportReference(char[][] tokens , long[] positions, int modif
 	super(tokens, positions, false, modifiers);
 }
 @Override
-public StringBuffer print(int indent, StringBuffer output, boolean withOnDemand) {
+public StringBuilder print(int indent, StringBuilder output, boolean withOnDemand) {
 
 	printIndent(indent, output).append("<CompleteOnImport:"); //$NON-NLS-1$
 	for (int i = 0; i < this.tokens.length; i++) {

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnJavadocAllocationExpression.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnJavadocAllocationExpression.java
@@ -61,7 +61,7 @@ public class CompletionOnJavadocAllocationExpression extends JavadocAllocationEx
 	}
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output) {
+	public StringBuilder printExpression(int indent, StringBuilder output) {
 		output.append("<CompleteOnJavadocAllocationExpression:"); //$NON-NLS-1$
 		super.printExpression(indent, output);
 		indent++;

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnJavadocFieldReference.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnJavadocFieldReference.java
@@ -98,7 +98,7 @@ public class CompletionOnJavadocFieldReference extends JavadocFieldReference imp
 	}
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output) {
+	public StringBuilder printExpression(int indent, StringBuilder output) {
 		output.append("<CompleteOnJavadocFieldReference:"); //$NON-NLS-1$
 		super.printExpression(indent, output);
 		indent++;

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnJavadocMessageSend.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnJavadocMessageSend.java
@@ -60,7 +60,7 @@ public class CompletionOnJavadocMessageSend extends JavadocMessageSend implement
 	}
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output) {
+	public StringBuilder printExpression(int indent, StringBuilder output) {
 		output.append("<CompleteOnJavadocMessageSend:"); //$NON-NLS-1$
 		super.printExpression(indent, output);
 		indent++;

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnJavadocModuleReference.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnJavadocModuleReference.java
@@ -57,7 +57,7 @@ public class CompletionOnJavadocModuleReference extends JavadocModuleReference i
 	}
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output) {
+	public StringBuilder printExpression(int indent, StringBuilder output) {
 		output.append("<CompletionOnJavadocModuleReference:"); //$NON-NLS-1$
 		super.printExpression(indent, output);
 		indent++;

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnJavadocParamNameReference.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnJavadocParamNameReference.java
@@ -41,7 +41,7 @@ public class CompletionOnJavadocParamNameReference extends JavadocSingleNameRefe
 	}
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output) {
+	public StringBuilder printExpression(int indent, StringBuilder output) {
 		output.append("<CompletionOnJavadocParamNameReference:"); //$NON-NLS-1$
 		if (this.token != null) super.printExpression(indent, output);
 		return output.append('>');

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnJavadocQualifiedTypeReference.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnJavadocQualifiedTypeReference.java
@@ -57,7 +57,7 @@ public class CompletionOnJavadocQualifiedTypeReference extends JavadocQualifiedT
 	}
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output) {
+	public StringBuilder printExpression(int indent, StringBuilder output) {
 		output.append("<CompletionOnJavadocQualifiedTypeReference:"); //$NON-NLS-1$
 		super.printExpression(indent, output);
 		indent++;

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnJavadocSingleTypeReference.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnJavadocSingleTypeReference.java
@@ -53,7 +53,7 @@ public class CompletionOnJavadocSingleTypeReference extends JavadocSingleTypeRef
 	}
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output) {
+	public StringBuilder printExpression(int indent, StringBuilder output) {
 		output.append("<CompletionOnJavadocSingleTypeReference:"); //$NON-NLS-1$
 		super.printExpression(indent, output);
 		indent++;

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnJavadocTag.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnJavadocTag.java
@@ -45,7 +45,7 @@ public class CompletionOnJavadocTag extends JavadocSingleNameReference implement
 	}
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output) {
+	public StringBuilder printExpression(int indent, StringBuilder output) {
 		output.append("<CompleteOnJavadocTag:"); //$NON-NLS-1$
 		output.append('@');
 		if (this.token != null) super.printExpression(indent, output);

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnJavadocTypeParamReference.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnJavadocTypeParamReference.java
@@ -40,7 +40,7 @@ public class CompletionOnJavadocTypeParamReference extends JavadocSingleTypeRefe
 	}
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output) {
+	public StringBuilder printExpression(int indent, StringBuilder output) {
 		output.append("<CompletionOnJavadocTypeParamReference:"); //$NON-NLS-1$
 		if (this.token != null) super.printExpression(indent, output);
 		return output.append('>');

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnKeyword1.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnKeyword1.java
@@ -44,7 +44,7 @@ public class CompletionOnKeyword1 extends SingleTypeReference implements Complet
 		throw new CompletionNodeFound(this, scope);
 	}
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output){
+	public StringBuilder printExpression(int indent, StringBuilder output){
 
 		return output.append("<CompleteOnKeyword:").append(this.token).append('>');  //$NON-NLS-1$
 	}

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnKeyword2.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnKeyword2.java
@@ -33,7 +33,7 @@ public class CompletionOnKeyword2 extends ImportReference implements CompletionO
 		return this.possibleKeywords;
 	}
 	@Override
-	public StringBuffer print(int indent, StringBuffer output, boolean withOnDemand) {
+	public StringBuilder print(int indent, StringBuilder output, boolean withOnDemand) {
 
 		return printIndent(indent, output).append("<CompleteOnKeyword:").append(this.token).append('>'); //$NON-NLS-1$
 	}

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnKeyword3.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnKeyword3.java
@@ -41,7 +41,7 @@ public class CompletionOnKeyword3 extends SingleNameReference implements Complet
 		return this.tryOrCatch;
 	}
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output) {
+	public StringBuilder printExpression(int indent, StringBuilder output) {
 
 		return output.append("<CompleteOnKeyword:").append(this.token).append('>'); //$NON-NLS-1$
 	}

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnLocalName.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnLocalName.java
@@ -36,7 +36,7 @@ public class CompletionOnLocalName extends LocalDeclaration implements Completio
 	}
 
 	@Override
-	public StringBuffer printAsExpression(int indent, StringBuffer output) {
+	public StringBuilder printAsExpression(int indent, StringBuilder output) {
 		printIndent(indent, output);
 		output.append("<CompleteOnLocalName:"); //$NON-NLS-1$
 		if (this.type != null)  this.type.print(0, output).append(' ');
@@ -49,7 +49,7 @@ public class CompletionOnLocalName extends LocalDeclaration implements Completio
 	}
 
 	@Override
-	public StringBuffer printStatement(int indent, StringBuffer output) {
+	public StringBuilder printStatement(int indent, StringBuilder output) {
 		printAsExpression(indent, output);
 		return output.append(';');
 	}

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnMemberAccess.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnMemberAccess.java
@@ -49,7 +49,7 @@ public class CompletionOnMemberAccess extends FieldReference implements Completi
 	}
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output) {
+	public StringBuilder printExpression(int indent, StringBuilder output) {
 
 		output.append("<CompleteOnMemberAccess:"); //$NON-NLS-1$
 		return super.printExpression(0, output).append('>');

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnMemberValueName.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnMemberValueName.java
@@ -34,7 +34,7 @@ public class CompletionOnMemberValueName extends MemberValuePair implements Comp
 	}
 
 	@Override
-	public StringBuffer print(int indent, StringBuffer output) {
+	public StringBuilder print(int indent, StringBuilder output) {
 		output.append("<CompleteOnAttributeName:"); //$NON-NLS-1$
 		output.append(this.name);
 		output.append('>');

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnMessageSend.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnMessageSend.java
@@ -68,7 +68,7 @@ public class CompletionOnMessageSend extends MessageSend implements CompletionNo
 	}
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output) {
+	public StringBuilder printExpression(int indent, StringBuilder output) {
 
 		output.append("<CompleteOnMessageSend:"); //$NON-NLS-1$
 		if (!this.receiver.isImplicitThis()) this.receiver.printExpression(0, output).append('.');

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnMessageSendName.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnMessageSendName.java
@@ -59,7 +59,7 @@ public class CompletionOnMessageSendName extends MessageSend implements Completi
 	}
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output) {
+	public StringBuilder printExpression(int indent, StringBuilder output) {
 
 		output.append("<CompleteOnMessageSendName:"); //$NON-NLS-1$
 		if (!this.receiver.isImplicitThis()) this.receiver.printExpression(0, output).append('.');

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnMethodName.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnMethodName.java
@@ -25,7 +25,7 @@ public class CompletionOnMethodName extends MethodDeclaration implements Complet
 	}
 
 	@Override
-	public StringBuffer print(int indent, StringBuffer output) {
+	public StringBuilder print(int indent, StringBuilder output) {
 
 		printIndent(indent, output);
 		output.append("<CompletionOnMethodName:"); //$NON-NLS-1$

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnMethodReturnType.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnMethodReturnType.java
@@ -31,7 +31,7 @@ public class CompletionOnMethodReturnType extends MethodDeclaration implements C
 	}
 
 	@Override
-	public StringBuffer print(int tab, StringBuffer output) {
+	public StringBuilder print(int tab, StringBuilder output) {
 		return this.returnType.print(tab, output);
 	}
 

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnMethodTypeParameter.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnMethodTypeParameter.java
@@ -33,7 +33,7 @@ public class CompletionOnMethodTypeParameter extends MethodDeclaration implement
 	}
 
 	@Override
-	public StringBuffer print(int tab, StringBuffer output) {
+	public StringBuilder print(int tab, StringBuilder output) {
 		printIndent(tab, output);
 		output.append('<');
 		int max = this.typeParameters.length - 1;

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnModuleReference.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnModuleReference.java
@@ -37,7 +37,7 @@ public class CompletionOnModuleReference extends ModuleReference implements Comp
 		//}
 	}
 	@Override
-	public StringBuffer print(int indent, StringBuffer output) {
+	public StringBuilder print(int indent, StringBuilder output) {
 
 		printIndent(indent, output).append("<CompleteOnModuleReference:"); //$NON-NLS-1$
 		for (int i = 0; i < this.tokens.length; i++) {

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnPackageReference.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnPackageReference.java
@@ -43,7 +43,7 @@ public CompletionOnPackageReference(char[][] tokens , long[] positions) {
 	super(tokens, positions, false, ClassFileConstants.AccDefault);
 }
 @Override
-public StringBuffer print(int indent, StringBuffer output, boolean withOnDemand) {
+public StringBuilder print(int indent, StringBuilder output, boolean withOnDemand) {
 
 	printIndent(indent, output).append("<CompleteOnPackage:"); //$NON-NLS-1$
 	for (int i = 0; i < this.tokens.length; i++) {

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnPackageVisibilityReference.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnPackageVisibilityReference.java
@@ -46,7 +46,7 @@ public class CompletionOnPackageVisibilityReference extends CompletionOnImportRe
 	}
 
 	@Override
-	public StringBuffer print(int indent, StringBuffer output) {
+	public StringBuilder print(int indent, StringBuilder output) {
 		printIndent(indent, output).append("<CompleteOnPackageVisibilityReference:"); //$NON-NLS-1$
 		output.append(this.pkgName);
 		return output.append('>');

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnParameterizedQualifiedTypeReference.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnParameterizedQualifiedTypeReference.java
@@ -83,7 +83,7 @@ public class CompletionOnParameterizedQualifiedTypeReference extends Parameteriz
 	}
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output) {
+	public StringBuilder printExpression(int indent, StringBuilder output) {
 		switch (this.kind) {
 			case K_CLASS :
 				output.append("<CompleteOnClass:");//$NON-NLS-1$

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnQualifiedAllocationExpression.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnQualifiedAllocationExpression.java
@@ -94,7 +94,7 @@ public TypeBinding resolveType(BlockScope scope) {
 	throw new CompletionNodeFound(this, this.resolvedType, scope);
 }
 @Override
-public StringBuffer printExpression(int indent, StringBuffer output) {
+public StringBuilder printExpression(int indent, StringBuilder output) {
 	if (this.enclosingInstance == null)
 		output.append("<CompleteOnAllocationExpression:" );  //$NON-NLS-1$
 	else

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnQualifiedNameReference.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnQualifiedNameReference.java
@@ -48,7 +48,7 @@ public CompletionOnQualifiedNameReference(char[][] previousIdentifiers, char[] c
 	this.isInsideAnnotationAttribute = isInsideAnnotationAttribute;
 }
 @Override
-public StringBuffer printExpression(int indent, StringBuffer output) {
+public StringBuilder printExpression(int indent, StringBuilder output) {
 
 	output.append("<CompleteOnName:"); //$NON-NLS-1$
 	for (int i = 0; i < this.tokens.length; i++) {

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnQualifiedTypeReference.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnQualifiedTypeReference.java
@@ -95,7 +95,7 @@ public void setKind(int kind) {
 	this.kind = kind;
 }
 @Override
-public StringBuffer printExpression(int indent, StringBuffer output) {
+public StringBuilder printExpression(int indent, StringBuilder output) {
 	switch (this.kind) {
 		case K_CLASS :
 			output.append("<CompleteOnClass:");//$NON-NLS-1$

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnRecordComponentName.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnRecordComponentName.java
@@ -29,7 +29,7 @@ public class CompletionOnRecordComponentName extends RecordComponent implements 
 	public char[] realName;
 
 	@Override
-	public StringBuffer printStatement(int tab, StringBuffer output) {
+	public StringBuilder printStatement(int tab, StringBuilder output) {
 
 		printIndent(tab, output).append("<CompletionOnRecordComponentName:"); //$NON-NLS-1$
 		if (this.type != null)

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnReferenceExpressionName.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnReferenceExpressionName.java
@@ -61,7 +61,7 @@ public class CompletionOnReferenceExpressionName extends ReferenceExpression imp
 	}
 
 	@Override
-	public StringBuffer printExpression(int tab, StringBuffer output) {
+	public StringBuilder printExpression(int tab, StringBuilder output) {
 		output.append("<CompletionOnReferenceExpressionName:"); //$NON-NLS-1$
 		this.lhs.print(0, output);
 		output.append("::"); //$NON-NLS-1$

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnSingleNameReference.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnSingleNameReference.java
@@ -56,7 +56,7 @@ public class CompletionOnSingleNameReference extends SingleNameReference impleme
 	}
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output) {
+	public StringBuilder printExpression(int indent, StringBuilder output) {
 
 		output.append("<CompleteOnName:"); //$NON-NLS-1$
 		return super.printExpression(0, output).append('>');

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnSingleTypeReference.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnSingleTypeReference.java
@@ -91,7 +91,7 @@ public boolean isSuperType(){
 	return this.kind == K_CLASS || this.kind == K_INTERFACE;
 }
 @Override
-public StringBuffer printExpression(int indent, StringBuffer output){
+public StringBuilder printExpression(int indent, StringBuilder output){
 	switch (this.kind) {
 		case K_CLASS :
 			output.append("<CompleteOnClass:");//$NON-NLS-1$

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnStringLiteral.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnStringLiteral.java
@@ -60,7 +60,7 @@ public class CompletionOnStringLiteral extends StringLiteral implements Completi
 	}
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output) {
+	public StringBuilder printExpression(int indent, StringBuilder output) {
 		output.append("<CompletionOnString:"); //$NON-NLS-1$
 		output = super.printExpression(indent, output);
 		return output.append('>');

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionParser.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionParser.java
@@ -6187,7 +6187,7 @@ protected boolean assistNodeNeedsStacking() {
 
 @Override
 public  String toString() {
-	StringBuffer buffer = new StringBuffer();
+	StringBuilder buffer = new StringBuilder();
 	buffer.append("elementKindStack : int[] = {"); //$NON-NLS-1$
 	for (int i = 0; i <= this.elementPtr; i++) {
 		buffer.append(String.valueOf(this.elementKindStack[i])).append(',');

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/impl/AssistSourceField.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/impl/AssistSourceField.java
@@ -69,7 +69,7 @@ public class AssistSourceField extends ResolvedSourceField {
 	}
 
 	@Override
-	protected void toStringInfo(int tab, StringBuffer buffer, Object info,boolean showResolvedInfo) {
+	protected void toStringInfo(int tab, StringBuilder buffer, Object info,boolean showResolvedInfo) {
 		super.toStringInfo(tab, buffer, info, showResolvedInfo && isResolved());
 	}
 

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/impl/AssistSourceMethod.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/impl/AssistSourceMethod.java
@@ -70,7 +70,7 @@ public class AssistSourceMethod extends ResolvedSourceMethod {
 	}
 
 	@Override
-	protected void toStringInfo(int tab, StringBuffer buffer, Object info,boolean showResolvedInfo) {
+	protected void toStringInfo(int tab, StringBuilder buffer, Object info,boolean showResolvedInfo) {
 		super.toStringInfo(tab, buffer, info, showResolvedInfo && isResolved());
 	}
 

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/impl/AssistSourceType.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/impl/AssistSourceType.java
@@ -81,7 +81,7 @@ public class AssistSourceType extends ResolvedSourceType {
 	}
 
 	@Override
-	protected void toStringInfo(int tab, StringBuffer buffer, Object info,boolean showResolvedInfo) {
+	protected void toStringInfo(int tab, StringBuilder buffer, Object info,boolean showResolvedInfo) {
 		super.toStringInfo(tab, buffer, info, showResolvedInfo && isResolved());
 	}
 

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionJavadoc.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionJavadoc.java
@@ -33,7 +33,7 @@ public class SelectionJavadoc extends Javadoc {
 	}
 
 	@Override
-	public StringBuffer print(int indent, StringBuffer output) {
+	public StringBuilder print(int indent, StringBuilder output) {
 		super.print(indent, output);
 		if (this.selectedNode != null) {
 			String selectedString = null;

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnArgumentName.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnArgumentName.java
@@ -39,7 +39,7 @@ public class SelectionOnArgumentName extends Argument {
 	}
 
 	@Override
-	public StringBuffer print(int indent, StringBuffer output) {
+	public StringBuilder print(int indent, StringBuilder output) {
 
 		printIndent(indent, output);
 		output.append("<SelectionOnArgumentName:"); //$NON-NLS-1$

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnExplicitConstructorCall.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnExplicitConstructorCall.java
@@ -42,7 +42,7 @@ public class SelectionOnExplicitConstructorCall extends ExplicitConstructorCall 
 	}
 
 	@Override
-	public StringBuffer printStatement(int tab, StringBuffer output) {
+	public StringBuilder printStatement(int tab, StringBuilder output) {
 
 		printIndent(tab, output);
 		output.append("<SelectOnExplicitConstructorCall:"); //$NON-NLS-1$

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnFieldReference.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnFieldReference.java
@@ -44,7 +44,7 @@ public class SelectionOnFieldReference extends FieldReference {
 	}
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output){
+	public StringBuilder printExpression(int indent, StringBuilder output){
 
 		output.append("<SelectionOnFieldReference:");  //$NON-NLS-1$
 		return super.printExpression(0, output).append('>');

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnFieldType.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnFieldType.java
@@ -26,7 +26,7 @@ public class SelectionOnFieldType extends FieldDeclaration {
 		this.name = CharOperation.NO_CHAR;
 	}
 	@Override
-	public StringBuffer printStatement(int tab, StringBuffer output) {
+	public StringBuilder printStatement(int tab, StringBuilder output) {
 		return this.type.print(tab, output).append(';');
 	}
 }

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnImportReference.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnImportReference.java
@@ -39,7 +39,7 @@ public SelectionOnImportReference(char[][] tokens , long[] positions, int modifi
 	super(tokens, positions, false, modifiers);
 }
 @Override
-public StringBuffer print(int indent, StringBuffer output, boolean withOnDemand) {
+public StringBuilder print(int indent, StringBuilder output, boolean withOnDemand) {
 
 	printIndent(indent, output).append("<SelectOnImport:"); //$NON-NLS-1$
 	for (int i = 0; i < this.tokens.length; i++) {

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnLambdaExpression.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnLambdaExpression.java
@@ -43,7 +43,7 @@ public class SelectionOnLambdaExpression extends LambdaExpression {
 	}
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output) {
+	public StringBuilder printExpression(int indent, StringBuilder output) {
 		output.append("<SelectOnLambdaExpression:"); //$NON-NLS-1$
 		super.printExpression(indent, output);
 		return output.append(")>"); //$NON-NLS-1$

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnLocalName.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnLocalName.java
@@ -51,7 +51,7 @@ public class SelectionOnLocalName extends LocalDeclaration{
 	}
 
 	@Override
-	public StringBuffer printAsExpression(int indent, StringBuffer output) {
+	public StringBuilder printAsExpression(int indent, StringBuilder output) {
 		printIndent(indent, output);
 		output.append("<SelectionOnLocalName:"); //$NON-NLS-1$
 		printModifiers(this.modifiers, output);
@@ -64,7 +64,7 @@ public class SelectionOnLocalName extends LocalDeclaration{
 	}
 
 	@Override
-	public StringBuffer printStatement(int indent, StringBuffer output) {
+	public StringBuilder printStatement(int indent, StringBuilder output) {
 		printAsExpression(indent, output);
 		return output.append(';');
 	}

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnMessageSend.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnMessageSend.java
@@ -79,7 +79,7 @@ public class SelectionOnMessageSend extends MessageSend {
 	}
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output) {
+	public StringBuilder printExpression(int indent, StringBuilder output) {
 
 		output.append("<SelectOnMessageSend:"); //$NON-NLS-1$
 		if (!this.receiver.isImplicitThis()) this.receiver.printExpression(0, output).append('.');

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnModuleReference.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnModuleReference.java
@@ -35,7 +35,7 @@ public class SelectionOnModuleReference extends ModuleReference {
 	}
 
 	@Override
-	public StringBuffer print(int tab, StringBuffer output) {
+	public StringBuilder print(int tab, StringBuilder output) {
 		printIndent(tab, output).append("<SelectOnModuleReference:"); //$NON-NLS-1$
 		for (int i = 0; i < this.tokens.length; i++) {
 			if (i > 0) output.append('.');

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnNameOfMemberValuePair.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnNameOfMemberValuePair.java
@@ -26,7 +26,7 @@ public class SelectionOnNameOfMemberValuePair extends MemberValuePair {
 	}
 
 	@Override
-	public StringBuffer print(int indent, StringBuffer output) {
+	public StringBuilder print(int indent, StringBuilder output) {
 		output.append("<SelectOnName:"); //$NON-NLS-1$
 		output.append(this.name);
 		output.append(">"); //$NON-NLS-1$

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnPackageReference.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnPackageReference.java
@@ -39,7 +39,7 @@ public SelectionOnPackageReference(char[][] tokens , long[] positions) {
 	super(tokens, positions, false, ClassFileConstants.AccDefault);
 }
 @Override
-public StringBuffer print(int tab, StringBuffer output, boolean withOnDemand) {
+public StringBuilder print(int tab, StringBuilder output, boolean withOnDemand) {
 	printIndent(tab, output).append("<SelectOnPackage:"); //$NON-NLS-1$
 	for (int i = 0; i < this.tokens.length; i++) {
 		if (i > 0) output.append('.');

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnPackageVisibilityReference.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnPackageVisibilityReference.java
@@ -37,7 +37,7 @@ public class SelectionOnPackageVisibilityReference extends ImportReference {
 	}
 
 	@Override
-	public StringBuffer print(int indent, StringBuffer output) {
+	public StringBuilder print(int indent, StringBuilder output) {
 
 		printIndent(indent, output).append("<SelectOnPackageVisibility:"); //$NON-NLS-1$
 		output.append(new String(CharOperation.concatWith(this.tokens, '.')));

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnParameterizedQualifiedTypeReference.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnParameterizedQualifiedTypeReference.java
@@ -57,7 +57,7 @@ public class SelectionOnParameterizedQualifiedTypeReference extends Parameterize
 	}
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output) {
+	public StringBuilder printExpression(int indent, StringBuilder output) {
 		output.append("<SelectOnType:");//$NON-NLS-1$
 		int length = this.tokens.length;
 		for (int i = 0; i < length; i++) {

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnParameterizedSingleTypeReference.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnParameterizedSingleTypeReference.java
@@ -39,7 +39,7 @@ public class SelectionOnParameterizedSingleTypeReference extends ParameterizedSi
 	}
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output){
+	public StringBuilder printExpression(int indent, StringBuilder output){
 		output.append("<SelectOnType:");//$NON-NLS-1$
 		output.append(this.token);
 		output.append('<');

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnQualifiedAllocationExpression.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnQualifiedAllocationExpression.java
@@ -53,7 +53,7 @@ public class SelectionOnQualifiedAllocationExpression extends QualifiedAllocatio
 	}
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output) {
+	public StringBuilder printExpression(int indent, StringBuilder output) {
 		if (this.enclosingInstance == null)
 			output.append("<SelectOnAllocationExpression:");  //$NON-NLS-1$
 		else

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnQualifiedNameReference.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnQualifiedNameReference.java
@@ -53,7 +53,7 @@ public SelectionOnQualifiedNameReference(char[][] previousIdentifiers, char[] se
 		(int) positions[positions.length - 1]);
 }
 @Override
-public StringBuffer printExpression(int indent, StringBuffer output) {
+public StringBuilder printExpression(int indent, StringBuilder output) {
 
 	output.append("<SelectOnName:"); //$NON-NLS-1$
 	for (int i = 0, length = this.tokens.length; i < length; i++) {

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnQualifiedSuperReference.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnQualifiedSuperReference.java
@@ -45,7 +45,7 @@ public SelectionOnQualifiedSuperReference(TypeReference name, int pos, int sourc
 	super(name, pos, sourceEnd);
 }
 @Override
-public StringBuffer printExpression(int indent, StringBuffer output) {
+public StringBuilder printExpression(int indent, StringBuilder output) {
 
 	output.append("<SelectOnQualifiedSuper:"); //$NON-NLS-1$
 	return super.printExpression(0, output).append('>');

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnQualifiedTypeReference.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnQualifiedTypeReference.java
@@ -66,7 +66,7 @@ protected TypeBinding getTypeBinding(Scope scope) {
 	throw new SelectionNodeFound(binding);
 }
 @Override
-public StringBuffer printExpression(int indent, StringBuffer output) {
+public StringBuilder printExpression(int indent, StringBuilder output) {
 
 	output.append("<SelectOnType:"); //$NON-NLS-1$
 	for (int i = 0, length = this.tokens.length; i < length; i++) {

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnReferenceExpressionName.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnReferenceExpressionName.java
@@ -29,7 +29,7 @@ public class SelectionOnReferenceExpressionName extends ReferenceExpression {
 	}
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output) {
+	public StringBuilder printExpression(int indent, StringBuilder output) {
 		output.append("<SelectionOnReferenceExpressionName:"); //$NON-NLS-1$
 		super.printExpression(indent, output);
 		return output.append('>');

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnSingleNameReference.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnSingleNameReference.java
@@ -80,7 +80,7 @@ public TypeBinding resolveType(BlockScope scope) {
 	throw new SelectionNodeFound(this.binding);
 }
 @Override
-public StringBuffer printExpression(int indent, StringBuffer output) {
+public StringBuilder printExpression(int indent, StringBuilder output) {
 	output.append("<SelectOnName:"); //$NON-NLS-1$
 	return super.printExpression(0, output).append('>');
 }

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnSingleTypeReference.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnSingleTypeReference.java
@@ -60,7 +60,7 @@ protected TypeBinding getTypeBinding(Scope scope) {
 	throw new SelectionNodeFound(binding);
 }
 @Override
-public StringBuffer printExpression(int indent, StringBuffer output) {
+public StringBuilder printExpression(int indent, StringBuilder output) {
 
 	return output.append("<SelectOnType:").append(this.token).append('>');//$NON-NLS-1$
 }

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnSuperReference.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnSuperReference.java
@@ -45,7 +45,7 @@ public SelectionOnSuperReference(int pos, int sourceEnd) {
 	super(pos, sourceEnd);
 }
 @Override
-public StringBuffer printExpression(int indent, StringBuffer output){
+public StringBuilder printExpression(int indent, StringBuilder output){
 
 	output.append("<SelectOnSuper:"); //$NON-NLS-1$
 	return super.printExpression(0, output).append('>');

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionParser.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionParser.java
@@ -1256,7 +1256,7 @@ protected void consumeMethodInvocationName() {
 				return null;
 			}
 			@Override
-			public StringBuffer printExpression(int indent, StringBuffer output) {
+			public StringBuilder printExpression(int indent, StringBuilder output) {
 				return output;
 			}
 		});
@@ -1308,7 +1308,7 @@ protected void consumeMethodInvocationPrimary() {
 				return null;
 			}
 			@Override
-			public StringBuffer printExpression(int indent, StringBuffer output) {
+			public StringBuilder printExpression(int indent, StringBuilder output) {
 				return output;
 			}
 		});

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ASTNode.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ASTNode.java
@@ -3420,7 +3420,7 @@ public abstract class ASTNode {
 	 */
 	@Override
 	public final String toString() {
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		int p = buffer.length();
 		try {
 			appendDebugString(buffer);
@@ -3453,7 +3453,7 @@ public abstract class ASTNode {
 	 *
 	 * @param buffer the string buffer to append to
 	 */
-	void appendDebugString(StringBuffer buffer) {
+	void appendDebugString(StringBuilder buffer) {
 		// print the subtree by default
 		appendPrintString(buffer);
 	}
@@ -3464,7 +3464,7 @@ public abstract class ASTNode {
 	 *
 	 * @param buffer the string buffer to append to
 	 */
-	final void appendPrintString(StringBuffer buffer) {
+	final void appendPrintString(StringBuilder buffer) {
 		NaiveASTFlattener printer = new NaiveASTFlattener();
 		accept(printer);
 		buffer.append(printer.getResult());

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ASTParser.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ASTParser.java
@@ -16,7 +16,6 @@
 package org.eclipse.jdt.core.dom;
 
 import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -1136,11 +1135,8 @@ public class ASTParser {
 								}
 							} catch(JavaModelException e) {
 								// an error occured accessing the java element
-								StringWriter stringWriter = new StringWriter();
-								try (PrintWriter writer = new PrintWriter(stringWriter)) {
-									e.printStackTrace(writer);
-								}
-								throw new IllegalStateException(String.valueOf(stringWriter.getBuffer()));
+								CharSequence stackTrace = org.eclipse.jdt.internal.compiler.util.Util.getStackTrace(e);
+								throw new IllegalStateException(stackTrace.toString());
 							}
 						}
 					}
@@ -1206,11 +1202,8 @@ public class ASTParser {
 							sourceUnit = new BasicCompilationUnit(sourceString.toCharArray(), Util.toCharArrays(packageFragment.names), fileNameString, this.typeRoot);
 						} catch(JavaModelException e) {
 							// an error occured accessing the java element
-							StringWriter stringWriter = new StringWriter();
-							try (PrintWriter writer = new PrintWriter(stringWriter)) {
-								e.printStackTrace(writer);
-							}
-							throw new IllegalStateException(String.valueOf(stringWriter.getBuffer()));
+							CharSequence stackTrace = org.eclipse.jdt.internal.compiler.util.Util.getStackTrace(e);
+							throw new IllegalStateException(stackTrace.toString());
 						}
 					} else if (this.rawSource != null) {
 						needToResolveBindings =

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/CharacterLiteral.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/CharacterLiteral.java
@@ -303,7 +303,7 @@ public class CharacterLiteral extends Expression {
 	 * @param value the character value
 	 */
 	public void setCharValue(char value) {
-		StringBuffer b = new StringBuffer(3);
+		StringBuilder b = new StringBuilder(3);
 
 		b.append('\''); // opening delimiter
 		Util.appendEscapedChar(b, value, false);

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/MemberValuePairBinding.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/MemberValuePairBinding.java
@@ -35,7 +35,7 @@ class MemberValuePairBinding implements IMemberValuePairBinding {
 	protected Object value = null;
 	protected BindingResolver bindingResolver;
 
-	static void appendValue(Object value, StringBuffer buffer) {
+	static void appendValue(Object value, StringBuilder buffer) {
 		if (value instanceof Object[]) {
 			Object[] values = (Object[]) value;
 			buffer.append('{');
@@ -245,7 +245,7 @@ class MemberValuePairBinding implements IMemberValuePairBinding {
 
 	@Override
 	public String toString() {
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append(getName());
 		buffer.append(" = "); //$NON-NLS-1$
 		appendValue(getValue(), buffer);

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ModuleQualifiedName.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ModuleQualifiedName.java
@@ -227,7 +227,7 @@ public class ModuleQualifiedName extends Name {
 	}
 
 	@Override
-	void appendName(StringBuffer buffer) {
+	void appendName(StringBuilder buffer) {
 		getModuleQualifier().appendName(buffer);
 		buffer.append('/');
 		if (getName() != null) {

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/Name.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/Name.java
@@ -103,7 +103,7 @@ public abstract class Name extends Expression implements IDocElement {
 			// avoid creating garbage for common case
 			return ((SimpleName) this).getIdentifier();
 		} else {
-			StringBuffer buffer = new StringBuffer(50);
+			StringBuilder buffer = new StringBuilder(50);
 			appendName(buffer);
 			return new String(buffer);
 		}
@@ -116,5 +116,5 @@ public abstract class Name extends Expression implements IDocElement {
 	 * @param buffer the buffer
 	 * @since 3.0
 	 */
-	abstract void appendName(StringBuffer buffer);
+	abstract void appendName(StringBuilder buffer);
 }

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/QualifiedName.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/QualifiedName.java
@@ -245,7 +245,7 @@ public class QualifiedName extends Name {
 	}
 
 	@Override
-	void appendName(StringBuffer buffer) {
+	void appendName(StringBuilder buffer) {
 		getQualifier().appendName(buffer);
 		buffer.append('.');
 		getName().appendName(buffer);

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/RecoveredTypeBinding.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/RecoveredTypeBinding.java
@@ -198,7 +198,7 @@ class RecoveredTypeBinding implements ITypeBinding {
 			brackets[i] = ']';
 			brackets[i - 1] = '[';
 		}
-		StringBuffer buffer = new StringBuffer(getInternalName());
+		StringBuilder buffer = new StringBuilder(getInternalName());
 		buffer.append(brackets);
 		return String.valueOf(buffer);
 	}
@@ -264,7 +264,7 @@ class RecoveredTypeBinding implements ITypeBinding {
 	public String getQualifiedName() {
 		ReferenceBinding referenceBinding = getReferenceBinding();
 		if (referenceBinding != null) {
-			StringBuffer buffer = new StringBuffer();
+			StringBuilder buffer = new StringBuilder();
 			char[] brackets = new char[this.dimensions * 2];
 			for (int i = this.dimensions * 2 - 1; i >= 0; i -= 2) {
 				brackets[i] = ']';
@@ -515,7 +515,7 @@ class RecoveredTypeBinding implements ITypeBinding {
 
 	@Override
 	public String getKey() {
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("Recovered#"); //$NON-NLS-1$
 		if (this.innerTypeBinding != null) {
 			buffer.append("innerTypeBinding") //$NON-NLS-1$
@@ -582,7 +582,7 @@ class RecoveredTypeBinding implements ITypeBinding {
 				return getTypeNameFrom(type);
 			case ASTNode.PARAMETERIZED_TYPE :
 				ParameterizedType parameterizedType = (ParameterizedType) type;
-				StringBuffer buffer = new StringBuffer(getTypeNameFrom(parameterizedType.getType()));
+				StringBuilder buffer = new StringBuilder(getTypeNameFrom(parameterizedType.getType()));
 				ITypeBinding[] tArguments = getTypeArguments();
 				final int typeArgumentsLength = tArguments.length;
 				if (typeArgumentsLength != 0) {

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/RecoveredVariableBinding.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/RecoveredVariableBinding.java
@@ -103,7 +103,7 @@ class RecoveredVariableBinding implements IVariableBinding {
 
 	@Override
 	public String getKey() {
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append("Recovered#"); //$NON-NLS-1$
 		if (this.variableDeclaration != null) {
 			buffer

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/SimpleName.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/SimpleName.java
@@ -357,7 +357,7 @@ public class SimpleName extends Name {
 	}
 
 	@Override
-	void appendName(StringBuffer buffer) {
+	void appendName(StringBuilder buffer) {
 		buffer.append(getIdentifier());
 	}
 

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/StringLiteral.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/StringLiteral.java
@@ -258,7 +258,7 @@ public class StringLiteral extends Expression {
 			throw new IllegalArgumentException();
 		}
 		int len = value.length();
-		StringBuffer b = new StringBuffer(len + 2);
+		StringBuilder b = new StringBuilder(len + 2);
 
 		b.append("\""); // opening delimiter //$NON-NLS-1$
 		for (int i = 0; i < len; i++) {

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/TypeBinding.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/TypeBinding.java
@@ -157,7 +157,7 @@ class TypeBinding implements ITypeBinding {
 		} else if (this.binding.isTypeVariable()) {
 			TypeVariableBinding typeVariableBinding = (TypeVariableBinding) this.binding;
 			org.eclipse.jdt.internal.compiler.lookup.Binding declaring = typeVariableBinding.declaringElement;
-			StringBuffer binaryName = new StringBuffer();
+			StringBuilder binaryName = new StringBuilder();
 			switch(declaring.kind()) {
 				case org.eclipse.jdt.internal.compiler.lookup.Binding.METHOD :
 					MethodBinding methodBinding = (MethodBinding) declaring;
@@ -629,13 +629,13 @@ class TypeBinding implements ITypeBinding {
 
 	@Override
 	public String getName() {
-		StringBuffer buffer;
+		StringBuilder buffer;
 		switch (this.binding.kind()) {
 
 			case Binding.WILDCARD_TYPE :
 			case Binding.INTERSECTION_TYPE:
 				WildcardBinding wildcardBinding = (WildcardBinding) this.binding;
-				buffer = new StringBuffer();
+				buffer = new StringBuilder();
 				buffer.append(TypeConstants.WILDCARD_NAME);
 				if (wildcardBinding.bound != null) {
 					switch(wildcardBinding.boundKind) {
@@ -658,7 +658,7 @@ class TypeBinding implements ITypeBinding {
 
 			case Binding.PARAMETERIZED_TYPE :
 				ParameterizedTypeBinding parameterizedTypeBinding = (ParameterizedTypeBinding) this.binding;
-				buffer = new StringBuffer();
+				buffer = new StringBuilder();
 				buffer.append(parameterizedTypeBinding.sourceName());
 				ITypeBinding[] tArguments = getTypeArguments();
 				final int typeArgumentsLength = tArguments.length;
@@ -688,7 +688,7 @@ class TypeBinding implements ITypeBinding {
 					brackets[i] = ']';
 					brackets[i - 1] = '[';
 				}
-				buffer = new StringBuffer(elementType.getName());
+				buffer = new StringBuilder(elementType.getName());
 				buffer.append(brackets);
 				return String.valueOf(buffer);
 
@@ -728,13 +728,13 @@ class TypeBinding implements ITypeBinding {
 	 */
 	@Override
 	public String getQualifiedName() {
-		StringBuffer buffer;
+		StringBuilder buffer;
 		switch (this.binding.kind()) {
 
 			case Binding.WILDCARD_TYPE :
 			case Binding.INTERSECTION_TYPE:
 				WildcardBinding wildcardBinding = (WildcardBinding) this.binding;
-				buffer = new StringBuffer();
+				buffer = new StringBuilder();
 				buffer.append(TypeConstants.WILDCARD_NAME);
 				final ITypeBinding bound = getBound();
 				if (bound != null) {
@@ -763,7 +763,7 @@ class TypeBinding implements ITypeBinding {
 					brackets[i] = ']';
 					brackets[i - 1] = '[';
 				}
-				buffer = new StringBuffer(elementType.getQualifiedName());
+				buffer = new StringBuilder(elementType.getQualifiedName());
 				buffer.append(brackets);
 				return String.valueOf(buffer);
 
@@ -778,7 +778,7 @@ class TypeBinding implements ITypeBinding {
 				if (this.binding.isLocalType()) {
 					return NO_NAME;
 				}
-				buffer = new StringBuffer();
+				buffer = new StringBuilder();
 				if (isMember()) {
 					buffer
 						.append(getDeclaringClass().getQualifiedName())
@@ -822,7 +822,7 @@ class TypeBinding implements ITypeBinding {
 					return new String(baseTypeBinding.simpleName);
 				}
 				if (isMember()) {
-					buffer = new StringBuffer();
+					buffer = new StringBuilder();
 					buffer
 						.append(getDeclaringClass().getQualifiedName())
 						.append('.');
@@ -830,7 +830,7 @@ class TypeBinding implements ITypeBinding {
 					return String.valueOf(buffer);
 				}
 				PackageBinding packageBinding = this.binding.getPackage();
-				buffer = new StringBuffer();
+				buffer = new StringBuilder();
 				if (packageBinding != null && packageBinding.compoundName != CharOperation.NO_CHAR_CHAR) {
 					buffer.append(CharOperation.concatWith(packageBinding.compoundName, '.')).append('.');
 				}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/NaiveASTFlattener.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/NaiveASTFlattener.java
@@ -95,7 +95,7 @@ public class NaiveASTFlattener extends ASTVisitor {
 	 * The string buffer into which the serialized representation of the AST is
 	 * written.
 	 */
-	protected StringBuffer buffer;
+	protected StringBuilder buffer;
 
 	private int indent = 0;
 
@@ -103,7 +103,7 @@ public class NaiveASTFlattener extends ASTVisitor {
 	 * Creates a new AST printer.
 	 */
 	public NaiveASTFlattener() {
-		this.buffer = new StringBuffer();
+		this.buffer = new StringBuilder();
 	}
 
 	/**

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/SourceRangeVerifier.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/SourceRangeVerifier.java
@@ -30,7 +30,7 @@ public class SourceRangeVerifier extends ASTVisitor {
 	public static boolean DEBUG = false;
 	public static boolean DEBUG_THROW = false;
 
-	private StringBuffer bugs;
+	private StringBuilder bugs;
 
 	/**
 	 * Verifies proper node nesting as specified in {@link ASTParser#setKind(int)}:
@@ -43,7 +43,7 @@ public class SourceRangeVerifier extends ASTVisitor {
 	 * @return <code>null</code> if everything is OK; a list of errors otherwise
 	 */
 	public String process(ASTNode node) {
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		this.bugs = buffer;
 		node.accept(this);
 		this.bugs = null;

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/ASTRewriteAnalyzer.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/ASTRewriteAnalyzer.java
@@ -1587,13 +1587,13 @@ public final class ASTRewriteAnalyzer extends ASTVisitor {
 				if (startPos != nextStart) {
 					int visibilityModifiers= addedModifiers & (Modifier.PUBLIC | Modifier.PRIVATE | Modifier.PROTECTED);
 					if (visibilityModifiers != 0) {
-						StringBuffer buf= new StringBuffer();
+						StringBuilder buf= new StringBuilder();
 						ASTRewriteFlattener.printModifiers(visibilityModifiers, buf);
 						doTextInsert(startPos, buf.toString(), editGroup);
 						addedModifiers &= ~visibilityModifiers;
 					}
 				}
-				StringBuffer buf= new StringBuffer();
+				StringBuilder buf= new StringBuilder();
 				ASTRewriteFlattener.printModifiers(addedModifiers, buf);
 				doTextInsert(nextStart, buf.toString(), editGroup);
 			}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/ASTRewriteFlattener.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/ASTRewriteFlattener.java
@@ -104,12 +104,12 @@ public class ASTRewriteFlattener extends ASTVisitor {
 		return flattener.getResult();
 	}
 
-	protected StringBuffer result;
+	protected StringBuilder result;
 	private final RewriteEventStore store;
 
 	public ASTRewriteFlattener(RewriteEventStore store) {
 		this.store= store;
-		this.result= new StringBuffer();
+		this.result= new StringBuilder();
 	}
 
 	/**
@@ -134,7 +134,7 @@ public class ASTRewriteFlattener extends ASTVisitor {
 	 * @param modifiers the modifiers
 	 * @param buf The <code>StringBuffer</code> to write the result to.
 	 */
-	public static void printModifiers(int modifiers, StringBuffer buf) {
+	public static void printModifiers(int modifiers, StringBuilder buf) {
 		if (Modifier.isPublic(modifiers)) {
 			buf.append("public "); //$NON-NLS-1$
 		}

--- a/org.eclipse.jdt.core/eval/org/eclipse/jdt/internal/eval/CodeSnippetThisReference.java
+++ b/org.eclipse.jdt.core/eval/org/eclipse/jdt/internal/eval/CodeSnippetThisReference.java
@@ -103,7 +103,7 @@ public class CodeSnippetThisReference extends ThisReference implements Evaluatio
 	}
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output){
+	public StringBuilder printExpression(int indent, StringBuilder output){
 
 		char[] declaringType = this.evaluationContext.declaringTypeName;
 		output.append('(');

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/compiler/SourceElementParser.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/compiler/SourceElementParser.java
@@ -1073,7 +1073,7 @@ private static class DummyTypeReference extends TypeReference {
 	}
 
 	@Override
-	public StringBuffer printExpression(int indent, StringBuffer output) {
+	public StringBuilder printExpression(int indent, StringBuilder output) {
 		return output.append(this.token);
 	}
 	@Override

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/AbstractModule.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/AbstractModule.java
@@ -70,7 +70,7 @@ public interface AbstractModule extends IModuleDescription {
 			return ModuleDescriptionInfo.NO_REQUIRES;
 		}
 		@Override
-		public void toStringContent(StringBuffer buffer, String lineDelimiter) throws JavaModelException {
+		public void toStringContent(StringBuilder buffer, String lineDelimiter) throws JavaModelException {
 			buffer.append("automatic module "); //$NON-NLS-1$
 			buffer.append(this.name);
 		}
@@ -156,7 +156,7 @@ public interface AbstractModule extends IModuleDescription {
 	}
 
 	default String toString(String lineDelimiter) {
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		try {
 			toStringContent(buffer, lineDelimiter);
 		} catch (JavaModelException e) {
@@ -166,7 +166,7 @@ public interface AbstractModule extends IModuleDescription {
 		}
 		return buffer.toString();
 	}
-	default void toStringContent(StringBuffer buffer, String lineDelimiter) throws JavaModelException {
+	default void toStringContent(StringBuilder buffer, String lineDelimiter) throws JavaModelException {
 		IPackageExport[] exports = getExportedPackages();
 		IModuleReference[] requires = getRequiredModules();
 		buffer.append("module "); //$NON-NLS-1$

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/Annotation.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/Annotation.java
@@ -146,7 +146,7 @@ public class Annotation extends SourceRefElement implements IAnnotation {
 	}
 
 	@Override
-	protected void toStringName(StringBuffer buffer) {
+	protected void toStringName(StringBuilder buffer) {
 		buffer.append('@');
 		buffer.append(getElementName());
 	}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/BinaryField.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/BinaryField.java
@@ -113,7 +113,7 @@ public JavaElement resolved(Binding binding) {
  * @private Debugging purposes
  */
 @Override
-protected void toStringInfo(int tab, StringBuffer buffer, Object info, boolean showResolvedInfo) {
+protected void toStringInfo(int tab, StringBuilder buffer, Object info, boolean showResolvedInfo) {
 	buffer.append(tabString(tab));
 	if (info == null) {
 		toStringName(buffer);

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/BinaryMethod.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/BinaryMethod.java
@@ -215,7 +215,7 @@ public int getFlags() throws JavaModelException {
  * @see JavaElement#getHandleMemento(StringBuffer)
  */
 @Override
-protected void getHandleMemento(StringBuffer buff) {
+protected void getHandleMemento(StringBuilder buff) {
 	getParent().getHandleMemento(buff);
 	char delimiter = getHandleMementoDelimiter();
 	buff.append(delimiter);
@@ -692,7 +692,7 @@ public JavaElement resolved(Binding binding) {
  * @private Debugging purposes
  */
 @Override
-protected void toStringInfo(int tab, StringBuffer buffer, Object info, boolean showResolvedInfo) {
+protected void toStringInfo(int tab, StringBuilder buffer, Object info, boolean showResolvedInfo) {
 	buffer.append(tabString(tab));
 	if (info == null) {
 		toStringName(buffer);
@@ -713,10 +713,10 @@ protected void toStringInfo(int tab, StringBuffer buffer, Object info, boolean s
 	}
 }
 @Override
-protected void toStringName(StringBuffer buffer) {
+protected void toStringName(StringBuilder buffer) {
 	toStringName(buffer, 0);
 }
-protected void toStringName(StringBuffer buffer, int flags) {
+protected void toStringName(StringBuilder buffer, int flags) {
 	buffer.append(getElementName());
 	buffer.append('(');
 	String[] parameters = getParameterTypes();

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/BinaryModule.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/BinaryModule.java
@@ -116,7 +116,7 @@ public class BinaryModule extends BinaryMember implements AbstractModule {
 		if (baseLocation == null) {
 			return null;
 		}
-		StringBuffer pathBuffer = new StringBuffer(baseLocation.toExternalForm());
+		StringBuilder pathBuffer = new StringBuilder(baseLocation.toExternalForm());
 
 		if (!(pathBuffer.charAt(pathBuffer.length() - 1) == '/')) {
 			pathBuffer.append('/');
@@ -132,7 +132,7 @@ public class BinaryModule extends BinaryMember implements AbstractModule {
 	}
 	@Override
 	public String toString(String lineDelimiter) {
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		try {
 			toStringContent(buffer, lineDelimiter);
 		} catch (JavaModelException e) {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/BinaryRecordComponent.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/BinaryRecordComponent.java
@@ -113,7 +113,7 @@ public JavaElement resolved(Binding binding) {
  * @private Debugging purposes
  */
 @Override
-protected void toStringInfo(int tab, StringBuffer buffer, Object info, boolean showResolvedInfo) {
+protected void toStringInfo(int tab, StringBuilder buffer, Object info, boolean showResolvedInfo) {
 	buffer.append(tabString(tab));
 	if (info == null) {
 		toStringName(buffer);

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/BinaryType.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/BinaryType.java
@@ -1014,7 +1014,7 @@ public String sourceFileName(IBinaryType info) {
  * @private Debugging purposes
  */
 @Override
-protected void toStringInfo(int tab, StringBuffer buffer, Object info, boolean showResolvedInfo) {
+protected void toStringInfo(int tab, StringBuilder buffer, Object info, boolean showResolvedInfo) {
 	buffer.append(tabString(tab));
 	if (info == null) {
 		toStringName(buffer);
@@ -1041,7 +1041,7 @@ protected void toStringInfo(int tab, StringBuffer buffer, Object info, boolean s
 	}
 }
 @Override
-protected void toStringName(StringBuffer buffer) {
+protected void toStringName(StringBuilder buffer) {
 	if (getElementName().length() > 0)
 		super.toStringName(buffer);
 	else
@@ -1067,7 +1067,7 @@ public JavadocContents getJavadocContents(IProgressMonitor monitor) throws JavaM
 	if (baseLocation == null) {
 		return null;
 	}
-	StringBuffer pathBuffer = new StringBuffer(baseLocation.toExternalForm());
+	StringBuilder pathBuffer = new StringBuilder(baseLocation.toExternalForm());
 
 	if (!(pathBuffer.charAt(pathBuffer.length() - 1) == '/')) {
 		pathBuffer.append('/');
@@ -1076,7 +1076,7 @@ public JavadocContents getJavadocContents(IProgressMonitor monitor) throws JavaM
 	String typeQualifiedName = null;
 	if (isMember()) {
 		IType currentType = this;
-		StringBuffer typeName = new StringBuffer();
+		StringBuilder typeName = new StringBuilder();
 		while (currentType != null) {
 			typeName.insert(0, currentType.getElementName());
 			currentType = currentType.getDeclaringType();
@@ -1104,7 +1104,7 @@ public boolean isLambda() {
 	return false;
 }
 
-private static void appendModulePath(IPackageFragment pack, StringBuffer buf) {
+private static void appendModulePath(IPackageFragment pack, StringBuilder buf) {
 	IModuleDescription moduleDescription= getModuleDescription(pack);
 	if (moduleDescription != null) {
 		String moduleName= moduleDescription.getElementName();

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ClassFileWorkingCopy.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ClassFileWorkingCopy.java
@@ -123,7 +123,7 @@ protected IBuffer openBuffer(IProgressMonitor pm, Object info) throws JavaModelE
 }
 
 @Override
-protected void toStringName(StringBuffer buffer) {
+protected void toStringName(StringBuilder buffer) {
 	buffer.append(this.classFile.getElementName());
 }
 

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ClasspathEntry.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ClasspathEntry.java
@@ -504,7 +504,7 @@ public class ClasspathEntry implements IClasspathEntry {
 		return null;
 	}
 
-	private static void decodeUnknownNode(Node node, StringBuffer buffer, IJavaProject project) {
+	private static void decodeUnknownNode(Node node, StringBuilder buffer, IJavaProject project) {
 		StringWriter writer = new StringWriter();
 		XMLWriter xmlWriter = new XMLWriter(writer, project, false/*don't print XML version*/);
 		decodeUnknownNode(node, xmlWriter, true/*insert new line*/);
@@ -804,7 +804,7 @@ public class ClasspathEntry implements IClasspathEntry {
 					if (node.getNodeType() != Node.ELEMENT_NODE) continue;
 					if (unknownChildren == null)
 						unknownChildren = new ArrayList();
-					StringBuffer buffer = new StringBuffer();
+					StringBuilder buffer = new StringBuilder();
 					decodeUnknownNode(node, buffer, project);
 					unknownChildren.add(buffer.toString());
 				}
@@ -1118,7 +1118,7 @@ public class ClasspathEntry implements IClasspathEntry {
 	 */
 	private static void encodePatterns(IPath[] patterns, String tag, Map parameters) {
 		if (patterns != null && patterns.length > 0) {
-			StringBuffer rule = new StringBuffer(10);
+			StringBuilder rule = new StringBuilder(10);
 			for (int i = 0, max = patterns.length; i < max; i++){
 				if (i > 0) rule.append('|');
 				rule.append(patterns[i]);

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/CompilationUnit.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/CompilationUnit.java
@@ -1377,7 +1377,7 @@ public void save(IProgressMonitor pm, boolean force) throws JavaModelException {
  * Debugging purposes
  */
 @Override
-protected void toStringInfo(int tab, StringBuffer buffer, Object info, boolean showResolvedInfo) {
+protected void toStringInfo(int tab, StringBuilder buffer, Object info, boolean showResolvedInfo) {
 	if (!isPrimary()) {
 		buffer.append(tabString(tab));
 		buffer.append("[Working copy] "); //$NON-NLS-1$

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ExternalPackageFragmentRoot.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ExternalPackageFragmentRoot.java
@@ -138,7 +138,7 @@ public class ExternalPackageFragmentRoot extends PackageFragmentRoot {
 	}
 
 	@Override
-	protected void toStringAncestors(StringBuffer buffer) {
+	protected void toStringAncestors(StringBuilder buffer) {
 		// don't show project as it is irrelevant for external folders.
 	}
 }

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ImportContainer.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ImportContainer.java
@@ -101,7 +101,7 @@ public String readableName() {
  * @private Debugging purposes
  */
 @Override
-protected void toString(int tab, StringBuffer buffer) {
+protected void toString(int tab, StringBuilder buffer) {
 	Object info = JavaModelManager.getJavaModelManager().peekAtInfo(this);
 	if (info == null || !(info instanceof JavaElementInfo)) return;
 	IJavaElement[] children = ((JavaElementInfo)info).getChildren();
@@ -114,7 +114,7 @@ protected void toString(int tab, StringBuffer buffer) {
  *  Debugging purposes
  */
 @Override
-protected void toStringInfo(int tab, StringBuffer buffer, Object info, boolean showResolvedInfo) {
+protected void toStringInfo(int tab, StringBuilder buffer, Object info, boolean showResolvedInfo) {
 	buffer.append(tabString(tab));
 	buffer.append("<import container>"); //$NON-NLS-1$
 	if (info == null) {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ImportDeclaration.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ImportDeclaration.java
@@ -65,11 +65,11 @@ public int getFlags() throws JavaModelException {
 	return info.getModifiers();
 }
 /**
- * @see JavaElement#getHandleMemento(StringBuffer)
+ * @see JavaElement#getHandleMemento(StringBuilder)
  * For import declarations, the handle delimiter is associated to the import container already
  */
 @Override
-protected void getHandleMemento(StringBuffer buff) {
+protected void getHandleMemento(StringBuilder buff) {
 	getParent().getHandleMemento(buff);
 	escapeMementoName(buff, getElementName());
 	if (this.occurrenceCount > 1) {
@@ -114,7 +114,7 @@ public String readableName() {
  * @private Debugging purposes
  */
 @Override
-protected void toStringInfo(int tab, StringBuffer buffer, Object info, boolean showResolvedInfo) {
+protected void toStringInfo(int tab, StringBuilder buffer, Object info, boolean showResolvedInfo) {
 	buffer.append(tabString(tab));
 	buffer.append("import "); //$NON-NLS-1$
 	toStringName(buffer);

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/Initializer.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/Initializer.java
@@ -49,10 +49,10 @@ public int getElementType() {
 	return INITIALIZER;
 }
 /**
- * @see JavaElement#getHandleMemento(StringBuffer)
+ * @see JavaElement#getHandleMemento(StringBuilder)
  */
 @Override
-protected void getHandleMemento(StringBuffer buff) {
+protected void getHandleMemento(StringBuilder buff) {
 	getParent().getHandleMemento(buff);
 	buff.append(getHandleMementoDelimiter());
 	buff.append(this.occurrenceCount);
@@ -101,7 +101,7 @@ public JavaElement getPrimaryElement(boolean checkOwner) {
  * @private Debugging purposes
  */
 @Override
-protected void toStringInfo(int tab, StringBuffer buffer, Object info, boolean showResolvedInfo) {
+protected void toStringInfo(int tab, StringBuilder buffer, Object info, boolean showResolvedInfo) {
 	buffer.append(tabString(tab));
 	if (info == null) {
 		buffer.append("<initializer #"); //$NON-NLS-1$

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JarPackageFragmentRoot.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JarPackageFragmentRoot.java
@@ -432,7 +432,7 @@ public class JarPackageFragmentRoot extends PackageFragmentRoot {
 	}
 
 	@Override
-	protected void toStringAncestors(StringBuffer buffer) {
+	protected void toStringAncestors(StringBuilder buffer) {
 		if (isExternal())
 			// don't show project as it is irrelevant for external jar files.
 			// also see https://bugs.eclipse.org/bugs/show_bug.cgi?id=146615

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaElement.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaElement.java
@@ -112,7 +112,7 @@ public abstract class JavaElement extends PlatformObject implements IJavaElement
 	 * the following escape character is being introduced and all the new delimiters must
 	 * be escaped with this. So, a lambda expression would be written as: "=)..."
 	 *
-	 * @see JavaElement#appendEscapedDelimiter(StringBuffer, char)
+	 * @see JavaElement#appendEscapedDelimiter(StringBuilder, char)
 	 */
 	public static final char JEM_DELIMITER_ESCAPE = JEM_JAVAPROJECT;
 
@@ -186,14 +186,14 @@ public abstract class JavaElement extends PlatformObject implements IJavaElement
 	/**
 	 * @see #JEM_DELIMITER_ESCAPE
 	 */
-	protected void appendEscapedDelimiter(StringBuffer buffer, char delimiter) {
+	protected void appendEscapedDelimiter(StringBuilder buffer, char delimiter) {
 		buffer.append(JEM_DELIMITER_ESCAPE);
 		buffer.append(delimiter);
 	}
 	/*
 	 * Do not add new delimiters here
 	 */
-	protected void escapeMementoName(StringBuffer buffer, String mementoName) {
+	protected void escapeMementoName(StringBuilder buffer, String mementoName) {
 		MementoTokenizer.escape(buffer, mementoName);
 	}
 	/**
@@ -335,11 +335,11 @@ public abstract class JavaElement extends PlatformObject implements IJavaElement
 	 * @see JavaElement#getHandleMemento()
 	 */
 	public String getHandleMemento(){
-		StringBuffer buff = new StringBuffer();
+		StringBuilder buff = new StringBuilder();
 		getHandleMemento(buff);
 		return buff.toString();
 	}
-	protected void getHandleMemento(StringBuffer buff) {
+	protected void getHandleMemento(StringBuilder buff) {
 		getParent().getHandleMemento(buff);
 		buff.append(getHandleMementoDelimiter());
 		escapeMementoName(buff, getElementName());
@@ -620,7 +620,7 @@ public abstract class JavaElement extends PlatformObject implements IJavaElement
 	 * Debugging purposes
 	 */
 	public String toDebugString() {
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		this.toStringInfo(0, buffer, NO_INFO, true/*show resolved info*/);
 		return buffer.toString();
 	}
@@ -629,14 +629,14 @@ public abstract class JavaElement extends PlatformObject implements IJavaElement
 	 */
 	@Override
 	public String toString() {
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		toString(0, buffer);
 		return buffer.toString();
 	}
 	/**
 	 *  Debugging purposes
 	 */
-	protected void toString(int tab, StringBuffer buffer) {
+	protected void toString(int tab, StringBuilder buffer) {
 		Object info = this.toStringInfo(tab, buffer);
 		if (tab == 0) {
 			toStringAncestors(buffer);
@@ -653,7 +653,7 @@ public abstract class JavaElement extends PlatformObject implements IJavaElement
 	 *  Debugging purposes
 	 */
 	public String toStringWithAncestors(boolean showResolvedInfo) {
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		this.toStringInfo(0, buffer, NO_INFO, showResolvedInfo);
 		toStringAncestors(buffer);
 		return buffer.toString();
@@ -661,7 +661,7 @@ public abstract class JavaElement extends PlatformObject implements IJavaElement
 	/**
 	 *  Debugging purposes
 	 */
-	protected void toStringAncestors(StringBuffer buffer) {
+	protected void toStringAncestors(StringBuilder buffer) {
 		JavaElement parentElement = getParent();
 		if (parentElement != null && parentElement.getParent() != null) {
 			buffer.append(" [in "); //$NON-NLS-1$
@@ -673,7 +673,7 @@ public abstract class JavaElement extends PlatformObject implements IJavaElement
 	/**
 	 *  Debugging purposes
 	 */
-	protected void toStringChildren(int tab, StringBuffer buffer, Object info) {
+	protected void toStringChildren(int tab, StringBuilder buffer, Object info) {
 		if (info == null || !(info instanceof JavaElementInfo)) return;
 		IJavaElement[] children = ((JavaElementInfo)info).getChildren();
 		for (int i = 0; i < children.length; i++) {
@@ -684,7 +684,7 @@ public abstract class JavaElement extends PlatformObject implements IJavaElement
 	/**
 	 *  Debugging purposes
 	 */
-	public Object toStringInfo(int tab, StringBuffer buffer) {
+	public Object toStringInfo(int tab, StringBuilder buffer) {
 		Object info = JavaModelManager.getJavaModelManager().peekAtInfo(this);
 		this.toStringInfo(tab, buffer, info, true/*show resolved info*/);
 		return info;
@@ -693,7 +693,7 @@ public abstract class JavaElement extends PlatformObject implements IJavaElement
 	 *  Debugging purposes
 	 * @param showResolvedInfo TODO
 	 */
-	protected void toStringInfo(int tab, StringBuffer buffer, Object info, boolean showResolvedInfo) {
+	protected void toStringInfo(int tab, StringBuilder buffer, Object info, boolean showResolvedInfo) {
 		buffer.append(tabString(tab));
 		toStringName(buffer);
 		if (info == null) {
@@ -703,7 +703,7 @@ public abstract class JavaElement extends PlatformObject implements IJavaElement
 	/**
 	 *  Debugging purposes
 	 */
-	protected void toStringName(StringBuffer buffer) {
+	protected void toStringName(StringBuilder buffer) {
 		buffer.append(getElementName());
 	}
 

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaElementDelta.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaElementDelta.java
@@ -663,7 +663,7 @@ public void sourceDetached(IJavaElement element) {
  * @see #toString()
  */
 public String toDebugString(int depth) {
-	StringBuffer buffer = new StringBuffer();
+	StringBuilder buffer = new StringBuilder();
 	for (int i= 0; i < depth; i++) {
 		buffer.append('\t');
 	}
@@ -718,7 +718,7 @@ public String toDebugString(int depth) {
 	return buffer.toString();
 }
 @Override
-protected boolean toDebugString(StringBuffer buffer, int flags) {
+protected boolean toDebugString(StringBuilder buffer, int flags) {
 	boolean prev = super.toDebugString(buffer, flags);
 
 	if ((flags & IJavaElementDelta.F_CHILDREN) != 0) {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModel.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModel.java
@@ -161,10 +161,10 @@ public IJavaElement getHandleFromMemento(String token, MementoTokenizer memento,
 	return null;
 }
 /**
- * @see JavaElement#getHandleMemento(StringBuffer)
+ * @see JavaElement#getHandleMemento(StringBuilder)
  */
 @Override
-protected void getHandleMemento(StringBuffer buff) {
+protected void getHandleMemento(StringBuilder buff) {
 	buff.append(getElementName());
 }
 /**
@@ -311,7 +311,7 @@ protected void runOperation(MultiOperation op, IJavaElement[] elements, IJavaEle
  * @private Debugging purposes
  */
 @Override
-protected void toStringInfo(int tab, StringBuffer buffer, Object info, boolean showResolvedInfo) {
+protected void toStringInfo(int tab, StringBuilder buffer, Object info, boolean showResolvedInfo) {
 	buffer.append(tabString(tab));
 	buffer.append("Java Model"); //$NON-NLS-1$
 	if (info == null) {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavadocContents.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavadocContents.java
@@ -307,7 +307,7 @@ public class JavadocContents {
 			computeChildrenSections();
 		}
 
-		StringBuffer buffer = new StringBuffer(field.getElementName());
+		StringBuilder buffer = new StringBuilder(field.getElementName());
 		buffer.append(JavadocConstants.ANCHOR_PREFIX_END);
 		char[] anchor = String.valueOf(buffer).toCharArray();
 

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JrtPackageFragmentRoot.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JrtPackageFragmentRoot.java
@@ -139,7 +139,7 @@ public class JrtPackageFragmentRoot extends JarPackageFragmentRoot implements IM
 		return hash;
 	}
 	@Override
-	protected void toStringInfo(int tab, StringBuffer buffer, Object info, boolean showResolvedInfo) {
+	protected void toStringInfo(int tab, StringBuilder buffer, Object info, boolean showResolvedInfo) {
 		buffer.append(tabString(tab));
 		buffer.append("<module:").append(this.moduleName).append(">"); //$NON-NLS-1$ //$NON-NLS-2$
 		if (info == null) {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/LambdaExpression.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/LambdaExpression.java
@@ -180,13 +180,13 @@ public class LambdaExpression extends SourceType {
 	}
 
 	@Override
-	protected void getHandleMemento(StringBuffer buff) {
+	protected void getHandleMemento(StringBuilder buff) {
 		getHandleMemento(buff, true, true);
 		// lambda method and lambda expression cannot share the same memento - add a trailing discriminator.
 		appendEscapedDelimiter(buff, getHandleMementoDelimiter());
 	}
 
-	protected void getHandleMemento(StringBuffer buff, boolean serializeParent, boolean serializeChild) {
+	protected void getHandleMemento(StringBuilder buff, boolean serializeParent, boolean serializeChild) {
 		if (serializeParent)
 			getParent().getHandleMemento(buff);
 		appendEscapedDelimiter(buff, getHandleMementoDelimiter());
@@ -277,7 +277,7 @@ public class LambdaExpression extends SourceType {
 	}
 
 	@Override
-	public void toStringName(StringBuffer buffer) {
+	public void toStringName(StringBuilder buffer) {
 		super.toStringName(buffer);
 		buffer.append("<lambda #"); //$NON-NLS-1$
 		buffer.append(this.occurrenceCount);
@@ -293,7 +293,7 @@ public class LambdaExpression extends SourceType {
 		IJavaElement primaryParent = this.getParent().getPrimaryElement(false);
 		if (primaryParent instanceof JavaElement) {
 			JavaElement ancestor = (JavaElement) primaryParent;
-			StringBuffer buffer = new StringBuffer(32);
+			StringBuilder buffer = new StringBuilder(32);
 			getHandleMemento(buffer, false, true);
 			String memento = buffer.toString();
 			return (JavaElement) ancestor.getHandleFromMemento(new MementoTokenizer(memento), DefaultWorkingCopyOwner.PRIMARY).getParent();

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/LambdaMethod.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/LambdaMethod.java
@@ -78,7 +78,7 @@ public class LambdaMethod extends SourceMethod {
 		return this.elementInfo;
 	}
 
-	public void getHandleMemento(StringBuffer buff, boolean serializeParent) {
+	public void getHandleMemento(StringBuilder buff, boolean serializeParent) {
 		if (serializeParent) {
 			((LambdaExpression) getParent()).getHandleMemento(buff, true, false);
 		}
@@ -103,7 +103,7 @@ public class LambdaMethod extends SourceMethod {
 		}
 	}
 	@Override
-	public void getHandleMemento(StringBuffer buff) {
+	public void getHandleMemento(StringBuilder buff) {
 		getHandleMemento(buff, true);
 		// lambda method and lambda expression cannot share the same memento - add a trailing discriminator.
 		appendEscapedDelimiter(buff, getHandleMementoDelimiter());

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/LocalVariable.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/LocalVariable.java
@@ -278,11 +278,11 @@ public class LocalVariable extends SourceRefElement implements ILocalVariable {
 	}
 
 	@Override
-	protected void getHandleMemento(StringBuffer buff) {
+	protected void getHandleMemento(StringBuilder buff) {
 		getHandleMemento(buff, true);
 	}
 
-	protected void getHandleMemento(StringBuffer buff, boolean memoizeParent) {
+	protected void getHandleMemento(StringBuilder buff, boolean memoizeParent) {
 		if (memoizeParent)
 			getParent().getHandleMemento(buff);
 		buff.append(getHandleMementoDelimiter());
@@ -519,7 +519,7 @@ public class LocalVariable extends SourceRefElement implements ILocalVariable {
 	}
 
 	@Override
-	protected void toStringInfo(int tab, StringBuffer buffer, Object info, boolean showResolvedInfo) {
+	protected void toStringInfo(int tab, StringBuilder buffer, Object info, boolean showResolvedInfo) {
 		buffer.append(tabString(tab));
 		if (info != NO_INFO) {
 			buffer.append(Signature.toString(getTypeSignature()));

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ModularClassFile.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ModularClassFile.java
@@ -228,7 +228,7 @@ public class ModularClassFile extends AbstractClassFile implements IModularClass
 		return JavaElement.JEM_MODULAR_CLASSFILE;
 	}
 	@Override
-	protected void escapeMementoName(StringBuffer buffer, String mementoName) {
+	protected void escapeMementoName(StringBuilder buffer, String mementoName) {
 		// nop, name is irrelevant
 	}
 	@Override

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ModuleDescriptionInfo.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ModuleDescriptionInfo.java
@@ -287,11 +287,11 @@ public class ModuleDescriptionInfo extends AnnotatableInfo implements ISourceMod
 
 	@Override
 	public String toString() {
-		StringBuffer buffer = new StringBuffer(getClass().getName());
+		StringBuilder buffer = new StringBuilder(getClass().getName());
 		toStringContent(buffer);
 		return buffer.toString();
 	}
-	protected void toStringContent(StringBuffer buffer) {
+	protected void toStringContent(StringBuilder buffer) {
 		buffer.append("\n"); //$NON-NLS-1$
 		if (this.isOpen())
 			buffer.append("open "); //$NON-NLS-1$

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/NamedMember.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/NamedMember.java
@@ -45,7 +45,7 @@ public abstract class NamedMember extends Member {
 		this.name = name;
 	}
 
-	private void appendTypeParameters(StringBuffer buffer) throws JavaModelException {
+	private void appendTypeParameters(StringBuilder buffer) throws JavaModelException {
 		ITypeParameter[] typeParameters = getTypeParameters();
 		int length = typeParameters.length;
 		if (length == 0) return;
@@ -207,7 +207,7 @@ public abstract class NamedMember extends Member {
 		switch (this.getParent().getElementType()) {
 			case IJavaElement.COMPILATION_UNIT:
 				if (showParameters) {
-					StringBuffer buffer = new StringBuffer(this.name);
+					StringBuilder buffer = new StringBuilder(this.name);
 					appendTypeParameters(buffer);
 					return buffer.toString();
 				}
@@ -225,7 +225,7 @@ public abstract class NamedMember extends Member {
 					typeName = classFileName.substring(0, classFileName.lastIndexOf('.'))/*remove .class*/.replace('$', enclosingTypeSeparator);
 				}
 				if (showParameters) {
-					StringBuffer buffer = new StringBuffer(typeName);
+					StringBuilder buffer = new StringBuilder(typeName);
 					appendTypeParameters(buffer);
 					return buffer.toString();
 				}
@@ -241,7 +241,7 @@ public abstract class NamedMember extends Member {
 			default:
 				return null;
 		}
-		StringBuffer buffer = new StringBuffer(declaringType.getTypeQualifiedName(enclosingTypeSeparator, showParameters));
+		StringBuilder buffer = new StringBuilder(declaringType.getTypeQualifiedName(enclosingTypeSeparator, showParameters));
 		buffer.append(enclosingTypeSeparator);
 		String simpleName = this.name.length() == 0 ? getOccurrenceCountSignature() : this.name;
 		buffer.append(simpleName);

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/PackageDeclaration.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/PackageDeclaration.java
@@ -69,7 +69,7 @@ public JavaElement getPrimaryElement(boolean checkOwner) {
  * @private Debugging purposes
  */
 @Override
-protected void toStringInfo(int tab, StringBuffer buffer, Object info, boolean showResolvedInfo) {
+protected void toStringInfo(int tab, StringBuilder buffer, Object info, boolean showResolvedInfo) {
 	buffer.append(tabString(tab));
 	buffer.append("package "); //$NON-NLS-1$
 	toStringName(buffer);

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/PackageFragment.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/PackageFragment.java
@@ -536,7 +536,7 @@ public void rename(String newName, boolean force, IProgressMonitor monitor) thro
  * Debugging purposes
  */
 @Override
-protected void toStringChildren(int tab, StringBuffer buffer, Object info) {
+protected void toStringChildren(int tab, StringBuilder buffer, Object info) {
 	if (tab == 0) {
 		super.toStringChildren(tab, buffer, info);
 	}
@@ -545,7 +545,7 @@ protected void toStringChildren(int tab, StringBuffer buffer, Object info) {
  * Debugging purposes
  */
 @Override
-protected void toStringInfo(int tab, StringBuffer buffer, Object info, boolean showResolvedInfo) {
+protected void toStringInfo(int tab, StringBuilder buffer, Object info, boolean showResolvedInfo) {
 	buffer.append(tabString(tab));
 	if (this.names.length == 0) {
 		buffer.append("<default>"); //$NON-NLS-1$
@@ -575,7 +575,7 @@ public String getAttachedJavadoc(IProgressMonitor monitor) throws JavaModelExcep
 	if (baseLocation == null) {
 		return null;
 	}
-	StringBuffer pathBuffer = new StringBuffer(baseLocation.toExternalForm());
+	StringBuilder pathBuffer = new StringBuilder(baseLocation.toExternalForm());
 
 	if (!(pathBuffer.charAt(pathBuffer.length() - 1) == '/')) {
 		pathBuffer.append('/');

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/PackageFragmentRoot.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/PackageFragmentRoot.java
@@ -482,10 +482,10 @@ public IJavaElement getHandleFromMemento(String token, MementoTokenizer memento,
 	return null;
 }
 /**
- * @see JavaElement#getHandleMemento(StringBuffer)
+ * @see JavaElement#getHandleMemento(StringBuilder)
  */
 @Override
-protected void getHandleMemento(StringBuffer buff) {
+protected void getHandleMemento(StringBuilder buff) {
 	IPath path;
 	IResource underlyingResource = getResource();
 	if (underlyingResource != null) {
@@ -837,7 +837,7 @@ public void move(
  * @private Debugging purposes
  */
 @Override
-protected void toStringInfo(int tab, StringBuffer buffer, Object info, boolean showResolvedInfo) {
+protected void toStringInfo(int tab, StringBuilder buffer, Object info, boolean showResolvedInfo) {
 	buffer.append(tabString(tab));
 	IPath path = getPath();
 	if (isExternal()) {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ResolvedBinaryField.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ResolvedBinaryField.java
@@ -49,7 +49,7 @@ public class ResolvedBinaryField extends BinaryField {
 	 * @private Debugging purposes
 	 */
 	@Override
-	protected void toStringInfo(int tab, StringBuffer buffer, Object info, boolean showResolvedInfo) {
+	protected void toStringInfo(int tab, StringBuilder buffer, Object info, boolean showResolvedInfo) {
 		super.toStringInfo(tab, buffer, info, showResolvedInfo);
 		if (showResolvedInfo) {
 			buffer.append(" {key="); //$NON-NLS-1$

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ResolvedBinaryMethod.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ResolvedBinaryMethod.java
@@ -51,7 +51,7 @@ public class ResolvedBinaryMethod extends BinaryMethod {
 	 * @private Debugging purposes
 	 */
 	@Override
-	protected void toStringInfo(int tab, StringBuffer buffer, Object info, boolean showResolvedInfo) {
+	protected void toStringInfo(int tab, StringBuilder buffer, Object info, boolean showResolvedInfo) {
 		super.toStringInfo(tab, buffer, info, showResolvedInfo);
 		if (showResolvedInfo) {
 			buffer.append(" {key="); //$NON-NLS-1$

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ResolvedBinaryType.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ResolvedBinaryType.java
@@ -56,7 +56,7 @@ public class ResolvedBinaryType extends BinaryType {
 	 * @private Debugging purposes
 	 */
 	@Override
-	protected void toStringInfo(int tab, StringBuffer buffer, Object info, boolean showResolvedInfo) {
+	protected void toStringInfo(int tab, StringBuilder buffer, Object info, boolean showResolvedInfo) {
 		super.toStringInfo(tab, buffer, info, showResolvedInfo);
 		if (showResolvedInfo) {
 			buffer.append(" {key="); //$NON-NLS-1$

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ResolvedLambdaExpression.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ResolvedLambdaExpression.java
@@ -50,7 +50,7 @@ public class ResolvedLambdaExpression extends LambdaExpression {
 	 * @private Debugging purposes
 	 */
 	@Override
-	protected void toStringInfo(int tab, StringBuffer buffer, Object info, boolean showResolvedInfo) {
+	protected void toStringInfo(int tab, StringBuilder buffer, Object info, boolean showResolvedInfo) {
 		super.toStringInfo(tab, buffer, info, showResolvedInfo);
 		if (showResolvedInfo) {
 			buffer.append(" {key="); //$NON-NLS-1$

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ResolvedSourceField.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ResolvedSourceField.java
@@ -43,7 +43,7 @@ public class ResolvedSourceField extends SourceField {
 	 * @private Debugging purposes
 	 */
 	@Override
-	protected void toStringInfo(int tab, StringBuffer buffer, Object info, boolean showResolvedInfo) {
+	protected void toStringInfo(int tab, StringBuilder buffer, Object info, boolean showResolvedInfo) {
 		super.toStringInfo(tab, buffer, info, showResolvedInfo);
 		if (showResolvedInfo) {
 			buffer.append(" {key="); //$NON-NLS-1$

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ResolvedSourceMethod.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ResolvedSourceMethod.java
@@ -43,7 +43,7 @@ public class ResolvedSourceMethod extends SourceMethod {
 	 * @private Debugging purposes
 	 */
 	@Override
-	protected void toStringInfo(int tab, StringBuffer buffer, Object info, boolean showResolvedInfo) {
+	protected void toStringInfo(int tab, StringBuilder buffer, Object info, boolean showResolvedInfo) {
 		super.toStringInfo(tab, buffer, info, showResolvedInfo);
 		if (showResolvedInfo) {
 			buffer.append(" {key="); //$NON-NLS-1$

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ResolvedSourceType.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ResolvedSourceType.java
@@ -50,7 +50,7 @@ public class ResolvedSourceType extends SourceType {
 	 * @private Debugging purposes
 	 */
 	@Override
-	protected void toStringInfo(int tab, StringBuffer buffer, Object info, boolean showResolvedInfo) {
+	protected void toStringInfo(int tab, StringBuilder buffer, Object info, boolean showResolvedInfo) {
 		super.toStringInfo(tab, buffer, info, showResolvedInfo);
 		if (showResolvedInfo) {
 			buffer.append(" {key="); //$NON-NLS-1$

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SimpleDelta.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SimpleDelta.java
@@ -81,7 +81,7 @@ public class SimpleDelta {
 		changed(IJavaElementDelta.F_SUPER_TYPES);
 	}
 
-	protected void toDebugString(StringBuffer buffer) {
+	protected void toDebugString(StringBuilder buffer) {
 		buffer.append("["); //$NON-NLS-1$
 		switch (getKind()) {
 			case IJavaElementDelta.ADDED :
@@ -102,7 +102,7 @@ public class SimpleDelta {
 		buffer.append("}"); //$NON-NLS-1$
 	}
 
-	protected boolean toDebugString(StringBuffer buffer, int flags) {
+	protected boolean toDebugString(StringBuilder buffer, int flags) {
 		boolean prev = false;
 		if ((flags & IJavaElementDelta.F_MODIFIERS) != 0) {
 			if (prev)
@@ -121,7 +121,7 @@ public class SimpleDelta {
 
 	@Override
 	public String toString() {
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		toDebugString(buffer);
 		return buffer.toString();
 	}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SourceField.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SourceField.java
@@ -162,7 +162,7 @@ public JavaElement resolved(Binding binding) {
  * @private Debugging purposes
  */
 @Override
-protected void toStringInfo(int tab, StringBuffer buffer, Object info, boolean showResolvedInfo) {
+protected void toStringInfo(int tab, StringBuilder buffer, Object info, boolean showResolvedInfo) {
 	buffer.append(tabString(tab));
 	if (info == null) {
 		toStringName(buffer);

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SourceMapper.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SourceMapper.java
@@ -96,7 +96,7 @@ public class SourceMapper
 		String name;
 
 		public LocalVariableElementKey(IJavaElement method, String name) {
-			StringBuffer buffer = new StringBuffer();
+			StringBuilder buffer = new StringBuilder();
 			buffer
 				.append(method.getParent().getHandleIdentifier())
 				.append('#')
@@ -148,7 +148,7 @@ public class SourceMapper
 		}
 		@Override
 		public String toString() {
-			StringBuffer buffer = new StringBuffer();
+			StringBuilder buffer = new StringBuilder();
 			buffer.append('(').append(this.parent).append('.').append(this.name).append(')');
 			return String.valueOf(buffer);
 		}
@@ -420,7 +420,7 @@ public class SourceMapper
 
 			// transforms signatures that contains a qualification into unqualified signatures
 			// e.g. "QX<+QMap.Entry;>;" becomes "QX<+QEntry;>;"
-			StringBuffer simpleTypeSig = null;
+			StringBuilder simpleTypeSig = null;
 			int start = 0;
 			int dot = -1;
 			int length = typeSig.length;
@@ -439,7 +439,7 @@ public class SourceMapper
 						if (matchingEnd > 0 && matchingEnd+1 < length && typeSig[matchingEnd+1] == Signature.C_DOT) {
 							// found Head<Param>.Tail -> discard everything except Tail
 							if (simpleTypeSig == null)
-								simpleTypeSig = new StringBuffer().append(typeSig, 0, start);
+								simpleTypeSig = new StringBuilder().append(typeSig, 0, start);
 							simpleTypeSig.append(Signature.C_UNRESOLVED);
 							start = j = matchingEnd+2;
 							break;
@@ -448,7 +448,7 @@ public class SourceMapper
 					case Signature.C_NAME_END:
 						if (dot > start) {
 							if (simpleTypeSig == null)
-								simpleTypeSig = new StringBuffer().append(typeSig, 0, start);
+								simpleTypeSig = new StringBuilder().append(typeSig, 0, start);
 							simpleTypeSig.append(Signature.C_UNRESOLVED);
 							simpleTypeSig.append(typeSig, dot+1, j-dot-1);
 							start = j;
@@ -1425,7 +1425,7 @@ public class SourceMapper
 		String[] qualifiedParameterTypes = method.getParameterTypes();
 		String[] unqualifiedParameterTypes = new String[qualifiedParameterTypes.length];
 		for (int i = 0; i < qualifiedParameterTypes.length; i++) {
-			StringBuffer unqualifiedTypeSig = new StringBuffer();
+			StringBuilder unqualifiedTypeSig = new StringBuilder();
 			getUnqualifiedTypeSignature(qualifiedParameterTypes[i], 0/*start*/, qualifiedParameterTypes[i].length(), unqualifiedTypeSig, noDollar);
 			unqualifiedParameterTypes[i] = unqualifiedTypeSig.toString();
 			hasDollar |= unqualifiedParameterTypes[i].lastIndexOf('$') != -1;
@@ -1441,7 +1441,7 @@ public class SourceMapper
 		return result;
 	}
 
-	private int getUnqualifiedTypeSignature(String qualifiedTypeSig, int start, int length, StringBuffer unqualifiedTypeSig, boolean noDollar) {
+	private int getUnqualifiedTypeSignature(String qualifiedTypeSig, int start, int length, StringBuilder unqualifiedTypeSig, boolean noDollar) {
 		char firstChar = qualifiedTypeSig.charAt(start);
 		int end = start + 1;
 		boolean sigStart = false;

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SourceMethod.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SourceMethod.java
@@ -80,10 +80,10 @@ public String[] getExceptionTypes() throws JavaModelException {
 	return CompilationUnitStructureRequestor.convertTypeNamesToSigs(exs);
 }
 /**
- * @see JavaElement#getHandleMemento(StringBuffer)
+ * @see JavaElement#getHandleMemento(StringBuilder)
  */
 @Override
-protected void getHandleMemento(StringBuffer buff) {
+protected void getHandleMemento(StringBuilder buff) {
 	getParent().getHandleMemento(buff);
 	char delimiter = getHandleMementoDelimiter();
 	buff.append(delimiter);
@@ -299,7 +299,7 @@ public JavaElement resolved(Binding binding) {
  * @private Debugging purposes
  */
 @Override
-protected void toStringInfo(int tab, StringBuffer buffer, Object info, boolean showResolvedInfo) {
+protected void toStringInfo(int tab, StringBuilder buffer, Object info, boolean showResolvedInfo) {
 	buffer.append(tabString(tab));
 	if (info == null) {
 		toStringName(buffer);
@@ -320,10 +320,10 @@ protected void toStringInfo(int tab, StringBuffer buffer, Object info, boolean s
 	}
 }
 @Override
-protected void toStringName(StringBuffer buffer) {
+protected void toStringName(StringBuilder buffer) {
 	toStringName(buffer, 0);
 }
-protected void toStringName(StringBuffer buffer, int flags) {
+protected void toStringName(StringBuilder buffer, int flags) {
 	buffer.append(getElementName());
 	buffer.append('(');
 	String[] parameters = getParameterTypes();

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SourceModule.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SourceModule.java
@@ -43,7 +43,7 @@ public class SourceModule extends NamedMember implements AbstractModule {
 	}
 	@Override
 	public String toString(String lineDelimiter) {
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		try {
 			toStringContent(buffer, lineDelimiter);
 		} catch (JavaModelException e) {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SourceRefElement.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SourceRefElement.java
@@ -150,7 +150,7 @@ public IJavaElement getHandleFromMemento(String token, MementoTokenizer memento,
 	return this;
 }
 @Override
-protected void getHandleMemento(StringBuffer buff) {
+protected void getHandleMemento(StringBuilder buff) {
 	super.getHandleMemento(buff);
 	if (this.occurrenceCount > 1) {
 		buff.append(JEM_COUNT);
@@ -288,7 +288,7 @@ public void rename(String newName, boolean force, IProgressMonitor monitor) thro
 	getJavaModel().rename(elements, dests, renamings, force, monitor);
 }
 @Override
-protected void toStringName(StringBuffer buffer) {
+protected void toStringName(StringBuilder buffer) {
 	super.toStringName(buffer);
 	if (this.occurrenceCount > 1) {
 		buffer.append("#"); //$NON-NLS-1$

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SourceType.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SourceType.java
@@ -960,7 +960,7 @@ public JavaElement resolved(Binding binding) {
  * @private Debugging purposes
  */
 @Override
-protected void toStringInfo(int tab, StringBuffer buffer, Object info, boolean showResolvedInfo) {
+protected void toStringInfo(int tab, StringBuilder buffer, Object info, boolean showResolvedInfo) {
 	buffer.append(tabString(tab));
 	if (info == null) {
 		if (isAnonymous()) {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/TypeParameter.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/TypeParameter.java
@@ -156,7 +156,7 @@ public class TypeParameter extends SourceRefElement implements ITypeParameter {
 	}
 
 	@Override
-	protected void toStringName(StringBuffer buffer) {
+	protected void toStringName(StringBuilder buffer) {
 		buffer.append('<');
 		buffer.append(getElementName());
 		buffer.append('>');

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/hierarchy/HierarchyResolver.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/hierarchy/HierarchyResolver.java
@@ -146,7 +146,7 @@ public void accept(ICompilationUnit sourceUnit, AccessRestriction accessRestrict
 		this.lookupEnvironment.completeTypeBindings(parsedUnit, true); // work done inside checkAndSetImports()
 	} else {
 		this.lookupEnvironment.problemReporter.abortDueToInternalError(
-			new StringBuffer(Messages.accept_cannot)
+			new StringBuilder(Messages.accept_cannot)
 				.append(sourceUnit.getFileName())
 				.toString());
 	}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/hierarchy/TypeHierarchy.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/hierarchy/TypeHierarchy.java
@@ -1546,7 +1546,7 @@ boolean subtypesIncludeSupertypeOf(IType type) {
  */
 @Override
 public String toString() {
-	StringBuffer buffer = new StringBuffer();
+	StringBuilder buffer = new StringBuilder();
 	buffer.append("Focus: "); //$NON-NLS-1$
 	if (this.focusType == null) {
 		buffer.append("<NONE>\n"); //$NON-NLS-1$
@@ -1590,7 +1590,7 @@ public String toString() {
  * beginning with the specified indentation level.
  * If ascendant, shows the super types, otherwise show the sub types.
  */
-private void toString(StringBuffer buffer, IJavaElement type, int indent, boolean ascendant) {
+private void toString(StringBuilder buffer, IJavaElement type, int indent, boolean ascendant) {
 	IType[] types= ascendant ? getSupertypes((IType) type) : getSubtypes((IType) type);
 	IJavaElement[] sortedTypes = Util.sortCopy(types);
 	for (int i= 0; i < sortedTypes.length; i++) {
@@ -1598,7 +1598,7 @@ private void toString(StringBuffer buffer, IJavaElement type, int indent, boolea
 		toString(buffer, sortedTypes[i], indent + 1, ascendant);
 	}
 }
-private void toString(StringBuffer buffer, IJavaElement type, int indent) {
+private void toString(StringBuilder buffer, IJavaElement type, int indent) {
 	for (int j= 0; j < indent; j++) {
 		buffer.append("  "); //$NON-NLS-1$
 	}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/DefaultBytecodeVisitor.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/DefaultBytecodeVisitor.java
@@ -41,7 +41,7 @@ public class DefaultBytecodeVisitor implements IBytecodeVisitor {
 	private static final int T_INT = 10;
 	private static final int T_LONG = 11;
 
-	private final StringBuffer buffer;
+	private final StringBuilder buffer;
 	private final String lineSeparator;
 	private final int tabNumber;
 	private final int digitNumberForPC;
@@ -52,7 +52,7 @@ public class DefaultBytecodeVisitor implements IBytecodeVisitor {
 	private final boolean isStatic;
 	private int[] argumentSizes;
 
-	public DefaultBytecodeVisitor(ICodeAttribute codeAttribute, char[][] parameterNames, char[] methodDescriptor, boolean isStatic, StringBuffer buffer, String lineSeparator, int tabNumber, int mode) {
+	public DefaultBytecodeVisitor(ICodeAttribute codeAttribute, char[][] parameterNames, char[] methodDescriptor, boolean isStatic, StringBuilder buffer, String lineSeparator, int tabNumber, int mode) {
 		ILocalVariableAttribute localVariableAttribute = codeAttribute.getLocalVariableAttribute();
 		this.localVariableAttributeLength = localVariableAttribute == null ? 0 : localVariableAttribute.getLocalVariableTableLength();
 		if (this.localVariableAttributeLength != 0) {
@@ -267,7 +267,7 @@ public class DefaultBytecodeVisitor implements IBytecodeVisitor {
 			final ILocalVariableTableEntry entry = this.localVariableTableEntries[i];
 			final int startPC = entry.getStartPC();
 			if (entry.getIndex() == index && (startPC <= nextPC) && ((startPC + entry.getLength()) > nextPC)) {
-				final StringBuffer stringBuffer = new StringBuffer();
+				final StringBuilder stringBuffer = new StringBuilder();
 				if (showIndex) {
 					stringBuffer.append(' ').append(index);
 				}
@@ -278,7 +278,7 @@ public class DefaultBytecodeVisitor implements IBytecodeVisitor {
 		if (this.parameterNames != null) {
 			if (index == 0) {
 				if (!this.isStatic) {
-					final StringBuffer stringBuffer = new StringBuffer();
+					final StringBuilder stringBuffer = new StringBuilder();
 					stringBuffer.append(' ').append('[').append("this").append(']'); //$NON-NLS-1$
 					return String.valueOf(stringBuffer);
 				}
@@ -300,7 +300,7 @@ public class DefaultBytecodeVisitor implements IBytecodeVisitor {
 			}
 			if (indexInParameterNames < this.parameterNames.length
 					&& this.parameterNames[indexInParameterNames] != null) {
-				final StringBuffer stringBuffer = new StringBuffer();
+				final StringBuilder stringBuffer = new StringBuilder();
 				if (showIndex) {
 					stringBuffer.append(' ').append(index);
 				}
@@ -309,7 +309,7 @@ public class DefaultBytecodeVisitor implements IBytecodeVisitor {
 			}
 		}
 		if (showIndex) {
-			final StringBuffer stringBuffer = new StringBuffer();
+			final StringBuilder stringBuffer = new StringBuilder();
 			stringBuffer.append(' ').append(index);
 			return String.valueOf(stringBuffer);
 		}
@@ -2107,7 +2107,7 @@ public class DefaultBytecodeVisitor implements IBytecodeVisitor {
 		writeNewLine();
 	}
 
-	private StringBuffer appendConstantMethodType(StringBuffer s, String messageKind, int opcode,
+	private StringBuilder appendConstantMethodType(StringBuilder s, String messageKind, int opcode,
 			int index, IConstantPoolEntry constantPoolEntry) {
 		return s.append(Messages.bind(messageKind, new String[] {
 				OpcodeStringValues.BYTECODE_NAMES[opcode],
@@ -2116,7 +2116,7 @@ public class DefaultBytecodeVisitor implements IBytecodeVisitor {
 			}));
 	}
 
-	private StringBuffer appendConstantMethodHandle(StringBuffer s, String messageKind, int opcode,
+	private StringBuilder appendConstantMethodHandle(StringBuilder s, String messageKind, int opcode,
 			int index, IConstantPoolEntry constantPoolEntry) {
 		return s.append(Messages.bind(messageKind, new String[] {
 				OpcodeStringValues.BYTECODE_NAMES[opcode],
@@ -2125,7 +2125,7 @@ public class DefaultBytecodeVisitor implements IBytecodeVisitor {
 				Integer.toString(((IConstantPoolEntry2) constantPoolEntry).getReferenceIndex())
 			}));
 	}
-	private StringBuffer appendConstantDynamic(StringBuffer s, String messageKind, int opcode,
+	private StringBuilder appendConstantDynamic(StringBuilder s, String messageKind, int opcode,
 			int index, IConstantPoolEntry entry) {
 		return s.append(Messages.bind(messageKind, new String[] {
 				OpcodeStringValues.BYTECODE_NAMES[opcode],
@@ -2792,7 +2792,7 @@ public class DefaultBytecodeVisitor implements IBytecodeVisitor {
 		}
 		switch(className[0]) {
 			case '[' :
-				StringBuffer classNameBuffer = new StringBuffer();
+				StringBuilder classNameBuffer = new StringBuilder();
 				Util.appendTypeSignature(className, 0, classNameBuffer, isCompact());
 				return classNameBuffer.toString();
 			default:

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/Disassembler.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/Disassembler.java
@@ -34,7 +34,7 @@ public class Disassembler extends ClassFileBytesDisassembler {
 	private static final char[] ANY_EXCEPTION = Messages.classfileformat_anyexceptionhandler.toCharArray();
 	private static final String VERSION_UNKNOWN = Messages.classfileformat_versionUnknown;
 
-	private boolean appendModifier(StringBuffer buffer, int accessFlags, int modifierConstant, String modifier, boolean firstModifier) {
+	private boolean appendModifier(StringBuilder buffer, int accessFlags, int modifierConstant, String modifier, boolean firstModifier) {
 		if ((accessFlags & modifierConstant) != 0) {
 			if (!firstModifier) {
 				buffer.append(Messages.disassembler_space);
@@ -47,11 +47,11 @@ public class Disassembler extends ClassFileBytesDisassembler {
 		return firstModifier;
 	}
 
-	private void decodeModifiers(StringBuffer buffer, int accessFlags, int[] checkBits) {
+	private void decodeModifiers(StringBuilder buffer, int accessFlags, int[] checkBits) {
 		decodeModifiers(buffer, accessFlags, false, false, checkBits);
 	}
 
-	private void decodeModifiers(StringBuffer buffer, int accessFlags, boolean printDefault, boolean asBridge, int[] checkBits) {
+	private void decodeModifiers(StringBuilder buffer, int accessFlags, boolean printDefault, boolean asBridge, int[] checkBits) {
 		if (checkBits == null) return;
 		boolean firstModifier = true;
 		for (int i = 0, max = checkBits.length; i < max; i++) {
@@ -113,7 +113,7 @@ public class Disassembler extends ClassFileBytesDisassembler {
 		}
 	}
 
-	private void decodeModifiersForField(StringBuffer buffer, int accessFlags) {
+	private void decodeModifiersForField(StringBuilder buffer, int accessFlags) {
 		decodeModifiers(buffer, accessFlags, new int[] {
 				IModifierConstants.ACC_PUBLIC,
 				IModifierConstants.ACC_PROTECTED,
@@ -126,7 +126,7 @@ public class Disassembler extends ClassFileBytesDisassembler {
 		});
 	}
 
-	private void decodeModifiersForFieldForWorkingCopy(StringBuffer buffer, int accessFlags) {
+	private void decodeModifiersForFieldForWorkingCopy(StringBuilder buffer, int accessFlags) {
 		decodeModifiers(buffer, accessFlags, new int[] {
 				IModifierConstants.ACC_PUBLIC,
 				IModifierConstants.ACC_PROTECTED,
@@ -138,7 +138,7 @@ public class Disassembler extends ClassFileBytesDisassembler {
 		});
 	}
 
-	private final void decodeModifiersForInnerClasses(StringBuffer buffer, int accessFlags, boolean printDefault) {
+	private final void decodeModifiersForInnerClasses(StringBuilder buffer, int accessFlags, boolean printDefault) {
 		decodeModifiers(buffer, accessFlags, printDefault, false, new int[] {
 				IModifierConstants.ACC_PUBLIC,
 				IModifierConstants.ACC_PROTECTED,
@@ -149,7 +149,7 @@ public class Disassembler extends ClassFileBytesDisassembler {
 		});
 	}
 
-	private final void decodeModifiersForMethod(StringBuffer buffer, int accessFlags) {
+	private final void decodeModifiersForMethod(StringBuilder buffer, int accessFlags) {
 		decodeModifiers(buffer, accessFlags, false, true, new int[] {
 				IModifierConstants.ACC_PUBLIC,
 				IModifierConstants.ACC_PROTECTED,
@@ -164,7 +164,7 @@ public class Disassembler extends ClassFileBytesDisassembler {
 		});
 	}
 
-	private final void decodeModifiersForMethodParameters(StringBuffer buffer, int accessFlags) {
+	private final void decodeModifiersForMethodParameters(StringBuilder buffer, int accessFlags) {
 		decodeModifiers(buffer, accessFlags, false, true, new int[] {
 				IModifierConstants.ACC_FINAL,
 				IModifierConstants.ACC_MANDATED,
@@ -172,14 +172,14 @@ public class Disassembler extends ClassFileBytesDisassembler {
 		});
 	}
 
-	private final void decodeModifiersForType(StringBuffer buffer, int accessFlags) {
+	private final void decodeModifiersForType(StringBuilder buffer, int accessFlags) {
 		decodeModifiers(buffer, accessFlags, new int[] {
 				IModifierConstants.ACC_PUBLIC,
 				IModifierConstants.ACC_ABSTRACT,
 				IModifierConstants.ACC_FINAL,
 		});
 	}
-	private final void decodeModifiersForModuleRequires(StringBuffer buffer, int accessFlags) {
+	private final void decodeModifiersForModuleRequires(StringBuilder buffer, int accessFlags) {
 		int[] checkBits = new int[] {
 				IModifierConstants.ACC_TRANSITIVE,
 				IModifierConstants.ACC_STATIC_PHASE,
@@ -199,7 +199,7 @@ public class Disassembler extends ClassFileBytesDisassembler {
 			buffer.append(Messages.disassembler_space);
 		}
 	}
-	private final void decodeModifiersForModule(StringBuffer buffer, int accessFlags) {
+	private final void decodeModifiersForModule(StringBuilder buffer, int accessFlags) {
 		appendModifier(buffer, accessFlags, IModifierConstants.ACC_OPEN, "open", true); //$NON-NLS-1$
 		buffer.append(Messages.disassembler_space);
 	}
@@ -208,7 +208,7 @@ public class Disassembler extends ClassFileBytesDisassembler {
 	}
 
 	static String decodeStringValue(char[] chars) {
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		for (int i = 0, max = chars.length; i < max; i++) {
 			char c = chars[i];
 			org.eclipse.jdt.internal.compiler.util.Util.appendEscapedChar(buffer, c, true);
@@ -216,7 +216,7 @@ public class Disassembler extends ClassFileBytesDisassembler {
 		return buffer.toString();
 	}
 
-	private static void escapeChar(StringBuffer buffer, char c) {
+	private static void escapeChar(StringBuilder buffer, char c) {
 		org.eclipse.jdt.internal.compiler.util.Util.appendEscapedChar(buffer, c, false);
 	}
 
@@ -248,7 +248,7 @@ public class Disassembler extends ClassFileBytesDisassembler {
 		}
 	}
 
-	private void disassemble(IAnnotation annotation, StringBuffer buffer, String lineSeparator, int tabNumber, int mode) {
+	private void disassemble(IAnnotation annotation, StringBuilder buffer, String lineSeparator, int tabNumber, int mode) {
 		writeNewLine(buffer, lineSeparator, tabNumber + 1);
 		final int typeIndex = annotation.getTypeIndex();
 		final char[] typeName = CharOperation.replaceOnCopy(annotation.getTypeName(), '/', '.');
@@ -265,7 +265,7 @@ public class Disassembler extends ClassFileBytesDisassembler {
 		buffer.append(Messages.disassembler_annotationentryend);
 	}
 
-	private void disassemble(IExtendedAnnotation extendedAnnotation, StringBuffer buffer, String lineSeparator, int tabNumber, int mode) {
+	private void disassemble(IExtendedAnnotation extendedAnnotation, StringBuilder buffer, String lineSeparator, int tabNumber, int mode) {
 		writeNewLine(buffer, lineSeparator, tabNumber + 1);
 		final int typeIndex = extendedAnnotation.getTypeIndex();
 		final char[] typeName = CharOperation.replaceOnCopy(extendedAnnotation.getTypeName(), '/', '.');
@@ -299,7 +299,7 @@ public class Disassembler extends ClassFileBytesDisassembler {
 		buffer.append(Messages.disassembler_extendedannotationentryend);
 	}
 
-	private void disassembleTypePathContents(int targetType, IExtendedAnnotation extendedAnnotation,StringBuffer buffer, String lineSeparator, int tabNumber, int mode) {
+	private void disassembleTypePathContents(int targetType, IExtendedAnnotation extendedAnnotation,StringBuilder buffer, String lineSeparator, int tabNumber, int mode) {
 		int[][] typepath = extendedAnnotation.getTypePath();
 		if (typepath.length != 0) {
 			writeNewLine(buffer, lineSeparator, tabNumber + 2);
@@ -309,7 +309,7 @@ public class Disassembler extends ClassFileBytesDisassembler {
 				}));
 		}
 	}
-	private void disassembleTargetTypeContents(boolean insideWildcard, int targetType, IExtendedAnnotation extendedAnnotation, StringBuffer buffer, String lineSeparator, int tabNumber, int mode) {
+	private void disassembleTargetTypeContents(boolean insideWildcard, int targetType, IExtendedAnnotation extendedAnnotation, StringBuilder buffer, String lineSeparator, int tabNumber, int mode) {
 		switch(targetType) {
 			case IExtendedAnnotationConstants.CLASS_TYPE_PARAMETER :
 			case IExtendedAnnotationConstants.METHOD_TYPE_PARAMETER :
@@ -459,7 +459,7 @@ public class Disassembler extends ClassFileBytesDisassembler {
 	}
 
 
-	private void disassemble(IAnnotationComponent annotationComponent, StringBuffer buffer, String lineSeparator, int tabNumber, int mode) {
+	private void disassemble(IAnnotationComponent annotationComponent, StringBuilder buffer, String lineSeparator, int tabNumber, int mode) {
 		writeNewLine(buffer, lineSeparator, tabNumber + 1);
 		buffer.append(
 			Messages.bind(Messages.disassembler_annotationcomponent,
@@ -470,7 +470,7 @@ public class Disassembler extends ClassFileBytesDisassembler {
 		disassemble(annotationComponent.getComponentValue(), buffer, lineSeparator, tabNumber + 1, mode);
 	}
 
-	private void disassemble(IAnnotationComponentValue annotationComponentValue, StringBuffer buffer, String lineSeparator, int tabNumber, int mode) {
+	private void disassemble(IAnnotationComponentValue annotationComponentValue, StringBuilder buffer, String lineSeparator, int tabNumber, int mode) {
 		switch(annotationComponentValue.getTag()) {
 			case IAnnotationComponentValue.BYTE_TAG:
 			case IAnnotationComponentValue.CHAR_TAG:
@@ -494,7 +494,7 @@ public class Disassembler extends ClassFileBytesDisassembler {
 						value = Double.toString(constantPoolEntry.getDoubleValue());
 						break;
 					case IConstantPoolConstant.CONSTANT_Integer:
-						StringBuffer temp = new StringBuffer();
+						StringBuilder temp = new StringBuilder();
 						switch(annotationComponentValue.getTag()) {
 							case IAnnotationComponentValue.CHAR_TAG :
 								temp.append('\'');
@@ -560,7 +560,7 @@ public class Disassembler extends ClassFileBytesDisassembler {
 		}
 	}
 
-	private void disassemble(IAnnotationDefaultAttribute annotationDefaultAttribute, StringBuffer buffer, String lineSeparator, int tabNumber, int mode) {
+	private void disassemble(IAnnotationDefaultAttribute annotationDefaultAttribute, StringBuilder buffer, String lineSeparator, int tabNumber, int mode) {
 		writeNewLine(buffer, lineSeparator, tabNumber + 1);
 		buffer.append(Messages.disassembler_annotationdefaultheader);
 		IAnnotationComponentValue componentValue = annotationDefaultAttribute.getMemberValue();
@@ -568,7 +568,7 @@ public class Disassembler extends ClassFileBytesDisassembler {
 		disassemble(componentValue, buffer, lineSeparator, tabNumber + 1, mode);
 	}
 
-	private void disassemble(IClassFileAttribute classFileAttribute, StringBuffer buffer, String lineSeparator, int tabNumber, int mode) {
+	private void disassemble(IClassFileAttribute classFileAttribute, StringBuilder buffer, String lineSeparator, int tabNumber, int mode) {
 		writeNewLine(buffer, lineSeparator, tabNumber + 1);
 		buffer.append(Messages.bind(Messages.disassembler_genericattributeheader,
 			new String[] {
@@ -577,7 +577,7 @@ public class Disassembler extends ClassFileBytesDisassembler {
 			}));
 	}
 
-	private void disassemble(IMethodParametersAttribute methodParametersAttribute, StringBuffer buffer, String lineSeparator, int tabNumber, int mode) {
+	private void disassemble(IMethodParametersAttribute methodParametersAttribute, StringBuilder buffer, String lineSeparator, int tabNumber, int mode) {
 		tabNumber += 2;
 		writeNewLine(buffer, lineSeparator, tabNumber);
 		buffer.append(Messages.disassembler_methodparametersheader);
@@ -592,7 +592,7 @@ public class Disassembler extends ClassFileBytesDisassembler {
 		}
 	}
 
-	private void disassembleEnumConstructor(IClassFileReader classFileReader, char[] className, IMethodInfo methodInfo, StringBuffer buffer, String lineSeparator, int tabNumber, int mode) {
+	private void disassembleEnumConstructor(IClassFileReader classFileReader, char[] className, IMethodInfo methodInfo, StringBuilder buffer, String lineSeparator, int tabNumber, int mode) {
 		writeNewLine(buffer, lineSeparator, tabNumber);
 		final ICodeAttribute codeAttribute = methodInfo.getCodeAttribute();
 		IMethodParametersAttribute methodParametersAttribute = (IMethodParametersAttribute) Util.getAttribute(methodInfo, IAttributeNamesConstants.METHOD_PARAMETERS);
@@ -674,7 +674,7 @@ public class Disassembler extends ClassFileBytesDisassembler {
 	/**
 	 * Disassemble a method info header
 	 */
-	private void disassemble(IClassFileReader classFileReader, char[] className, IMethodInfo methodInfo, StringBuffer buffer, String lineSeparator, int tabNumber, int mode) {
+	private void disassemble(IClassFileReader classFileReader, char[] className, IMethodInfo methodInfo, StringBuilder buffer, String lineSeparator, int tabNumber, int mode) {
 		writeNewLine(buffer, lineSeparator, tabNumber);
 		final ICodeAttribute codeAttribute = methodInfo.getCodeAttribute();
 		final char[] methodDescriptor = methodInfo.getDescriptor();
@@ -789,7 +789,7 @@ public class Disassembler extends ClassFileBytesDisassembler {
 			}
 			int insertionPosition = CharOperation.indexOf('(', methodHeader) + 1;
 			int start = 0;
-			StringBuffer stringBuffer = new StringBuffer();
+			StringBuilder stringBuffer = new StringBuilder();
 			stringBuffer.append(methodHeader, 0, insertionPosition);
 			for (int i = 0; i < length; i++) {
 				if (i > 0) {
@@ -977,7 +977,7 @@ public class Disassembler extends ClassFileBytesDisassembler {
 		final int accessFlags = classFileReader.getAccessFlags();
 		final boolean isEnum = (accessFlags & IModifierConstants.ACC_ENUM) != 0;
 
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		ISourceAttribute sourceAttribute = classFileReader.getSourceFileAttribute();
 		IClassFileAttribute classFileAttribute = Util.getAttribute(classFileReader, IAttributeNamesConstants.SIGNATURE);
 		ISignatureAttribute signatureAttribute = (ISignatureAttribute) classFileAttribute;
@@ -1269,7 +1269,7 @@ public class Disassembler extends ClassFileBytesDisassembler {
 		return buffer.toString();
 	}
 
-	private void disassembleModule(IModuleAttribute moduleAttribute, StringBuffer buffer, String lineSeparator, int tabNumber) {
+	private void disassembleModule(IModuleAttribute moduleAttribute, StringBuilder buffer, String lineSeparator, int tabNumber) {
 		writeNewLine(buffer, lineSeparator, tabNumber);
 		char[] moduleVersion = moduleAttribute.getModuleVersionValue();
 		if (moduleVersion == null) {
@@ -1317,11 +1317,11 @@ public class Disassembler extends ClassFileBytesDisassembler {
 			}
 		}
 	}
-	private void convertModuleNames(StringBuffer buffer, char[] name) {
+	private void convertModuleNames(StringBuilder buffer, char[] name) {
 		buffer.append(CharOperation.replaceOnCopy(CharOperation.replaceOnCopy(name, '$','.'), '/','.'));
 	}
 
-	private void disassembleModule(IModulePackagesAttribute modulePackagesAttribute, StringBuffer buffer, String lineSeparator, int tabNumber) {
+	private void disassembleModule(IModulePackagesAttribute modulePackagesAttribute, StringBuilder buffer, String lineSeparator, int tabNumber) {
 		if (modulePackagesAttribute == null) return;
 		writeNewLine(buffer, lineSeparator, tabNumber);
 		writeNewLine(buffer, lineSeparator, tabNumber);
@@ -1334,7 +1334,7 @@ public class Disassembler extends ClassFileBytesDisassembler {
 		writeNewLine(buffer, lineSeparator, 0);
 	}
 
-	private void disassembleModule(IModuleMainClassAttribute moduleMainClassAttribute, StringBuffer buffer, String lineSeparator, int tabNumber) {
+	private void disassembleModule(IModuleMainClassAttribute moduleMainClassAttribute, StringBuilder buffer, String lineSeparator, int tabNumber) {
 		if (moduleMainClassAttribute == null) return;
 		writeNewLine(buffer, lineSeparator, tabNumber);
 		buffer.append(Messages.disassembler_modulemainclassattributeheader);
@@ -1343,7 +1343,7 @@ public class Disassembler extends ClassFileBytesDisassembler {
 		writeNewLine(buffer, lineSeparator, 0);
 	}
 
-	private void disassemble(IProvidesInfo iProvidesInfo, StringBuffer buffer, String lineSeparator, int tabNumber) {
+	private void disassemble(IProvidesInfo iProvidesInfo, StringBuilder buffer, String lineSeparator, int tabNumber) {
 		buffer.append("provides"); //$NON-NLS-1$
 		buffer.append(Messages.disassembler_space);
 		convertModuleNames(buffer, iProvidesInfo.getServiceName());
@@ -1364,7 +1364,7 @@ public class Disassembler extends ClassFileBytesDisassembler {
 		buffer.append(';');
 	}
 
-	private void disassemble(INestHostAttribute nestHostAttribute, StringBuffer buffer, String lineSeparator, int tabNumber) {
+	private void disassemble(INestHostAttribute nestHostAttribute, StringBuilder buffer, String lineSeparator, int tabNumber) {
 		writeNewLine(buffer, lineSeparator, tabNumber);
 		writeNewLine(buffer, lineSeparator, tabNumber); // additional line
 		buffer.append(Messages.disassembler_nesthost);
@@ -1374,7 +1374,7 @@ public class Disassembler extends ClassFileBytesDisassembler {
 			.append(" ")//$NON-NLS-1$
 			.append(nestHostAttribute.getNestHostName());
 	}
-	private void disassemble(IRecordAttribute recordAttribute, StringBuffer buffer, String lineSeparator, int tabNumber, int mode) {
+	private void disassemble(IRecordAttribute recordAttribute, StringBuilder buffer, String lineSeparator, int tabNumber, int mode) {
 		writeNewLine(buffer, lineSeparator, tabNumber);
 		writeNewLine(buffer, lineSeparator, tabNumber); // additional line
 		buffer.append(Messages.disassembler_record);
@@ -1389,7 +1389,7 @@ public class Disassembler extends ClassFileBytesDisassembler {
 			disassemble(e, buffer, lineSeparator, tabNumber, mode);
 		}
 	}
-	private void disassemble(IComponentInfo componentInfo, StringBuffer buffer, String lineSeparator, int tabNumber, int mode) {
+	private void disassemble(IComponentInfo componentInfo, StringBuilder buffer, String lineSeparator, int tabNumber, int mode) {
 		writeNewLine(buffer, lineSeparator, tabNumber);
 		final char[] descriptor = componentInfo.getDescriptor();
 		final ISignatureAttribute signatureAttribute = (ISignatureAttribute) Util.getAttribute(componentInfo, IAttributeNamesConstants.SIGNATURE);
@@ -1463,7 +1463,7 @@ public class Disassembler extends ClassFileBytesDisassembler {
 		}
 	}
 
-	private void disassemble(INestMembersAttribute nestMembersAttribute, StringBuffer buffer, String lineSeparator, int tabNumber) {
+	private void disassemble(INestMembersAttribute nestMembersAttribute, StringBuilder buffer, String lineSeparator, int tabNumber) {
 		writeNewLine(buffer, lineSeparator, tabNumber);
 		writeNewLine(buffer, lineSeparator, tabNumber); // additional line
 		buffer.append(Messages.disassembler_nestmembers);
@@ -1489,7 +1489,7 @@ public class Disassembler extends ClassFileBytesDisassembler {
 			}
 		}
 	}
-	private void disassemble(IPermittedSubclassesAttribute permittedSubclassesAttribute, StringBuffer buffer, String lineSeparator, int tabNumber) {
+	private void disassemble(IPermittedSubclassesAttribute permittedSubclassesAttribute, StringBuilder buffer, String lineSeparator, int tabNumber) {
 		writeNewLine(buffer, lineSeparator, tabNumber);
 		writeNewLine(buffer, lineSeparator, tabNumber); // additional line
 		buffer.append(Messages.disassembler_permittedsubclasses);
@@ -1515,7 +1515,7 @@ public class Disassembler extends ClassFileBytesDisassembler {
 			}
 		}
 	}
-	private void disassemble(IPackageVisibilityInfo iPackageVisibilityInfo, StringBuffer buffer, String lineSeparator,
+	private void disassemble(IPackageVisibilityInfo iPackageVisibilityInfo, StringBuilder buffer, String lineSeparator,
 			int tabNumber, boolean isExports) {
 		buffer.append(isExports ? "exports" : "opens"); //$NON-NLS-1$ //$NON-NLS-2$
 		buffer.append(Messages.disassembler_space);
@@ -1537,14 +1537,14 @@ public class Disassembler extends ClassFileBytesDisassembler {
 		buffer.append(';');
 	}
 
-	private void disassemble(IRequiresInfo iRequiresInfo, StringBuffer buffer, String lineSeparator, int tabNumber) {
+	private void disassemble(IRequiresInfo iRequiresInfo, StringBuilder buffer, String lineSeparator, int tabNumber) {
 		buffer.append("requires "); //$NON-NLS-1$
 		decodeModifiersForModuleRequires(buffer, iRequiresInfo.getRequiresFlags());
 		buffer.append(iRequiresInfo.getRequiresModuleName());
 		buffer.append(';');
 	}
 
-	private void disassembleGenericSignature(int mode, StringBuffer buffer, final char[] signature) {
+	private void disassembleGenericSignature(int mode, StringBuilder buffer, final char[] signature) {
 		CharOperation.replace(signature, '/', '.');
 		final char[][] typeParameters = Signature.getTypeParameters(signature);
 		final int typeParametersLength = typeParameters.length;
@@ -1592,7 +1592,7 @@ public class Disassembler extends ClassFileBytesDisassembler {
 		// check the presence of the unspecified Varargs attribute
 		return Util.getAttribute(methodInfo, AttributeNamesConstants.VarargsName) != null;
 	}
-	private void disassemble(ICodeAttribute codeAttribute, char[][] parameterNames, char[] methodDescriptor, boolean isStatic, StringBuffer buffer, String lineSeparator, int tabNumber, int mode) {
+	private void disassemble(ICodeAttribute codeAttribute, char[][] parameterNames, char[] methodDescriptor, boolean isStatic, StringBuilder buffer, String lineSeparator, int tabNumber, int mode) {
 		writeNewLine(buffer, lineSeparator, tabNumber - 1);
 		DefaultBytecodeVisitor visitor = new DefaultBytecodeVisitor(codeAttribute, parameterNames, methodDescriptor, isStatic, buffer, lineSeparator, tabNumber, mode);
 		try {
@@ -1777,7 +1777,7 @@ public class Disassembler extends ClassFileBytesDisassembler {
 		}
 	}
 
-	private void disassemble(IStackMapTableAttribute attribute, StringBuffer buffer, String lineSeparator, int tabNumber, int mode) {
+	private void disassemble(IStackMapTableAttribute attribute, StringBuilder buffer, String lineSeparator, int tabNumber, int mode) {
 		writeNewLine(buffer, lineSeparator, tabNumber + 3);
 		int numberOfEntries = attribute.getNumberOfEntries();
 		final IStackMapFrame[] stackMapFrames = attribute.getStackMapFrame();
@@ -1865,7 +1865,7 @@ public class Disassembler extends ClassFileBytesDisassembler {
 		}
 	}
 
-	private void disassemble(IStackMapAttribute attribute, StringBuffer buffer, String lineSeparator, int tabNumber, int mode) {
+	private void disassemble(IStackMapAttribute attribute, StringBuilder buffer, String lineSeparator, int tabNumber, int mode) {
 		writeNewLine(buffer, lineSeparator, tabNumber + 3);
 		int numberOfEntries = attribute.getNumberOfEntries();
 		final IStackMapFrame[] stackMapFrames = attribute.getStackMapFrame();
@@ -1980,7 +1980,7 @@ public class Disassembler extends ClassFileBytesDisassembler {
 				new String(constantPoolEntry.getMethodDescriptor())};
 	}
 
-	private void disassemble(IConstantPool constantPool, StringBuffer buffer, String lineSeparator, int tabNumber) {
+	private void disassemble(IConstantPool constantPool, StringBuilder buffer, String lineSeparator, int tabNumber) {
 		writeNewLine(buffer, lineSeparator, tabNumber);
 		int length = constantPool.getConstantPoolCount();
 		buffer.append(Messages.disassembler_constantpoolheader);
@@ -2173,7 +2173,7 @@ public class Disassembler extends ClassFileBytesDisassembler {
 		return Messages.bind(message, new String[] { Integer.toString(referenceKind) });
 	}
 
-	private void disassemble(IEnclosingMethodAttribute enclosingMethodAttribute, StringBuffer buffer, String lineSeparator, int tabNumber) {
+	private void disassemble(IEnclosingMethodAttribute enclosingMethodAttribute, StringBuilder buffer, String lineSeparator, int tabNumber) {
 		writeNewLine(buffer, lineSeparator, tabNumber + 1);
 		buffer.append(Messages.disassembler_enclosingmethodheader);
 		buffer
@@ -2192,7 +2192,7 @@ public class Disassembler extends ClassFileBytesDisassembler {
 		}
 	}
 
-	private void disassembleEnumConstants(IFieldInfo fieldInfo, StringBuffer buffer, String lineSeparator, int tabNumber, char[][] argumentTypes, int mode) {
+	private void disassembleEnumConstants(IFieldInfo fieldInfo, StringBuilder buffer, String lineSeparator, int tabNumber, char[][] argumentTypes, int mode) {
 		writeNewLine(buffer, lineSeparator, tabNumber);
 		final IClassFileAttribute runtimeVisibleAnnotationsAttribute = Util.getAttribute(fieldInfo, IAttributeNamesConstants.RUNTIME_VISIBLE_ANNOTATIONS);
 		final IClassFileAttribute runtimeInvisibleAnnotationsAttribute = Util.getAttribute(fieldInfo, IAttributeNamesConstants.RUNTIME_INVISIBLE_ANNOTATIONS);
@@ -2245,7 +2245,7 @@ public class Disassembler extends ClassFileBytesDisassembler {
 	/**
 	 * Disassemble a field info
 	 */
-	private void disassemble(IFieldInfo fieldInfo, StringBuffer buffer, String lineSeparator, int tabNumber, int mode) {
+	private void disassemble(IFieldInfo fieldInfo, StringBuilder buffer, String lineSeparator, int tabNumber, int mode) {
 		writeNewLine(buffer, lineSeparator, tabNumber);
 		final char[] fieldDescriptor = fieldInfo.getDescriptor();
 		final ISignatureAttribute signatureAttribute = (ISignatureAttribute) Util.getAttribute(fieldInfo, IAttributeNamesConstants.SIGNATURE);
@@ -2377,7 +2377,7 @@ public class Disassembler extends ClassFileBytesDisassembler {
 		}
 	}
 
-	private void disassemble(IInnerClassesAttribute innerClassesAttribute, StringBuffer buffer, String lineSeparator, int tabNumber) {
+	private void disassemble(IInnerClassesAttribute innerClassesAttribute, StringBuilder buffer, String lineSeparator, int tabNumber) {
 		writeNewLine(buffer, lineSeparator, tabNumber);
 		buffer.append(Messages.disassembler_innerattributesheader);
 		writeNewLine(buffer, lineSeparator, tabNumber + 1);
@@ -2440,7 +2440,7 @@ public class Disassembler extends ClassFileBytesDisassembler {
 		}
 	}
 
-	private void disassemble(IBootstrapMethodsAttribute bootstrapMethodsAttribute, StringBuffer buffer, String lineSeparator, int tabNumber, IConstantPool constantPool) {
+	private void disassemble(IBootstrapMethodsAttribute bootstrapMethodsAttribute, StringBuilder buffer, String lineSeparator, int tabNumber, IConstantPool constantPool) {
 		writeNewLine(buffer, lineSeparator, tabNumber);
 		buffer.append(Messages.disassembler_bootstrapmethodattributesheader);
 		writeNewLine(buffer, lineSeparator, tabNumber + 1);
@@ -2467,7 +2467,7 @@ public class Disassembler extends ClassFileBytesDisassembler {
 	}
 
 	private String getArguments(int[] arguments, String[] argumentsName) {
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		for (int i = 0, max = arguments.length; i < max; i++) {
 			buffer.append(
 				Messages.bind(
@@ -2481,7 +2481,7 @@ public class Disassembler extends ClassFileBytesDisassembler {
 		}
 		return String.valueOf(buffer);
 	}
-	private void disassemble(int index, IParameterAnnotation parameterAnnotation, StringBuffer buffer, String lineSeparator, int tabNumber, int mode) {
+	private void disassemble(int index, IParameterAnnotation parameterAnnotation, StringBuilder buffer, String lineSeparator, int tabNumber, int mode) {
 		IAnnotation[] annotations = parameterAnnotation.getAnnotations();
 		writeNewLine(buffer, lineSeparator, tabNumber + 1);
 		buffer.append(
@@ -2491,7 +2491,7 @@ public class Disassembler extends ClassFileBytesDisassembler {
 		}
 	}
 
-	private void disassemble(IRuntimeInvisibleAnnotationsAttribute runtimeInvisibleAnnotationsAttribute, StringBuffer buffer, String lineSeparator, int tabNumber, int mode) {
+	private void disassemble(IRuntimeInvisibleAnnotationsAttribute runtimeInvisibleAnnotationsAttribute, StringBuilder buffer, String lineSeparator, int tabNumber, int mode) {
 		writeNewLine(buffer, lineSeparator, tabNumber + 1);
 		buffer.append(Messages.disassembler_runtimeinvisibleannotationsattributeheader);
 		IAnnotation[] annotations = runtimeInvisibleAnnotationsAttribute.getAnnotations();
@@ -2500,7 +2500,7 @@ public class Disassembler extends ClassFileBytesDisassembler {
 		}
 	}
 
-	private void disassemble(IRuntimeInvisibleParameterAnnotationsAttribute runtimeInvisibleParameterAnnotationsAttribute, StringBuffer buffer, String lineSeparator, int tabNumber, int mode) {
+	private void disassemble(IRuntimeInvisibleParameterAnnotationsAttribute runtimeInvisibleParameterAnnotationsAttribute, StringBuilder buffer, String lineSeparator, int tabNumber, int mode) {
 		writeNewLine(buffer, lineSeparator, tabNumber + 1);
 		buffer.append(Messages.disassembler_runtimeinvisibleparameterannotationsattributeheader);
 		IParameterAnnotation[] parameterAnnotations = runtimeInvisibleParameterAnnotationsAttribute.getParameterAnnotations();
@@ -2509,7 +2509,7 @@ public class Disassembler extends ClassFileBytesDisassembler {
 		}
 	}
 
-	private void disassemble(IRuntimeInvisibleTypeAnnotationsAttribute runtimeInvisibleTypeAnnotationsAttribute, StringBuffer buffer, String lineSeparator, int tabNumber, int mode) {
+	private void disassemble(IRuntimeInvisibleTypeAnnotationsAttribute runtimeInvisibleTypeAnnotationsAttribute, StringBuilder buffer, String lineSeparator, int tabNumber, int mode) {
 		writeNewLine(buffer, lineSeparator, tabNumber + 1);
 		buffer.append(Messages.disassembler_runtimeinvisibletypeannotationsattributeheader);
 		IExtendedAnnotation[] extendedAnnotations = runtimeInvisibleTypeAnnotationsAttribute.getExtendedAnnotations();
@@ -2518,7 +2518,7 @@ public class Disassembler extends ClassFileBytesDisassembler {
 		}
 	}
 
-	private void disassemble(IRuntimeVisibleAnnotationsAttribute runtimeVisibleAnnotationsAttribute, StringBuffer buffer, String lineSeparator, int tabNumber, int mode) {
+	private void disassemble(IRuntimeVisibleAnnotationsAttribute runtimeVisibleAnnotationsAttribute, StringBuilder buffer, String lineSeparator, int tabNumber, int mode) {
 		writeNewLine(buffer, lineSeparator, tabNumber + 1);
 		buffer.append(Messages.disassembler_runtimevisibleannotationsattributeheader);
 		IAnnotation[] annotations = runtimeVisibleAnnotationsAttribute.getAnnotations();
@@ -2527,7 +2527,7 @@ public class Disassembler extends ClassFileBytesDisassembler {
 		}
 	}
 
-	private void disassemble(IRuntimeVisibleParameterAnnotationsAttribute runtimeVisibleParameterAnnotationsAttribute, StringBuffer buffer, String lineSeparator, int tabNumber, int mode) {
+	private void disassemble(IRuntimeVisibleParameterAnnotationsAttribute runtimeVisibleParameterAnnotationsAttribute, StringBuilder buffer, String lineSeparator, int tabNumber, int mode) {
 		writeNewLine(buffer, lineSeparator, tabNumber + 1);
 		buffer.append(Messages.disassembler_runtimevisibleparameterannotationsattributeheader);
 		IParameterAnnotation[] parameterAnnotations = runtimeVisibleParameterAnnotationsAttribute.getParameterAnnotations();
@@ -2536,7 +2536,7 @@ public class Disassembler extends ClassFileBytesDisassembler {
 		}
 	}
 
-	private void disassemble(IRuntimeVisibleTypeAnnotationsAttribute runtimeVisibleTypeAnnotationsAttribute, StringBuffer buffer, String lineSeparator, int tabNumber, int mode) {
+	private void disassemble(IRuntimeVisibleTypeAnnotationsAttribute runtimeVisibleTypeAnnotationsAttribute, StringBuilder buffer, String lineSeparator, int tabNumber, int mode) {
 		writeNewLine(buffer, lineSeparator, tabNumber + 1);
 		buffer.append(Messages.disassembler_runtimevisibletypeannotationsattributeheader);
 		IExtendedAnnotation[] extendedAnnotations = runtimeVisibleTypeAnnotationsAttribute.getExtendedAnnotations();
@@ -2546,7 +2546,7 @@ public class Disassembler extends ClassFileBytesDisassembler {
  	}
 
 	private String disassemble(IVerificationTypeInfo[] infos, int mode) {
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append('{');
 		for (int i = 0, max = infos.length; i < max; i++) {
 			if(i != 0) {
@@ -2594,7 +2594,7 @@ public class Disassembler extends ClassFileBytesDisassembler {
 		return String.valueOf(buffer);
 	}
 
-	private void disassembleAsModifier(IAnnotation annotation, StringBuffer buffer, String lineSeparator, int tabNumber, int mode) {
+	private void disassembleAsModifier(IAnnotation annotation, StringBuilder buffer, String lineSeparator, int tabNumber, int mode) {
 		final char[] typeName = CharOperation.replaceOnCopy(annotation.getTypeName(), '/', '.');
 		buffer.append('@').append(returnClassName(Signature.toCharArray(typeName), '.', mode));
 		final IAnnotationComponent[] components = annotation.getComponents();
@@ -2612,12 +2612,12 @@ public class Disassembler extends ClassFileBytesDisassembler {
 		}
 	}
 
-	private void disassembleAsModifier(IAnnotationComponent annotationComponent, StringBuffer buffer, String lineSeparator, int tabNumber, int mode) {
+	private void disassembleAsModifier(IAnnotationComponent annotationComponent, StringBuilder buffer, String lineSeparator, int tabNumber, int mode) {
 		buffer.append(annotationComponent.getComponentName()).append('=');
 		disassembleAsModifier(annotationComponent.getComponentValue(), buffer, lineSeparator, tabNumber + 1, mode);
 	}
 
-	private void disassembleAsModifier(IAnnotationComponentValue annotationComponentValue, StringBuffer buffer, String lineSeparator, int tabNumber, int mode) {
+	private void disassembleAsModifier(IAnnotationComponentValue annotationComponentValue, StringBuilder buffer, String lineSeparator, int tabNumber, int mode) {
 		switch(annotationComponentValue.getTag()) {
 			case IAnnotationComponentValue.BYTE_TAG:
 			case IAnnotationComponentValue.CHAR_TAG:
@@ -2641,7 +2641,7 @@ public class Disassembler extends ClassFileBytesDisassembler {
 						value = Double.toString(constantPoolEntry.getDoubleValue());
 						break;
 					case IConstantPoolConstant.CONSTANT_Integer:
-						StringBuffer temp = new StringBuffer();
+						StringBuilder temp = new StringBuilder();
 						switch(annotationComponentValue.getTag()) {
 							case IAnnotationComponentValue.CHAR_TAG :
 								temp.append('\'');
@@ -2694,25 +2694,25 @@ public class Disassembler extends ClassFileBytesDisassembler {
 		}
 	}
 
-	private void disassembleAsModifier(IAnnotationDefaultAttribute annotationDefaultAttribute, StringBuffer buffer, String lineSeparator, int tabNumber, int mode) {
+	private void disassembleAsModifier(IAnnotationDefaultAttribute annotationDefaultAttribute, StringBuilder buffer, String lineSeparator, int tabNumber, int mode) {
 		IAnnotationComponentValue componentValue = annotationDefaultAttribute.getMemberValue();
 		disassembleAsModifier(componentValue, buffer, lineSeparator, tabNumber + 1, mode);
 	}
 
-	private void disassembleAsModifier(IRuntimeInvisibleAnnotationsAttribute runtimeInvisibleAnnotationsAttribute, StringBuffer buffer, String lineSeparator, int tabNumber, int mode) {
+	private void disassembleAsModifier(IRuntimeInvisibleAnnotationsAttribute runtimeInvisibleAnnotationsAttribute, StringBuilder buffer, String lineSeparator, int tabNumber, int mode) {
 		IAnnotation[] annotations = runtimeInvisibleAnnotationsAttribute.getAnnotations();
 		for (int i = 0, max = annotations.length; i < max; i++) {
 			disassembleAsModifier(annotations[i], buffer, lineSeparator, tabNumber + 1, mode);
 		}
 	}
 
-	private void disassembleAsModifier(IParameterAnnotation[] parameterAnnotations, StringBuffer buffer, int index, String lineSeparator, int tabNumber, int mode) {
+	private void disassembleAsModifier(IParameterAnnotation[] parameterAnnotations, StringBuilder buffer, int index, String lineSeparator, int tabNumber, int mode) {
 		if (parameterAnnotations.length > index) {
 			disassembleAsModifier(parameterAnnotations[index], buffer, lineSeparator, tabNumber + 1, mode);
 		}
 	}
 
-	private void disassembleAsModifier(IParameterAnnotation parameterAnnotation, StringBuffer buffer, String lineSeparator, int tabNumber, int mode) {
+	private void disassembleAsModifier(IParameterAnnotation parameterAnnotation, StringBuilder buffer, String lineSeparator, int tabNumber, int mode) {
 		if (parameterAnnotation == null) return;
 		IAnnotation[] annotations = parameterAnnotation.getAnnotations();
 		for (int i = 0, max = annotations.length; i < max; i++) {
@@ -2723,7 +2723,7 @@ public class Disassembler extends ClassFileBytesDisassembler {
 		}
 	}
 
-	private void disassembleAsModifier(IRuntimeVisibleAnnotationsAttribute runtimeVisibleAnnotationsAttribute, StringBuffer buffer, String lineSeparator, int tabNumber, int mode) {
+	private void disassembleAsModifier(IRuntimeVisibleAnnotationsAttribute runtimeVisibleAnnotationsAttribute, StringBuilder buffer, String lineSeparator, int tabNumber, int mode) {
 		IAnnotation[] annotations = runtimeVisibleAnnotationsAttribute.getAnnotations();
 		for (int i = 0, max = annotations.length; i < max; i++) {
 			if (i > 0) {
@@ -2733,7 +2733,7 @@ public class Disassembler extends ClassFileBytesDisassembler {
 		}
 	}
 
-	private void disassembleTypeMembers(IClassFileReader classFileReader, char[] className, StringBuffer buffer, String lineSeparator, int tabNumber, int mode, boolean isEnum) {
+	private void disassembleTypeMembers(IClassFileReader classFileReader, char[] className, StringBuilder buffer, String lineSeparator, int tabNumber, int mode, boolean isEnum) {
 		IFieldInfo[] fields = classFileReader.getFieldInfos();
 		if (isEnum && checkMode(mode, WORKING_COPY)) {
 			int index = 0;
@@ -2821,14 +2821,14 @@ public class Disassembler extends ClassFileBytesDisassembler {
 		return null;
 	}
 
-	private final void dumpTab(int tabNumber, StringBuffer buffer) {
+	private final void dumpTab(int tabNumber, StringBuilder buffer) {
 		for (int i = 0; i < tabNumber; i++) {
 			buffer.append(Messages.disassembler_indentation);
 		}
 	}
 
 	private final String dumpNewLineWithTabs(String lineSeparator, int tabNumber) {
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		writeNewLine(buffer, lineSeparator, tabNumber);
 		return String.valueOf(buffer);
 	}
@@ -2972,13 +2972,13 @@ public class Disassembler extends ClassFileBytesDisassembler {
 		return classInfoName;
 	}
 
-	private void writeNewLine(StringBuffer buffer, String lineSeparator, int tabNumber) {
+	private void writeNewLine(StringBuilder buffer, String lineSeparator, int tabNumber) {
 		buffer.append(lineSeparator);
 		dumpTab(tabNumber, buffer);
 	}
 
 	private String toTypePathString(int[][] typepath) {
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		buffer.append('[');
 		for (int i = 0, max = typepath.length; i < max; i++) {
 			int[] typepathElement = typepath[i];

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/KeyToSignature.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/KeyToSignature.java
@@ -34,7 +34,7 @@ public class KeyToSignature extends BindingKeyParser {
 	public static final int DECLARING_TYPE = 2;
 	public static final int THROWN_EXCEPTIONS = 3;
 
-	public StringBuffer signature = new StringBuffer();
+	public StringBuilder signature = new StringBuilder();
 	private final int kind;
 	private boolean asBinarySignature = false; // '.' vs. '/' and '$'
 	private ArrayList arguments = new ArrayList();
@@ -88,7 +88,7 @@ public class KeyToSignature extends BindingKeyParser {
 
 	@Override
 	public void consumeLocalType(char[] uniqueKey) {
-		this.signature = new StringBuffer();
+		this.signature = new StringBuilder();
 		// remove trailing semi-colon as it is added later in comsumeType()
 		uniqueKey = CharOperation.subarray(uniqueKey, 0, uniqueKey.length-1);
 		if (!this.asBinarySignature)
@@ -104,7 +104,7 @@ public class KeyToSignature extends BindingKeyParser {
 			CharOperation.replace(methodSignature, '/', '.');
 		switch(this.kind) {
 			case SIGNATURE:
-				this.signature = new StringBuffer();
+				this.signature = new StringBuilder();
 				this.signature.append(methodSignature);
 				break;
 			case THROWN_EXCEPTIONS:
@@ -141,7 +141,7 @@ public class KeyToSignature extends BindingKeyParser {
 			char[][] typeParameterSigs = Signature.getTypeParameters(methodSignature);
 			if (typeParameterSigs.length != typeParametersSize)
 				return;
-			this.signature = new StringBuffer();
+			this.signature = new StringBuilder();
 
 			// type parameters
 			for (int i = 0; i < typeParametersSize; i++)
@@ -319,7 +319,7 @@ public class KeyToSignature extends BindingKeyParser {
 
 	@Override
 	public void consumeTypeVariable(char[] position, char[] typeVariableName) {
-		this.signature = new StringBuffer();
+		this.signature = new StringBuilder();
 		this.signature.append('T');
 		this.signature.append(typeVariableName);
 		this.signature.append(';');
@@ -337,7 +337,7 @@ public class KeyToSignature extends BindingKeyParser {
 	@Override
 	public void consumeWildCard(int wildCardKind) {
 		// don't put generic type in signature
-		this.signature = new StringBuffer();
+		this.signature = new StringBuilder();
 		switch (wildCardKind) {
 			case Wildcard.UNBOUND:
 				this.signature.append('*');

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/MementoTokenizer.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/MementoTokenizer.java
@@ -52,12 +52,12 @@ public class MementoTokenizer {
 	}
 
 	public static String escape( String mementoName) {
-		StringBuffer sb = new StringBuffer();
+		StringBuilder sb = new StringBuilder();
 		escape(sb,mementoName);
 		return sb.toString();
 	}
 
-	public static void escape(StringBuffer buffer, String mementoName) {
+	public static void escape(StringBuilder buffer, String mementoName) {
 		for (int i = 0, length = mementoName.length(); i < length; i++) {
 			char character = mementoName.charAt(i);
 			switch (character) {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/SimpleDocument.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/SimpleDocument.java
@@ -27,11 +27,11 @@ import org.eclipse.jface.text.Position;
  */
 public class SimpleDocument implements IDocument {
 
-	private final StringBuffer buffer;
+	private final StringBuilder buffer;
 
 
 	public SimpleDocument(String source) {
-		this.buffer = new StringBuffer(source);
+		this.buffer = new StringBuilder(source);
 	}
 
 	@Override

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/Util.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/Util.java
@@ -1046,7 +1046,7 @@ public class Util {
 	 * Put all the arguments in one String.
 	 */
 	public static String getProblemArgumentsForMarker(String[] arguments){
-		StringBuffer args = new StringBuffer(10);
+		StringBuilder args = new StringBuilder(10);
 
 		args.append(arguments.length);
 		args.append(':');
@@ -1074,7 +1074,7 @@ public class Util {
 	 * @param argument the given argument
 	 * @param buffer the buffer in which the encoded argument is stored
 	 */
-	private static void encodeArgument(String argument, StringBuffer buffer) {
+	private static void encodeArgument(String argument, StringBuilder buffer) {
 		for (int i = 0, max = argument.length(); i < max; i++) {
 			char charAt = argument.charAt(i);
 			switch(charAt) {
@@ -1120,7 +1120,7 @@ public class Util {
 		}
 		String[] result = new String[length];
 		int count = 0;
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		for (int i = 0, max = argumentsString.length(); i < max; i++) {
 			char current = argumentsString.charAt(i);
 			switch(current) {
@@ -1230,7 +1230,7 @@ public class Util {
 	 * Returns the signature of the given type.
 	 */
 	public static String getSignature(Type type) {
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder buffer = new StringBuilder();
 		getFullyQualifiedName(type, buffer);
 		return Signature.createTypeSignature(buffer.toString(), false/*not resolved in source*/);
 	}
@@ -1293,7 +1293,7 @@ public class Util {
 	/*
 	 * Appends to the given buffer the fully qualified name (as it appears in the source) of the given type
 	 */
-	private static void getFullyQualifiedName(Type type, StringBuffer buffer) {
+	private static void getFullyQualifiedName(Type type, StringBuilder buffer) {
 		switch (type.getNodeType()) {
 			case ASTNode.ARRAY_TYPE:
 				ArrayType arrayType = (ArrayType) type;
@@ -2500,7 +2500,7 @@ public class Util {
 		int length = signature.length;
 		if (length <= 1)
 			return signature;
-		StringBuffer buffer = new StringBuffer(length);
+		StringBuilder buffer = new StringBuilder(length);
 		toUnresolvedTypeSignature(signature, 0, length, buffer);
 		int bufferLength = buffer.length();
 		char[] result = new char[bufferLength];
@@ -2508,7 +2508,7 @@ public class Util {
 		return result;
 	}
 
-	private static int toUnresolvedTypeSignature(char[] signature, int start, int length, StringBuffer buffer) {
+	private static int toUnresolvedTypeSignature(char[] signature, int start, int length, StringBuilder buffer) {
 		if (signature[start] == Signature.C_RESOLVED)
 			buffer.append(Signature.C_UNRESOLVED);
 		else
@@ -2534,7 +2534,7 @@ public class Util {
 		}
 		return length;
 	}
-	private static void appendArrayTypeSignature(char[] string, int start, StringBuffer buffer, boolean compact) {
+	private static void appendArrayTypeSignature(char[] string, int start, StringBuilder buffer, boolean compact) {
 		int length = string.length;
 		// need a minimum 2 char
 		if (start >= length - 1) {
@@ -2561,7 +2561,7 @@ public class Util {
 			buffer.append('[').append(']');
 		}
 	}
-	private static void appendClassTypeSignature(char[] string, int start, StringBuffer buffer, boolean compact) {
+	private static void appendClassTypeSignature(char[] string, int start, StringBuilder buffer, boolean compact) {
 		char c = string[start];
 		if (c != Signature.C_RESOLVED) {
 			return;
@@ -2598,7 +2598,7 @@ public class Util {
 			p++;
 		}
 	}
-	static void appendTypeSignature(char[] string, int start, StringBuffer buffer, boolean compact) {
+	static void appendTypeSignature(char[] string, int start, StringBuilder buffer, boolean compact) {
 		char c = string[start];
 		switch (c) {
 			case Signature.C_ARRAY :
@@ -2647,7 +2647,7 @@ public class Util {
 			return ""; //$NON-NLS-1$
 		}
 
-		StringBuffer buffer = new StringBuffer(methodSignature.length + 10);
+		StringBuilder buffer = new StringBuilder(methodSignature.length + 10);
 
 		// decode declaring class name
 		// it can be either an array signature or a type signature
@@ -3035,7 +3035,7 @@ public class Util {
 			throw new IllegalArgumentException(String.valueOf(methodSignature));
 		}
 
-		StringBuffer buffer = new StringBuffer(methodSignature.length + 10);
+		StringBuilder buffer = new StringBuilder(methodSignature.length + 10);
 
 		// selector
 		if (methodName != null) {
@@ -3062,7 +3062,7 @@ public class Util {
 		return result;
 	}
 
-	private static int appendTypeSignatureForAnchor(char[] string, int start, StringBuffer buffer, boolean isVarArgs) {
+	private static int appendTypeSignatureForAnchor(char[] string, int start, StringBuilder buffer, boolean isVarArgs) {
 		// need a minimum 1 char
 		if (start >= string.length) {
 			throw newIllegalArgumentException(string, start);
@@ -3140,7 +3140,7 @@ public class Util {
 		}
 	}
 
-	private static int appendTypeArgumentSignatureForAnchor(char[] string, int start, StringBuffer buffer) {
+	private static int appendTypeArgumentSignatureForAnchor(char[] string, int start, StringBuilder buffer) {
 		// need a minimum 1 char
 		if (start >= string.length) {
 			throw newIllegalArgumentException(string, start);
@@ -3157,7 +3157,7 @@ public class Util {
 				return appendTypeSignatureForAnchor(string, start, buffer, false);
 		}
 	}
-	private static int appendCaptureTypeSignatureForAnchor(char[] string, int start, StringBuffer buffer) {
+	private static int appendCaptureTypeSignatureForAnchor(char[] string, int start, StringBuilder buffer) {
 		// need a minimum 2 char
 		if (start >= string.length - 1) {
 			throw newIllegalArgumentException(string, start);
@@ -3168,7 +3168,7 @@ public class Util {
 		}
 		return appendTypeArgumentSignatureForAnchor(string, start + 1, buffer);
 	}
-	private static int appendArrayTypeSignatureForAnchor(char[] string, int start, StringBuffer buffer, boolean isVarArgs) {
+	private static int appendArrayTypeSignatureForAnchor(char[] string, int start, StringBuilder buffer, boolean isVarArgs) {
 		int length = string.length;
 		// need a minimum 2 char
 		if (start >= length - 1) {
@@ -3202,7 +3202,7 @@ public class Util {
 		}
 		return e;
 	}
-	private static int appendClassTypeSignatureForAnchor(char[] string, int start, StringBuffer buffer) {
+	private static int appendClassTypeSignatureForAnchor(char[] string, int start, StringBuilder buffer) {
 		// need a minimum 3 chars "Lx;"
 		if (start >= string.length - 2) {
 			throw newIllegalArgumentException(string, start);

--- a/org.eclipse.jdt.core/pom.xml
+++ b/org.eclipse.jdt.core/pom.xml
@@ -17,7 +17,7 @@
     <version>4.31.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.eclipse.jdt.core</artifactId>
-  <version>3.36.0-SNAPSHOT</version>
+  <version>3.36.100-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/ConstructorPattern.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/ConstructorPattern.java
@@ -562,7 +562,7 @@ public EntryResult[] queryIn(Index index) throws IOException {
 	return index.query(getIndexCategories(), key, matchRule); // match rule is irrelevant when the key is null
 }
 @Override
-protected StringBuffer print(StringBuffer output) {
+protected StringBuilder print(StringBuilder output) {
 	if (this.findDeclarations) {
 		output.append(this.findReferences
 			? "ConstructorCombinedPattern: " //$NON-NLS-1$

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/FieldPattern.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/FieldPattern.java
@@ -107,7 +107,7 @@ protected boolean mustResolve() {
 	return super.mustResolve();
 }
 @Override
-protected StringBuffer print(StringBuffer output) {
+protected StringBuilder print(StringBuilder output) {
 	if (this.findDeclarations) {
 		output.append(this.findReferences
 			? "FieldCombinedPattern: " //$NON-NLS-1$

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/JavaSearchPattern.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/JavaSearchPattern.java
@@ -333,7 +333,7 @@ public class JavaSearchPattern extends SearchPattern implements IIndexConstants,
 		return true;
 	}
 
-	protected StringBuffer print(StringBuffer output) {
+	protected StringBuilder print(StringBuilder output) {
 		output.append(", "); //$NON-NLS-1$
 		if (hasTypeArguments() && hasSignatures()) {
 			output.append("signature:\""); //$NON-NLS-1$
@@ -448,7 +448,7 @@ public class JavaSearchPattern extends SearchPattern implements IIndexConstants,
 	}
 	@Override
 	public final String toString() {
-		return print(new StringBuffer(30)).toString();
+		return print(new StringBuilder(30)).toString();
 	}
 
 	@Override

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/LocalVariablePattern.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/LocalVariablePattern.java
@@ -78,7 +78,7 @@ public void findIndexMatches(Index index, IndexQueryRequestor requestor, SearchP
 }
 
 @Override
-protected StringBuffer print(StringBuffer output) {
+protected StringBuilder print(StringBuilder output) {
 	if (this.findDeclarations) {
 		output.append(this.findReferences
 			? "LocalVarCombinedPattern: " //$NON-NLS-1$

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/MatchingNodeSet.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/MatchingNodeSet.java
@@ -179,7 +179,7 @@ public Object removeTrustedMatch(ASTNode node) {
 @Override
 public String toString() {
 	// TODO (jerome) should show both tables
-	StringBuffer result = new StringBuffer();
+	StringBuilder result = new StringBuilder();
 	result.append("Exact matches:"); //$NON-NLS-1$
 	Object[] keyTable = this.matchingNodes.keyTable;
 	Object[] valueTable = this.matchingNodes.valueTable;

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/MethodPattern.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/MethodPattern.java
@@ -363,7 +363,7 @@ public EntryResult[] queryIn(Index index) throws IOException {
 	return index.query(getIndexCategories(), key, matchRule); // match rule is irrelevant when the key is null
 }
 @Override
-protected StringBuffer print(StringBuffer output) {
+protected StringBuilder print(StringBuilder output) {
 	if (this.findDeclarations) {
 		output.append(this.findReferences
 			? "MethodCombinedPattern: " //$NON-NLS-1$

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/ModulePattern.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/ModulePattern.java
@@ -131,7 +131,7 @@ public class ModulePattern extends JavaSearchPattern {
 		return true;
 	}
 	@Override
-	protected StringBuffer print(StringBuffer output) {
+	protected StringBuilder print(StringBuilder output) {
 		if (this.findDeclarations) {
 			output.append(this.findReferences
 				? "ModuleCombinedPattern: " //$NON-NLS-1$

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/MultiTypeDeclarationPattern.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/MultiTypeDeclarationPattern.java
@@ -168,7 +168,7 @@ public EntryResult[] queryIn(Index index) throws IOException {
 	return allEntries;
 }
 @Override
-protected StringBuffer print(StringBuffer output) {
+protected StringBuilder print(StringBuilder output) {
 	switch (this.typeSuffix){
 		case CLASS_SUFFIX :
 			output.append("MultiClassDeclarationPattern: "); //$NON-NLS-1$

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/PackageDeclarationPattern.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/PackageDeclarationPattern.java
@@ -29,7 +29,7 @@ public EntryResult[] queryIn(Index index) {
 	return null;
 }
 @Override
-protected StringBuffer print(StringBuffer output) {
+protected StringBuilder print(StringBuilder output) {
 	output.append("PackageDeclarationPattern: <"); //$NON-NLS-1$
 	if (this.pkgName != null)
 		output.append(this.pkgName);

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/PackageReferencePattern.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/PackageReferencePattern.java
@@ -77,7 +77,7 @@ protected void resetQuery() {
 	this.currentSegment = this.segments.length - 1;
 }
 @Override
-protected StringBuffer print(StringBuffer output) {
+protected StringBuilder print(StringBuilder output) {
 	output.append("PackageReferencePattern: <"); //$NON-NLS-1$
 	if (this.pkgName != null)
 		output.append(this.pkgName);

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/QualifiedTypeDeclarationPattern.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/QualifiedTypeDeclarationPattern.java
@@ -103,7 +103,7 @@ public boolean matchesDecodedKey(SearchPattern decodedPattern) {
 		(this.qualification == null || this.packagePattern == null || this.packagePattern.matchesName(this.qualification, pattern.qualification));
 }
 @Override
-protected StringBuffer print(StringBuffer output) {
+protected StringBuilder print(StringBuilder output) {
 	switch (this.typeSuffix){
 		case CLASS_SUFFIX :
 			output.append("ClassDeclarationPattern: qualification<"); //$NON-NLS-1$

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/SecondaryTypeDeclarationPattern.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/SecondaryTypeDeclarationPattern.java
@@ -37,7 +37,7 @@ public SearchPattern getBlankPattern() {
 	return new SecondaryTypeDeclarationPattern(R_EXACT_MATCH | R_CASE_SENSITIVE);
 }
 @Override
-protected StringBuffer print(StringBuffer output) {
+protected StringBuilder print(StringBuilder output) {
 	output.append("Secondary"); //$NON-NLS-1$
 	return super.print(output);
 }

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/SuperTypeReferencePattern.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/SuperTypeReferencePattern.java
@@ -280,7 +280,7 @@ public EntryResult[] queryIn(Index index) throws IOException {
 	return index.query(getIndexCategories(), key, matchRule); // match rule is irrelevant when the key is null
 }
 @Override
-protected StringBuffer print(StringBuffer output) {
+protected StringBuilder print(StringBuilder output) {
 	switch (this.superRefKind) {
 		case ALL_SUPER_TYPES:
 			output.append("SuperTypeReferencePattern: <"); //$NON-NLS-1$

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/TypeDeclarationPattern.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/TypeDeclarationPattern.java
@@ -353,7 +353,7 @@ public EntryResult[] queryIn(Index index) throws IOException {
 	return index.query(getIndexCategories(), key, matchRule); // match rule is irrelevant when the key is null
 }
 @Override
-protected StringBuffer print(StringBuffer output) {
+protected StringBuilder print(StringBuilder output) {
 	switch (this.typeSuffix){
 		case CLASS_SUFFIX :
 			output.append("ClassDeclarationPattern: pkg<"); //$NON-NLS-1$

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/TypeParameterPattern.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/TypeParameterPattern.java
@@ -118,7 +118,7 @@ public class TypeParameterPattern extends JavaSearchPattern {
 	}
 
 	@Override
-	protected StringBuffer print(StringBuffer output) {
+	protected StringBuilder print(StringBuilder output) {
 		if (this.findDeclarations) {
 			output.append(this.findReferences
 				? "TypeParamCombinedPattern: " //$NON-NLS-1$

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/TypeReferencePattern.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/TypeReferencePattern.java
@@ -155,7 +155,7 @@ public class TypeReferencePattern extends IntersectingPattern {
 			this.currentSegment = this.segments.length - 1;
 	}
 	@Override
-	protected StringBuffer print(StringBuffer output) {
+	protected StringBuilder print(StringBuilder output) {
 		String patternClassName = getClass().getName();
 		output.append(patternClassName.substring(patternClassName.lastIndexOf('.')+1));
 		output.append(": qualification<"); //$NON-NLS-1$

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/processing/JobManager.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/processing/JobManager.java
@@ -461,7 +461,7 @@ public abstract class JobManager {
 				protected IStatus run(IProgressMonitor monitor) {
 					IJob job = currentJob();
 					while (!monitor.isCanceled() && job != null) {
-						 String taskName = new StringBuffer(Messages.jobmanager_indexing)
+						 String taskName = new StringBuilder(Messages.jobmanager_indexing)
 							.append(Messages.bind(Messages.jobmanager_filesToIndex, job.getJobFamily(), Integer.toString(awaitingJobsCount())))
 							.toString();
 						monitor.subTask(taskName);


### PR DESCRIPTION
## What it does
Replace all usages of `StringBuffer` in the signature and implementations of `ASTNode.print*()` by StringBuilder since the code seems to be purely single-threaded and `StringBuilder` is generally slightly faster since it is not synchronized unlike `StringBuffer`.

The changes were not made using a JDT clean-up, but by changing the root `ASTNode.print()` to use `StringBuilder` instead of `StringBuffer` and subsequently fixing all compiler errors.

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
