### PR TITLE
Version bumps for 4.30 stream

### DIFF
--- a/org.eclipse.jdt.apt.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.apt.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.apt.core; singleton:=true
-Bundle-Version: 3.8.100.qualifier
+Bundle-Version: 3.8.200.qualifier
 Bundle-Localization: plugin
 Export-Package: com.sun.mirror.apt,
  com.sun.mirror.declaration,

--- a/org.eclipse.jdt.apt.core/pom.xml
+++ b/org.eclipse.jdt.apt.core/pom.xml
@@ -17,6 +17,6 @@
     <version>4.30.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.eclipse.jdt.apt.core</artifactId>
-  <version>3.8.100-SNAPSHOT</version>
+  <version>3.8.200-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.eclipse.jdt.apt.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.apt.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.apt.tests; singleton:=true
-Bundle-Version: 3.6.100.qualifier
+Bundle-Version: 3.6.200.qualifier
 Bundle-ClassPath: apt.jar,
  aptext.jar,
  .

--- a/org.eclipse.jdt.apt.tests/pom.xml
+++ b/org.eclipse.jdt.apt.tests/pom.xml
@@ -19,7 +19,7 @@
     <relativePath>../tests-pom/</relativePath>
   </parent>
   <artifactId>org.eclipse.jdt.apt.tests</artifactId>
-  <version>3.6.100-SNAPSHOT</version>
+  <version>3.6.200-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   
   <build>

--- a/org.eclipse.jdt.apt.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.apt.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.apt.ui; singleton:=true
-Bundle-Version: 3.8.100.qualifier
+Bundle-Version: 3.8.200.qualifier
 Bundle-Activator: org.eclipse.jdt.apt.ui.internal.AptUIPlugin
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.jdt.apt.core;bundle-version="[3.6.0,4.0.0)",

--- a/org.eclipse.jdt.apt.ui/pom.xml
+++ b/org.eclipse.jdt.apt.ui/pom.xml
@@ -17,6 +17,6 @@
     <version>4.30.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.eclipse.jdt.apt.ui</artifactId>
-  <version>3.8.100-SNAPSHOT</version>
+  <version>3.8.200-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.eclipse.jdt.compiler.tool.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.compiler.tool.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.compiler.tool.tests
-Bundle-Version: 1.4.100.qualifier
+Bundle-Version: 1.4.200.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/org.eclipse.jdt.compiler.tool.tests/pom.xml
+++ b/org.eclipse.jdt.compiler.tool.tests/pom.xml
@@ -19,7 +19,7 @@
     <relativePath>../tests-pom/</relativePath>
   </parent>
   <artifactId>org.eclipse.jdt.compiler.tool.tests</artifactId>
-  <version>1.4.100-SNAPSHOT</version>
+  <version>1.4.200-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <properties>
   	<testSuite>${project.artifactId}</testSuite>

--- a/org.eclipse.jdt.core.tests.performance/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.tests.performance/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.core.tests.performance
-Bundle-Version: 3.12.100.qualifier
+Bundle-Version: 3.12.200.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jdt.core.tests.performance,

--- a/org.eclipse.jdt.core.tests.performance/pom.xml
+++ b/org.eclipse.jdt.core.tests.performance/pom.xml
@@ -19,7 +19,7 @@
     <relativePath>../tests-pom/</relativePath>
   </parent>
   <artifactId>org.eclipse.jdt.core.tests.performance</artifactId>
-  <version>3.12.100-SNAPSHOT</version>
+  <version>3.12.200-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <properties>
   	<testSuite>${project.artifactId}</testSuite>


### PR DESCRIPTION
## What it does
Bump versions of jdt.core plugins listed in https://download.eclipse.org/eclipse/downloads/drops4/I20231025-1800/buildlogs/reporeports/reports/versionChecks.html "IUs in current repo that increase versions but with qualifier only" section.

## How to test
Build still works and tomorrow's I-build doesn't have any jdt.core bundles listed in that section.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
