### PR TITLE
Revert "Disable API check on Jenkins / Java 21"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,7 +32,7 @@ pipeline {
 					mvn clean install -f org.eclipse.jdt.core.compiler.batch -DlocalEcjVersion=99.99 -Dmaven.repo.local=$WORKSPACE/.m2/repository -DcompilerBaselineMode=disable -DcompilerBaselineReplace=none
 					
 					mvn -U clean verify --batch-mode --fail-at-end -Dmaven.repo.local=$WORKSPACE/.m2/repository \
-					-Ptest-on-javase-21 -Pbree-libs \
+					-Ptest-on-javase-21 -Pbree-libs -Papi-check \
 					-Djava.io.tmpdir=$WORKSPACE/tmp -Dproject.build.sourceEncoding=UTF-8 \
 					-Dtycho.surefire.argLine="--add-modules ALL-SYSTEM -Dcompliance=1.8,11,17,19,21 -Djdt.performance.asserts=disabled" \
 					-Dcbi-ecj-version=99.99


### PR DESCRIPTION
Reverts eclipse-jdt/eclipse.jdt.core#1442

API check errors seem to be unstable!

See https://github.com/eclipse-pde/eclipse.pde/issues/771