### PR TITLE
Do not add blanks to NLS comments after text block when formatting

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/formatter/FormatterBugsTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/formatter/FormatterBugsTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -13338,4 +13338,27 @@ public void testIssue369() {
 		"public record ValueWithPosition( String position, String value ) {\n" +
 		"}");
 }
-}
+/**
+ * https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1510
+ */
+public void testIssue1510() {
+	setComplianceLevel(CompilerOptions.VERSION_15);
+	this.formatterPrefs.comment_format_line_comment = true;
+	String source =
+			"class A {\n" +
+			"\tpublic void foo() {\n" +
+			"\t\tString x=\"\"\"\n" +
+			"\tabc\n" +
+			"\t\"\"\"; //$NON-NLS-1$\n" +
+			"\t}\n" +
+			"}";
+
+	formatSource(source,
+		"class A {\n" +
+		"\tpublic void foo() {\n" +
+		"\t\tString x = \"\"\"\n" +
+		"\t\t\t\tabc\n" +
+		"\t\t\t\t\"\"\"; //$NON-NLS-1$\n" +
+		"\t}\n" +
+		"}");
+}}

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/CommentsPreparator.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/CommentsPreparator.java
@@ -22,6 +22,7 @@ import static org.eclipse.jdt.internal.compiler.parser.TerminalTokens.TokenNameC
 import static org.eclipse.jdt.internal.compiler.parser.TerminalTokens.TokenNameCOMMENT_LINE;
 import static org.eclipse.jdt.internal.compiler.parser.TerminalTokens.TokenNameNotAToken;
 import static org.eclipse.jdt.internal.compiler.parser.TerminalTokens.TokenNameStringLiteral;
+import static org.eclipse.jdt.internal.compiler.parser.TerminalTokens.TokenNameTextBlock;
 import static org.eclipse.jdt.internal.compiler.parser.TerminalTokens.TokenNameWHITESPACE;
 import static org.eclipse.jdt.internal.compiler.parser.TerminalTokens.TokenNamepackage;
 
@@ -358,7 +359,7 @@ public class CommentsPreparator extends ASTVisitor {
 			Token token = this.tm.get(i);
 			if (this.tm.countLineBreaksBetween(token, previous) > 0)
 				break;
-			if (token.tokenType == TokenNameStringLiteral)
+			if (token.tokenType == TokenNameStringLiteral || token.tokenType == TokenNameTextBlock)
 				stringLiterals.add(token);
 			previous = token;
 		}

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/TextEditsBuilder.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/TextEditsBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2018 Mateusz Matela and others.
+ * Copyright (c) 2014, 2023 Mateusz Matela and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -136,7 +136,7 @@ public class TextEditsBuilder extends TokenTraverser {
 			}
 		}
 
-		if (token.tokenType == TokenNameStringLiteral)
+		if (token.tokenType == TokenNameStringLiteral || token.tokenType == TokenNameTextBlock)
 			this.stringLiteralsInLine.add(token);
 
 		if (getNext() == null) {

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/TokenManager.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/TokenManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2022 Mateusz Matela and others.
+ * Copyright (c) 2014, 2023 Mateusz Matela and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -260,7 +260,7 @@ public class TokenManager implements Iterable<Token> {
 				return false;
 			}
 			if (traversed.hasNLSTag()) {
-				assert traversed.tokenType == TokenNameStringLiteral;
+				assert traversed.tokenType == TokenNameStringLiteral || traversed.tokenType == TokenNameTextBlock;
 				this.isNLSTagInLine = true;
 			}
 			if (traversed.getAlign() > 0)

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/linewrap/WrapPreparator.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/linewrap/WrapPreparator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2022 Mateusz Matela and others.
+ * Copyright (c) 2014, 2023 Mateusz Matela and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -40,6 +40,7 @@ import static org.eclipse.jdt.internal.compiler.parser.TerminalTokens.TokenNamei
 import static org.eclipse.jdt.internal.compiler.parser.TerminalTokens.TokenNamenew;
 import static org.eclipse.jdt.internal.compiler.parser.TerminalTokens.TokenNameRestrictedIdentifierpermits;
 import static org.eclipse.jdt.internal.compiler.parser.TerminalTokens.TokenNamesuper;
+import static org.eclipse.jdt.internal.compiler.parser.TerminalTokens.TokenNameTextBlock;
 import static org.eclipse.jdt.internal.compiler.parser.TerminalTokens.TokenNamethis;
 import static org.eclipse.jdt.internal.compiler.parser.TerminalTokens.TokenNamethrows;
 import static org.eclipse.jdt.internal.compiler.parser.TerminalTokens.TokenNameto;
@@ -1566,7 +1567,7 @@ public class WrapPreparator extends ASTVisitor {
 			if (token.getLineBreaksBefore() > 0 || token.getLineBreaksAfter() > 0)
 				isNLSTagInLine = false;
 			if (token.hasNLSTag()) {
-				assert token.tokenType == TokenNameStringLiteral;
+				assert token.tokenType == TokenNameStringLiteral || token.tokenType == TokenNameTextBlock;
 				isNLSTagInLine = true;
 			}
 			List<Token> structure = token.getInternalStructure();


### PR DESCRIPTION
- fixes #1510
- add new test to FormatterBugsTests

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes line comment formatting to properly recognize NLS comment for a text block.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
