### PR TITLE
Maven artifact org.eclipse.jdt.annotation has wrong Maven model version in pom

### DIFF
--- a/org.eclipse.jdt.annotation/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.annotation/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-Localization: bundle
 Bundle-SymbolicName: org.eclipse.jdt.annotation
-Bundle-Version: 2.2.700.qualifier
+Bundle-Version: 2.2.800.qualifier
 Export-Package: org.eclipse.jdt.annotation
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Vendor: %providerName

--- a/org.eclipse.jdt.annotation/pom.xml
+++ b/org.eclipse.jdt.annotation/pom.xml
@@ -17,7 +17,7 @@
     <version>4.30.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.eclipse.jdt.annotation</artifactId>
-  <version>2.2.700-SNAPSHOT</version>
+  <version>2.2.800-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <build>


### PR DESCRIPTION
fixes #1416 by bumping up version although semantically nothing changed

## What it does
Bump up version to trigger re-deployment after the fix in [eclipse-platform/eclipse.platform#180](https://github.com/eclipse-platform/eclipse.platform/issues/180)

## How to test
Need to wait for the 2023-12 release to appear on maven central (latest snapshot at https://repo.eclipse.org/service/local/repo_groups/eclipse/content/org/eclipse/jdt/org.eclipse.jdt.annotation/2.2.700-SNAPSHOT/org.eclipse.jdt.annotation-2.2.700-20231019.003952-1.pom already shows the correct maven model version).

## Author checklist

- [ ] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
