### PR TITLE
InvalidInputException: fix "illegally instantiates" warnings

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/IntersectionTypeBinding18.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/IntersectionTypeBinding18.java
@@ -25,7 +25,6 @@ package org.eclipse.jdt.internal.compiler.lookup;
 
 import java.util.Set;
 
-import org.eclipse.jdt.core.compiler.InvalidInputException;
 import org.eclipse.jdt.internal.compiler.ast.Wildcard;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 
@@ -69,7 +68,7 @@ public class IntersectionTypeBinding18 extends ReferenceBinding {
 	}
 
 	@Override
-	protected MethodBinding[] getInterfaceAbstractContracts(Scope scope, boolean replaceWildcards, boolean filterDefaultMethods) throws InvalidInputException {
+	protected MethodBinding[] getInterfaceAbstractContracts(Scope scope, boolean replaceWildcards, boolean filterDefaultMethods) throws InvalidBindingException {
 		int typesLength = this.intersectingTypes.length;
 		MethodBinding[][] methods = new MethodBinding[typesLength][];
 		int contractsLength = 0;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedTypeBinding.java
@@ -53,7 +53,6 @@ import java.util.List;
 import java.util.Set;
 
 import org.eclipse.jdt.core.compiler.CharOperation;
-import org.eclipse.jdt.core.compiler.InvalidInputException;
 import org.eclipse.jdt.internal.compiler.ast.ASTNode;
 import org.eclipse.jdt.internal.compiler.ast.NullAnnotationMatching;
 import org.eclipse.jdt.internal.compiler.ast.ParameterizedSingleTypeReference;
@@ -1702,7 +1701,7 @@ public class ParameterizedTypeBinding extends ReferenceBinding implements Substi
 	}
 
 	@Override
-	protected MethodBinding[] getInterfaceAbstractContracts(Scope scope, boolean replaceWildcards, boolean filterDefaultMethods) throws InvalidInputException {
+	protected MethodBinding[] getInterfaceAbstractContracts(Scope scope, boolean replaceWildcards, boolean filterDefaultMethods) throws InvalidBindingException {
 		if (replaceWildcards) {
 			TypeBinding[] types = getNonWildcardParameters(scope);
 			if (types == null)

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
@@ -56,7 +56,6 @@ import java.util.Arrays;
 import java.util.Comparator;
 
 import org.eclipse.jdt.core.compiler.CharOperation;
-import org.eclipse.jdt.core.compiler.InvalidInputException;
 import org.eclipse.jdt.internal.compiler.ast.LambdaExpression;
 import org.eclipse.jdt.internal.compiler.ast.MethodDeclaration;
 import org.eclipse.jdt.internal.compiler.ast.NullAnnotationMatching;
@@ -2221,10 +2220,10 @@ protected int applyCloseableInterfaceWhitelists() {
 	return 0;
 }
 
-protected MethodBinding [] getInterfaceAbstractContracts(Scope scope, boolean replaceWildcards, boolean filterDefaultMethods) throws InvalidInputException {
+protected MethodBinding [] getInterfaceAbstractContracts(Scope scope, boolean replaceWildcards, boolean filterDefaultMethods) throws InvalidBindingException {
 
 	if (!isInterface() || !isValidBinding()) {
-		throw new InvalidInputException("Not a functional interface"); //$NON-NLS-1$
+		throw new InvalidBindingException("Not a functional interface"); //$NON-NLS-1$
 	}
 
 	MethodBinding [] methods = methods();
@@ -2251,7 +2250,7 @@ protected MethodBinding [] getInterfaceAbstractContracts(Scope scope, boolean re
 		if (method == null || method.isStatic() || method.redeclaresPublicObjectMethod(scope) || method.isPrivate())
 			continue;
 		if (!method.isValidBinding())
-			throw new InvalidInputException("Not a functional interface"); //$NON-NLS-1$
+			throw new InvalidBindingException("Not a functional interface"); //$NON-NLS-1$
 		for (int j = 0; j < contractsCount;) {
 			if ( contracts[j] != null && MethodVerifier.doesMethodOverride(method, contracts[j], environment)) {
 				contractsCount--;
@@ -2344,7 +2343,7 @@ public MethodBinding getSingleAbstractMethod(Scope scope, boolean replaceWildcar
 					return this.singleAbstractMethod[index] = samProblemBinding;
 			}
 		}
-	} catch (InvalidInputException e) {
+	} catch (InvalidBindingException e) {
 		return this.singleAbstractMethod[index] = samProblemBinding;
 	}
 	if (methods.length == 1)
@@ -2491,5 +2490,12 @@ public boolean hasEnclosingInstanceContext() {
 	if (enclosingMethod != null)
 		return !enclosingMethod.isStatic();
 	return false;
+}
+static class InvalidBindingException extends Exception {
+	private static final long serialVersionUID = 1L;
+
+	InvalidBindingException(String message) {
+		super(message);
+	}
 }
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/AbstractCommentParser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/AbstractCommentParser.java
@@ -683,7 +683,7 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 			}
 
 			// Something wrong happened => Invalid input
-			throw new InvalidInputException();
+			throw Scanner.invalidInput();
 		} finally {
 			// we have to make sure that this is reset to the previous value even if an exception occurs
 			this.scanner.tokenizeWhiteSpace = tokenWhiteSpace;
@@ -1175,11 +1175,11 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 					break;
 
 				case TerminalTokens.TokenNameRestrictedIdentifierYield:
-					throw new InvalidInputException(); // unexpected.
+					throw Scanner.invalidInput(); // unexpected.
 
 				case TerminalTokens.TokenNameDOT :
 					if ((iToken & 1) == 0) { // dots must be even tokens
-						throw new InvalidInputException();
+						throw Scanner.invalidInput();
 					}
 					consumeToken();
 					break;
@@ -1246,7 +1246,7 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 				case TerminalTokens.TokenNameDIVIDE:
 					if (parsingJava15Plus && lookForModule) {
 						if (((iToken & 1) == 0) || (moduleRefTokenCount > 0)) { // '/' must be even token
-							throw new InvalidInputException();
+							throw Scanner.invalidInput();
 						}
 						moduleRefTokenCount = (iToken+1) / 2;
 						consumeToken();
@@ -1284,7 +1284,7 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 								}
 								// $FALL-THROUGH$ - fall through default case to raise exception
 							default:
-								throw new InvalidInputException();
+								throw Scanner.invalidInput();
 						}
 					}
 					break nextToken;
@@ -1505,7 +1505,7 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 		boolean parsingJava18Plus = this.scanner != null ? this.scanner.sourceLevel >= ClassFileConstants.JDK18 : false;
 		boolean valid = true;
 		if (!parsingJava18Plus) {
-			throw new InvalidInputException();
+			throw Scanner.invalidInput();
 		}
 		Object snippetTag = null;
 		this.nonRegionTagCount = 0;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/JavadocParser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/JavadocParser.java
@@ -201,7 +201,7 @@ public class JavadocParser extends AbstractCommentParser {
 			return new JavadocArgumentExpression(name, argTypeRef.sourceStart, argEnd, argTypeRef);
 		}
 		catch (ClassCastException ex) {
-			throw new InvalidInputException();
+			throw Scanner.invalidInput();
 		}
 	}
 
@@ -233,7 +233,7 @@ public class JavadocParser extends AbstractCommentParser {
 			return field;
 		}
 		catch (ClassCastException ex) {
-			throw new InvalidInputException();
+			throw Scanner.invalidInput();
 		}
 	}
 
@@ -284,7 +284,7 @@ public class JavadocParser extends AbstractCommentParser {
 						}
 					}
 				} else {
-					throw new InvalidInputException();
+					throw Scanner.invalidInput();
 				}
 			}
 			// Create node
@@ -336,7 +336,7 @@ public class JavadocParser extends AbstractCommentParser {
 			}
 		}
 		catch (ClassCastException ex) {
-			throw new InvalidInputException();
+			throw Scanner.invalidInput();
 		}
 	}
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/JavadocScanner.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/JavadocScanner.java
@@ -19,9 +19,9 @@ import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 public class JavadocScanner extends Scanner{
 
 	public boolean tokenizeSingleQuotes = false;
-	
+
 	public boolean considerRegexInStringLiteral = false;
-	
+
 	public JavadocScanner() {
 		this(false /*comment*/, false /*whitespace*/, false /*nls*/, ClassFileConstants.JDK1_3 /*sourceLevel*/, null/*taskTag*/, null/*taskPriorities*/, true /*taskCaseSensitive*/);
 	}
@@ -71,7 +71,7 @@ public class JavadocScanner extends Scanner{
 			taskPriorities,
 			isTaskCaseSensitive,
 			isPreviewEnabled);
-		
+
 	}
 
 	public JavadocScanner(
@@ -94,7 +94,7 @@ public class JavadocScanner extends Scanner{
 			isTaskCaseSensitive,
 			false);
 	}
-	
+
 	public JavadocScanner(
 			boolean tokenizeComments,
 			boolean tokenizeWhiteSpace,
@@ -144,7 +144,7 @@ public class JavadocScanner extends Scanner{
 				while (this.currentCharacter != '"') {
 					boolean isRegex = false;
 					if (this.currentPosition >= this.eofPosition) {
-						throw new InvalidInputException(UNTERMINATED_STRING);
+						throw unterminatedString();
 					}
 					/**** \r and \n are not valid in string literals ****/
 					if ((this.currentCharacter == '\n') || (this.currentCharacter == '\r')) {
@@ -167,13 +167,13 @@ public class JavadocScanner extends Scanner{
 									break;
 								}
 								if (this.currentCharacter == '\"') {
-									throw new InvalidInputException(INVALID_CHAR_IN_STRING);
+									throw invalidCharInString();
 								}
 							}
 						} else {
 							this.currentPosition--; // set current position on new line character
 						}
-						throw new InvalidInputException(INVALID_CHAR_IN_STRING);
+						throw invalidCharInString();
 					}
 					if (this.currentCharacter == '\\') {
 						if (this.unicodeAsBackSlash) {
@@ -225,7 +225,7 @@ public class JavadocScanner extends Scanner{
 				}
 			} catch (IndexOutOfBoundsException e) {
 				this.currentPosition--;
-				throw new InvalidInputException(UNTERMINATED_STRING);
+				throw unterminatedString();
 			} catch (InvalidInputException e) {
 				if (e.getMessage().equals(INVALID_ESCAPE)) {
 					// relocate if finding another quote fairly close: thus unicode '/u000D' will be fully consumed
@@ -246,9 +246,9 @@ public class JavadocScanner extends Scanner{
 			return TokenNameStringLiteral;
 		} else {
 			return super.scanForStringLiteral();
-		}		
+		}
 	}
-	
+
 	@Override
 	protected int processSingleQuotes(boolean checkIfUnicode) throws InvalidInputException{
 		if (this.tokenizeSingleQuotes) {
@@ -278,7 +278,7 @@ public class JavadocScanner extends Scanner{
 			while (this.currentCharacter != '\'') {
 				boolean isRegex = false;
 				if (this.currentPosition >= this.eofPosition) {
-					throw new InvalidInputException(UNTERMINATED_STRING);
+					throw unterminatedString();
 				}
 				/**** \r and \n are not valid in string literals ****/
 				if ((this.currentCharacter == '\n') || (this.currentCharacter == '\r')) {
@@ -301,13 +301,13 @@ public class JavadocScanner extends Scanner{
 								break;
 							}
 							if (this.currentCharacter == '\'') {
-								throw new InvalidInputException(INVALID_CHAR_IN_STRING);
+								throw invalidCharInString();
 							}
 						}
 					} else {
 						this.currentPosition--; // set current position on new line character
 					}
-					throw new InvalidInputException(INVALID_CHAR_IN_STRING);
+					throw invalidCharInString();
 				}
 				if (this.currentCharacter == '\\') {
 					if (this.unicodeAsBackSlash) {
@@ -361,7 +361,7 @@ public class JavadocScanner extends Scanner{
 			}
 		} catch (IndexOutOfBoundsException e) {
 			this.currentPosition--;
-			throw new InvalidInputException(UNTERMINATED_STRING);
+			throw unterminatedString();
 		} catch (InvalidInputException e) {
 			if (e.getMessage().equals(INVALID_ESCAPE)) {
 				// relocate if finding another quote fairly close: thus unicode '/u000D' will be fully consumed
@@ -379,7 +379,7 @@ public class JavadocScanner extends Scanner{
 			}
 			throw e; // rethrow
 		}
-		return TokenNameSingleQuoteStringLiteral;		
+		return TokenNameSingleQuoteStringLiteral;
 	}
 
 	protected boolean scanRegexCharacter() {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Scanner.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Scanner.java
@@ -1038,16 +1038,17 @@ private final void consumeDigits(int radix, boolean expectingDigitFirst) throws 
 	switch(consumeDigits0(radix, USING_UNDERSCORE, INVALID_POSITION, expectingDigitFirst)) {
 		case USING_UNDERSCORE :
 			if (this.sourceLevel < ClassFileConstants.JDK1_7) {
-				throw new InvalidInputException(UNDERSCORES_IN_LITERALS_NOT_BELOW_17);
+				throw invalidUnderscoresInLiterals();
 			}
 			break;
 		case INVALID_POSITION :
 			if (this.sourceLevel < ClassFileConstants.JDK1_7) {
-				throw new InvalidInputException(UNDERSCORES_IN_LITERALS_NOT_BELOW_17);
+				throw invalidUnderscoresInLiterals();
 			}
-			throw new InvalidInputException(INVALID_UNDERSCORE);
+			throw invalidUnderscore();
 	}
 }
+
 private final int consumeDigits0(int radix, int usingUnderscore, int invalidPosition, boolean expectingDigitFirst) throws InvalidInputException {
 	int kind = 0;
 	if (getNextChar('_')) {
@@ -1370,20 +1371,20 @@ public int scanIdentifier() throws InvalidInputException {
 		boolean isJavaIdStart;
 		if (c >= HIGH_SURROGATE_MIN_VALUE && c <= HIGH_SURROGATE_MAX_VALUE) {
 			if (this.complianceLevel < ClassFileConstants.JDK1_5) {
-				throw new InvalidInputException(INVALID_UNICODE_ESCAPE);
+				throw invalidUnicodeEscape();
 			}
 			// Unicode 4 detection
 			char low = (char) getNextCharWithBoundChecks();
 			if (low < LOW_SURROGATE_MIN_VALUE || low > LOW_SURROGATE_MAX_VALUE) {
 				// illegal low surrogate
-				throw new InvalidInputException(INVALID_LOW_SURROGATE);
+				throw invalidLowSurrogate();
 			}
 			isJavaIdStart = ScannerHelper.isJavaIdentifierStart(this.complianceLevel, c, low);
 		} else if (c >= LOW_SURROGATE_MIN_VALUE && c <= LOW_SURROGATE_MAX_VALUE) {
 			if (this.complianceLevel < ClassFileConstants.JDK1_5) {
-				throw new InvalidInputException(INVALID_UNICODE_ESCAPE);
+				throw invalidUnicodeEscape();
 			}
-			throw new InvalidInputException(INVALID_HIGH_SURROGATE);
+			throw invalidHighSurrogate();
 		} else {
 			// optimized case already checked
 			isJavaIdStart = ScannerHelper.isJavaIdentifierStart(this.complianceLevel, c);
@@ -1828,7 +1829,7 @@ protected int getNextToken0() throws InvalidInputException {
 								int firstTag = 0;
 								while ((this.currentCharacter != '/') || (!star)) {
 									if (this.currentPosition >= this.eofPosition) {
-										throw new InvalidInputException(UNTERMINATED_COMMENT);
+										throw unterminatedComment();
 									}
 									if ((this.currentCharacter == '\r') || (this.currentCharacter == '\n')) {
 										if (this.recordLineSeparator) {
@@ -1881,7 +1882,7 @@ protected int getNextToken0() throws InvalidInputException {
 								}
 							} catch (IndexOutOfBoundsException e) {
 								this.currentPosition--;
-								throw new InvalidInputException(UNTERMINATED_COMMENT);
+								throw unterminatedComment();
 							}
 							break;
 						}
@@ -1893,7 +1894,7 @@ protected int getNextToken0() throws InvalidInputException {
 					if (atEnd())
 						return TokenNameEOF;
 					//the atEnd may not be <currentPosition == source.length> if source is only some part of a real (external) stream
-					throw new InvalidInputException("Ctrl-Z"); //$NON-NLS-1$
+					throw invalidEof();
 				default :
 					char c = this.currentCharacter;
 					if (c < ScannerHelper.MAX_OBVIOUS) {
@@ -1908,21 +1909,21 @@ protected int getNextToken0() throws InvalidInputException {
 					boolean isJavaIdStart;
 					if (c >= HIGH_SURROGATE_MIN_VALUE && c <= HIGH_SURROGATE_MAX_VALUE) {
 						if (this.complianceLevel < ClassFileConstants.JDK1_5) {
-							throw new InvalidInputException(INVALID_UNICODE_ESCAPE);
+							throw invalidUnicodeEscape();
 						}
 						// Unicode 4 detection
 						char low = (char) getNextChar();
 						if (low < LOW_SURROGATE_MIN_VALUE || low > LOW_SURROGATE_MAX_VALUE) {
 							// illegal low surrogate
-							throw new InvalidInputException(INVALID_LOW_SURROGATE);
+							throw invalidLowSurrogate();
 						}
 						isJavaIdStart = ScannerHelper.isJavaIdentifierStart(this.complianceLevel, c, low);
 					}
 					else if (c >= LOW_SURROGATE_MIN_VALUE && c <= LOW_SURROGATE_MAX_VALUE) {
 						if (this.complianceLevel < ClassFileConstants.JDK1_5) {
-							throw new InvalidInputException(INVALID_UNICODE_ESCAPE);
+							throw invalidUnicodeEscape();
 						}
-						throw new InvalidInputException(INVALID_HIGH_SURROGATE);
+						throw invalidHighSurrogate();
 					} else {
 						// optimized case already checked
 						isJavaIdStart = ScannerHelper.isJavaIdentifierStart(this.complianceLevel, c);
@@ -1950,7 +1951,7 @@ protected int processSingleQuotes(boolean checkIfUnicode) throws InvalidInputExc
 	{
 		int test;
 		if ((test = getNextChar('\n', '\r')) == 0) {
-			throw new InvalidInputException(INVALID_CHARACTER_CONSTANT);
+			throw invalidCharacter();
 		}
 		if (test > 0) {
 			// relocate if finding another quote fairly close: thus unicode '/u000D' will be fully consumed
@@ -1964,7 +1965,7 @@ protected int processSingleQuotes(boolean checkIfUnicode) throws InvalidInputExc
 					break;
 				}
 			}
-			throw new InvalidInputException(INVALID_CHARACTER_CONSTANT);
+			throw invalidCharacter();
 		}
 	}
 	if (getNextChar('\'')) {
@@ -1979,7 +1980,7 @@ protected int processSingleQuotes(boolean checkIfUnicode) throws InvalidInputExc
 				break;
 			}
 		}
-		throw new InvalidInputException(INVALID_CHARACTER_CONSTANT);
+		throw invalidCharacter();
 	}
 	if (getNextChar('\\')) {
 		if (this.unicodeAsBackSlash) {
@@ -2004,7 +2005,7 @@ protected int processSingleQuotes(boolean checkIfUnicode) throws InvalidInputExc
 			&& (this.source[this.currentPosition] == 'u');
 		} catch(IndexOutOfBoundsException e) {
 			this.currentPosition--;
-			throw new InvalidInputException(INVALID_CHARACTER_CONSTANT);
+			throw invalidCharacter();
 		}
 		if (checkIfUnicode) {
 			getNextUnicodeChar();
@@ -2027,7 +2028,7 @@ protected int processSingleQuotes(boolean checkIfUnicode) throws InvalidInputExc
 			break;
 		}
 	}
-	throw new InvalidInputException(INVALID_CHARACTER_CONSTANT);
+	throw invalidCharacter();
 }
 protected int scanForStringLiteral() throws InvalidInputException {
 	boolean isTextBlock = false;
@@ -2055,7 +2056,7 @@ protected int scanForStringLiteral() throws InvalidInputException {
 
 			while (this.currentCharacter != '"') {
 				if (this.currentPosition >= this.eofPosition) {
-					throw new InvalidInputException(UNTERMINATED_STRING);
+					throw unterminatedString();
 				}
 				/**** \r and \n are not valid in string literals ****/
 				if ((this.currentCharacter == '\n') || (this.currentCharacter == '\r')) {
@@ -2078,13 +2079,13 @@ protected int scanForStringLiteral() throws InvalidInputException {
 								break;
 							}
 							if (this.currentCharacter == '\"') {
-								throw new InvalidInputException(INVALID_CHAR_IN_STRING);
+								throw invalidCharInString();
 							}
 						}
 					} else {
 						this.currentPosition--; // set current position on new line character
 					}
-					throw new InvalidInputException(INVALID_CHAR_IN_STRING);
+					throw invalidCharInString();
 				}
 				if (this.currentCharacter == '\\') {
 					if (this.unicodeAsBackSlash) {
@@ -2127,7 +2128,7 @@ protected int scanForStringLiteral() throws InvalidInputException {
 			}
 		} catch (IndexOutOfBoundsException e) {
 			this.currentPosition--;
-			throw new InvalidInputException(UNTERMINATED_STRING);
+			throw unterminatedString();
 		} catch (InvalidInputException e) {
 			if (e.getMessage().equals(INVALID_ESCAPE)) {
 				// relocate if finding another quote fairly close: thus unicode '/u000D' will be fully consumed
@@ -2243,10 +2244,10 @@ protected int scanForTextBlock() throws InvalidInputException {
 		if (lastQuotePos > 0)
 			this.currentPosition = lastQuotePos;
 		this.currentPosition = (lastQuotePos > 0) ? lastQuotePos : this.startPosition + this.rawStart;
-		throw new InvalidInputException(UNTERMINATED_TEXT_BLOCK);
+		throw unterminatedTextBlock();
 	} catch (IndexOutOfBoundsException e) {
 		this.currentPosition = (lastQuotePos > 0) ? lastQuotePos : this.startPosition + this.rawStart;
-		throw new InvalidInputException(UNTERMINATED_TEXT_BLOCK);
+		throw unterminatedTextBlock();
 	}
 }
 public void getNextUnicodeChar()
@@ -2265,18 +2266,18 @@ public void getNextUnicodeChar()
 			this.currentPosition++;
 			if (this.currentPosition >= this.eofPosition) {
 				this.currentPosition--;
-				throw new InvalidInputException(INVALID_UNICODE_ESCAPE);
+				throw invalidUnicodeEscape();
 			}
 			unicodeSize++;
 		}
 	} else {
 		this.currentPosition--;
-		throw new InvalidInputException(INVALID_UNICODE_ESCAPE);
+		throw invalidUnicodeEscape();
 	}
 
 	if ((this.currentPosition + 4) > this.eofPosition) {
 		this.currentPosition += (this.eofPosition - this.currentPosition);
-		throw new InvalidInputException(INVALID_UNICODE_ESCAPE);
+		throw invalidUnicodeEscape();
 	}
 	if ((c1 = ScannerHelper.getHexadecimalValue(this.source[this.currentPosition++])) > 15
     		|| c1 < 0
@@ -2286,7 +2287,7 @@ public void getNextUnicodeChar()
     		|| c3 < 0
     		|| (c4 = ScannerHelper.getHexadecimalValue(this.source[this.currentPosition++])) > 15
     		|| c4 < 0){
-		throw new InvalidInputException(INVALID_UNICODE_ESCAPE);
+		throw invalidUnicodeEscape();
 	}
 	this.currentCharacter = (char) (((c1 * 16 + c2) * 16 + c3) * 16 + c4);
 	//need the unicode buffer
@@ -2698,7 +2699,7 @@ public final void jumpOverMethodBody() {
 						boolean isJavaIdStart;
 						if (c >= HIGH_SURROGATE_MIN_VALUE && c <= HIGH_SURROGATE_MAX_VALUE) {
 							if (this.complianceLevel < ClassFileConstants.JDK1_5) {
-								throw new InvalidInputException(INVALID_UNICODE_ESCAPE);
+								throw invalidUnicodeEscape();
 							}
 							// Unicode 4 detection
 							char low = (char) getNextChar();
@@ -3095,7 +3096,7 @@ protected final void scanEscapeCharacter() throws InvalidInputException {
 			break;
 		case 's' :
 			if (this.sourceLevel < ClassFileConstants.JDK15) {
-				throw new InvalidInputException(INVALID_ESCAPE);
+				throw invalidEscape();
 			}
 			this.currentCharacter = ' ';
 			break;
@@ -3136,12 +3137,13 @@ protected final void scanEscapeCharacter() throws InvalidInputException {
 					this.currentPosition--;
 				}
 				if (number > 255)
-					throw new InvalidInputException(INVALID_ESCAPE);
+					throw invalidEscape();
 				this.currentCharacter = (char) number;
 			} else
-				throw new InvalidInputException(INVALID_ESCAPE);
+				throw invalidEscape();
 	}
 }
+
 public int scanIdentifierOrKeywordWithBoundCheck() {
 	//test keywords
 
@@ -3989,7 +3991,7 @@ public int scanNumber(boolean dotPrefix) throws InvalidInputException {
 			int end = this.currentPosition;
 			if (getNextChar('l', 'L') >= 0) {
 				if (end == start) {
-					throw new InvalidInputException(INVALID_HEXA);
+					throw invalidHexa();
 				}
 				return TokenNameLongLiteral;
 			} else if (getNextChar('.')) {
@@ -4001,9 +4003,9 @@ public int scanNumber(boolean dotPrefix) throws InvalidInputException {
 				end = this.currentPosition;
 				if (hasNoDigitsBeforeDot && end == start) {
 					if (this.sourceLevel < ClassFileConstants.JDK1_5) {
-						throw new InvalidInputException(ILLEGAL_HEXA_LITERAL);
+						throw illegalHexaLiteral();
 					}
-					throw new InvalidInputException(INVALID_HEXA);
+					throw invalidHexa();
 				}
 
 				if (getNextChar('p', 'P') >= 0) { // consume next character
@@ -4031,50 +4033,50 @@ public int scanNumber(boolean dotPrefix) throws InvalidInputException {
 					}
 					if (!ScannerHelper.isDigit(this.currentCharacter)) {
 						if (this.sourceLevel < ClassFileConstants.JDK1_5) {
-							throw new InvalidInputException(ILLEGAL_HEXA_LITERAL);
+							throw illegalHexaLiteral();
 						}
 						if (this.currentCharacter == '_') {
 							// wrongly place '_'
 							consumeDigits(10);
-							throw new InvalidInputException(INVALID_UNDERSCORE);
+							throw invalidUnderscore();
 						}
-						throw new InvalidInputException(INVALID_HEXA);
+						throw invalidHexa();
 					}
 					consumeDigits(10);
 					if (getNextChar('f', 'F') >= 0) {
 						if (this.sourceLevel < ClassFileConstants.JDK1_5) {
-							throw new InvalidInputException(ILLEGAL_HEXA_LITERAL);
+							throw illegalHexaLiteral();
 						}
 						return TokenNameFloatingPointLiteral;
 					}
 					if (getNextChar('d', 'D') >= 0) {
 						if (this.sourceLevel < ClassFileConstants.JDK1_5) {
-							throw new InvalidInputException(ILLEGAL_HEXA_LITERAL);
+							throw illegalHexaLiteral();
 						}
 						return TokenNameDoubleLiteral;
 					}
 					if (getNextChar('l', 'L') >= 0) {
 						if (this.sourceLevel < ClassFileConstants.JDK1_5) {
-							throw new InvalidInputException(ILLEGAL_HEXA_LITERAL);
+							throw illegalHexaLiteral();
 						}
-						throw new InvalidInputException(INVALID_HEXA);
+						throw invalidHexa();
 					}
 					if (this.sourceLevel < ClassFileConstants.JDK1_5) {
-						throw new InvalidInputException(ILLEGAL_HEXA_LITERAL);
+						throw illegalHexaLiteral();
 					}
 					return TokenNameDoubleLiteral;
 				} else {
 					if (this.sourceLevel < ClassFileConstants.JDK1_5) {
-						throw new InvalidInputException(ILLEGAL_HEXA_LITERAL);
+						throw illegalHexaLiteral();
 					}
-					throw new InvalidInputException(INVALID_HEXA);
+					throw invalidHexa();
 				}
 			} else if (getNextChar('p', 'P') >= 0) { // consume next character
 				if (end == start) { // Has no digits before exponent
 					if (this.sourceLevel < ClassFileConstants.JDK1_5) {
-						throw new InvalidInputException(ILLEGAL_HEXA_LITERAL);
+						throw illegalHexaLiteral();
 					}
-					throw new InvalidInputException(INVALID_HEXA);
+					throw invalidHexa();
 				}
 				this.unicodeAsBackSlash = false;
 				if (((this.currentCharacter = this.source[this.currentPosition++]) == '\\')
@@ -4100,41 +4102,41 @@ public int scanNumber(boolean dotPrefix) throws InvalidInputException {
 				}
 				if (!ScannerHelper.isDigit(this.currentCharacter)) {
 					if (this.sourceLevel < ClassFileConstants.JDK1_5) {
-						throw new InvalidInputException(ILLEGAL_HEXA_LITERAL);
+						throw illegalHexaLiteral();
 					}
 					if (this.currentCharacter == '_') {
 						// wrongly place '_'
 						consumeDigits(10);
-						throw new InvalidInputException(INVALID_UNDERSCORE);
+						throw invalidUnderscore();
 					}
-					throw new InvalidInputException(INVALID_FLOAT);
+					throw invalidFloat();
 				}
 				consumeDigits(10);
 				if (getNextChar('f', 'F') >= 0) {
 					if (this.sourceLevel < ClassFileConstants.JDK1_5) {
-						throw new InvalidInputException(ILLEGAL_HEXA_LITERAL);
+						throw illegalHexaLiteral();
 					}
 					return TokenNameFloatingPointLiteral;
 				}
 				if (getNextChar('d', 'D') >= 0) {
 					if (this.sourceLevel < ClassFileConstants.JDK1_5) {
-						throw new InvalidInputException(ILLEGAL_HEXA_LITERAL);
+						throw illegalHexaLiteral();
 					}
 					return TokenNameDoubleLiteral;
 				}
 				if (getNextChar('l', 'L') >= 0) {
 					if (this.sourceLevel < ClassFileConstants.JDK1_5) {
-						throw new InvalidInputException(ILLEGAL_HEXA_LITERAL);
+						throw illegalHexaLiteral();
 					}
-					throw new InvalidInputException(INVALID_HEXA);
+					throw invalidHexa();
 				}
 				if (this.sourceLevel < ClassFileConstants.JDK1_5) {
-					throw new InvalidInputException(ILLEGAL_HEXA_LITERAL);
+					throw illegalHexaLiteral();
 				}
 				return TokenNameDoubleLiteral;
 			} else {
 				if (end == start)
-					throw new InvalidInputException(INVALID_HEXA);
+					throw invalidHexa();
 				return TokenNameIntegerLiteral;
 			}
 		} else if (getNextChar('b', 'B') >= 0) { //----------binary-----------------
@@ -4143,18 +4145,18 @@ public int scanNumber(boolean dotPrefix) throws InvalidInputException {
 			int end = this.currentPosition;
 			if (end == start) {
 				if (this.sourceLevel < ClassFileConstants.JDK1_7) {
-					throw new InvalidInputException(BINARY_LITERAL_NOT_BELOW_17);
+					throw invalidBinaryLiteral();
 				}
-				throw new InvalidInputException(INVALID_BINARY);
+				throw invalidBinary();
 			}
 			if (getNextChar('l', 'L') >= 0) {
 				if (this.sourceLevel < ClassFileConstants.JDK1_7) {
-					throw new InvalidInputException(BINARY_LITERAL_NOT_BELOW_17);
+					throw invalidBinaryLiteral();
 				}
 				return TokenNameLongLiteral;
 			}
 			if (this.sourceLevel < ClassFileConstants.JDK1_7) {
-				throw new InvalidInputException(BINARY_LITERAL_NOT_BELOW_17);
+				throw invalidBinaryLiteral();
 			}
 			return TokenNameIntegerLiteral;
 		}
@@ -4208,9 +4210,9 @@ public int scanNumber(boolean dotPrefix) throws InvalidInputException {
 						if (this.currentCharacter == '_') {
 							// wrongly place '_'
 							consumeDigits(10);
-							throw new InvalidInputException(INVALID_UNDERSCORE);
+							throw invalidUnderscore();
 						}
-						throw new InvalidInputException(INVALID_FLOAT);
+						throw invalidFloat();
 					}
 					consumeDigits(10);
 				}
@@ -4266,9 +4268,9 @@ public int scanNumber(boolean dotPrefix) throws InvalidInputException {
 			if (this.currentCharacter == '_') {
 				// wrongly place '_'
 				consumeDigits(10);
-				throw new InvalidInputException(INVALID_UNDERSCORE);
+				throw invalidUnderscore();
 			}
-			throw new InvalidInputException(INVALID_FLOAT);
+			throw invalidFloat();
 		}
 		// current character is a digit so we expect no digit first (the next character could be an underscore)
 		consumeDigits(10);
@@ -5643,4 +5645,65 @@ public int fastForward(Statement unused) {
 protected int getNextNotFakedToken() throws InvalidInputException {
 	return getNextToken();
 }
+
+protected static InvalidInputException invalidCharacter() {
+	return new InvalidInputException(INVALID_CHARACTER_CONSTANT);
+}
+protected static InvalidInputException invalidCharInString() {
+	return new InvalidInputException(INVALID_CHAR_IN_STRING);
+}
+protected static InvalidInputException unterminatedString() {
+	return new InvalidInputException(UNTERMINATED_STRING);
+}
+protected static InvalidInputException invalidUnicodeEscape() {
+	return new InvalidInputException(INVALID_UNICODE_ESCAPE);
+}
+protected static InvalidInputException invalidLowSurrogate() {
+	return new InvalidInputException(INVALID_LOW_SURROGATE);
+}
+protected static InvalidInputException invalidHighSurrogate() {
+	return new InvalidInputException(INVALID_HIGH_SURROGATE);
+}
+protected static InvalidInputException unterminatedComment() {
+	return new InvalidInputException(UNTERMINATED_COMMENT);
+}
+protected static InvalidInputException unterminatedTextBlock() {
+	return new InvalidInputException(UNTERMINATED_TEXT_BLOCK);
+}
+protected static InvalidInputException invalidEof() {
+	return new InvalidInputException("Ctrl-Z"); //$NON-NLS-1$
+}
+protected static InvalidInputException invalidUnderscore() {
+	return new InvalidInputException(INVALID_UNDERSCORE);
+}
+protected static InvalidInputException invalidUnderscoresInLiterals() {
+	return new InvalidInputException(UNDERSCORES_IN_LITERALS_NOT_BELOW_17);
+}
+protected static InvalidInputException invalidEscape() {
+	return new InvalidInputException(INVALID_ESCAPE);
+}
+protected static InvalidInputException invalidHexa() {
+	return new InvalidInputException(INVALID_HEXA);
+}
+protected static InvalidInputException illegalHexaLiteral() {
+	return new InvalidInputException(ILLEGAL_HEXA_LITERAL);
+}
+protected static InvalidInputException invalidFloat() {
+	return new InvalidInputException(INVALID_FLOAT);
+}
+protected static InvalidInputException invalidBinaryLiteral() {
+	return new InvalidInputException(BINARY_LITERAL_NOT_BELOW_17);
+}
+protected static InvalidInputException invalidBinary() {
+	return new InvalidInputException(INVALID_BINARY);
+}
+public static InvalidInputException invalidToken(int token) {
+	return new InvalidInputException("Unknown token (check Scanner/TerminalTokens): " + token); //$NON-NLS-1$
+}
+public static InvalidInputException invalidInput() {
+	return new InvalidInputException();
+}
+
+
+
 }

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionJavadocParser.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionJavadocParser.java
@@ -22,6 +22,7 @@ import org.eclipse.jdt.internal.codeassist.CompletionEngine;
 import org.eclipse.jdt.internal.compiler.ast.*;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 import org.eclipse.jdt.internal.compiler.parser.JavadocParser;
+import org.eclipse.jdt.internal.compiler.parser.Scanner;
 import org.eclipse.jdt.internal.compiler.parser.ScannerHelper;
 import org.eclipse.jdt.internal.compiler.parser.TerminalTokens;
 
@@ -581,7 +582,7 @@ public class CompletionJavadocParser extends JavadocParser {
 			}
 
 			// Something wrong happened => Invalid input
-			throw new InvalidInputException();
+			throw Scanner.invalidInput();
 		} finally {
 			// we have to make sure that this is reset to the previous value even if an exception occurs
 			this.scanner.tokenizeWhiteSpace = tokenWhiteSpace;

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionScanner.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionScanner.java
@@ -364,7 +364,7 @@ protected int getNextToken0() throws InvalidInputException {
 					{
 						int test;
 						if ((test = getNextChar('\n', '\r')) == 0) {
-							throw new InvalidInputException(INVALID_CHARACTER_CONSTANT);
+							throw invalidCharacter();
 						}
 						if (test > 0) {
 							// relocate if finding another quote fairly close: thus unicode '/u000D' will be fully consumed
@@ -378,7 +378,7 @@ protected int getNextToken0() throws InvalidInputException {
 									break;
 								}
 							}
-							throw new InvalidInputException(INVALID_CHARACTER_CONSTANT);
+							throw invalidCharacter();
 						}
 					}
 					if (getNextChar('\'')) {
@@ -393,7 +393,7 @@ protected int getNextToken0() throws InvalidInputException {
 								break;
 							}
 						}
-						throw new InvalidInputException(INVALID_CHARACTER_CONSTANT);
+						throw invalidCharacter();
 					}
 					if (getNextChar('\\')) {
 						if (this.unicodeAsBackSlash) {
@@ -418,7 +418,7 @@ protected int getNextToken0() throws InvalidInputException {
 							&& (this.source[this.currentPosition] == 'u');
 						} catch(IndexOutOfBoundsException e) {
 							this.currentPosition--;
-							throw new InvalidInputException(INVALID_CHARACTER_CONSTANT);
+							throw invalidCharacter();
 						}
 						if (checkIfUnicode) {
 							getNextUnicodeChar();
@@ -441,7 +441,7 @@ protected int getNextToken0() throws InvalidInputException {
 							break;
 						}
 					}
-					throw new InvalidInputException(INVALID_CHARACTER_CONSTANT);
+					throw invalidCharacter();
 				case '"' :
 					boolean isTextBlock = scanForTextBlockBeginning();
 					if (isTextBlock) {
@@ -492,7 +492,7 @@ protected int getNextToken0() throws InvalidInputException {
 											break;
 										}
 										if (this.currentCharacter == '\"') {
-											throw new InvalidInputException(INVALID_CHAR_IN_STRING);
+											throw invalidCharInString();
 										}
 									}
 								} else {
@@ -503,7 +503,7 @@ protected int getNextToken0() throws InvalidInputException {
 										return TokenNameStringLiteral;
 									}
 								}
-								throw new InvalidInputException(INVALID_CHAR_IN_STRING);
+								throw invalidCharInString();
 							}
 							if (this.currentCharacter == '\\') {
 								if (this.unicodeAsBackSlash) {
@@ -551,7 +551,7 @@ protected int getNextToken0() throws InvalidInputException {
 							// complete inside a string literal
 							return TokenNameStringLiteral;
 						}
-						throw new InvalidInputException(UNTERMINATED_STRING);
+						throw unterminatedString();
 					} catch (InvalidInputException e) {
 						if (e.getMessage().equals(INVALID_ESCAPE)) {
 							// relocate if finding another quote fairly close: thus unicode '/u000D' will be fully consumed
@@ -592,7 +592,7 @@ protected int getNextToken0() throws InvalidInputException {
 										|| c3 < 0
 										|| (c4 = ScannerHelper.getHexadecimalValue(this.source[this.currentPosition++])) > 15
 										|| c4 < 0) {
-										throw new InvalidInputException(INVALID_UNICODE_ESCAPE);
+										throw invalidUnicodeEscape();
 									} else {
 										this.currentCharacter = (char) (((c1 * 16 + c2) * 16 + c3) * 16 + c4);
 									}
@@ -625,7 +625,7 @@ protected int getNextToken0() throws InvalidInputException {
 											|| c3 < 0
 											|| (c4 = ScannerHelper.getHexadecimalValue(this.source[this.currentPosition++])) > 15
 											|| c4 < 0) {
-											throw new InvalidInputException(INVALID_UNICODE_ESCAPE);
+											throw invalidUnicodeEscape();
 										} else {
 											this.currentCharacter = (char) (((c1 * 16 + c2) * 16 + c3) * 16 + c4);
 										}
@@ -664,7 +664,7 @@ protected int getNextToken0() throws InvalidInputException {
 											|| (c4 = ScannerHelper.getHexadecimalValue(this.source[index++])) > 15
 											|| c4 < 0) {
 											this.currentPosition = index;
-											throw new InvalidInputException(INVALID_UNICODE_ESCAPE);
+											throw invalidUnicodeEscape();
 										} else {
 											unicodeChar = (char) (((c1 * 16 + c2) * 16 + c3) * 16 + c4);
 										}
@@ -809,7 +809,7 @@ protected int getNextToken0() throws InvalidInputException {
 								}
 							} catch (IndexOutOfBoundsException e) {
 								this.currentPosition--;
-								throw new InvalidInputException(UNTERMINATED_COMMENT);
+								throw unterminatedComment();
 							}
 							break;
 						}
@@ -821,7 +821,7 @@ protected int getNextToken0() throws InvalidInputException {
 					if (atEnd())
 						return TokenNameEOF;
 					//the atEnd may not be <this.currentPosition == this.source.length> if source is only some part of a real (external) stream
-					throw new InvalidInputException("Ctrl-Z"); //$NON-NLS-1$
+					throw invalidEof();
 
 				default :
 					char c = this.currentCharacter;
@@ -837,21 +837,21 @@ protected int getNextToken0() throws InvalidInputException {
 					boolean isJavaIdStart;
 					if (c >= HIGH_SURROGATE_MIN_VALUE && c <= HIGH_SURROGATE_MAX_VALUE) {
 						if (this.complianceLevel < ClassFileConstants.JDK1_5) {
-							throw new InvalidInputException(INVALID_UNICODE_ESCAPE);
+							throw invalidUnicodeEscape();
 						}
 						// Unicode 4 detection
 						char low = (char) getNextChar();
 						if (low < LOW_SURROGATE_MIN_VALUE || low > LOW_SURROGATE_MAX_VALUE) {
 							// illegal low surrogate
-							throw new InvalidInputException(INVALID_LOW_SURROGATE);
+							throw invalidLowSurrogate();
 						}
 						isJavaIdStart = ScannerHelper.isJavaIdentifierStart(this.complianceLevel, c, low);
 					}
 					else if (c >= LOW_SURROGATE_MIN_VALUE && c <= LOW_SURROGATE_MAX_VALUE) {
 						if (this.complianceLevel < ClassFileConstants.JDK1_5) {
-							throw new InvalidInputException(INVALID_UNICODE_ESCAPE);
+							throw invalidUnicodeEscape();
 						}
-						throw new InvalidInputException(INVALID_HIGH_SURROGATE);
+						throw invalidHighSurrogate();
 					} else {
 						// optimized case already checked
 						isJavaIdStart = Character.isJavaIdentifierStart(c);
@@ -1001,7 +1001,7 @@ protected int scanForTextBlock() throws InvalidInputException {
 		if (lastQuotePos > 0)
 			this.currentPosition = lastQuotePos;
 		this.currentPosition = (lastQuotePos > 0) ? lastQuotePos : this.startPosition + this.rawStart;
-		throw new InvalidInputException(UNTERMINATED_TEXT_BLOCK);
+		throw unterminatedTextBlock();
 	} catch (IndexOutOfBoundsException e) {
 		this.currentPosition = (lastQuotePos > 0) ? lastQuotePos : this.startPosition + this.rawStart;
 		if(this.startPosition <= this.cursorLocation
@@ -1009,7 +1009,7 @@ protected int scanForTextBlock() throws InvalidInputException {
 				// complete inside a string literal
 			return TokenNameStringLiteral;
 		}
-		throw new InvalidInputException(UNTERMINATED_TEXT_BLOCK);
+		throw unterminatedTextBlock();
 	}
 }
 

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/DocCommentParser.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/DocCommentParser.java
@@ -155,7 +155,7 @@ class DocCommentParser extends AbstractCommentParser {
 			return argument;
 		}
 		catch (ClassCastException ex) {
-				throw new InvalidInputException();
+				throw Scanner.invalidInput();
 		}
 	}
 
@@ -182,7 +182,7 @@ class DocCommentParser extends AbstractCommentParser {
 			return fieldRef;
 		}
 		catch (ClassCastException ex) {
-				throw new InvalidInputException();
+				throw Scanner.invalidInput();
 		}
 	}
 
@@ -219,7 +219,7 @@ class DocCommentParser extends AbstractCommentParser {
 			return methodRef;
 		}
 		catch (ClassCastException ex) {
-				throw new InvalidInputException();
+				throw Scanner.invalidInput();
 		}
 	}
 

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/PublicScanner.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/PublicScanner.java
@@ -267,7 +267,7 @@ public class PublicScanner implements IScanner, ITerminalSymbols {
 			case TerminalTokens.TokenNamewhile : nextToken = ITerminalSymbols.TokenNamewhile; break;
 			case TerminalTokens.TokenNameRestrictedIdentifierWhen : nextToken = ITerminalSymbols.TokenNameRestrictedIdentifierWhen; break;
 			default:
-				throw new InvalidInputException("Unknown token (check Scanner/TerminalTokens): " + nextToken); //$NON-NLS-1$
+				throw Scanner.invalidToken(nextToken);
 		}
 		return nextToken;
 	}


### PR DESCRIPTION
InvalidInputException is marked @noinstantiate and should only be constructed by Scannner
