### PR TITLE
Reconciler cannot use eea for nested source class

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ExternalAnnotationSuperimposer.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ExternalAnnotationSuperimposer.java
@@ -66,6 +66,12 @@ class ExternalAnnotationSuperimposer extends TypeBindingVisitor {
 					// nothing
 				}
 		}
+		if (typeBinding.memberTypes != null) {
+			for (ReferenceBinding memberType : typeBinding.memberTypes) {
+				if (memberType instanceof SourceTypeBinding)
+					apply((SourceTypeBinding) memberType, externalAnnotationPath);
+			}
+		}
 	}
 
 	static void annotateType(SourceTypeBinding binding, ExternalAnnotationProvider provider, LookupEnvironment environment) {
@@ -78,7 +84,7 @@ class ExternalAnnotationSuperimposer extends TypeBindingVisitor {
 					typeParameters[i] = visitor.superimpose(typeParameters[i], TypeVariableBinding.class);
 			}
 		}
-		binding.externalAnnotationProvider = provider; // for superimposing method signatures
+		binding.externalAnnotationProvider = provider; // for superimposing method & field signatures
 	}
 
 	public static void annotateComponentBinding(RecordComponentBinding componentBinding, ExternalAnnotationProvider provider, LookupEnvironment environment) {


### PR DESCRIPTION
fixes #1425

ExternalAnnotationSuperimposer must check for eea for member types, too, which it didn't.