### PR TITLE
Add Java 21 holders in JavadocTagConstants

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/JavadocTagConstants.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/JavadocTagConstants.java
@@ -226,6 +226,8 @@ public interface JavadocTagConstants {
 		{},
 		// since 20
 		{},
+		// since 21
+		{}
 	};
 	public static final char[][][] INLINE_TAGS = {
 		// since 1.0
@@ -270,6 +272,8 @@ public interface JavadocTagConstants {
 		{},
 		// since 20
 		{},
+		//since 21
+		{}
 	};
 	public static final char[][][] IN_SNIPPET_TAGS = {
 		//since 18

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/parser/TestAll.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/parser/TestAll.java
@@ -254,6 +254,18 @@ public static TestSuite getTestSuite(boolean addComplianceDiagnoseTest) {
 		TestCase.RUN_ONLY_ID = null;
 		all.addTest(AbstractCompilerTest.buildComplianceTestSuite(ClassFileConstants.getComplianceLevelForJavaVersion(ClassFileConstants.MAJOR_VERSION_19), tests_19));
 	}
+	if ((possibleComplianceLevels & AbstractCompilerTest.F_21) != 0) {
+		ArrayList tests_21 = (ArrayList)testClasses.clone();
+		tests_21.addAll(TEST_CLASSES_1_5);
+		addJava16Tests(tests_21);
+		// Reset forgotten subsets tests
+		TestCase.TESTS_PREFIX = null;
+		TestCase.TESTS_NAMES = null;
+		TestCase.TESTS_NUMBERS= null;
+		TestCase.TESTS_RANGE = null;
+		TestCase.RUN_ONLY_ID = null;
+		all.addTest(AbstractCompilerTest.buildComplianceTestSuite(ClassFileConstants.getComplianceLevelForJavaVersion(ClassFileConstants.MAJOR_VERSION_21), tests_21));
+	}
 	return all;
 }
 


### PR DESCRIPTION
## What it does
Fixes the problem of no tags being considered valid for Java 21 
Reported at https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/879

## How to test
Java 21 projects have completion for javadoc tags.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
