### PR TITLE
Touch batch compiler to fix unanticipated comparator errors in I20230922-1800

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/forceQualifierUpdate.txt
+++ b/org.eclipse.jdt.core.compiler.batch/forceQualifierUpdate.txt
@@ -1,2 +1,3 @@
 Comparator errors in I20230607-0720
 Comparator errors in I20230906-0400
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1388


### PR DESCRIPTION
See https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1388
