### PR TITLE
Cannot infer type argument

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ReferenceExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ReferenceExpression.java
@@ -802,6 +802,7 @@ public class ReferenceExpression extends FunctionalExpression implements IPolyEx
         	}
         } else {
         	this.binding = null;
+        	this.exactMethodBinding = null;
         	this.bits &= ~ASTNode.DepthMASK;
         }
 

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_1_8.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_1_8.java
@@ -10495,4 +10495,34 @@ public void testBug508834_comment0() {
 				"""
 			});
 	}
+	public void testGH973() {
+		runConformTest(
+			new String[] {
+				"Seq.java",
+				"""
+				import java.util.List;
+				import java.util.function.Consumer;
+				import java.util.function.Function;
+
+				public interface Seq<T> {
+
+					void consume(Consumer<T> consumer);
+
+					default <R> Seq<R> map(Function<T, R> mapFunction) {
+						return c -> consume(t -> c.accept(mapFunction.apply(t)));
+					}
+
+					default <R> Seq<R> flatMap(Function<T, Seq<R>> mapFunction) {
+						return c -> consume(t -> mapFunction.apply(t).consume(c));
+					}
+
+					static void main(String[] args) {
+						Seq<Integer> seq = List.of(1, 2, 3)::forEach;
+						seq.map(e -> e * 2).flatMap(e -> List.of(e - 1, e)::forEach).consume(System.out::println);
+					}
+
+				}
+				"""
+			});
+	}
 }


### PR DESCRIPTION
fixes #973

## What it does

Keep ReferenceExpression.{binding,exactMethodBinding} in sync

This is needed to trigger re-resolving after a failed attempt during type inference.

