### PR TITLE
Migrate Tests from javax.inject to jakarta.inject annotations

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.tests.compiler/META-INF/MANIFEST.MF
@@ -23,7 +23,7 @@ Require-Bundle: org.junit;bundle-version="3.8.1",
  org.eclipse.core.resources;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.jdt.annotation;bundle-version="[1.1.0,2.0.0)";resolution:=optional,
  org.eclipse.jdt.annotation;bundle-version="[2.0.0,3.0.0)";resolution:=optional
-Import-Package: javax.annotation;version="[1.3.0,2.0.0)",
+Import-Package: jakarta.annotation;version="[2.1.0,3.0.0)",
  org.eclipse.jdt.internal.compiler.apt.dispatch
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Eclipse-BundleShape: dir

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractComparableTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractComparableTest.java
@@ -44,7 +44,7 @@ public class AbstractComparableTest extends AbstractRegressionTest {
 
 	protected static final String JAVAX_INJECT_NAME = "javax/inject/Inject.java";
 	protected static final String JAVAX_INJECT_CONTENT =
-		"package javax.inject;\n" +
+		"package jakarta.inject;\n" +
 		"import static java.lang.annotation.ElementType.*;\n" +
 		"import java.lang.annotation.Retention;\n" +
 		"import static java.lang.annotation.RetentionPolicy.RUNTIME;\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AnnotationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AnnotationTest.java
@@ -10732,7 +10732,7 @@ public void testBug376590a() {
 		JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 }
 // https://bugs.eclipse.org/376590 - Private fields with @Inject are ignored by unused field validation
-// using javax.inject.Inject - slight variation
+// using jakarta.inject.Inject - slight variation
 public void testBug376590b() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.ERROR);
@@ -10744,17 +10744,17 @@ public void testBug376590b() {
 			JAVAX_INJECT_CONTENT,
 			"Example.java",
 			"class Example {\n" +
-			"  private @javax.inject.Inject Object o;\n" +
+			"  private @jakarta.inject.Inject Object o;\n" +
 			"  private Example() {} // also warn here: no @Inject\n" +
 			"  public Example(Object o) { this.o = o; }\n" +
-			"  private @javax.inject.Inject void setO(Object o) { this.o = o;}\n" +
+			"  private @jakarta.inject.Inject void setO(Object o) { this.o = o;}\n" +
 			"}\n"
 		},
 		null, customOptions,
 		"----------\n" +
 		"1. ERROR in Example.java (at line 2)\n" +
-		"	private @javax.inject.Inject Object o;\n" +
-		"	                                    ^\n" +
+		"	private @jakarta.inject.Inject Object o;\n" +
+		"	                                      ^\n" +
 		"The value of the field Example.o is not used\n" +
 		"----------\n" +
 		"2. ERROR in Example.java (at line 3)\n" +
@@ -10765,7 +10765,7 @@ public void testBug376590b() {
 		JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 }
 // https://bugs.eclipse.org/376590 - Private fields with @Inject are ignored by unused field validation
-// using javax.inject.Inject, combined with standard as well as custom annotations
+// using jakarta.inject.Inject, combined with standard as well as custom annotations
 public void testBug376590c() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.ERROR);
@@ -10778,7 +10778,7 @@ public void testBug376590c() {
 			JAVAX_INJECT_NAME,
 			JAVAX_INJECT_CONTENT,
 			"Example.java",
-			"import javax.inject.Inject;\n" +
+			"import jakarta.inject.Inject;\n" +
 			"class Example {\n" +
 			"  private @Inject @p.NonNull Object o; // do warn, annotations don't signal a read\n" +
 			"  private @Deprecated @Inject String old; // do warn, annotations don't signal a read\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullAnnotationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullAnnotationTest.java
@@ -4567,7 +4567,7 @@ public void test_nonnull_field_16() {
 		"----------\n");
 }
 
-// Using javax.inject.Inject, slight variations
+// Using jakarta.inject.Inject, slight variations
 // [compiler] Null analysis for fields does not take @com.google.inject.Inject into account
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=400421
 public void test_nonnull_field_17() {
@@ -4577,7 +4577,7 @@ public void test_nonnull_field_17() {
 			JAVAX_INJECT_CONTENT,
 			"X.java",
 			"import org.eclipse.jdt.annotation.*;\n" +
-			"import javax.inject.Inject;\n" +
+			"import jakarta.inject.Inject;\n" +
 			"public class X {\n" +
 			"    @NonNull @Inject static String s; // warn since injection of static field is less reliable\n" + // variation: static field
 			"    @NonNull @Inject @Deprecated Object o;\n" +
@@ -8764,12 +8764,12 @@ public void testBug418236() {
 }
 public void testBug461878() {
 	Map compilerOptions = getCompilerOptions();
-	compilerOptions.put(JavaCore.COMPILER_NONNULL_ANNOTATION_NAME, "javax.annotation.Nonnull");
+	compilerOptions.put(JavaCore.COMPILER_NONNULL_ANNOTATION_NAME, "jakarta.annotation.Nonnull");
 	runNegativeTest(
 		true, /*flush*/
 		new String[] {
-			"javax/annotation/Nonnull.java",
-			"package javax.annotation;\n" +
+			"jakarta/annotation/Nonnull.java",
+			"package jakarta.annotation;\n" +
 			"import java.lang.annotation.Retention;\n" +
 			"import java.lang.annotation.RetentionPolicy;\n" +
 			"@Retention(RetentionPolicy.RUNTIME)\n" +
@@ -8777,7 +8777,7 @@ public void testBug461878() {
 			"}\n",
 			"edu/umd/cs/findbugs/annotations/PossiblyNull.java",
 			"package edu.umd.cs.findbugs.annotations;\n" +
-			"@javax.annotation.Nonnull // <-- error!!!\n" +
+			"@jakarta.annotation.Nonnull // <-- error!!!\n" +
 			"public @interface PossiblyNull {\n" +
 			"}\n"
 		},
@@ -8785,8 +8785,8 @@ public void testBug461878() {
 		compilerOptions,
 		"----------\n" +
 		"1. WARNING in edu\\umd\\cs\\findbugs\\annotations\\PossiblyNull.java (at line 2)\n" +
-		"	@javax.annotation.Nonnull // <-- error!!!\n" +
-		"	^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
+		"	@jakarta.annotation.Nonnull // <-- error!!!\n" +
+		"	^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
 		"The nullness annotation \'Nonnull\' is not applicable at this location\n" +
 		"----------\n",
 		JavacTestOptions.Excuse.EclipseHasSomeMoreWarnings);


### PR DESCRIPTION
## What it does

The Platform now supports the jakarta-annotations and also starts to migrate from javax to jakarta annotations as part of https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1056.
Therefore it would be good, wherever reasonably doable to migrate the JDT tests as well (the rest of JDT does not seem to use javax.annotations that have been moved to jakarta).

But running a negative test about the accessibility of `jakarta.annotion` for later java versions is of course pointless so I cannot tell if it is possible to fully migrate to jakarta.

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
