### PR TITLE
Ensure that ECJ does not recommend use of diamond operator if that would lead to compile errors.

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ASTNode.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ASTNode.java
@@ -361,9 +361,9 @@ public abstract class ASTNode implements TypeConstants, TypeIds {
 			if (allocExp.typeExpected == null && !allocExp.expectedTypeWasInferred) {
 				final boolean isDiamond = allocExp.type != null && (allocExp.type.bits & ASTNode.IsDiamond) != 0;
 				allocExp.typeExpected = parameterType;
-				if (!isDiamond && allocExp.resolvedType.isParameterizedTypeWithActualArguments()) {
-					ParameterizedTypeBinding pbinding = (ParameterizedTypeBinding) allocExp.resolvedType;
-					scope.problemReporter().redundantSpecificationOfTypeArguments(allocExp.type, pbinding.arguments);
+				if (!isDiamond && allocExp.type.resolvedType.isParameterizedTypeWithActualArguments()) {
+					ParameterizedTypeBinding ptb = (ParameterizedTypeBinding) allocExp.type.resolvedType;
+					allocExp.reportTypeArgumentRedundancyProblem(ptb, scope);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AllocationExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AllocationExpression.java
@@ -671,7 +671,7 @@ public void checkTypeArgumentRedundancy(ParameterizedTypeBinding allocationType,
 					break;
 			}
 			if (i == allocationType.arguments.length) {
-				scope.problemReporter().redundantSpecificationOfTypeArguments(this.type, allocationType.arguments);
+				reportTypeArgumentRedundancyProblem(allocationType, scope);
 				return;
 			}
 		}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/QualifiedAllocationExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/QualifiedAllocationExpression.java
@@ -696,18 +696,18 @@ public class QualifiedAllocationExpression extends AllocationExpression {
 	}
 	@Override
 	protected void reportTypeArgumentRedundancyProblem(ParameterizedTypeBinding allocationType, final BlockScope scope) {
-		if (checkDiamondOperatorCanbeRemoved(scope)) {
+		if (diamondOperatorCanbeDeployed(scope)) {
 			scope.problemReporter().redundantSpecificationOfTypeArguments(this.type, allocationType.arguments);
 		}
 	}
-	private boolean checkDiamondOperatorCanbeRemoved(final BlockScope scope) {
+	private boolean diamondOperatorCanbeDeployed(final BlockScope scope) {
 		if (this.anonymousType != null &&
 				this.anonymousType.methods != null &&
 				this.anonymousType.methods.length > 0) {
 			//diamond operator is allowed for anonymous types only from java 9
 			if (scope.compilerOptions().complianceLevel < ClassFileConstants.JDK9) return false;
 			for (AbstractMethodDeclaration method : this.anonymousType.methods) {
-				if ( method.binding != null && (method.binding.modifiers & ExtraCompilerModifiers.AccOverriding) == 0)
+				if (method.binding != null && !method.binding.isConstructor() && !method.binding.isPrivate() && (method.binding.modifiers & (ExtraCompilerModifiers.AccOverriding | ExtraCompilerModifiers.AccImplementing)) == 0)
 					return false;
 			}
 		}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
@@ -671,7 +671,7 @@ public void testBug533644() {
 	runner.runConformTest();
 }
 //As All non-private methods of an anonymous class instantiated with '<>' must be treated as being annotated with @override,
-//"Remove redundant type arguments" error should be reported if all the non-private methods defined in the anonymous class
+//"Remove redundant type arguments" diagnostic should be reported ONLY if all the non-private methods defined in the anonymous class
 //are also present in the parent class.
 public void testBug551913_001() {
 	Map<String, String> options = getCompilerOptions();
@@ -696,7 +696,7 @@ public void testBug551913_001() {
 		},"10", options);
 }
 // As All non-private methods of an anonymous class instantiated with '<>' must be treated as being annotated with @override,
-// "Remove redundant type arguments" error should be reported if all the non-private methods defined in the anonymous class
+// "Remove redundant type arguments" diagnostic should be reported ONLY if all the non-private methods defined in the anonymous class
 // are also present in the parent class.
 public void testBug551913_002() {
 	Map<String, String> options = getCompilerOptions();
@@ -720,6 +720,192 @@ public void testBug551913_002() {
 		"	                                            ^^^^^^^\n" +
 		"Redundant specification of type arguments <String>\n" +
 		"----------\n",
+		null, true, options);
+}
+
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1506
+// https://bugs.eclipse.org/bugs/show_bug.cgi?id=551913
+public void testBug551913_003() {
+	Map<String, String> options = getCompilerOptions();
+	options.put(CompilerOptions.OPTION_ReportRedundantSpecificationOfTypeArguments, CompilerOptions.ERROR);
+	this.runNegativeTest(
+		new String[] {
+			"X.java",
+			"public class X {\n" +
+			"	void foo() {\n" +
+			"		java.util.HashSet<String> a = new java.util.HashSet<>();\n" +
+			"		java.util.HashSet<String> b = new java.util.HashSet<String>(a) {\n" +
+			"			private static final long serialVersionUID = 1L;\n" +
+			"			public String toString() {return asString();}\n" +
+			"           private String asString() { return null;}\n" +
+			"		};\n" +
+			"	}\n" +
+			"}",
+		},
+		"----------\n" +
+		"1. ERROR in X.java (at line 4)\n" +
+		"	java.util.HashSet<String> b = new java.util.HashSet<String>(a) {\n" +
+		"	                                            ^^^^^^^\n" +
+		"Redundant specification of type arguments <String>\n" +
+		"----------\n",
+		null, true, options);
+}
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1506
+// https://bugs.eclipse.org/bugs/show_bug.cgi?id=551913
+public void testBug551913_004() {
+	Map<String, String> options = getCompilerOptions();
+	options.put(CompilerOptions.OPTION_ReportRedundantSpecificationOfTypeArguments, CompilerOptions.ERROR);
+	this.runNegativeTest(
+		new String[] {
+			"X.java",
+			"public class X {\n" +
+			"	void foo() {\n" +
+			"		java.util.HashSet<String> a = new java.util.HashSet<>();\n" +
+			"		java.util.HashSet<String> b = new java.util.HashSet<String>(a) {\n" +
+			"			private static final long serialVersionUID = 1L;\n" +
+			"			public String toString() {return asString();}\n" +
+			"           public String asString() { return null;}\n" +
+			"		};\n" +
+			"	}\n" +
+			"}",
+		},
+		"",
+		null, true, options);
+}
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1506
+// Recommendation from compiler to drop type arguments leads to compile error
+public void testGH1506() {
+	Map<String, String> options = getCompilerOptions();
+	options.put(CompilerOptions.OPTION_ReportRedundantSpecificationOfTypeArguments, CompilerOptions.ERROR);
+	this.runNegativeTest(
+		new String[] {
+			"X.java",
+			"import java.io.File;\n" +
+			"import java.util.Arrays;\n" +
+			"import java.util.Iterator;\n" +
+			"\n" +
+			"public class X {\n" +
+			"\n" +
+			"	public Iterable<File> getStackFramesClassesLocations(Object element) {\n" +
+			"		return new Iterable<File>() {\n" +
+			"			@Override\n" +
+			"			public Iterator<File> iterator() {\n" +
+			"				return Arrays.stream(new Object[0]) //\n" +
+			"						.map(frame -> getClassesLocation(frame)) //\n" +
+			"						.iterator();\n" +
+			"			}\n" +
+			"			\n" +
+			"			File getClassesLocation(Object frame) {\n" +
+			"				return null;\n" +
+			"			}\n" +
+			"		};\n" +
+			"	}\n" +
+			"}\n",
+		},
+		"",
+		null, true, options);
+}
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1506
+// Recommendation from compiler to drop type arguments leads to compile error
+public void testGH1506_2() {
+	Map<String, String> options = getCompilerOptions();
+	options.put(CompilerOptions.OPTION_ReportRedundantSpecificationOfTypeArguments, CompilerOptions.ERROR);
+	this.runNegativeTest(
+		new String[] {
+			"X.java",
+			"import java.io.File;\n" +
+			"import java.util.Arrays;\n" +
+			"import java.util.Iterator;\n" +
+			"\n" +
+			"public class X {\n" +
+			"\n" +
+			"	public Iterable<File> getStackFramesClassesLocations(Object element) {\n" +
+			"		return new Iterable<File>() {\n" +
+			"			@Override\n" +
+			"			public Iterator<File> iterator() {\n" +
+			"				return Arrays.stream(new Object[0]) //\n" +
+			"						.map(frame -> getClassesLocation(frame)) //\n" +
+			"						.iterator();\n" +
+			"			}\n" +
+			"			\n" +
+			"			private File getClassesLocation(Object frame) {\n" +
+			"				return null;\n" +
+			"			}\n" +
+			"		};\n" +
+			"	}\n" +
+			"}\n",
+		},
+		"----------\n"
+		+ "1. ERROR in X.java (at line 8)\n"
+		+ "	return new Iterable<File>() {\n"
+		+ "	           ^^^^^^^^\n"
+		+ "Redundant specification of type arguments <File>\n"
+		+ "----------\n",
+		null, true, options);
+}
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1506
+// Recommendation from compiler to drop type arguments leads to compile error
+public void testGH1506_3() {
+	Map<String, String> options = getCompilerOptions();
+	options.put(CompilerOptions.OPTION_ReportRedundantSpecificationOfTypeArguments, CompilerOptions.ERROR);
+	this.runNegativeTest(
+		new String[] {
+			"X.java",
+			"public class X<E> {\n" +
+			"    static class AX<T>{}\n" +
+			"    X(E e) {}\n" +
+			"    X() {}\n" +
+			"    public static void main(String[] args) {\n" +
+			"    	X<? extends AX> x5 = new X<AX<String>>(new AX<String>() { private void foo() {} });\n" +
+			"	}\n" +
+			"} \n",
+		},
+		"----------\n"
+		+ "1. WARNING in X.java (at line 6)\n"
+		+ "	X<? extends AX> x5 = new X<AX<String>>(new AX<String>() { private void foo() {} });\n"
+		+ "	            ^^\n"
+		+ "X.AX is a raw type. References to generic type X.AX<T> should be parameterized\n"
+		+ "----------\n"
+		+ "2. ERROR in X.java (at line 6)\n"
+		+ "	X<? extends AX> x5 = new X<AX<String>>(new AX<String>() { private void foo() {} });\n"
+		+ "	                                           ^^\n"
+		+ "Redundant specification of type arguments <String>\n"
+		+ "----------\n"
+		+ "3. WARNING in X.java (at line 6)\n"
+		+ "	X<? extends AX> x5 = new X<AX<String>>(new AX<String>() { private void foo() {} });\n"
+		+ "	                                                                       ^^^^^\n"
+		+ "The method foo() from the type new X.AX<String>(){} is never used locally\n"
+		+ "----------\n",
+		null, true, options);
+}
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1506
+// Recommendation from compiler to drop type arguments leads to compile error
+public void testGH1506_4() {
+	Map<String, String> options = getCompilerOptions();
+	options.put(CompilerOptions.OPTION_ReportRedundantSpecificationOfTypeArguments, CompilerOptions.ERROR);
+	this.runNegativeTest(
+		new String[] {
+			"X.java",
+			"public class X<E> {\n" +
+			"    static class AX<T>{}\n" +
+			"    X(E e) {}\n" +
+			"    X() {}\n" +
+			"    public static void main(String[] args) {\n" +
+			"    	X<? extends AX> x5 = new X<AX<String>>(new AX<String>() { public void foo() {} });\n" +
+			"	}\n" +
+			"} \n",
+		},
+		"----------\n"
+		+ "1. WARNING in X.java (at line 6)\n"
+		+ "	X<? extends AX> x5 = new X<AX<String>>(new AX<String>() { public void foo() {} });\n"
+		+ "	            ^^\n"
+		+ "X.AX is a raw type. References to generic type X.AX<T> should be parameterized\n"
+		+ "----------\n"
+		+ "2. WARNING in X.java (at line 6)\n"
+		+ "	X<? extends AX> x5 = new X<AX<String>>(new AX<String>() { public void foo() {} });\n"
+		+ "	                                                                      ^^^^^\n"
+		+ "The method foo() from the type new X.AX<String>(){} is never used locally\n"
+		+ "----------\n",
 		null, true, options);
 }
 public static Class<GenericsRegressionTest_9> testClass() {


### PR DESCRIPTION

## What it does
JLS 15.9.5 requires that where an anonymous class is instantiated with <>, all its non-private methods be treated as though they were annotated with @override. As a result where that is not the case, ECJ should not recommend the use of <> operator. Fix ECJ's behavior to ensure that its recommendations to use <> operator does not lead to a subsequent compiler error.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1506

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
