### PR TITLE
Grammar use 1 option per line

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/grammar/java.g
+++ b/org.eclipse.jdt.core.compiler.batch/grammar/java.g
@@ -1,7 +1,15 @@
 --main options
-%options ACTION, AN=JavaAction.java, GP=java, 
-%options FILE-PREFIX=java, ESCAPE=$, PREFIX=TokenName, OUTPUT-SIZE=125 ,
-%options NOGOTO-DEFAULT, SINGLE-PRODUCTIONS, LALR=1 , TABLE, 
+%options ACTION
+%options AN=JavaAction.java
+%options GP=java, 
+%options FILE-PREFIX=java
+%options ESCAPE=$
+%options PREFIX=TokenName
+%options OUTPUT-SIZE=125
+%options NOGOTO-DEFAULT
+%options SINGLE-PRODUCTIONS
+%options LALR=1
+%options TABLE
 
 --error recovering options.....
 %options ERROR_MAPS 


### PR DESCRIPTION
jikespg doesn't succeed to properly read multiple options per line locally (maybe because of different default line ending, or encoding). 1 option per line works fine.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test

Regenerate grammar and verify no error is shown by jikespg

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
