### PR TITLE
Check for record superclass before generic type

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BinaryTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BinaryTypeBinding.java
@@ -518,15 +518,15 @@ void cachePartsFrom(IBinaryType binaryType, boolean needFieldsAndMethods) {
 				this.typeVariables = addMethodTypeVariables(typeVars);
 			}
 		}
+		char[] superclassName = binaryType.getSuperclassName();
+		if (superclassName != null && CharOperation.equals(superclassName, TypeConstants.CharArray_JAVA_LANG_RECORD_SLASH)) {
+			this.modifiers |= ExtraCompilerModifiers.AccRecord;
+		}
 		if (typeSignature == null)  {
-			char[] superclassName = binaryType.getSuperclassName();
 			if (superclassName != null) {
 				// attempt to find the superclass if it exists in the cache (otherwise - resolve it when requested)
 				this.superclass = this.environment.getTypeFromConstantPoolName(superclassName, 0, -1, false, missingTypeNames, toplevelWalker.toSupertype((short) -1, superclassName));
 				this.tagBits |= TagBits.HasUnresolvedSuperclass;
-				if (CharOperation.equals(superclassName, TypeConstants.CharArray_JAVA_LANG_RECORD_SLASH)){
-					this.modifiers |= ExtraCompilerModifiers.AccRecord;
-				}
 			}
 
 			this.superInterfaces = Binding.NO_SUPERINTERFACES;


### PR DESCRIPTION
## Check for record superclass before generic type in BinaryTypeBinding
Supposedly fixes the issue https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1497 , unit test is included

The best i could think of is just rearrange checks so java.lang.Record is being detected no matter generic type
I'm not entirely sure if this is a proper solution - apart from this particular scenario, record modifier is set even if there is generic interface. I tried a bunch of similar yet working cases and it seems like record modifier ends up in binding either from this check, or just inherited from package modifiers in constructor https://github.com/eclipse-jdt/eclipse.jdt.core/blob/master/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BinaryTypeBinding.java#L321
Maybe real problem lies somewhere deeper, like inner classes resolution order or something.

## How to test
Run `org.eclipse.jdt.core.tests.compiler.regression.RecordsRestrictedClassTest#testBugGH1497readFromRecordWithGenericInterface` test
It is in separate commit so it's easy to debug current implementation without any fixes

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
