### PR TITLE
Fix Javadoc formatting when do not put block tags on separate line set

### DIFF
--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/CommentsPreparator.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/CommentsPreparator.java
@@ -833,6 +833,11 @@ public class CommentsPreparator extends ASTVisitor {
 					handleSeparateLineTag(startPos, endPos);
 				} else if (matcher.start(4) < matcher.end(4)) {
 					handleBreakBeforeTag(startPos, endPos, isOpeningTag);
+					if (this.options.comment_javadoc_do_not_separate_block_tags) {
+						if (!isOpeningTag) {
+							handleBreakAfterTag(startPos, endPos);
+						}
+					}
 				} else if (matcher.start(5) < matcher.end(5)) {
 					handleBreakAfterTag(startPos, endPos);
 				} else if (matcher.start(6) < matcher.end(6)) {
@@ -840,6 +845,9 @@ public class CommentsPreparator extends ASTVisitor {
 				} else if (matcher.start(7) < matcher.end(7)) {
 					if (this.options.comment_javadoc_do_not_separate_block_tags) {
 						handleBreakBeforeTag(startPos, endPos, isOpeningTag);
+						if (!isOpeningTag) {
+							handleBreakAfterTag(startPos, endPos);
+						}
 					} else {
 						handleSeparateLineTag(startPos, endPos);
 					}
@@ -972,12 +980,8 @@ public class CommentsPreparator extends ASTVisitor {
 			return;
 		}
 
-		if (this.options.comment_javadoc_do_not_separate_block_tags) {
-			handleBreakBeforeTag(startPos, endPos, isOpeningTag);
-		} else {
-			// add empty lines before opening and after closing token
-			handleSeparateLineTag(startPos, endPos);
-		}
+		// add empty lines before opening and after closing token
+		handleSeparateLineTag(startPos, endPos);
 
 		int startIndex = tokenStartingAt(startPos);
 		int endTagIndex = tokenEndingAt(endPos);
@@ -1045,6 +1049,11 @@ public class CommentsPreparator extends ASTVisitor {
 			this.formatCodeOpenTagEndIndex = -1;
 			this.lastFormatCodeClosingTagIndex = this.ctm.findIndex(startPos, -1, true);
 		}
+//		if (!isOpeningTag) {
+//			if (this.options.comment_javadoc_do_not_separate_block_tags) {
+//				handleBreakAfterTag(startIndex, endTagIndex);
+//			}
+//		}
 	}
 
 	private void handleSnippet(TagElement node, int startIndex, int endIndex) {


### PR DESCRIPTION
- fix problem with block tags not putting newline after closing tag
- revert logic for handling pre tags
- fixes #1131

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes regression in Javadoc comment formatting when "do not put block tags on seprate line" is enabled

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue.

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
