### PR TITLE
Fix ECJ's incorrect behavior in recognizing inner records with generic super types

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BinaryTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BinaryTypeBinding.java
@@ -518,15 +518,15 @@ void cachePartsFrom(IBinaryType binaryType, boolean needFieldsAndMethods) {
 				this.typeVariables = addMethodTypeVariables(typeVars);
 			}
 		}
+		char[] superclassName = binaryType.getSuperclassName();
+		if (CharOperation.equals(superclassName, TypeConstants.CharArray_JAVA_LANG_RECORD_SLASH)){
+			this.modifiers |= ExtraCompilerModifiers.AccRecord;
+		}
 		if (typeSignature == null)  {
-			char[] superclassName = binaryType.getSuperclassName();
 			if (superclassName != null) {
 				// attempt to find the superclass if it exists in the cache (otherwise - resolve it when requested)
 				this.superclass = this.environment.getTypeFromConstantPoolName(superclassName, 0, -1, false, missingTypeNames, toplevelWalker.toSupertype((short) -1, superclassName));
 				this.tagBits |= TagBits.HasUnresolvedSuperclass;
-				if (CharOperation.equals(superclassName, TypeConstants.CharArray_JAVA_LANG_RECORD_SLASH)){
-					this.modifiers |= ExtraCompilerModifiers.AccRecord;
-				}
 			}
 
 			this.superInterfaces = Binding.NO_SUPERINTERFACES;


### PR DESCRIPTION

## What it does

ECJ fails to record the recordness of an inner record that has a generic supertype - Corrected

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1497

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
