### PR TITLE
The target type of this expression must be a functional interface at Main:5

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AllocationExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AllocationExpression.java
@@ -597,13 +597,17 @@ public MethodBinding inferConstructorOfElidedParameterizedType(final Scope scope
 	MethodBinding constructor = inferDiamondConstructor(scope, this, this.type.resolvedType, this.argumentTypes, inferredReturnTypeOut);
 	if (constructor != null) {
 		this.inferredReturnType = inferredReturnTypeOut[0];
-		if (constructor instanceof ParameterizedGenericMethodBinding && scope.compilerOptions().sourceLevel >= ClassFileConstants.JDK1_8) {
-			// force an inference context to be established for nested poly allocations (to be able to transfer b2), but avoid tunneling through overload resolution. We know this is the MSMB.
-			if (this.expressionContext == INVOCATION_CONTEXT && this.typeExpected == null)
+		if (scope.compilerOptions().sourceLevel >= ClassFileConstants.JDK1_8
+				&& this.expressionContext == INVOCATION_CONTEXT && this.typeExpected == null) { // not ready for invocation type inference
+			if (constructor instanceof PolyParameterizedGenericMethodBinding) {
+				return constructor; // keep this placeholder binding, which also serves as a key into #inferenceContexts
+			} else if (constructor instanceof ParameterizedGenericMethodBinding) {
+				// force an inference context to be established for nested poly allocations (to be able to transfer b2), but avoid tunneling through overload resolution. We know this is the MSMB.
 				constructor = ParameterizedGenericMethodBinding.computeCompatibleMethod18(constructor.shallowOriginal(), this.argumentTypes, scope, this);
-		}
-		if (this.typeExpected != null && this.typeExpected.isProperType(true))
+			}
+		} else if (this.typeExpected != null && this.typeExpected.isProperType(true)) {
 			registerResult(this.typeExpected, constructor);
+		}
 	}
 	return constructor;
 }
@@ -616,6 +620,8 @@ public static MethodBinding inferDiamondConstructor(Scope scope, InvocationSite 
 	// Given the allocation type and the arguments to the constructor, see if we can infer the constructor of the elided parameterized type.
 	MethodBinding factory = scope.getStaticFactory(allocationType, enclosingType, argumentTypes, site);
 	if (factory instanceof ParameterizedGenericMethodBinding && factory.isValidBinding()) {
+		if (site.invocationTargetType() == null && site.getExpressionContext().definesTargetType() && factory instanceof PolyParameterizedGenericMethodBinding)
+			return factory; // during applicability inference keep the PolyParameterizedGenericMethodBinding
 		ParameterizedGenericMethodBinding genericFactory = (ParameterizedGenericMethodBinding) factory;
 		inferredReturnTypeOut[0] = genericFactory.inferredReturnType;
 		SyntheticFactoryMethodBinding sfmb = (SyntheticFactoryMethodBinding) factory.original();

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_1_8.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_1_8.java
@@ -10525,4 +10525,22 @@ public void testBug508834_comment0() {
 				"""
 			});
 	}
+	public void testGH1427_class() {
+		runConformTest(
+			new String[] {
+				"Main.java",
+				"""
+				import java.util.List;
+				import java.util.function.Supplier;
+
+				public class Main {
+				    private static final List<Pair<Supplier<String>>> ATTRIBUTE = List.of(new Pair<>(String::new));
+
+				    static class Pair<T> { Pair(T first) {} }
+
+				    public static void main(String[] args) {}
+				}
+				"""
+			});
+	}
 }


### PR DESCRIPTION
fixes #1427

## What it does

Ensure that during invocation applicability inference the `PolyParameterizedGenericMethodBinding` is kept to represent the not-yet-fully-inferred method (which is also used as a key for retrieving the inference-context-in-progress later).

## How to test

JUnit included.
