### PR TITLE
Use DebugTrace instead of System.out.println() and printStackTrace()

### DIFF
--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/CompletionEngine.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/CompletionEngine.java
@@ -21,6 +21,8 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.codeassist;
 
+import static org.eclipse.jdt.internal.core.JavaModelManager.trace;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -1896,7 +1898,7 @@ public final class CompletionEngine
 		buildTokenLocationContext(context, scope, astNode, astNodeParent);
 
 		if(DEBUG) {
-			System.out.println(context.toString());
+			trace(context.toString());
 		}
 		this.requestor.acceptContext(context);
 	}
@@ -2116,12 +2118,8 @@ public final class CompletionEngine
 	public void complete(ICompilationUnit sourceUnit, int completionPosition, int pos, ITypeRoot root) {
 
 		if(DEBUG) {
-			System.out.print("COMPLETION IN "); //$NON-NLS-1$
-			System.out.print(sourceUnit.getFileName());
-			System.out.print(" AT POSITION "); //$NON-NLS-1$
-			System.out.println(completionPosition);
-			System.out.println("COMPLETION - Source :"); //$NON-NLS-1$
-			System.out.println(sourceUnit.getContents());
+			trace("COMPLETION IN " + new String(sourceUnit.getFileName()) + " AT POSITION " + completionPosition);  //$NON-NLS-1$//$NON-NLS-2$
+			trace("COMPLETION - Source :" + new String(sourceUnit.getContents())); //$NON-NLS-1$
 		}
 		if (this.monitor != null) this.monitor.beginTask(Messages.engine_completing, IProgressMonitor.UNKNOWN);
 		this.requestor.beginReporting();
@@ -2142,8 +2140,8 @@ public final class CompletionEngine
 			//		boolean completionNodeFound = false;
 			if (parsedUnit != null) {
 				if(DEBUG) {
-					System.out.println("COMPLETION - Diet AST :"); //$NON-NLS-1$
-					System.out.println(parsedUnit.toString());
+					trace("COMPLETION - Diet AST :"); //$NON-NLS-1$
+					trace(parsedUnit.toString());
 				}
 
 				if (parsedUnit.isModuleInfo()) {
@@ -2229,11 +2227,9 @@ public final class CompletionEngine
 						if (e.astNode != null) {
 							// if null then we found a problem in the completion node
 							if(DEBUG) {
-								System.out.print("COMPLETION - Completion node : "); //$NON-NLS-1$
-								System.out.println(e.astNode.toString());
+								trace("COMPLETION - Completion node : " + e.astNode.toString()); //$NON-NLS-1$
 								if(this.parser.assistNodeParent != null) {
-									System.out.print("COMPLETION - Parent Node : ");  //$NON-NLS-1$
-									System.out.println(this.parser.assistNodeParent);
+									trace("COMPLETION - Parent Node : " + this.parser.assistNodeParent); //$NON-NLS-1$
 								}
 							}
 							this.lookupEnvironment.unitBeingCompleted = parsedUnit; // better resilient to further error reporting
@@ -2337,8 +2333,8 @@ public final class CompletionEngine
 							this.unitScope.throwDeferredException();
 							parseBlockStatements(parsedUnit, this.actualCompletionPosition);
 							if(DEBUG) {
-								System.out.println("COMPLETION - AST :"); //$NON-NLS-1$
-								System.out.println(parsedUnit.toString());
+								trace("COMPLETION - AST :"); //$NON-NLS-1$
+								trace(parsedUnit.toString());
 							}
 							parsedUnit.resolve();
 						}
@@ -2347,11 +2343,9 @@ public final class CompletionEngine
 						if (e.astNode != null) {
 							// if null then we found a problem in the completion node
 							if(DEBUG) {
-								System.out.print("COMPLETION - Completion node : "); //$NON-NLS-1$
-								System.out.println(e.astNode.toString());
+								trace("COMPLETION - Completion node : " + e.astNode.toString()); //$NON-NLS-1$
 								if(this.parser.assistNodeParent != null) {
-									System.out.print("COMPLETION - Parent Node : ");  //$NON-NLS-1$
-									System.out.println(this.parser.assistNodeParent);
+									trace("COMPLETION - Parent Node : " + this.parser.assistNodeParent); //$NON-NLS-1$
 								}
 							}
 							this.lookupEnvironment.unitBeingCompleted = parsedUnit; // better resilient to further error reporting
@@ -2396,8 +2390,7 @@ public final class CompletionEngine
 			*/
 		} catch (IndexOutOfBoundsException | InvalidCursorLocation | AbortCompilation | CompletionNodeFound e){ // internal failure - bugs 5618
 			if(DEBUG) {
-				System.out.println("Exception caught by CompletionEngine:"); //$NON-NLS-1$
-				e.printStackTrace(System.out);
+				trace("Exception caught by CompletionEngine:", e); //$NON-NLS-1$
 			}
 		} finally {
 			if(!contextAccepted) {
@@ -2429,11 +2422,9 @@ public final class CompletionEngine
 				if (e.astNode != null) {
 					// if null then we found a problem in the completion node
 					if(DEBUG) {
-						System.out.print("COMPLETION - Completion node : "); //$NON-NLS-1$
-						System.out.println(e.astNode.toString());
+						trace("COMPLETION - Completion node : " + e.astNode.toString()); //$NON-NLS-1$
 						if(this.parser.assistNodeParent != null) {
-							System.out.print("COMPLETION - Parent Node : ");  //$NON-NLS-1$
-							System.out.println(this.parser.assistNodeParent);
+							trace("COMPLETION - Parent Node : " + this.parser.assistNodeParent); //$NON-NLS-1$
 						}
 					}
 					this.lookupEnvironment.unitBeingCompleted = parsedUnit; // better resilient to further error reporting
@@ -2594,8 +2585,8 @@ public final class CompletionEngine
 				typeDeclaration.fields = newFields;
 
 				if(DEBUG) {
-					System.out.println("SNIPPET COMPLETION AST :"); //$NON-NLS-1$
-					System.out.println(compilationUnit.toString());
+					trace("SNIPPET COMPLETION AST :"); //$NON-NLS-1$
+					trace(compilationUnit.toString());
 				}
 
 				if (compilationUnit.types != null) {
@@ -2638,8 +2629,7 @@ public final class CompletionEngine
 			}
 		}  catch (IndexOutOfBoundsException | InvalidCursorLocation | AbortCompilation | CompletionNodeFound e){ // internal failure - bugs 5618 (added with fix of 99629)
 			if(DEBUG) {
-				System.out.println("Exception caught by CompletionEngine:"); //$NON-NLS-1$
-				e.printStackTrace(System.out);
+				trace("Exception caught by CompletionEngine:", e); //$NON-NLS-1$
 			}
 		} catch(JavaModelException e) {
 			// Do nothing
@@ -12001,8 +11991,7 @@ public final class CompletionEngine
 			);
 		} catch (CoreException e) {
 			if(DEBUG) {
-				System.out.println("Exception caught by CompletionEngine:"); //$NON-NLS-1$
-				e.printStackTrace(System.out);
+				trace("Exception caught by CompletionEngine:", e); //$NON-NLS-1$
 			}
 		}
 
@@ -12979,8 +12968,9 @@ public final class CompletionEngine
 				acceptTypes(scope);
 			}
 		} catch (CoreException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
+			if (JavaModelManager.VERBOSE) {
+				trace("", e); //$NON-NLS-1$
+			}
 		}
 		if(!this.requestor.isIgnored(CompletionProposal.PACKAGE_REF)) {
 			checkCancel();
@@ -13993,15 +13983,13 @@ public final class CompletionEngine
 	}
 	protected void printDebug(CategorizedProblem error) {
 		if(CompletionEngine.DEBUG) {
-			System.out.print("COMPLETION - completionFailure("); //$NON-NLS-1$
-			System.out.print(error);
-			System.out.println(")"); //$NON-NLS-1$
+			trace("COMPLETION - completionFailure(" + error + ")"); //$NON-NLS-1$ //$NON-NLS-2$
 		}
 	}
 	protected void printDebug(CompletionProposal proposal){
 		StringBuffer buffer = new StringBuffer();
 		printDebug(proposal, 0, buffer);
-		System.out.println(buffer.toString());
+		trace(buffer.toString());
 	}
 
 	private void printDebug(CompletionProposal proposal, int tab, StringBuffer buffer){

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/NameEnvironmentWithProgress.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/NameEnvironmentWithProgress.java
@@ -15,6 +15,8 @@
  *******************************************************************************/
 package org.eclipse.jdt.core.dom;
 
+import static org.eclipse.jdt.internal.core.JavaModelManager.trace;
+
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.jdt.core.compiler.CharOperation;
@@ -39,7 +41,7 @@ class NameEnvironmentWithProgress extends FileSystem implements INameEnvironment
 	private void checkCanceled() {
 		if (this.monitor != null && this.monitor.isCanceled()) {
 			if (NameLookup.VERBOSE) {
-				System.out.println(Thread.currentThread() + " CANCELLING LOOKUP "); //$NON-NLS-1$
+				trace(Thread.currentThread() + " CANCELLING LOOKUP "); //$NON-NLS-1$
 			}
 			throw new AbortCompilation(true/*silent*/, new OperationCanceledException());
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/ASTRewriteAnalyzer.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/ASTRewriteAnalyzer.java
@@ -35,6 +35,7 @@ import org.eclipse.jdt.internal.compiler.parser.Scanner;
 import org.eclipse.jdt.internal.compiler.parser.ScannerHelper;
 import org.eclipse.jdt.internal.compiler.parser.TerminalTokens;
 import org.eclipse.jdt.internal.compiler.util.Util;
+import org.eclipse.jdt.internal.core.JavaModelManager;
 import org.eclipse.jdt.internal.core.dom.rewrite.ASTRewriteFormatter.BlockContext;
 import org.eclipse.jdt.internal.core.dom.rewrite.ASTRewriteFormatter.NodeMarker;
 import org.eclipse.jdt.internal.core.dom.rewrite.ASTRewriteFormatter.Prefix;
@@ -2109,7 +2110,9 @@ public final class ASTRewriteAnalyzer extends ASTVisitor {
 			try {
 				offset = getScanner().getPreviousTokenEndOffset(token, offset);
 			} catch (CoreException e1) {
-				e1.printStackTrace();
+				if (JavaModelManager.VERBOSE) {
+					JavaModelManager.trace("", e1); //$NON-NLS-1$
+				}
 			}
 		}
 		return offset;
@@ -2141,7 +2144,9 @@ public final class ASTRewriteAnalyzer extends ASTVisitor {
 					delEnd = getScanner().getNextStartOffset(delStart, false);
 					doTextRemove(delStart, delEnd - delStart, null); /* remove spaces after the annotation */
 				} catch (CoreException e) {
-					e.printStackTrace();
+					if (JavaModelManager.VERBOSE) {
+						JavaModelManager.trace("", e); //$NON-NLS-1$
+					}
 				}
 			} else if (oldAnnotationSize == 0 && newAnnotationSize > 0) { /* inserting first annotation */
 				if (ScannerHelper.isWhitespace(this.content[node.getStartPosition() - 1])) {

--- a/org.eclipse.jdt.core/eval/org/eclipse/jdt/internal/eval/CodeSnippetEnvironment.java
+++ b/org.eclipse.jdt.core/eval/org/eclipse/jdt/internal/eval/CodeSnippetEnvironment.java
@@ -20,6 +20,7 @@ import org.eclipse.jdt.internal.compiler.classfmt.ClassFormatException;
 import org.eclipse.jdt.internal.compiler.env.IBinaryType;
 import org.eclipse.jdt.internal.compiler.env.INameEnvironment;
 import org.eclipse.jdt.internal.compiler.env.NameEnvironmentAnswer;
+import org.eclipse.jdt.internal.core.JavaModelManager;
 
 /**
  * An environment that wraps the client's name environment.
@@ -63,7 +64,10 @@ public NameEnvironmentAnswer findType(char[][] compoundTypeName) {
 			try {
 				binary = new ClassFileReader(classFile.getBytes(), null);
 			} catch (ClassFormatException e) {
-				e.printStackTrace();  // Should never happen since we compiled this type
+				if (JavaModelManager.VERBOSE) {
+					JavaModelManager.trace("", e); //$NON-NLS-1$
+				}
+				// Should never happen since we compiled this type
 				return null;
 			}
 			return new NameEnvironmentAnswer(binary, null /*no access restriction*/);

--- a/org.eclipse.jdt.core/eval/org/eclipse/jdt/internal/eval/CodeSnippetEvaluator.java
+++ b/org.eclipse.jdt.core/eval/org/eclipse/jdt/internal/eval/CodeSnippetEvaluator.java
@@ -27,6 +27,7 @@ import org.eclipse.jdt.internal.compiler.classfmt.ClassFormatException;
 import org.eclipse.jdt.internal.compiler.env.IBinaryType;
 import org.eclipse.jdt.internal.compiler.env.INameEnvironment;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
+import org.eclipse.jdt.internal.core.JavaModelManager;
 
 /**
  * A code snippet evaluator compiles and returns class file for a code snippet.
@@ -150,7 +151,10 @@ Compiler getCompiler(ICompilerRequestor compilerRequestor) {
 				try {
 					binaryType = new ClassFileReader(globalClassFiles[i].getBytes(), null);
 				} catch (ClassFormatException e) {
-					e.printStackTrace(); // Should never happen since we compiled this type
+					if (JavaModelManager.VERBOSE) {
+						JavaModelManager.trace("", e); //$NON-NLS-1$
+					}
+					// Should never happen since we compiled this type
 				}
 				compiler.lookupEnvironment.cacheBinaryType(binaryType, null /*no access restriction*/);
 			}

--- a/org.eclipse.jdt.core/eval/org/eclipse/jdt/internal/eval/EvaluationContext.java
+++ b/org.eclipse.jdt.core/eval/org/eclipse/jdt/internal/eval/EvaluationContext.java
@@ -36,6 +36,7 @@ import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jdt.internal.compiler.problem.DefaultProblemFactory;
 import org.eclipse.jdt.internal.compiler.problem.ProblemSeverities;
 import org.eclipse.jdt.internal.compiler.util.SuffixConstants;
+import org.eclipse.jdt.internal.core.JavaModelManager;
 import org.eclipse.jdt.internal.core.SearchableEnvironment;
 import org.eclipse.jdt.internal.core.util.Util;
 
@@ -192,7 +193,10 @@ public void complete(
 			try {
 				binary = new ClassFileReader(classFile.getBytes(), null);
 			} catch (ClassFormatException e) {
-				e.printStackTrace(); // Should never happen since we compiled this type
+				if (JavaModelManager.VERBOSE) {
+					JavaModelManager.trace("", e); //$NON-NLS-1$
+				}
+				// Should never happen since we compiled this type
 			}
 			engine.lookupEnvironment.cacheBinaryType(binary, null /*no access restriction*/);
 		}

--- a/org.eclipse.jdt.core/eval/org/eclipse/jdt/internal/eval/VariablesEvaluator.java
+++ b/org.eclipse.jdt.core/eval/org/eclipse/jdt/internal/eval/VariablesEvaluator.java
@@ -24,6 +24,7 @@ import org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFormatException;
 import org.eclipse.jdt.internal.compiler.env.IBinaryType;
 import org.eclipse.jdt.internal.compiler.env.INameEnvironment;
+import org.eclipse.jdt.internal.core.JavaModelManager;
 
 /**
  * A variables evaluator compiles the global variables of an evaluation context and returns
@@ -167,7 +168,10 @@ Compiler getCompiler(ICompilerRequestor compilerRequestor) {
 			try {
 				binary = new ClassFileReader(classFile.getBytes(), null);
 			} catch (ClassFormatException e) {
-				e.printStackTrace(); // Should never happen since we compiled this type
+				if (JavaModelManager.VERBOSE) {
+					JavaModelManager.trace("", e); //$NON-NLS-1$
+				}
+				// Should never happen since we compiled this type
 			}
 			compiler.lookupEnvironment.cacheBinaryType(binary, null /*no access restriction*/);
 		}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/core/JavaCore.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/core/JavaCore.java
@@ -114,6 +114,8 @@
 
 package org.eclipse.jdt.core;
 
+import static org.eclipse.jdt.internal.core.JavaModelManager.trace;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -3878,8 +3880,7 @@ public final class JavaCore extends Plugin {
 						} catch(CoreException e) {
 							// executable extension could not be created: ignore this initializer
 							if (JavaModelManager.CP_RESOLVE_VERBOSE || JavaModelManager.CP_RESOLVE_VERBOSE_FAILURE) {
-								verbose_failed_to_instanciate_container_initializer(containerID, configurationElement);
-								e.printStackTrace();
+								verbose_failed_to_instanciate_container_initializer(containerID, configurationElement, e);
 							}
 						}
 					}
@@ -3889,16 +3890,16 @@ public final class JavaCore extends Plugin {
 		return null;
 	}
 
-	private static void verbose_failed_to_instanciate_container_initializer(String containerID, IConfigurationElement configurationElement) {
-		Util.verbose(
+	private static void verbose_failed_to_instanciate_container_initializer(String containerID, IConfigurationElement configurationElement, CoreException e) {
+		trace(
 			"CPContainer INIT - failed to instanciate initializer\n" + //$NON-NLS-1$
 			"	container ID: " + containerID + '\n' + //$NON-NLS-1$
 			"	class: " + configurationElement.getAttribute("class"), //$NON-NLS-1$ //$NON-NLS-2$
-			System.err);
+			e);
 	}
 
 	private static void verbose_found_container_initializer(String containerID, IConfigurationElement configurationElement) {
-		Util.verbose(
+		trace(
 			"CPContainer INIT - found initializer\n" + //$NON-NLS-1$
 			"	container ID: " + containerID + '\n' + //$NON-NLS-1$
 			"	class: " + configurationElement.getAttribute("class")); //$NON-NLS-1$ //$NON-NLS-2$
@@ -3959,7 +3960,7 @@ public final class JavaCore extends Plugin {
 				ok = true;
 			} catch (RuntimeException | Error e) {
 				if (JavaModelManager.CP_RESOLVE_VERBOSE || JavaModelManager.CP_RESOLVE_VERBOSE_FAILURE)
-					e.printStackTrace();
+					trace("", new Exception(e)); //$NON-NLS-1$
 				throw e;
 			} finally {
 				if (!ok) JavaModelManager.getJavaModelManager().variablePut(variableName, null); // flush cache
@@ -3972,30 +3973,29 @@ public final class JavaCore extends Plugin {
 	}
 
 	private static void verbose_no_variable_initializer_found(String variableName) {
-		Util.verbose(
+		trace(
 			"CPVariable INIT - no initializer found\n" + //$NON-NLS-1$
 			"	variable: " + variableName); //$NON-NLS-1$
 	}
 
 	private static void verbose_variable_value_after_initialization(String variableName, IPath variablePath) {
-		Util.verbose(
+		trace(
 			"CPVariable INIT - after initialization\n" + //$NON-NLS-1$
 			"	variable: " + variableName +'\n' + //$NON-NLS-1$
 			"	variable path: " + variablePath); //$NON-NLS-1$
 	}
 
 	private static void verbose_triggering_variable_initialization(String variableName, ClasspathVariableInitializer initializer) {
-		Util.verbose(
+		trace(
 			"CPVariable INIT - triggering initialization\n" + //$NON-NLS-1$
 			"	variable: " + variableName + '\n' + //$NON-NLS-1$
 			"	initializer: " + initializer); //$NON-NLS-1$
 	}
 
 	private static void verbose_triggering_variable_initialization_invocation_trace() {
-		Util.verbose(
+		trace(
 			"CPVariable INIT - triggering initialization\n" + //$NON-NLS-1$
-			"	invocation trace:"); //$NON-NLS-1$
-		new Exception("<Fake exception>").printStackTrace(System.out); //$NON-NLS-1$
+			"	invocation trace:", new Exception("<Fake exception>")); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
 	/**
@@ -4088,8 +4088,7 @@ public final class JavaCore extends Plugin {
 					} catch(CoreException e){
 						// executable extension could not be created: ignore this initializer
 						if (JavaModelManager.CP_RESOLVE_VERBOSE || JavaModelManager.CP_RESOLVE_VERBOSE_FAILURE) {
-							verbose_failed_to_instanciate_variable_initializer(variable, configElement);
-							e.printStackTrace();
+							verbose_failed_to_instanciate_variable_initializer(variable, configElement, e);
 						}
 					}
 				}
@@ -4098,16 +4097,16 @@ public final class JavaCore extends Plugin {
 		return null;
 	}
 
-	private static void verbose_failed_to_instanciate_variable_initializer(String variable, IConfigurationElement configElement) {
-		Util.verbose(
+	private static void verbose_failed_to_instanciate_variable_initializer(String variable, IConfigurationElement configElement, CoreException e) {
+		trace(
 			"CPContainer INIT - failed to instanciate initializer\n" + //$NON-NLS-1$
 			"	variable: " + variable + '\n' + //$NON-NLS-1$
 			"	class: " + configElement.getAttribute("class"), //$NON-NLS-1$ //$NON-NLS-2$
-			System.err);
+			e);
 	}
 
 	private static void verbose_found_variable_initializer(String variable, IConfigurationElement configElement) {
-		Util.verbose(
+		trace(
 			"CPVariable INIT - found initializer\n" + //$NON-NLS-1$
 			"	variable: " + variable + '\n' + //$NON-NLS-1$
 			"	class: " + configElement.getAttribute("class")); //$NON-NLS-1$ //$NON-NLS-2$
@@ -4251,7 +4250,9 @@ public final class JavaCore extends Plugin {
 					outputLocation = entryOutputLocation;
 				}
 			} catch (JavaModelException e) {
-				e.printStackTrace();
+				if (JavaModelManager.VERBOSE) {
+					trace("", e); //$NON-NLS-1$
+				}
 			}
 			if (outputLocation == null) continue;
 			IContainer container = (IContainer) project.getWorkspace().getRoot().findMember(outputLocation);
@@ -4710,16 +4711,18 @@ public final class JavaCore extends Plugin {
 		String newVersionNumber = Byte.toString(State.VERSION);
 		if (!newVersionNumber.equals(versionNumber)) {
 			// build state version number has changed: touch every projects to force a rebuild
-			if (JavaBuilder.DEBUG)
-				System.out.println("Build state version number has changed"); //$NON-NLS-1$
+			if (JavaBuilder.DEBUG) {
+				trace("Build state version number has changed"); //$NON-NLS-1$
+			}
 			IWorkspaceRunnable runnable = new IWorkspaceRunnable() {
 				@Override
 				public void run(IProgressMonitor progressMonitor2) throws CoreException {
 					for (int i = 0, length = projects.length; i < length; i++) {
 						IJavaProject project = projects[i];
 						try {
-							if (JavaBuilder.DEBUG)
-								System.out.println("Touching " + project.getElementName()); //$NON-NLS-1$
+							if (JavaBuilder.DEBUG) {
+								trace("Touching " + project.getElementName()); //$NON-NLS-1$
+							}
 							new ClasspathValidation((JavaProject) project).validate(); // https://bugs.eclipse.org/bugs/show_bug.cgi?id=287164
 							project.getProject().touch(progressMonitor2);
 						} catch (CoreException e) {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/core/ToolFactory.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/core/ToolFactory.java
@@ -358,7 +358,7 @@ public class ToolFactory {
 		ZipFile zipFile = null;
 		try {
 			if (JavaModelManager.ZIP_ACCESS_VERBOSE) {
-				System.out.println("(" + Thread.currentThread() + ") [ToolFactory.createDefaultClassFileReader()] Creating ZipFile on " + zipFileName); //$NON-NLS-1$	//$NON-NLS-2$
+				JavaModelManager.trace("(" + Thread.currentThread() + ") [ToolFactory.createDefaultClassFileReader()] Creating ZipFile on " + zipFileName); //$NON-NLS-1$	//$NON-NLS-2$
 			}
 			zipFile = new ZipFile(zipFileName);
 			ZipEntry zipEntry = zipFile.getEntry(zipEntryName);

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/AbstractModule.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/AbstractModule.java
@@ -160,8 +160,9 @@ public interface AbstractModule extends IModuleDescription {
 		try {
 			toStringContent(buffer, lineDelimiter);
 		} catch (JavaModelException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
+			if (JavaModelManager.VERBOSE) {
+				JavaModelManager.trace("", e); //$NON-NLS-1$
+			}
 		}
 		return buffer.toString();
 	}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/BinaryModule.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/BinaryModule.java
@@ -136,8 +136,9 @@ public class BinaryModule extends BinaryMember implements AbstractModule {
 		try {
 			toStringContent(buffer, lineDelimiter);
 		} catch (JavaModelException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
+			if (JavaModelManager.VERBOSE) {
+				JavaModelManager.trace("", e); //$NON-NLS-1$
+			}
 		}
 		return buffer.toString();
 	}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/BinaryType.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/BinaryType.java
@@ -140,8 +140,8 @@ public void codeComplete(
 		engine.complete(this, snippet, position, localVariableTypeNames, localVariableNames, localVariableModifiers, isStatic);
 	}
 	if (NameLookup.VERBOSE) {
-		System.out.println(Thread.currentThread() + " TIME SPENT in NameLoopkup#seekTypesInSourcePackage: " + environment.nameLookup.timeSpentInSeekTypesInSourcePackage + "ms");  //$NON-NLS-1$ //$NON-NLS-2$
-		System.out.println(Thread.currentThread() + " TIME SPENT in NameLoopkup#seekTypesInBinaryPackage: " + environment.nameLookup.timeSpentInSeekTypesInBinaryPackage + "ms");  //$NON-NLS-1$ //$NON-NLS-2$
+		JavaModelManager.trace(Thread.currentThread() + " TIME SPENT in NameLoopkup#seekTypesInSourcePackage: " + environment.nameLookup.timeSpentInSeekTypesInSourcePackage + "ms");  //$NON-NLS-1$ //$NON-NLS-2$
+		JavaModelManager.trace(Thread.currentThread() + " TIME SPENT in NameLoopkup#seekTypesInBinaryPackage: " + environment.nameLookup.timeSpentInSeekTypesInBinaryPackage + "ms");  //$NON-NLS-1$ //$NON-NLS-2$
 	}
 }
 

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ClassFile.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ClassFile.java
@@ -206,7 +206,7 @@ public IBinaryType getBinaryTypeInfo() throws JavaModelException {
 	} catch (ClassFormatException cfe) {
 		//the structure remains unknown
 		if (JavaCore.getPlugin().isDebugging()) {
-			cfe.printStackTrace(System.err);
+			JavaModelManager.trace("", cfe); //$NON-NLS-1$
 		}
 		return null;
 	} catch (IOException ioe) {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ClasspathChange.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ClasspathChange.java
@@ -15,6 +15,8 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.core;
 
+import static org.eclipse.jdt.internal.core.JavaModelManager.trace;
+
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
@@ -290,7 +292,7 @@ public class ClasspathChange {
 			deltaProcessor.projectCachesToReset.add(this.project);
 		} catch (JavaModelException e) {
 			if (DeltaProcessor.VERBOSE) {
-				e.printStackTrace();
+				trace("", e); //$NON-NLS-1$
 			}
 			// project no longer exist
 			return result;
@@ -459,8 +461,9 @@ public class ClasspathChange {
 					delta.removed(frag);
 				}
 			} catch (JavaModelException e) {
-				if (DeltaProcessor.VERBOSE)
-					e.printStackTrace();
+				if (DeltaProcessor.VERBOSE) {
+					trace("", e); //$NON-NLS-1$
+				}
 			}
 		}
 

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ClasspathEntry.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ClasspathEntry.java
@@ -22,6 +22,7 @@ package org.eclipse.jdt.internal.core;
 
 import static org.eclipse.jdt.internal.compiler.util.Util.UTF_8;
 import static org.eclipse.jdt.internal.compiler.util.Util.getInputStreamAsCharArray;
+import static org.eclipse.jdt.internal.core.JavaModelManager.trace;
 
 import java.io.File;
 import java.io.IOException;
@@ -983,14 +984,14 @@ public class ClasspathEntry implements IClasspathEntry {
 				String calledFileName = (String) calledFilesIterator.next();
 				if (!directoryPath.isValidPath(calledFileName)) {
 					if (JavaModelManager.CP_RESOLVE_VERBOSE_FAILURE) {
-						Util.verbose("Invalid Class-Path entry " + calledFileName + " in manifest of jar file: " + jarPath.toOSString()); //$NON-NLS-1$ //$NON-NLS-2$
+						trace("Invalid Class-Path entry " + calledFileName + " in manifest of jar file: " + jarPath.toOSString()); //$NON-NLS-1$ //$NON-NLS-2$
 					}
 				} else {
 					IPath calledJar = directoryPath.append(new Path(calledFileName));
 					// Ignore if segment count is Zero (https://bugs.eclipse.org/bugs/show_bug.cgi?id=308150)
 					if (calledJar.segmentCount() == 0) {
 						if (JavaModelManager.CP_RESOLVE_VERBOSE_FAILURE) {
-							Util.verbose("Invalid Class-Path entry " + calledFileName + " in manifest of jar file: " + jarPath.toOSString()); //$NON-NLS-1$ //$NON-NLS-2$
+							trace("Invalid Class-Path entry " + calledFileName + " in manifest of jar file: " + jarPath.toOSString()); //$NON-NLS-1$ //$NON-NLS-2$
 						}
 						continue;
 					}
@@ -1042,20 +1043,19 @@ public class ClasspathEntry implements IClasspathEntry {
 			calledFileNames = analyzer.getCalledFileNames();
 			if (!success || analyzer.getClasspathSectionsCount() == 1 && calledFileNames == null) {
 				if (JavaModelManager.CP_RESOLVE_VERBOSE_FAILURE) {
-					Util.verbose("Invalid Class-Path header in manifest of jar file: " + jarPath.toOSString()); //$NON-NLS-1$
+					trace("Invalid Class-Path header in manifest of jar file: " + jarPath.toOSString()); //$NON-NLS-1$
 				}
 				return null;
 			} else if (analyzer.getClasspathSectionsCount() > 1) {
 				if (JavaModelManager.CP_RESOLVE_VERBOSE_FAILURE) {
-					Util.verbose("Multiple Class-Path headers in manifest of jar file: " + jarPath.toOSString()); //$NON-NLS-1$
+					trace("Multiple Class-Path headers in manifest of jar file: " + jarPath.toOSString()); //$NON-NLS-1$
 				}
 				return null;
 			}
 		} catch (CoreException | IOException e) {
 			// not a zip file
 			if (JavaModelManager.CP_RESOLVE_VERBOSE_FAILURE) {
-				Util.verbose("Could not read Class-Path header in manifest of jar file: " + jarPath.toOSString()); //$NON-NLS-1$
-				e.printStackTrace();
+				trace("Could not read Class-Path header in manifest of jar file: " + jarPath.toOSString(), e); //$NON-NLS-1$
 			}
 		}
 		return calledFileNames;

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/CompilationUnit.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/CompilationUnit.java
@@ -500,8 +500,9 @@ public void destroy() {
 	try {
 		discardWorkingCopy();
 	} catch (JavaModelException e) {
-		if (JavaModelManager.VERBOSE)
-			e.printStackTrace();
+		if (JavaModelManager.VERBOSE) {
+			JavaModelManager.trace("", e); //$NON-NLS-1$
+		}
 	}
 }
 
@@ -1448,8 +1449,9 @@ public char[] getModuleName() {
 		if (module != null)
 			return module.getElementName().toCharArray();
 	} catch (JavaModelException e) {
-		// TODO Auto-generated catch block
-		e.printStackTrace();
+		if (JavaModelManager.VERBOSE) {
+			JavaModelManager.trace("", e); //$NON-NLS-1$
+		}
 	}
 	return null;
 }

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/CompilationUnitProblemFinder.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/CompilationUnitProblemFinder.java
@@ -305,8 +305,8 @@ public class CompilationUnitProblemFinder extends Compiler {
 					problems.put(IJavaModelMarker.TASK_MARKER, categorizedProblems);
 				}
 				if (NameLookup.VERBOSE) {
-					System.out.println(Thread.currentThread() + " TIME SPENT in NameLoopkup#seekTypesInSourcePackage: " + environment.nameLookup.timeSpentInSeekTypesInSourcePackage + "ms");  //$NON-NLS-1$ //$NON-NLS-2$
-					System.out.println(Thread.currentThread() + " TIME SPENT in NameLoopkup#seekTypesInBinaryPackage: " + environment.nameLookup.timeSpentInSeekTypesInBinaryPackage + "ms");  //$NON-NLS-1$ //$NON-NLS-2$
+					JavaModelManager.trace(Thread.currentThread() + " TIME SPENT in NameLoopkup#seekTypesInSourcePackage: " + environment.nameLookup.timeSpentInSeekTypesInSourcePackage + "ms");  //$NON-NLS-1$ //$NON-NLS-2$
+					JavaModelManager.trace(Thread.currentThread() + " TIME SPENT in NameLoopkup#seekTypesInBinaryPackage: " + environment.nameLookup.timeSpentInSeekTypesInBinaryPackage + "ms");  //$NON-NLS-1$ //$NON-NLS-2$
 				}
 			}
 		} catch (OperationCanceledException e) {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/DeltaProcessingState.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/DeltaProcessingState.java
@@ -373,7 +373,9 @@ public class DeltaProcessingState implements IResourceChangeListener {
 				try {
 					propertyString = Util.getSourceAttachmentProperty(path);
 				} catch (JavaModelException e) {
-					e.printStackTrace();
+					if (JavaModelManager.VERBOSE) {
+						JavaModelManager.trace("", e); //$NON-NLS-1$
+					}
 				}
 				IPath sourceAttachmentPath;
 				if (propertyString != null) {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/DeltaProcessor.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/DeltaProcessor.java
@@ -16,6 +16,8 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.core;
 
+import static org.eclipse.jdt.internal.core.JavaModelManager.trace;
+
 import java.io.File;
 import java.net.URL;
 import java.util.*;
@@ -636,7 +638,7 @@ public class DeltaProcessor {
 				perProjectInfo.readAndCacheClasspath(javaProject);
 		} catch (JavaModelException e) {
 			if (VERBOSE) {
-				e.printStackTrace();
+				trace("", e); //$NON-NLS-1$
 			}
 		}
 	}
@@ -899,8 +901,9 @@ public class DeltaProcessor {
 									IProject project = projectsToTouch[i];
 
 									// touch to force a build of this project
-									if (JavaBuilder.DEBUG)
-										System.out.println("Touching project " + project.getName() + " due to external jar file change"); //$NON-NLS-1$ //$NON-NLS-2$
+									if (JavaBuilder.DEBUG) {
+										trace("Touching project " + project.getName() + " due to external jar file change"); //$NON-NLS-1$ //$NON-NLS-2$
+									}
 									project.touch(progressMonitor);
 								}
 							}
@@ -1083,7 +1086,7 @@ public class DeltaProcessor {
 						if (status == EXTERNAL_JAR_ADDED){
 							PackageFragmentRoot root = (PackageFragmentRoot) javaProject.getPackageFragmentRoot(entryPath.toString());
 							if (VERBOSE){
-								System.out.println("- External JAR ADDED, affecting root: "+root.getElementName()); //$NON-NLS-1$
+								trace("- External JAR ADDED, affecting root: "+root.getElementName()); //$NON-NLS-1$
 							}
 							elementAdded(root, null, null);
 							deltaContainsModifiedJar = true;
@@ -1092,7 +1095,7 @@ public class DeltaProcessor {
 						} else if (status == EXTERNAL_JAR_CHANGED) {
 							PackageFragmentRoot root = (PackageFragmentRoot) javaProject.getPackageFragmentRoot(entryPath.toString());
 							if (VERBOSE){
-								System.out.println("- External JAR CHANGED, affecting root: "+root.getElementName()); //$NON-NLS-1$
+								trace("- External JAR CHANGED, affecting root: "+root.getElementName()); //$NON-NLS-1$
 							}
 							// TODO(sxenos): this is causing each change event for an external jar file to be fired twice.
 							// We need to preserve the clearing of cached information in the jar but defer the actual firing of
@@ -1103,7 +1106,7 @@ public class DeltaProcessor {
 						} else if (status == EXTERNAL_JAR_REMOVED) {
 							PackageFragmentRoot root = (PackageFragmentRoot) javaProject.getPackageFragmentRoot(entryPath.toString());
 							if (VERBOSE){
-								System.out.println("- External JAR REMOVED, affecting root: "+root.getElementName()); //$NON-NLS-1$
+								trace("- External JAR REMOVED, affecting root: "+root.getElementName()); //$NON-NLS-1$
 							}
 							elementRemoved(root, null, null);
 							deltaContainsModifiedJar = true;
@@ -1513,7 +1516,7 @@ public class DeltaProcessor {
 		if (!this.isFiring) return;
 
 		if (DEBUG) {
-			System.out.println("-----------------------------------------------------------------------------------------------------------------------");//$NON-NLS-1$
+			trace("-----------------------------------------------------------------------------------------------------------------------");//$NON-NLS-1$
 		}
 
 		IJavaElementDelta deltaToNotify;
@@ -1565,8 +1568,8 @@ public class DeltaProcessor {
 
 		// post change deltas
 		if (DEBUG){
-			System.out.println("FIRING POST_CHANGE Delta ["+Thread.currentThread()+"]:"); //$NON-NLS-1$//$NON-NLS-2$
-			System.out.println(deltaToNotify == null ? "<NONE>" : deltaToNotify.toString()); //$NON-NLS-1$
+			trace("FIRING POST_CHANGE Delta ["+Thread.currentThread()+"]:"); //$NON-NLS-1$//$NON-NLS-2$
+			trace(deltaToNotify == null ? "<NONE>" : deltaToNotify.toString()); //$NON-NLS-1$
 		}
 		if (deltaToNotify != null) {
 			// flush now so as to keep listener reactions to post their own deltas for subsequent iteration
@@ -1586,8 +1589,8 @@ public class DeltaProcessor {
 
 		IJavaElementDelta deltaToNotify = mergeDeltas(this.reconcileDeltas.values());
 		if (DEBUG){
-			System.out.println("FIRING POST_RECONCILE Delta ["+Thread.currentThread()+"]:"); //$NON-NLS-1$//$NON-NLS-2$
-			System.out.println(deltaToNotify == null ? "<NONE>" : deltaToNotify.toString()); //$NON-NLS-1$
+			trace("FIRING POST_RECONCILE Delta ["+Thread.currentThread()+"]:"); //$NON-NLS-1$//$NON-NLS-2$
+			trace(deltaToNotify == null ? "<NONE>" : deltaToNotify.toString()); //$NON-NLS-1$
 		}
 		if (deltaToNotify != null) {
 			// flush now so as to keep listener reactions to post their own deltas for subsequent iteration
@@ -1697,7 +1700,7 @@ public class DeltaProcessor {
 		if (deltas.size() == 1) return deltas.iterator().next();
 
 		if (VERBOSE) {
-			System.out.println("MERGING " + deltas.size() + " DELTAS ["+Thread.currentThread()+"]"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+			trace("MERGING " + deltas.size() + " DELTAS ["+Thread.currentThread()+"]"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 		}
 
 		Iterator<IJavaElementDelta> iterator = deltas.iterator();
@@ -1706,7 +1709,7 @@ public class DeltaProcessor {
 		while (iterator.hasNext()) {
 			JavaElementDelta delta = (JavaElementDelta)iterator.next();
 			if (VERBOSE) {
-				System.out.println(delta.toString());
+				trace(delta.toString());
 			}
 			IJavaElement element = delta.getElement();
 			if (this.manager.javaModel.equals(element)) {
@@ -1761,7 +1764,7 @@ public class DeltaProcessor {
 					}
 				});
 				if (VERBOSE) {
-					System.out.println(" -> " + (System.currentTimeMillis()-start) + "ms"); //$NON-NLS-1$ //$NON-NLS-2$
+					trace(" -> " + (System.currentTimeMillis()-start) + "ms"); //$NON-NLS-1$ //$NON-NLS-2$
 				}
 			}
 		}
@@ -1947,7 +1950,7 @@ public class DeltaProcessor {
 					model.open(null);
 				} catch (JavaModelException e) {
 					if (VERBOSE) {
-						e.printStackTrace();
+						trace("", e); //$NON-NLS-1$
 					}
 					return null;
 				}
@@ -2619,8 +2622,9 @@ public class DeltaProcessor {
 
 				if (deltaRes.getType() == IResource.PROJECT){
 					// reset the corresponding project built state, since cannot reuse if added back
-					if (JavaBuilder.DEBUG)
-						System.out.println("Clearing last state for removed project : " + deltaRes); //$NON-NLS-1$
+					if (JavaBuilder.DEBUG) {
+						trace("Clearing last state for removed project : " + deltaRes); //$NON-NLS-1$
+					}
 					this.manager.setLastBuiltState((IProject)deltaRes, null /*no state*/);
 
 					// clean up previous session containers (see https://bugs.eclipse.org/bugs/show_bug.cgi?id=89850)
@@ -2697,8 +2701,9 @@ public class DeltaProcessor {
 								this.manager.indexManager.discardJobs(element.getElementName());
 								this.manager.indexManager.removeIndexFamily(res.getFullPath());
 								// reset the corresponding project built state, since cannot reuse if added back
-								if (JavaBuilder.DEBUG)
-									System.out.println("Clearing last state for project loosing Java nature: " + res); //$NON-NLS-1$
+								if (JavaBuilder.DEBUG) {
+									trace("Clearing last state for project loosing Java nature: " + res); //$NON-NLS-1$
+								}
 								this.manager.setLastBuiltState(res, null /*no state*/);
 							}
 							return false; // when a project's nature is added/removed don't process children

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JarEntryFile.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JarEntryFile.java
@@ -67,7 +67,7 @@ public class JarEntryFile  extends JarEntryResource {
 			try {
 				zipFile = getZipFile();
 				if (JavaModelManager.ZIP_ACCESS_VERBOSE) {
-					System.out.println("(" + Thread.currentThread() + ") [JarEntryFile.getContents()] Creating ZipFile on " +zipFile.getName()); //$NON-NLS-1$	//$NON-NLS-2$
+					JavaModelManager.trace("(" + Thread.currentThread() + ") [JarEntryFile.getContents()] Creating ZipFile on " +zipFile.getName()); //$NON-NLS-1$	//$NON-NLS-2$
 				}
 				String entryName = getEntryName();
 				ZipEntry zipEntry = zipFile.getEntry(entryName);

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModel.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModel.java
@@ -410,7 +410,7 @@ static private boolean isExternalFile(IPath path) {
 		return true;
 	}
 	if (JavaModelManager.ZIP_ACCESS_VERBOSE) {
-		System.out.println("(" + Thread.currentThread() + ") [JavaModel.isExternalFile(...)] Checking existence of " + path.toString()); //$NON-NLS-1$ //$NON-NLS-2$
+		JavaModelManager.trace("(" + Thread.currentThread() + ") [JavaModel.isExternalFile(...)] Checking existence of " + path.toString()); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 	boolean isFile = path.toFile().isFile();
 	if (isFile) {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelCache.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelCache.java
@@ -218,7 +218,7 @@ protected Object peekAtInfo(IJavaElement element) {
  */
 protected void putInfo(IJavaElement element, Object info) {
 	if (DEBUG_CACHE_INSERTIONS) {
-		System.out.println(Thread.currentThread() + " cache putInfo (" + getElementType(element) + " " + element.toString() + ", " + info + ")");  //$NON-NLS-1$//$NON-NLS-2$//$NON-NLS-3$//$NON-NLS-4$
+		JavaModelManager.trace(Thread.currentThread() + " cache putInfo (" + getElementType(element) + " " + element.toString() + ", " + info + ")");  //$NON-NLS-1$//$NON-NLS-2$//$NON-NLS-3$//$NON-NLS-4$
 	}
 	switch (element.getElementType()) {
 		case IJavaElement.JAVA_MODEL:
@@ -275,7 +275,7 @@ public static String getElementType(IJavaElement element) {
 protected void removeInfo(JavaElement element) {
 	if (DEBUG_CACHE_INSERTIONS) {
 		String elementToString = element.toString();
-		System.out.println(Thread.currentThread() + " cache removeInfo " + getElementType(element) + " " + elementToString);  //$NON-NLS-1$//$NON-NLS-2$
+		JavaModelManager.trace(Thread.currentThread() + " cache removeInfo " + getElementType(element) + " " + elementToString);  //$NON-NLS-1$//$NON-NLS-2$
 	}
 	switch (element.getElementType()) {
 		case IJavaElement.JAVA_MODEL:

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelManager.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelManager.java
@@ -216,7 +216,7 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 				ZipFile zipFile = iterator.next();
 				try {
 					if (JavaModelManager.ZIP_ACCESS_VERBOSE) {
-						System.out.println("(" + currentThread + ") [ZipCache[" + this.owner //$NON-NLS-1$//$NON-NLS-2$
+						trace("(" + currentThread + ") [ZipCache[" + this.owner //$NON-NLS-1$//$NON-NLS-2$
 								+ "].flush()] Closing ZipFile on " + zipFile.getName()); //$NON-NLS-1$
 					}
 					zipFile.close();
@@ -236,12 +236,14 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 				if (old != null) {
 					if (JavaModelManager.ZIP_ACCESS_VERBOSE) {
 						Thread currentThread = Thread.currentThread();
-						System.out.println("(" + currentThread + ") [ZipCache[" + this.owner //$NON-NLS-1$//$NON-NLS-2$
+						trace("(" + currentThread + ") [ZipCache[" + this.owner //$NON-NLS-1$//$NON-NLS-2$
 								+ "].setCache()] leaked ZipFile on " + old.getName() + " for path: " + path); //$NON-NLS-1$ //$NON-NLS-2$
 					}
 				}
 			} catch (IOException e) {
-				e.printStackTrace();
+				if (VERBOSE) {
+					trace("", e); //$NON-NLS-1$
+				}
 			}
 		}
 	}
@@ -819,7 +821,7 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 			final IClasspathContainer container,
 			final IClasspathEntry[] newEntries,
 			final IClasspathEntry[] oldEntries) {
-		Util.verbose(
+		trace(
 			"CPContainer SET  - missbehaving container\n" + //$NON-NLS-1$
 			"	container path: " + containerPath + '\n' + //$NON-NLS-1$
 			"	projects: {" +//$NON-NLS-1$
@@ -882,7 +884,7 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 	}
 
 	void verbose_missbehaving_container(IJavaProject project, IPath containerPath, IClasspathEntry[] classpathEntries) {
-		Util.verbose(
+		trace(
 			"CPContainer GET - missbehaving container (returning null classpath entry)\n" + //$NON-NLS-1$
 			"	project: " + project.getElementName() + '\n' + //$NON-NLS-1$
 			"	container path: " + containerPath + '\n' + //$NON-NLS-1$
@@ -906,7 +908,7 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 	}
 
 	void verbose_missbehaving_container_null_entries(IJavaProject project, IPath containerPath) {
-		Util.verbose(
+		trace(
 			"CPContainer GET - missbehaving container (returning null as classpath entries)\n" + //$NON-NLS-1$
 			"	project: " + project.getElementName() + '\n' + //$NON-NLS-1$
 			"	container path: " + containerPath + '\n' + //$NON-NLS-1$
@@ -1101,7 +1103,7 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 			pkg = root.getPackageFragment(CharOperation.NO_STRINGS);
 
 			if (VERBOSE){
-				System.out.println("WARNING : creating unit element outside classpath ("+ Thread.currentThread()+"): " + file.getFullPath()); //$NON-NLS-1$//$NON-NLS-2$
+				trace("WARNING : creating unit element outside classpath ("+ Thread.currentThread()+"): " + file.getFullPath()); //$NON-NLS-1$//$NON-NLS-2$
 			}
 		}
 		return pkg.getCompilationUnit(file.getName());
@@ -1406,12 +1408,12 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 
 		private ClasspathChange setClasspath(IClasspathEntry[] newRawClasspath, IClasspathEntry[] referencedEntries, IPath newOutputLocation, IJavaModelStatus newRawClasspathStatus, IClasspathEntry[] newResolvedClasspath, Map<IPath, IClasspathEntry> newRootPathToRawEntries, Map<IPath, IClasspathEntry> newRootPathToResolvedEntries, IJavaModelStatus newUnresolvedEntryStatus, boolean addClasspathChange) {
 			if (DEBUG_CLASSPATH) {
-				System.out.println("Setting resolved classpath for " + this.project.getFullPath()); //$NON-NLS-1$
+				trace("Setting resolved classpath for " + this.project.getFullPath()); //$NON-NLS-1$
 				if (newResolvedClasspath == null) {
-					System.out.println("New classpath = null"); //$NON-NLS-1$
+					trace("New classpath = null"); //$NON-NLS-1$
 				} else {
 					for (IClasspathEntry next : newResolvedClasspath) {
-						System.out.println("    " + next); //$NON-NLS-1$
+						trace("    " + next); //$NON-NLS-1$
 					}
 				}
 			}
@@ -1864,7 +1866,7 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 
 	public void addInvalidArchive(IPath path, ArchiveValidity reason) {
 		if (DEBUG_INVALID_ARCHIVES) {
-			System.out.println("JAR cache: adding " + reason + " " + path);  //$NON-NLS-1$//$NON-NLS-2$
+			trace("JAR cache: adding " + reason + " " + path);  //$NON-NLS-1$//$NON-NLS-2$
 		}
 		synchronized (this.invalidArchives) {
 			this.invalidArchives.put(path, new InvalidArchiveInfo(System.currentTimeMillis() + INVALID_ARCHIVE_TTL_MILLISECONDS, reason));
@@ -1902,13 +1904,13 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 		if (zipFile == null) return;
 		if (this.zipFiles.get() != null) {
 			if (JavaModelManager.ZIP_ACCESS_VERBOSE) {
-				System.out.println("(" + Thread.currentThread() + ") [JavaModelManager.closeZipFile(ZipFile)] NOT closed ZipFile (cache exist!) on " +zipFile.getName()); //$NON-NLS-1$	//$NON-NLS-2$
+				trace("(" + Thread.currentThread() + ") [JavaModelManager.closeZipFile(ZipFile)] NOT closed ZipFile (cache exist!) on " +zipFile.getName()); //$NON-NLS-1$	//$NON-NLS-2$
 			}
 			return; // zip file will be closed by call to flushZipFiles
 		}
 		try {
 			if (JavaModelManager.ZIP_ACCESS_VERBOSE) {
-				System.out.println("(" + Thread.currentThread() + ") [JavaModelManager.closeZipFile(ZipFile)] Closing ZipFile on " +zipFile.getName()); //$NON-NLS-1$	//$NON-NLS-2$
+				trace("(" + Thread.currentThread() + ") [JavaModelManager.closeZipFile(ZipFile)] Closing ZipFile on " +zipFile.getName()); //$NON-NLS-1$	//$NON-NLS-2$
 			}
 			zipFile.close();
 		} catch (IOException e) {
@@ -2095,7 +2097,7 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 		ZipCache zipCache = this.zipFiles.get();
 		if (zipCache == null) {
 			if (JavaModelManager.ZIP_ACCESS_VERBOSE) {
-				System.out.println("(" + Thread.currentThread() + ") [JavaModelManager.flushZipFiles(String)] NOT found cache for " + owner); //$NON-NLS-1$	//$NON-NLS-2$
+				trace("(" + Thread.currentThread() + ") [JavaModelManager.flushZipFiles(String)] NOT found cache for " + owner); //$NON-NLS-1$	//$NON-NLS-2$
 			}
 			return;
 		}
@@ -2106,7 +2108,7 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 			zipCache.flush();
 		} else {
 			if (JavaModelManager.ZIP_ACCESS_VERBOSE) {
-				System.out.println("(" + Thread.currentThread() //$NON-NLS-1$
+				trace("(" + Thread.currentThread() //$NON-NLS-1$
 						+ ") [JavaModelManager.flushZipFiles(String)] NOT closed cache, wrong owner, expected: " //$NON-NLS-1$
 						+ zipCache.owner + ", got: " + owner); //$NON-NLS-1$
 			}
@@ -2321,8 +2323,9 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 	 */
 	public Object getLastBuiltState(IProject project, IProgressMonitor monitor) {
 		if (!JavaProject.hasJavaNature(project)) {
-			if (JavaBuilder.DEBUG)
-				System.out.println(project + " is not a Java project"); //$NON-NLS-1$
+			if (JavaBuilder.DEBUG) {
+				trace(project + " is not a Java project"); //$NON-NLS-1$
+			}
 			return null; // should never be requested on non-Java projects
 		}
 		PerProjectInfo info = getPerProjectInfo(project, true/*create if missing*/);
@@ -2638,8 +2641,7 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 			}
 		}
 		buffer.append(" 	}"); //$NON-NLS-1$
-		Util.verbose(buffer.toString());
-		new Exception("<Fake exception>").printStackTrace(System.out); //$NON-NLS-1$
+		trace(buffer.toString(), new Exception("<Fake exception>")); //$NON-NLS-1$
 	}
 
 	/**
@@ -2656,11 +2658,10 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 	}
 
 	private void verbose_reentering_variable_access(String variableName, IPath previousPath) {
-		Util.verbose(
+		trace(
 			"CPVariable INIT - reentering access to variable during its initialization, will see previous value\n" + //$NON-NLS-1$
 			"	variable: "+ variableName + '\n' + //$NON-NLS-1$
-			"	previous value: " + previousPath); //$NON-NLS-1$
-		new Exception("<Fake exception>").printStackTrace(System.out); //$NON-NLS-1$
+			"	previous value: " + previousPath, new Exception("<Fake exception>")); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
 	/**
@@ -2960,7 +2961,7 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 
 		try {
 			if (ZIP_ACCESS_VERBOSE) {
-				System.out.println("(" + Thread.currentThread() + ") [JavaModelManager.getZipFile(IPath)] Creating ZipFile on " + localFile ); //$NON-NLS-1$ //$NON-NLS-2$
+				trace("(" + Thread.currentThread() + ") [JavaModelManager.getZipFile(IPath)] Creating ZipFile on " + localFile ); //$NON-NLS-1$ //$NON-NLS-2$
 			}
 			if (throwIoExceptionsInGetZipFile) {
 				throw new IOException();
@@ -3181,7 +3182,7 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 	}
 
 	private void verbose_batching_containers_initialization(IJavaProject javaProjectToInit, IPath containerToInit) {
-		Util.verbose(
+		trace(
 			"CPContainer INIT - batching containers initialization\n" + //$NON-NLS-1$
 			"	project to init: " + (javaProjectToInit == null ? "null" : javaProjectToInit.getElementName()) + '\n' + //$NON-NLS-1$ //$NON-NLS-2$
 			"	container path to init: " + containerToInit); //$NON-NLS-1$
@@ -3240,8 +3241,9 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 					throw new JavaModelException(e);
 				}
 			} catch (RuntimeException | Error e) {
-				if (JavaModelManager.CP_RESOLVE_VERBOSE || CP_RESOLVE_VERBOSE_FAILURE)
-					e.printStackTrace();
+				if (JavaModelManager.CP_RESOLVE_VERBOSE || CP_RESOLVE_VERBOSE_FAILURE) {
+					trace("", new Exception(e)); //$NON-NLS-1$
+				}
 				throw e;
 			} finally {
 				if(JavaModelManager.PERF_CONTAINER_INITIALIZER) {
@@ -3272,7 +3274,7 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 	}
 
 	private void verbose_no_container_initializer_found(IJavaProject project, IPath containerPath) {
-		Util.verbose(
+		trace(
 			"CPContainer INIT - no initializer found\n" + //$NON-NLS-1$
 			"	project: " + project.getElementName() + '\n' + //$NON-NLS-1$
 			"	container path: " + containerPath); //$NON-NLS-1$
@@ -3295,19 +3297,19 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 		} else {
 			buffer.append("	container: {unbound}");//$NON-NLS-1$
 		}
-		Util.verbose(buffer.toString());
+		trace(buffer.toString());
 	}
 
 	private void verbose_container_initialization_failed(IJavaProject project, IPath containerPath, IClasspathContainer container, ClasspathContainerInitializer initializer) {
 		if (container == CONTAINER_INITIALIZATION_IN_PROGRESS) {
-			Util.verbose(
+			trace(
 				"CPContainer INIT - FAILED (initializer did not initialize container)\n" + //$NON-NLS-1$
 				"	project: " + project.getElementName() + '\n' + //$NON-NLS-1$
 				"	container path: " + containerPath + '\n' + //$NON-NLS-1$
 				"	initializer: " + initializer); //$NON-NLS-1$
 
 		} else {
-			Util.verbose(
+			trace(
 				"CPContainer INIT - FAILED (see exception above)\n" + //$NON-NLS-1$
 				"	project: " + project.getElementName() + '\n' + //$NON-NLS-1$
 				"	container path: " + containerPath + '\n' + //$NON-NLS-1$
@@ -3316,7 +3318,7 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 	}
 
 	private void verbose_container_null_failure_container(IJavaProject project, IPath containerPath,  ClasspathContainerInitializer initializer) {
-		Util.verbose(
+		trace(
 			"CPContainer INIT - FAILED (and failure container is null)\n" + //$NON-NLS-1$
 			"	project: " + project.getElementName() + '\n' + //$NON-NLS-1$
 			"	container path: " + containerPath + '\n' + //$NON-NLS-1$
@@ -3324,7 +3326,7 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 	}
 
 	private void verbose_container_using_failure_container(IJavaProject project, IPath containerPath,  ClasspathContainerInitializer initializer) {
-		Util.verbose(
+		trace(
 			"CPContainer INIT - FAILED (using failure container)\n" + //$NON-NLS-1$
 			"	project: " + project.getElementName() + '\n' + //$NON-NLS-1$
 			"	container path: " + containerPath + '\n' + //$NON-NLS-1$
@@ -3332,7 +3334,7 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 	}
 
 	private void verbose_triggering_container_initialization(IJavaProject project, IPath containerPath,  ClasspathContainerInitializer initializer) {
-		Util.verbose(
+		trace(
 			"CPContainer INIT - triggering initialization\n" + //$NON-NLS-1$
 			"	project: " + project.getElementName() + '\n' + //$NON-NLS-1$
 			"	container path: " + containerPath + '\n' + //$NON-NLS-1$
@@ -3340,10 +3342,9 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 	}
 
 	private void verbose_triggering_container_initialization_invocation_trace() {
-		Util.verbose(
+		trace(
 			"CPContainer INIT - triggering initialization\n" + //$NON-NLS-1$
-			"	invocation trace:"); //$NON-NLS-1$
-		new Exception("<Fake exception>").printStackTrace(System.out); //$NON-NLS-1$
+			"	invocation trace:", new Exception("<Fake exception>")); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
 	/**
@@ -3403,7 +3404,7 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 				SubMonitor subMonitor = SubMonitor.convert(monitor, projectsToTouch.length);
 				for (IProject iProject : projectsToTouch) {
 					if (JavaBuilder.DEBUG) {
-						System.out.println("Touching project " + iProject.getName()); //$NON-NLS-1$
+						trace("Touching project " + iProject.getName()); //$NON-NLS-1$
 					}
 					if (iProject.isAccessible()) {
 						iProject.touch(subMonitor.split(1));
@@ -3452,7 +3453,7 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 		}
 		if (invalidArchiveInfo == null) {
 			if (DEBUG_INVALID_ARCHIVES) {
-				System.out.println("JAR cache: UNKNOWN validity for " + path);  //$NON-NLS-1$
+				trace("JAR cache: UNKNOWN validity for " + path);  //$NON-NLS-1$
 			}
 			return null;
 		}
@@ -3473,7 +3474,7 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 			return ArchiveValidity.INVALID;
 		}
 		if (DEBUG_INVALID_ARCHIVES) {
-			System.out.println("JAR cache: " + invalidArchiveInfo.reason + " " + path);  //$NON-NLS-1$ //$NON-NLS-2$
+			trace("JAR cache: " + invalidArchiveInfo.reason + " " + path);  //$NON-NLS-1$ //$NON-NLS-2$
 		}
 		return invalidArchiveInfo.reason;
 	}
@@ -3483,14 +3484,14 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 			InvalidArchiveInfo entry = this.invalidArchives.get(path);
 			if (entry != null && entry.reason == ArchiveValidity.VALID) {
 				if (DEBUG_INVALID_ARCHIVES) {
-					System.out.println("JAR cache: keep VALID " + path);  //$NON-NLS-1$
+					trace("JAR cache: keep VALID " + path);  //$NON-NLS-1$
 				}
 				return; // do not remove the VALID information
 			}
 			// If it transitioned to being valid then force an update to project caches.
 			if (this.invalidArchives.remove(path) != null) {
 				if (DEBUG_INVALID_ARCHIVES) {
-					System.out.println("JAR cache: removed INVALID " + path);  //$NON-NLS-1$
+					trace("JAR cache: removed INVALID " + path);  //$NON-NLS-1$
 				}
 				try {
 					// Bug 455042: Force an update of the JavaProjectElementInfo project caches.
@@ -4173,7 +4174,7 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 		Object result = readStateTimed(project);
 		if (JavaBuilder.DEBUG) {
 			long stopTime = System.currentTimeMillis();
-			System.out.println("readState took " + (stopTime - startTime) + "ms:" + project.getName()); //$NON-NLS-1$ //$NON-NLS-2$
+			trace("readState took " + (stopTime - startTime) + "ms:" + project.getName()); //$NON-NLS-1$ //$NON-NLS-2$
 		}
 		return result;
 	}
@@ -4190,17 +4191,21 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 					throw new IOException(Messages.build_wrongFileFormat);
 				if (in.readBoolean())
 					return JavaBuilder.readState(project, in);
-				if (JavaBuilder.DEBUG)
-					System.out.println("Saved state thinks last build failed for " + project.getName()); //$NON-NLS-1$
+				if (JavaBuilder.DEBUG) {
+					trace("Saved state thinks last build failed for " + project.getName()); //$NON-NLS-1$
+				}
 			} catch (Exception e) {
-				e.printStackTrace();
+				if (JavaBuilder.DEBUG) {
+					trace("", e); //$NON-NLS-1$
+				}
 				throw new CoreException(new Status(IStatus.ERROR, JavaCore.PLUGIN_ID, Platform.PLUGIN_ERROR, "Error reading last build state for project "+ project.getName(), e)); //$NON-NLS-1$
 			}
 		} else if (JavaBuilder.DEBUG) {
-			if (file == null)
-				System.out.println("Project does not exist: " + project); //$NON-NLS-1$
-			else
-				System.out.println("Build state file " + file.getPath() + " does not exist"); //$NON-NLS-1$ //$NON-NLS-2$
+			if (file == null) {
+				trace("Project does not exist: " + project); //$NON-NLS-1$
+			} else {
+				trace("Build state file " + file.getPath() + " does not exist"); //$NON-NLS-1$ //$NON-NLS-2$
+			}
 		}
 		return null;
 	}
@@ -4288,7 +4293,7 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 			try {
 				if (JavaModelCache.VERBOSE) {
 					String elementType = JavaModelCache.getElementType(element);
-					System.out.println(Thread.currentThread() + " CLOSING "+ elementType + " " + element.toStringWithAncestors());  //$NON-NLS-1$//$NON-NLS-2$
+					trace(Thread.currentThread() + " CLOSING "+ elementType + " " + element.toStringWithAncestors());  //$NON-NLS-1$//$NON-NLS-2$
 					wasVerbose = true;
 					JavaModelCache.VERBOSE = false;
 				}
@@ -4298,7 +4303,7 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 				}
 				this.cache.removeInfo(element);
 				if (wasVerbose) {
-					System.out.println(this.cache.toStringFillingRation("-> ")); //$NON-NLS-1$
+					trace(this.cache.toStringFillingRation("-> ")); //$NON-NLS-1$
 				}
 			} finally {
 				JavaModelCache.VERBOSE = wasVerbose;
@@ -4400,7 +4405,7 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 			saveBuiltState(info);
 			if (JavaBuilder.DEBUG) {
 				long stopTime = System.currentTimeMillis();
-				System.out.println("saveState took " + (stopTime - startTime) + "ms:" + info.project.getName()); //$NON-NLS-1$ //$NON-NLS-2$
+				trace("saveState took " + (stopTime - startTime) + "ms:" + info.project.getName()); //$NON-NLS-1$ //$NON-NLS-2$
 			}
 		}
 	}
@@ -4409,8 +4414,9 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 	 * Saves the built state for the project.
 	 */
 	private void saveBuiltState(PerProjectInfo info) throws CoreException {
-		if (JavaBuilder.DEBUG)
-			System.out.println(Messages.bind(Messages.build_saveStateProgress, info.project.getName()));
+		if (JavaBuilder.DEBUG) {
+			trace(Messages.bind(Messages.build_saveStateProgress, info.project.getName()));
+		}
 		File file = getSerializationFile(info.project);
 		if (file == null) return;
 		long t = System.currentTimeMillis();
@@ -4437,7 +4443,7 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 		}
 		if (JavaBuilder.DEBUG) {
 			t = System.currentTimeMillis() - t;
-			System.out.println(Messages.bind(Messages.build_saveStateComplete, String.valueOf(t)));
+			trace(Messages.bind(Messages.build_saveStateComplete, String.valueOf(t)));
 		}
 	}
 
@@ -4722,7 +4728,7 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 		String pattern = "{0} {1} bytes in variablesAndContainers.dat in {2}ms"; //$NON-NLS-1$
 		String message = MessageFormat.format(pattern, new Object[]{action, length, delta});
 
-		System.out.println(message);
+		trace(message);
 	}
 
 	public static void trace(String msg) {
@@ -4746,7 +4752,7 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 		savingTimed(context);
 		if (JavaBuilder.DEBUG) {
 			long stopTime = System.currentTimeMillis();
-			System.out.println("saving took " + (stopTime - startTime) + "ms:" + this.perProjectInfos.values().size()); //$NON-NLS-1$ //$NON-NLS-2$
+			trace("saving took " + (stopTime - startTime) + "ms:" + this.perProjectInfos.values().size()); //$NON-NLS-1$ //$NON-NLS-2$
 		}
 	}
 
@@ -4853,7 +4859,7 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 			buffer.append(new String(typeName));
 			buffer.append(']');
 			buffer.append(')');
-			Util.verbose(buffer.toString());
+			trace(buffer.toString());
 		}
 		IWorkspaceRoot wRoot = ResourcesPlugin.getWorkspace().getRoot();
 		IResource resource = wRoot.findMember(path);
@@ -4887,7 +4893,7 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 						packageTypes.put(typeString, type);
 					}
 					if (VERBOSE) {
-						Util.verbose("	- indexing cache:"); //$NON-NLS-1$
+						trace("	- indexing cache:"); //$NON-NLS-1$
 						dumpIndexingSecondaryTypes(indexedSecondaryTypes);
 					}
 				}
@@ -4904,7 +4910,7 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 			while (entries.hasNext()) {
 				Entry<IFile, Map<String, Map<String, IType>>> entry = entries.next();
 				IFile file = entry.getKey();
-				Util.verbose("		+ "+file.getFullPath()+':'+ entry.getValue()); //$NON-NLS-1$
+				trace("		+ "+file.getFullPath()+':'+ entry.getValue()); //$NON-NLS-1$
 			}
 		}
 	}
@@ -4915,7 +4921,7 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 			while (entries.hasNext()) {
 				Entry<String, Map<String, IType>> entry = entries.next();
 				String packName = entry.getKey();
-				Util.verbose("		+ " + packName + ':' + entry.getValue()); //$NON-NLS-1$
+				trace("		+ " + packName + ':' + entry.getValue()); //$NON-NLS-1$
 			}
 		}
 	}
@@ -4945,7 +4951,7 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 		if (VERBOSE) {
 			StringBuilder buffer = new StringBuilder("JavaModelManager.secondaryTypes("); //$NON-NLS-1$
 			buffer.append(project.getElementName()).append(',').append(waitForIndexes).append(')');
-			Util.verbose(buffer.toString());
+			trace(buffer.toString());
 		}
 
 		// Return cache if not empty and there's no new secondary types created during indexing
@@ -5022,8 +5028,8 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 			return secondaryTypes;
 		}
 		if (VERBOSE) {
-			Util.verbose("JavaModelManager.getSecondaryTypesMerged()"); //$NON-NLS-1$
-			Util.verbose("	- current cache to merge:"); //$NON-NLS-1$
+			trace("JavaModelManager.getSecondaryTypesMerged()"); //$NON-NLS-1$
+			trace("	- current cache to merge:"); //$NON-NLS-1$
 			dumpSecondaryTypes(secondaryTypes);
 		}
 		Map<IFile, Map<String, Map<String, IType>>> indexedSecondaryTypes = cache.indexingSecondaryCache();
@@ -5062,7 +5068,7 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 			}
 		}
 		if (VERBOSE) {
-			Util.verbose("	- secondary types cache merged:"); //$NON-NLS-1$
+			trace("	- secondary types cache merged:"); //$NON-NLS-1$
 			dumpSecondaryTypes(secondaryTypes);
 		}
 		projectInfo.secondaryTypes.indexingDone();
@@ -5081,7 +5087,7 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 			buffer.append(',');
 			buffer.append(waitForIndexes);
 			buffer.append(')');
-			Util.verbose(buffer.toString());
+			trace(buffer.toString());
 		}
 
 		final Hashtable<String, Map<String, String>> secondaryTypesSearch = new Hashtable<>(3);
@@ -5138,7 +5144,7 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 				stCache = projectInfo.secondaryTypes.doneSearching(secondaryTypes);
 
 				if (VERBOSE || BasicSearchEngine.VERBOSE) {
-					Util.verbose("	-> secondary paths stored in cache: ");  //$NON-NLS-1$
+					trace("	-> secondary paths stored in cache: ");  //$NON-NLS-1$
 					dumpSecondaryTypes(secondaryTypes);
 				}
 			}
@@ -5159,7 +5165,7 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 			StringBuilder buffer = new StringBuilder("JavaModelManager.removeFromSecondaryTypesCache("); //$NON-NLS-1$
 			buffer.append(file.getName());
 			buffer.append(')');
-			Util.verbose(buffer.toString());
+			trace(buffer.toString());
 		}
 		if (file != null) {
 			PerProjectInfo projectInfo = getPerProjectInfo(file.getProject(), false);
@@ -5173,7 +5179,7 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 					return;
 				}
 				if (VERBOSE) {
-					Util.verbose("-> remove file from cache of project: "+file.getProject().getName()); //$NON-NLS-1$
+					trace("-> remove file from cache of project: "+file.getProject().getName()); //$NON-NLS-1$
 				}
 
 				// Clean current cache
@@ -5204,7 +5210,7 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 		if (VERBOSE) {
 			StringBuilder buffer = new StringBuilder("JavaModelManager.removeSecondaryTypesFromMap("); //$NON-NLS-1$
 			buffer.append(',').append(file.getFullPath()).append(')');
-			Util.verbose(buffer.toString());
+			trace(buffer.toString());
 			dumpSecondaryTypes(secondaryTypesMap);
 		}
 		Set<Entry<String, Map<String, IType>>> packageEntries = secondaryTypesMap.entrySet();
@@ -5246,7 +5252,7 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 			}
 		}
 		if (VERBOSE) {
-			Util.verbose("	- new secondary types map:"); //$NON-NLS-1$
+			trace("	- new secondary types map:"); //$NON-NLS-1$
 			dumpSecondaryTypes(secondaryTypesMap);
 		}
 	}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelOperation.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelOperation.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.core;
 
+import static org.eclipse.jdt.internal.core.JavaModelManager.trace;
+
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -634,16 +636,16 @@ public abstract class JavaModelOperation implements IWorkspaceRunnable, IProgres
 	 */
 	protected void postAction(IPostAction action, int insertionMode) {
 		if (POST_ACTION_VERBOSE) {
-			System.out.print("(" + Thread.currentThread() + ") [JavaModelOperation.postAction(IPostAction, int)] Posting action " + action.getID()); //$NON-NLS-1$ //$NON-NLS-2$
+			trace("(" + Thread.currentThread() + ") [JavaModelOperation.postAction(IPostAction, int)] Posting action " + action.getID()); //$NON-NLS-1$ //$NON-NLS-2$
 			switch(insertionMode) {
 				case REMOVEALL_APPEND:
-					System.out.println(" (REMOVEALL_APPEND)"); //$NON-NLS-1$
+					trace(" (REMOVEALL_APPEND)"); //$NON-NLS-1$
 					break;
 				case KEEP_EXISTING:
-					System.out.println(" (KEEP_EXISTING)"); //$NON-NLS-1$
+					trace(" (KEEP_EXISTING)"); //$NON-NLS-1$
 					break;
 				case APPEND:
-					System.out.println(" (APPEND)"); //$NON-NLS-1$
+					trace(" (APPEND)"); //$NON-NLS-1$
 					break;
 			}
 		}
@@ -700,7 +702,7 @@ public abstract class JavaModelOperation implements IWorkspaceRunnable, IProgres
 	 */
 	protected void removeAllPostAction(String actionID) {
 		if (POST_ACTION_VERBOSE) {
-			System.out.println("(" + Thread.currentThread() + ") [JavaModelOperation.removeAllPostAction(String)] Removing actions " + actionID); //$NON-NLS-1$ //$NON-NLS-2$
+			trace("(" + Thread.currentThread() + ") [JavaModelOperation.removeAllPostAction(String)] Removing actions " + actionID); //$NON-NLS-1$ //$NON-NLS-2$
 		}
 
 		JavaModelOperation topLevelOp = (JavaModelOperation)getCurrentOperationStack().get(0);
@@ -828,7 +830,7 @@ public abstract class JavaModelOperation implements IWorkspaceRunnable, IProgres
 		while (this.actionsStart <= this.actionsEnd) {
 			IPostAction postAction = this.actions[this.actionsStart++];
 			if (POST_ACTION_VERBOSE) {
-				System.out.println("(" + Thread.currentThread() + ") [JavaModelOperation.runPostActions()] Running action " + postAction.getID()); //$NON-NLS-1$ //$NON-NLS-2$
+				trace("(" + Thread.currentThread() + ") [JavaModelOperation.runPostActions()] Running action " + postAction.getID()); //$NON-NLS-1$ //$NON-NLS-2$
 			}
 			postAction.run();
 		}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaProject.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaProject.java
@@ -16,6 +16,8 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.core;
 
+import static org.eclipse.jdt.internal.core.JavaModelManager.trace;
+
 import java.io.*;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
@@ -447,7 +449,6 @@ public class JavaProject
 				}
 			}
 		}
-		//System.out.println("updateAllCycleMarkers: " + (System.currentTimeMillis() - start) + " ms");
 
 		for (int i = 0; i < length; i++){
 			JavaProject project = projects[i];
@@ -1290,7 +1291,7 @@ public class JavaProject
 		} catch (CoreException e) {
 			// could not create marker: cannot do much
 			if (JavaModelManager.VERBOSE) {
-				e.printStackTrace();
+				trace("", e); //$NON-NLS-1$
 			}
 		}
 	}
@@ -1829,7 +1830,7 @@ public class JavaProject
 		} catch (CoreException e) {
 			// could not flush markers: not much we can do
 			if (JavaModelManager.VERBOSE) {
-				e.printStackTrace();
+				trace("", e); //$NON-NLS-1$
 			}
 		}
 	}
@@ -2571,11 +2572,10 @@ public class JavaProject
 	}
 
 	private void verbose_reentering_classpath_resolution() {
-		Util.verbose(
+		trace(
 			"CPResolution: reentering raw classpath resolution, will use empty classpath instead" + //$NON-NLS-1$
 			"	project: " + getElementName() + '\n' + //$NON-NLS-1$
-			"	invocation stack trace:"); //$NON-NLS-1$
-		new Exception("<Fake exception>").printStackTrace(System.out); //$NON-NLS-1$
+			"	invocation stack trace:", new Exception("<Fake exception>")); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
 	/**

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ModularClassFile.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ModularClassFile.java
@@ -145,7 +145,7 @@ public class ModularClassFile extends AbstractClassFile implements IModularClass
 		} catch (ClassFormatException cfe) {
 			//the structure remains unknown
 			if (JavaCore.getPlugin().isDebugging()) {
-				cfe.printStackTrace(System.err);
+				JavaModelManager.trace("", cfe); //$NON-NLS-1$
 			}
 			return null;
 		} catch (IOException ioe) {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ModulePathContainerInitializer.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ModulePathContainerInitializer.java
@@ -19,7 +19,6 @@ import org.eclipse.jdt.core.ClasspathContainerInitializer;
 import org.eclipse.jdt.core.IClasspathContainer;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
-import org.eclipse.jdt.internal.core.util.Util;
 
 public class ModulePathContainerInitializer extends ClasspathContainerInitializer {
 
@@ -41,7 +40,7 @@ public class ModulePathContainerInitializer extends ClasspathContainerInitialize
 		return path != null && JavaCore.MODULE_PATH_CONTAINER_ID.equals(path.segment(0));
 	}
 	private void verbose_not_a_module_project(IJavaProject project, IPath containerPath) {
-		Util.verbose(
+		JavaModelManager.trace(
 			"Module path INIT - FAILED (not a module project)\n" + //$NON-NLS-1$
 			"	project: " + project.getElementName() + '\n' + //$NON-NLS-1$
 			"	container path: " + containerPath); //$NON-NLS-1$

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ModuleSourcePathManager.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ModuleSourcePathManager.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.core;
 
+import static org.eclipse.jdt.internal.core.JavaModelManager.trace;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -37,8 +39,9 @@ public class ModuleSourcePathManager {
 			try {
 				seekModule(name.toCharArray(),false, new JavaElementRequestor());
 			} catch (JavaModelException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
+				if (JavaModelManager.VERBOSE) {
+					trace("", e); //$NON-NLS-1$
+				}
 			}
 		}
 		root = this.knownModules.get(name);
@@ -94,15 +97,19 @@ public class ModuleSourcePathManager {
 		if (root != null)
 			try {
 				return root.getModule();
-			} catch (Exception e1) {
-				//
+			} catch (Exception e) {
+				if (JavaModelManager.VERBOSE) {
+					trace("", e); //$NON-NLS-1$
+				}
 				return null;
 			}
 		JavaElementRequestor requestor = new JavaElementRequestor();
 		try {
 			seekModule(name, false, requestor);
 		} catch (JavaModelException e) {
-			//
+			if (JavaModelManager.VERBOSE) {
+				trace("", e); //$NON-NLS-1$
+			}
 		}
 		IModuleDescription[] modules = requestor.getModules();
 		if (modules.length > 0) {
@@ -110,24 +117,12 @@ public class ModuleSourcePathManager {
 			try {
 				return (IModule) ((JavaElement) module).getElementInfo();
 			} catch (JavaModelException e) {
-				e.printStackTrace();
+				if (JavaModelManager.VERBOSE) {
+					trace("", e); //$NON-NLS-1$
+				}
 			}
 		}
 		return null;
 	}
-//	public IModuleDeclaration[] getModules() {
-//		if (this.knownModules.size() == 0) {
-//			return new IModuleDeclaration[0];
-//		}
-//		List<IModuleDeclaration> modules = new ArrayList<IModuleDeclaration>();
-//		for (IModulePathEntry val : this.knownModules.values()) {
-//			try {
-//				modules.add(val.getModule());
-//			} catch (Exception e) {
-//				// TODO Auto-generated catch block
-//				e.printStackTrace();
-//			}
-//		}
-//		return modules.toArray(new IModuleDeclaration[modules.size()]);
-//	}
+
 }

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/NameLookup.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/NameLookup.java
@@ -14,6 +14,8 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.core;
 
+import static org.eclipse.jdt.internal.core.JavaModelManager.trace;
+
 import java.io.File;
 import java.util.*;
 import java.util.function.Function;
@@ -248,10 +250,10 @@ public class NameLookup implements SuffixConstants {
 		this.rootProject = rootProject;
 		long start = -1;
 		if (VERBOSE) {
-			Util.verbose(" BUILDING NameLoopkup");  //$NON-NLS-1$
-			Util.verbose(" -> pkg roots size: " + (packageFragmentRoots == null ? 0 : packageFragmentRoots.length));  //$NON-NLS-1$
-			Util.verbose(" -> pkgs size: " + (packageFragments == null ? 0 : packageFragments.size()));  //$NON-NLS-1$
-			Util.verbose(" -> working copy size: " + (workingCopies == null ? 0 : workingCopies.length));  //$NON-NLS-1$
+			trace(" BUILDING NameLoopkup");  //$NON-NLS-1$
+			trace(" -> pkg roots size: " + (packageFragmentRoots == null ? 0 : packageFragmentRoots.length));  //$NON-NLS-1$
+			trace(" -> pkgs size: " + (packageFragments == null ? 0 : packageFragments.size()));  //$NON-NLS-1$
+			trace(" -> working copy size: " + (workingCopies == null ? 0 : workingCopies.length));  //$NON-NLS-1$
 			start = System.currentTimeMillis();
 		}
 		this.rootToModule = new HashMap<>();
@@ -361,7 +363,7 @@ public class NameLookup implements SuffixConstants {
 
 		this.rootToResolvedEntries = rootToResolvedEntries;
         if (VERBOSE) {
-            Util.verbose(" -> spent: " + (System.currentTimeMillis() - start) + "ms");  //$NON-NLS-1$ //$NON-NLS-2$
+        	trace(" -> spent: " + (System.currentTimeMillis() - start) + "ms");  //$NON-NLS-1$ //$NON-NLS-2$
         }
 	}
 
@@ -716,11 +718,11 @@ public class NameLookup implements SuffixConstants {
 					IType type = types.get(typeName);
 					if (type != null) {
 						if (JavaModelManager.VERBOSE) {
-							Util.verbose("NameLookup FIND SECONDARY TYPES:"); //$NON-NLS-1$
-							Util.verbose(" -> pkg name: " + packageName);  //$NON-NLS-1$
-							Util.verbose(" -> type name: " + typeName);  //$NON-NLS-1$
-							Util.verbose(" -> project: "+project.getElementName()); //$NON-NLS-1$
-							Util.verbose(" -> type: " + type.getElementName());  //$NON-NLS-1$
+							trace("NameLookup FIND SECONDARY TYPES:"); //$NON-NLS-1$
+							trace(" -> pkg name: " + packageName);  //$NON-NLS-1$
+							trace(" -> type name: " + typeName);  //$NON-NLS-1$
+							trace(" -> project: "+project.getElementName()); //$NON-NLS-1$
+							trace(" -> type: " + type.getElementName());  //$NON-NLS-1$
 						}
 						return type;
 					}
@@ -1776,14 +1778,14 @@ public class NameLookup implements SuffixConstants {
 		if(!NameLookup.VERBOSE)
 			return;
 
-		Util.verbose(" TIME SPENT NameLoopkup");  //$NON-NLS-1$
-		Util.verbose(" -> seekTypesInSourcePackage..................." + this.timeSpentInSeekTypesInSourcePackage + "ms");  //$NON-NLS-1$ //$NON-NLS-2$
-		Util.verbose(" -> seekTypesInBinaryPackage..................." + this.timeSpentInSeekTypesInBinaryPackage + "ms");  //$NON-NLS-1$ //$NON-NLS-2$
-		Util.verbose(" -> seekTypesInType............................" + this.timeSpentInSeekTypesInType + "ms");  //$NON-NLS-1$ //$NON-NLS-2$
-		Util.verbose(" -> seekModule................................." + this.timeSpentInSeekModule + "ms");  //$NON-NLS-1$ //$NON-NLS-2$
-		Util.verbose(" -> seekModuleAwarePartialPackageFragments....." + this.timeSpentInSeekModuleAwarePartialPackageFragments + "ms");  //$NON-NLS-1$ //$NON-NLS-2$
-		Util.verbose(" -> seekPackageFragments......................." + this.timeSpentInSeekPackageFragments + "ms");  //$NON-NLS-1$ //$NON-NLS-2$
-		Util.verbose(" -> seekPackageFragmentsWithModuleContext......" + this.timeSpentInSeekPackageFragmentsWithModuleContext + "ms");  //$NON-NLS-1$ //$NON-NLS-2$
-		Util.verbose(" -> isPackage(pkg,moduleCtx)..................." + this.timeSpentInIsPackageWithModuleContext + "ms");  //$NON-NLS-1$ //$NON-NLS-2$
+		trace(" TIME SPENT NameLoopkup");  //$NON-NLS-1$
+		trace(" -> seekTypesInSourcePackage..................." + this.timeSpentInSeekTypesInSourcePackage + "ms");  //$NON-NLS-1$ //$NON-NLS-2$
+		trace(" -> seekTypesInBinaryPackage..................." + this.timeSpentInSeekTypesInBinaryPackage + "ms");  //$NON-NLS-1$ //$NON-NLS-2$
+		trace(" -> seekTypesInType............................" + this.timeSpentInSeekTypesInType + "ms");  //$NON-NLS-1$ //$NON-NLS-2$
+		trace(" -> seekModule................................." + this.timeSpentInSeekModule + "ms");  //$NON-NLS-1$ //$NON-NLS-2$
+		trace(" -> seekModuleAwarePartialPackageFragments....." + this.timeSpentInSeekModuleAwarePartialPackageFragments + "ms");  //$NON-NLS-1$ //$NON-NLS-2$
+		trace(" -> seekPackageFragments......................." + this.timeSpentInSeekPackageFragments + "ms");  //$NON-NLS-1$ //$NON-NLS-2$
+		trace(" -> seekPackageFragmentsWithModuleContext......" + this.timeSpentInSeekPackageFragmentsWithModuleContext + "ms");  //$NON-NLS-1$ //$NON-NLS-2$
+		trace(" -> isPackage(pkg,moduleCtx)..................." + this.timeSpentInIsPackageWithModuleContext + "ms");  //$NON-NLS-1$ //$NON-NLS-2$
 	}
 }

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/NamedMember.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/NamedMember.java
@@ -327,8 +327,8 @@ public abstract class NamedMember extends Member {
 
 		engine.selectType(typeName.toCharArray(), (IType) this);
 		if (NameLookup.VERBOSE) {
-			System.out.println(Thread.currentThread() + " TIME SPENT in NameLoopkup#seekTypesInSourcePackage: " + environment.nameLookup.timeSpentInSeekTypesInSourcePackage + "ms");  //$NON-NLS-1$ //$NON-NLS-2$
-			System.out.println(Thread.currentThread() + " TIME SPENT in NameLoopkup#seekTypesInBinaryPackage: " + environment.nameLookup.timeSpentInSeekTypesInBinaryPackage + "ms");  //$NON-NLS-1$ //$NON-NLS-2$
+			JavaModelManager.trace(Thread.currentThread() + " TIME SPENT in NameLoopkup#seekTypesInSourcePackage: " + environment.nameLookup.timeSpentInSeekTypesInSourcePackage + "ms");  //$NON-NLS-1$ //$NON-NLS-2$
+			JavaModelManager.trace(Thread.currentThread() + " TIME SPENT in NameLoopkup#seekTypesInBinaryPackage: " + environment.nameLookup.timeSpentInSeekTypesInBinaryPackage + "ms");  //$NON-NLS-1$ //$NON-NLS-2$
 		}
 		return requestor.answers;
 	}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/Openable.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/Openable.java
@@ -241,7 +241,7 @@ protected void generateInfos(Object info, HashMap newElements, IProgressMonitor 
 			default:
 				element = "element"; //$NON-NLS-1$
 		}
-		System.out.println(Thread.currentThread() +" OPENING " + element + " " + this.toStringWithAncestors()); //$NON-NLS-1$//$NON-NLS-2$
+		JavaModelManager.trace(Thread.currentThread() +" OPENING " + element + " " + this.toStringWithAncestors()); //$NON-NLS-1$//$NON-NLS-2$
 	}
 
 	// open its ancestors if needed
@@ -274,7 +274,7 @@ protected void generateInfos(Object info, HashMap newElements, IProgressMonitor 
 	JavaModelManager.getJavaModelManager().getElementsOutOfSynchWithBuffers().remove(this);
 
 	if (JavaModelCache.VERBOSE) {
-		System.out.println(JavaModelManager.getJavaModelManager().cacheToString("-> ")); //$NON-NLS-1$
+		JavaModelManager.trace(JavaModelManager.getJavaModelManager().cacheToString("-> ")); //$NON-NLS-1$
 	}
 }
 protected boolean ignoreErrorStatus(IStatus status) {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ReconcileWorkingCopyOperation.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ReconcileWorkingCopyOperation.java
@@ -138,7 +138,7 @@ public class ReconcileWorkingCopyOperation extends JavaModelOperation {
 				for (int i = 0, length = categorizedProblems.length; i < length; i++) {
 					CategorizedProblem problem = categorizedProblems[i];
 					if (JavaModelManager.VERBOSE){
-						System.out.println("PROBLEM FOUND while reconciling : " + problem.getMessage());//$NON-NLS-1$
+						JavaModelManager.trace("PROBLEM FOUND while reconciling : " + problem.getMessage());//$NON-NLS-1$
 					}
 					if (this.progressMonitor != null && this.progressMonitor.isCanceled()) break;
 					problemRequestor.acceptProblem(problem);

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SearchableEnvironment.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SearchableEnvironment.java
@@ -1285,9 +1285,9 @@ private void findPackagesFromRequires(char[] prefix, boolean isMatchAllPrefix, I
 		if(!NameLookup.VERBOSE)
 			return;
 
-		Util.verbose(" TIME SPENT SearchableEnvironment");  //$NON-NLS-1$
-		Util.verbose(" -> getModulesDeclaringPackage..." +  this.timeSpentInGetModulesDeclaringPackage + "ms");  //$NON-NLS-1$ //$NON-NLS-2$
-		Util.verbose(" -> findTypes...................." +  this.timeSpentInFindTypes + "ms");  //$NON-NLS-1$ //$NON-NLS-2$
+		JavaModelManager.trace(" TIME SPENT SearchableEnvironment");  //$NON-NLS-1$
+		JavaModelManager.trace(" -> getModulesDeclaringPackage..." +  this.timeSpentInGetModulesDeclaringPackage + "ms");  //$NON-NLS-1$ //$NON-NLS-2$
+		JavaModelManager.trace(" -> findTypes...................." +  this.timeSpentInFindTypes + "ms");  //$NON-NLS-1$ //$NON-NLS-2$
 
 		this.nameLookup.printTimeSpent();
 	}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SelectionRequestor.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SelectionRequestor.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.core;
 
+import static org.eclipse.jdt.internal.core.JavaModelManager.trace;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -108,9 +110,7 @@ private void acceptBinaryMethod(
 
 			addElement(method);
 			if(SelectionEngine.DEBUG){
-				System.out.print("SELECTION - accept method("); //$NON-NLS-1$
-				System.out.print(method.toString());
-				System.out.println(")"); //$NON-NLS-1$
+				trace("SELECTION - accept method(" + method.toString() + ")"); //$NON-NLS-1$ //$NON-NLS-2$
 			}
 		} else {
 			ISourceRange range = method.getSourceRange();
@@ -126,17 +126,13 @@ private void acceptBinaryMethod(
 				}
 				addElement(method);
 				if(SelectionEngine.DEBUG){
-					System.out.print("SELECTION - accept method("); //$NON-NLS-1$
-					System.out.print(method.toString());
-					System.out.println(")"); //$NON-NLS-1$
+					trace("SELECTION - accept method(" + method.toString() + ")"); //$NON-NLS-1$ //$NON-NLS-2$
 				}
 			} else {
 				// no range was actually found, but a method was originally given -> default constructor
 				addElement(type);
 				if(SelectionEngine.DEBUG){
-					System.out.print("SELECTION - accept type("); //$NON-NLS-1$
-					System.out.print(type.toString());
-					System.out.println(")"); //$NON-NLS-1$
+					trace("SELECTION - accept type(" + type.toString()+ ")"); //$NON-NLS-1$ //$NON-NLS-2$
 				}
 			}
 		}
@@ -225,9 +221,7 @@ public void acceptType(char[] packageName, char[] typeName, int modifiers, boole
 	if (type != null) {
 		addElement(type);
 		if(SelectionEngine.DEBUG){
-			System.out.print("SELECTION - accept type("); //$NON-NLS-1$
-			System.out.print(type.toString());
-			System.out.println(")"); //$NON-NLS-1$
+			trace("SELECTION - accept type(" + type.toString() + ")"); //$NON-NLS-1$ //$NON-NLS-2$
 		}
 	}
 }
@@ -248,9 +242,7 @@ public void acceptType(IType type) {
 
 	addElement(type);
 	if(SelectionEngine.DEBUG){
-		System.out.print("SELECTION - accept type("); //$NON-NLS-1$
-		System.out.print(type.toString());
-		System.out.println(")"); //$NON-NLS-1$
+		trace("SELECTION - accept type(" + type.toString() + ")"); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 }
 /**
@@ -288,9 +280,7 @@ public void acceptField(char[] declaringTypePackageName, char[] declaringTypeNam
 							&& field.getElementName().equals(new String(name))) {
 						addElement(fields[i]);
 						if(SelectionEngine.DEBUG){
-							System.out.print("SELECTION - accept field("); //$NON-NLS-1$
-							System.out.print(field.toString());
-							System.out.println(")"); //$NON-NLS-1$
+							trace("SELECTION - accept field(" + field.toString() + ")"); //$NON-NLS-1$ //$NON-NLS-2$
 						}
 						return; // only one method is possible
 					}
@@ -323,9 +313,7 @@ public void acceptField(char[] declaringTypePackageName, char[] declaringTypeNam
 				}
 				addElement(field);
 				if(SelectionEngine.DEBUG){
-					System.out.print("SELECTION - accept field("); //$NON-NLS-1$
-					System.out.print(field.toString());
-					System.out.println(")"); //$NON-NLS-1$
+					trace("SELECTION - accept field(" + field.toString() + ")"); //$NON-NLS-1$ //$NON-NLS-2$
 				}
 			}
 		}
@@ -362,9 +350,7 @@ public void acceptLocalField(FieldBinding fieldBinding) {
 			}
 			addElement(field);
 			if(SelectionEngine.DEBUG){
-				System.out.print("SELECTION - accept field("); //$NON-NLS-1$
-				System.out.print(field.toString());
-				System.out.println(")"); //$NON-NLS-1$
+				trace("SELECTION - accept field(" + field.toString() + ")"); //$NON-NLS-1$ //$NON-NLS-2$
 			}
 		}
 	}
@@ -395,18 +381,14 @@ public void acceptLocalMethod(MethodBinding methodBinding) {
 			}
 			addElement(res);
 			if(SelectionEngine.DEBUG){
-				System.out.print("SELECTION - accept method("); //$NON-NLS-1$
-				System.out.print(res.toString());
-				System.out.println(")"); //$NON-NLS-1$
+				trace("SELECTION - accept method(" + res.toString() + ")"); //$NON-NLS-1$ //$NON-NLS-2$
 			}
 		} else if(methodBinding.selector == TypeConstants.INIT && res.getElementType() == IJavaElement.TYPE) {
 			// it's a default constructor
 			res = ((JavaElement)res).resolved(methodBinding.declaringClass);
 			addElement(res);
 			if(SelectionEngine.DEBUG){
-				System.out.print("SELECTION - accept type("); //$NON-NLS-1$
-				System.out.print(res.toString());
-				System.out.println(")"); //$NON-NLS-1$
+				trace("SELECTION - accept type(" + res.toString() + ")"); //$NON-NLS-1$ //$NON-NLS-2$
 			}
 		}
 	}
@@ -423,9 +405,7 @@ public void acceptLocalType(TypeBinding typeBinding) {
 		res = ((JavaElement)res).resolved(typeBinding);
 		addElement(res);
 		if(SelectionEngine.DEBUG){
-			System.out.print("SELECTION - accept type("); //$NON-NLS-1$
-			System.out.print(res.toString());
-			System.out.println(")"); //$NON-NLS-1$
+			trace("SELECTION - accept type(" + res.toString() + ")"); //$NON-NLS-1$ //$NON-NLS-2$
 		}
 	}
 }
@@ -444,9 +424,7 @@ public void acceptLocalTypeParameter(TypeVariableBinding typeVariableBinding) {
 		if (typeParameter.exists()) {
 			addElement(typeParameter);
 			if(SelectionEngine.DEBUG){
-				System.out.print("SELECTION - accept type parameter("); //$NON-NLS-1$
-				System.out.print(typeParameter.toString());
-				System.out.println(")"); //$NON-NLS-1$
+				trace("SELECTION - accept type parameter(" + typeParameter.toString() + ")"); //$NON-NLS-1$ //$NON-NLS-2$
 			}
 		}
 	}
@@ -461,9 +439,7 @@ public void acceptLocalMethodTypeParameter(TypeVariableBinding typeVariableBindi
 		if (typeParameter.exists()) {
 			addElement(typeParameter);
 			if(SelectionEngine.DEBUG){
-				System.out.print("SELECTION - accept type parameter("); //$NON-NLS-1$
-				System.out.print(typeParameter.toString());
-				System.out.println(")"); //$NON-NLS-1$
+				trace("SELECTION - accept type parameter(" + typeParameter.toString() + ")"); //$NON-NLS-1$ //$NON-NLS-2$
 			}
 		}
 	}
@@ -505,9 +481,7 @@ public void acceptLocalVariable(LocalVariableBinding binding, org.eclipse.jdt.in
 	if (localVar != null) {
 		addElement(localVar);
 		if(SelectionEngine.DEBUG){
-			System.out.print("SELECTION - accept local variable("); //$NON-NLS-1$
-			System.out.print(localVar.toString());
-			System.out.println(")"); //$NON-NLS-1$
+			trace("SELECTION - accept local variable(" + localVar.toString() + ")"); //$NON-NLS-1$ //$NON-NLS-2$
 		}
 	}
 }
@@ -608,9 +582,7 @@ public void acceptPackage(char[] packageName) {
 		for (int i = 0, length = pkgs.length; i < length; i++) {
 			addElement(pkgs[i]);
 			if(SelectionEngine.DEBUG){
-				System.out.print("SELECTION - accept package("); //$NON-NLS-1$
-				System.out.print(pkgs[i].toString());
-				System.out.println(")"); //$NON-NLS-1$
+				trace("SELECTION - accept package(" + pkgs[i].toString() + ")"); //$NON-NLS-1$ //$NON-NLS-2$
 			}
 		}
 	}
@@ -669,9 +641,7 @@ protected void acceptSourceMethod(
 						// no match was actually found, but a method was originally given -> default accessor
 						 addElement(comp);
 						 if(SelectionEngine.DEBUG){
-								System.out.print("SELECTION - accept field("); //$NON-NLS-1$
-								System.out.print(comp.toString());
-								System.out.println(")"); //$NON-NLS-1$
+								trace("SELECTION - accept field(" + comp.toString() + ")"); //$NON-NLS-1$ //$NON-NLS-2$
 						 }
 					 }
 				}
@@ -683,9 +653,7 @@ protected void acceptSourceMethod(
 			// no match was actually found, but a method was originally given -> default constructor
 			addElement(type);
 			if(SelectionEngine.DEBUG){
-				System.out.print("SELECTION - accept type("); //$NON-NLS-1$
-				System.out.print(type.toString());
-				System.out.println(")"); //$NON-NLS-1$
+				trace("SELECTION - accept type(" + type.toString() + ")"); //$NON-NLS-1$ //$NON-NLS-2$
 			}
 		}
 		return;
@@ -694,9 +662,7 @@ protected void acceptSourceMethod(
 	// if there is only one match, we've got it
 	if (this.elementIndex == 0) {
 		if(SelectionEngine.DEBUG){
-			System.out.print("SELECTION - accept method("); //$NON-NLS-1$
-			System.out.print(this.elements[0].toString());
-			System.out.println(")"); //$NON-NLS-1$
+			trace("SELECTION - accept method(" + this.elements[0].toString() + ")"); //$NON-NLS-1$ //$NON-NLS-2$
 		}
 		return;
 	}
@@ -726,9 +692,7 @@ protected void acceptSourceMethod(
 		if (match) {
 			addElement(method);
 			if(SelectionEngine.DEBUG){
-				System.out.print("SELECTION - accept method("); //$NON-NLS-1$
-				System.out.print(method.toString());
-				System.out.println(")"); //$NON-NLS-1$
+				trace("SELECTION - accept method(" + method.toString() + ")"); //$NON-NLS-1$ //$NON-NLS-2$
 			}
 		}
 	}
@@ -746,9 +710,7 @@ protected void acceptMethodDeclaration(IType type, char[] selector, int start, i
 					&& methods[i].getElementName().equals(name)) {
 				addElement(methods[i]);
 				if(SelectionEngine.DEBUG){
-					System.out.print("SELECTION - accept method("); //$NON-NLS-1$
-					System.out.print(this.elements[0].toString());
-					System.out.println(")"); //$NON-NLS-1$
+					trace("SELECTION - accept method(" + this.elements[0].toString() + ")"); //$NON-NLS-1$ //$NON-NLS-2$
 				}
 				return; // only one method is possible
 			}
@@ -760,9 +722,7 @@ protected void acceptMethodDeclaration(IType type, char[] selector, int start, i
 	// no match was actually found
 	addElement(type);
 	if(SelectionEngine.DEBUG){
-		System.out.print("SELECTION - accept type("); //$NON-NLS-1$
-		System.out.print(type.toString());
-		System.out.println(")"); //$NON-NLS-1$
+		trace("SELECTION - accept type(" + type.toString()+ ")"); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 	return;
 }
@@ -783,16 +743,12 @@ public void acceptTypeParameter(char[] declaringTypePackageName, char[] declarin
 		if(typeParameter == null) {
 			addElement(type);
 			if(SelectionEngine.DEBUG){
-				System.out.print("SELECTION - accept type("); //$NON-NLS-1$
-				System.out.print(type.toString());
-				System.out.println(")"); //$NON-NLS-1$
+				trace("SELECTION - accept type(" + type.toString() + ")"); //$NON-NLS-1$ //$NON-NLS-2$
 			}
 		} else {
 			addElement(typeParameter);
 			if(SelectionEngine.DEBUG){
-				System.out.print("SELECTION - accept type parameter("); //$NON-NLS-1$
-				System.out.print(typeParameter.toString());
-				System.out.println(")"); //$NON-NLS-1$
+				trace("SELECTION - accept type parameter(" + typeParameter.toString() + ")"); //$NON-NLS-1$ //$NON-NLS-2$
 			}
 		}
 	}
@@ -827,25 +783,19 @@ public void acceptMethodTypeParameter(char[] declaringTypePackageName, char[] de
 		if(method == null) {
 			addElement(type);
 			if(SelectionEngine.DEBUG){
-				System.out.print("SELECTION - accept type("); //$NON-NLS-1$
-				System.out.print(type.toString());
-				System.out.println(")"); //$NON-NLS-1$
+				trace("SELECTION - accept type(" + type.toString() + ")"); //$NON-NLS-1$ //$NON-NLS-2$
 			}
 		} else {
 			ITypeParameter typeParameter = method.getTypeParameter(new String(typeParameterName));
 			if(typeParameter == null) {
 				addElement(method);
 				if(SelectionEngine.DEBUG){
-					System.out.print("SELECTION - accept method("); //$NON-NLS-1$
-					System.out.print(method.toString());
-					System.out.println(")"); //$NON-NLS-1$
+					trace("SELECTION - accept method(" + method.toString() + ")"); //$NON-NLS-1$ //$NON-NLS-2$
 				}
 			} else {
 				addElement(typeParameter);
 				if(SelectionEngine.DEBUG){
-					System.out.print("SELECTION - accept method type parameter("); //$NON-NLS-1$
-					System.out.print(typeParameter.toString());
-					System.out.println(")"); //$NON-NLS-1$
+					trace("SELECTION - accept method type parameter(" + typeParameter.toString() + ")"); //$NON-NLS-1$ //$NON-NLS-2$
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SetContainerOperation.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SetContainerOperation.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.core;
 
+import static org.eclipse.jdt.internal.core.JavaModelManager.trace;
+
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
@@ -23,7 +25,6 @@ import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaModelStatusConstants;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaModelException;
-import org.eclipse.jdt.internal.core.util.Util;
 
 public class SetContainerOperation extends ChangeClasspathOperation {
 
@@ -150,22 +151,21 @@ public class SetContainerOperation extends ChangeClasspathOperation {
 	}
 
 	private void verbose_failure(CoreException e) {
-		Util.verbose(
+		trace(
 			"CPContainer SET  - FAILED DUE TO EXCEPTION\n" + //$NON-NLS-1$
 			"	container path: " + this.containerPath, //$NON-NLS-1$
-			System.err);
-		e.printStackTrace();
+			e);
 	}
 
 	private void verbose_update_project(JavaProject affectedProject) {
-		Util.verbose(
+		trace(
 			"CPContainer SET  - updating affected project due to setting container\n" + //$NON-NLS-1$
 			"	project: " + affectedProject.getElementName() + '\n' + //$NON-NLS-1$
 			"	container path: " + this.containerPath); //$NON-NLS-1$
 	}
 
 	private void verbose_set_container() {
-		Util.verbose(
+		trace(
 			"CPContainer SET  - setting container\n" + //$NON-NLS-1$
 			"	container path: " + this.containerPath + '\n' + //$NON-NLS-1$
 			"	projects: {" +//$NON-NLS-1$
@@ -205,10 +205,9 @@ public class SetContainerOperation extends ChangeClasspathOperation {
 	}
 
 	private void verbose_set_container_invocation_trace() {
-		Util.verbose(
+		trace(
 			"CPContainer SET  - setting container\n" + //$NON-NLS-1$
-			"	invocation stack trace:"); //$NON-NLS-1$
-			new Exception("<Fake exception>").printStackTrace(System.out); //$NON-NLS-1$
+			"	invocation stack trace:", new Exception("<Fake exception>")); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 
 }

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SetVariablesOperation.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SetVariablesOperation.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.core;
 
+import static org.eclipse.jdt.internal.core.JavaModelManager.trace;
+
 import java.util.HashMap;
 import java.util.Iterator;
 
@@ -24,7 +26,6 @@ import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaModel;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaModelException;
-import org.eclipse.jdt.internal.core.util.Util;
 
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class SetVariablesOperation extends ChangeClasspathOperation {
@@ -158,8 +159,7 @@ public class SetVariablesOperation extends ChangeClasspathOperation {
 					}
 				} catch (CoreException e) {
 					if (JavaModelManager.CP_RESOLVE_VERBOSE || JavaModelManager.CP_RESOLVE_VERBOSE_FAILURE){
-						verbose_failure(dbgVariableNames);
-						e.printStackTrace();
+						verbose_failure(dbgVariableNames, e);
 					}
 					if (e instanceof JavaModelException) {
 						throw (JavaModelException)e;
@@ -173,23 +173,22 @@ public class SetVariablesOperation extends ChangeClasspathOperation {
 		}
 	}
 
-	private void verbose_failure(String[] dbgVariableNames) {
-		Util.verbose(
+	private void verbose_failure(String[] dbgVariableNames, CoreException e) {
+		trace(
 			"CPVariable SET  - FAILED DUE TO EXCEPTION\n" + //$NON-NLS-1$
-			"	variables: " + org.eclipse.jdt.internal.compiler.util.Util.toString(dbgVariableNames), //$NON-NLS-1$
-			System.err);
+			"	variables: " + org.eclipse.jdt.internal.compiler.util.Util.toString(dbgVariableNames), e); //$NON-NLS-1$
 	}
 
 	private void verbose_update_project(String[] dbgVariableNames,
 			JavaProject affectedProject) {
-		Util.verbose(
+		trace(
 			"CPVariable SET  - updating affected project due to setting variables\n" + //$NON-NLS-1$
 			"	project: " + affectedProject.getElementName() + '\n' + //$NON-NLS-1$
 			"	variables: " + org.eclipse.jdt.internal.compiler.util.Util.toString(dbgVariableNames)); //$NON-NLS-1$
 	}
 
 	private void verbose_set_variables() {
-		Util.verbose(
+		trace(
 			"CPVariable SET  - setting variables\n" + //$NON-NLS-1$
 			"	variables: " + org.eclipse.jdt.internal.compiler.util.Util.toString(this.variableNames) + '\n' +//$NON-NLS-1$
 			"	values: " + org.eclipse.jdt.internal.compiler.util.Util.toString(this.variablePaths)); //$NON-NLS-1$

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SourceMapper.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SourceMapper.java
@@ -15,6 +15,8 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.core;
 
+import static org.eclipse.jdt.internal.core.JavaModelManager.trace;
+
 import java.io.IOException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.attribute.BasicFileAttributes;
@@ -547,7 +549,7 @@ public class SourceMapper
 		final HashSet tempRoots = new HashSet();
 		long time = 0;
 		if (VERBOSE) {
-			System.out.println("compute all root paths for " + root.getElementName()); //$NON-NLS-1$
+			trace("compute all root paths for " + root.getElementName()); //$NON-NLS-1$
 			time = System.currentTimeMillis();
 		}
 		final HashSet firstLevelPackageNames = new HashSet();
@@ -568,7 +570,7 @@ public class SourceMapper
 			} catch (IOException e) {
 				// We are not reading any specific file, so, move on for now
 				if (VERBOSE) {
-					e.printStackTrace();
+					trace("", e); //$NON-NLS-1$
 				}
 			}
 		} else if (root.isArchive()) {
@@ -708,11 +710,11 @@ public class SourceMapper
 		}
 		this.areRootPathsComputed = true;
 		if (VERBOSE) {
-			System.out.println("Spent " + (System.currentTimeMillis() - time) + "ms"); //$NON-NLS-1$ //$NON-NLS-2$
-			System.out.println("Found " + size + " root paths");	//$NON-NLS-1$ //$NON-NLS-2$
+			trace("Spent " + (System.currentTimeMillis() - time) + "ms"); //$NON-NLS-1$ //$NON-NLS-2$
+			trace("Found " + size + " root paths");	//$NON-NLS-1$ //$NON-NLS-2$
 			int i = 0;
 			for (Iterator iterator = this.rootPaths.iterator(); iterator.hasNext();) {
-				System.out.println("root[" + i + "]=" + ((String) iterator.next()));//$NON-NLS-1$ //$NON-NLS-2$
+				trace("root[" + i + "]=" + ((String) iterator.next()));//$NON-NLS-1$ //$NON-NLS-2$
 				i++;
 			}
 		}
@@ -752,8 +754,9 @@ public class SourceMapper
 				}
 			}
 		} catch (CoreException e) {
-			// ignore
-			e.printStackTrace();
+			if (VERBOSE) {
+				trace("", e); //$NON-NLS-1$
+			}
 		}
 	}
 

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SourceModule.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SourceModule.java
@@ -47,8 +47,9 @@ public class SourceModule extends NamedMember implements AbstractModule {
 		try {
 			toStringContent(buffer, lineDelimiter);
 		} catch (JavaModelException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
+			if (JavaModelManager.VERBOSE) {
+				JavaModelManager.trace("", e); //$NON-NLS-1$
+			}
 		}
 		return buffer.toString();
 	}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SourceType.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SourceType.java
@@ -142,8 +142,8 @@ public void codeComplete(
 		engine.complete(this, snippet, position, localVariableTypeNames, localVariableNames, localVariableModifiers, isStatic);
 	}
 	if (NameLookup.VERBOSE) {
-		System.out.println(Thread.currentThread() + " TIME SPENT in NameLoopkup#seekTypesInSourcePackage: " + environment.nameLookup.timeSpentInSeekTypesInSourcePackage + "ms");  //$NON-NLS-1$ //$NON-NLS-2$
-		System.out.println(Thread.currentThread() + " TIME SPENT in NameLoopkup#seekTypesInBinaryPackage: " + environment.nameLookup.timeSpentInSeekTypesInBinaryPackage + "ms");  //$NON-NLS-1$ //$NON-NLS-2$
+		JavaModelManager.trace(Thread.currentThread() + " TIME SPENT in NameLoopkup#seekTypesInSourcePackage: " + environment.nameLookup.timeSpentInSeekTypesInSourcePackage + "ms");  //$NON-NLS-1$ //$NON-NLS-2$
+		JavaModelManager.trace(Thread.currentThread() + " TIME SPENT in NameLoopkup#seekTypesInBinaryPackage: " + environment.nameLookup.timeSpentInSeekTypesInBinaryPackage + "ms");  //$NON-NLS-1$ //$NON-NLS-2$
 	}
 }
 /**

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/UserLibraryClasspathContainer.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/UserLibraryClasspathContainer.java
@@ -18,7 +18,6 @@ import org.eclipse.core.runtime.Path;
 import org.eclipse.jdt.core.IClasspathContainer;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.JavaCore;
-import org.eclipse.jdt.internal.core.util.Util;
 
 /**
  *
@@ -68,7 +67,7 @@ public class UserLibraryClasspathContainer implements IClasspathContainer {
 	}
 
 	private void verbose_no_user_library_found(String userLibraryName) {
-		Util.verbose(
+		JavaModelManager.trace(
 			"UserLibrary INIT - FAILED (no user library found)\n" + //$NON-NLS-1$
 			"	userLibraryName: " + userLibraryName); //$NON-NLS-1$
 	}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/UserLibraryClasspathContainerInitializer.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/UserLibraryClasspathContainerInitializer.java
@@ -19,7 +19,6 @@ import org.eclipse.jdt.core.ClasspathContainerInitializer;
 import org.eclipse.jdt.core.IClasspathContainer;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
-import org.eclipse.jdt.internal.core.util.Util;
 
 /**
  *
@@ -84,14 +83,14 @@ public class UserLibraryClasspathContainerInitializer extends ClasspathContainer
 	}
 
 	private void verbose_no_user_library_found(IJavaProject project, String userLibraryName) {
-		Util.verbose(
+		JavaModelManager.trace(
 			"UserLibrary INIT - FAILED (no user library found)\n" + //$NON-NLS-1$
 			"	project: " + project.getElementName() + '\n' + //$NON-NLS-1$
 			"	userLibraryName: " + userLibraryName); //$NON-NLS-1$
 	}
 
 	private void verbose_not_a_user_library(IJavaProject project, IPath containerPath) {
-		Util.verbose(
+		JavaModelManager.trace(
 			"UserLibrary INIT - FAILED (not a user library)\n" + //$NON-NLS-1$
 			"	project: " + project.getElementName() + '\n' + //$NON-NLS-1$
 			"	container path: " + containerPath); //$NON-NLS-1$

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/VerboseElementCache.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/VerboseElementCache.java
@@ -36,10 +36,10 @@ public class VerboseElementCache<K extends IJavaElement & IOpenable> extends Ele
 		boolean result = super.makeSpace(space);
 		String newFillingRatio = toStringFillingRation(this.name);
 		if (!fillingRatio.equals(newFillingRatio)) {
-			System.out.println(Thread.currentThread() + " " + new Date(System.currentTimeMillis()).toString()); //$NON-NLS-1$
-			System.out.println(Thread.currentThread() + " MADE SPACE FOR " + fillingRatio + " (NOW " + NumberFormat.getInstance().format(fillingRatio()) + "% full)"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-			System.out.println(Thread.currentThread() + " WHILE OPENING "+ ((JavaElement) this.beingAdded).toStringWithAncestors());  //$NON-NLS-1$
-			System.out.println();
+			JavaModelManager.trace(Thread.currentThread() + " " + new Date(System.currentTimeMillis()).toString()); //$NON-NLS-1$
+			JavaModelManager.trace(Thread.currentThread() + " MADE SPACE FOR " + fillingRatio + " (NOW " + NumberFormat.getInstance().format(fillingRatio()) + "% full)"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+			JavaModelManager.trace(Thread.currentThread() + " WHILE OPENING "+ ((JavaElement) this.beingAdded).toStringWithAncestors());  //$NON-NLS-1$
+			JavaModelManager.trace(""); //$NON-NLS-1$
 		}
 		return result;
 	}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/AbstractImageBuilder.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/AbstractImageBuilder.java
@@ -35,6 +35,8 @@ import org.eclipse.jdt.internal.core.PackageFragment;
 import org.eclipse.jdt.internal.core.util.Messages;
 import org.eclipse.jdt.internal.core.util.Util;
 
+import static org.eclipse.jdt.internal.core.JavaModelManager.trace;
+
 import java.io.*;
 import java.util.*;
 
@@ -332,9 +334,11 @@ protected void compile(SourceFile[] units) {
 	this.compiledAllAtOnce = MAX_AT_ONCE == 0 || unitsLength <= MAX_AT_ONCE;
 	if (this.compiledAllAtOnce) {
 		// do them all now
-		if (JavaBuilder.DEBUG)
-			for (int i = 0; i < unitsLength; i++)
-				System.out.println("About to compile " + units[i].typeLocator()); //$NON-NLS-1$
+		if (JavaBuilder.DEBUG) {
+			for (int i = 0; i < unitsLength; i++) {
+				trace("About to compile " + units[i].typeLocator()); //$NON-NLS-1$
+			}
+		}
 		compile(units, null, true);
 	} else {
 		SourceFile[] remainingUnits = new SourceFile[unitsLength]; // copy of units, removing units when about to compile
@@ -350,8 +354,9 @@ protected void compile(SourceFile[] units) {
 				// already been compiled when it was referenced by another unit.
 				SourceFile unit = remainingUnits[remainingIndex];
 				if (unit != null && (compilingFirstGroup || this.workQueue.isWaiting(unit))) {
-					if (JavaBuilder.DEBUG)
-						System.out.println("About to compile #" + remainingIndex + " : "+ unit.typeLocator()); //$NON-NLS-1$ //$NON-NLS-2$
+					if (JavaBuilder.DEBUG) {
+						trace("About to compile #" + remainingIndex + " : "+ unit.typeLocator()); //$NON-NLS-1$ //$NON-NLS-2$
+					}
 					toCompile[count++] = unit;
 				}
 				remainingUnits[remainingIndex++] = null;
@@ -732,8 +737,9 @@ protected void storeProblemsFor(SourceFile sourceFile, CategorizedProblem[] prob
 				break;
 		}
 		if (buildPathProblemMessage != null) {
-			if (JavaBuilder.DEBUG)
-				System.out.println(buildPathProblemMessage);
+			if (JavaBuilder.DEBUG) {
+				trace(buildPathProblemMessage);
+			}
 			boolean isInvalidClasspathError = JavaCore.ERROR.equals(this.javaBuilder.javaProject.getOption(JavaCore.CORE_INCOMPLETE_CLASSPATH, true));
 			// insert extra classpath problem, and make it the only problem for this project (optional)
 			if (isInvalidClasspathError && JavaCore.ABORT.equals(this.javaBuilder.javaProject.getOption(JavaCore.CORE_JAVA_BUILD_INVALID_CLASSPATH, true))) {
@@ -779,7 +785,7 @@ protected void storeProblemsFor(SourceFile sourceFile, CategorizedProblem[] prob
 					} catch (CoreException e) {
 						// marker retrieval failed, cannot do much
 						if (JavaModelManager.VERBOSE) {
-							e.printStackTrace();
+							trace("", e); //$NON-NLS-1$
 						}
 					}
 					IResource tempRes = pkg.resource();
@@ -909,15 +915,18 @@ protected void writeClassFileContents(ClassFile classFile, IFile file, String qu
 	InputStream input = new ByteArrayInputStream(classFile.getBytes());
 	if (file.exists()) {
 		// Deal with shared output folders... last one wins... no collision cases detected
-		if (JavaBuilder.DEBUG)
-			System.out.println("Writing changed class file " + file.getName());//$NON-NLS-1$
-		if (!file.isDerived())
+		if (JavaBuilder.DEBUG) {
+			trace("Writing changed class file " + file.getName());//$NON-NLS-1$
+		}
+		if (!file.isDerived()) {
 			file.setDerived(true, null);
+		}
 		file.setContents(input, true, false, null);
 	} else {
 		// Default implementation just writes out the bytes for the new class file...
-		if (JavaBuilder.DEBUG)
-			System.out.println("Writing new class file " + file.getName());//$NON-NLS-1$
+		if (JavaBuilder.DEBUG) {
+			trace("Writing new class file " + file.getName());//$NON-NLS-1$
+		}
 		file.create(input, IResource.FORCE | IResource.DERIVED, null);
 	}
 }

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/ClasspathDirectory.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/ClasspathDirectory.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.core.builder;
 
+import static org.eclipse.jdt.internal.core.JavaModelManager.trace;
+
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
@@ -34,6 +36,7 @@ import org.eclipse.jdt.internal.compiler.env.IModule;
 import org.eclipse.jdt.internal.compiler.env.NameEnvironmentAnswer;
 import org.eclipse.jdt.internal.compiler.util.SimpleLookupTable;
 import org.eclipse.jdt.internal.compiler.util.SuffixConstants;
+import org.eclipse.jdt.internal.core.JavaModelManager;
 import org.eclipse.jdt.internal.core.util.Util;
 
 
@@ -84,15 +87,18 @@ IModule initializeModule() {
 							ClassFileReader cfr = Util.newClassFileReader(m);
 							return cfr.getModuleDeclaration();
 						} catch (ClassFormatException | IOException e) {
-							// TODO Java 9 Auto-generated catch block
-							e.printStackTrace();
+							if (JavaModelManager.VERBOSE) {
+								trace("", e); //$NON-NLS-1$
+							}
 						}
 					}
 				}
 			}
 		}
 	} catch (CoreException e1) {
-		e1.printStackTrace();
+		if (JavaModelManager.VERBOSE) {
+			trace("", e1); //$NON-NLS-1$
+		}
 	}
 	return null;
 }

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/ClasspathJar.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/ClasspathJar.java
@@ -16,6 +16,8 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.core.builder;
 
+import static org.eclipse.jdt.internal.core.JavaModelManager.trace;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -50,6 +52,7 @@ import org.eclipse.jdt.internal.compiler.env.NameEnvironmentAnswer;
 import org.eclipse.jdt.internal.compiler.lookup.TypeConstants;
 import org.eclipse.jdt.internal.compiler.util.SimpleSet;
 import org.eclipse.jdt.internal.compiler.util.SuffixConstants;
+import org.eclipse.jdt.internal.core.JavaModelManager;
 import org.eclipse.jdt.internal.core.util.Util;
 
 @SuppressWarnings("rawtypes")
@@ -133,7 +136,9 @@ IModule initializeModule() {
 		try {
 			classfile = ClassFileReader.read(file, releasePath);
 		} catch (Exception e) {
-			e.printStackTrace();
+			if (JavaModelManager.VERBOSE) {
+				trace("", e); //$NON-NLS-1$
+			}
 			// move on to the default
 		}
 		if (classfile == null) {
@@ -210,8 +215,8 @@ public void cleanup() {
 		if (this.zipFile != null) {
 			try {
 				this.zipFile.close();
-				if (org.eclipse.jdt.internal.core.JavaModelManager.ZIP_ACCESS_VERBOSE) {
-					System.out.println("(" + Thread.currentThread() + ") [ClasspathJar.cleanup()] Closed ZipFile on " + this.zipFilename); //$NON-NLS-1$	//$NON-NLS-2$
+				if (JavaModelManager.ZIP_ACCESS_VERBOSE) {
+					trace("(" + Thread.currentThread() + ") [ClasspathJar.cleanup()] Closed ZipFile on " + this.zipFilename); //$NON-NLS-1$	//$NON-NLS-2$
 				}
 			} catch(IOException e) { // ignore it
 				JavaCore.getPlugin().getLog().log(new Status(IStatus.ERROR, JavaCore.PLUGIN_ID, "Error closing " + this.zipFile.getName(), e)); //$NON-NLS-1$
@@ -221,8 +226,8 @@ public void cleanup() {
 		if (this.annotationZipFile != null) {
 			try {
 				this.annotationZipFile.close();
-				if (org.eclipse.jdt.internal.core.JavaModelManager.ZIP_ACCESS_VERBOSE) {
-					System.out.println("(" + Thread.currentThread() + ") [ClasspathJar.cleanup()] Closed Annotation ZipFile on " + this.zipFilename); //$NON-NLS-1$	//$NON-NLS-2$
+				if (JavaModelManager.ZIP_ACCESS_VERBOSE) {
+					trace("(" + Thread.currentThread() + ") [ClasspathJar.cleanup()] Closed Annotation ZipFile on " + this.zipFilename); //$NON-NLS-1$	//$NON-NLS-2$
 				}
 			} catch(IOException e) { // ignore it
 				JavaCore.getPlugin().getLog().log(new Status(IStatus.ERROR, JavaCore.PLUGIN_ID, "Error closing " + this.annotationZipFile.getName(), e)); //$NON-NLS-1$
@@ -230,10 +235,10 @@ public void cleanup() {
 			this.annotationZipFile = null;
 		}
 	} else {
-		if (this.zipFile != null && org.eclipse.jdt.internal.core.JavaModelManager.ZIP_ACCESS_VERBOSE) {
+		if (this.zipFile != null && JavaModelManager.ZIP_ACCESS_VERBOSE) {
 			try {
 				this.zipFile.size();
-				System.out.println("(" + Thread.currentThread() + ") [ClasspathJar.cleanup()] ZipFile NOT closed on " + this.zipFilename); //$NON-NLS-1$	//$NON-NLS-2$
+				trace("(" + Thread.currentThread() + ") [ClasspathJar.cleanup()] ZipFile NOT closed on " + this.zipFilename); //$NON-NLS-1$	//$NON-NLS-2$
 			} catch (IllegalStateException e) {
 				// OK: the file was already closed
 			}
@@ -332,8 +337,8 @@ public boolean hasCompilationUnit(String pkgName, String moduleName) {
 private boolean scanContent() {
 	try {
 		if (this.zipFile == null) {
-			if (org.eclipse.jdt.internal.core.JavaModelManager.ZIP_ACCESS_VERBOSE) {
-				System.out.println("(" + Thread.currentThread() + ") [ClasspathJar.isPackage(String)] Creating ZipFile on " + this.zipFilename); //$NON-NLS-1$	//$NON-NLS-2$
+			if (JavaModelManager.ZIP_ACCESS_VERBOSE) {
+				trace("(" + Thread.currentThread() + ") [ClasspathJar.isPackage(String)] Creating ZipFile on " + this.zipFilename); //$NON-NLS-1$	//$NON-NLS-2$
 			}
 			this.zipFile = new ZipFile(this.zipFilename);
 			this.closeZipFileAtEnd = true;

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/State.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/State.java
@@ -18,6 +18,8 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.core.builder;
 
+import static org.eclipse.jdt.internal.core.JavaModelManager.trace;
+
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -279,19 +281,22 @@ void removeQualifiedTypeName(String qualifiedTypeNameToRemove) {
 
 static State read(IProject project, DataInputStream input) throws IOException, CoreException {
 	CompressedReader in = new CompressedReader(input);
-	if (JavaBuilder.DEBUG)
-		System.out.println("About to read state " + project.getName()); //$NON-NLS-1$
+	if (JavaBuilder.DEBUG) {
+		trace("About to read state " + project.getName()); //$NON-NLS-1$
+	}
 	if (VERSION != in.readByte()) {
-		if (JavaBuilder.DEBUG)
-			System.out.println("Found non-compatible state version... answered null for " + project.getName()); //$NON-NLS-1$
+		if (JavaBuilder.DEBUG) {
+			trace("Found non-compatible state version... answered null for " + project.getName()); //$NON-NLS-1$
+		}
 		return null;
 	}
 
 	State newState = new State();
 	newState.javaProjectName = in.readStringUsingDictionary();
 	if (!project.getName().equals(newState.javaProjectName)) {
-		if (JavaBuilder.DEBUG)
-			System.out.println("Project's name does not match... answered null"); //$NON-NLS-1$
+		if (JavaBuilder.DEBUG) {
+			trace("Project's name does not match... answered null"); //$NON-NLS-1$
+		}
 		return null;
 	}
 	newState.buildNumber = in.readInt();
@@ -370,8 +375,9 @@ static State read(IProject project, DataInputStream input) throws IOException, C
 		}
 		newState.references.put(typeLocator, collection);
 	}
-	if (JavaBuilder.DEBUG)
-		System.out.println("Successfully read state for " + newState.javaProjectName); //$NON-NLS-1$
+	if (JavaBuilder.DEBUG) {
+		trace("Successfully read state for " + newState.javaProjectName); //$NON-NLS-1$
+	}
 	return newState;
 }
 
@@ -579,8 +585,9 @@ void write(DataOutputStream output) throws IOException {
 				out.writeLong(((Long) valueTable[i]).longValue());
 			}
 		}
-		if (JavaBuilder.DEBUG && length != 0)
-			System.out.println("structuralBuildNumbers table is inconsistent"); //$NON-NLS-1$
+		if (JavaBuilder.DEBUG && length != 0) {
+			trace("structuralBuildNumbers table is inconsistent"); //$NON-NLS-1$
+		}
 	}
 
 /*
@@ -597,8 +604,9 @@ void write(DataOutputStream output) throws IOException {
 				internedTypeLocators.put(key, Integer.valueOf(internedTypeLocators.elementSize));
 			}
 		}
-		if (JavaBuilder.DEBUG && length != 0)
-			System.out.println("references table is inconsistent"); //$NON-NLS-1$
+		if (JavaBuilder.DEBUG && length != 0) {
+			trace("references table is inconsistent"); //$NON-NLS-1$
+		}
 	}
 
 /*
@@ -619,8 +627,9 @@ void write(DataOutputStream output) throws IOException {
 				out.writeIntInRange(index.intValue(), internedTypeLocators.elementSize);
 			}
 		}
-		if (JavaBuilder.DEBUG && length != 0)
-			System.out.println("typeLocators table is inconsistent"); //$NON-NLS-1$
+		if (JavaBuilder.DEBUG && length != 0) {
+			trace("typeLocators table is inconsistent"); //$NON-NLS-1$
+		}
 	}
 
 /*
@@ -741,8 +750,9 @@ void write(DataOutputStream output) throws IOException {
 				out.writeIntInRange(index.intValue(), internedRootNames.elementSize);
 			}
 		}
-		if (JavaBuilder.DEBUG && length != 0)
-			System.out.println("references table is inconsistent"); //$NON-NLS-1$
+		if (JavaBuilder.DEBUG && length != 0) {
+			trace("references table is inconsistent"); //$NON-NLS-1$
+		}
 	}
 }
 

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/eval/RequestorWrapper.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/eval/RequestorWrapper.java
@@ -23,6 +23,7 @@ import org.eclipse.jdt.core.IJavaModelMarker;
 import org.eclipse.jdt.core.compiler.CategorizedProblem;
 import org.eclipse.jdt.core.eval.ICodeSnippetRequestor;
 import org.eclipse.jdt.internal.compiler.ClassFile;
+import org.eclipse.jdt.internal.core.JavaModelManager;
 import org.eclipse.jdt.internal.core.builder.JavaBuilder;
 import org.eclipse.jdt.internal.eval.IRequestor;
 
@@ -72,7 +73,9 @@ public void acceptProblem(CategorizedProblem problem, char[] fragmentSource, int
 		IMarker marker = ResourcesPlugin.getWorkspace().getRoot().createMarker(IJavaModelMarker.TRANSIENT_PROBLEM, attributes);
 		this.requestor.acceptProblem(marker, new String(fragmentSource), fragmentKind);
 	} catch (CoreException e) {
-		e.printStackTrace();
+		if (JavaModelManager.VERBOSE) {
+			JavaModelManager.trace("", e); //$NON-NLS-1$
+		}
 	}
 }
 }

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/hierarchy/HierarchyBuilder.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/hierarchy/HierarchyBuilder.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.core.hierarchy;
 
+import static org.eclipse.jdt.internal.core.JavaModelManager.trace;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -150,22 +152,21 @@ public abstract class HierarchyBuilder {
 		if (typeHandle == null)
 			return;
 		if (TypeHierarchy.DEBUG) {
-			System.out.println(
+			trace(
 				"Connecting: " + ((JavaElement) typeHandle).toStringWithAncestors()); //$NON-NLS-1$
-			System.out.println(
+			trace(
 				"  to superclass: " //$NON-NLS-1$
 					+ (superclassHandle == null
 						? "<None>" //$NON-NLS-1$
 						: ((JavaElement) superclassHandle).toStringWithAncestors()));
-			System.out.print("  and superinterfaces:"); //$NON-NLS-1$
+			trace("  and superinterfaces:"); //$NON-NLS-1$
 			if (superinterfaceHandles == null || superinterfaceHandles.length == 0) {
-				System.out.println(" <None>"); //$NON-NLS-1$
+				trace(" <None>"); //$NON-NLS-1$
 			} else {
-				System.out.println();
+				trace(""); //$NON-NLS-1$
 				for (int i = 0, length = superinterfaceHandles.length; i < length; i++) {
 					if (superinterfaceHandles[i] == null) continue;
-					System.out.println(
-						"    " + ((JavaElement) superinterfaceHandles[i]).toStringWithAncestors()); //$NON-NLS-1$
+					trace("    " + ((JavaElement) superinterfaceHandles[i]).toStringWithAncestors()); //$NON-NLS-1$
 				}
 			}
 		}
@@ -299,7 +300,7 @@ protected IBinaryType createInfoFromClassFile(Openable handle, IResource file) {
 		info = Util.newClassFileReader(file);
 	} catch (org.eclipse.jdt.internal.compiler.classfmt.ClassFormatException | java.io.IOException | CoreException e) {
 		if (TypeHierarchy.DEBUG) {
-			e.printStackTrace();
+			trace("", e); //$NON-NLS-1$
 		}
 		return null;
 	}
@@ -316,7 +317,7 @@ protected IBinaryType createInfoFromClassFileInJar(Openable classFile) {
 		info = BinaryTypeFactory.create(cf, null);
 	} catch (JavaModelException | ClassFormatException e) {
 		if (TypeHierarchy.DEBUG) {
-			e.printStackTrace();
+			trace("", e); //$NON-NLS-1$
 		}
 		return null;
 	}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/hierarchy/HierarchyResolver.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/hierarchy/HierarchyResolver.java
@@ -148,7 +148,6 @@ public void accept(ICompilationUnit sourceUnit, AccessRestriction accessRestrict
 		this.lookupEnvironment.buildTypeBindings(parsedUnit, accessRestriction);
 		this.lookupEnvironment.completeTypeBindings(parsedUnit, true); // work done inside checkAndSetImports()
 	} else {
-		//System.out.println("Cannot accept compilation units inside the HierarchyResolver.");
 		this.lookupEnvironment.problemReporter.abortDueToInternalError(
 			new StringBuffer(Messages.accept_cannot)
 				.append(sourceUnit.getFileName())
@@ -895,8 +894,9 @@ public void resolve(Openable[] openables, HashSet localTypes, IProgressMonitor m
 
 	} catch (ClassCastException e){ // work-around for 1GF5W1S - can happen in case duplicates are fed to the hierarchy with binaries hiding sources
 	} catch (AbortCompilation e) { // ignore this exception for now since it typically means we cannot find java.lang.Object
-		if (TypeHierarchy.DEBUG)
-			e.printStackTrace();
+		if (TypeHierarchy.DEBUG) {
+			JavaModelManager.trace("", e); //$NON-NLS-1$
+		}
 	} finally {
 		reset();
 	}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/hierarchy/IndexBasedHierarchyBuilder.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/hierarchy/IndexBasedHierarchyBuilder.java
@@ -596,7 +596,7 @@ private static void legacySearchAllPossibleSubTypes(
 		job.finished();
 		if (JobManager.VERBOSE) {
 			long wallClockTime = System.currentTimeMillis() - startTime;
-			Util.verbose("-> execution time: " + wallClockTime + "ms - " + IndexBasedHierarchyBuilder.class.getSimpleName());//$NON-NLS-1$//$NON-NLS-2$
+			JavaModelManager.trace("-> execution time: " + wallClockTime + "ms - " + IndexBasedHierarchyBuilder.class.getSimpleName());//$NON-NLS-1$//$NON-NLS-2$
 		}
 	}
 }

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/hierarchy/TypeHierarchy.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/hierarchy/TypeHierarchy.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.core.hierarchy;
 
+import static org.eclipse.jdt.internal.core.JavaModelManager.trace;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -54,6 +56,7 @@ import org.eclipse.jdt.core.search.SearchEngine;
 import org.eclipse.jdt.internal.core.ClassFile;
 import org.eclipse.jdt.internal.core.CompilationUnit;
 import org.eclipse.jdt.internal.core.JavaElement;
+import org.eclipse.jdt.internal.core.JavaModelManager;
 import org.eclipse.jdt.internal.core.JavaModelStatus;
 import org.eclipse.jdt.internal.core.JavaProject;
 import org.eclipse.jdt.internal.core.Openable;
@@ -375,9 +378,9 @@ public void fireChange() {
 		return;
 	}
 	if (DEBUG) {
-		System.out.println("FIRING hierarchy change ["+Thread.currentThread()+"]"); //$NON-NLS-1$ //$NON-NLS-2$
+		trace("FIRING hierarchy change ["+Thread.currentThread()+"]"); //$NON-NLS-1$ //$NON-NLS-2$
 		if (this.focusType != null) {
-			System.out.println("    for hierarchy focused on " + ((JavaElement)this.focusType).toStringWithAncestors()); //$NON-NLS-1$
+			trace("    for hierarchy focused on " + ((JavaElement)this.focusType).toStringWithAncestors()); //$NON-NLS-1$
 		}
 	}
 
@@ -1056,8 +1059,9 @@ protected boolean isAffectedByOpenable(IJavaElementDelta delta, IJavaElement ele
 		try {
 			collector.addChange(cu, delta);
 		} catch (JavaModelException e) {
-			if (DEBUG)
-				e.printStackTrace();
+			if (DEBUG) {
+				JavaModelManager.trace("", e); //$NON-NLS-1$
+			}
 		}
 		if (cu.isWorkingCopy() && eventType == ElementChangedEvent.POST_RECONCILE) {
 			// changes to working copies are batched
@@ -1307,12 +1311,12 @@ public synchronized void refresh(IProgressMonitor monitor) throws JavaModelExcep
 		if (DEBUG) {
 			start = System.currentTimeMillis();
 			if (this.computeSubtypes) {
-				System.out.println("CREATING TYPE HIERARCHY [" + Thread.currentThread() + "]"); //$NON-NLS-1$ //$NON-NLS-2$
+				trace("CREATING TYPE HIERARCHY [" + Thread.currentThread() + "]"); //$NON-NLS-1$ //$NON-NLS-2$
 			} else {
-				System.out.println("CREATING SUPER TYPE HIERARCHY [" + Thread.currentThread() + "]"); //$NON-NLS-1$ //$NON-NLS-2$
+				trace("CREATING SUPER TYPE HIERARCHY [" + Thread.currentThread() + "]"); //$NON-NLS-1$ //$NON-NLS-2$
 			}
 			if (this.focusType != null) {
-				System.out.println("  on type " + ((JavaElement)this.focusType).toStringWithAncestors()); //$NON-NLS-1$
+				trace("  on type " + ((JavaElement)this.focusType).toStringWithAncestors()); //$NON-NLS-1$
 			}
 		}
 
@@ -1323,11 +1327,11 @@ public synchronized void refresh(IProgressMonitor monitor) throws JavaModelExcep
 
 		if (DEBUG) {
 			if (this.computeSubtypes) {
-				System.out.println("CREATED TYPE HIERARCHY in " + (System.currentTimeMillis() - start) + "ms"); //$NON-NLS-1$ //$NON-NLS-2$
+				trace("CREATED TYPE HIERARCHY in " + (System.currentTimeMillis() - start) + "ms"); //$NON-NLS-1$ //$NON-NLS-2$
 			} else {
-				System.out.println("CREATED SUPER TYPE HIERARCHY in " + (System.currentTimeMillis() - start) + "ms"); //$NON-NLS-1$ //$NON-NLS-2$
+				trace("CREATED SUPER TYPE HIERARCHY in " + (System.currentTimeMillis() - start) + "ms"); //$NON-NLS-1$ //$NON-NLS-2$
 			}
-			System.out.println(this.toString());
+			trace(this.toString());
 		}
 	} catch (JavaModelException e) {
 		throw e;
@@ -1509,7 +1513,7 @@ boolean subtypesIncludeSupertypeOf(IType type) {
 		superclassName = type.getSuperclassName();
 	} catch (JavaModelException e) {
 		if (DEBUG) {
-			e.printStackTrace();
+			trace("", e); //$NON-NLS-1$
 		}
 		return false;
 	}
@@ -1525,8 +1529,9 @@ boolean subtypesIncludeSupertypeOf(IType type) {
 	try {
 		interfaceNames = type.getSuperInterfaceNames();
 	} catch (JavaModelException e) {
-		if (DEBUG)
-			e.printStackTrace();
+		if (DEBUG) {
+			trace("", e); //$NON-NLS-1$
+		}
 		return false;
 	}
 	for (int i = 0, length = interfaceNames.length; i < length; i++) {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/ClassFileReader.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/ClassFileReader.java
@@ -34,6 +34,7 @@ import org.eclipse.jdt.core.util.IPermittedSubclassesAttribute;
 import org.eclipse.jdt.core.util.IRecordAttribute;
 import org.eclipse.jdt.core.util.ISourceAttribute;
 import org.eclipse.jdt.internal.compiler.util.Util;
+import org.eclipse.jdt.internal.core.JavaModelManager;
 
 public class ClassFileReader extends ClassFileStruct implements IClassFileReader {
 	private static final IFieldInfo[] NO_FIELD_INFOS = new IFieldInfo[0];
@@ -337,7 +338,9 @@ public class ClassFileReader extends ClassFileStruct implements IClassFileReader
 		} catch(ClassFormatException e) {
 			throw e;
 		} catch (Exception e) {
-			e.printStackTrace();
+			if (JavaModelManager.VERBOSE) {
+				JavaModelManager.trace("", e); //$NON-NLS-1$
+			}
 			throw new ClassFormatException(ClassFormatException.ERROR_TRUNCATED_INPUT);
 		}
 	}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/Util.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/Util.java
@@ -15,6 +15,8 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.core.util;
 
+import static org.eclipse.jdt.internal.core.JavaModelManager.trace;
+
 import java.io.*;
 import java.net.URI;
 import java.util.*;
@@ -445,7 +447,9 @@ public class Util {
 			edit.apply(document, TextEdit.NONE);
 			return document.get();
 		} catch (MalformedTreeException | BadLocationException e) {
-			e.printStackTrace();
+			if (JavaModelManager.VERBOSE) {
+				trace("", e); //$NON-NLS-1$
+			}
 		}
 		return original;
 	}
@@ -1268,7 +1272,9 @@ public class Util {
 		try {
 			ResourcesPlugin.getWorkspace().getRoot().setPersistentProperty(getSourceAttachmentPropertyName(path), property);
 		} catch (CoreException e) {
-			e.printStackTrace();
+			if (JavaModelManager.VERBOSE) {
+				trace("", e); //$NON-NLS-1$
+			}
 		}
 	}
 
@@ -2758,20 +2764,6 @@ public class Util {
 	 */
 	public static void validateTypeSignature(String sig, boolean allowVoid) {
 		Assert.isTrue(isValidTypeSignature(sig, allowVoid));
-	}
-	public static void verbose(String log) {
-		verbose(log, System.out);
-	}
-	public static synchronized void verbose(String log, PrintStream printStream) {
-		int start = 0;
-		do {
-			int end = log.indexOf('\n', start);
-			printStream.print(Thread.currentThread());
-			printStream.print(" "); //$NON-NLS-1$
-			printStream.print(log.substring(start, end == -1 ? log.length() : end+1));
-			start = end+1;
-		} while (start != 0);
-		printStream.println();
 	}
 
 	/**

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/BasicSearchEngine.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/BasicSearchEngine.java
@@ -15,6 +15,8 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.core.search;
 
+import static org.eclipse.jdt.internal.core.JavaModelManager.trace;
+
 import java.util.*;
 import java.util.regex.Pattern;
 
@@ -37,7 +39,6 @@ import org.eclipse.jdt.internal.core.*;
 import org.eclipse.jdt.internal.core.search.indexing.*;
 import org.eclipse.jdt.internal.core.search.matching.*;
 import org.eclipse.jdt.internal.core.util.Messages;
-import org.eclipse.jdt.internal.core.util.Util;
 
 /**
  * Search basic engine. Public search engine (see {@link org.eclipse.jdt.core.search.SearchEngine}
@@ -210,11 +211,13 @@ public class BasicSearchEngine {
 	void findMatches(SearchPattern pattern, SearchParticipant[] participants, IJavaSearchScope scope, SearchRequestor requestor, IProgressMonitor monitor) throws CoreException {
 		try {
 			if (VERBOSE) {
-				Util.verbose("Searching for pattern: " + pattern.toString()); //$NON-NLS-1$
-				Util.verbose(scope.toString());
+				trace("Searching for pattern: " + pattern.toString()); //$NON-NLS-1$
+				trace(scope.toString());
 			}
 			if (participants == null) {
-				if (VERBOSE) Util.verbose("No participants => do nothing!"); //$NON-NLS-1$
+				if (VERBOSE) {
+					trace("No participants => do nothing!"); //$NON-NLS-1$
+				}
 				return;
 			}
 
@@ -597,7 +600,7 @@ public class BasicSearchEngine {
 	 */
 	public void search(SearchPattern pattern, SearchParticipant[] participants, IJavaSearchScope scope, SearchRequestor requestor, IProgressMonitor monitor) throws CoreException {
 		if (VERBOSE) {
-			Util.verbose("BasicSearchEngine.search(SearchPattern, SearchParticipant[], IJavaSearchScope, SearchRequestor, IProgressMonitor)"); //$NON-NLS-1$
+			trace("BasicSearchEngine.search(SearchPattern, SearchParticipant[], IJavaSearchScope, SearchRequestor, IProgressMonitor)"); //$NON-NLS-1$
 		}
 		findMatches(pattern, participants, scope, requestor, monitor);
 	}
@@ -647,14 +650,14 @@ public class BasicSearchEngine {
 
 			// Debug
 			if (VERBOSE) {
-				Util.verbose("BasicSearchEngine.searchAllConstructorDeclarations(char[], char[], int, IJavaSearchScope, IRestrictedAccessConstructorRequestor, int, IProgressMonitor)"); //$NON-NLS-1$
-				Util.verbose("	- package name: "+(packageName==null?"null":new String(packageName))); //$NON-NLS-1$ //$NON-NLS-2$
-				Util.verbose("	- type name: "+(typeName==null?"null":new String(typeName))); //$NON-NLS-1$ //$NON-NLS-2$
-				Util.verbose("	- type match rule: "+getMatchRuleString(typeMatchRule)); //$NON-NLS-1$
+				trace("BasicSearchEngine.searchAllConstructorDeclarations(char[], char[], int, IJavaSearchScope, IRestrictedAccessConstructorRequestor, int, IProgressMonitor)"); //$NON-NLS-1$
+				trace("	- package name: "+(packageName==null?"null":new String(packageName))); //$NON-NLS-1$ //$NON-NLS-2$
+				trace("	- type name: "+(typeName==null?"null":new String(typeName))); //$NON-NLS-1$ //$NON-NLS-2$
+				trace("	- type match rule: "+getMatchRuleString(typeMatchRule)); //$NON-NLS-1$
 				if (validatedTypeMatchRule != typeMatchRule) {
-					Util.verbose("	- validated type match rule: "+getMatchRuleString(validatedTypeMatchRule)); //$NON-NLS-1$
+					trace("	- validated type match rule: "+getMatchRuleString(validatedTypeMatchRule)); //$NON-NLS-1$
 				}
-				Util.verbose("	- scope: "+scope); //$NON-NLS-1$
+				trace("	- scope: "+scope); //$NON-NLS-1$
 			}
 			if (validatedTypeMatchRule == -1) return; // invalid match rule => return no results
 
@@ -993,15 +996,15 @@ public class BasicSearchEngine {
 			final int validatedMethodMatchRule = SearchPattern.validateMatchRule(methodName == null ? null : new String (methodName), methodMatchRule);
 			// Debug
 			if (VERBOSE) {
-				Util.verbose("BasicSearchEngine.searchAllMethodDeclarations(char[] qualifier,  "//$NON-NLS-1$
+				trace("BasicSearchEngine.searchAllMethodDeclarations(char[] qualifier,  "//$NON-NLS-1$
 						+ "char[] methodName, int methodMatchRule, IJavaSearchScope, IRestrictedAccessConstructorRequestor, int waitingPolicy, IProgressMonitor)"); //$NON-NLS-1$
-				Util.verbose("	- qualifier name: "+(qualifier==null?"null":new String(qualifier))); //$NON-NLS-1$ //$NON-NLS-2$
-				Util.verbose("	- method name: "+(methodName==null?"null":new String(methodName))); //$NON-NLS-1$ //$NON-NLS-2$
-				Util.verbose("	- method match rule: "+getMatchRuleString(methodMatchRule)); //$NON-NLS-1$
+				trace("	- qualifier name: "+(qualifier==null?"null":new String(qualifier))); //$NON-NLS-1$ //$NON-NLS-2$
+				trace("	- method name: "+(methodName==null?"null":new String(methodName))); //$NON-NLS-1$ //$NON-NLS-2$
+				trace("	- method match rule: "+getMatchRuleString(methodMatchRule)); //$NON-NLS-1$
 				if (validatedMethodMatchRule != methodMatchRule) {
-					Util.verbose("	- validated method match rule: "+getMatchRuleString(validatedMethodMatchRule)); //$NON-NLS-1$
+					trace("	- validated method match rule: "+getMatchRuleString(validatedMethodMatchRule)); //$NON-NLS-1$
 				}
-				Util.verbose("	- scope: "+scope); //$NON-NLS-1$
+				trace("	- scope: "+scope); //$NON-NLS-1$
 			}
 			if (validatedMethodMatchRule == -1) return; // invalid match rule => return no results
 
@@ -1261,17 +1264,17 @@ public class BasicSearchEngine {
 			final int validatedMethodMatchRule = SearchPattern.validateMatchRule(methodName == null ? null : new String (methodName), methodMatchRule);
 			// Debug
 			if (VERBOSE) {
-				Util.verbose("BasicSearchEngine.searchAllMethodDeclarations(char[] packageName, char[] declaringQualification, char[] declaringSimpleName, "//$NON-NLS-1$
+				trace("BasicSearchEngine.searchAllMethodDeclarations(char[] packageName, char[] declaringQualification, char[] declaringSimpleName, "//$NON-NLS-1$
 						+ "char[] methodName, int methodMatchRule, IJavaSearchScope, IRestrictedAccessConstructorRequestor, int waitingPolicy, IProgressMonitor)"); //$NON-NLS-1$
-				Util.verbose("	- package name: "+(packageName==null?"null":new String(packageName))); //$NON-NLS-1$ //$NON-NLS-2$
-				Util.verbose("	- declaringQualification name: "+(declaringQualification==null?"null":new String(declaringQualification))); //$NON-NLS-1$ //$NON-NLS-2$
-				Util.verbose("	- declaringSimple name: "+(declaringSimpleName==null?"null":new String(declaringSimpleName))); //$NON-NLS-1$ //$NON-NLS-2$
-				Util.verbose("	- method name: "+(methodName==null?"null":new String(methodName))); //$NON-NLS-1$ //$NON-NLS-2$
-				Util.verbose("	- method match rule: "+getMatchRuleString(methodMatchRule)); //$NON-NLS-1$
+				trace("	- package name: "+(packageName==null?"null":new String(packageName))); //$NON-NLS-1$ //$NON-NLS-2$
+				trace("	- declaringQualification name: "+(declaringQualification==null?"null":new String(declaringQualification))); //$NON-NLS-1$ //$NON-NLS-2$
+				trace("	- declaringSimple name: "+(declaringSimpleName==null?"null":new String(declaringSimpleName))); //$NON-NLS-1$ //$NON-NLS-2$
+				trace("	- method name: "+(methodName==null?"null":new String(methodName))); //$NON-NLS-1$ //$NON-NLS-2$
+				trace("	- method match rule: "+getMatchRuleString(methodMatchRule)); //$NON-NLS-1$
 				if (validatedMethodMatchRule != methodMatchRule) {
-					Util.verbose("	- validated method match rule: "+getMatchRuleString(validatedMethodMatchRule)); //$NON-NLS-1$
+					trace("	- validated method match rule: "+getMatchRuleString(validatedMethodMatchRule)); //$NON-NLS-1$
 				}
-				Util.verbose("	- scope: "+scope); //$NON-NLS-1$
+				trace("	- scope: "+scope); //$NON-NLS-1$
 			}
 			if (validatedMethodMatchRule == -1) return; // invalid match rule => return no results
 
@@ -1616,7 +1619,7 @@ public class BasicSearchEngine {
 
 		try {
 			if (VERBOSE) {
-				Util.verbose("BasicSearchEngine.searchAllSecondaryTypeNames(IPackageFragmentRoot[], IRestrictedAccessTypeRequestor, boolean, IProgressMonitor)"); //$NON-NLS-1$
+				trace("BasicSearchEngine.searchAllSecondaryTypeNames(IPackageFragmentRoot[], IRestrictedAccessTypeRequestor, boolean, IProgressMonitor)"); //$NON-NLS-1$
 				StringBuilder buffer = new StringBuilder("	- source folders: "); //$NON-NLS-1$
 				int length = sourceFolders.length;
 				for (int i=0; i<length; i++) {
@@ -1629,7 +1632,7 @@ public class BasicSearchEngine {
 				}
 				buffer.append("]\n	- waitForIndexes: "); //$NON-NLS-1$
 				buffer.append(waitForIndexes);
-				Util.verbose(buffer.toString());
+				trace(buffer.toString());
 			}
 
 			IndexManager indexManager = JavaModelManager.getIndexManager();
@@ -1790,16 +1793,16 @@ public class BasicSearchEngine {
 
 			// Debug
 			if (VERBOSE) {
-				Util.verbose("BasicSearchEngine.searchAllTypeNames(char[], char[], int, int, IJavaSearchScope, IRestrictedAccessTypeRequestor, int, IProgressMonitor)"); //$NON-NLS-1$
-				Util.verbose("	- package name: "+(packageName==null?"null":new String(packageName))); //$NON-NLS-1$ //$NON-NLS-2$
-				Util.verbose("	- package match rule: "+getMatchRuleString(packageMatchRule)); //$NON-NLS-1$
-				Util.verbose("	- type name: "+(typeName==null?"null":new String(typeName))); //$NON-NLS-1$ //$NON-NLS-2$
-				Util.verbose("	- type match rule: "+getMatchRuleString(typeMatchRule)); //$NON-NLS-1$
+				trace("BasicSearchEngine.searchAllTypeNames(char[], char[], int, int, IJavaSearchScope, IRestrictedAccessTypeRequestor, int, IProgressMonitor)"); //$NON-NLS-1$
+				trace("	- package name: "+(packageName==null?"null":new String(packageName))); //$NON-NLS-1$ //$NON-NLS-2$
+				trace("	- package match rule: "+getMatchRuleString(packageMatchRule)); //$NON-NLS-1$
+				trace("	- type name: "+(typeName==null?"null":new String(typeName))); //$NON-NLS-1$ //$NON-NLS-2$
+				trace("	- type match rule: "+getMatchRuleString(typeMatchRule)); //$NON-NLS-1$
 				if (validatedTypeMatchRule != typeMatchRule) {
-					Util.verbose("	- validated type match rule: "+getMatchRuleString(validatedTypeMatchRule)); //$NON-NLS-1$
+					trace("	- validated type match rule: "+getMatchRuleString(validatedTypeMatchRule)); //$NON-NLS-1$
 				}
-				Util.verbose("	- search for: "+searchFor); //$NON-NLS-1$
-				Util.verbose("	- scope: "+scope); //$NON-NLS-1$
+				trace("	- search for: "+searchFor); //$NON-NLS-1$
+				trace("	- scope: "+scope); //$NON-NLS-1$
 			}
 			if (validatedTypeMatchRule == -1) return; // invalid match rule => return no results
 
@@ -2059,12 +2062,12 @@ public class BasicSearchEngine {
 		try {
 			// Debug
 			if (VERBOSE) {
-				Util.verbose("BasicSearchEngine.searchAllTypeNames(char[][], char[][], int, int, IJavaSearchScope, IRestrictedAccessTypeRequestor, int, IProgressMonitor)"); //$NON-NLS-1$
-				Util.verbose("	- package name: "+(qualifications==null?"null":new String(CharOperation.concatWith(qualifications, ',')))); //$NON-NLS-1$ //$NON-NLS-2$
-				Util.verbose("	- type name: "+(typeNames==null?"null":new String(CharOperation.concatWith(typeNames, ',')))); //$NON-NLS-1$ //$NON-NLS-2$
-				Util.verbose("	- match rule: "+getMatchRuleString(matchRule)); //$NON-NLS-1$
-				Util.verbose("	- search for: "+searchFor); //$NON-NLS-1$
-				Util.verbose("	- scope: "+scope); //$NON-NLS-1$
+				trace("BasicSearchEngine.searchAllTypeNames(char[][], char[][], int, int, IJavaSearchScope, IRestrictedAccessTypeRequestor, int, IProgressMonitor)"); //$NON-NLS-1$
+				trace("	- package name: "+(qualifications==null?"null":new String(CharOperation.concatWith(qualifications, ',')))); //$NON-NLS-1$ //$NON-NLS-2$
+				trace("	- type name: "+(typeNames==null?"null":new String(CharOperation.concatWith(typeNames, ',')))); //$NON-NLS-1$ //$NON-NLS-2$
+				trace("	- match rule: "+getMatchRuleString(matchRule)); //$NON-NLS-1$
+				trace("	- search for: "+searchFor); //$NON-NLS-1$
+				trace("	- scope: "+scope); //$NON-NLS-1$
 			}
 			IndexManager indexManager = JavaModelManager.getIndexManager();
 
@@ -2278,7 +2281,7 @@ public class BasicSearchEngine {
 	public void searchDeclarations(IJavaElement enclosingElement, SearchRequestor requestor, SearchPattern pattern, IProgressMonitor monitor) throws JavaModelException {
 		try {
 			if (VERBOSE) {
-				Util.verbose("	- java element: "+enclosingElement); //$NON-NLS-1$
+				trace("	- java element: "+enclosingElement); //$NON-NLS-1$
 			}
 			IJavaSearchScope scope = createJavaSearchScope(new IJavaElement[] {enclosingElement});
 			IResource resource = ((JavaElement) enclosingElement).resource();
@@ -2298,7 +2301,7 @@ public class BasicSearchEngine {
 					try {
 						requestor.beginReporting();
 						if (VERBOSE) {
-							Util.verbose("Searching for " + pattern + " in " + resource.getFullPath()); //$NON-NLS-1$//$NON-NLS-2$
+							trace("Searching for " + pattern + " in " + resource.getFullPath()); //$NON-NLS-1$//$NON-NLS-2$
 						}
 						SearchParticipant participant = getDefaultSearchParticipant();
 						SearchDocument[] documents = MatchLocator.addWorkingCopies(
@@ -2345,7 +2348,7 @@ public class BasicSearchEngine {
 	 */
 	public void searchDeclarationsOfAccessedFields(IJavaElement enclosingElement, SearchRequestor requestor, IProgressMonitor monitor) throws JavaModelException {
 		if (VERBOSE) {
-			Util.verbose("BasicSearchEngine.searchDeclarationsOfAccessedFields(IJavaElement, SearchRequestor, SearchPattern, IProgressMonitor)"); //$NON-NLS-1$
+			trace("BasicSearchEngine.searchDeclarationsOfAccessedFields(IJavaElement, SearchRequestor, SearchPattern, IProgressMonitor)"); //$NON-NLS-1$
 		}
 		// Do not accept other kind of element type than those specified in the spec
 		switch (enclosingElement.getElementType()) {
@@ -2372,7 +2375,7 @@ public class BasicSearchEngine {
 	 */
 	public void searchDeclarationsOfReferencedTypes(IJavaElement enclosingElement, SearchRequestor requestor, IProgressMonitor monitor) throws JavaModelException {
 		if (VERBOSE) {
-			Util.verbose("BasicSearchEngine.searchDeclarationsOfReferencedTypes(IJavaElement, SearchRequestor, SearchPattern, IProgressMonitor)"); //$NON-NLS-1$
+			trace("BasicSearchEngine.searchDeclarationsOfReferencedTypes(IJavaElement, SearchRequestor, SearchPattern, IProgressMonitor)"); //$NON-NLS-1$
 		}
 		// Do not accept other kind of element type than those specified in the spec
 		switch (enclosingElement.getElementType()) {
@@ -2399,7 +2402,7 @@ public class BasicSearchEngine {
 	 */
 	public void searchDeclarationsOfSentMessages(IJavaElement enclosingElement, SearchRequestor requestor, IProgressMonitor monitor) throws JavaModelException {
 		if (VERBOSE) {
-			Util.verbose("BasicSearchEngine.searchDeclarationsOfSentMessages(IJavaElement, SearchRequestor, SearchPattern, IProgressMonitor)"); //$NON-NLS-1$
+			trace("BasicSearchEngine.searchDeclarationsOfSentMessages(IJavaElement, SearchRequestor, SearchPattern, IProgressMonitor)"); //$NON-NLS-1$
 		}
 		// Do not accept other kind of element type than those specified in the spec
 		switch (enclosingElement.getElementType()) {

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/IndexSelector.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/IndexSelector.java
@@ -14,6 +14,8 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.core.search;
 
+import static org.eclipse.jdt.internal.core.JavaModelManager.trace;
+
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.Optional;
@@ -51,7 +53,6 @@ import org.eclipse.jdt.internal.core.search.matching.MatchLocator;
 import org.eclipse.jdt.internal.core.search.matching.MethodPattern;
 import org.eclipse.jdt.internal.core.search.matching.ModulePattern;
 import org.eclipse.jdt.internal.core.search.processing.JobManager;
-import org.eclipse.jdt.internal.core.util.Util;
 
 /**
  * Selects the indexes that correspond to projects in a given search scope
@@ -323,7 +324,7 @@ public IndexLocation[] getIndexLocations() {
 					.toArray(IndexLocation[]::new);
 			if (filtered.length == 0) {
 				if (JobManager.VERBOSE) {
-					Util.verbose(String.format(
+					trace(String.format(
 							"-> current index selection and qualifying indexes has no intersection, " + //$NON-NLS-1$
 									"to keep search backward compatible using selected index locations - %s", //$NON-NLS-1$
 							this.toString()));
@@ -333,7 +334,7 @@ public IndexLocation[] getIndexLocations() {
 		}
 	}
 	if (JobManager.VERBOSE) {
-		Util.verbose(String.format("-> selected %s indexes out of total indexes %s after qualify filtering - %s",  //$NON-NLS-1$
+		trace(String.format("-> selected %s indexes out of total indexes %s after qualify filtering - %s",  //$NON-NLS-1$
 				filtered.length, this.indexLocations.length, this.toString()));
 	}
 	return filtered;

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/JavaSearchDocument.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/JavaSearchDocument.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.core.search;
 
+import static org.eclipse.jdt.internal.core.JavaModelManager.trace;
+
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
@@ -50,7 +52,7 @@ public class JavaSearchDocument extends SearchDocument {
 			return Util.getResourceContentsAsByteArray(getFile());
 		} catch (JavaModelException e) {
 			if (BasicSearchEngine.VERBOSE || JobManager.VERBOSE) { // used during search and during indexing
-				e.printStackTrace();
+				trace("", e); //$NON-NLS-1$
 			}
 			return null;
 		}
@@ -62,7 +64,7 @@ public class JavaSearchDocument extends SearchDocument {
 			return Util.getResourceContentsAsCharArray(getFile());
 		} catch (JavaModelException e) {
 			if (BasicSearchEngine.VERBOSE || JobManager.VERBOSE) { // used during search and during indexing
-				e.printStackTrace();
+				trace("", e); //$NON-NLS-1$
 			}
 			return null;
 		}

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/JavaWorkspaceScope.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/JavaWorkspaceScope.java
@@ -118,7 +118,7 @@ public IPath[] enclosingProjectsAndJars() {
 		if (BasicSearchEngine.VERBOSE) {
 			long time = System.currentTimeMillis() - start;
 			int length = result == null ? 0 : result.length;
-			Util.verbose("JavaWorkspaceScope.enclosingProjectsAndJars: "+length+" paths computed in "+time+"ms."); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+			JavaModelManager.trace("JavaWorkspaceScope.enclosingProjectsAndJars: "+length+" paths computed in "+time+"ms."); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 		}
 	}
 }

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/PatternSearchJob.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/PatternSearchJob.java
@@ -14,6 +14,8 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.core.search;
 
+import static org.eclipse.jdt.internal.core.JavaModelManager.trace;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -122,11 +124,11 @@ public boolean execute(IProgressMonitor progressMonitor) {
 		if (JobManager.VERBOSE) {
 			if (this.parallel) {
 				long wallClockTime = System.currentTimeMillis() - startTime;
-				Util.verbose("-> execution time: " + wallClockTime + "ms - " + this);//$NON-NLS-1$//$NON-NLS-2$
-				Util.verbose("-> cumulative execution time (" + ForkJoinPool.getCommonPoolParallelism() + "): " //$NON-NLS-1$//$NON-NLS-2$
+				trace("-> execution time: " + wallClockTime + "ms - " + this);//$NON-NLS-1$//$NON-NLS-2$
+				trace("-> cumulative execution time (" + ForkJoinPool.getCommonPoolParallelism() + "): " //$NON-NLS-1$//$NON-NLS-2$
 						+ this.executionTime.get() + "ms - " + this);//$NON-NLS-1$
 			} else {
-				Util.verbose("-> execution time: " + this.executionTime.get() + "ms - " + this);//$NON-NLS-1$//$NON-NLS-2$
+				trace("-> execution time: " + this.executionTime.get() + "ms - " + this);//$NON-NLS-1$//$NON-NLS-2$
 			}
 		}
 		return isComplete;
@@ -243,7 +245,9 @@ public boolean search(Index index, IndexQueryRequestor queryRequestor, IProgress
 		return COMPLETE;
 	} catch (IOException e) {
 		if (e instanceof java.io.EOFException) {
-			e.printStackTrace();
+			if(JavaModelManager.VERBOSE) {
+				trace("", e); //$NON-NLS-1$
+			}
 		} else {
 			Throwable cause = e.getCause();
 			if (cause != null) {

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/AddJarFileToIndex.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/AddJarFileToIndex.java
@@ -136,7 +136,7 @@ class AddJarFileToIndex extends BinaryContainer {
 					URI location = this.resource.getLocationURI();
 					if (location == null) return false;
 					if (JavaModelManager.ZIP_ACCESS_VERBOSE)
-						System.out.println("(" + Thread.currentThread() + ") [AddJarFileToIndex.execute()] Creating ZipFile on " + location.getPath()); //$NON-NLS-1$	//$NON-NLS-2$
+						trace("(" + Thread.currentThread() + ") [AddJarFileToIndex.execute()] Creating ZipFile on " + location.getPath()); //$NON-NLS-1$	//$NON-NLS-2$
 					File file = null;
 					try {
 						file = org.eclipse.jdt.internal.core.util.Util.toLocalFile(location, progressMonitor);
@@ -151,13 +151,13 @@ class AddJarFileToIndex extends BinaryContainer {
 						return false;
 					}
 					if (JavaModelManager.ZIP_ACCESS_VERBOSE)
-						System.out.println("(" + Thread.currentThread() + ") [AddJarFileToIndex.execute()] Creating ZipFile on " + this.containerPath); //$NON-NLS-1$	//$NON-NLS-2$
+						trace("(" + Thread.currentThread() + ") [AddJarFileToIndex.execute()] Creating ZipFile on " + this.containerPath); //$NON-NLS-1$	//$NON-NLS-2$
 					zip = new ZipFile(file);
 					zipFilePath = (Path) this.resource.getFullPath().makeRelative();
 					// absolute path relative to the workspace
 				} else {
 					if (JavaModelManager.ZIP_ACCESS_VERBOSE)
-						System.out.println("(" + Thread.currentThread() + ") [AddJarFileToIndex.execute()] Creating ZipFile on " + this.containerPath); //$NON-NLS-1$	//$NON-NLS-2$
+						trace("(" + Thread.currentThread() + ") [AddJarFileToIndex.execute()] Creating ZipFile on " + this.containerPath); //$NON-NLS-1$	//$NON-NLS-2$
 					// external file -> it is ok to use toFile()
 					zip = new ZipFile(this.containerPath.toFile());
 					zipFilePath = (Path) this.containerPath;
@@ -261,8 +261,9 @@ class AddJarFileToIndex extends BinaryContainer {
 						JavaSearchDocument entryDocument = new JavaSearchDocument(ze, zipFilePath, new String(contents).getBytes(Charset.defaultCharset()), participant);
 						this.manager.indexDocument(entryDocument, participant, index, indexPath);
 					} catch (CoreException e) {
-						// TODO Auto-generated catch block
-//						e.printStackTrace();
+						if (JobManager.VERBOSE) {
+							JavaModelManager.trace("", e); //$NON-NLS-1$
+						}
 					}
 				}
 				if(this.forceIndexUpdate) {
@@ -277,8 +278,9 @@ class AddJarFileToIndex extends BinaryContainer {
 						+ (System.currentTimeMillis() - initialTime) + "ms)"); //$NON-NLS-1$
 			} finally {
 				if (zip != null) {
-					if (JavaModelManager.ZIP_ACCESS_VERBOSE)
-						System.out.println("(" + Thread.currentThread() + ") [AddJarFileToIndex.execute()] Closing ZipFile " + this.containerPath); //$NON-NLS-1$	//$NON-NLS-2$
+					if (JavaModelManager.ZIP_ACCESS_VERBOSE) {
+						trace("(" + Thread.currentThread() + ") [AddJarFileToIndex.execute()] Closing ZipFile " + this.containerPath); //$NON-NLS-1$	//$NON-NLS-2$
+					}
 					zip.close();
 				}
 				monitor.exitWrite(); // free write lock

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/AddJrtToIndex.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/AddJrtToIndex.java
@@ -14,6 +14,7 @@
 package org.eclipse.jdt.internal.core.search.indexing;
 
 import static org.eclipse.jdt.internal.compiler.util.Util.isClassFileName;
+import static org.eclipse.jdt.internal.core.JavaModelManager.trace;
 
 import java.io.File;
 import java.io.IOException;
@@ -166,22 +167,25 @@ public class AddJrtToIndex extends BinaryContainer {
 			// if index is already cached, then do not perform any check
 			// MUST reset the IndexManager if a jar file is changed
 			if (this.manager.getIndexForUpdate(this.containerPath, false, /*do not reuse index file*/ false /*do not create if none*/) != null) {
-				if (JobManager.VERBOSE)
-					Util.verbose("-> no indexing required (index already exists) for " + this.containerPath); //$NON-NLS-1$
+				if (JobManager.VERBOSE) {
+					trace("-> no indexing required (index already exists) for " + this.containerPath); //$NON-NLS-1$
+				}
 				return true;
 			}
 
 			final Index index = this.manager.getIndexForUpdate(this.containerPath, true, /*reuse index file*/ true /*create if none*/);
 			if (index == null) {
-				if (JobManager.VERBOSE)
-					Util.verbose("-> index could not be created for " + this.containerPath); //$NON-NLS-1$
+				if (JobManager.VERBOSE) {
+					trace("-> index could not be created for " + this.containerPath); //$NON-NLS-1$
+				}
 				return true;
 			}
 			index.separator = JAR_SEPARATOR;
 			ReadWriteMonitor monitor = index.monitor;
 			if (monitor == null) {
-				if (JobManager.VERBOSE)
-					Util.verbose("-> index for " + this.containerPath + " just got deleted"); //$NON-NLS-1$//$NON-NLS-2$
+				if (JobManager.VERBOSE) {
+					trace("-> index for " + this.containerPath + " just got deleted"); //$NON-NLS-1$//$NON-NLS-2$
+				}
 				return true; // index got deleted since acquired
 			}
 			try {
@@ -192,20 +196,21 @@ public class AddJrtToIndex extends BinaryContainer {
 				if (this.resource != null) {
 					URI location = this.resource.getLocationURI();
 					if (location == null) return false;
-					if (JavaModelManager.JRT_ACCESS_VERBOSE)
-						System.out.println("(" + Thread.currentThread() + ") [AddJrtFileToIndex.execute()] Creating ZipFile on " + location.getPath()); //$NON-NLS-1$	//$NON-NLS-2$
+					if (JavaModelManager.JRT_ACCESS_VERBOSE) {
+						trace("(" + Thread.currentThread() + ") [AddJrtFileToIndex.execute()] Creating ZipFile on " + location.getPath()); //$NON-NLS-1$	//$NON-NLS-2$
+					}
 					File file = null;
 					try {
 						file = Util.toLocalFile(location, progressMonitor);
 					} catch (CoreException e) {
 						if (JobManager.VERBOSE) {
-							Util.verbose("-> failed to index " + location.getPath() + " because of the following exception:"); //$NON-NLS-1$ //$NON-NLS-2$
-							e.printStackTrace();
+							trace("-> failed to index " + location.getPath() + " because of the following exception:", e); //$NON-NLS-1$ //$NON-NLS-2$
 						}
 					}
 					if (file == null) {
-						if (JobManager.VERBOSE)
-							Util.verbose("-> failed to index " + location.getPath() + " because the file could not be fetched"); //$NON-NLS-1$ //$NON-NLS-2$
+						if (JobManager.VERBOSE) {
+							trace("-> failed to index " + location.getPath() + " because the file could not be fetched"); //$NON-NLS-1$ //$NON-NLS-2$
+						}
 						return false;
 					}
 					fileName = file.getAbsolutePath();
@@ -218,8 +223,9 @@ public class AddJrtToIndex extends BinaryContainer {
 				}
 
 
-				if (JobManager.VERBOSE)
-					Util.verbose("-> indexing " + fileName); //$NON-NLS-1$
+				if (JobManager.VERBOSE) {
+					trace("-> indexing " + fileName); //$NON-NLS-1$
+				}
 				long initialTime = System.currentTimeMillis();
 				String[] paths = index.queryDocumentNames(""); // all file names //$NON-NLS-1$
 				if (paths != null) {
@@ -248,7 +254,7 @@ public class AddJrtToIndex extends BinaryContainer {
 						}
 						if (!needToReindex) {
 							if (JobManager.VERBOSE)
-								Util.verbose("-> no indexing required (index is consistent with library) for " //$NON-NLS-1$
+								trace("-> no indexing required (index is consistent with library) for " //$NON-NLS-1$
 								+ fileName + " (" //$NON-NLS-1$
 								+ (System.currentTimeMillis() - initialTime) + "ms)"); //$NON-NLS-1$
 							this.manager.saveIndex(index); // to ensure its placed into the saved state
@@ -276,7 +282,7 @@ public class AddJrtToIndex extends BinaryContainer {
 					this.manager.saveIndex(index);
 				}
 				if (JobManager.VERBOSE)
-					Util.verbose("-> done indexing of " //$NON-NLS-1$
+					trace("-> done indexing of " //$NON-NLS-1$
 						+ fileName + " (" //$NON-NLS-1$
 						+ (System.currentTimeMillis() - initialTime) + "ms)"); //$NON-NLS-1$
 			} finally {

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/IndexManager.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/IndexManager.java
@@ -508,7 +508,6 @@ public synchronized Index getIndex(IPath containerPath, IndexLocation indexLocat
 			}
 		}
 	}
-	//System.out.println(" index name: " + path.toOSString() + " <----> " + index.getIndexFile().getName());
 	return index;
 }
 /**

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/SourceIndexer.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/SourceIndexer.java
@@ -214,7 +214,9 @@ public class SourceIndexer extends AbstractIndexer implements ITypeRequestor, Su
 	@Override
 	public void indexResolvedDocument() {
 		try {
-			if (DEBUG) System.out.println(new String(this.cud.compilationResult.fileName) + ':');
+			if (DEBUG) {
+				trace(new String(this.cud.compilationResult.fileName) + ':');
+			}
 			for (int i = 0, length = this.cud.functionalExpressionsCount; i < length; i++) {
 				FunctionalExpression expression = this.cud.functionalExpressions[i];
 				if (expression instanceof LambdaExpression) {
@@ -222,7 +224,7 @@ public class SourceIndexer extends AbstractIndexer implements ITypeRequestor, Su
 					if (lambdaExpression.binding != null && lambdaExpression.binding.isValidBinding()) {
 						final char[] superinterface = lambdaExpression.resolvedType.sourceName();
 						if (DEBUG) {
-							System.out.println('\t' + new String(superinterface) + '.' +
+							trace('\t' + new String(superinterface) + '.' +
 									new String(lambdaExpression.descriptor.selector) + "-> {}"); //$NON-NLS-1$
 						}
 						SourceIndexer.this.addIndexEntry(IIndexConstants.METHOD_DECL, MethodPattern.createIndexKey(lambdaExpression.descriptor.selector, lambdaExpression.descriptor.parameters.length));
@@ -237,7 +239,9 @@ public class SourceIndexer extends AbstractIndexer implements ITypeRequestor, Su
 								true); // not primary.
 
 					} else {
-						if (DEBUG) System.out.println("\tnull/bad binding in lambda"); //$NON-NLS-1$
+						if (DEBUG) {
+							trace("\tnull/bad binding in lambda"); //$NON-NLS-1$
+						}
 					}
 				} else {
 					ReferenceExpression referenceExpression = (ReferenceExpression) expression;
@@ -246,7 +250,7 @@ public class SourceIndexer extends AbstractIndexer implements ITypeRequestor, Su
 					MethodBinding binding = referenceExpression.getMethodBinding();
 					if (binding != null && binding.isValidBinding()) {
 						if (DEBUG) {
-							System.out.println('\t' + new String(referenceExpression.resolvedType.sourceName()) + "::"  //$NON-NLS-1$
+							trace('\t' + new String(referenceExpression.resolvedType.sourceName()) + "::"  //$NON-NLS-1$
 									+ new String(referenceExpression.descriptor.selector) + " == " + new String(binding.declaringClass.sourceName()) + '.' + //$NON-NLS-1$
 									new String(binding.selector));
 						}
@@ -255,7 +259,9 @@ public class SourceIndexer extends AbstractIndexer implements ITypeRequestor, Su
 						else
 							SourceIndexer.this.addConstructorReference(binding.declaringClass.sourceName(), binding.parameters.length);
 					} else {
-						if (DEBUG) System.out.println("\tnull/bad binding in reference expression"); //$NON-NLS-1$
+						if (DEBUG) {
+							trace("\tnull/bad binding in reference expression"); //$NON-NLS-1$
+						}
 					}
 				}
 			}

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/JavaSearchNameEnvironment.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/JavaSearchNameEnvironment.java
@@ -14,6 +14,7 @@
 package org.eclipse.jdt.internal.core.search.matching;
 
 import static java.util.stream.Collectors.joining;
+import static org.eclipse.jdt.internal.core.JavaModelManager.trace;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -56,6 +57,7 @@ import org.eclipse.jdt.internal.core.JrtPackageFragmentRoot;
 import org.eclipse.jdt.internal.core.NameLookup;
 import org.eclipse.jdt.internal.core.PackageFragmentRoot;
 import org.eclipse.jdt.internal.core.builder.ClasspathLocation;
+import org.eclipse.jdt.internal.core.search.processing.JobManager;
 import org.eclipse.jdt.internal.core.util.Util;
 
 /*
@@ -86,9 +88,9 @@ public JavaSearchNameEnvironment(IJavaProject javaProject, org.eclipse.jdt.core.
 
 	long start = 0;
 	if (NameLookup.VERBOSE) {
-		Util.verbose(" BUILDING JavaSearchNameEnvironment");  //$NON-NLS-1$
-		Util.verbose(" -> project: " + javaProject);  //$NON-NLS-1$
-		Util.verbose(" -> working copy size: " + (copies == null ? 0 : copies.length));  //$NON-NLS-1$
+		trace(" BUILDING JavaSearchNameEnvironment");  //$NON-NLS-1$
+		trace(" -> project: " + javaProject);  //$NON-NLS-1$
+		trace(" -> working copy size: " + (copies == null ? 0 : copies.length));  //$NON-NLS-1$
 		start = System.currentTimeMillis();
 	}
 
@@ -109,7 +111,7 @@ public JavaSearchNameEnvironment(IJavaProject javaProject, org.eclipse.jdt.core.
 			 */
 			//throw new IllegalArgumentException("Missing source folder for searching working copies: " + javaProject); //$NON-NLS-1$
 		    if (NameLookup.VERBOSE) {
-				Util.verbose(" -> ignoring working copies; no ClasspathSourceDirectory on project classpath ");  //$NON-NLS-1$
+				trace(" -> ignoring working copies; no ClasspathSourceDirectory on project classpath ");  //$NON-NLS-1$
 		    }
 		} else {
 			for (String qualifiedMainTypeName : this.workingCopies.keySet()) {
@@ -126,9 +128,9 @@ public JavaSearchNameEnvironment(IJavaProject javaProject, org.eclipse.jdt.core.
 
 
     if (NameLookup.VERBOSE) {
-		Util.verbose(" -> pkg roots size: " + (this.locationSet == null ? 0 : this.locationSet.size()));  //$NON-NLS-1$
-		Util.verbose(" -> pkgs size: " + this.packageNameToClassPathLocations.size());  //$NON-NLS-1$
-        Util.verbose(" -> spent: " + (System.currentTimeMillis() - start) + "ms");  //$NON-NLS-1$ //$NON-NLS-2$
+		trace(" -> pkg roots size: " + (this.locationSet == null ? 0 : this.locationSet.size()));  //$NON-NLS-1$
+		trace(" -> pkgs size: " + this.packageNameToClassPathLocations.size());  //$NON-NLS-1$
+        trace(" -> spent: " + (System.currentTimeMillis() - start) + "ms");  //$NON-NLS-1$ //$NON-NLS-2$
     }
 }
 
@@ -168,8 +170,8 @@ protected /* visible for testing only */ void addProjectClassPath(JavaProject ja
 void addProjectClassPath(JavaProject javaProject, boolean onlyExported) {
 	long start = 0;
 	if (NameLookup.VERBOSE) {
-		Util.verbose(" EXTENDING JavaSearchNameEnvironment");  //$NON-NLS-1$
-		Util.verbose(" -> project: " + javaProject);  //$NON-NLS-1$
+		trace(" EXTENDING JavaSearchNameEnvironment");  //$NON-NLS-1$
+		trace(" -> project: " + javaProject);  //$NON-NLS-1$
 		start = System.currentTimeMillis();
 	}
 
@@ -177,9 +179,9 @@ void addProjectClassPath(JavaProject javaProject, boolean onlyExported) {
 	if (locations != null) this.locationSet.addAll(locations);
 
     if (NameLookup.VERBOSE) {
-		Util.verbose(" -> pkg roots size: " + (this.locationSet == null ? 0 : this.locationSet.size()));  //$NON-NLS-1$
-		Util.verbose(" -> pkgs size: " + this.packageNameToClassPathLocations.size());  //$NON-NLS-1$
-        Util.verbose(" -> spent: " + (System.currentTimeMillis() - start) + "ms");  //$NON-NLS-1$ //$NON-NLS-2$
+		trace(" -> pkg roots size: " + (this.locationSet == null ? 0 : this.locationSet.size()));  //$NON-NLS-1$
+		trace(" -> pkgs size: " + this.packageNameToClassPathLocations.size());  //$NON-NLS-1$
+        trace(" -> spent: " + (System.currentTimeMillis() - start) + "ms");  //$NON-NLS-1$ //$NON-NLS-2$
     }
 }
 
@@ -199,7 +201,9 @@ private LinkedHashSet<ClasspathLocation> computeClasspathLocations(JavaProject j
 	try {
 		projectModule = javaProject.getModuleDescription();
 	} catch (JavaModelException e) {
-		// e.printStackTrace(); // ignore
+		if (JobManager.VERBOSE) {
+			trace("", e); //$NON-NLS-1$
+		}
 	}
 
 	LinkedHashSet<ClasspathLocation> locations = new LinkedHashSet<ClasspathLocation>();
@@ -399,9 +403,9 @@ private NameEnvironmentAnswer findClass(String qualifiedTypeName, char[] typeNam
 			if (!answer.ignoreIfBetter()) {
 				if (answer.isBetter(suggestedAnswer)) {
 					if(NameLookup.VERBOSE) {
-						Util.verbose(" Result for JavaSearchNameEnvironment#findClass( " + qualifiedTypeName + ", " + CharOperation.charToString(typeName) + ", " + strategy + ", " + moduleName + ")"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
-						Util.verbose(" -> answer: " + answer); //$NON-NLS-1$
-						Util.verbose(" -> location: " + location); //$NON-NLS-1$
+						trace(" Result for JavaSearchNameEnvironment#findClass( " + qualifiedTypeName + ", " + CharOperation.charToString(typeName) + ", " + strategy + ", " + moduleName + ")"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
+						trace(" -> answer: " + answer); //$NON-NLS-1$
+						trace(" -> location: " + location); //$NON-NLS-1$
 					}
 					return answer;
 				}
@@ -409,9 +413,9 @@ private NameEnvironmentAnswer findClass(String qualifiedTypeName, char[] typeNam
 				// remember suggestion and keep looking
 				suggestedAnswer = answer;
 				if(NameLookup.VERBOSE) {
-					Util.verbose(" Potential answer for JavaSearchNameEnvironment#findClass( " + qualifiedTypeName + ", " + CharOperation.charToString(typeName) + ", " + strategy + ", " + moduleName + ")"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
-					Util.verbose(" -> answer: " + answer); //$NON-NLS-1$
-					Util.verbose(" -> location: " + location); //$NON-NLS-1$
+					trace(" Potential answer for JavaSearchNameEnvironment#findClass( " + qualifiedTypeName + ", " + CharOperation.charToString(typeName) + ", " + strategy + ", " + moduleName + ")"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
+					trace(" -> answer: " + answer); //$NON-NLS-1$
+					trace(" -> location: " + location); //$NON-NLS-1$
 				}
 			}
 		}
@@ -420,7 +424,7 @@ private NameEnvironmentAnswer findClass(String qualifiedTypeName, char[] typeNam
 		// no better answer was found
 		return suggestedAnswer;
 	if(NameLookup.VERBOSE) {
-		Util.verbose(" NO result for JavaSearchNameEnvironment#findClass( " + qualifiedTypeName + ", " + CharOperation.charToString(typeName) + ", " + strategy + ", " + moduleName + ")"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
+		trace(" NO result for JavaSearchNameEnvironment#findClass( " + qualifiedTypeName + ", " + CharOperation.charToString(typeName) + ", " + strategy + ", " + moduleName + ")"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$ //$NON-NLS-5$
 	}
 	return null;
 }
@@ -436,18 +440,18 @@ protected /* visible for testing only */ Iterable<ClasspathLocation> getLocation
 		LinkedHashSet<ClasspathLocation> cpls = this.packageNameToClassPathLocations.get(qualifiedPackageName);
 		if(cpls == null) {
 			if(NameLookup.VERBOSE) {
-				Util.verbose(" No result for JavaSearchNameEnvironment#getLocationsFor( " + moduleName + ", " + qualifiedPackageName + ")"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+				trace(" No result for JavaSearchNameEnvironment#getLocationsFor( " + moduleName + ", " + qualifiedPackageName + ")"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 			}
 			return Collections.emptySet();
 		}
 		if(NameLookup.VERBOSE) {
-			Util.verbose(" Result for JavaSearchNameEnvironment#getLocationsFor( " + moduleName + ", " + qualifiedPackageName + ")"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-			Util.verbose(" -> " + cpls.stream().map(Object::toString).collect(joining(" | "))); //$NON-NLS-1$ //$NON-NLS-2$
+			trace(" Result for JavaSearchNameEnvironment#getLocationsFor( " + moduleName + ", " + qualifiedPackageName + ")"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+			trace(" -> " + cpls.stream().map(Object::toString).collect(joining(" | "))); //$NON-NLS-1$ //$NON-NLS-2$
 		}
 		return cpls;
 	}
 	if(NameLookup.VERBOSE) {
-		Util.verbose(" Potentially expensive search in JavaSearchNameEnvironment#getLocationsFor( " + moduleName + ", " + qualifiedPackageName + ")"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+		trace(" Potentially expensive search in JavaSearchNameEnvironment#getLocationsFor( " + moduleName + ", " + qualifiedPackageName + ")"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 	}
 	return this.locationSet;
 }
@@ -502,8 +506,8 @@ public char[][] getModulesDeclaringPackage(char[][] packageName, char[] moduleNa
 		}
 	}
 	if(NameLookup.VERBOSE) {
-		Util.verbose(" Result for JavaSearchNameEnvironment#getModulesDeclaringPackage( " + qualifiedPackageName + ", " + CharOperation.charToString(moduleName) + ")"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-		Util.verbose(" -> " + CharOperation.toString(moduleNames)); //$NON-NLS-1$
+		trace(" Result for JavaSearchNameEnvironment#getModulesDeclaringPackage( " + qualifiedPackageName + ", " + CharOperation.charToString(moduleName) + ")"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+		trace(" -> " + CharOperation.toString(moduleNames)); //$NON-NLS-1$
 	}
 	return moduleNames == CharOperation.NO_CHAR_CHAR ? null : moduleNames;
 }
@@ -540,8 +544,8 @@ public boolean hasCompilationUnit(char[][] qualifiedPackageName, char[] moduleNa
 			if (strategy.matches(location, ClasspathLocation::hasModule) )
 				if (location.hasCompilationUnit(qualifiedPackageNameString, moduleNameString)) {
 					if(NameLookup.VERBOSE) {
-						Util.verbose(" Result for JavaSearchNameEnvironment#hasCompilationUnit( " + qualifiedPackageNameString + ", " + moduleNameString + ")"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-						Util.verbose(" -> " + location); //$NON-NLS-1$
+						trace(" Result for JavaSearchNameEnvironment#hasCompilationUnit( " + qualifiedPackageNameString + ", " + moduleNameString + ")"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+						trace(" -> " + location); //$NON-NLS-1$
 					}
 					return true;
 				}

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/MatchLocator.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/MatchLocator.java
@@ -16,6 +16,8 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.core.search.matching;
 
+import static org.eclipse.jdt.internal.core.JavaModelManager.trace;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -95,6 +97,7 @@ import org.eclipse.jdt.internal.core.SourceTypeElementInfo;
 import org.eclipse.jdt.internal.core.index.Index;
 import org.eclipse.jdt.internal.core.search.*;
 import org.eclipse.jdt.internal.core.search.indexing.QualifierQuery;
+import org.eclipse.jdt.internal.core.search.processing.JobManager;
 import org.eclipse.jdt.internal.core.util.ASTNodeFinder;
 import org.eclipse.jdt.internal.core.util.HandleFactory;
 import org.eclipse.jdt.internal.core.util.Util;
@@ -283,8 +286,9 @@ public static IBinaryType classFileReader(IType type) {
 			ZipFile zipFile = null;
 			try {
 				IPath zipPath = root.getPath();
-				if (JavaModelManager.ZIP_ACCESS_VERBOSE)
-					System.out.println("(" + Thread.currentThread() + ") [MatchLocator.classFileReader()] Creating ZipFile on " + zipPath); //$NON-NLS-1$	//$NON-NLS-2$
+				if (JavaModelManager.ZIP_ACCESS_VERBOSE) {
+					trace("(" + Thread.currentThread() + ") [MatchLocator.classFileReader()] Creating ZipFile on " + zipPath); //$NON-NLS-1$	//$NON-NLS-2$
+				}
 				zipFile = manager.getZipFile(zipPath);
 				String classFileName = classFile.getElementName();
 				String path = Util.concatWith(pkg.names, classFileName, '/');
@@ -391,7 +395,7 @@ public void accept(ICompilationUnit sourceUnit, AccessRestriction accessRestrict
 	// Display unit error in debug mode
 	if (BasicSearchEngine.VERBOSE) {
 		if (unitResult.problemCount > 0) {
-			System.out.println(unitResult);
+			trace(unitResult.toString());
 		}
 	}
 }
@@ -533,7 +537,7 @@ protected IJavaElement createHandle(AbstractMethodDeclaration method, IJavaEleme
 						typeName = declaringType.getFullyQualifiedName().toCharArray();
 					} else {
 						if (BasicSearchEngine.VERBOSE) {
-							System.out.println("Null declaring type for " + type); //$NON-NLS-1$
+							trace("Null declaring type for " + type); //$NON-NLS-1$
 						}
 					}
 				} else if (arguments != null) {
@@ -565,7 +569,7 @@ protected IJavaElement createHandle(AbstractMethodDeclaration method, IJavaEleme
 			return binaryMethod;
 		}
 		if (BasicSearchEngine.VERBOSE) {
-			System.out.println("Not able to createHandle for the method " + //$NON-NLS-1$
+			trace("Not able to createHandle for the method " + //$NON-NLS-1$
 					CharOperation.charToString(method.selector) + " May miss some results");  //$NON-NLS-1$
 		}
 		return null;
@@ -920,7 +924,9 @@ protected IBinaryType getBinaryInfo(ClassFile classFile, IResource resource) thr
 		if (info == null) throw binaryType.newNotPresentException();
 		return info;
 	} catch (ClassFormatException e) {
-		//e.printStackTrace();
+		if (JobManager.VERBOSE) {
+			trace("", e); //$NON-NLS-1$
+		}
 		return null;
 	} catch (java.io.IOException e) {
 		throw new JavaModelException(e, IJavaModelStatusConstants.IO_EXCEPTION);
@@ -1411,10 +1417,11 @@ public void locateMatches(SearchDocument[] searchDocuments) throws CoreException
 	int docsLength = searchDocuments.length;
 	int progressLength = docsLength;
 	if (BasicSearchEngine.VERBOSE) {
-		System.out.println("Locating matches in documents ["); //$NON-NLS-1$
-		for (int i = 0; i < docsLength; i++)
-			System.out.println("\t" + searchDocuments[i]); //$NON-NLS-1$
-		System.out.println("]"); //$NON-NLS-1$
+		trace("Locating matches in documents ["); //$NON-NLS-1$
+		for (int i = 0; i < docsLength; i++) {
+			trace("\t" + searchDocuments[i]); //$NON-NLS-1$
+		}
+		trace("]"); //$NON-NLS-1$
 	}
 	IJavaProject[] javaModelProjects = null;
 	if (this.searchPackageDeclaration) {
@@ -1935,8 +1942,9 @@ protected boolean parseAndBuildBindings(PossibleMatch possibleMatch, boolean mus
 		throw new OperationCanceledException();
 
 	try {
-		if (BasicSearchEngine.VERBOSE)
-			System.out.println("Parsing " + possibleMatch.openable.toStringWithAncestors()); //$NON-NLS-1$
+		if (BasicSearchEngine.VERBOSE) {
+			trace("Parsing " + possibleMatch.openable.toStringWithAncestors()); //$NON-NLS-1$
+		}
 
 		this.parser.nodeSet = possibleMatch.nodeSet;
 		CompilationResult unitResult = new CompilationResult(possibleMatch, 1, 1, this.options.maxProblemsPerUnit);
@@ -2021,8 +2029,9 @@ protected void process(PossibleMatch possibleMatch, boolean bindingsWereCreated)
 		boolean mustResolve = (this.pattern.mustResolve || possibleMatch.nodeSet.mustResolve);
 		if (bindingsWereCreated && mustResolve) {
 			if (unit.types != null) {
-				if (BasicSearchEngine.VERBOSE)
-					System.out.println("Resolving " + this.currentPossibleMatch.openable.toStringWithAncestors()); //$NON-NLS-1$
+				if (BasicSearchEngine.VERBOSE) {
+					trace("Resolving " + this.currentPossibleMatch.openable.toStringWithAncestors()); //$NON-NLS-1$
+				}
 
 				this.lookupEnvironment.unitBeingCompleted = unit;
 				reduceParseTree(unit);
@@ -2033,12 +2042,14 @@ protected void process(PossibleMatch possibleMatch, boolean bindingsWereCreated)
 				}
 				unit.resolve();
 			} else if (unit.isPackageInfo()) {
-				if (BasicSearchEngine.VERBOSE)
-					System.out.println("Resolving " + this.currentPossibleMatch.openable.toStringWithAncestors()); //$NON-NLS-1$
+				if (BasicSearchEngine.VERBOSE) {
+					trace("Resolving " + this.currentPossibleMatch.openable.toStringWithAncestors()); //$NON-NLS-1$
+				}
 				unit.resolve();
 			} else if (unit.isModuleInfo()) {
-				if (BasicSearchEngine.VERBOSE)
-					System.out.println("Resolving " + this.currentPossibleMatch.openable.toStringWithAncestors()); //$NON-NLS-1$
+				if (BasicSearchEngine.VERBOSE) {
+					trace("Resolving " + this.currentPossibleMatch.openable.toStringWithAncestors()); //$NON-NLS-1$
+				}
 				this.lookupEnvironment.unitBeingCompleted = unit;
 				if (unit.scope != null && unit.moduleDeclaration != null) {
 					unit.moduleDeclaration.resolveTypeDirectives(unit.scope);
@@ -2048,8 +2059,7 @@ protected void process(PossibleMatch possibleMatch, boolean bindingsWereCreated)
 		reportMatching(unit, mustResolve);
 	} catch (AbortCompilation e) {
 		if (BasicSearchEngine.VERBOSE) {
-			System.out.println("AbortCompilation while resolving unit " + String.valueOf(unit.getFileName())); //$NON-NLS-1$
-			e.printStackTrace();
+			trace("AbortCompilation while resolving unit " + String.valueOf(unit.getFileName()), e); //$NON-NLS-1$
 		}
 		// could not resolve: report inaccurate matches
 		reportMatching(unit, false); // do not resolve when cu has errors
@@ -2109,35 +2119,35 @@ public SearchParticipant getParticipant() {
 protected void report(SearchMatch match) throws CoreException {
 	if (match == null) {
 		if (BasicSearchEngine.VERBOSE) {
-			System.out.println("Cannot report a null match!!!"); //$NON-NLS-1$
+			trace("Cannot report a null match!!!"); //$NON-NLS-1$
 		}
 		return;
 	}
 	if (filterEnum(match)){
 		if (BasicSearchEngine.VERBOSE) {
-			System.out.println("Filtered package with name enum"); //$NON-NLS-1$
+			trace("Filtered package with name enum"); //$NON-NLS-1$
 		}
 		return;
 	}
 	long start = -1;
 	if (BasicSearchEngine.VERBOSE) {
 		start = System.currentTimeMillis();
-		System.out.println("Reporting match"); //$NON-NLS-1$
-		System.out.println("\tResource: " + match.getResource());//$NON-NLS-1$
-		System.out.println("\tPositions: [offset=" + match.getOffset() + ", length=" + match.getLength() + "]"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+		trace("Reporting match"); //$NON-NLS-1$
+		trace("\tResource: " + match.getResource());//$NON-NLS-1$
+		trace("\tPositions: [offset=" + match.getOffset() + ", length=" + match.getLength() + "]"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 		try {
 			if (this.parser != null && match.getOffset() > 0 && match.getLength() > 0 && !(match.getElement() instanceof BinaryMember)) {
 				String selection = new String(this.parser.scanner.source, match.getOffset(), match.getLength());
-				System.out.println("\tSelection: -->" + selection + "<--"); //$NON-NLS-1$ //$NON-NLS-2$
+				trace("\tSelection: -->" + selection + "<--"); //$NON-NLS-1$ //$NON-NLS-2$
 			}
 		} catch (Exception e) {
 			// it's just for debug purposes... ignore all exceptions in this area
 		}
 		try {
 			JavaElement javaElement = (JavaElement)match.getElement();
-			System.out.println("\tJava element: "+ javaElement.toStringWithAncestors()); //$NON-NLS-1$
+			trace("\tJava element: "+ javaElement.toStringWithAncestors()); //$NON-NLS-1$
 			if (!javaElement.exists()) {
-				System.out.println("\t\tWARNING: this element does NOT exist!"); //$NON-NLS-1$
+				trace("\t\tWARNING: this element does NOT exist!"); //$NON-NLS-1$
 			}
 		} catch (Exception e) {
 			// it's just for debug purposes... ignore all exceptions in this area
@@ -2147,17 +2157,17 @@ protected void report(SearchMatch match) throws CoreException {
 				ReferenceMatch refMatch = (ReferenceMatch) match;
 				JavaElement local = (JavaElement) refMatch.getLocalElement();
 				if (local != null) {
-					System.out.println("\tLocal element: "+ local.toStringWithAncestors()); //$NON-NLS-1$
+					trace("\tLocal element: "+ local.toStringWithAncestors()); //$NON-NLS-1$
 				}
 				if (match instanceof TypeReferenceMatch) {
 					IJavaElement[] others = ((TypeReferenceMatch) refMatch).getOtherElements();
 					if (others != null) {
 						int length = others.length;
 						if (length > 0) {
-							System.out.println("\tOther elements:"); //$NON-NLS-1$
+							trace("\tOther elements:"); //$NON-NLS-1$
 							for (int i=0; i<length; i++) {
 								JavaElement other = (JavaElement) others[i];
-								System.out.println("\t\t- "+ other.toStringWithAncestors()); //$NON-NLS-1$
+								trace("\t\t- "+ other.toStringWithAncestors()); //$NON-NLS-1$
 							}
 						}
 					}
@@ -2166,32 +2176,32 @@ protected void report(SearchMatch match) throws CoreException {
 				// it's just for debug purposes... ignore all exceptions in this area
 			}
 		}
-		System.out.println(match.getAccuracy() == SearchMatch.A_ACCURATE
+		trace(match.getAccuracy() == SearchMatch.A_ACCURATE
 			? "\tAccuracy: EXACT_MATCH" //$NON-NLS-1$
 			: "\tAccuracy: POTENTIAL_MATCH"); //$NON-NLS-1$
-		System.out.print("\tRule: "); //$NON-NLS-1$
+		trace("\tRule: "); //$NON-NLS-1$
 		if (match.isExact()) {
-			System.out.print("EXACT"); //$NON-NLS-1$
+			trace("EXACT"); //$NON-NLS-1$
 		} else if (match.isEquivalent()) {
-			System.out.print("EQUIVALENT"); //$NON-NLS-1$
+			trace("EQUIVALENT"); //$NON-NLS-1$
 		} else if (match.isErasure()) {
-			System.out.print("ERASURE"); //$NON-NLS-1$
+			trace("ERASURE"); //$NON-NLS-1$
 		} else {
-			System.out.print("INVALID RULE"); //$NON-NLS-1$
+			trace("INVALID RULE"); //$NON-NLS-1$
 		}
 		if (match instanceof MethodReferenceMatch) {
 			MethodReferenceMatch methodReferenceMatch = (MethodReferenceMatch) match;
 			if (methodReferenceMatch.isSuperInvocation()) {
-				System.out.print("+SUPER INVOCATION"); //$NON-NLS-1$
+				trace("+SUPER INVOCATION"); //$NON-NLS-1$
 			}
 			if (methodReferenceMatch.isImplicit()) {
-				System.out.print("+IMPLICIT"); //$NON-NLS-1$
+				trace("+IMPLICIT"); //$NON-NLS-1$
 			}
 			if (methodReferenceMatch.isSynthetic()) {
-				System.out.print("+SYNTHETIC"); //$NON-NLS-1$
+				trace("+SYNTHETIC"); //$NON-NLS-1$
 			}
 		}
-		System.out.println("\n\tRaw: "+match.isRaw()); //$NON-NLS-1$
+		trace("\n\tRaw: "+match.isRaw()); //$NON-NLS-1$
 	}
 	this.requestor.acceptSearchMatch(match);
 	if (BasicSearchEngine.VERBOSE)
@@ -2772,15 +2782,15 @@ protected void reportMatching(CompilationUnitDeclaration unit, boolean mustResol
 	boolean locatorMustResolve = this.patternLocator.mustResolve;
 	if (nodeSet.mustResolve) this.patternLocator.mustResolve = true;
 	if (BasicSearchEngine.VERBOSE) {
-		System.out.println("Report matching: "); //$NON-NLS-1$
+		trace("Report matching: "); //$NON-NLS-1$
 		int size = nodeSet.matchingNodes==null ? 0 : nodeSet.matchingNodes.elementSize;
-		System.out.print("	- node set: accurate="+ size); //$NON-NLS-1$
+		trace("	- node set: accurate="+ size); //$NON-NLS-1$
 		size = nodeSet.possibleMatchingNodesSet==null ? 0 : nodeSet.possibleMatchingNodesSet.elementSize;
-		System.out.println(", possible="+size); //$NON-NLS-1$
-		System.out.print("	- must resolve: "+mustResolve); //$NON-NLS-1$
-		System.out.print(" (locator: "+this.patternLocator.mustResolve); //$NON-NLS-1$
-		System.out.println(", nodeSet: "+nodeSet.mustResolve+')'); //$NON-NLS-1$
-		System.out.println("	- fine grain flags="+ JavaSearchPattern.getFineGrainFlagString(this.patternLocator.fineGrain())); //$NON-NLS-1$
+		trace(", possible="+size); //$NON-NLS-1$
+		trace("	- must resolve: "+mustResolve); //$NON-NLS-1$
+		trace(" (locator: "+this.patternLocator.mustResolve); //$NON-NLS-1$
+		trace(", nodeSet: "+nodeSet.mustResolve+')'); //$NON-NLS-1$
+		trace("	- fine grain flags="+ JavaSearchPattern.getFineGrainFlagString(this.patternLocator.fineGrain())); //$NON-NLS-1$
 	}
 	if (mustResolve) {
 		this.unitScope= unit.scope.compilationUnitScope();
@@ -2812,9 +2822,9 @@ protected void reportMatching(CompilationUnitDeclaration unit, boolean mustResol
 		nodeSet.possibleMatchingNodesSet = new SimpleSet(3);
 		if (BasicSearchEngine.VERBOSE) {
 			int size = nodeSet.matchingNodes==null ? 0 : nodeSet.matchingNodes.elementSize;
-			System.out.print("	- node set: accurate="+size); //$NON-NLS-1$
+			trace("	- node set: accurate="+size); //$NON-NLS-1$
 			size = nodeSet.possibleMatchingNodesSet==null ? 0 : nodeSet.possibleMatchingNodesSet.elementSize;
-			System.out.println(", possible="+size); //$NON-NLS-1$
+			trace(", possible="+size); //$NON-NLS-1$
 		}
 	} else {
 		this.unitScope = null;
@@ -3123,8 +3133,9 @@ private void reportMatching(UsesStatement[] uses, ModuleDeclaration module, Matc
 				}
 			}
 		} catch (CoreException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
+			if (JobManager.VERBOSE) {
+				trace("", e); //$NON-NLS-1$
+			}
 		}
 	}
 }

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/MethodLocator.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/MethodLocator.java
@@ -16,6 +16,8 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.core.search.matching;
 
+import static org.eclipse.jdt.internal.core.JavaModelManager.trace;
+
 import java.util.Arrays;
 import java.util.HashMap;
 
@@ -132,7 +134,7 @@ public void initializePolymorphicSearch(MatchLocator locator) {
 		// inaccurate matches will be found
 	}
 	if (BasicSearchEngine.VERBOSE) {
-		System.out.println("Time to initialize polymorphic search: "+(System.currentTimeMillis()-start)); //$NON-NLS-1$
+		trace("Time to initialize polymorphic search: "+(System.currentTimeMillis()-start)); //$NON-NLS-1$
 	}
 }
 /*

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/TypeDeclarationLocator.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/TypeDeclarationLocator.java
@@ -165,8 +165,10 @@ private HashSet<String> getModuleGraph(String mName, TypeDeclarationPattern type
 	final SearchRequestor requestor = new SearchRequestor() {
 		@Override
 		public void acceptSearchMatch(SearchMatch searchMatch) throws CoreException {
-			System.out.println(searchMatch.toString());
 			// do nothing
+			if (JavaModelManager.VERBOSE) {
+				JavaModelManager.trace(searchMatch.toString());
+			}
 		}
 	};
 	try {

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/processing/JobManager.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/processing/JobManager.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.core.search.processing;
 
+import static org.eclipse.jdt.internal.core.JavaModelManager.trace;
+
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -117,8 +119,9 @@ public abstract class JobManager {
 
 	public synchronized void disable() {
 		this.enableCount--;
-		if (VERBOSE)
-			Util.verbose("DISABLING background indexing"); //$NON-NLS-1$
+		if (VERBOSE) {
+			trace("DISABLING background indexing"); //$NON-NLS-1$
+		}
 	}
 
 	/**
@@ -134,8 +137,9 @@ public abstract class JobManager {
 	 */
 	public void discardJobs(String jobFamily) {
 
-		if (VERBOSE)
-			Util.verbose("DISCARD   background job family - " + jobFamily); //$NON-NLS-1$
+		if (VERBOSE) {
+			trace("DISCARD   background job family - " + jobFamily); //$NON-NLS-1$
+		}
 
 		try {
 			IJob currentJob;
@@ -151,8 +155,9 @@ public abstract class JobManager {
 					// wait until current active job has finished
 					while (getProcessingThread() != null && this.executing){
 						try {
-							if (VERBOSE)
-								Util.verbose("-> waiting end of current background job - " + currentJob); //$NON-NLS-1$
+							if (VERBOSE) {
+								trace("-> waiting end of current background job - " + currentJob); //$NON-NLS-1$
+							}
 							this.wait(50);
 						} catch(InterruptedException e){
 							// ignore
@@ -168,7 +173,7 @@ public abstract class JobManager {
 					currentJob = it.next();
 					if (jobFamily == null || currentJob.belongsTo(jobFamily)) {
 						if (VERBOSE) {
-							Util.verbose("-> discarding background job  - " + currentJob); //$NON-NLS-1$
+							trace("-> discarding background job  - " + currentJob); //$NON-NLS-1$
 						}
 						currentJob.cancel();
 						it.remove();
@@ -182,13 +187,15 @@ public abstract class JobManager {
 		} finally {
 			enable();
 		}
-		if (VERBOSE)
-			Util.verbose("DISCARD   DONE with background job family - " + jobFamily); //$NON-NLS-1$
+		if (VERBOSE) {
+			trace("DISCARD   DONE with background job family - " + jobFamily); //$NON-NLS-1$
+		}
 	}
 	public synchronized void enable() {
 		this.enableCount++;
-		if (VERBOSE)
-			Util.verbose("ENABLING  background indexing"); //$NON-NLS-1$
+		if (VERBOSE) {
+			trace("ENABLING  background indexing"); //$NON-NLS-1$
+		}
 		notifyAll(); // wake up the background thread if it is waiting (context must be synchronized)
 	}
 	protected synchronized boolean isJobWaiting(IJob request) {
@@ -256,8 +263,9 @@ public abstract class JobManager {
 	 *
 	 */
 	public boolean performConcurrentJob(IJob searchJob, int waitingPolicy, IProgressMonitor monitor) {
-		if (VERBOSE)
-			Util.verbose("STARTING  concurrent job - " + searchJob); //$NON-NLS-1$
+		if (VERBOSE) {
+			trace("STARTING  concurrent job - " + searchJob); //$NON-NLS-1$
+		}
 
 		searchJob.ensureReadyToRun();
 
@@ -265,29 +273,32 @@ public abstract class JobManager {
 		try {
 			SubMonitor subMonitor = SubMonitor.convert(monitor);
 			if (awaitingJobsCount() > 0) {
-				if (VERBOSE)
-					Util.verbose("-> NOT READY - " + awaitingJobsCount() + " awaiting jobs - " + searchJob);//$NON-NLS-1$ //$NON-NLS-2$
+				if (VERBOSE) {
+					trace("-> NOT READY - " + awaitingJobsCount() + " awaiting jobs - " + searchJob);//$NON-NLS-1$ //$NON-NLS-2$
+				}
 
 				switch (waitingPolicy) {
 
 					case IJob.ForceImmediate :
-						if (VERBOSE)
-							Util.verbose("-> NOT READY - forcing immediate - " + searchJob);//$NON-NLS-1$
+						if (VERBOSE) {
+							trace("-> NOT READY - forcing immediate - " + searchJob);//$NON-NLS-1$
+						}
 						try {
 							disable(); // pause indexing
 							status = searchJob.execute(subMonitor);
 						} finally {
 							enable();
 						}
-						if (VERBOSE)
-							Util.verbose("FINISHED  concurrent job - " + searchJob); //$NON-NLS-1$
+						if (VERBOSE) {
+							trace("FINISHED  concurrent job - " + searchJob); //$NON-NLS-1$
+						}
 						return status;
 
 					case IJob.CancelIfNotReady :
-						if (VERBOSE)
-							Util.verbose("-> NOT READY - cancelling - " + searchJob); //$NON-NLS-1$
-						if (VERBOSE)
-							Util.verbose("CANCELED concurrent job - " + searchJob); //$NON-NLS-1$
+						if (VERBOSE) {
+							trace("-> NOT READY - cancelling - " + searchJob); //$NON-NLS-1$
+							trace("CANCELED concurrent job - " + searchJob); //$NON-NLS-1$
+						}
 						throw new OperationCanceledException();
 
 					case IJob.WaitUntilReady :
@@ -314,10 +325,11 @@ public abstract class JobManager {
 								IJob currentJob = currentJobForced();
 								if (currentJob != null) {
 									if (!isEnabled()) {
-										if (VERBOSE)
-											Util.verbose("-> NOT READY (" + this.enableCount //$NON-NLS-1$
+										if (VERBOSE) {
+											trace("-> NOT READY (" + this.enableCount //$NON-NLS-1$
 													+ ") - enabling indexer to process " //$NON-NLS-1$
 													+ awaitingJobsCount + " jobs - " + searchJob);//$NON-NLS-1$
+										}
 										enable();
 										shouldDisable = true;
 									}
@@ -326,8 +338,9 @@ public abstract class JobManager {
 									}
 								}
 								if (currentJob != null && currentJob != previousJob) {
-									if (VERBOSE)
-										Util.verbose("-> NOT READY - waiting until ready  to process " + awaitingJobsCount + " awaiting jobs - " + searchJob);//$NON-NLS-1$ //$NON-NLS-2$
+									if (VERBOSE) {
+										trace("-> NOT READY - waiting until ready  to process " + awaitingJobsCount + " awaiting jobs - " + searchJob);//$NON-NLS-1$ //$NON-NLS-2$
+									}
 									String indexing = Messages.bind(Messages.jobmanager_filesToIndex, currentJob.getJobFamily(), Integer.toString(awaitingJobsCount));
 									waitMonitor.subTask(indexing);
 									// ratio of the amount of work relative to the total work
@@ -355,9 +368,10 @@ public abstract class JobManager {
 									}
 								}
 								if (shouldDisable) {
-									if (VERBOSE)
-										Util.verbose("-> NOT READY (" + this.enableCount + ") - disabling indexer again, still awaiting jobs: " //$NON-NLS-1$ //$NON-NLS-2$
+									if (VERBOSE) {
+										trace("-> NOT READY (" + this.enableCount + ") - disabling indexer again, still awaiting jobs: " //$NON-NLS-1$ //$NON-NLS-2$
 												+ awaitingJobsCount + " - " + searchJob);//$NON-NLS-1$
+									}
 									disable();
 								}
 							}
@@ -371,8 +385,9 @@ public abstract class JobManager {
 			status = searchJob.execute(subMonitor);
 		} finally {
 			SubMonitor.done(monitor);
-			if (VERBOSE)
-				Util.verbose("FINISHED  concurrent job - " + searchJob); //$NON-NLS-1$
+			if (VERBOSE) {
+				trace("FINISHED  concurrent job - " + searchJob); //$NON-NLS-1$
+			}
 		}
 		return status;
 	}
@@ -397,8 +412,8 @@ public abstract class JobManager {
 		// append the job to the list of ones to process later on
 		this.awaitingJobs.add(job);
 		if (VERBOSE) {
-			Util.verbose("REQUEST   background job - " + job); //$NON-NLS-1$
-			Util.verbose("AWAITING JOBS count: " + awaitingJobsCount()); //$NON-NLS-1$
+			trace("REQUEST   background job - " + job); //$NON-NLS-1$
+			trace("AWAITING JOBS count: " + awaitingJobsCount()); //$NON-NLS-1$
 		}
 		notifyAll(); // wake up the background thread if it is waiting
 	}
@@ -406,8 +421,9 @@ public abstract class JobManager {
 	 * Flush current state
 	 */
 	public void reset() {
-		if (VERBOSE)
-			Util.verbose("Reset"); //$NON-NLS-1$
+		if (VERBOSE) {
+			trace("Reset"); //$NON-NLS-1$
+		}
 
 		Thread thread = getProcessingThread();
 
@@ -508,8 +524,8 @@ public abstract class JobManager {
 					}
 					idlingStart = null;
 					if (VERBOSE) {
-						Util.verbose(awaitingJobsCount() + " awaiting jobs"); //$NON-NLS-1$
-						Util.verbose("STARTING background job - " + job); //$NON-NLS-1$
+						trace(awaitingJobsCount() + " awaiting jobs"); //$NON-NLS-1$
+						trace("STARTING background job - " + job); //$NON-NLS-1$
 					}
 					try {
 						this.executing = true;
@@ -527,12 +543,13 @@ public abstract class JobManager {
 						job.execute(null); // may enqueue a new job
 					} finally {
 						this.executing = false;
-						if (VERBOSE)
-							Util.verbose("FINISHED background job - " + job); //$NON-NLS-1$
+						if (VERBOSE) {
+							trace("FINISHED background job - " + job); //$NON-NLS-1$
+						}
 						moveToNextJob();
 						if (this.awaitingClients.get() == 0 && job.waitNeeded()) {
 							if (VERBOSE) {
-								Util.verbose("WAITING after job - " + job); //$NON-NLS-1$
+								trace("WAITING after job - " + job); //$NON-NLS-1$
 							}
 							synchronized (this.idleMonitor) {
 								this.idleMonitor.wait(5); // avoid sleep fixed time
@@ -570,8 +587,9 @@ public abstract class JobManager {
 	 */
 	public void shutdown() {
 
-		if (VERBOSE)
-			Util.verbose("Shutdown"); //$NON-NLS-1$
+		if (VERBOSE) {
+			trace("Shutdown"); //$NON-NLS-1$
+		}
 
 		disable();
 		discardJobs(null); // will wait until current executing job has completed


### PR DESCRIPTION
This makes JDT core tracing instantly available at runtime Eclipse instance by modifying preferences. Also this allows redirecting all of the tracing into the default platform tracing file (if configured).

- Removed org.eclipse.jdt.internal.core.util.Util.verbose()
- replaced almost all System.out.println() and printStackTrace() occurrences with JavaModelManager.trace()
- added JavaModelManager.trace() in few places where exceptions were silently dropped

See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1303
