### PR TITLE
Use the computed JDK home as the cache key

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/util/JRTUtil.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/util/JRTUtil.java
@@ -141,8 +141,8 @@ public class JRTUtil {
 	 * @param release <code>--release</code> version
 	 */
 	public static JrtFileSystem getJrtSystem(File image, String release) throws IOException {
-		String key = image.toString();
 		Jdk jdk = new Jdk(image);
+		String key = jdk.path;
 
 		if (release != null && !jdk.sameRelease(release)) {
 			key = key + "|" + release; //$NON-NLS-1$


### PR DESCRIPTION
The Jdk performs internal normalization of a passed in image but the cache uses the unnormalized value as a key. This can result in the same Jrt indexed multiple times.

This changes the key to always use the normalized value to prevent duplicate caching.

@iloveeclipse @stephan-herrmann this seems as a trivial improvement towards
- https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1526

what currently can even have things cached multiple times.