### PR TITLE
Add some API filters

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/.settings/.api_filters
+++ b/org.eclipse.jdt.core.compiler.batch/.settings/.api_filters
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<component id="org.eclipse.jdt.core.compiler.batch" version="2">
+    <resource path="src/org/eclipse/jdt/core/compiler/CategorizedProblem.java" type="org.eclipse.jdt.core.compiler.CategorizedProblem">
+        <filter id="576725006">
+            <message_arguments>
+                <message_argument value="IProblem"/>
+                <message_argument value="CategorizedProblem"/>
+            </message_arguments>
+        </filter>
+    </resource>
+</component>


### PR DESCRIPTION
Get rid of some unnecessary warnings saying that some classes illegally use or instantiate `InvalidInputException` and `CategorizedProblem`, the classes are all part of the same plugin group so it's safe to assume that they are allowed to do it.