### PR TITLE
Make the compiler baseline configuration configurable by properties

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ pipeline {
 					# via configuration/argLine property in pom.xml
 					# export MAVEN_OPTS="-Xmx2G"
 					
-					mvn clean install -f org.eclipse.jdt.core.compiler.batch -DlocalEcjVersion=99.99 -Dmaven.repo.local=$WORKSPACE/.m2/repository
+					mvn clean install -f org.eclipse.jdt.core.compiler.batch -DlocalEcjVersion=99.99 -Dmaven.repo.local=$WORKSPACE/.m2/repository -DcompilerBaselineMode=disable -DcompilerBaselineReplace=none
 					
 					mvn -U clean verify --batch-mode --fail-at-end -Dmaven.repo.local=$WORKSPACE/.m2/repository \
 					-Ptest-on-javase-21 -Pbree-libs -Papi-check \

--- a/org.eclipse.jdt.core.compiler.batch/pom.xml
+++ b/org.eclipse.jdt.core.compiler.batch/pom.xml
@@ -21,6 +21,8 @@
   <packaging>eclipse-plugin</packaging>
 
   <properties>
+    <compilerBaselineReplace>common</compilerBaselineReplace>
+    <compilerBaselineMode>warn</compilerBaselineMode>
     <defaultSigning-excludeInnerJars>true</defaultSigning-excludeInnerJars>
     <code.ignoredWarnings>-warn:+fieldHiding,-unavoidableGenericProblems</code.ignoredWarnings>
     <localEcjVersion>${project.version}</localEcjVersion>
@@ -76,8 +78,8 @@
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-p2-plugin</artifactId>
         <configuration>
-          <baselineMode>warn</baselineMode>
-          <baselineReplace>common</baselineReplace>
+          <baselineMode>${compilerBaselineMode}</baselineMode>
+          <baselineReplace>${compilerBaselineReplace}</baselineReplace>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
Currently the baseline settings are hardcoded (and always override the platform parent configuration), this extract these into some properties that can be overridden from the commandline.

This also adjust the Jenkinsfile to use this new way of selectively disable replace/compare of the baseline in case of building the compiler-compiler.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1395

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
