### PR TITLE
Jenkins file changes to debug random API analysis errors

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,6 +35,7 @@ pipeline {
 					-Ptest-on-javase-21 -Pbree-libs -Papi-check \
 					-Djava.io.tmpdir=$WORKSPACE/tmp -Dproject.build.sourceEncoding=UTF-8 \
 					-Dtycho.surefire.argLine="--add-modules ALL-SYSTEM -Dcompliance=1.8,11,17,19,21 -Djdt.performance.asserts=disabled" \
+					-DDetectVMInstallationsJob.disabled=true \
 					-Dcbi-ecj-version=99.99
 					"""
 			}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,6 +36,7 @@ pipeline {
 					-Djava.io.tmpdir=$WORKSPACE/tmp -Dproject.build.sourceEncoding=UTF-8 \
 					-Dtycho.surefire.argLine="--add-modules ALL-SYSTEM -Dcompliance=1.8,11,17,19,21 -Djdt.performance.asserts=disabled" \
 					-DDetectVMInstallationsJob.disabled=true \
+					-Dtycho.apitools.debug \
 					-Dcbi-ecj-version=99.99
 					"""
 			}


### PR DESCRIPTION
- Enable debug for API tooling on Jenkins
Should help to understand strange API analysis errors.
- Disable DetectVMInstallationsJob in Jenkins
That should reduce possible side effects on API analysis.

See https://github.com/eclipse-pde/eclipse.pde/issues/782