### PR TITLE
Eclipse reports Type mismatch for @Deprecated class

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/CompilationResult.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/CompilationResult.java
@@ -86,6 +86,7 @@ public class CompilationResult {
 	private int numberOfErrors;
 	private boolean hasMandatoryErrors;
 	public List<AnnotationBinding[]> annotations = new ArrayList<>(1);
+	private List<Runnable> scheduledProblems;
 
 	private static final int[] EMPTY_LINE_ENDS = Util.EMPTY_INT_ARRAY;
 	private static final Comparator PROBLEM_COMPARATOR = new Comparator() {
@@ -475,5 +476,19 @@ public String toString(){
 		buffer.append("No PROBLEM\n"); //$NON-NLS-1$
 	}
 	return buffer.toString();
+}
+
+public void scheduleProblem(Runnable task) {
+	if (this.scheduledProblems == null)
+		this.scheduledProblems = new ArrayList<>();
+	this.scheduledProblems.add(task);
+}
+
+public void materializeProblems() {
+	if (this.scheduledProblems != null) {
+		for (Runnable task : this.scheduledProblems) {
+			task.run();
+		}
+	}
 }
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AbstractMethodDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AbstractMethodDeclaration.java
@@ -651,14 +651,15 @@ public abstract class AbstractMethodDeclaration
 			// Set javadoc visibility
 			int javadocVisibility = this.binding.modifiers & ExtraCompilerModifiers.AccVisibilityMASK;
 			ClassScope classScope = this.scope.classScope();
-			ProblemReporter reporter = this.scope.problemReporter();
-			int severity = reporter.computeSeverity(IProblem.JavadocMissing);
-			if (severity != ProblemSeverities.Ignore) {
-				if (classScope != null) {
-					javadocVisibility = Util.computeOuterMostVisibility(classScope.referenceType(), javadocVisibility);
+			try (ProblemReporter reporter = this.scope.problemReporter()) {
+				int severity = reporter.computeSeverity(IProblem.JavadocMissing);
+				if (severity != ProblemSeverities.Ignore) {
+					if (classScope != null) {
+						javadocVisibility = Util.computeOuterMostVisibility(classScope.referenceType(), javadocVisibility);
+					}
+					int javadocModifiers = (this.binding.modifiers & ~ExtraCompilerModifiers.AccVisibilityMASK) | javadocVisibility;
+					reporter.javadocMissing(this.sourceStart, this.sourceEnd, severity, javadocModifiers);
 				}
-				int javadocModifiers = (this.binding.modifiers & ~ExtraCompilerModifiers.AccVisibilityMASK) | javadocVisibility;
-				reporter.javadocMissing(this.sourceStart, this.sourceEnd, severity, javadocModifiers);
 			}
 		}
 	}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/CompilationUnitDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/CompilationUnitDeclaration.java
@@ -245,6 +245,7 @@ public TypeDeclaration declarationOfType(char[][] typeName) {
 }
 
 public void finalizeProblems() {
+	this.compilationResult.materializeProblems();
 	int problemCount = this.compilationResult.problemCount;
 	CategorizedProblem[] problems = this.compilationResult.problems;
 	if (this.suppressWarningsCount == 0) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypeDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypeDeclaration.java
@@ -1517,14 +1517,15 @@ public void resolve() {
 		} else if (!sourceType.isLocalType()) {
 			// Set javadoc visibility
 			int visibility = sourceType.modifiers & ExtraCompilerModifiers.AccVisibilityMASK;
-			ProblemReporter reporter = this.scope.problemReporter();
-			int severity = reporter.computeSeverity(IProblem.JavadocMissing);
-			if (severity != ProblemSeverities.Ignore) {
-				if (this.enclosingType != null) {
-					visibility = Util.computeOuterMostVisibility(this.enclosingType, visibility);
+			try (ProblemReporter reporter = this.scope.problemReporter()) {
+				int severity = reporter.computeSeverity(IProblem.JavadocMissing);
+				if (severity != ProblemSeverities.Ignore) {
+					if (this.enclosingType != null) {
+						visibility = Util.computeOuterMostVisibility(this.enclosingType, visibility);
+					}
+					int javadocModifiers = (this.binding.modifiers & ~ExtraCompilerModifiers.AccVisibilityMASK) | visibility;
+					reporter.javadocMissing(this.sourceStart, this.sourceEnd, severity, javadocModifiers);
 				}
-				int javadocModifiers = (this.binding.modifiers & ~ExtraCompilerModifiers.AccVisibilityMASK) | visibility;
-				reporter.javadocMissing(this.sourceStart, this.sourceEnd, severity, javadocModifiers);
 			}
 		}
 		updateNestHost();

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/FieldBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/FieldBinding.java
@@ -245,7 +245,7 @@ public Constant constant(Scope scope) {
 		return this.constant;
 	ProblemReporter problemReporter = scope.problemReporter();
 	IErrorHandlingPolicy suspendedPolicy = problemReporter.suspendTempErrorHandlingPolicy();
-	try {
+	try (problemReporter) {
 		return constant();
 	} finally {
 		problemReporter.resumeTempErrorHandlingPolicy(suspendedPolicy);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Scope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Scope.java
@@ -5157,6 +5157,7 @@ public abstract class Scope {
 		return NOT_COMPATIBLE;
 	}
 
+	/** See also the contract of {@link ProblemReporter#close()}. */
 	public abstract ProblemReporter problemReporter();
 
 	public final CompilationUnitDeclaration referenceCompilationUnit() {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SourceTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SourceTypeBinding.java
@@ -2750,7 +2750,7 @@ public FieldBinding resolveTypeFor(FieldBinding field) {
 public MethodBinding resolveTypesFor(MethodBinding method) {
 	ProblemReporter problemReporter = this.scope.problemReporter();
 	IErrorHandlingPolicy suspendedPolicy = problemReporter.suspendTempErrorHandlingPolicy();
-	try {
+	try (problemReporter) {
 		return resolveTypesWithSuspendedTempErrorHandlingPolicy(method);
 	} finally {
 		problemReporter.resumeTempErrorHandlingPolicy(suspendedPolicy);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SourceTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SourceTypeBinding.java
@@ -1649,6 +1649,17 @@ public long getAnnotationTagBits() {
 	}
 	return this.tagBits;
 }
+@Override
+public boolean isReadyForAnnotations() {
+	if ((this.tagBits & TagBits.AnnotationResolved) != 0)
+		return true;
+	TypeDeclaration type;
+	if (this.scope != null && (type = this.scope.referenceType()) != null) {
+		if (type.annotations == null)
+			return true; // nothing here to resolve
+	}
+	return false;
+}
 public MethodBinding[] getDefaultAbstractMethods() {
 	if (!isPrototype())
 		return this.prototype.getDefaultAbstractMethods();

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeBinding.java
@@ -1175,6 +1175,9 @@ private boolean isProvablyDistinctTypeArgument(TypeBinding otherArgument, final 
 	}
 }
 
+public boolean isReadyForAnnotations() {
+	return true;
+}
 /**
  * Answer true if the receiver is an annotation which may be repeatable. Overridden as appropriate.
  */

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
@@ -219,8 +219,9 @@ import org.eclipse.jdt.internal.compiler.parser.TerminalTokens;
 import org.eclipse.jdt.internal.compiler.util.Messages;
 import org.eclipse.jdt.internal.compiler.util.Util;
 
+/** See contract of {@link #close()}. */
 @SuppressWarnings("rawtypes")
-public class ProblemReporter extends ProblemHandler {
+public class ProblemReporter extends ProblemHandler implements AutoCloseable {
 
 	public ReferenceContext referenceContext;
 	private Scanner positionScanner;
@@ -2016,7 +2017,7 @@ String deprecatedSinceValue(Supplier<AnnotationBinding[]> annotations) {
 				}
 			}
 		} finally {
-			this.referenceContext = contextSave;
+			this.referenceContext = contextSave; // resolving could have manipulated the referenceContext
 		}
 	}
 	return null;
@@ -4853,130 +4854,132 @@ public void invalidParenthesizedExpression(ASTNode reference) {
 		reference.sourceEnd);
 }
 public void invalidType(ASTNode location, TypeBinding type) {
-	if (type instanceof ReferenceBinding) {
-		if (isRecoveredName(((ReferenceBinding)type).compoundName)) return;
-	}
-	else if (type instanceof ArrayBinding) {
-		TypeBinding leafType = ((ArrayBinding)type).leafComponentType;
-		if (leafType instanceof ReferenceBinding) {
-			if (isRecoveredName(((ReferenceBinding)leafType).compoundName)) return;
+	try (this) { // ensure clean-up despite the many exits without calling handle(..)
+		if (type instanceof ReferenceBinding) {
+			if (isRecoveredName(((ReferenceBinding)type).compoundName)) return;
 		}
-	}
+		else if (type instanceof ArrayBinding) {
+			TypeBinding leafType = ((ArrayBinding)type).leafComponentType;
+			if (leafType instanceof ReferenceBinding) {
+				if (isRecoveredName(((ReferenceBinding)leafType).compoundName)) return;
+			}
+		}
 
-	if (type.isParameterizedType()) {
-		List missingTypes = type.collectMissingTypes(null);
-		if (missingTypes != null) {
-			ReferenceContext savedContext = this.referenceContext;
-			for (Iterator iterator = missingTypes.iterator(); iterator.hasNext(); ) {
-				try {
-					invalidType(location, (TypeBinding) iterator.next());
-				} finally {
-					this.referenceContext = savedContext;
+		if (type.isParameterizedType()) {
+			List missingTypes = type.collectMissingTypes(null);
+			if (missingTypes != null) {
+				ReferenceContext savedContext = this.referenceContext;
+				for (Iterator iterator = missingTypes.iterator(); iterator.hasNext(); ) {
+					try {
+						invalidType(location, (TypeBinding) iterator.next());
+					} finally {
+						this.referenceContext = savedContext; // nested reporting will have reset referenceContext
+					}
+				}
+				return;
+			}
+		}
+		int id = IProblem.UndefinedType; // default
+		switch (type.problemId()) {
+			case ProblemReasons.NotFound :
+				id = IProblem.UndefinedType;
+				break;
+			case ProblemReasons.NotVisible :
+				id = IProblem.NotVisibleType;
+				break;
+			case ProblemReasons.NotAccessible :
+				id = IProblem.NotAccessibleType;
+				break;
+			case ProblemReasons.Ambiguous :
+				id = IProblem.AmbiguousType;
+				break;
+			case ProblemReasons.InternalNameProvided :
+				id = IProblem.InternalTypeNameProvided;
+				break;
+			case ProblemReasons.InheritedNameHidesEnclosingName :
+				id = IProblem.InheritedTypeHidesEnclosingName;
+				break;
+			case ProblemReasons.NonStaticReferenceInStaticContext :
+				id = IProblem.NonStaticTypeFromStaticInvocation;
+				break;
+			case ProblemReasons.IllegalSuperTypeVariable :
+				id = IProblem.IllegalTypeVariableSuperReference;
+				break;
+			case ProblemReasons.NoError : // 0
+			default :
+				needImplementation(location); // want to fail to see why we were here...
+				break;
+		}
+
+		int end = location.sourceEnd;
+		if (location instanceof QualifiedNameReference) {
+			QualifiedNameReference ref = (QualifiedNameReference) location;
+			if (isRecoveredName(ref.tokens)) return;
+			if (ref.indexOfFirstFieldBinding >= 1)
+				end = (int) ref.sourcePositions[ref.indexOfFirstFieldBinding - 1];
+		} else if (location instanceof ParameterizedQualifiedTypeReference) {
+			// must be before instanceof ArrayQualifiedTypeReference
+			ParameterizedQualifiedTypeReference ref = (ParameterizedQualifiedTypeReference) location;
+			if (isRecoveredName(ref.tokens)) return;
+			if (type instanceof ReferenceBinding) {
+				char[][] name = ((ReferenceBinding) type).compoundName;
+				if (name.length <= ref.sourcePositions.length) {
+					end = (int) ref.sourcePositions[name.length - 1];
 				}
 			}
-			return;
-		}
-	}
-	int id = IProblem.UndefinedType; // default
-	switch (type.problemId()) {
-		case ProblemReasons.NotFound :
-			id = IProblem.UndefinedType;
-			break;
-		case ProblemReasons.NotVisible :
-			id = IProblem.NotVisibleType;
-			break;
-		case ProblemReasons.NotAccessible :
-			id = IProblem.NotAccessibleType;
-			break;
-		case ProblemReasons.Ambiguous :
-			id = IProblem.AmbiguousType;
-			break;
-		case ProblemReasons.InternalNameProvided :
-			id = IProblem.InternalTypeNameProvided;
-			break;
-		case ProblemReasons.InheritedNameHidesEnclosingName :
-			id = IProblem.InheritedTypeHidesEnclosingName;
-			break;
-		case ProblemReasons.NonStaticReferenceInStaticContext :
-			id = IProblem.NonStaticTypeFromStaticInvocation;
-			break;
-		case ProblemReasons.IllegalSuperTypeVariable :
-			id = IProblem.IllegalTypeVariableSuperReference;
-			break;
-		case ProblemReasons.NoError : // 0
-		default :
-			needImplementation(location); // want to fail to see why we were here...
-			break;
-	}
-
-	int end = location.sourceEnd;
-	if (location instanceof QualifiedNameReference) {
-		QualifiedNameReference ref = (QualifiedNameReference) location;
-		if (isRecoveredName(ref.tokens)) return;
-		if (ref.indexOfFirstFieldBinding >= 1)
-			end = (int) ref.sourcePositions[ref.indexOfFirstFieldBinding - 1];
-	} else if (location instanceof ParameterizedQualifiedTypeReference) {
-		// must be before instanceof ArrayQualifiedTypeReference
-		ParameterizedQualifiedTypeReference ref = (ParameterizedQualifiedTypeReference) location;
-		if (isRecoveredName(ref.tokens)) return;
-		if (type instanceof ReferenceBinding) {
-			char[][] name = ((ReferenceBinding) type).compoundName;
-			if (name.length <= ref.sourcePositions.length) {
+		} else if (location instanceof ArrayQualifiedTypeReference) {
+			ArrayQualifiedTypeReference arrayQualifiedTypeReference = (ArrayQualifiedTypeReference) location;
+			if (isRecoveredName(arrayQualifiedTypeReference.tokens)) return;
+			TypeBinding leafType = type.leafComponentType();
+			if (leafType instanceof ReferenceBinding) {
+				char[][] name = ((ReferenceBinding) leafType).compoundName; // problem type will tell how much got resolved
+				if (name.length <= arrayQualifiedTypeReference.sourcePositions.length) {
+					end = (int) arrayQualifiedTypeReference.sourcePositions[name.length-1];
+				}
+			} else {
+				long[] positions = arrayQualifiedTypeReference.sourcePositions;
+				end = (int) positions[positions.length - 1];
+			}
+		} else if (location instanceof QualifiedTypeReference) {
+			QualifiedTypeReference ref = (QualifiedTypeReference) location;
+			if (isRecoveredName(ref.tokens)) return;
+			if (type instanceof ReferenceBinding) {
+				char[][] name = ((ReferenceBinding) type).compoundName;
+				if (name.length <= ref.sourcePositions.length)
+					end = (int) ref.sourcePositions[name.length - 1];
+			}
+		} else if (location instanceof ImportReference) {
+			ImportReference ref = (ImportReference) location;
+			if (isRecoveredName(ref.tokens)) return;
+			if (type instanceof ReferenceBinding) {
+				char[][] name = ((ReferenceBinding) type).compoundName;
 				end = (int) ref.sourcePositions[name.length - 1];
 			}
+		} else if (location instanceof ArrayTypeReference) {
+			ArrayTypeReference arrayTypeReference = (ArrayTypeReference) location;
+			if (isRecoveredName(arrayTypeReference.token)) return;
+			end = arrayTypeReference.originalSourceEnd;
 		}
-	} else if (location instanceof ArrayQualifiedTypeReference) {
-		ArrayQualifiedTypeReference arrayQualifiedTypeReference = (ArrayQualifiedTypeReference) location;
-		if (isRecoveredName(arrayQualifiedTypeReference.tokens)) return;
-		TypeBinding leafType = type.leafComponentType();
-		if (leafType instanceof ReferenceBinding) {
-			char[][] name = ((ReferenceBinding) leafType).compoundName; // problem type will tell how much got resolved
-			if (name.length <= arrayQualifiedTypeReference.sourcePositions.length) {
-				end = (int) arrayQualifiedTypeReference.sourcePositions[name.length-1];
-			}
-		} else {
-			long[] positions = arrayQualifiedTypeReference.sourcePositions;
-			end = (int) positions[positions.length - 1];
-		}
-	} else if (location instanceof QualifiedTypeReference) {
-		QualifiedTypeReference ref = (QualifiedTypeReference) location;
-		if (isRecoveredName(ref.tokens)) return;
-		if (type instanceof ReferenceBinding) {
-			char[][] name = ((ReferenceBinding) type).compoundName;
-			if (name.length <= ref.sourcePositions.length)
-				end = (int) ref.sourcePositions[name.length - 1];
-		}
-	} else if (location instanceof ImportReference) {
-		ImportReference ref = (ImportReference) location;
-		if (isRecoveredName(ref.tokens)) return;
-		if (type instanceof ReferenceBinding) {
-			char[][] name = ((ReferenceBinding) type).compoundName;
-			end = (int) ref.sourcePositions[name.length - 1];
-		}
-	} else if (location instanceof ArrayTypeReference) {
-		ArrayTypeReference arrayTypeReference = (ArrayTypeReference) location;
-		if (isRecoveredName(arrayTypeReference.token)) return;
-		end = arrayTypeReference.originalSourceEnd;
-	}
 
-	int start = location.sourceStart;
-	if (location instanceof org.eclipse.jdt.internal.compiler.ast.SingleTypeReference) {
-		org.eclipse.jdt.internal.compiler.ast.SingleTypeReference ref =
-				(org.eclipse.jdt.internal.compiler.ast.SingleTypeReference) location;
-		if (ref.annotations != null)
-			start = end - ref.token.length + 1;
-	} else if (location instanceof QualifiedTypeReference) {
-		QualifiedTypeReference ref = (QualifiedTypeReference) location;
-		if (ref.annotations != null)
-			start = (int) (ref.sourcePositions[0] & 0x00000000FFFFFFFFL ) - ref.tokens[0].length + 1;
-	}
+		int start = location.sourceStart;
+		if (location instanceof org.eclipse.jdt.internal.compiler.ast.SingleTypeReference) {
+			org.eclipse.jdt.internal.compiler.ast.SingleTypeReference ref =
+					(org.eclipse.jdt.internal.compiler.ast.SingleTypeReference) location;
+			if (ref.annotations != null)
+				start = end - ref.token.length + 1;
+		} else if (location instanceof QualifiedTypeReference) {
+			QualifiedTypeReference ref = (QualifiedTypeReference) location;
+			if (ref.annotations != null)
+				start = (int) (ref.sourcePositions[0] & 0x00000000FFFFFFFFL ) - ref.tokens[0].length + 1;
+		}
 
-	this.handle(
-		id,
-		new String[] {new String(type.leafComponentType().readableName()) },
-		new String[] {new String(type.leafComponentType().shortReadableName())},
-		start,
-		end);
+		this.handle(
+			id,
+			new String[] {new String(type.leafComponentType().readableName()) },
+			new String[] {new String(type.leafComponentType().shortReadableName())},
+			start,
+			end);
+	}
 }
 public void invalidTypeForCollection(Expression expression) {
 	this.handle(
@@ -8420,7 +8423,14 @@ private boolean handleSyntaxErrorOnNewTokens(
 	String errorTokenName,
 	String expectedToken) {
 	if (isIdentifier(currentKind)) {
-		return validateRestrictedKeywords(errorTokenSource, expectedToken, start, end, true);
+		if (expectedToken != null) {
+			String tokenName= new String(errorTokenSource);
+			String restrictedIdentifier= permittedRestrictedKeyWordMap.get(tokenName);
+			if (restrictedIdentifier == null || !restrictedIdentifier.equals(expectedToken)) {
+				return false;
+			}
+		}
+		return validateRestrictedKeywords(errorTokenSource, start, end, true);
 	}
 	return false;
 }
@@ -9709,18 +9719,8 @@ public void previewAPIUsed(int sourceStart, int sourceEnd, boolean isFatal) {
 			sourceEnd);
 }
 //Returns true if the problem is handled and reported (only errors considered and not warnings)
-public boolean validateRestrictedKeywords(char[] name, int start, int end, boolean reportSyntaxError) {
-	return validateRestrictedKeywords(name, null, start, end, reportSyntaxError);
-}
-private boolean validateRestrictedKeywords(char[] name, String expectedToken, int start, int end, boolean reportSyntaxError) {
+private boolean validateRestrictedKeywords(char[] name, int start, int end, boolean reportSyntaxError) {
 	boolean isPreviewEnabled = this.options.enablePreviewFeatures;
-	if (expectedToken != null) {
-		String tokenName= new String(name);
-		String restrictedIdentifier= permittedRestrictedKeyWordMap.get(tokenName);
-		if (restrictedIdentifier == null || !restrictedIdentifier.equals(expectedToken)) {
-			return false;
-		}
-	}
 	for (JavaFeature feature : JavaFeature.values()) {
 		char[][] restrictedKeywords = feature.getRestrictedKeywords();
 		for (char[] k : restrictedKeywords) {
@@ -9752,7 +9752,10 @@ private boolean validateRestrictedKeywords(char[] name, String expectedToken, in
 	return false;
 }
 public boolean validateRestrictedKeywords(char[] name, ASTNode node) {
-	return validateRestrictedKeywords(name, node.sourceStart, node.sourceEnd, false);
+	// ensure clean-up because inner method is not guaranteed to invoke handle(..)
+	try (this) {
+		return validateRestrictedKeywords(name, node.sourceStart, node.sourceEnd, false);
+	}
 }
 //Returns true if the problem is handled and reported (only errors considered and not warnings)
 public boolean validateJavaFeatureSupport(JavaFeature feature, int sourceStart, int sourceEnd) {
@@ -11631,7 +11634,7 @@ public void conflictingPackageInModules(char[][] wellKnownTypeName, CompilationU
 				start,
 				end);
 	} finally {
-		this.referenceContext = savedContext;
+		this.referenceContext = savedContext; // unsure from which phase we are called, so better to reset to previous
 	}
 }
 
@@ -12459,17 +12462,36 @@ public boolean scheduleProblemForContext(Runnable problemComputation) {
 	if (this.referenceContext != null) {
 		CompilationResult result = this.referenceContext.compilationResult();
 		if (result != null) {
-			result.scheduleProblem(() -> {
-				ReferenceContext save = this.referenceContext;
-				try {
-					problemComputation.run();
-				} finally {
-					this.referenceContext = save;
-				}
-			});
+			try (this) {
+				ReferenceContext capturedContext = this.referenceContext;
+				result.scheduleProblem(() -> {
+					ReferenceContext save = this.referenceContext;
+					this.referenceContext = capturedContext;
+					try {
+						problemComputation.run();
+					} finally {
+						this.referenceContext = save;
+					}
+				});
+			}
 			return true;
 		}
 	}
 	return false;
+}
+/**
+ * General strategy:
+ * <ul>
+ * <li>clients are responsible for assigning {@link #referenceContext} prior to invoking any
+ * reporting method (usually, by obtaining an instance using {@link Scope#problemReporter()}).
+ * <li>individual methods should ensure that {@link #referenceContext} is reset to {@code null} afterwards. This may
+ * happen in two ways:
+ * <ul><li>by calling any of the {@code handle(..)} methods on all paths, or failing that
+ * <li>wrap their body in {@code try(this) { ... }}.
+ * </ul></ul>
+ */
+@Override
+public void close() {
+	this.referenceContext = null;
 }
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/Deprecated9Test.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/Deprecated9Test.java
@@ -1007,6 +1007,34 @@ public class Deprecated9Test extends AbstractRegressionTest9 {
 				"----------\n";
 		runner.runNegativeTest();
 	}
+	public void testGH1412() {
+		Runner runner = new Runner();
+		runner.testFiles = new String[] {
+			"AbstractClass.java",
+			"""
+			public abstract class AbstractClass<T> {}
+			""",
+			"AnnotationWithClassValue.java",
+			"""
+			public @interface AnnotationWithClassValue {
+				Class<? extends AbstractClass<?>> value();
+			}
+			""",
+			"ConcreteClass.java",
+			"""
+			//Adding @Deprecated here fixes the bug
+			//@Deprecated
+			public class ConcreteClass extends AbstractClass<AnnotatedClass> {}
+			""",
+			"AnnotatedClass.java",
+			"""
+			@Deprecated
+			@AnnotationWithClassValue(ConcreteClass.class) //Type mismatch: cannot convert from Class<ConcreteClass> to Class<? extends AbstractClass<?>>
+			public class AnnotatedClass {}
+			"""
+		};
+		runner.runConformTest();
+	}
 	public static Class<?> testClass() {
 		return Deprecated9Test.class;
 	}


### PR DESCRIPTION
fixes #1412

## What it does

Defer problem reporting if it would require ahead-of-time resolving of annotations (tasks stored in `CompilationResult`).
Materialize such problems just at the beginning of `CompilationUnitDeclaration.finalizeProblems()`.

## How to test

JUnit included
