### PR TITLE
Fixes an ArrayIndexOutOfBoundsException when using a return statement in

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TryStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TryStatement.java
@@ -598,7 +598,9 @@ public void generateCode(BlockScope currentScope, CodeStream codeStream) {
 		if (resourceCount > 0) {
 			for (int i = resourceCount; i >= 0; i--) {
 				BranchLabel exitLabel = new BranchLabel(codeStream);
-				this.resourceExceptionLabels[i].placeEnd(); // outer handler if any is the one that should catch exceptions out of close()
+				if (this.resourceExceptionLabels[i].getCount() % 2 != 0) {
+					this.resourceExceptionLabels[i].placeEnd(); // outer handler if any is the one that should catch exceptions out of close()
+				}
 
 				Statement stmt = i > 0 ? this.resources[i - 1] : null;
 				if ((this.bits & ASTNode.IsTryBlockExiting) == 0) {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TryWithResourcesStatementTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TryWithResourcesStatementTest.java
@@ -4396,6 +4396,26 @@ public void testGHIssue1063() {
 			"	at X.main(X.java:7)\n",
 			null);
 }
+
+// https://github.com/eclipse-jdt/eclipse.jdt.core/pull/1495
+public void testGHissue1495() {
+    this.runConformTest(
+        new String[] {
+                "X.java",
+                "import java.io.*;\n" +
+                "interface I extends Closeable {}\n" +
+                "public class X {\n" +
+                "   public static void main(String[] args) {\n" +
+                "       try (I i = i()) {\n" +
+                "         return;\n" +
+                "       } finally {\n" +
+                "         return;\n" +
+                "       }" +
+                "   }" +
+                "   public static I i() { return null; }\n" +
+                "}\n"
+    });
+}
 public static Class testClass() {
 	return TryWithResourcesStatementTest.class;
 }


### PR DESCRIPTION
a finally statement of a try with resources

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
Fixes an `ArrayIndexOutOfBoundsException` when attempting to compile
```java
public void test() {
    try (Scanner scanner = new Scanner(new File("."))) {
        return;
    } finally {
        return;
    }
}
```

## How to test
Add
```java
public void test() {
    try (Scanner scanner = new Scanner(new File("."))) {
        return;
    } finally {
        return;
    }
}
```
to any class

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
