### PR TITLE
Fixed AIOOBE when auto format on save

### DIFF
--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/DefaultCodeFormatter.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/DefaultCodeFormatter.java
@@ -314,7 +314,7 @@ public class DefaultCodeFormatter extends CodeFormatter {
 		kind = kind & K_MASK;
 		if (kind != K_UNKNOWN) {
 			ASTNode astNode = createParser(kind).createAST(null);
-			if (kind == K_COMPILATION_UNIT || kind == K_MODULE_INFO)
+			if (kind == K_MODULE_INFO)
 				return astNode;
 			return hasErrors(astNode) ? null : astNode;
 		}


### PR DESCRIPTION
if the kind is `K_COMPILATION_UNIT` and the source is not syntactically correct, it will not format it.

## What it does
Fixes: https://github.com/vi-eclipse/Eclipse-JDT/issues/10

## How to test
The bug can be reproduced by running this code given in this link: https://bugs.eclipse.org/bugs/show_bug.cgi?id=471825#c11

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
