### PR TITLE
Fix ASTMatcher for PatternInstanceofExpression when ast api level >= 21

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTMatcherTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTMatcherTest.java
@@ -52,6 +52,8 @@ public class ASTMatcherTest extends org.eclipse.jdt.core.tests.junit.extension.T
 				suite.addTest(new ASTMatcherTest(methods[i].getName(), JLS3_INTERNAL));
 				// https://bugs.eclipse.org/bugs/show_bug.cgi?id=391898
 				suite.addTest(new ASTMatcherTest(methods[i].getName(), getJLS8()));
+				suite.addTest(new ASTMatcherTest(methods[i].getName(), AST.JLS17));
+				suite.addTest(new ASTMatcherTest(methods[i].getName(), AST.JLS21));
 			}
 		}
 		return suite;
@@ -273,7 +275,16 @@ public class ASTMatcherTest extends org.eclipse.jdt.core.tests.junit.extension.T
 			case JLS3_INTERNAL:
 				name = "JLS3 - " + name;
 				break;
-		}
+			case AST.JLS8:
+				name = "JLS8 - " + name;
+				break;
+			case AST.JLS17:
+				name = "JLS17 - " + name;
+				break;
+			case AST.JLS21:
+				name = "JLS21 - " + name;
+				break;
+	}
 		return name;
 	}
 
@@ -584,6 +595,12 @@ public class ASTMatcherTest extends org.eclipse.jdt.core.tests.junit.extension.T
 			return standardBody(node, other, this.superMatch ? super.match(node, other) : false);
 		}
 		public boolean match(IntersectionType node, Object other) {
+			return standardBody(node, other, this.superMatch ? super.match(node, other) : false);
+		}
+		public boolean match(TypePattern node, Object other) {
+			return standardBody(node, other, this.superMatch ? super.match(node, other) : false);
+		}
+		public boolean match(PatternInstanceofExpression node, Object other) {
 			return standardBody(node, other, this.superMatch ? super.match(node, other) : false);
 		}
 	}
@@ -1135,6 +1152,25 @@ public class ASTMatcherTest extends org.eclipse.jdt.core.tests.junit.extension.T
 	}
 	public void testParenthesizedExpression() {
 		ParenthesizedExpression x1 = this.ast.newParenthesizedExpression();
+		basicMatch(x1);
+	}
+	public void testPatternInstanceofExpression() {
+		if (this.ast.apiLevel() < AST.JLS17) {
+			return;
+		}
+		PatternInstanceofExpression x1 = this.ast.newPatternInstanceofExpression();
+		x1.setLeftOperand(this.N1);
+		SingleVariableDeclaration svd = this.ast.newSingleVariableDeclaration();
+		svd.setType(this.T1);
+		svd.setName(this.N2);
+
+		if (this.ast.apiLevel() <= AST.JLS20) {
+			x1.setRightOperand(svd);
+		} else {
+			TypePattern tp = this.ast.newTypePattern();
+			tp.setPatternVariable(svd);
+			x1.setPattern(tp);
+		}
 		basicMatch(x1);
 	}
 	public void testPostfixExpression() {

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ASTMatcher.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ASTMatcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -1976,15 +1976,19 @@ public class ASTMatcher {
 	 *   different node type or is <code>null</code>
 	 * @since 3.26
 	 */
-	@SuppressWarnings("deprecation")
 	public boolean match(PatternInstanceofExpression node, Object other) {
 		if (!(other instanceof PatternInstanceofExpression)) {
 			return false;
 		}
 		PatternInstanceofExpression o = (PatternInstanceofExpression) other;
-		return
-			safeSubtreeMatch(node.getLeftOperand(), o.getLeftOperand())
-			&& safeSubtreeMatch(node.getRightOperand(), o.getRightOperand());
+		AST ast= node.getAST();
+		if (ast.apiLevel() <= 20) {
+			return
+					safeSubtreeMatch(node.getLeftOperand(), o.getLeftOperand())
+					&& safeSubtreeMatch(node.getRightOperand(), o.getRightOperand());
+		}
+		return safeSubtreeMatch(node.getLeftOperand(), o.getLeftOperand())
+				&& safeSubtreeMatch(node.getPattern(), o.getPattern());
 	}
 
 	/**


### PR DESCRIPTION
- fix the match method for PatternInstanceofExpression to use the getRightOperand() when ast level <= 20 and the getPattern() method when ast level 21 or higher
- fixes: #1480

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes the ASTMatcher to properly compare two PatternInstanceofExpressions based on the ast api level.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
