### PR TITLE
Recognize instance main methods as main methods.

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/impl/JavaFeature.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/impl/JavaFeature.java
@@ -102,6 +102,11 @@ public enum JavaFeature {
 			return preview;
 		return this.getCompliance() <= comp;
 	}
+	public boolean isSupported(String comp, boolean preview) {
+		if (this.isPreview)
+			return preview;
+		return this.getCompliance() <= CompilerOptions.versionToJdkLevel(comp);
+	}
 
 	JavaFeature(long compliance, String name, char[][] restrictedKeywords, boolean isPreview) {
         this.compliance = compliance;

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AllJavaModelTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AllJavaModelTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -226,6 +226,7 @@ private static Class[] getAllTestClasses() {
 		JavaElement8Tests.class,
 
 		Java9ElementTests.class,
+		Java21ElementTests.class,
 
 		NullAnnotationModelTests9.class,
 
@@ -254,6 +255,7 @@ private static Class[] getAllTestClasses() {
 /**
  * @deprecated JDOM is obsolete
  */
+@Deprecated
 private static Class[] getDeprecatedJDOMTestClasses() {
 	return new Class[] {
 		//Create type source tests

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/Java21ElementTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/Java21ElementTests.java
@@ -1,0 +1,370 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.core.tests.model;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.tests.util.AbstractCompilerTest;
+
+import junit.framework.Test;
+
+public class Java21ElementTests extends AbstractJavaModelTests {
+
+	private IJavaProject project;
+	public Java21ElementTests(String name) {
+		super(name);
+	}
+
+	public static Test suite() {
+		return buildModelTestSuite(AbstractCompilerTest.F_21, Java21ElementTests.class);
+	}
+
+	@Override
+	protected void setUp() throws Exception {
+		super.setUp();
+		this.project = createJavaProject("Java21Elements", new String[] { "src" },
+				new String[] { "JCL21_LIB" }, "bin", "21");
+	}
+
+	@Override
+	protected void tearDown() throws Exception {
+		deleteProject("Java21Elements");
+		super.tearDown();
+	}
+
+	public void test001() throws Exception {
+		this.project.setOption(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, JavaCore.ENABLED);
+		this.project.open(null);
+		String fileContent = """
+				public interface Test {
+					public static void main(String[] args) {
+					}
+				}
+					""";
+		createFile("/Java21Elements/src/Test.java", fileContent);
+
+		ICompilationUnit unit = getCompilationUnit("/Java21Elements/src/Test.java");
+		assertTrue(unit.getTypes()[0].getMethods()[0].isMainMethodCandidate());
+	}
+
+	public void test002() throws Exception {
+		this.project.setOption(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, JavaCore.ENABLED);
+		this.project.open(null);
+		String fileContent = """
+				public class Test {
+					public static void main() {
+					}
+				}
+					""";
+		createFile("/Java21Elements/src/Test.java", fileContent);
+
+		ICompilationUnit unit = getCompilationUnit("/Java21Elements/src/Test.java");
+		assertTrue(unit.getTypes()[0].getMethods()[0].isMainMethodCandidate());
+	}
+
+	public void test003() throws Exception {
+		this.project.setOption(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, JavaCore.ENABLED);
+		this.project.open(null);
+		String fileContent = """
+				public class Test {
+					public void main() {
+					}
+				}
+					""";
+		createFile("/Java21Elements/src/Test.java", fileContent);
+
+		ICompilationUnit unit = getCompilationUnit("/Java21Elements/src/Test.java");
+		assertTrue(unit.getTypes()[0].getMethods()[0].isMainMethodCandidate());
+	}
+
+	public void test004() throws Exception {
+		this.project.setOption(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, JavaCore.ENABLED);
+		this.project.open(null);
+		String fileContent = """
+				public class Test {
+					protected void main() {
+					}
+				}
+					""";
+		createFile("/Java21Elements/src/Test.java", fileContent);
+
+		ICompilationUnit unit = getCompilationUnit("/Java21Elements/src/Test.java");
+		assertTrue(unit.getTypes()[0].getMethods()[0].isMainMethodCandidate());
+	}
+
+	public void test005() throws Exception {
+		this.project.setOption(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, JavaCore.ENABLED);
+		this.project.open(null);
+		String fileContent = """
+				public class Test {
+					void main() {
+					}
+				}
+					""";
+		createFile("/Java21Elements/src/Test.java", fileContent);
+
+		ICompilationUnit unit = getCompilationUnit("/Java21Elements/src/Test.java");
+		assertTrue(unit.getTypes()[0].getMethods()[0].isMainMethodCandidate());
+	}
+
+	public void test006() throws Exception {
+		this.project.setOption(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, JavaCore.ENABLED);
+		this.project.open(null);
+		String fileContent = """
+				public class Test {
+					private void main() {
+					}
+				}
+					""";
+		createFile("/Java21Elements/src/Test.java", fileContent);
+
+		ICompilationUnit unit = getCompilationUnit("/Java21Elements/src/Test.java");
+		assertFalse(unit.getTypes()[0].getMethods()[0].isMainMethodCandidate());
+	}
+
+	public void test007() throws Exception {
+		this.project.setOption(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, JavaCore.ENABLED);
+		this.project.open(null);
+		String fileContent = """
+				public class Test {
+					protected void main(String[] args) {
+					}
+				}
+					""";
+		createFile("/Java21Elements/src/Test.java", fileContent);
+
+		ICompilationUnit unit = getCompilationUnit("/Java21Elements/src/Test.java");
+		assertTrue(unit.getTypes()[0].getMethods()[0].isMainMethodCandidate());
+	}
+
+	public void test008() throws Exception {
+		this.project.setOption(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, JavaCore.ENABLED);
+		this.project.open(null);
+		String fileContent = """
+				public class Test {
+					void main(String[] args) {
+					}
+				}
+					""";
+		createFile("/Java21Elements/src/Test.java", fileContent);
+
+		ICompilationUnit unit = getCompilationUnit("/Java21Elements/src/Test.java");
+		assertTrue(unit.getTypes()[0].getMethods()[0].isMainMethodCandidate());
+	}
+
+	public void test009() throws Exception {
+		this.project.setOption(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, JavaCore.ENABLED);
+		this.project.open(null);
+		String fileContent = """
+				public class Test {
+					private void main(String[] args) {
+					}
+				}
+					""";
+		createFile("/Java21Elements/src/Test.java", fileContent);
+
+		ICompilationUnit unit = getCompilationUnit("/Java21Elements/src/Test.java");
+		assertFalse(unit.getTypes()[0].getMethods()[0].isMainMethodCandidate());
+	}
+
+	public void test010() throws Exception {
+		this.project.setOption(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, JavaCore.ENABLED);
+		this.project.open(null);
+		String fileContent = """
+				public class Test {
+					protected void main(int args) {
+					}
+				}
+					""";
+		createFile("/Java21Elements/src/Test.java", fileContent);
+
+		ICompilationUnit unit = getCompilationUnit("/Java21Elements/src/Test.java");
+		assertFalse(unit.getTypes()[0].getMethods()[0].isMainMethodCandidate());
+	}
+
+	public void test011() throws Exception {
+		this.project.setOption(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, JavaCore.ENABLED);
+		this.project.open(null);
+		String fileContent = """
+				public class Test {
+					void main(int args) {
+					}
+				}
+					""";
+		createFile("/Java21Elements/src/Test.java", fileContent);
+
+		ICompilationUnit unit = getCompilationUnit("/Java21Elements/src/Test.java");
+		assertFalse(unit.getTypes()[0].getMethods()[0].isMainMethodCandidate());
+	}
+
+	public void test012() throws Exception {
+		this.project.setOption(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, JavaCore.ENABLED);
+		this.project.open(null);
+		String fileContent = """
+				public class Test {
+					private void main(int args) {
+					}
+				}
+					""";
+		createFile("/Java21Elements/src/Test.java", fileContent);
+
+		ICompilationUnit unit = getCompilationUnit("/Java21Elements/src/Test.java");
+		assertFalse(unit.getTypes()[0].getMethods()[0].isMainMethodCandidate());
+	}
+	
+	public void test013() throws Exception {
+		this.project.open(null);
+		String fileContent = """
+				public class Test {
+					public static void main() {
+					}
+				}
+					""";
+		createFile("/Java21Elements/src/Test.java", fileContent);
+
+		ICompilationUnit unit = getCompilationUnit("/Java21Elements/src/Test.java");
+		assertFalse(unit.getTypes()[0].getMethods()[0].isMainMethodCandidate());
+	}
+
+	public void test014() throws Exception {
+		this.project.open(null);
+		String fileContent = """
+				public class Test {
+					public void main() {
+					}
+				}
+					""";
+		createFile("/Java21Elements/src/Test.java", fileContent);
+
+		ICompilationUnit unit = getCompilationUnit("/Java21Elements/src/Test.java");
+		assertFalse(unit.getTypes()[0].getMethods()[0].isMainMethodCandidate());
+	}
+
+	public void test015() throws Exception {
+		this.project.open(null);
+		String fileContent = """
+				public class Test {
+					protected void main() {
+					}
+				}
+					""";
+		createFile("/Java21Elements/src/Test.java", fileContent);
+
+		ICompilationUnit unit = getCompilationUnit("/Java21Elements/src/Test.java");
+		assertFalse(unit.getTypes()[0].getMethods()[0].isMainMethodCandidate());
+	}
+
+	public void test016() throws Exception {
+		this.project.open(null);
+		String fileContent = """
+				public class Test {
+					void main() {
+					}
+				}
+					""";
+		createFile("/Java21Elements/src/Test.java", fileContent);
+
+		ICompilationUnit unit = getCompilationUnit("/Java21Elements/src/Test.java");
+		assertFalse(unit.getTypes()[0].getMethods()[0].isMainMethodCandidate());
+	}
+
+	public void test017() throws Exception {
+		this.project.open(null);
+		String fileContent = """
+				public class Test {
+					private void main() {
+					}
+				}
+					""";
+		createFile("/Java21Elements/src/Test.java", fileContent);
+
+		ICompilationUnit unit = getCompilationUnit("/Java21Elements/src/Test.java");
+		assertFalse(unit.getTypes()[0].getMethods()[0].isMainMethodCandidate());
+	}
+
+	public void test018() throws Exception {
+		this.project.open(null);
+		String fileContent = """
+				public class Test {
+					protected void main(String[] args) {
+					}
+				}
+					""";
+		createFile("/Java21Elements/src/Test.java", fileContent);
+
+		ICompilationUnit unit = getCompilationUnit("/Java21Elements/src/Test.java");
+		assertFalse(unit.getTypes()[0].getMethods()[0].isMainMethodCandidate());
+	}
+
+	public void test019() throws Exception {
+		this.project.open(null);
+		String fileContent = """
+				public class Test {
+					void main(String[] args) {
+					}
+				}
+					""";
+		createFile("/Java21Elements/src/Test.java", fileContent);
+
+		ICompilationUnit unit = getCompilationUnit("/Java21Elements/src/Test.java");
+		assertFalse(unit.getTypes()[0].getMethods()[0].isMainMethodCandidate());
+	}
+
+	public void test020() throws Exception {
+		this.project.setOption(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, JavaCore.ENABLED);
+		this.project.open(null);
+		String fileContent = """
+				public class Test {
+					protected void main(java.lang.String[] args) {
+					}
+				}
+					""";
+		createFile("/Java21Elements/src/Test.java", fileContent);
+
+		ICompilationUnit unit = getCompilationUnit("/Java21Elements/src/Test.java");
+		assertTrue(unit.getTypes()[0].getMethods()[0].isMainMethodCandidate());
+	}
+
+	public void test021() throws Exception {
+		this.project.setOption(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, JavaCore.ENABLED);
+		this.project.open(null);
+		String fileContent = """
+				public class Test {
+					void main(java.lang.String[] args) {
+					}
+				}
+					""";
+		createFile("/Java21Elements/src/Test.java", fileContent);
+
+		ICompilationUnit unit = getCompilationUnit("/Java21Elements/src/Test.java");
+		assertTrue(unit.getTypes()[0].getMethods()[0].isMainMethodCandidate());
+	}
+
+	public void test022() throws Exception {
+		this.project.setOption(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, JavaCore.ENABLED);
+		this.project.open(null);
+		String fileContent = """
+				public class Test {
+					private void main(java.lang.String[] args) {
+					}
+				}
+					""";
+		createFile("/Java21Elements/src/Test.java", fileContent);
+
+		ICompilationUnit unit = getCompilationUnit("/Java21Elements/src/Test.java");
+		assertFalse(unit.getTypes()[0].getMethods()[0].isMainMethodCandidate());
+	}
+
+}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/core/IMethod.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/core/IMethod.java
@@ -264,6 +264,31 @@ boolean isConstructor() throws JavaModelException;
 boolean isMainMethod() throws JavaModelException;
 
 /**
+ * Returns whether this method is a main method candidate.
+ * It is a main method if:
+ * <ul>
+ * <li>its name is equal to <code>"main"</code></li>
+ * <li>its return type is <code>void</code></li>
+ * <li>it is <code>static</code> and <code>public</code></li>
+ * <li>it defines one parameter whose type's simple name is <code>String[]</code></li>
+ * </ul>
+ * Starting with Java 21 there is "preview feature" that allows <a href="https://openjdk.org/jeps/445">instance main methods</a>.
+ * It is a main method according to this JEP if:
+ * <ul>
+ * <li>its name is equal to <code>"main"</code></li>
+ * <li>its return type is <code>void</code></li>
+ * <li>it is non-<code>private</code></li>
+ * <li>it defines one parameter whose type's simple name is <code>String[]</code> or no parameter at all</li>
+ * </ul>
+ *
+ * @exception JavaModelException if this element does not exist or if an
+ *      exception occurs while accessing its corresponding resource.
+ * @since 3.36
+ * @return true if this method is a main method, false otherwise
+ */
+boolean isMainMethodCandidate() throws JavaModelException;
+
+/**
  * Returns whether this method represents a lambda expression.
  *
  * @since 3.10

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/BinaryMethod.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/BinaryMethod.java
@@ -636,6 +636,11 @@ public boolean isConstructor() throws JavaModelException {
 public boolean isMainMethod() throws JavaModelException {
 	return this.isMainMethod(this);
 }
+
+@Override
+public boolean isMainMethodCandidate() throws JavaModelException {
+	return this.isMainMethodCandidate(this);
+}
 /*
  * @see IMethod#isLambdaMethod()
  */

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/Member.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/Member.java
@@ -15,6 +15,7 @@ package org.eclipse.jdt.internal.core;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Map;
 
 import org.eclipse.jdt.core.*;
 import org.eclipse.jdt.core.compiler.CharOperation;
@@ -22,6 +23,7 @@ import org.eclipse.jdt.core.compiler.IScanner;
 import org.eclipse.jdt.core.compiler.ITerminalSymbols;
 import org.eclipse.jdt.core.compiler.InvalidInputException;
 import org.eclipse.jdt.internal.compiler.impl.Constant;
+import org.eclipse.jdt.internal.compiler.impl.JavaFeature;
 import org.eclipse.jdt.internal.compiler.lookup.TypeIds;
 import org.eclipse.jdt.internal.core.util.MementoTokenizer;
 
@@ -394,20 +396,47 @@ public boolean isBinary() {
 }
 protected boolean isMainMethod(IMethod method) throws JavaModelException {
 	if ("main".equals(method.getElementName()) && Signature.SIG_VOID.equals(method.getReturnType())) { //$NON-NLS-1$
-		int flags= method.getFlags();
+		int flags = method.getFlags();
 		IType declaringType = null;
 		if (Flags.isStatic(flags) &&
 				(Flags.isPublic(flags) ||
 						((declaringType = getDeclaringType()) != null && declaringType.isInterface()))) {
-			String[] paramTypes= method.getParameterTypes();
+			String[] paramTypes = method.getParameterTypes();
 			if (paramTypes.length == 1) {
-				String typeSignature=  Signature.toString(paramTypes[0]);
-				return "String[]".equals(Signature.getSimpleName(typeSignature)); //$NON-NLS-1$
+				return isStringArrayParameter(paramTypes[0]);
 			}
 		}
 	}
 	return false;
 }
+
+protected boolean isMainMethodCandidate(IMethod method) throws JavaModelException {
+	Map<String, String> options = method.getJavaProject().getOptions(true);
+	if (JavaFeature.UNNAMMED_CLASSES_AND_INSTANCE_MAIN_METHODS.isSupported(
+				options.get(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM),
+				JavaCore.ENABLED.equals(options.get(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES)))) {
+		if ("main".equals(method.getElementName()) && Signature.SIG_VOID.equals(method.getReturnType())) { //$NON-NLS-1$
+			int flags = method.getFlags();
+			if (!Flags.isPrivate(flags)) {
+				String[] paramTypes = method.getParameterTypes();
+				if (paramTypes.length == 1) {
+					return isStringArrayParameter(paramTypes[0]);
+				} else if (paramTypes.length == 0) {
+					return true;
+				}
+			}
+		}
+		return false;
+	} else {
+		return isMainMethod(method);
+	}
+}
+
+private boolean isStringArrayParameter(String paramType) {
+	String typeSignature = Signature.toString(paramType);
+    return "String[]".equals(Signature.getSimpleName(typeSignature)); //$NON-NLS-1$
+}
+
 /**
  * @see IJavaElement
  */

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SourceMethod.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SourceMethod.java
@@ -242,6 +242,12 @@ public boolean isConstructor() throws JavaModelException {
 public boolean isMainMethod() throws JavaModelException {
 	return this.isMainMethod(this);
 }
+
+@Override
+public boolean isMainMethodCandidate() throws JavaModelException {
+	return this.isMainMethodCandidate(this);
+}
+
 /**
  * @see IMethod#isLambdaMethod()
  */


### PR DESCRIPTION
## What it does
Implements the JEP 445 definition of main methods on Java 21 with --enable-preview.
This is the jdt.core model part which makes "Run As" recognize the new main methods although it fails after that due to changes needed in jdt.debug or jdt.ui

## How to test
Run the newly created Java21ElementTests in your workspace with Java 21.
Note: this test case is not added in any suite as I didn't manage to figure Java 21 specific testing yet thus information where to add the test case would be much appreciated.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
