### PR TITLE
Allow creating a source file for the 1st time even if it already exists

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/apt/dispatch/BatchFilerImpl.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/apt/dispatch/BatchFilerImpl.java
@@ -24,7 +24,6 @@ import java.util.HashSet;
 import javax.annotation.processing.Filer;
 import javax.annotation.processing.FilerException;
 import javax.lang.model.element.Element;
-import javax.lang.model.element.TypeElement;
 import javax.tools.FileObject;
 import javax.tools.JavaFileManager;
 import javax.tools.JavaFileObject;
@@ -143,10 +142,6 @@ public class BatchFilerImpl implements Filer {
 		if (slash != -1) {
 			name = moduleAndPkgString.substring(slash + 1, name.length());
 			mod = moduleAndPkgString.substring(0, slash);
-		}
-		TypeElement typeElement = this._env._elementUtils.getTypeElement(name);
-		if (typeElement != null) {
-			throw new FilerException("Source file already exists : " + moduleAndPkgString); //$NON-NLS-1$
 		}
 		Location location = mod == null ? StandardLocation.SOURCE_OUTPUT : this._fileManager.getLocationForModule(StandardLocation.SOURCE_OUTPUT, mod);
 		JavaFileObject jfo = this._fileManager.getJavaFileForOutput(location, name.toString(), JavaFileObject.Kind.SOURCE, null);


### PR DESCRIPTION
Fixes #1482.
This makes BatchFilerImpl conform to the Filer specification.

## How to test
The change can be tested with an arbitraty annotation processor that generates source files during a compilation that wasn't necessarily initiated from a *clean state*. In particular, the source file being generated should already exist before the compilation takes place.
I tested this using IntelliJ IDEA, where, in compiler settings, you can specify the path to the Eclipse compiler JAR. Compiling with the original version produces a *Source file already exists* message and fails to regenerate the respective source file, while the version proposed by this pull request successfully generated the source files.

## Author checklist

- [ ] I have thoroughly tested my changes
  - I have _roughly_ tested my changes.
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
