### PR TITLE
DefaultCodeFormatterConstants#getJavaConventionsSettings: use Generics

### DIFF
--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/core/formatter/DefaultCodeFormatterConstants.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/core/formatter/DefaultCodeFormatterConstants.java
@@ -6001,7 +6001,7 @@ public class DefaultCodeFormatterConstants {
 	 * @return the settings according to the Java conventions
 	 * @since 3.0
 	 */
-	public static Map getJavaConventionsSettings() {
+	public static Map<String, String> getJavaConventionsSettings() {
 		return DefaultCodeFormatterOptions.getJavaConventionsSettings().getMap();
 	}
 	/**


### PR DESCRIPTION
so that caller needs no typecast
