### PR TITLE
Index implicit record constructors Fix #1519

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchBugs16Tests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchBugs16Tests.java
@@ -660,6 +660,24 @@ public class JavaSearchBugs16Tests extends AbstractJavaSearchTests {
 			deleteProject(testProjectName);
 		}
 	}
+	public void testGH1519_ImplicitRecordConstructors() throws CoreException {
+		String testProjectName = "testGH1519_ImplicitRecordConstructors";
+		try {
+			IJavaProject project = createJava16Project(testProjectName, new String[] {"src"});
+			String packageFolder = "/" + testProjectName + "/src";
+			createFolder(packageFolder);
+			String source = "public record Person (String name, int age) {}";
+			createFile(packageFolder + "/Person.java", source);
+			buildAndExpectNoProblems(project);
+
+			ConstructorDeclarationsCollector requestor = new ConstructorDeclarationsCollector();
+			searchAllConstructorDeclarations("Perso", SearchPattern.R_PREFIX_MATCH, requestor);
+			assertSearchResults(
+					".Person#Person(String name,int age)", requestor);
+		} finally {
+			deleteProject(testProjectName);
+		}
+	}
 
 	/*
 	 * unit test for https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1297

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/compiler/ISourceElementRequestor.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/compiler/ISourceElementRequestor.java
@@ -243,4 +243,12 @@ public interface ISourceElementRequestor {
 	default void exitModule(int declarationEnd) {
 		// do nothing
 	}
+
+	default void enterCompactConstructor(MethodInfo methodInfo) {
+		// do nothing
+	}
+
+	default void exitCompactConstructor(int declarationEnd) {
+		// do nothing
+	}
 }

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/compiler/SourceElementNotifier.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/compiler/SourceElementNotifier.java
@@ -254,8 +254,8 @@ protected void notifySourceElementRequestor(AbstractMethodDeclaration methodDecl
 		this.visitIfNeeded(methodDeclaration);
 		return;
 	}
-	if ((methodDeclaration.bits & org.eclipse.jdt.internal.compiler.ast.ASTNode.IsImplicit) != 0)
-		return;
+
+	final boolean isImplicit = (methodDeclaration.bits & org.eclipse.jdt.internal.compiler.ast.ASTNode.IsImplicit) != 0;
 
 	if (methodDeclaration.isDefaultConstructor()) {
 		if (this.reportReferenceInfo) {
@@ -328,7 +328,11 @@ protected void notifySourceElementRequestor(AbstractMethodDeclaration methodDecl
 			methodInfo.declaringTypeModifiers = declaringType.modifiers;
 			methodInfo.extraFlags = ExtraFlags.getExtraFlags(declaringType);
 			methodInfo.node = methodDeclaration;
-			this.requestor.enterConstructor(methodInfo);
+			if(isImplicit) {
+				this.requestor.enterCompactConstructor(methodInfo);
+			} else {
+				this.requestor.enterConstructor(methodInfo);
+			}
 		}
 		if (this.reportReferenceInfo) {
 			ConstructorDeclaration constructorDeclaration = (ConstructorDeclaration) methodDeclaration;
@@ -353,7 +357,11 @@ protected void notifySourceElementRequestor(AbstractMethodDeclaration methodDecl
 		}
 		this.visitIfNeeded(methodDeclaration);
 		if (isInRange){
-			this.requestor.exitConstructor(methodDeclaration.declarationSourceEnd);
+			if(isImplicit) {
+				this.requestor.exitCompactConstructor(methodDeclaration.declarationSourceEnd);
+			} else {
+				this.requestor.exitConstructor(methodDeclaration.declarationSourceEnd);
+			}
 		}
 		return;
 	}

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/SourceIndexerRequestor.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/SourceIndexerRequestor.java
@@ -534,4 +534,12 @@ public void pushTypeName(char[] typeName) {
 		System.arraycopy(this.enclosingTypeNames, 0, this.enclosingTypeNames = new char[this.depth*2][], 0, this.depth);
 	this.enclosingTypeNames[this.depth++] = typeName;
 }
+@Override
+public void enterCompactConstructor(MethodInfo methodInfo) {
+	this.enterConstructor(methodInfo);
+}
+@Override
+public void exitCompactConstructor(int declarationEnd) {
+	this.exitConstructor(declarationEnd);
+}
 }


### PR DESCRIPTION
## What it does
The change does index implicit record constructors which will provide support for constructor completions on inferred scopes such as `returns` and `var` type variables.

## How to test
- Unit tests
- Test case on the issue

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
