### PR TITLE
Confusion about File.separatorChar() causes failure to load .eea on windows

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/ClasspathDirectory.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/ClasspathDirectory.java
@@ -80,6 +80,9 @@ ClasspathDirectory(File directory, String encoding, int mode,
 	this.encoding = encoding;
 }
 String[] directoryList(String qualifiedPackageName) {
+	if (File.separatorChar != '/' && qualifiedPackageName.indexOf('/') != -1) {
+		qualifiedPackageName = qualifiedPackageName.replace('/', File.separatorChar);
+	}
 	String[] dirList = (String[]) this.directoryCache.get(qualifiedPackageName);
 	if (dirList == this.missingPackageHolder) return null; // package exists in another classpath directory or jar
 	if (dirList != null) return dirList;


### PR DESCRIPTION
fixes issue #1452:

defensively cope with separator mix, explicitly convert to File.separatorChar for directoryList, which performs actual file I/O.
