### PR TITLE
Fix some of the warnings about deprecated types, empty block, malformed javadoc etc.

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/apt/dispatch/BaseMessagerImpl.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/apt/dispatch/BaseMessagerImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007, 2020 BEA Systems, Inc. and others
+ * Copyright (c) 2007, 2023 BEA Systems, Inc. and others
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -57,7 +57,7 @@ public class BaseMessagerImpl {
 	 * @param e the element against which to report the message.  If the element is not
 	 * in the set of elements being compiled in the current round, the reference context
 	 * and filename will be set to null.
-	 * @return
+	 * @return a new {@link AptProblem}
 	 */
 	public static AptProblem createProblem(Kind kind, CharSequence msg, Element e,
 			AnnotationMirror a, AnnotationValue v) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/apt/dispatch/BatchAnnotationProcessorManager.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/apt/dispatch/BatchAnnotationProcessorManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2017 IBM Corporation and others.
+ * Copyright (c) 2005, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -35,7 +35,6 @@ import org.eclipse.jdt.internal.compiler.problem.AbortCompilation;
 /**
  * Java 6 annotation processor manager used when compiling from the command line
  * or via the javax.tools.JavaCompiler interface.
- * @see org.eclipse.jdt.internal.apt.pluggable.core.dispatch.IdeAnnotationProcessorManager
  */
 public class BatchAnnotationProcessorManager extends BaseAnnotationProcessorManager
 {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/apt/dispatch/BatchProcessingEnvImpl.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/apt/dispatch/BatchProcessingEnvImpl.java
@@ -35,7 +35,6 @@ import org.eclipse.jdt.internal.compiler.problem.AbortCompilation;
  * The implementation of ProcessingEnvironment that is used when compilation is
  * driven by the command line or by the Tool interface.  This environment uses
  * the JavaFileManager provided by the compiler.
- * @see org.eclipse.jdt.internal.apt.pluggable.core.dispatch.IdeProcessingEnvImpl
  */
 public class BatchProcessingEnvImpl extends BaseProcessingEnvImpl {
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/apt/model/AnnotationValueImpl.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/apt/model/AnnotationValueImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2017 IBM Corporation and others.
+ * Copyright (c) 2005, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -124,7 +124,7 @@ public class AnnotationValueImpl implements AnnotationValue, TypeIds {
 	 * BaseTypeBinding, this is ignored and the value is inspected to determine type.
 	 * @param kind an int array whose first element will be set to the type of the
 	 * converted object, represented with T_* values from TypeIds or from this class.
-	 * @return
+	 * @return converted mirror type
 	 */
 	private Object convertToMirrorType(Object value, TypeBinding type, int kind[]) {
 		if (type == null) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/apt/model/TypeElementImpl.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/apt/model/TypeElementImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2021 IBM Corporation and others.
+ * Copyright (c) 2005, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -128,9 +128,8 @@ public class TypeElementImpl extends ElementImpl implements TypeElement {
 	private final ElementKind _kindHint;
 
 	/**
-	 * In general, clients should call {@link Factory#newDeclaredType(ReferenceBinding)} or
-	 * {@link Factory#newElement(org.eclipse.jdt.internal.compiler.lookup.Binding)} to
-	 * create new instances.
+	 * In general, clients should call {@link Factory#newElement(org.eclipse.jdt.internal.compiler.lookup.Binding)}
+	 * to create new instances.
 	 */
 	TypeElementImpl(BaseProcessingEnvImpl env, ReferenceBinding binding, ElementKind kindHint) {
 		super(env, binding);

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/util/JrtUtilTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/util/JrtUtilTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022 Andrey Loskutov, and others.
+ * Copyright (c) 2022, 2023 Andrey Loskutov, and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -60,14 +60,14 @@ public class JrtUtilTest extends TestCase {
 	@Test
 	public void testGetNewJrtFileSystem() throws Exception {
 		int majorVersionSegment = getMajorVersionSegment(this.jdkRelease);
-		Object jrtSystem = JRTUtil.getJrtSystem(this.image);
+		Object jrtSystem = JRTUtil.getJrtSystem(this.image, null);
 		Object jrtSystem2 = JRTUtil.getJrtSystem(this.image, String.valueOf(majorVersionSegment));
 		assertSame(jrtSystem, jrtSystem2);
 
 		jrtSystem2 = JRTUtil.getJrtSystem(this.image, String.valueOf(majorVersionSegment-2));
 		assertNotSame(jrtSystem, jrtSystem2);
 
-		Object jrtSystem3 = JRTUtil.getJrtSystem(this.image);
+		Object jrtSystem3 = JRTUtil.getJrtSystem(this.image, null);
 		assertSame(jrtSystem, jrtSystem3);
 	}
 

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionNode.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionNode.java
@@ -16,5 +16,5 @@ package org.eclipse.jdt.internal.codeassist.complete;
  * Marker interface for all completion nodes
  */
 public interface CompletionNode {
-
+	// Nothing to declare
 }


### PR DESCRIPTION
Fix some of the warnings about deprecated types, empty block, malformed javadoc etc.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
