### PR TITLE
Add null guard for scope in SourceTypeBinding.storeAnnotations

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SourceTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SourceTypeBinding.java
@@ -3343,7 +3343,8 @@ SimpleLookupTable storedAnnotations(boolean forceInitialize, boolean forceStore)
 @Override
 void storeAnnotations(Binding binding, AnnotationBinding[] annotations, boolean forceStore) {
 	super.storeAnnotations(binding, annotations, forceStore);
-	this.scope.referenceCompilationUnit().compilationResult.annotations.add(annotations);
+	if (this.scope != null)
+		this.scope.referenceCompilationUnit().compilationResult.annotations.add(annotations);
 }
 
 @Override


### PR DESCRIPTION
As discussed with @laeubi in https://github.com/eclipse-jdt/eclipse.jdt.core/commit/8d512be7b8594e8c6dfefff06b36a0b95d7250d7#r128469112, when using JDT Core from the AspectJ compiler, we ran into NPEs in this place. This is difficult to reproduce without AspectJ, but when looking on how and when `this.scope` is initialised, we see that it is not checked for null in the constructor. Furthermore, it is set to null in the public `cleanUp()` method. I.e., chances are, that it can be null in some JDT Core situations, too, even without AspectJ in the mix.

## Author checklist

- [ ] I have thoroughly tested my changes → No, I made the changes in a web editor. I did not want to build locally. Please either review and test this change by yourself or discard it. I just mean to help a little bit. I made the same change in the AspectJ fork of JDT Core already, using it in the AspectJ compiler.
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
