### PR TITLE
Import static with protected base class yiels wrong class reference compiled in resulting classfile

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Scope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Scope.java
@@ -2246,7 +2246,12 @@ public abstract class Scope {
 										if (importReference != null && needResolve) {
 											importReference.bits |= ASTNode.Used;
 										}
-										invocationSite.setActualReceiverType(foundField.declaringClass);
+										TypeBinding importedType = this.getType(importBinding.compoundName, importBinding.compoundName.length-1);
+										if (importedType instanceof ReferenceBinding && importBinding.isValidBinding()) {
+											invocationSite.setActualReceiverType((ReferenceBinding) importedType);
+										} else {
+											invocationSite.setActualReceiverType(foundField.declaringClass);
+										}
 										if (foundField.isValidBinding()) {
 											return foundField;
 										}
@@ -2258,12 +2263,14 @@ public abstract class Scope {
 						}
 						// check on demand imports
 						boolean foundInImport = false;
+						ReferenceBinding sourceCodeReceiver = null;
 						for (int i = 0, length = imports.length; i < length; i++) {
 							ImportBinding importBinding = imports[i];
 							if (importBinding.isStatic() && importBinding.onDemand) {
 								Binding resolvedImport = importBinding.resolvedImport;
 								if (resolvedImport instanceof ReferenceBinding) {
-									FieldBinding temp = findField((ReferenceBinding) resolvedImport, name, invocationSite, needResolve);
+									ReferenceBinding importedReferenceBinding = (ReferenceBinding) resolvedImport;
+									FieldBinding temp = findField(importedReferenceBinding, name, invocationSite, needResolve);
 									if (temp != null) {
 										if (!temp.isValidBinding()) {
 											if (problemField == null)
@@ -2282,6 +2289,7 @@ public abstract class Scope {
 														name,
 														ProblemReasons.Ambiguous);
 											foundField = temp;
+											sourceCodeReceiver = importedReferenceBinding;
 											foundInImport = true;
 										}
 									}
@@ -2289,7 +2297,10 @@ public abstract class Scope {
 							}
 						}
 						if (foundField != null) {
-							invocationSite.setActualReceiverType(foundField.declaringClass);
+							if (sourceCodeReceiver != null)
+								invocationSite.setActualReceiverType(sourceCodeReceiver);
+							else
+								invocationSite.setActualReceiverType(foundField.declaringClass);
 							return foundField;
 						}
 					}
@@ -2725,6 +2736,7 @@ public abstract class Scope {
 			scope = scope.parent;
 		}
 
+		Map<MethodBinding,ReferenceBinding> method2sourceDeclaring = new HashMap<>();
 		if (insideStaticContext && options.sourceLevel >= ClassFileConstants.JDK1_5) {
 			if (foundProblem != null) {
 				if (foundProblem.declaringClass != null && foundProblem.declaringClass.id == TypeIds.T_JavaLangObject)
@@ -2747,15 +2759,25 @@ public abstract class Scope {
 						Binding resolvedImport = importBinding.resolvedImport;
 						MethodBinding possible = null;
 						if (importBinding.onDemand) {
-							if (!skipOnDemand && resolvedImport instanceof ReferenceBinding)
+							if (!skipOnDemand && resolvedImport instanceof ReferenceBinding) {
 								// answers closest approximation, may not check argumentTypes or visibility
-								possible = findMethod((ReferenceBinding) resolvedImport, selector, argumentTypes, invocationSite, true);
+								ReferenceBinding resolvedImportReferenceBinding = (ReferenceBinding) resolvedImport;
+								possible = findMethod(resolvedImportReferenceBinding, selector, argumentTypes, invocationSite, true);
+								if (possible != null && possible.isValidBinding())
+									method2sourceDeclaring.put(possible, resolvedImportReferenceBinding);
+							}
 						} else {
 							if (resolvedImport instanceof MethodBinding) {
 								MethodBinding staticMethod = (MethodBinding) resolvedImport;
-								if (CharOperation.equals(staticMethod.selector, selector))
+								if (CharOperation.equals(staticMethod.selector, selector)) {
 									// answers closest approximation, may not check argumentTypes or visibility
 									possible = findMethod(staticMethod.declaringClass, selector, argumentTypes, invocationSite, true);
+									if (possible != null && possible.isValidBinding()) {
+										TypeBinding importedType = getType(importBinding.compoundName, importBinding.compoundName.length-1);
+										if (importedType instanceof ReferenceBinding && importedType.isValidBinding())
+											method2sourceDeclaring.put(possible, (ReferenceBinding) importedType);
+									}
+								}
 							} else if (resolvedImport instanceof FieldBinding) {
 								// check to see if there are also methods with the same name
 								FieldBinding staticField = (FieldBinding) resolvedImport;
@@ -2777,6 +2799,7 @@ public abstract class Scope {
 								MethodBinding compatibleMethod = computeCompatibleMethod(possible, argumentTypes, invocationSite);
 								if (compatibleMethod != null) {
 									if (compatibleMethod.isValidBinding()) {
+										method2sourceDeclaring.put(compatibleMethod, method2sourceDeclaring.get(possible));
 										if (compatibleMethod.canBeSeenBy(unitScope.fPackage)) {
 											if (!skipOnDemand && !importBinding.onDemand) {
 												visible = null; // forget previous matches from on demand imports
@@ -2817,7 +2840,12 @@ public abstract class Scope {
 		}
 
 		if (foundMethod != null) {
-			invocationSite.setActualReceiverType(foundMethod.declaringClass);
+			ReferenceBinding sourceDeclaring = method2sourceDeclaring.get(foundMethod);
+			if (sourceDeclaring != null) {
+				invocationSite.setActualReceiverType(sourceDeclaring);
+			} else {
+				invocationSite.setActualReceiverType(foundMethod.declaringClass);
+			}
 			return foundMethod;
 		}
 		if (foundProblem != null)

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/StaticImportTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/StaticImportTest.java
@@ -3418,4 +3418,178 @@ public class StaticImportTest extends AbstractComparableTest {
 				"The import p.Bar is never used\n" +
 				"----------\n");
 	}
+	public void testGH809_field_a() {
+		Runner runner = new Runner();
+		runner.testFiles = new String[] {
+			"p2/Client.java",
+			"""
+			package p2;
+			import static p1.Sub.*;
+			public class Client {
+				public static void main(String... args) {
+					System.out.println(ONE);
+				}
+			}
+			""",
+			"p1/Super.java",
+			"""
+			package p1;
+			class Super {
+				public static int ONE = 1;
+			}
+			""",
+			"p1/Sub.java",
+			"""
+			package p1;
+			public class Sub extends Super {}
+			"""
+		};
+		runner.expectedOutputString = "1";
+		runner.runConformTest();
+	}
+	public void testGH809_field_b() {
+		Runner runner = new Runner();
+		runner.testFiles = new String[] {
+			"p2/Client.java",
+			"""
+			package p2;
+			import static p1.Sub.ONE;
+			public class Client {
+				public static void main(String... args) {
+					System.out.println(ONE);
+				}
+			}
+			""",
+			"p1/Super.java",
+			"""
+			package p1;
+			class Super {
+				public static int ONE = 1;
+			}
+			""",
+			"p1/Sub.java",
+			"""
+			package p1;
+			public class Sub extends Super {}
+			"""
+		};
+		runner.expectedOutputString = "1";
+		runner.runConformTest();
+	}
+	public void testGH809_field_c() {
+		Runner runner = new Runner();
+		runner.testFiles = new String[] {
+			"p2/Client.java",
+			"""
+			package p2;
+			import p1.Sub;
+			public class Client {
+				public static void main(String... args) {
+					System.out.println(Sub.ONE);
+				}
+			}
+			""",
+			"p1/Super.java",
+			"""
+			package p1;
+			class Super {
+				public static int ONE = 1;
+			}
+			""",
+			"p1/Sub.java",
+			"""
+			package p1;
+			public class Sub extends Super {}
+			"""
+		};
+		runner.expectedOutputString = "1";
+		runner.runConformTest();
+	}
+	public void testGH809_method_a() {
+		Runner runner = new Runner();
+		runner.testFiles = new String[] {
+			"p2/Client.java",
+			"""
+			package p2;
+			import static p1.Sub.*;
+			public class Client {
+				public static void main(String... args) {
+					System.out.println(ONE());
+				}
+			}
+			""",
+			"p1/Super.java",
+			"""
+			package p1;
+			class Super {
+				public static int ONE() { return 1; }
+			}
+			""",
+			"p1/Sub.java",
+			"""
+			package p1;
+			public class Sub extends Super {}
+			"""
+		};
+		runner.expectedOutputString = "1";
+		runner.runConformTest();
+	}
+	public void testGH809_method_b() {
+		Runner runner = new Runner();
+		runner.testFiles = new String[] {
+			"p2/Client.java",
+			"""
+			package p2;
+			import static p1.Sub.ONE;
+			public class Client {
+				public static void main(String... args) {
+					System.out.println(ONE());
+				}
+			}
+			""",
+			"p1/Super.java",
+			"""
+			package p1;
+			class Super {
+				public static int ONE() { return 1; }
+			}
+			""",
+			"p1/Sub.java",
+			"""
+			package p1;
+			public class Sub extends Super {}
+			"""
+		};
+		runner.expectedOutputString = "1";
+		runner.runConformTest();
+	}
+	public void testGH809_method_c() {
+		Runner runner = new Runner();
+		runner.testFiles = new String[] {
+			"p2/Client.java",
+			"""
+			package p2;
+			import p1.Sub;
+			public class Client {
+				public static void main(String... args) {
+					System.out.println(Sub.ONE());
+				}
+			}
+			""",
+			"p1/Super.java",
+			"""
+			package p1;
+			class Super {
+				public static int ONE() { return 1; }
+			}
+			""",
+			"p1/Sub.java",
+			"""
+			package p1;
+			public class Sub extends Super {}
+			"""
+		};
+		runner.expectedOutputString = "1";
+		runner.runConformTest();
+	}
 }


### PR DESCRIPTION
fixes #809


## What it does
Remember the receiver type through which in import resolved a field or method, and if necessary use that "source-level" declaring class during code generation.

## How to test
JUnit test cases included.
@jukzi  can you think of any other failing situations not covered by my junits?

