### PR TITLE
Remove blank Javadoc

### DIFF
--- a/JCL/converterJclMin/src/java/lang/AssertionError.java
+++ b/JCL/converterJclMin/src/java/lang/AssertionError.java
@@ -14,7 +14,6 @@ public class AssertionError extends Error {
 
 	/**
 	 * Constructor for AssertionError.
-	 * @param s
 	 */
 	public AssertionError(String s) {
 		super(s);

--- a/JCL/converterJclMin/src/java/lang/NullPointerException.java
+++ b/JCL/converterJclMin/src/java/lang/NullPointerException.java
@@ -14,7 +14,6 @@ public class NullPointerException extends RuntimeException {
 
 	/**
 	 * Constructor for NullPointerException.
-	 * @param s
 	 */
 	public NullPointerException(String s) {
 		super(s);

--- a/JCL/converterJclMin1.5/src/java/lang/AssertionError.java
+++ b/JCL/converterJclMin1.5/src/java/lang/AssertionError.java
@@ -14,7 +14,6 @@ public class AssertionError extends Error {
 
 	/**
 	 * Constructor for AssertionError.
-	 * @param s
 	 */
 	public AssertionError(String s) {
 		super(s);

--- a/JCL/converterJclMin1.5/src/java/lang/NullPointerException.java
+++ b/JCL/converterJclMin1.5/src/java/lang/NullPointerException.java
@@ -14,7 +14,6 @@ public class NullPointerException extends RuntimeException {
 
 	/**
 	 * Constructor for NullPointerException.
-	 * @param s
 	 */
 	public NullPointerException(String s) {
 		super(s);

--- a/JCL/converterJclMin1.7/src/java/lang/AssertionError.java
+++ b/JCL/converterJclMin1.7/src/java/lang/AssertionError.java
@@ -14,7 +14,6 @@ public class AssertionError extends Error {
 	private static final long serialVersionUID = 3910378697039934416L;
 	/**
 	 * Constructor for AssertionError.
-	 * @param s
 	 */
 	public AssertionError(String s) {
 		super(s);

--- a/JCL/converterJclMin1.7/src/java/lang/NullPointerException.java
+++ b/JCL/converterJclMin1.7/src/java/lang/NullPointerException.java
@@ -15,7 +15,6 @@ public class NullPointerException extends RuntimeException {
 
 	/**
 	 * Constructor for NullPointerException.
-	 * @param s
 	 */
 	public NullPointerException(String s) {
 		super(s);

--- a/JCL/converterJclMin1.8/src/java/lang/AssertionError.java
+++ b/JCL/converterJclMin1.8/src/java/lang/AssertionError.java
@@ -14,7 +14,6 @@ public class AssertionError extends Error {
 	private static final long serialVersionUID = 3910378697039934416L;
 	/**
 	 * Constructor for AssertionError.
-	 * @param s
 	 */
 	public AssertionError(String s) {
 		super(s);

--- a/JCL/converterJclMin1.8/src/java/lang/NullPointerException.java
+++ b/JCL/converterJclMin1.8/src/java/lang/NullPointerException.java
@@ -15,7 +15,6 @@ public class NullPointerException extends RuntimeException {
 
 	/**
 	 * Constructor for NullPointerException.
-	 * @param s
 	 */
 	public NullPointerException(String s) {
 		super(s);

--- a/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/env/EclipseAnnotationProcessorFactory.java
+++ b/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/env/EclipseAnnotationProcessorFactory.java
@@ -24,7 +24,6 @@ import com.sun.mirror.declaration.AnnotationTypeDeclaration;
  * Implementation of this annotation processor is treated just like
  * the regular annotation processor during build and reconcile.
  * @author tyeung
- *
  */
 public interface EclipseAnnotationProcessorFactory extends
 		AnnotationProcessorFactory

--- a/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/APTDispatchRunnable.java
+++ b/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/APTDispatchRunnable.java
@@ -321,7 +321,6 @@ public class APTDispatchRunnable implements IWorkspaceRunnable
 	}
 
 	/**
-	 * @param factories
 	 * @return <code>true</code> iff there are factories that can only be run in batch mode.
 	 */
 	private boolean hasBatchFactory()
@@ -336,8 +335,6 @@ public class APTDispatchRunnable implements IWorkspaceRunnable
 
 	/**
 	 * Batch processor should only be invoked during a clean build.
-	 * @param factories
-	 * @param processorEnv
 	 * @return <code>true</code> iff batch processors should be dispatched.
 	 * Return <code>false</code> otherwise. Return <code>false</code> if
 	 * there are no batch processors.
@@ -368,15 +365,11 @@ public class APTDispatchRunnable implements IWorkspaceRunnable
 	}
 
 	/**
-	 * @param curResult
 	 * @param lastGeneratedFiles files generated from previous apt run.
 	 * @param generatedFiles all files generated from current apt run.
 	 * @param modifiedGeneratedFiles new generated files or files differs from those from
 	 *        previous run.
 	 * @param problems problems from current apt run.
-	 * @param deps
-	 * @param gfm
-	 * @param processorEnv
 	 */
 	private void reportResult(
 			BuildContext curResult,
@@ -452,7 +445,6 @@ public class APTDispatchRunnable implements IWorkspaceRunnable
 
 	/**
 	 * mixed mode - allow batch processor to be run as well as filed based ones.
-	 * @param processorEnv
 	 * @param currentRoundDispatchedBatchFactories output parameter. At return contains the
 	 * set of batch factories that has been dispatched.
 	 */
@@ -679,9 +671,6 @@ public class APTDispatchRunnable implements IWorkspaceRunnable
 	}
 
 	/**
-	 * @param processorEnv
-	 * @param filesWithMissingType
-	 * @param internalRound
 	 * @param result output parameter
 	 */
 	private Set<AnnotationProcessorFactory> build(final BuildEnv processorEnv)
@@ -732,8 +721,6 @@ public class APTDispatchRunnable implements IWorkspaceRunnable
 	}
 
 	/**
-	 * @param one
-	 * @param two
 	 * @return the set intersect of the two given sets
 	 */
 	private Set<AnnotationTypeDeclaration> setIntersect(Set<AnnotationTypeDeclaration> one, Set<AnnotationTypeDeclaration> two ){
@@ -792,9 +779,6 @@ public class APTDispatchRunnable implements IWorkspaceRunnable
 	 * on the current build; typically stored in the BuildEnv, but
 	 * an empty set can be passed in to remove all generated files
 	 * of this parent.
-	 * @param gfm
-	 * @param processorEnv
-	 * @param deleted
 	 */
 	private void cleanupNoLongerGeneratedFiles(
 			IFile parentFile,

--- a/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/AnnotationProcessorFactoryLoader.java
+++ b/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/AnnotationProcessorFactoryLoader.java
@@ -690,7 +690,6 @@ public class AnnotationProcessorFactoryLoader {
 
 	/**
 	 * When a project is deleted, remove its factory path information from the loader.
-	 * @param jproj
 	 */
     private void uncacheProject(IJavaProject jproj) {
     	ClassLoader c;

--- a/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/AptPlugin.java
+++ b/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/AptPlugin.java
@@ -140,7 +140,6 @@ public class AptPlugin extends Plugin implements DebugOptionsListener {
 
 	/**
 	 * Log a status message to the platform log.  Use this for reporting exceptions.
-	 * @param status
 	 */
 	public static void log(IStatus status) {
 		thePlugin.getLog().log(status);

--- a/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/AptProject.java
+++ b/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/AptProject.java
@@ -25,7 +25,6 @@ import org.eclipse.jdt.core.IJavaProject;
 /**
  * Stores project-specific data for APT. Analagous to JavaProject
  * @author jgarms
- *
  */
 public class AptProject {
 

--- a/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/PluginFactoryContainer.java
+++ b/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/PluginFactoryContainer.java
@@ -32,8 +32,6 @@ public class PluginFactoryContainer extends FactoryContainer
 	/**
 	 * In general clients should not construct this object.  This c'tor should
 	 * only be called from @see FactoryPathUtil#loadPluginFactories().
-	 * @param pluginId
-	 * @param enableDefault
 	 */
 	public PluginFactoryContainer(final String pluginId, boolean enableDefault) {
 		this.id = pluginId;

--- a/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/VarJarFactoryContainer.java
+++ b/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/VarJarFactoryContainer.java
@@ -28,9 +28,6 @@ public class VarJarFactoryContainer extends JarFactoryContainer {
 	private final String _id;
 	private final File _jarFile;
 
-	/**
-	 * @param jarPath
-	 */
 	public VarJarFactoryContainer(IPath jarPath) {
 		_id = jarPath.toString();
 		IPath resolved = JavaCore.getResolvedVariablePath(jarPath);

--- a/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/declaration/AnnotationValueImpl.java
+++ b/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/declaration/AnnotationValueImpl.java
@@ -59,7 +59,6 @@ public class AnnotationValueImpl implements EclipseMirrorObject, AnnotationValue
 	 * @param element the annotation element declaration.
 	 * @param index zero-based index into the array if the this value is an array element.
 	 *        <code>-1</code> otherwise.
-	 * @param env
 	 */
     public AnnotationValueImpl( final Object value,
 								final int index,
@@ -83,7 +82,6 @@ public class AnnotationValueImpl implements EclipseMirrorObject, AnnotationValue
 	 * @param index zero-based index into the array if the this value is an array element.
 	 *        <code>-1</code> otherwise.
 	 * @param annotation the annotation containing this value
-	 * @param env
 	 */
 	public AnnotationValueImpl( final Object value,
 								final String name,

--- a/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/declaration/EclipseMirrorObject.java
+++ b/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/declaration/EclipseMirrorObject.java
@@ -18,7 +18,6 @@ import org.eclipse.jdt.apt.core.internal.env.BaseProcessorEnv;
 /**
  * The base of all eclipse type system object
  * @author tyeung
- *
  */
 public interface EclipseMirrorObject {
 

--- a/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/declaration/EclipseMirrorType.java
+++ b/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/declaration/EclipseMirrorType.java
@@ -20,7 +20,6 @@ import com.sun.mirror.type.TypeMirror;
 /**
  * The base type for all Mirror type objects
  * @author thanson
- *
  */
 public interface EclipseMirrorType extends EclipseMirrorObject, TypeMirror {
 	public boolean isAssignmentCompatible(EclipseMirrorType left);

--- a/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/declaration/SourceParameterDeclarationImpl.java
+++ b/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/declaration/SourceParameterDeclarationImpl.java
@@ -36,7 +36,6 @@ public class SourceParameterDeclarationImpl
      * Parameter declaration from source files
      * @param astNode the ast node that defines this parameter
      * @param file the file where the ast node originates
-     * @param env
      */
     public SourceParameterDeclarationImpl(SingleVariableDeclaration astNode,
     									  IFile file,

--- a/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/env/AbstractCompilationEnv.java
+++ b/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/env/AbstractCompilationEnv.java
@@ -329,8 +329,6 @@ public abstract class AbstractCompilationEnv
 
 	/**
 	 * Check typeName to ensure it doesn't contain any bogus characters.
-	 * @param typeName
-	 * @throws CoreException
 	 */
 	public void validateTypeName(String typeName) throws CoreException
 	{

--- a/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/env/BaseProcessorEnv.java
+++ b/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/env/BaseProcessorEnv.java
@@ -480,7 +480,6 @@ public class BaseProcessorEnv implements AnnotationProcessorEnvironment
     }
 
     /**
-     * @param key
      * @param unit the unit that contains the definition of type whose type key is <code>key</code>
      * if <code>key</code> is a wild card, primitive, array type or parameterized type, this should be null.
      * @return return the type binding for the given key or null if none is found.
@@ -665,7 +664,6 @@ public class BaseProcessorEnv implements AnnotationProcessorEnvironment
 	/**
 	 * Retrieve the <code>ICompilationUnit</code> whose top-level type has
 	 * <code>topTypeQName</code> as its fully qualified name.
-	 * @param topTypeQName
 	 * @return the <code>ICompilationUnit</code> matching <code>topTypeQName</code> or
 	 * <code>null</code> if one doesn't exist.
 	 */
@@ -855,7 +853,6 @@ public class BaseProcessorEnv implements AnnotationProcessorEnvironment
 
 	/**
 	 * Parse and fully resolve all files.
-	 * @param javaProject
 	 * @param parseUnits the files to be parsed and resolved.
 	 */
 	static void createASTs(

--- a/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/env/BuildEnv.java
+++ b/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/env/BuildEnv.java
@@ -88,12 +88,6 @@ public class BuildEnv extends AbstractCompilationEnv
 
     /**
      * Constructor for creating a processor environment used during build.
-     * @param filesWithAnnotations
-     * @param additionalFiles
-     * @param units
-     * @param javaProj
-     * @param isTestCode
-     * @param phase
      */
     BuildEnv(
 			final BuildContext[] filesWithAnnotations,
@@ -498,7 +492,6 @@ public class BuildEnv extends AbstractCompilationEnv
 	/**
 	 * Go through the list of compilation unit in this environment and looking for
 	 * the declaration node of the given binding.
-	 * @param binding
 	 * @return the compilation unit that defines the given binding or null if no
 	 * match is found.
 	 */
@@ -519,7 +512,6 @@ public class BuildEnv extends AbstractCompilationEnv
 	/**
 	 * Go through the list of compilation unit in this environment and looking for
 	 * the declaration node of the given binding.
-	 * @param binding
 	 * @return the compilation unit that defines the given binding or null if no
 	 * match is found.
 	 */
@@ -538,7 +530,6 @@ public class BuildEnv extends AbstractCompilationEnv
 	}
 
 	/**
-     * @param file
      * @return the compilation unit associated with the given file.
      * If the file is not one of those that this environment is currently processing,
      * return null;

--- a/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/env/BuildFilerImpl.java
+++ b/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/env/BuildFilerImpl.java
@@ -32,7 +32,6 @@ import com.sun.mirror.apt.Filer;
 
 /**
  * @author wharley
- *
  */
 public class BuildFilerImpl extends FilerImpl {
 

--- a/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/env/EnvUtil.java
+++ b/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/env/EnvUtil.java
@@ -89,12 +89,10 @@ import org.eclipse.jdt.core.dom.SimpleName;
     }
 
     /**
-     * @param file
      * @return length 3 int array with the following information.
      * at index 0: contains the starting offset, always >= 0
      * at index 1: contains the ending offset, may be a negative number.
      * at index 2: the line number
-     *
      */
     private static int[] getClassNameRange(final CompilationUnit astUnit){
     	int[] startAndEnd = null;

--- a/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/env/MarkerInfo.java
+++ b/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/env/MarkerInfo.java
@@ -20,7 +20,6 @@ import org.eclipse.jdt.apt.core.internal.env.MessagerImpl.Severity;
 
 /**
  * Simple container class for attributes of IMarker
- *
  */
 public class MarkerInfo {
 

--- a/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/env/ReconcileEnv.java
+++ b/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/env/ReconcileEnv.java
@@ -38,7 +38,6 @@ public class ReconcileEnv extends AbstractCompilationEnv implements EclipseAnnot
 
 	/**
 	 * Create a reconcile environment from the given context.
-	 * @param reconcileContext
 	 * @return the reconcile environment or null if creation failed.
 	 */
 	static ReconcileEnv newEnv(ReconcileContext context)

--- a/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/generatedfile/ClasspathUtil.java
+++ b/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/generatedfile/ClasspathUtil.java
@@ -39,7 +39,6 @@ public class ClasspathUtil {
 	 * @param jp - the java project
 	 * @param folder - the folder that you want to see if it is a classpath entry for the java project
 	 * @return the IClasspathEntry corresponding to folder, or null if none was found.
-	 * @throws JavaModelException
 	 */
 	public static IClasspathEntry findProjectSourcePath( IJavaProject jp, IFolder folder )
 		throws JavaModelException
@@ -61,9 +60,7 @@ public class ClasspathUtil {
 	 * @param jp if non-null, get this project's classpath and ignore cp
 	 * @param cp if non-null, use this classpath and ignore jp
 	 * @param path the entry to look for on the classpath
-	 * @param progressMonitor
 	 * @return true if classpath contains the path specified.
-	 * @throws JavaModelException
 	 */
 	public static boolean doesClasspathContainEntry(
 			IJavaProject jp,
@@ -148,7 +145,6 @@ public class ClasspathUtil {
 
 	/**
 	 * returns true if we updated the classpath, false otherwise
-	 * @param specificOutputLocation
 	 */
 	public static boolean updateProjectClasspath( IJavaProject jp, IFolder folder, IProgressMonitor progressMonitor, boolean isTestCode, IPath specificOutputLocation )
 		throws JavaModelException

--- a/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/generatedfile/CompilationUnitHelper.java
+++ b/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/generatedfile/CompilationUnitHelper.java
@@ -36,7 +36,6 @@ public class CompilationUnitHelper
 
 	/**
 	 * Update the contents of a working copy and commit it to disk.
-	 * @throws JavaModelException
 	 */
 	public void commitNewContents(ICompilationUnit wc, String contents, IProgressMonitor monitor) throws JavaModelException {
 		IBuffer b = wc.getBuffer();
@@ -138,7 +137,6 @@ public class CompilationUnitHelper
 	 * Create a package fragment on disk.
 	 * @param pkgName the name of the package.
 	 * @param root the package fragment root under which to place the package.
-	 * @param progressMonitor
 	 * @return a package fragment, or null if there was an error.
 	 */
 	public IPackageFragment createPackageFragment(String pkgName, IPackageFragmentRoot root, IProgressMonitor progressMonitor) {

--- a/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/generatedfile/GeneratedFileManager.java
+++ b/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/generatedfile/GeneratedFileManager.java
@@ -458,8 +458,6 @@ public class GeneratedFileManager
 	 * Removes any files parented by this file, and removes the file from dependency maps
 	 * if it is generated. This does not remove working copies parented by the file; that
 	 * will happen when the working copy corresponding to the parent file is discarded.
-	 *
-	 * @param f
 	 */
 	public void fileDeleted(IFile f)
 	{
@@ -492,7 +490,6 @@ public class GeneratedFileManager
 	 * @param progressMonitor
 	 *            a progress monitor. This may be null.
 	 * @return - the newly created IFile along with whether it was modified
-	 * @throws CoreException
 	 */
 	public FileGenerationResult generateFileDuringBuild(Collection<IFile> parentFiles, String typeName, String contents,
 			boolean clearDuringReconcile, IProgressMonitor progressMonitor) throws CoreException
@@ -600,7 +597,6 @@ public class GeneratedFileManager
 	 * @return The FileGenerationResult. This will return null if the generated source
 	 *         folder is not configured, or if there is some other error during type
 	 *         generation.
-	 *
 	 */
 	public FileGenerationResult generateFileDuringReconcile(ICompilationUnit parentCompilationUnit, String typeName,
 			String contents) throws CoreException
@@ -728,7 +724,6 @@ public class GeneratedFileManager
 	 *
 	 * @param wc
 	 *            must not be null, but does not have to be a parent.
-	 * @throws CoreException
 	 */
 	public void workingCopyDiscarded(ICompilationUnit wc) throws CoreException
 	{
@@ -1500,7 +1495,6 @@ public class GeneratedFileManager
 	 *            the simple name of the type, with extension, such as 'Obj.java'
 	 * @param contents
 	 *            the text of the compilation unit
-	 * @param progressMonitor
 	 */
 	private void saveCompilationUnit(IPackageFragment pkgFrag, final String cuName, String contents,
 			IProgressMonitor progressMonitor)

--- a/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/generatedfile/GeneratedFileMap.java
+++ b/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/generatedfile/GeneratedFileMap.java
@@ -194,7 +194,6 @@ public class GeneratedFileMap extends ManyToMany<IFile, IFile> {
 	/**
 	 * Returns the File to use for saving and restoring the last built state for the given project.
 	 * Returns null if the project does not exists (e.g. has been deleted)
-	 * @param isTestCode
 	 */
 	private File getStateFile(IProject project, boolean isTestCode) {
 		if (!project.exists()) return null;

--- a/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/generatedfile/GeneratedSourceFolderManager.java
+++ b/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/generatedfile/GeneratedSourceFolderManager.java
@@ -64,7 +64,6 @@ import org.eclipse.jdt.core.JavaModelException;
  * <p>
  * GeneratedSourceFolderManager is responsible only for the folder itself, not
  * its contents.  Contents are managed by @see GeneratedFileManager.
- *
  */
 public class GeneratedSourceFolderManager {
 
@@ -125,7 +124,6 @@ public class GeneratedSourceFolderManager {
 	/**
 	 * Add the folder to the classpath, unless it's already there.
 	 * @param srcFolder the folder to add to the classpath.  Must not be null.
-	 * @param specificOutputLocation
 	 * @return true if, at the end of the routine, the folder is on the classpath.
 	 */
 	private boolean addToClasspath(IFolder srcFolder, IPath specificOutputLocation) {
@@ -445,7 +443,6 @@ public class GeneratedSourceFolderManager {
 
 	/**
 	 * Remove a folder from disk and from the classpath.
-	 * @param srcFolder
 	 */
 	private void removeFolder(boolean waitForWorkspaceEvents) {
 		final IFolder srcFolder = _generatedSourceFolder;

--- a/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/util/Factory.java
+++ b/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/util/Factory.java
@@ -210,7 +210,6 @@ public class Factory
     /**
      * @param annotation the ast node.
      * @param annotated the declaration that <code>annotation</code> annotated
-     * @param env
      * @return a newly created {@link AnnotationMirror} object
      */
     public static AnnotationMirror createAnnotationMirror(final IAnnotationBinding annotation,
@@ -238,7 +237,6 @@ public class Factory
 	 * @param decl the element declaration whose default value is <code>domValue</code>
 	 * 			   if domValue is an annotation, then this is the declaration it annotated.
 	 * 			   In all other case, this parameter is ignored.
-	 * @param env
 	 * @return an annotation value
 	 */
     public static AnnotationValue createDefaultValue(Object domValue,
@@ -257,7 +255,6 @@ public class Factory
 	 * @param domValue annotation member value according to the DOM API.
 	 * @param elementName the name of the member value
 	 * @param anno the annotation that directly contains <code>domValue</code>
-	 * @param env
 	 * @return an annotation value
 	 */
 	public static AnnotationValue createAnnotationMemberValue(Object domValue,
@@ -279,7 +276,6 @@ public class Factory
 	 * @param index the number indicate the source order of the annotation member value
 	 *              in the annotation instance.
 	 * @param mirror either {@link AnnotationMirrorImpl } or {@link AnnotationElementDeclarationImpl}
-	 * @param env
 	 */
 	public static AnnotationValue createAnnotationValueFromDOMValue(Object convertedValue,
 																	String name,
@@ -444,7 +440,6 @@ public class Factory
      * see CR260743 and 260563.
      * @param value the current value from the annotation instance.
      * @param expectedType the expected type of the value.
-     *
      */
     public static Object performNecessaryPrimitiveTypeConversion(
     		final Class<?> expectedType,
@@ -654,7 +649,6 @@ public class Factory
      * @param value the value where conversion may be applied to
      * @param name name of the member value
      * @param parent the of the annotation of the member value
-     * @param env
      * @return the value matching the expected type or itself if no conversion can be applied.
      */
     private static Object performNecessaryTypeConversion(final TypeMirror expectedType,

--- a/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/util/FactoryContainer.java
+++ b/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/util/FactoryContainer.java
@@ -67,7 +67,6 @@ public abstract class FactoryContainer
 	/**
 	 * Subclasses must return a map of implementation name to service
 	 * name, for all the processor services this container provides.
-	 * @throws IOException
 	 */
 	protected abstract Map<String, String> loadFactoryNames() throws IOException;
 

--- a/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/util/FactoryPathUtil.java
+++ b/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/util/FactoryPathUtil.java
@@ -163,7 +163,6 @@ public final class FactoryPathUtil {
 
 	/**
 	 * Returns an XML string encoding all of the factories.
-	 * @param factories
 	 */
 	public static String encodeFactoryPath(Map<FactoryContainer, FactoryPath.Attributes> factories) {
 		StringBuilder sb = new StringBuilder();

--- a/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/util/FileSystemUtil.java
+++ b/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/util/FileSystemUtil.java
@@ -45,9 +45,7 @@ public final class FileSystemUtil
 	 * and if itself is also a derived resource.
 	 * If the given resource is a file, delete it iff it is a derived resource.
 	 * The resource is left untouched if it is no a folder or a file.
-	 * @param resource
 	 * @return <code>true</code> iff the resource has been deleted.
-	 * @throws CoreException
 	 */
 	public static boolean deleteDerivedResources(final IResource resource)
 		throws CoreException
@@ -179,7 +177,6 @@ public final class FileSystemUtil
     /**
      * Stores a string into an ordinary workspace file in UTF8 format.
      * The file will be created if it does not already exist.
-     * @throws IOException
      */
     public static void writeStringToFile(File file, String contents) throws IOException {
     	byte[] data = contents.getBytes("UTF8"); //$NON-NLS-1$

--- a/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/util/Messages.java
+++ b/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/util/Messages.java
@@ -16,9 +16,6 @@ package org.eclipse.jdt.apt.core.internal.util;
 
 import org.eclipse.osgi.util.NLS;
 
-/**
- *
- */
 public class Messages extends NLS {
 	private static final String BUNDLE_NAME = "org.eclipse.jdt.apt.core.internal.util.messages"; //$NON-NLS-1$
 

--- a/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/util/TypesUtil.java
+++ b/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/util/TypesUtil.java
@@ -297,7 +297,6 @@ public class TypesUtil implements Types
     /**
      * @return the binding correspond to the given type.
      *         Return null if the type is an error marker.
-     * @throws NonEclipseImplementationException
      */
 
     private static ITypeBinding getTypeBinding(TypeMirror type)
@@ -314,7 +313,6 @@ public class TypesUtil implements Types
 
     /**
      * @return the binding correspond to the given type.
-     * @throws NonEclipseImplementationException
      */
     public static ITypeBinding getTypeBinding(TypeDeclaration type)
         throws NonEclipseImplementationException

--- a/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/util/Visitors.java
+++ b/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/util/Visitors.java
@@ -252,7 +252,6 @@ public class Visitors {
      * Given an annotation locate the declaration that its annotates.
      * This visitor only operates at the declaration level. Method body
      * and field initializers and static block will be ignored.
-     *
      */
     public static final class DeclarationFinder extends ASTVisitor
     {

--- a/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/util/AptConfig.java
+++ b/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/util/AptConfig.java
@@ -759,7 +759,6 @@ public class AptConfig {
 	 * setting; the older setting is still set (and read) in order to preserve backward
 	 * compatibility.
 	 * @param jproject an IJavaProject, or null to set workspace preferences.
-	 * @param enabled
 	 */
 	public static void setEnabled(IJavaProject jproject, boolean enabled) {
 		if (jproject == null && enabled == true) {

--- a/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/util/EclipseMessager.java
+++ b/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/util/EclipseMessager.java
@@ -41,7 +41,6 @@ public interface EclipseMessager extends Messager
 	/**
 	 * Print an error message on the given AST node.
 	 * The AST node must came from the AST that is associated with the environment.
-	 * @param node
 	 * @param msg the error message
 	 * @throws IllegalArgumentException if <code>node</code> or <code>msg</code> is null.
 	 *         Also, if the node did not come from the ast in the environment.
@@ -51,7 +50,6 @@ public interface EclipseMessager extends Messager
 	/**
 	 * Print a warning on the given AST node.
 	 * The AST node must came from the AST that is associated with the environment.
-	 * @param node
 	 * @param msg the warning message
 	 * @throws IllegalArgumentException if <code>node</code> or <code>msg</code> is null.
 	 * 		   Also, if the node did not come from the ast in the environment.
@@ -61,7 +59,6 @@ public interface EclipseMessager extends Messager
 	/**
 	 * Print a notice on the given AST node.
 	 * The AST node must came from the AST that is associated with the environment.
-	 * @param node
 	 * @param msg the warning message
 	 * @throws IllegalArgumentException if <code>node</code> or <code>msg</code> is null.
 	 *         Also, if the node did not come from the ast in the environment.

--- a/org.eclipse.jdt.apt.pluggable.core/src/org/eclipse/jdt/internal/apt/pluggable/core/Apt6Plugin.java
+++ b/org.eclipse.jdt.apt.pluggable.core/src/org/eclipse/jdt/internal/apt/pluggable/core/Apt6Plugin.java
@@ -82,7 +82,6 @@ public class Apt6Plugin extends Plugin implements DebugOptionsListener {
 
 	/**
 	 * Log a status message to the platform log.  Use this for reporting exceptions.
-	 * @param status
 	 */
 	public static void log(IStatus status) {
 		thePlugin.getLog().log(status);

--- a/org.eclipse.jdt.apt.pluggable.core/src/org/eclipse/jdt/internal/apt/pluggable/core/dispatch/IdeProcessingEnvImpl.java
+++ b/org.eclipse.jdt.apt.pluggable.core/src/org/eclipse/jdt/internal/apt/pluggable/core/dispatch/IdeProcessingEnvImpl.java
@@ -140,7 +140,6 @@ public abstract class IdeProcessingEnvImpl extends BaseProcessingEnvImpl {
 	 * of some sort (nested type, method, etc.) then get the IFile corresponding
 	 * to the containing top-level type.
 	 * If the element is not a source type at all, then return null.
-	 * @param elem
 	 * @return may be null
 	 */
 	public IFile getEnclosingIFile(Element elem) {

--- a/org.eclipse.jdt.apt.pluggable.core/src/org/eclipse/jdt/internal/apt/pluggable/core/filer/IdeFilerImpl.java
+++ b/org.eclipse.jdt.apt.pluggable.core/src/org/eclipse/jdt/internal/apt/pluggable/core/filer/IdeFilerImpl.java
@@ -251,7 +251,6 @@ public class IdeFilerImpl implements Filer {
     /**
      * Validate that a path fits the rules for being created.
      * @see IWorkspace#validatePath()
-     * @throws IOException
      */
     private void validatePath(IFile file) throws IOException
 	{

--- a/org.eclipse.jdt.apt.pluggable.core/src/org/eclipse/jdt/internal/apt/pluggable/core/filer/IdeOutputNonSourceFileObject.java
+++ b/org.eclipse.jdt.apt.pluggable.core/src/org/eclipse/jdt/internal/apt/pluggable/core/filer/IdeOutputNonSourceFileObject.java
@@ -43,9 +43,6 @@ public class IdeOutputNonSourceFileObject extends IdeOutputFileObject
 	 * Create a new IdeOutputFileObject for writing.  The file will not actually be written until the Writer or OutputStream is closed.
 	 * @param env among other roles, the ProcessingEnvironment tracks what files have been generated in a given build.
 	 * @param location must be an output location (see {@link Location#isOutputLocation()}).
-	 * @param pkg
-	 * @param relativeName
-	 * @param parentFiles
 	 * @see javax.tools.StandardLocation
 	 */
 	public IdeOutputNonSourceFileObject(IdeProcessingEnvImpl env, IFile file, Set<IFile> parentFiles) {

--- a/org.eclipse.jdt.apt.pluggable.tests/src/org/eclipse/jdt/apt/pluggable/tests/IdeTestUtils.java
+++ b/org.eclipse.jdt.apt.pluggable.tests/src/org/eclipse/jdt/apt/pluggable/tests/IdeTestUtils.java
@@ -83,7 +83,6 @@ public class IdeTestUtils {
 	 *            the full path to the resource location.
 	 * @param destFolder
 	 *            the full path to the destination location.
-	 * @throws IOException
 	 */
 	private static void copyResource(File src, File dest) throws IOException {
 		if (dest.exists() &&

--- a/org.eclipse.jdt.apt.pluggable.tests/src/org/eclipse/jdt/apt/pluggable/tests/ScalingTests.java
+++ b/org.eclipse.jdt.apt.pluggable.tests/src/org/eclipse/jdt/apt/pluggable/tests/ScalingTests.java
@@ -27,9 +27,6 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.jdt.apt.core.util.AptConfig;
 import org.eclipse.jdt.core.IJavaProject;
 
-/**
- *
- */
 public class ScalingTests extends TestBase
 {
 	private final boolean VERBOSE = true;

--- a/org.eclipse.jdt.apt.pluggable.tests/src/org/eclipse/jdt/apt/pluggable/tests/TestBase.java
+++ b/org.eclipse.jdt.apt.pluggable.tests/src/org/eclipse/jdt/apt/pluggable/tests/TestBase.java
@@ -89,9 +89,7 @@ public class TestBase extends BuilderTests
 	 * (compiler level is 1.6). Use "src" as source folder and "bin" as output folder. APT
 	 * is not enabled.
 	 *
-	 * @param projectName
 	 * @return a java project that has been added to the current workspace.
-	 * @throws Exception
 	 */
 	protected static IJavaProject createJavaProject(final String projectName) throws Exception
 	{
@@ -111,9 +109,7 @@ public class TestBase extends BuilderTests
 	 * (compiler level is 1.8). Use "src" as source folder and "bin" as output folder. APT
 	 * is not enabled.
 	 *
-	 * @param projectName
 	 * @return a java project that has been added to the current workspace.
-	 * @throws Exception
 	 */
 	protected static IJavaProject createJava8Project(final String projectName) throws Exception {
 		// Note, make sure this is run only with a JRE 8 and above.
@@ -137,9 +133,7 @@ public class TestBase extends BuilderTests
 	 * (compiler level is 1.9). Use "src" as source folder and "bin" as output folder. APT
 	 * is not enabled.
 	 *
-	 * @param projectName
 	 * @return a java project that has been added to the current workspace.
-	 * @throws Exception
 	 */
 	protected static IJavaProject createJava9Project(final String projectName) throws Exception {
 		// Note, make sure this is run only with a JRE 9 and above.
@@ -159,7 +153,6 @@ public class TestBase extends BuilderTests
 	 * units to be multiply compiled, which can mess up tests that expect a certain number
 	 * of compilations to occur.
 	 * @param jproj the project whose factory path will be edited
-	 * @throws CoreException
 	 */
 	protected void disableJava5Factories(IJavaProject jproj) throws CoreException {
 		FactoryPath fp = (FactoryPath) AptConfig.getFactoryPath(jproj);

--- a/org.eclipse.jdt.apt.pluggable.tests/src/org/eclipse/jdt/apt/pluggable/tests/processors/genclass6/GenClass6Proc.java
+++ b/org.eclipse.jdt.apt.pluggable.tests/src/org/eclipse/jdt/apt/pluggable/tests/processors/genclass6/GenClass6Proc.java
@@ -93,9 +93,6 @@ public class GenClass6Proc extends AbstractProcessor {
 		}
 	}
 
-	/**
-	 * @param genClassMirror
-	 */
 	private void processType(GenClass6 genClassMirror, Element annotatedEl) {
 		// Collect and validate the parameters of the annotation
 		String pkg = null;

--- a/org.eclipse.jdt.apt.tests/src-annotations/org/eclipse/jdt/apt/tests/annotations/listener/ListenerAnnotationProcessorFactory.java
+++ b/org.eclipse.jdt.apt.tests/src-annotations/org/eclipse/jdt/apt/tests/annotations/listener/ListenerAnnotationProcessorFactory.java
@@ -22,9 +22,6 @@ import com.sun.mirror.apt.AnnotationProcessor;
 import com.sun.mirror.apt.AnnotationProcessorEnvironment;
 import com.sun.mirror.declaration.AnnotationTypeDeclaration;
 
-/**
- *
- */
 public class ListenerAnnotationProcessorFactory extends BaseFactory
 {
 

--- a/org.eclipse.jdt.apt.tests/src-annotations/org/eclipse/jdt/apt/tests/annotations/messager/MessagerAnnotation.java
+++ b/org.eclipse.jdt.apt.tests/src-annotations/org/eclipse/jdt/apt/tests/annotations/messager/MessagerAnnotation.java
@@ -14,9 +14,6 @@
 
 package org.eclipse.jdt.apt.tests.annotations.messager;
 
-/**
- *
- */
 public @interface MessagerAnnotation {
 	enum Severity { ERROR, WARNING, INFO, OK }
 

--- a/org.eclipse.jdt.apt.tests/src-annotations/org/eclipse/jdt/apt/tests/annotations/mirrortest/MirrorDeclarationTestAnnotationProcessor.java
+++ b/org.eclipse.jdt.apt.tests/src-annotations/org/eclipse/jdt/apt/tests/annotations/mirrortest/MirrorDeclarationTestAnnotationProcessor.java
@@ -96,7 +96,6 @@ public class MirrorDeclarationTestAnnotationProcessor extends BaseProcessor {
 	 * AnnotationValue
 	 *
 	 * @param testClass TypeDeclaration
-	 *
 	 */
 	private void testAnnotationImplementations(TypeDeclaration testClass) {
 
@@ -148,8 +147,6 @@ public class MirrorDeclarationTestAnnotationProcessor extends BaseProcessor {
 	 * Tests for:
 	 * ClassDeclaration
 	 * ConstructorDeclaration
-	 *
-	 * @param testClass
 	 */
 	private void testClassDeclaration(ClassDeclaration testClassDec) {
 
@@ -189,8 +186,6 @@ public class MirrorDeclarationTestAnnotationProcessor extends BaseProcessor {
 	 * Tests for:
 	 * EnumConstantDeclaration
 	 * EnumDeclaration
-	 *
-	 * @param testClass
 	 */
 	private void testEnumImplementations(TypeDeclaration testClass) {
 		//EnumDeclaration tests
@@ -243,8 +238,6 @@ public class MirrorDeclarationTestAnnotationProcessor extends BaseProcessor {
 	/**
 	 * Tests for:
 	 * FieldDeclaration
-	 *
-	 * @param testClassDec
 	 */
 	private void testFieldDeclaration(ClassDeclaration testClassDec) {
 		//FieldDeclaration tests
@@ -286,8 +279,6 @@ public class MirrorDeclarationTestAnnotationProcessor extends BaseProcessor {
 	 * Tests for:
 	 * MethodDeclaration
 	 * ParameterDeclaration
-	 *
-	 * @param testClassDec
 	 */
 	private void testMethodDeclaration(ClassDeclaration testClassDec) {
 		//Tests for MethodDeclaration

--- a/org.eclipse.jdt.apt.tests/src-annotations/org/eclipse/jdt/apt/tests/annotations/mirrortest/MirrorTestAnnotation.java
+++ b/org.eclipse.jdt.apt.tests/src-annotations/org/eclipse/jdt/apt/tests/annotations/mirrortest/MirrorTestAnnotation.java
@@ -19,7 +19,6 @@ package org.eclipse.jdt.apt.tests.annotations.mirrortest;
 /**
  * Annotation for testing the Mirror API implementation.
  * Work takes place in the MirrorTestAnnotationProcessor.
- *
  */
 public @interface MirrorTestAnnotation {
 

--- a/org.eclipse.jdt.apt.tests/src/org/eclipse/jdt/apt/tests/APTTestBase.java
+++ b/org.eclipse.jdt.apt.tests/src/org/eclipse/jdt/apt/tests/APTTestBase.java
@@ -91,9 +91,7 @@ public abstract class APTTestBase extends BuilderTests{
 	 * (compiler level is 1.5). Use "src" as source folder and "bin" as output folder.
 	 * APT is not enabled.
 	 *
-	 * @param projectName
 	 * @return a java project that has been added to the current workspace.
-	 * @throws Exception
 	 */
 	protected IJavaProject createJavaProject(final String projectName )
 		throws Exception
@@ -112,7 +110,6 @@ public abstract class APTTestBase extends BuilderTests{
 	/**
 	 * Add a test source folder to the current project and return it
 	 * @return IPath
-	 * @throws JavaModelException
 	 */
 	protected IPath addTestSourceFolder() throws JavaModelException {
 		IJavaProject currentJavaProject = getCurrentJavaProject();

--- a/org.eclipse.jdt.apt.tests/src/org/eclipse/jdt/apt/tests/AnnotationValueConversionTests.java
+++ b/org.eclipse.jdt.apt.tests/src/org/eclipse/jdt/apt/tests/AnnotationValueConversionTests.java
@@ -133,7 +133,6 @@ public class AnnotationValueConversionTests extends APTTestBase
 
 	/**
 	 * Test conversion on short.
-	 * @throws Exception
 	 */
 	public void testShortConversion() throws Exception {
 		IProject project = setupTest();
@@ -191,7 +190,6 @@ public class AnnotationValueConversionTests extends APTTestBase
 
 	/**
 	 * Test conversion on char.
-	 * @throws Exception
 	 */
 	public void testCharConversion() throws Exception {
 		IProject project = setupTest();
@@ -222,7 +220,6 @@ public class AnnotationValueConversionTests extends APTTestBase
 
 	/**
 	 * Test conversion on char through reflection
-	 * @throws Exception
 	 */
 	public void testCharConversion_Reflection() throws Exception {
 		IProject project = setupTest();
@@ -253,7 +250,6 @@ public class AnnotationValueConversionTests extends APTTestBase
 
 	/**
 	 * Test conversion on int.
-	 * @throws Exception
 	 */
 	public void testIntConversion() throws Exception {
 		IProject project = setupTest();
@@ -284,7 +280,6 @@ public class AnnotationValueConversionTests extends APTTestBase
 
 	/**
 	 * Test conversion on int through reflection
-	 * @throws Exception
 	 */
 	public void testIntConversion_Reflection() throws Exception {
 		IProject project = setupTest();
@@ -315,7 +310,6 @@ public class AnnotationValueConversionTests extends APTTestBase
 
 	/**
 	 * Test conversion on long.
-	 * @throws Exception
 	 */
 	public void testLongConversion() throws Exception {
 		IProject project = setupTest();
@@ -354,7 +348,6 @@ public class AnnotationValueConversionTests extends APTTestBase
 
 	/**
 	 * Test conversion on long.
-	 * @throws Exception
 	 */
 	public void testLongConversion_Reflection() throws Exception {
 		IProject project = setupTest();
@@ -393,7 +386,6 @@ public class AnnotationValueConversionTests extends APTTestBase
 
 	/**
 	 * Test conversion on Float.
-	 * @throws Exception
 	 */
 	public void testFloatConversion() throws Exception {
 		IProject project = setupTest();
@@ -438,7 +430,6 @@ public class AnnotationValueConversionTests extends APTTestBase
 
 	/**
 	 * Test conversion on Float.
-	 * @throws Exception
 	 */
 	public void testFloatConversion_Reflection() throws Exception {
 		IProject project = setupTest();
@@ -483,7 +474,6 @@ public class AnnotationValueConversionTests extends APTTestBase
 
 	/**
 	 * Test conversion on double. No arrayification.
-	 * @throws Exception
 	 */
 	public void testDoubleConversion() throws Exception {
 		IProject project = setupTest();
@@ -526,7 +516,6 @@ public class AnnotationValueConversionTests extends APTTestBase
 
 	/**
 	 * Test conversion on double. No arrayification.
-	 * @throws Exception
 	 */
 	public void testDoubleConversion_Reflection() throws Exception {
 		IProject project = setupTest();
@@ -569,7 +558,6 @@ public class AnnotationValueConversionTests extends APTTestBase
 
 	/**
 	 * Convert "singleton" instance to array of the correct type
-	 * @throws Exception
 	 */
 	public void testArrayification() throws Exception {
 		IProject project = setupTest();
@@ -597,7 +585,6 @@ public class AnnotationValueConversionTests extends APTTestBase
 
 	/**
 	 * Convert "singleton" instance to array of the correct type
-	 * @throws Exception
 	 */
 	public void testArrayification_Reflection() throws Exception {
 		IProject project = setupTest();
@@ -625,7 +612,6 @@ public class AnnotationValueConversionTests extends APTTestBase
 
 	/**
 	 * Test conversion on array elements.
-	 * @throws Exception
 	 */
 	public void testArrayElementConversion() throws Exception {
 		IProject project = setupTest();
@@ -657,7 +643,6 @@ public class AnnotationValueConversionTests extends APTTestBase
 
 	/**
 	 * Test conversion on array elements.
-	 * @throws Exception
 	 */
 	public void testArrayElementConversion_Reflection() throws Exception {
 		IProject project = setupTest();

--- a/org.eclipse.jdt.apt.tests/src/org/eclipse/jdt/apt/tests/AptReconcileTests.java
+++ b/org.eclipse.jdt.apt.tests/src/org/eclipse/jdt/apt/tests/AptReconcileTests.java
@@ -124,7 +124,6 @@ public class AptReconcileTests extends ModifyingResourceTests
 	 *   This tests an annotation that generates a file with an annotation that
 	 *   generates a file that should fix an error in the parent file.
 	 *   TODO: re-enable this test - it seems sporadically flaky, need to find out why.
-	 * @throws Throwable
 	 */
 	public void testNestedGeneratedFile() throws Throwable
 	{
@@ -512,7 +511,6 @@ public class AptReconcileTests extends ModifyingResourceTests
 	/***************************************************************************
 	 *
 	 * copied from ReconcilerTests...
-	 *
 	 */
 
 	private void setWorkingCopyContents(String contents)

--- a/org.eclipse.jdt.apt.tests/src/org/eclipse/jdt/apt/tests/ExpectedProblem.java
+++ b/org.eclipse.jdt.apt.tests/src/org/eclipse/jdt/apt/tests/ExpectedProblem.java
@@ -19,7 +19,6 @@ import org.eclipse.jdt.core.tests.builder.Problem;
 /**
  * Represents a problem expected to be found by the test.
  * Similar to an IProblem, but allows skipping of offset and category
- *
  */
 public class ExpectedProblem {
 

--- a/org.eclipse.jdt.apt.tests/src/org/eclipse/jdt/apt/tests/FactoryLoaderTests.java
+++ b/org.eclipse.jdt.apt.tests/src/org/eclipse/jdt/apt/tests/FactoryLoaderTests.java
@@ -33,9 +33,6 @@ import org.eclipse.jdt.apt.tests.external.annotations.loadertest.LoaderTestCodeE
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 
-/**
- *
- */
 public class FactoryLoaderTests extends APTTestBase {
 
 	private File _extJar; // external annotation jar

--- a/org.eclipse.jdt.apt.tests/src/org/eclipse/jdt/apt/tests/ListenerTests.java
+++ b/org.eclipse.jdt.apt.tests/src/org/eclipse/jdt/apt/tests/ListenerTests.java
@@ -21,9 +21,6 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.jdt.apt.tests.annotations.listener.ListenerProcessor;
 
-/**
- *
- */
 public class ListenerTests extends APTTestBase
 {
 

--- a/org.eclipse.jdt.apt.tests/src/org/eclipse/jdt/apt/tests/MirrorDeclarationTests.java
+++ b/org.eclipse.jdt.apt.tests/src/org/eclipse/jdt/apt/tests/MirrorDeclarationTests.java
@@ -144,8 +144,6 @@ public class MirrorDeclarationTests extends APTTestBase {
 	 * (iii) field declaration with unresolvable type.
 	 *
 	 * This test focus on declarations from file in context.
-	 *
-	 * @throws Exception
 	 */
 	public void testUnresolvableDeclarations0()
 		throws Exception
@@ -189,8 +187,6 @@ public class MirrorDeclarationTests extends APTTestBase {
 	 *
 	 * This test focus on declarations from file outside of processor
 	 * environment context.
-	 *
-	 * @throws Exception
 	 */
 	public void testUnresolvableDeclarations1()
 		throws Exception

--- a/org.eclipse.jdt.apt.tests/src/org/eclipse/jdt/apt/tests/MirrorUtilTests.java
+++ b/org.eclipse.jdt.apt.tests/src/org/eclipse/jdt/apt/tests/MirrorUtilTests.java
@@ -67,9 +67,6 @@ public class MirrorUtilTests extends APTTestBase {
 		}
 	}
 
-	/**
-	 *
-	 */
 	private void assertNoUnexpectedProblems() {
 		Problem[] problems = env.getProblems();
 		for (Problem problem : problems) {

--- a/org.eclipse.jdt.apt.tests/src/org/eclipse/jdt/apt/tests/MixedModeTesting.java
+++ b/org.eclipse.jdt.apt.tests/src/org/eclipse/jdt/apt/tests/MixedModeTesting.java
@@ -96,7 +96,6 @@ public class MixedModeTesting extends APTTestBase{
 	/**
 	 * What this tests test.
 	 * This makes sure the internal apt rounding occurs correctly in batch mode.
-	 * @throws CoreException
 	 */
 	public void testAPTRoundingInMixedMode0()
 	{

--- a/org.eclipse.jdt.apt.tests/src/org/eclipse/jdt/apt/tests/PreferencesTests.java
+++ b/org.eclipse.jdt.apt.tests/src/org/eclipse/jdt/apt/tests/PreferencesTests.java
@@ -131,7 +131,6 @@ public class PreferencesTests extends APTTestBase {
 
 	/**
 	 * Test the config API for settings other than factory path
-	 * @throws Exception
 	 */
 	public void testSimpleConfigApi() throws Exception {
 		IJavaProject jproj = env.getJavaProject( getProjectName() );
@@ -261,7 +260,6 @@ public class PreferencesTests extends APTTestBase {
 	 * with and without apt enabled.
 	 *
 	 * See comments in method body for detail testing scenarios
-	 * @throws Exception
 	 */
 	public void testConfigGenSrcDir() throws Exception {
 

--- a/org.eclipse.jdt.apt.tests/src/org/eclipse/jdt/apt/tests/RegressionTests.java
+++ b/org.eclipse.jdt.apt.tests/src/org/eclipse/jdt/apt/tests/RegressionTests.java
@@ -29,9 +29,6 @@ import org.eclipse.jdt.apt.core.util.IFactoryPath;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.tests.util.Util;
 
-/**
- *
- */
 public class RegressionTests extends APTTestBase {
 
 	public RegressionTests(String name) {
@@ -244,7 +241,6 @@ public class RegressionTests extends APTTestBase {
 
     /**
      * Test the Types.isAssignable() API, in various inheritance scenarios
-     * @throws Exception
      */
     public void testBugzilla206591B() throws Exception {
     	final String projName = RegressionTests.class.getName() + "206591.Project"; //$NON-NLS-1$
@@ -298,8 +294,6 @@ public class RegressionTests extends APTTestBase {
 	 * {@link AptConfig#hasProjectSpecificFactoryPath(IJavaProject)} checks if
 	 * the project's factory path is equivalent to the default factory path, not
 	 * just that it has created a factory path.
-	 *
-	 * @throws Exception
 	 */
 	public void testBugzilla423254() throws Exception {
 		final String projName = RegressionTests.class.getName()

--- a/org.eclipse.jdt.apt.tests/src/org/eclipse/jdt/apt/tests/TestUtil.java
+++ b/org.eclipse.jdt.apt.tests/src/org/eclipse/jdt/apt/tests/TestUtil.java
@@ -293,7 +293,6 @@ public class TestUtil
 	 * @param input a map of root directories and corresponding filters.  Each
 	 * root directory will be searched, and any files that pass the filter will
 	 * be added to the zip file.
-	 * @throws IOException
 	 */
 	public static void zip(String zipPath, Map<File, FileFilter> input)
 		throws IOException

--- a/org.eclipse.jdt.apt.ui/src/org/eclipse/jdt/apt/ui/internal/Messages.java
+++ b/org.eclipse.jdt.apt.ui/src/org/eclipse/jdt/apt/ui/internal/Messages.java
@@ -16,9 +16,6 @@ package org.eclipse.jdt.apt.ui.internal;
 
 import org.eclipse.osgi.util.NLS;
 
-/**
- *
- */
 public class Messages extends NLS {
 	private static final String BUNDLE_NAME = "org.eclipse.jdt.apt.ui.messages"; //$NON-NLS-1$
 

--- a/org.eclipse.jdt.apt.ui/src/org/eclipse/jdt/apt/ui/internal/preferences/AptConfigurationBlock.java
+++ b/org.eclipse.jdt.apt.ui/src/org/eclipse/jdt/apt/ui/internal/preferences/AptConfigurationBlock.java
@@ -73,7 +73,6 @@ import org.eclipse.jdt.internal.ui.wizards.dialogfields.StringDialogField;
  * see org.eclipse.jdt.ui.internal.preferences.TodoTaskConfigurationBlock
  * for the conceptual source of some of this code.
  * <p>
- *
  */
 public class AptConfigurationBlock extends BaseConfigurationBlock {
 
@@ -418,7 +417,6 @@ public class AptConfigurationBlock extends BaseConfigurationBlock {
 	 * but we continue to set both values in order to ensure backward
 	 * compatibility with prior versions.
 	 * the aptEnabled setting.
-	 * @param enable
 	 */
 	private void setJDTProcessAnnotationsSetting(boolean enable) {
 		IScopeContext context = (null != fJProj) ?

--- a/org.eclipse.jdt.apt.ui/src/org/eclipse/jdt/apt/ui/internal/preferences/BaseConfigurationBlock.java
+++ b/org.eclipse.jdt.apt.ui/src/org/eclipse/jdt/apt/ui/internal/preferences/BaseConfigurationBlock.java
@@ -550,7 +550,6 @@ public abstract class BaseConfigurationBlock {
 
 	/**
 	 * Retuens the value as actually stored in the preference store.
-	 * @param key
 	 * @return the value as actually stored in the preference store.
 	 */
 	protected String getStoredValue(Key key) {

--- a/org.eclipse.jdt.apt.ui/src/org/eclipse/jdt/apt/ui/internal/preferences/FactoryPathConfigurationBlock.java
+++ b/org.eclipse.jdt.apt.ui/src/org/eclipse/jdt/apt/ui/internal/preferences/FactoryPathConfigurationBlock.java
@@ -262,7 +262,6 @@ public class FactoryPathConfigurationBlock extends BaseConfigurationBlock {
 	 * Respond to a button in the button bar.
 	 * Most buttons are handled by code in CheckedListDialogField;
 	 * this method is for the rest, e.g., Add External Jar.
-	 * @param index
 	 */
 	public void customButtonPressed(int index) {
 		FactoryPathEntry[] newEntries = null;

--- a/org.eclipse.jdt.apt.ui/src/org/eclipse/jdt/apt/ui/internal/preferences/FactoryPathPreferencePage.java
+++ b/org.eclipse.jdt.apt.ui/src/org/eclipse/jdt/apt/ui/internal/preferences/FactoryPathPreferencePage.java
@@ -19,17 +19,11 @@ import org.eclipse.jdt.apt.ui.internal.util.IAptHelpContextIds;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.preferences.IWorkbenchPreferenceContainer;
 
-/**
- *
- */
 public class FactoryPathPreferencePage extends BasePreferencePage {
 
 	private static final String PREF_ID= "org.eclipse.jdt.apt.ui.preferences.factoryPathPreferences"; //$NON-NLS-1$
 	private static final String PROP_ID= "org.eclipse.jdt.apt.ui.propertyPages.factoryPathPreferences"; //$NON-NLS-1$
 
-	/**
-	 *
-	 */
 	public FactoryPathPreferencePage() {
 		setPreferenceStore(AptUIPlugin.getDefault().getPreferenceStore());
 		//setDescription(Messages.FactoryPathPreferencePage_factoryPath);

--- a/org.eclipse.jdt.apt.ui/src/org/eclipse/jdt/apt/ui/internal/util/Messages.java
+++ b/org.eclipse.jdt.apt.ui/src/org/eclipse/jdt/apt/ui/internal/util/Messages.java
@@ -16,9 +16,6 @@ package org.eclipse.jdt.apt.ui.internal.util;
 
 import org.eclipse.osgi.util.NLS;
 
-/**
- *
- */
 public class Messages extends NLS {
 	private static final String BUNDLE_NAME = "org.eclipse.jdt.apt.ui.internal.util.messages"; //$NON-NLS-1$
 

--- a/org.eclipse.jdt.compiler.apt.tests/processors/org/eclipse/jdt/compiler/apt/tests/processors/base/BaseProcessor.java
+++ b/org.eclipse.jdt.compiler.apt.tests/processors/org/eclipse/jdt/compiler/apt/tests/processors/base/BaseProcessor.java
@@ -29,7 +29,6 @@ public abstract class BaseProcessor extends AbstractProcessor
 
 	/**
 	 * Report an error to the test case code
-	 * @param value
 	 */
 	public void reportError(String value) {
 		// Debugging - don't report error

--- a/org.eclipse.jdt.compiler.apt.tests/processors/org/eclipse/jdt/compiler/apt/tests/processors/base/XMLComparer.java
+++ b/org.eclipse.jdt.compiler.apt.tests/processors/org/eclipse/jdt/compiler/apt/tests/processors/base/XMLComparer.java
@@ -140,7 +140,6 @@ public class XMLComparer implements IXMLNames {
 	 * this class to compare it to a known reference model.  The models
 	 * should match.
 	 * @return true if the models matched, i.e., if the test passed
-	 * @throws Exception
 	 */
 	public static boolean test() throws Exception {
 		final String XML_FRAMEWORK_TEST_MODEL =

--- a/org.eclipse.jdt.compiler.apt.tests/processors/org/eclipse/jdt/compiler/apt/tests/processors/base/XMLConverter.java
+++ b/org.eclipse.jdt.compiler.apt.tests/processors/org/eclipse/jdt/compiler/apt/tests/processors/base/XMLConverter.java
@@ -142,7 +142,6 @@ public class XMLConverter extends ElementScanner6<Void, Node> implements IXMLNam
 	 * Recursively convert a collection of language elements (declarations) into an XML representation.
 	 * @param declarations the collection of language elements to convert
 	 * @return an XML document whose root node is named &lt;model&gt;.
-	 * @throws ParserConfigurationException
 	 */
 	public static Document convertModel(Iterable<? extends javax.lang.model.element.Element> declarations) throws ParserConfigurationException {
 		Document model = org.eclipse.core.internal.runtime.XmlProcessorFactory.createDocumentBuilderWithErrorOnDOCTYPE().newDocument();
@@ -311,8 +310,6 @@ public class XMLConverter extends ElementScanner6<Void, Node> implements IXMLNam
 
 	/**
 	 * Create a node representing a class declaration's superclass
-	 * @param tmSuper
-	 * @param target
 	 */
 	private void convertSuperclass(TypeElement e, Node target) {
 		TypeMirror tmSuper = e.getSuperclass();

--- a/org.eclipse.jdt.compiler.apt.tests/processors/org/eclipse/jdt/compiler/apt/tests/processors/filer/FilerProc.java
+++ b/org.eclipse.jdt.compiler.apt.tests/processors/org/eclipse/jdt/compiler/apt/tests/processors/filer/FilerProc.java
@@ -90,9 +90,6 @@ public class FilerProc extends BaseProcessor {
 		}
 	}
 
-	/**
-	 * @param genResourceMirror
-	 */
 	private void generateType(GenResource genResourceMirror, Element annotatedEl) {
 		// Collect and validate the parameters of the annotation
 		String pkg = null;

--- a/org.eclipse.jdt.compiler.apt.tests/processors/org/eclipse/jdt/compiler/apt/tests/processors/inherited/InheritedAnnoProc.java
+++ b/org.eclipse.jdt.compiler.apt.tests/processors/org/eclipse/jdt/compiler/apt/tests/processors/inherited/InheritedAnnoProc.java
@@ -166,7 +166,6 @@ public class InheritedAnnoProc extends BaseProcessor
 
 	/**
 	 * Test the getRootElements implementation.
-	 * @param roundEnv
 	 * @return true if tests passed
 	 */
 	private boolean examineGetRootElements(RoundEnvironment roundEnv)

--- a/org.eclipse.jdt.compiler.apt.tests/processors/org/eclipse/jdt/compiler/apt/tests/processors/negative/NegativeModelProc.java
+++ b/org.eclipse.jdt.compiler.apt.tests/processors/org/eclipse/jdt/compiler/apt/tests/processors/negative/NegativeModelProc.java
@@ -830,14 +830,12 @@ public class NegativeModelProc extends AbstractProcessor
 	 * Compare a set of elements to a reference model, and output error information if there is a
 	 * mismatch.
 	 *
-	 * @param rootElements
 	 * @param expected
 	 *            a string representation of the XML reference model, as it would be serialized by
 	 *            XMLConverter
 	 * @param name
 	 *            the name of the test, which is used for human-readable output
 	 * @return true if the actual and expected models were equivalent
-	 * @throws Exception
 	 */
 	private boolean checkModel(List<TypeElement> rootElements, String expected, String name) throws Exception {
 		Document actualModel = XMLConverter.convertModel(rootElements);

--- a/org.eclipse.jdt.compiler.apt.tests/src/org/eclipse/jdt/compiler/apt/tests/BatchDispatchTests.java
+++ b/org.eclipse.jdt.compiler.apt.tests/src/org/eclipse/jdt/compiler/apt/tests/BatchDispatchTests.java
@@ -86,7 +86,6 @@ public class BatchDispatchTests extends TestCase {
 	/**
 	 * Veriy that processor sees correct environment options
 	 * (sanity check with system compiler)
-	 * @throws IOException
 	 */
 	public void testProcessorArgumentsWithSystemCompiler() throws IOException {
 		// System compiler
@@ -101,7 +100,6 @@ public class BatchDispatchTests extends TestCase {
 	/**
 	 * Veriy that processor sees correct environment options
 	 * when called from Eclipse compiler
-	 * @throws IOException
 	 */
 	public void _testProcessorArgumentsWithEclipseCompiler() throws IOException {
 		JavaCompiler compiler = BatchTestUtils.getEclipseCompiler();
@@ -112,7 +110,6 @@ public class BatchDispatchTests extends TestCase {
 	 * Read annotation values and generate a class using system compiler (javac)
 	 * This is a sanity check to verify that the processors, sample code, and
 	 * compiler options are correct.
-	 * @throws IOException
 	 */
 	public void testCompilerOneClassWithSystemCompiler() throws IOException {
 		// System compiler
@@ -126,7 +123,6 @@ public class BatchDispatchTests extends TestCase {
 
 	/**
 	 * Read annotation values and generate a class using Eclipse compiler
-	 * @throws IOException
 	 */
 	public void testCompilerOneClassWithEclipseCompiler() throws IOException {
 		// Eclipse compiler
@@ -186,7 +182,6 @@ public class BatchDispatchTests extends TestCase {
 
 	/**
 	 * Validate the inherited annotations test against the javac compiler.
-	 * @throws IOException
 	 */
 	public void testInheritedAnnosWithSystemCompiler() throws IOException {
 		JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
@@ -199,7 +194,6 @@ public class BatchDispatchTests extends TestCase {
 
 	/**
 	 * Test dispatch of annotation processor on inherited annotations.
-	 * @throws IOException
 	 */
 	public void testInheritedAnnosWithEclipseCompiler() throws IOException {
 		JavaCompiler compiler = BatchTestUtils.getEclipseCompiler();
@@ -208,7 +202,6 @@ public class BatchDispatchTests extends TestCase {
 
 	/**
 	 * Verify that if a type has two annotations, both processors are run.
-	 * @throws IOException
 	 */
 	public void _testTwoAnnotations() throws IOException {
 		File targetFolder = TestUtils.concatPath(BatchTestUtils.getSrcFolderName(), "targets", "dispatch");
@@ -273,7 +266,6 @@ public class BatchDispatchTests extends TestCase {
 	 * Test functionality by running a particular processor against the types in
 	 * resources/targets.  The processor must support "*" (the set of all annotations)
 	 * and must report its errors or success via the methods in BaseProcessor.
-	 * @throws IOException
 	 */
 	private void internalTestInheritance(JavaCompiler compiler, String processorClass) throws IOException {
 		System.clearProperty(processorClass);

--- a/org.eclipse.jdt.compiler.apt.tests/src/org/eclipse/jdt/compiler/apt/tests/BatchTestUtils.java
+++ b/org.eclipse.jdt.compiler.apt.tests/src/org/eclipse/jdt/compiler/apt/tests/BatchTestUtils.java
@@ -593,7 +593,6 @@ public class BatchTestUtils {
 	 *            the full path to the resource location.
 	 * @param destFolder
 	 *            the full path to the destination location.
-	 * @throws IOException
 	 */
 	public static void copyResource(File src, File dest) throws IOException {
 		if (dest.exists() &&
@@ -648,7 +647,6 @@ public class BatchTestUtils {
 	 *            the absolute path of the folder under which the resource will be copied. Folder
 	 *            and subfolders will be created if necessary.
 	 * @return a file representing the copied resource
-	 * @throws IOException
 	 */
 	public static File copyResource(String resourcePath, File targetFolder) throws IOException {
 		File resDir = new File(getPluginDirectoryPath(), RESOURCES_DIR);
@@ -668,7 +666,6 @@ public class BatchTestUtils {
 	 * @param resourceFolderName the name of the source folder, relative to
 	 * <code>[plugin-root]/resources</code>
 	 * @param the absolute path of the destination folder
-	 * @throws IOException
 	 */
 	public static void copyResources(String resourceFolderName, File destFolder) throws IOException {
 		File resDir = new File(getPluginDirectoryPath(), RESOURCES_DIR);

--- a/org.eclipse.jdt.compiler.apt.tests/src/org/eclipse/jdt/compiler/apt/tests/FilerTests.java
+++ b/org.eclipse.jdt.compiler.apt.tests/src/org/eclipse/jdt/compiler/apt/tests/FilerTests.java
@@ -36,7 +36,6 @@ public class FilerTests extends TestCase {
 
 	/**
 	 * Validate the testElement test against the javac compiler.
-	 * @throws IOException
 	 */
 	public void testElementWithSystemCompiler() throws IOException {
 		JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
@@ -49,7 +48,6 @@ public class FilerTests extends TestCase {
 
 	/**
 	 * Attempt to read various elements of the Element hierarchy.
-	 * @throws IOException
 	 */
 	public void _testElementWithEclipseCompiler() throws IOException {
 		JavaCompiler compiler = BatchTestUtils.getEclipseCompiler();
@@ -59,7 +57,6 @@ public class FilerTests extends TestCase {
 	/**
 	 * Test the createResource() by processing resources/targets/filer/FilerTarget1.java
 	 * and verifying the existence and content of the resulting files.
-	 * @throws IOException
 	 */
 	private void internalTestCreateResource(JavaCompiler compiler, boolean isSystemCommpiler) throws IOException {
 		File targetFolder = TestUtils.concatPath(BatchTestUtils.getSrcFolderName(), "targets", "filer");

--- a/org.eclipse.jdt.compiler.apt.tests/src/org/eclipse/jdt/compiler/apt/tests/Java8FilerTests.java
+++ b/org.eclipse.jdt.compiler.apt.tests/src/org/eclipse/jdt/compiler/apt/tests/Java8FilerTests.java
@@ -32,7 +32,6 @@ public class Java8FilerTests extends TestCase {
 
 	/**
 	 * Validate the testElement test against the javac compiler.
-	 * @throws IOException
 	 */
 	public void testFilerWithSystemCompiler() throws IOException {
 		JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
@@ -45,7 +44,6 @@ public class Java8FilerTests extends TestCase {
 
 	/**
 	 * Attempt to read various elements of the Element hierarchy.
-	 * @throws IOException
 	 */
 	public void testFilerWithEclipseCompiler() throws IOException {
 		JavaCompiler compiler = BatchTestUtils.getEclipseCompiler();

--- a/org.eclipse.jdt.compiler.apt.tests/src/org/eclipse/jdt/compiler/apt/tests/MessagerTests.java
+++ b/org.eclipse.jdt.compiler.apt.tests/src/org/eclipse/jdt/compiler/apt/tests/MessagerTests.java
@@ -48,7 +48,6 @@ public class MessagerTests extends TestCase {
 
 	/**
 	 * Validate the testMessager test against the javac compiler.
-	 * @throws IOException
 	 */
 	public void testMessagerWithSystemCompiler() throws IOException {
 		JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
@@ -69,7 +68,6 @@ public class MessagerTests extends TestCase {
 
 	/**
 	 * Attempt to report errors on various elements, using the Eclipse compiler.
-	 * @throws IOException
 	 */
 	public void testMessagerWithEclipseCompiler() throws IOException {
 		internalTestMessagerEclipse(2, 2);
@@ -106,7 +104,6 @@ public class MessagerTests extends TestCase {
 
 	/**
 	 * Attempt to report errors on various elements.
-	 * @throws IOException
 	 */
 	private void internalTestMessager(JavaCompiler compiler, DiagnosticListener<? super JavaFileObject> diagnosticListener, String... extraOptions ) throws IOException {
 		System.clearProperty(MESSAGERPROCNAME);

--- a/org.eclipse.jdt.compiler.apt.tests/src/org/eclipse/jdt/compiler/apt/tests/ModelTests.java
+++ b/org.eclipse.jdt.compiler.apt.tests/src/org/eclipse/jdt/compiler/apt/tests/ModelTests.java
@@ -57,7 +57,6 @@ public class ModelTests extends TestCase {
 
 	/**
 	 * Validate the testElement test against the javac compiler.
-	 * @throws IOException
 	 */
 	public void testElementWithSystemCompiler() throws IOException {
 		JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
@@ -70,7 +69,6 @@ public class ModelTests extends TestCase {
 
 	/**
 	 * Attempt to read various elements of the Element hierarchy.
-	 * @throws IOException
 	 */
 	public void testElementWithEclipseCompiler() throws IOException {
 		JavaCompiler compiler = BatchTestUtils.getEclipseCompiler();
@@ -79,7 +77,6 @@ public class ModelTests extends TestCase {
 
 	/**
 	 * Validate the testTypeMirror test against the javac compiler.
-	 * @throws IOException
 	 */
 	public void testTypeMirrorWithSystemCompiler() throws IOException {
 		JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
@@ -92,7 +89,6 @@ public class ModelTests extends TestCase {
 
 	/**
 	 * Attempt to read various elements of the TypeMirror hierarchy.
-	 * @throws IOException
 	 */
 	public void testTypeMirrorWithEclipseCompiler() throws IOException {
 		JavaCompiler compiler = BatchTestUtils.getEclipseCompiler();
@@ -101,7 +97,6 @@ public class ModelTests extends TestCase {
 
 	/**
 	 * Validate the generics test against the javac compiler.
-	 * @throws IOException
 	 */
 	public void testGenericsWithSystemCompiler() throws IOException {
 		JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
@@ -114,7 +109,6 @@ public class ModelTests extends TestCase {
 
 	/**
 	 * Test handling of generic types.
-	 * @throws IOException
 	 */
 	public void testGenericsWithEclipseCompiler() throws IOException {
 		JavaCompiler compiler = BatchTestUtils.getEclipseCompiler();
@@ -123,7 +117,6 @@ public class ModelTests extends TestCase {
 
 	/**
 	 * Validate the visitors test against the javac compiler.
-	 * @throws IOException
 	 */
 	public void testVisitorsWithSystemCompiler() throws IOException {
 		JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
@@ -136,7 +129,6 @@ public class ModelTests extends TestCase {
 
 	/**
 	 * Test the Visitor method implementations.
-	 * @throws IOException
 	 */
 	public void testVisitorsWithEclipseCompiler() throws IOException {
 		JavaCompiler compiler = BatchTestUtils.getEclipseCompiler();
@@ -153,7 +145,6 @@ public class ModelTests extends TestCase {
 	 * Test functionality by running a particular processor against the types in
 	 * resources/targets.  The processor must support "*" (the set of all annotations)
 	 * and must report its errors or success via the methods in BaseProcessor.
-	 * @throws IOException
 	 */
 	private void internalTest(JavaCompiler compiler, String processorClass) throws IOException {
 		System.clearProperty(processorClass);

--- a/org.eclipse.jdt.compiler.apt.tests/src/org/eclipse/jdt/compiler/apt/tests/ModelUtilTests.java
+++ b/org.eclipse.jdt.compiler.apt.tests/src/org/eclipse/jdt/compiler/apt/tests/ModelUtilTests.java
@@ -43,7 +43,6 @@ public class ModelUtilTests extends TestCase
 
 	/**
 	 * Validate the testElements test against the javac compiler.
-	 * @throws IOException
 	 */
 	public void _testElementsWithSystemCompiler() throws IOException {
 		// Commented out - to be fixed by https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1306
@@ -60,7 +59,6 @@ public class ModelUtilTests extends TestCase
 
 	/**
 	 * Test the Elements utility implementation.
-	 * @throws IOException
 	 */
 	public void testElementsWithEclipseCompiler() throws IOException {
 		JavaCompiler compiler = BatchTestUtils.getEclipseCompiler();
@@ -69,7 +67,6 @@ public class ModelUtilTests extends TestCase
 
 	/**
 	 * Validate the testTypes test against the javac compiler.
-	 * @throws IOException
 	 */
 	public void testTypesWithSystemCompiler() throws IOException {
 		JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
@@ -82,7 +79,6 @@ public class ModelUtilTests extends TestCase
 
 	/**
 	 * Test the Types utility implementation.
-	 * @throws IOException
 	 */
 	public void testTypesWithEclipseCompiler() throws IOException {
 		JavaCompiler compiler = BatchTestUtils.getEclipseCompiler();
@@ -93,7 +89,6 @@ public class ModelUtilTests extends TestCase
 	 * Test functionality by running a particular processor against the types in
 	 * resources/targets.  The processor must support "*" (the set of all annotations)
 	 * and must report its errors or success via the methods in BaseProcessor.
-	 * @throws IOException
 	 */
 	private void internalTest(JavaCompiler compiler, String processorClass) throws IOException {
 		System.clearProperty(processorClass);

--- a/org.eclipse.jdt.compiler.apt.tests/src/org/eclipse/jdt/compiler/apt/tests/NegativeTests.java
+++ b/org.eclipse.jdt.compiler.apt.tests/src/org/eclipse/jdt/compiler/apt/tests/NegativeTests.java
@@ -78,7 +78,6 @@ public class NegativeTests extends TestCase {
 	/**
 	 * Validate the testNegativeModel test against the javac compiler.
 	 * All test routines are executed.
-	 * @throws IOException
 	 */
 	public void testNegativeModelWithSystemCompiler() throws IOException {
 		JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
@@ -97,7 +96,6 @@ public class NegativeTests extends TestCase {
 	/**
 	 * Inspect model of resources/targets.negative.pa.Negative1,
 	 * using the Eclipse compiler.
-	 * @throws IOException
 	 */
 	public void testNegativeModel1WithEclipseCompiler() throws IOException {
 		JavaCompiler compiler = BatchTestUtils.getEclipseCompiler();
@@ -107,7 +105,6 @@ public class NegativeTests extends TestCase {
 	/**
 	 * Inspect model of resources/targets.negative.pa.Negative2,
 	 * using the Eclipse compiler.
-	 * @throws IOException
 	 */
 	public void testNegativeModel2WithEclipseCompiler() throws IOException {
 		JavaCompiler compiler = BatchTestUtils.getEclipseCompiler();
@@ -117,7 +114,6 @@ public class NegativeTests extends TestCase {
 	/**
 	 * Inspect model of resources/targets.negative.pa.Negative3,
 	 * using the Eclipse compiler.
-	 * @throws IOException
 	 */
 	public void testNegativeModel3WithEclipseCompiler() throws IOException {
 		JavaCompiler compiler = BatchTestUtils.getEclipseCompiler();
@@ -127,7 +123,6 @@ public class NegativeTests extends TestCase {
 	/**
 	 * Inspect model of resources/targets.negative.pa.Negative4,
 	 * using the Eclipse compiler.
-	 * @throws IOException
 	 */
 	public void testNegativeModel4WithEclipseCompiler() throws IOException {
 		JavaCompiler compiler = BatchTestUtils.getEclipseCompiler();
@@ -137,7 +132,6 @@ public class NegativeTests extends TestCase {
 	/**
 	 * Inspect model of resources/targets.negative.pa.Negative5,
 	 * using the Eclipse compiler.
-	 * @throws IOException
 	 */
 	public void testNegativeModel5WithEclipseCompiler() throws IOException {
 		JavaCompiler compiler = BatchTestUtils.getEclipseCompiler();
@@ -147,7 +141,6 @@ public class NegativeTests extends TestCase {
 	/**
 	 * Inspect model of resources/targets.negative.pa.Negative6,
 	 * using the Eclipse compiler.
-	 * @throws IOException
 	 */
 	public void testNegativeModel6WithEclipseCompiler() throws IOException {
 		JavaCompiler compiler = BatchTestUtils.getEclipseCompiler();
@@ -157,7 +150,6 @@ public class NegativeTests extends TestCase {
 	/**
 	 * Inspect model of resources/targets.negative.pa.Negative7,
 	 * using the Eclipse compiler.
-	 * @throws IOException
 	 */
 	public void testNegativeModel7WithEclipseCompiler() throws IOException {
 		JavaCompiler compiler = BatchTestUtils.getEclipseCompiler();
@@ -167,7 +159,6 @@ public class NegativeTests extends TestCase {
 	/**
 	 * Inspect model of resources/targets.negative.pa.Negative8,
 	 * using the Eclipse compiler.
-	 * @throws IOException
 	 */
 	public void testNegativeModel8WithEclipseCompiler() throws IOException {
 		JavaCompiler compiler = BatchTestUtils.getEclipseCompiler();
@@ -177,7 +168,6 @@ public class NegativeTests extends TestCase {
 	/**
 	 * Inspect model of resources/targets.negative.pa.Negative9,
 	 * using the Eclipse compiler.
-	 * @throws IOException
 	 */
 	public void testNegativeModel9WithEclipseCompiler() throws IOException {
 		JavaCompiler compiler = BatchTestUtils.getEclipseCompiler();
@@ -246,7 +236,6 @@ public class NegativeTests extends TestCase {
 
 	/**
 	 * Attempt to report errors on various elements.
-	 * @throws IOException
 	 */
 	private void internalTestNegativeModel(JavaCompiler compiler, int test, Collection<String> extraOptions) throws IOException {
 		System.clearProperty(NEGATIVEMODELPROCNAME);

--- a/org.eclipse.jdt.compiler.tool.tests/src/org/eclipse/jdt/compiler/tool/tests/CompilerToolJava9Tests.java
+++ b/org.eclipse.jdt.compiler.tool.tests/src/org/eclipse/jdt/compiler/tool/tests/CompilerToolJava9Tests.java
@@ -1091,7 +1091,6 @@ public class CompilerToolJava9Tests extends TestCase {
 	 * This is not optimized to handle very large or deep directory trees efficiently.
 	 * @param f is either a normal file (which will be deleted) or a directory
 	 * (which will be emptied and then deleted).
-	 * @throws IOException
 	 */
 	public static void deleteTree(File f) throws IOException
 	{
@@ -1117,7 +1116,6 @@ public class CompilerToolJava9Tests extends TestCase {
 	 *            the full path to the resource location.
 	 * @param destFolder
 	 *            the full path to the destination location.
-	 * @throws IOException
 	 */
 	public static void copyResource(File src, File dest) throws IOException {
 		if (dest.exists() &&
@@ -1158,7 +1156,6 @@ public class CompilerToolJava9Tests extends TestCase {
 	 *            the absolute path of the folder under which the resource will be copied. Folder
 	 *            and subfolders will be created if necessary.
 	 * @return a file representing the copied resource
-	 * @throws IOException
 	 */
 	public static File copyResource(String resourcePath, File targetFolder) throws IOException {
 		File resDir = new File(getPluginDirectoryPath(), RESOURCES_DIR);
@@ -1178,7 +1175,6 @@ public class CompilerToolJava9Tests extends TestCase {
 	 * @param resourceFolderName the name of the source folder, relative to
 	 * <code>[plugin-root]/resources</code>
 	 * @param the absolute path of the destination folder
-	 * @throws IOException
 	 */
 	public static void copyResources(String resourceFolderName, File destFolder) throws IOException {
 		File resDir = new File(getPluginDirectoryPath(), RESOURCES_DIR);

--- a/org.eclipse.jdt.core.compiler.batch/scripts/GenerateParserScript.java
+++ b/org.eclipse.jdt.core.compiler.batch/scripts/GenerateParserScript.java
@@ -7,7 +7,6 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
- *
  */
 import java.io.BufferedReader;
 import java.io.File;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/core/JDTCompilerAdapter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/core/JDTCompilerAdapter.java
@@ -352,7 +352,6 @@ public class JDTCompilerAdapter extends DefaultCompilerAdapter {
 
 	/**
 	 * Get the compiler arguments
-	 * @param javacClass
 	 * @return String[] the array of arguments
 	 */
 	private String[] processCompilerArguments(Class javacClass) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/core/compiler/CharOperation.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/core/compiler/CharOperation.java
@@ -933,7 +933,6 @@ public static String charToString(char[] charArray) {
  * Converts the given list of strings to an array of equal size,
  * containing the individual strings converted to char[] each.
  *
- * @param stringList
  * @return an array of char[], representing the elements in the input list, or {@code null} if the list was {@code null}.
  * @since 3.14
  */
@@ -1981,8 +1980,6 @@ public static final boolean contains(char[] characters, char[] array) {
 
 /**
  * Does the given array contain a char sequence that is equal to the give sequence?
- * @param array
- * @param sequence
  * @return true if sequence is equal to an element in array
  * @since 3.14
  */

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ASTVisitor.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ASTVisitor.java
@@ -287,31 +287,17 @@ public abstract class ASTVisitor {
 		// do nothing by default
 	}
 	/**
-	 * @param annotation
-	 * @param scope
 	 * @since 3.1
 	 */
 	public void endVisit(MarkerAnnotation annotation, BlockScope scope) {
 		// do nothing by default
 	}
-	/**
-	 * @param annotation
-	 * @param scope
-	 */
 	public void endVisit(MarkerAnnotation annotation, ClassScope scope) {
 		// do nothing by default
 	}
-	/**
-	 * @param pair
-	 * @param scope
-	 */
 	public void endVisit(MemberValuePair pair, BlockScope scope) {
 		// do nothing by default
 	}
-	/**
-	 * @param pair
-	 * @param scope
-	 */
 	public void endVisit(MemberValuePair pair, ClassScope scope) {
 		// do nothing by default
 	}
@@ -325,8 +311,6 @@ public abstract class ASTVisitor {
 		// do nothing by default
 	}
 	/**
-	 * @param annotation
-	 * @param scope
 	 * @since 3.1
 	 */
 	public void endVisit(NormalAnnotation annotation, BlockScope scope) {
@@ -414,17 +398,11 @@ public abstract class ASTVisitor {
 		// do nothing by default
 	}
 	/**
-	 * @param annotation
-	 * @param scope
 	 * @since 3.1
 	 */
 	public void endVisit(SingleMemberAnnotation annotation, BlockScope scope) {
 		// do nothing by default
 	}
-	/**
-	 * @param annotation
-	 * @param scope
-	 */
 	public void endVisit(SingleMemberAnnotation annotation, ClassScope scope) {
 		// do nothing by default
 	}
@@ -807,32 +785,20 @@ public abstract class ASTVisitor {
 		return true; // do nothing by default, keep traversing
 	}
 	/**
-	 * @param annotation
-	 * @param scope
 	 * @since 3.1
 	 */
 	public boolean visit(MarkerAnnotation annotation, BlockScope scope) {
 		return true;
 	}
-	/**
-	 * @param annotation
-	 * @param scope
-	 */
 	public boolean visit(MarkerAnnotation annotation, ClassScope scope) {
 		return true;
 	}
 	/**
-	 * @param pair
-	 * @param scope
 	 * @since 3.1
 	 */
 	public boolean visit(MemberValuePair pair, BlockScope scope) {
 		return true;
 	}
-	/**
-	 * @param pair
-	 * @param scope
-	 */
 	public boolean visit(MemberValuePair pair, ClassScope scope) {
 		return true;
 	}
@@ -848,17 +814,11 @@ public abstract class ASTVisitor {
 		return true; // do nothing by default, keep traversing
 	}
 	/**
-	 * @param annotation
-	 * @param scope
 	 * @since 3.1
 	 */
 	public boolean visit(NormalAnnotation annotation, BlockScope scope) {
 		return true;
 	}
-	/**
-	 * @param annotation
-	 * @param scope
-	 */
 	public boolean visit(NormalAnnotation annotation, ClassScope scope) {
 		return true;
 	}
@@ -938,17 +898,11 @@ public abstract class ASTVisitor {
 		return true; // do nothing by default, keep traversing
 	}
 	/**
-	 * @param annotation
-	 * @param scope
 	 * @since 3.1
 	 */
 	public boolean visit(SingleMemberAnnotation annotation, BlockScope scope) {
 		return true;
 	}
-	/**
-	 * @param annotation
-	 * @param scope
-	 */
 	public boolean visit(SingleMemberAnnotation annotation, ClassScope scope) {
 		return true;
 	}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/AbstractAnnotationProcessorManager.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/AbstractAnnotationProcessorManager.java
@@ -38,7 +38,6 @@ public abstract class AbstractAnnotationProcessorManager {
 	 * @param compiler the given compiler
 	 * @param compilationUnitLocator the given compilation unit locator
 	 * @param javaProject the given java project
-	 * @param isTestCode
 	 */
 	public abstract void configureFromPlatform(Compiler compiler, Object compilationUnitLocator, Object javaProject, boolean isTestCode);
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ClassFile.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ClassFile.java
@@ -2039,9 +2039,6 @@ public class ClassFile implements TypeConstants, TypeIds {
 	}
 
 
-	/**
-	 *
-	 */
 	public void completeCodeAttributeForMissingAbstractProblemMethod(
 			MethodBinding binding,
 			int codeAttributeOffset,
@@ -3311,9 +3308,6 @@ public class ClassFile implements TypeConstants, TypeIds {
 			}
 		}
 	}
-	/**
-	 * @param attributeOffset
-	 */
 	private void generateElementValue(int attributeOffset, Expression defaultValue, Constant constant, TypeBinding binding) {
 		if (this.contentsOffset + 3 >= this.contents.length) {
 			resizeContents(3);
@@ -4704,7 +4698,6 @@ public class ClassFile implements TypeConstants, TypeIds {
 		return false;
 	}
 	/**
-	 * @param annotations
 	 * @param targetMask allowed targets
 	 * @return the number of attributes created while dumping the annotations in the .class file
 	 */

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/DefaultErrorHandlingPolicies.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/DefaultErrorHandlingPolicies.java
@@ -20,7 +20,6 @@ public class DefaultErrorHandlingPolicies {
  *
  * Typically, the #proceedWithProblems(Problem[]) should
  * show the problems.
- *
  */
 public static IErrorHandlingPolicy exitAfterAllProblems() {
 	return new IErrorHandlingPolicy() {
@@ -41,7 +40,6 @@ public static IErrorHandlingPolicy exitAfterAllProblems() {
 /*
  * Exit without proceeding on the first problem wich appears
  * to be an error.
- *
  */
 public static IErrorHandlingPolicy exitOnFirstError() {
 	return new IErrorHandlingPolicy() {
@@ -61,7 +59,6 @@ public static IErrorHandlingPolicy exitOnFirstError() {
 }
 /*
  * Proceed on the first error met.
- *
  */
 public static IErrorHandlingPolicy proceedOnFirstError() {
 	return new IErrorHandlingPolicy() {
@@ -81,7 +78,6 @@ public static IErrorHandlingPolicy proceedOnFirstError() {
 }
 /*
  * Accumulate all problems, then proceed with them.
- *
  */
 public static IErrorHandlingPolicy proceedWithAllProblems() {
 	return new IErrorHandlingPolicy() {
@@ -101,7 +97,6 @@ public static IErrorHandlingPolicy proceedWithAllProblems() {
 }
 /*
  * Accumulate all problems, then proceed with them, but never report them.
- *
  */
 public static IErrorHandlingPolicy ignoreAllProblems() {
 	return new IErrorHandlingPolicy() {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/apt/dispatch/IProcessorProvider.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/apt/dispatch/IProcessorProvider.java
@@ -44,7 +44,6 @@ public interface IProcessorProvider {
 	 * unchecked exception, etc; the caller should not assume that this method will return.
 	 *
 	 * @param p the processor, if known, or null if not.
-	 * @param e
 	 */
 	void reportProcessorException(Processor p, Exception e);
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/apt/dispatch/RoundDispatcher.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/apt/dispatch/RoundDispatcher.java
@@ -49,7 +49,6 @@ public class RoundDispatcher {
 	 * avoid modifying the set passed in.
 	 * @param traceProcessorInfo a PrintWriter that processor trace output will be sent
 	 * to, or null if tracing is not desired.
-	 * @param traceRounds
 	 */
 	public RoundDispatcher(
 			IProcessorProvider provider,

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/apt/model/ExecutableTypeImpl.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/apt/model/ExecutableTypeImpl.java
@@ -34,7 +34,6 @@ import org.eclipse.jdt.internal.compiler.lookup.TypeVariableBinding;
 
 /**
  * Implementation of the ExecutableType
- *
  */
 public class ExecutableTypeImpl extends TypeMirrorImpl implements ExecutableType {
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/apt/model/Factory.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/apt/model/Factory.java
@@ -585,7 +585,6 @@ public class Factory {
      *
      * @param value the current value from the annotation instance.
      * @param expectedType the expected type of the value.
-     *
      */
     public static Object performNecessaryPrimitiveTypeConversion(
     		final Class<?> expectedType,
@@ -776,9 +775,6 @@ public class Factory {
 
     /**
      * Set an element of an array to the appropriate dummy value type
-     * @param array
-     * @param i
-     * @param expectedLeafType
      */
 	public static void setArrayMatchingDummyValue(Object array, int i, Class<?> expectedLeafType)
 	{

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/apt/model/TypeElementImpl.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/apt/model/TypeElementImpl.java
@@ -56,7 +56,6 @@ public class TypeElementImpl extends ElementImpl implements TypeElement {
 	/**
 	 * Compares Element instances possibly returned by
 	 * {@link TypeElement#getEnclosedElements()} based on their source location, if available.
-	 *
 	 */
 	private static final class SourceLocationComparator implements Comparator<Element> {
 		private final IdentityHashMap<ElementImpl, Integer> sourceStartCache = new IdentityHashMap<>();

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/apt/model/TypeParameterElementImpl.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/apt/model/TypeParameterElementImpl.java
@@ -38,9 +38,6 @@ import org.eclipse.jdt.internal.compiler.lookup.TypeBinding;
 import org.eclipse.jdt.internal.compiler.lookup.TypeConstants;
 import org.eclipse.jdt.internal.compiler.lookup.TypeVariableBinding;
 
-/**
- *
- */
 public class TypeParameterElementImpl extends ElementImpl implements TypeParameterElement
 {
 	private final Element _declaringElement;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ASTNode.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ASTNode.java
@@ -1071,7 +1071,6 @@ public abstract class ASTNode implements TypeConstants, TypeIds {
 	/**
 	 * "early" handling of NonNullByDefault because for local variables annotations are resolved after their type because of bug
 	 * 96991.
-	 * @param localDeclaration
 	 */
 	public static void handleNonNullByDefault(BlockScope scope, Annotation[] sourceAnnotations, LocalDeclaration localDeclaration) {
 		if (sourceAnnotations == null || sourceAnnotations.length == 0) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AbstractMethodDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AbstractMethodDeclaration.java
@@ -257,8 +257,6 @@ public abstract class AbstractMethodDeclaration
 
 	/**
 	 * Bytecode generation for a method
-	 * @param classScope
-	 * @param classFile
 	 */
 	public void generateCode(ClassScope classScope, ClassFile classFile) {
 
@@ -487,8 +485,6 @@ public abstract class AbstractMethodDeclaration
 
 	/**
 	 * Fill up the method body with statement
-	 * @param parser
-	 * @param unit
 	 */
 	public abstract void parseStatements(Parser parser, CompilationUnitDeclaration unit);
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/CaseStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/CaseStatement.java
@@ -150,7 +150,6 @@ public StringBuffer printStatement(int tab, StringBuffer output) {
 
 /**
  * Case code generation
- *
  */
 @Override
 public void generateCode(BlockScope currentScope, CodeStream codeStream) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/DoStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/DoStatement.java
@@ -155,7 +155,6 @@ public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext, Fl
 
 /**
  * Do statement code generation
- *
  */
 @Override
 public void generateCode(BlockScope currentScope, CodeStream codeStream) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/EqualExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/EqualExpression.java
@@ -486,7 +486,6 @@ public class EqualExpression extends BinaryExpression {
 	}
 	/**
 	 * Boolean generation for == with non-boolean operands
-	 *
 	 */
 	public void generateNonBooleanEqual(BlockScope currentScope, CodeStream codeStream, boolean valueRequired) {
 
@@ -695,7 +694,6 @@ public class EqualExpression extends BinaryExpression {
 
 	/**
 	 * Boolean generation for == with non-boolean operands
-	 *
 	 */
 	public void generateOptimizedNonBooleanEqual(BlockScope currentScope, CodeStream codeStream, BranchLabel trueLabel, BranchLabel falseLabel, boolean valueRequired) {
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Expression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Expression.java
@@ -247,10 +247,6 @@ public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext, Fl
  * More sophisticated for of the flow analysis used for analyzing expressions, and be able to optimize out
  * portions of expressions where no actual value is required.
  *
- * @param currentScope
- * @param flowContext
- * @param flowInfo
- * @param valueRequired
  * @return The state of initialization after the analysis of the current expression
  */
 public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext, FlowInfo flowInfo, boolean valueRequired) {
@@ -825,11 +821,6 @@ public void collectPatternVariablesToScope(LocalVariableBinding[] variables, Blo
 
 /**
  * Default generation of a boolean value
- * @param currentScope
- * @param codeStream
- * @param trueLabel
- * @param falseLabel
- * @param valueRequired
  */
 public void generateOptimizedBoolean(BlockScope currentScope, CodeStream codeStream, BranchLabel trueLabel, BranchLabel falseLabel, boolean valueRequired) {
 	// a label valued to nil means: by default we fall through the case...
@@ -1174,7 +1165,6 @@ public TypeBinding resolveExpressionType(BlockScope scope) {
 /**
  * Resolve the type of this expression in the context of a blockScope
  *
- * @param scope
  * @return
  * 	Return the actual type of this expression after resolution
  */
@@ -1186,7 +1176,6 @@ public TypeBinding resolveType(BlockScope scope) {
 /**
  * Resolve the type of this expression in the context of a classScope
  *
- * @param scope
  * @return
  * 	Return the actual type of this expression after resolution
  */
@@ -1351,9 +1340,6 @@ public void tagAsNeedCheckCast() {
 
 /**
  * Record the fact a cast expression got detected as being unnecessary.
- *
- * @param scope
- * @param castType
  */
 public void tagAsUnnecessaryCast(Scope scope, TypeBinding castType) {
     // do nothing by default
@@ -1372,8 +1358,6 @@ public Expression toTypeReference() {
 
 /**
  * Traverse an expression in the context of a blockScope
- * @param visitor
- * @param scope
  */
 @Override
 public void traverse(ASTVisitor visitor, BlockScope scope) {
@@ -1382,8 +1366,6 @@ public void traverse(ASTVisitor visitor, BlockScope scope) {
 
 /**
  * Traverse an expression in the context of a classScope
- * @param visitor
- * @param scope
  */
 public void traverse(ASTVisitor visitor, ClassScope scope) {
 	// nothing to do

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/FakeDefaultLiteral.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/FakeDefaultLiteral.java
@@ -20,7 +20,6 @@ import org.eclipse.jdt.internal.compiler.lookup.*;
  * Sole purpose of {@link FakeDefaultLiteral} is to appear
  * in case 'default' of switch patterns (JEP 406 at the time
  * of writing this comment)
- *
  */
 public class FakeDefaultLiteral extends MagicLiteral {
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/FakedTrackingVariable.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/FakedTrackingVariable.java
@@ -174,7 +174,6 @@ public class FakedTrackingVariable extends LocalDeclaration {
 	 * <li>value is a local variable reference, create tracking variable it if needed.
 	 * <li>value is an allocation expression, return a preliminary tracking variable if set.
 	 * </ul>
-	 * @param expression
 	 * @return a new {@link FakedTrackingVariable} or null.
 	 */
 	public static FakedTrackingVariable getCloseTrackingVariable(Expression expression, FlowInfo flowInfo, FlowContext flowContext) {
@@ -535,7 +534,6 @@ public class FakedTrackingVariable extends LocalDeclaration {
 	 * @param scope scope containing the assignment
 	 * @param upstreamInfo info without analysis of the rhs, use this to determine the status of a resource being disconnected
 	 * @param flowInfo info with analysis of the rhs, use this for recording resource status because this will be passed downstream
-	 * @param flowContext
 	 * @param location where to report warnigs/errors against
 	 * @param rhs the right hand side of the assignment, this expression is to be analyzed.
 	 *			The caller has already checked that the rhs is either of a closeable type or null.
@@ -796,8 +794,6 @@ public class FakedTrackingVariable extends LocalDeclaration {
 
 	/**
 	 * Get the null status looking even into unreachable flows
-	 * @param local
-	 * @param flowInfo
 	 * @return one of the constants FlowInfo.{NULL,POTENTIALLY_NULL,POTENTIALLY_NON_NULL,NON_NULL}.
 	 */
 	private int getNullStatusAggressively(LocalVariableBinding local, FlowInfo flowInfo) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/FalseLiteral.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/FalseLiteral.java
@@ -66,9 +66,6 @@ public void generateOptimizedBoolean(BlockScope currentScope, CodeStream codeStr
 public TypeBinding literalType(BlockScope scope) {
 	return TypeBinding.BOOLEAN;
 }
-/**
- *
- */
 @Override
 public char[] source() {
 	return source;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/IJavadocTypeReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/IJavadocTypeReference.java
@@ -17,7 +17,6 @@ package org.eclipse.jdt.internal.compiler.ast;
  * Interface to allow Javadoc parser to collect both JavaSingleTypeReference and JavaQualifiedTypeReferences
  *
  * @author jjohnstn
- *
  */
 public interface IJavadocTypeReference {
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ModuleStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ModuleStatement.java
@@ -16,7 +16,6 @@ package org.eclipse.jdt.internal.compiler.ast;
 
 /**
  * Just a marker class to represent statements that can occur in a module declaration
- *
  */
 public abstract class ModuleStatement extends ASTNode {
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/NullAnnotationMatching.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/NullAnnotationMatching.java
@@ -216,8 +216,6 @@ public class NullAnnotationMatching {
 
 	/**
 	 * Find any mismatches between the two given types, which are caused by null type annotations.
-	 * @param requiredType
-	 * @param providedType
 	 * @param nullStatus we are only interested in NULL or NON_NULL, -1 indicates that we are in a recursion, where flow info is ignored
 	 * @return a status object representing the severity of mismatching plus optionally a supertype hint
 	 */
@@ -226,8 +224,6 @@ public class NullAnnotationMatching {
 	}
 	/**
 	 * Find any mismatches between the two given types, which are caused by null type annotations.
-	 * @param requiredType
-	 * @param providedType
 	 * @param providedSubstitute in inheritance situations this maps the providedType into the realm of the subclass, needed for TVB identity checks.
 	 * 		Pass null if not interested in these added checks.
 	 * @param substitution TODO

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ParameterizedQualifiedTypeReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ParameterizedQualifiedTypeReference.java
@@ -40,11 +40,6 @@ public class ParameterizedQualifiedTypeReference extends ArrayQualifiedTypeRefer
 	public TypeReference[][] typeArguments;
 	ReferenceBinding[] typesPerToken;
 
-	/**
-	 * @param tokens
-	 * @param dim
-	 * @param positions
-	 */
 	public ParameterizedQualifiedTypeReference(char[][] tokens, TypeReference[][] typeArguments, int dim, long[] positions) {
 
 		super(tokens, dim, positions);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Pattern.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Pattern.java
@@ -76,7 +76,6 @@ public abstract class Pattern extends Expression {
 	/**
 	 * Implement the rules in the spec under 14.11.1.1 Exhaustive Switch Blocks
 	 *
-	 * @param type
 	 * @return whether pattern covers the given type or not
 	 */
 	public boolean coversType(TypeBinding type) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ReturnStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ReturnStatement.java
@@ -251,7 +251,6 @@ public void generateCode(BlockScope currentScope, CodeStream codeStream) {
 
 /**
  * Dump the suitable return bytecode for a return statement
- *
  */
 public void generateReturnBytecode(CodeStream codeStream) {
 	codeStream.generateReturnBytecode(this.expression);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SubRoutineStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SubRoutineStatement.java
@@ -62,11 +62,6 @@ public abstract class SubRoutineStatement extends Statement {
 
 	/**
 	 * Generate an invocation of a subroutine (e.g. jsr finally) in current context.
-	 * @param currentScope
-	 * @param codeStream
-	 * @param targetLocation
-	 * @param stateIndex
-	 * @param secretLocal
 	 * @return boolean, <code>true</code> if the generated code will abrupt completion
 	 */
 	public abstract boolean generateSubRoutineInvocation(BlockScope currentScope, CodeStream codeStream, Object targetLocation, int stateIndex, LocalVariableBinding secretLocal);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TrueLiteral.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TrueLiteral.java
@@ -67,9 +67,6 @@ public void generateOptimizedBoolean(BlockScope currentScope, CodeStream codeStr
 public TypeBinding literalType(BlockScope scope) {
 	return TypeBinding.BOOLEAN;
 }
-/**
- *
- */
 @Override
 public char[] source() {
 	return source;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypeDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypeDeclaration.java
@@ -237,7 +237,6 @@ public MethodDeclaration addMissingAbstractMethodFor(MethodBinding methodBinding
 
 /**
  *	Flow analysis for a local innertype
- *
  */
 @Override
 public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext, FlowInfo flowInfo) {
@@ -260,7 +259,6 @@ public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext, Fl
 
 /**
  *	Flow analysis for a member innertype
- *
  */
 public void analyseCode(ClassScope enclosingClassScope) {
 	if (this.ignoreFurtherInvestigation)
@@ -276,7 +274,6 @@ public void analyseCode(ClassScope enclosingClassScope) {
 
 /**
  *	Flow analysis for a local member innertype
- *
  */
 public void analyseCode(ClassScope currentScope, FlowContext flowContext, FlowInfo flowInfo) {
 	if (this.ignoreFurtherInvestigation)
@@ -297,7 +294,6 @@ public void analyseCode(ClassScope currentScope, FlowContext flowContext, FlowIn
 
 /**
  *	Flow analysis for a package member type
- *
  */
 public void analyseCode(CompilationUnitScope unitScope) {
 	if (this.ignoreFurtherInvestigation)
@@ -1647,7 +1643,6 @@ public void tagAsHavingIgnoredMandatoryErrors(int problemId) {
 
 /**
  *	Iteration for a package member type
- *
  */
 public void traverse(ASTVisitor visitor, CompilationUnitScope unitScope) {
 	try {
@@ -1779,7 +1774,6 @@ public void traverse(ASTVisitor visitor, BlockScope blockScope) {
 
 /**
  *	Iteration for a member innertype
- *
  */
 public void traverse(ASTVisitor visitor, ClassScope classScope) {
 	try {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypeReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypeReference.java
@@ -429,9 +429,6 @@ public AnnotationContext[] getAllAnnotationContexts(int targetType) {
 }
 /**
  * info can be either a type index (superclass/superinterfaces) or a pc into the bytecode
- * @param targetType
- * @param info
- * @param allAnnotationContexts
  */
 public void getAllAnnotationContexts(int targetType, int info, List<AnnotationContext> allAnnotationContexts) {
 	AnnotationCollector collector = new AnnotationCollector(this, targetType, info, allAnnotationContexts);
@@ -484,7 +481,6 @@ public TypeReference [][] getTypeArguments() {
  * view since extended dimensions bind more readily than type components that precede the identifier. This is how it ought
  * to be encoded in bindings and how it ought to be persisted in class files. However for DOM/AST construction, we need the
  * dimensions in source order, so we provide a way for the clients to ask what they want.
- *
  */
 public Annotation[][] getAnnotationsOnDimensions(boolean useSourceOrder) {
 	return null;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/UnlikelyArgumentCheck.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/UnlikelyArgumentCheck.java
@@ -39,7 +39,6 @@ public class UnlikelyArgumentCheck {
 
 	/**
 	 * Check if the invocation is likely a bug.
-	 * @param currentScope
 	 * @return false, if the typeToCheck does not seem to related to the expectedType
 	 */
 	public boolean isDangerous(BlockScope currentScope) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/FileSystem.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/FileSystem.java
@@ -120,8 +120,6 @@ public class FileSystem implements IModuleAwareNameEnvironment, SuffixConstants 
 		boolean hasAnnotationFileFor(String qualifiedTypeName);
 		/**
 		 * Accepts to represent a module location with the given module description.
-		 *
-		 * @param module
 		 */
 		public void acceptModule(IModule module);
 		public String getDestinationPath();

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/Main.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/Main.java
@@ -253,9 +253,6 @@ public class Main implements ProblemSeverities, SuffixConstants {
 			}
 		}
 
-		/**
-		 *
-		 */
 		public void compiling() {
 			printlnOut(this.main.bind("progress.compiling")); //$NON-NLS-1$
 		}
@@ -718,9 +715,6 @@ public class Main implements ProblemSeverities, SuffixConstants {
 			this.printlnErr(this.main.bind("configure.incorrectVMVersionforAPT")); //$NON-NLS-1$
 		}
 
-		/**
-		 *
-		 */
 		public void logNoClassFileCreated(String outputDir, String relativeFileName, IOException e) {
 			if ((this.tagBits & Logger.XML) != 0) {
 				HashMap<String, Object> parameters = new HashMap<>();
@@ -740,9 +734,6 @@ public class Main implements ProblemSeverities, SuffixConstants {
 				}));
 		}
 
-		/**
-		 * @param exportedClassFilesCounter
-		 */
 		public void logNumberOfClassFilesGenerated(int exportedClassFilesCounter) {
 			if ((this.tagBits & Logger.XML) != 0) {
 				HashMap<String, Object> parameters = new HashMap<>();
@@ -909,11 +900,6 @@ public class Main implements ProblemSeverities, SuffixConstants {
 			return localErrorCount;
 		}
 
-		/**
-		 * @param globalProblemsCount
-		 * @param globalErrorsCount
-		 * @param globalWarningsCount
-		 */
 		public void logProblemsSummary(int globalProblemsCount,
 			int globalErrorsCount, int globalWarningsCount, int globalInfoCount, int globalTasksCount) {
 			if ((this.tagBits & Logger.XML) != 0) {
@@ -1002,9 +988,6 @@ public class Main implements ProblemSeverities, SuffixConstants {
 			}
 		}
 
-		/**
-		 *
-		 */
 		public void logProgress() {
 			printOut('.');
 		}
@@ -1019,9 +1002,6 @@ public class Main implements ProblemSeverities, SuffixConstants {
 			printlnOut(this.main.bind("compile.repetition", //$NON-NLS-1$
 				String.valueOf(i + 1), String.valueOf(repetitions)));
 		}
-		/**
-		 * @param compilerStats
-		 */
 		public void logTiming(CompilerStats compilerStats) {
 			long time = compilerStats.elapsedTime();
 			long lineCount = compilerStats.lineCount;
@@ -1065,7 +1045,6 @@ public class Main implements ProblemSeverities, SuffixConstants {
 
 		/**
 		 * Print the usage of the compiler
-		 * @param usage
 		 */
 		public void logUsage(String usage) {
 			printlnOut(usage);
@@ -1221,9 +1200,6 @@ public class Main implements ProblemSeverities, SuffixConstants {
 			}
 		}
 
-		/**
-		 *
-		 */
 		public void printNewLine() {
 			this.out.println();
 		}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/ModuleFinder.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/ModuleFinder.java
@@ -154,7 +154,6 @@ public class ModuleFinder {
 	 * element, first being the source module and second being the target module.
 	 * The expected format is:
 	 *  --add-reads <source-module>=<target-module>
-	 * @param option
 	 * @return a String[] with source and target module of the "reads" clause.
 	 */
 	protected static String[] extractAddonRead(String option) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/AnnotationInfo.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/AnnotationInfo.java
@@ -44,7 +44,6 @@ AnnotationInfo(byte[] classFileBytes, int[] contantPoolOffsets, int offset) {
 	super(classFileBytes, contantPoolOffsets, offset);
 }
 /**
- * @param classFileBytes
  * @param offset the offset into <code>classFileBytes</code> for the "type_index" of the annotation attribute.
  * @param populate <code>true</code> to indicate to build out the annotation structure.
  */

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/CodeStream.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/CodeStream.java
@@ -3759,10 +3759,6 @@ final public byte[] getContents() {
 
 /**
  * Returns the type that should be substituted to original binding declaring class as the proper receiver type
- * @param currentScope
- * @param codegenBinding
- * @param actualReceiverType
- * @param isImplicitThisReceiver
  * @return the receiver type to use in constant pool
  */
 public static TypeBinding getConstantPoolDeclaringClass(Scope currentScope, FieldBinding codegenBinding, TypeBinding actualReceiverType, boolean isImplicitThisReceiver) {
@@ -3789,10 +3785,6 @@ public static TypeBinding getConstantPoolDeclaringClass(Scope currentScope, Fiel
 
 /**
  * Returns the type that should be substituted to original binding declaring class as the proper receiver type
- * @param currentScope
- * @param codegenBinding
- * @param actualReceiverType
- * @param isImplicitThisReceiver
  * @return the receiver type to use in constant pool
  */
 public static TypeBinding getConstantPoolDeclaringClass(Scope currentScope, MethodBinding codegenBinding, TypeBinding actualReceiverType, boolean isImplicitThisReceiver) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/env/IModuleAwareNameEnvironment.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/env/IModuleAwareNameEnvironment.java
@@ -124,7 +124,6 @@ public interface IModuleAwareNameEnvironment extends INameEnvironment {
 
 	/**
 	 * Answer whether the given package (within the given module) contains any compilation unit.
-	 * @param qualifiedPackageName
 	 * @param checkCUs - if true, check contained Compilation Units for a matching package declaration
 	 * @return true iff the package contains at least one compilation unit.
 	 */
@@ -144,7 +143,6 @@ public interface IModuleAwareNameEnvironment extends INameEnvironment {
 	/**
 	 * Lists all packages in the module identified by the given, real module name
 	 * (i.e., this method is implemented only for {@link LookupStrategy#Named}).
-	 * @param moduleName
 	 * @return array of flat, dot-separated package names
 	 */
 	char[][] listPackages(char[] moduleName);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/env/IModulePathEntry.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/env/IModulePathEntry.java
@@ -18,7 +18,6 @@ import org.eclipse.jdt.core.compiler.CharOperation;
 /**
  * Represents an entry on the module path of a project. Could be a single module or a collection of
  * modules (like a jimage or an exploded module directory structure)
- *
  */
 public interface IModulePathEntry {
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/env/IMultiModuleEntry.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/env/IMultiModuleEntry.java
@@ -18,7 +18,6 @@ import java.util.Collection;
 /**
  * Represents a module path entry that represents a collection of modules
  * like a jimage or an exploded module directory structure
- *
  */
 public interface IMultiModuleEntry extends IModulePathEntry {
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/env/INameEnvironmentExtension.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/env/INameEnvironmentExtension.java
@@ -21,7 +21,6 @@ package org.eclipse.jdt.internal.compiler.env;
  *
  * This name environment adds a method to switch on/off the search for secondary types.
  * Refer {@link #findType(char[], char[][], boolean)}.
- *
  */
 public interface INameEnvironmentExtension extends INameEnvironment {
 	/**

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/env/ITypeAnnotationWalker.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/env/ITypeAnnotationWalker.java
@@ -91,7 +91,6 @@ public interface ITypeAnnotationWalker {
 	/**
 	 * Detail of {@link #toTypeParameterBounds(boolean, int)}: walk to the bounds
 	 * of the previously selected type parameter.
-	 * @param boundIndex
 	 */
 	public abstract ITypeAnnotationWalker toTypeBound(short boundIndex);
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/flow/ConditionalFlowInfo.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/flow/ConditionalFlowInfo.java
@@ -22,7 +22,6 @@ import org.eclipse.jdt.internal.compiler.lookup.LocalVariableBinding;
 
 /**
  * Record conditional initialization status during definite assignment analysis
- *
  */
 public class ConditionalFlowInfo extends FlowInfo {
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/flow/FlowInfo.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/flow/FlowInfo.java
@@ -324,7 +324,6 @@ abstract public void markAsDefinitelyUnknown(LocalVariableBinding local);
 
 /**
  * Mark the null status of the given local according to the given status
- * @param local
  * @param nullStatus bitset of FLowInfo.UNKNOWN ... FlowInfo.POTENTIALLY_NON_NULL
  */
 public void markNullStatus(LocalVariableBinding local, int nullStatus) {
@@ -355,7 +354,6 @@ public void markNullStatus(LocalVariableBinding local, int nullStatus) {
 
 /**
  * Answer the null status of the given local
- * @param local
  * @return bitset of FlowInfo.UNKNOWN ... FlowInfo.POTENTIALLY_NON_NULL
  */
 public int nullStatus(LocalVariableBinding local) {
@@ -674,7 +672,6 @@ abstract public UnconditionalFlowInfo unconditionalInitsWithoutSideEffect();
 
 /**
  * Resets the definite and potential initialization info for the given local variable
- * @param local
  */
 abstract public void resetAssignmentInfo(LocalVariableBinding local);
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/impl/CompilerOptions.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/impl/CompilerOptions.java
@@ -598,7 +598,6 @@ public class CompilerOptions {
 
 	/**
 	 * Initializing the compiler options with external settings
-	 * @param settings
 	 */
 	public CompilerOptions(Map<String, String> settings){
 		resetDefaults();

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/impl/Constant.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/impl/Constant.java
@@ -1472,7 +1472,6 @@ public abstract class Constant implements TypeIds, OperatorIds {
 
 	/**
 	 * Returns true if both constants have the same type and the same actual value
-	 * @param otherConstant
 	 */
 	public boolean hasSameValue(Constant otherConstant) {
 		if (this == otherConstant)

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/impl/IrritantSet.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/impl/IrritantSet.java
@@ -236,8 +236,6 @@ public class IrritantSet {
 
 	/**
 	 * Initialize a set of irritants in one group
-	 *
-	 * @param singleGroupIrritants
 	 */
 	public void initialize(int singleGroupIrritants) {
 		if (singleGroupIrritants == 0)
@@ -254,7 +252,6 @@ public class IrritantSet {
 
 	/**
 	 * Returns true if any of the irritants in given other set is positionned in receiver
-	 * @param other
 	 */
 	public boolean isAnySet(IrritantSet other) {
 		if (other == null)
@@ -295,8 +292,6 @@ public class IrritantSet {
 
 	/**
 	 * Return updated irritantSet or null if it was a no-op
-	 *
-	 * @param other
 	 */
 	public IrritantSet set(IrritantSet other) {
 		if (other == null)

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/AnnotationBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/AnnotationBinding.java
@@ -31,8 +31,6 @@ public class AnnotationBinding {
  * Add the standard annotations encoded in the tag bits to the recorded annotations.
  *
  * @param recordedAnnotations existing annotations already created
- * @param annotationTagBits
- * @param env
  * @return the combined list of annotations
  */
 public static AnnotationBinding[] addStandardAnnotations(AnnotationBinding[] recordedAnnotations, long annotationTagBits, LookupEnvironment env) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BinaryTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BinaryTypeBinding.java
@@ -283,19 +283,12 @@ public BinaryTypeBinding(BinaryTypeBinding prototype) {
 
 /**
  * Standard constructor for creating binary type bindings from binary models (classfiles)
- * @param packageBinding
- * @param binaryType
- * @param environment
  */
 public BinaryTypeBinding(PackageBinding packageBinding, IBinaryType binaryType, LookupEnvironment environment) {
 	this(packageBinding, binaryType, environment, false);
 }
 /**
  * Standard constructor for creating binary type bindings from binary models (classfiles)
- * @param packageBinding
- * @param binaryType
- * @param environment
- * @param needFieldsAndMethods
  */
 public BinaryTypeBinding(PackageBinding packageBinding, IBinaryType binaryType, LookupEnvironment environment, boolean needFieldsAndMethods) {
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/CompilationUnitScope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/CompilationUnitScope.java
@@ -987,10 +987,6 @@ private void recordImportBinding(ImportBinding bindingToAdd) {
  * Checks additional bindings (methods or types) imported from a single static import.
  * Method is tried first, followed by type. If found, records them.
  * If in the process, import is flagged as duplicate, -1 is returned.
- * @param compoundName
- * @param typesBySimpleNames
- * @param mask
- * @param importReference
  */
 private void checkMoreStaticBindings(
 		char[][] compoundName,
@@ -1020,10 +1016,6 @@ private void checkMoreStaticBindings(
 /**
  * Checks for duplicates. If all ok, records the importBinding
  * returns -1 when this import is flagged as duplicate.
- * @param importBinding
- * @param typesBySimpleNames
- * @param importReference
- * @param compoundName
  * @return -1 when this import is flagged as duplicate, importPtr otherwise.
  */
 private int checkAndRecordImportBinding(

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
@@ -1081,7 +1081,6 @@ public class InferenceContext18 {
 
 	/**
 	 * JLS 18.2. reduce all initial constraints
-	 * @throws InferenceFailureException
 	 */
 	private boolean reduce() throws InferenceFailureException {
 		// Caution: This can be reentered recursively even as an earlier call is munching through the constraints !
@@ -1115,7 +1114,6 @@ public class InferenceContext18 {
 
 	/**
 	 * Retrieve the resolved solutions for all given type variables.
-	 * @param typeParameters
 	 * @param boundSet where instantiations are to be found
 	 * @return array containing the substituted types or <code>null</code> elements for any type variable that could not be substituted.
 	 */
@@ -1151,7 +1149,6 @@ public class InferenceContext18 {
 	 /** <b>JLS 18.4 </b> Resolution
 	  * @param isRecordPatternTypeInference for 18.5.5_item_3_bullet_5
 	 * @return answer null if some constraint resolved to FALSE, otherwise the boundset representing the solution
-	 * @throws InferenceFailureException
 	 */
 	private /*@Nullable*/ BoundSet resolve(
 			InferenceVariable[] toResolve,
@@ -1304,7 +1301,6 @@ public class InferenceContext18 {
 	/**
 	 * <b>JLS 18.4</b> Resolution
 	 * @return answer null if some constraint resolved to FALSE, otherwise the boundset representing the solution
-	 * @throws InferenceFailureException
 	 */
 	private /*@Nullable*/ BoundSet resolve(InferenceVariable[] toResolve) throws InferenceFailureException {
 		return resolve(toResolve, false);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MethodBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MethodBinding.java
@@ -501,8 +501,6 @@ public final char[] constantPoolName() {
 
 /**
  * After method verifier has finished, fill in missing @NonNull specification from the applicable default.
- * @param needToApplyParameterNonNullDefault
- * @param needToApplyReturnNonNullDefault
  */
 protected void fillInDefaultNonNullness(AbstractMethodDeclaration sourceMethod, boolean needToApplyReturnNonNullDefault, ParameterNonNullDefaultProvider needToApplyParameterNonNullDefault) {
 	if (this.parameterNonNullness == null)
@@ -1474,7 +1472,6 @@ public void updateTypeVariableBinding(TypeVariableBinding previousBinding, TypeV
  *  <li> It has a single variable arity parameter (§8.4.1) whose declared type is Object[]. </li>
  *  <li> It is native. </li>
  * <br/>
- * @param  scope
  * @return true if the method has Polymorphic Signature
  */
 public boolean hasPolymorphicSignature(Scope scope) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MissingTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MissingTypeBinding.java
@@ -23,9 +23,6 @@ public class MissingTypeBinding extends BinaryTypeBinding {
 
 /**
  * Special constructor for constructing proxies of missing types (114349)
- * @param packageBinding
- * @param compoundName
- * @param environment
  */
 public MissingTypeBinding(PackageBinding packageBinding, char[][] compoundName, LookupEnvironment environment) {
 	this.compoundName = compoundName;
@@ -76,7 +73,6 @@ public int problemId() {
 
 /**
  * Only used to fixup the superclass hierarchy of proxy binary types
- * @param missingSuperclass
  * @see LookupEnvironment#createMissingType(PackageBinding, char[][])
  */
 void setMissingSuperclass(ReferenceBinding missingSuperclass) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedGenericMethodBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedGenericMethodBinding.java
@@ -814,9 +814,7 @@ public class ParameterizedGenericMethodBinding extends ParameterizedMethodBindin
 		final private Scope scope;
 
 		/**
-		 * @param variables
 		 * @param substitutes when null, substitute type variable by unbounded wildcard
-		 * @param scope
 		 */
 		public LingeringTypeVariableEliminator(TypeVariableBinding [] variables, TypeBinding [] substitutes, Scope scope) {
 			this.variables = variables;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
@@ -173,8 +173,6 @@ public static FieldBinding binarySearch(char[] name, FieldBinding[] sortedFields
  * (remember methods are sorted alphabetically on selectors), and end is the index of last contiguous methods with same
  * selector.
  * -1 means no method got found
- * @param selector
- * @param sortedMethods
  * @return (start + (end<<32)) or -1 if no method found
  */
 public static long binarySearch(char[] selector, MethodBinding[] sortedMethods) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Scope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Scope.java
@@ -891,8 +891,6 @@ public abstract class Scope {
 
 	/**
 	 * Connect type variable supertypes, and returns true if no problem was detected
-	 * @param typeParameters
-	 * @param checkForErasedCandidateCollisions
 	 */
 	protected boolean connectTypeVariables(TypeParameter[] typeParameters, boolean checkForErasedCandidateCollisions) {
 		/* https://bugs.eclipse.org/bugs/show_bug.cgi?id=305259 - We used to not bother with connecting
@@ -5466,7 +5464,6 @@ public abstract class Scope {
 	/**
 	 * Check whether the given null default is redundant at the given position inside this scope.
 	 * @param nullBits locally defined nullness default, see Binding.NullnessDefaultMASK
-	 * @param sourceStart
 	 * @return enclosing binding that already has a matching NonNullByDefault annotation,
 	 * 		or the special binding {@link #NOT_REDUNDANT}, indicating that a different enclosing nullness default was found,
 	 * 		or null to indicate that no enclosing nullness default was found.

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SignatureWrapper.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SignatureWrapper.java
@@ -106,7 +106,6 @@ public class SignatureWrapper {
 	 * <p>
 	 * But for the signature <code>(Lp18/Klass&lt;TT;&gt;.MethodInfo&lt;Ljava/lang/String;&gt;.InnerMethodInfo&lt;Ljava/lang/String;&gt;;)V</code>
 	 * it produces <code>(Lp18/Klass.MethodInfo.InnerMethodInfo;)V</code>
-	 *
 	 */
 	private void removeTypeArguments() {
 		StringBuilder buffer = new StringBuilder();

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SourceTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SourceTypeBinding.java
@@ -659,7 +659,6 @@ public SyntheticMethodBinding addSyntheticMethod(LambdaExpression lambda) {
 /*
  * Add a synthetic method for the reference expression as a place holder for code generation
  * only if the reference expression's target is serializable
- *
  */
 public SyntheticMethodBinding addSyntheticMethod(ReferenceExpression ref) {
 	if (!isPrototype()) throw new IllegalStateException();

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SyntheticFactoryMethodBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SyntheticFactoryMethodBinding.java
@@ -38,7 +38,6 @@ public class SyntheticFactoryMethodBinding extends MethodBinding {
 
 	/** Apply the given type arguments on the (declaring class of the) actual constructor being represented by this factory method and
 	    if method type arguments is not empty materialize the parameterized generic constructor
-	 * @param targetType
 	*/
 	public ParameterizedMethodBinding applyTypeArgumentsOnConstructor(TypeBinding[] typeArguments, TypeBinding[] constructorTypeArguments, boolean inferredWithUncheckedConversion, TypeBinding targetType) {
 		ReferenceBinding parameterizedType = typeArguments == null

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeBinding.java
@@ -235,7 +235,6 @@ public TypeBinding closestMatch() {
 
 /**
  * Iterate through the type components to collect instances of leaf missing types
- * @param missingTypes
  * @return missing types
  */
 public List<TypeBinding> collectMissingTypes(List<TypeBinding> missingTypes) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
@@ -2949,9 +2949,6 @@ protected void consumeConditionalExpression(int op) {
 			this.expressionStack[this.expressionPtr + 1],
 			this.expressionStack[this.expressionPtr + 2]);
 }
-/**
- * @param op
- */
 protected void consumeConditionalExpressionWithName(int op) {
 	// ConditionalExpression ::= Name '?' Expression ':' ConditionalExpression
 	this.intPtr -= 2;//consume position of the question mark
@@ -4144,7 +4141,6 @@ protected void consumeEqualityExpression(int op) {
 			op);
 }
 /*
- * @param op
  */
 protected void consumeEqualityExpressionWithName(int op) {
 	// EqualityExpression ::= Name '==' RelationalExpression

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Scanner.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Scanner.java
@@ -122,7 +122,6 @@ public class Scanner implements TerminalTokens {
 	boolean breakPreviewAllowed = false;
 	/**
 	 * The current context of the scanner w.r.t restricted keywords
-	 *
 	 */
 	enum ScanContext {
 		EXPECTING_KEYWORD, EXPECTING_IDENTIFIER, AFTER_REQUIRES, INACTIVE

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemHandler.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemHandler.java
@@ -52,7 +52,6 @@ public class ProblemHandler {
  * Problem handler can be supplied with a policy to specify
  * its behavior in error handling. Also see static methods for
  * built-in policies.
- *
  */
 public ProblemHandler(IErrorHandlingPolicy policy, CompilerOptions options, IProblemFactory problemFactory) {
 	this.policy = policy;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
@@ -731,7 +731,6 @@ public static int getIrritant(int problemID) {
 }
 /**
  * Compute problem category ID based on problem ID
- * @param problemID
  * @return a category ID
  * @see CategorizedProblem
  */

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/tool/Util.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/tool/Util.java
@@ -29,7 +29,6 @@ import javax.tools.FileObject;
 
 /**
  * Util class that defines helper methods to read class contents with handling of wrong encoding
- *
  */
 public final class Util {
 	public static String LINE_SEPARATOR = System.getProperty("line.separator"); //$NON-NLS-1$

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/util/CtSym.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/util/CtSym.java
@@ -225,7 +225,6 @@ public class CtSym {
 	 *
 	 * @param releaseCode release number encoded (7,8,9,A,B...)
 	 * @param qualifiedSignatureFileName signature file name (without module)
-	 * @param moduleName
 	 * @return corresponding path in ct.sym file system or null if not found
 	 */
 	public Path getFullPath(String releaseCode, String qualifiedSignatureFileName, String moduleName) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/util/HashtableOfObject.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/util/HashtableOfObject.java
@@ -19,7 +19,6 @@ import org.eclipse.jdt.core.compiler.CharOperation;
 
 /**
  * Hashtable of {char[] --> Object }
- *
  */
 public final class HashtableOfObject {
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/util/JRTUtil.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/util/JRTUtil.java
@@ -176,7 +176,6 @@ public class JRTUtil {
 	 * @param path
 	 *            absolute file path to a jar archive
 	 * @return never null
-	 * @throws IOException
 	 */
 	public static FileSystem getJarFileSystem(Path path) throws IOException {
 		URI uri = URI.create("jar:file:" + path.toUri().getRawPath()); //$NON-NLS-1$
@@ -236,7 +235,6 @@ public class JRTUtil {
 	 * @param image a java.io.File handle to the JRT image.
 	 * @param visitor an instance of JrtFileVisitor to be notified of the entries in the JRT image.
 	 * @param notify flag indicating the notifications the client is interested in.
-	 * @throws IOException
 	 */
 	public static void walkModuleImage(File image, final JRTUtil.JrtFileVisitor<java.nio.file.Path> visitor, int notify) throws IOException {
 		JrtFileSystem system = getJrtSystem(image, null);
@@ -316,7 +314,6 @@ public class JRTUtil {
 	/**
 	 * Tries to read all bytes of the file denoted by path,
 	 * returns null if the file could not be found or if the read was interrupted.
-	 * @param path
 	 * @return bytes or null
 	 * @throws IOException any IO exception other than NoSuchFileException
 	 */
@@ -360,7 +357,6 @@ class JrtFileSystemWithOlderRelease extends JrtFileSystem {
 	 * need to be loaded.
 	 *
 	 * @param release the older release where classes and modules should be searched for.
-	 * @throws IOException
 	 */
 	JrtFileSystemWithOlderRelease(Jdk jdkHome, String release) throws IOException {
 		super(jdkHome, release);
@@ -528,9 +524,6 @@ class JrtFileSystem {
 	/**
 	 * The jrt file system is based on the location of the JRE home whose libraries
 	 * need to be loaded.
-	 *
-	 * @param jdkHome
-	 * @throws IOException
 	 */
 	JrtFileSystem(Jdk jdkHome, String release) throws IOException {
 		this.jdk = jdkHome;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/util/Util.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/util/Util.java
@@ -554,7 +554,6 @@ public class Util implements SuffixConstants {
 
 	/**
 	 * Returns a one line summary for an exception (extracted from its stacktrace: name + first frame)
-	 * @param exception
 	 * @return one line summary for an exception
 	 */
 	public static String getExceptionSummary(Throwable exception) {
@@ -984,7 +983,6 @@ public class Util implements SuffixConstants {
 	 * @param outputPath the given output directory
 	 * @param relativeFileName the given relative file name
 	 * @param classFile the given classFile to write
-	 *
 	 */
 	public static void writeToDisk(boolean generatePackagesStructure, String outputPath, String relativeFileName, ClassFile classFile) throws IOException {
 		FileOutputStream file = getFileOutputStream(generatePackagesStructure, outputPath, relativeFileName);

--- a/org.eclipse.jdt.core.tests.builder/src/org/eclipse/jdt/core/tests/builder/ParticipantBuildTests.java
+++ b/org.eclipse.jdt.core.tests.builder/src/org/eclipse/jdt/core/tests/builder/ParticipantBuildTests.java
@@ -380,7 +380,6 @@ public class ParticipantBuildTests extends BuilderTests {
 
 	/**
 	 * Test that a build participant can inspect the declared annotations by name
-	 * @throws JavaModelException
 	 */
 	public void testProcessAnnotationHasAnnotation() throws JavaModelException {
 		IPath projectPath = env.addProject("Project", "1.5"); //$NON-NLS-1$ //$NON-NLS-2$

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/parser/DietCompletionTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/parser/DietCompletionTest.java
@@ -1308,7 +1308,6 @@ public void test35() {
 }
 /*
  * Invalid completion inside a comment
- *
  */
 public void test36() {
 
@@ -1342,7 +1341,6 @@ public void test36() {
 }
 /*
  * Invalid completion inside a string literal
- *
  */
 public void test37() {
 
@@ -1378,7 +1376,6 @@ public void test37() {
 }
 /*
  * Invalid completion inside a number literal
- *
  */
 public void test38() {
 

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/parser/SourceElementParserTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/parser/SourceElementParserTest.java
@@ -5197,7 +5197,6 @@ public void test76() {
 /**
  * Bug 99662:[1.5] JavaModel returns inexistent IType for package-info ICompilationUnits
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=99662"
- *
  */
 public void testBug99662() {
 

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericTypeSignatureTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericTypeSignatureTest.java
@@ -92,8 +92,6 @@ public class GenericTypeSignatureTest extends AbstractRegressionTest {
 		super(name);
 	}
 
-	/**
-	 */
 	protected void cleanUp() {
 		Util.flushDirectoryContent(new File(OUTPUT_DIR));
 	}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/InternalHexFloatTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/InternalHexFloatTest.java
@@ -52,8 +52,6 @@ public class InternalHexFloatTest extends AbstractRegressionTest {
 		return InternalHexFloatTest.class;
 	}
 
-	/**
-	 */
 	public void test001() {
 		List x = new ArrayList();
 
@@ -187,8 +185,6 @@ public class InternalHexFloatTest extends AbstractRegressionTest {
 		}
 	}
 
-	/**
-	 */
 	public void test002() {
 		List x = new ArrayList();
 		// various forms of zero

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LookupTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LookupTest.java
@@ -134,9 +134,6 @@ public void test003() {
 		"SUCCESS"
 	);
 }
-/**
- *
- */
 public void test004() {
 	this.runConformTest(
 		new String[] {
@@ -174,9 +171,6 @@ public void test004() {
 		"SUCCESS"
 	);
 }
-/**
- *
- */
 public void test005() {
 	this.runConformTest(
 		new String[] {
@@ -359,9 +353,6 @@ public void test010() {
 		"Cannot make a static reference to the non-static field A.success\n" +
 		"----------\n");
 }
-/**
- *
- */
 public void test011() {
 	this.runNegativeTest(
 		new String[] {
@@ -399,9 +390,6 @@ public void test011() {
 		"----------\n"
 	);
 }
-/**
- *
- */
 public void test012() {
 	this.runConformTest(
 		new String[] {
@@ -428,9 +416,6 @@ public void test012() {
 		"SUCCESS"
 	);
 }
-/**
- *
- */
 public void test013() {
 	this.runNegativeTest(
 		new String[] {
@@ -485,9 +470,6 @@ public void test013() {
 		"----------\n"
 	);
 }
-/**
- *
- */
 public void test014() {
 	this.runNegativeTest(
 		new String[] {
@@ -512,9 +494,6 @@ public void test014() {
 		"----------\n"
 	);
 }
-/**
- *
- */
 public void test015() {
 	this.runConformTest(
 		new String[] {
@@ -535,9 +514,6 @@ public void test015() {
 		"SUCCESS"
 	);
 }
-/**
- *
- */
 public void test016() {
 	this.runConformTest(
 		new String[] {
@@ -583,9 +559,6 @@ public void test016() {
 		}
 	);
 }
-/**
- *
- */
 public void test017() {
 	this.runConformTest(
 		new String[] {
@@ -751,9 +724,6 @@ public void test021() {
 		}
 	);
 }
-/**
- *
- */
 public void test022() {
 	this.runConformTest(
 		new String[] {
@@ -791,9 +761,6 @@ public void test022() {
 		}
 	);
 }
-/**
- *
- */
 public void test023() {
 	this.runConformTest(
 		new String[] {
@@ -820,9 +787,6 @@ public void test023() {
 		}
 	);
 }
-/**
- *
- */
 public void test024() {
 	this.runConformTest(
 		new String[] {
@@ -847,9 +811,6 @@ public void test024() {
 		}
 	);
 }
-/**
- *
- */
 public void test025() {
 	this.runConformTest(
 		new String[] {
@@ -887,9 +848,6 @@ public void test025() {
 		"SUCCESS"
 	);
 }
-/**
- *
- */
 public void test026() {
 	this.runNegativeTest(
 		new String[] {
@@ -930,9 +888,6 @@ public void test026() {
 		"The field A.B.B is not visible\n" +
 		"----------\n");
 }
-/**
- *
- */
 public void test027() {
 	this.runNegativeTest(
 		new String[] {
@@ -974,9 +929,6 @@ public void test027() {
 		"----------\n"
 	);
 }
-/**
- *
- */
 public void test028() {
 	this.runConformTest(
 		new String[] {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchExpressionsYieldTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchExpressionsYieldTest.java
@@ -694,7 +694,6 @@ public class SwitchExpressionsYieldTest extends AbstractRegressionTest {
 				expectedProblemLog);
 	}
 	/*
-	 *
 	 */
 	public void testBug544073_021() {
 		String[] testFiles = new String[] {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TextBlockTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TextBlockTest.java
@@ -27,7 +27,6 @@ import junit.framework.Test;
  * strategy is to keep this one updated and when the time comes, move this over
  * to the other bundle after synch-up of tests from both.
  * @author jay
- *
  */
 public class TextBlockTest extends AbstractRegressionTest {
 

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/dom/StandAloneASTParserTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/dom/StandAloneASTParserTest.java
@@ -399,7 +399,6 @@ public class StandAloneASTParserTest extends AbstractRegressionTest {
 
 	/**
 	 * @deprecated
-	 * @throws IOException
 	 */
 	public void testBug415066_001() throws IOException {
 		File rootDir = new File(System.getProperty("java.io.tmpdir"));
@@ -488,7 +487,6 @@ public class StandAloneASTParserTest extends AbstractRegressionTest {
 	/**
 	 * Negative test case
 	 * @deprecated
-	 * @throws IOException
 	 */
 	public void testBug415066_002() throws IOException {
 		File rootDir = new File(System.getProperty("java.io.tmpdir"));

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/junit/extension/TestCase.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/junit/extension/TestCase.java
@@ -653,7 +653,6 @@ public static List buildTestsList(Class evaluationTestClass, int inheritedDepth,
  *
  * Note that this lis maybe reduced using some mechanisms detailed in {@link #buildTestsList(Class)} method.
  *
- * @param evaluationTestClass
  * @return a {@link Test test suite}
  */
 public static Test buildTestSuite(Class evaluationTestClass) {
@@ -667,8 +666,6 @@ public static Test buildTestSuite(Class evaluationTestClass) {
  *
  * Note that this lis maybe reduced using some mechanisms detailed in {@link #buildTestsList(Class)} method.
  *
- * @param evaluationTestClass
- * @param suiteName
  * @return a test suite ({@link Test})
  */
 public static Test buildTestSuite(Class evaluationTestClass, String suiteName) {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/runtime/AbstractReader.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/runtime/AbstractReader.java
@@ -34,7 +34,6 @@ public AbstractReader(String name) {
 abstract protected void readerLoop();
 /**
  * Start the thread that reads events.
- *
  */
 public void start() {
 	this.readerThread = new Thread(

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/util/Util.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/util/Util.java
@@ -1533,8 +1533,6 @@ public static void zipFiles(File[] files, String zipPath) throws IOException {
  * Returns the compilation errors / warnings for the given CompilationResult.
  *
  * @param compilationResult the compilation result
- * @param showCategory
- * @param showWarningToken
  * @return String the problem log
  */
 public static String getProblemLog(CompilationResult compilationResult, boolean showCategory, boolean showWarningToken) {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter14Test.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter14Test.java
@@ -47,7 +47,6 @@ import junit.framework.Test;
  * This test, although originally was created for AST Level 14,
  * during the second iteration of preview feature Records,
  * being migrated to AST 15.
- *
  */
 @SuppressWarnings("rawtypes")
 public class ASTConverter14Test extends ConverterTestSetup {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter15JLS4Test.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter15JLS4Test.java
@@ -1808,9 +1808,6 @@ public class ASTConverter15JLS4Test extends ConverterTestSetup {
 		assertNotNull("No javadoc", annotationTypeDeclaration.getJavadoc());
 	}
 
-	/**
-	 *
-	 */
 	public void test0056() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter15" , "src", "test0056", "X.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		ASTNode result = runJLS4Conversion(sourceUnit, true, true);

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter15JLS8Test.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter15JLS8Test.java
@@ -1801,9 +1801,6 @@ public class ASTConverter15JLS8Test extends ConverterTestSetup {
 		assertNotNull("No javadoc", annotationTypeDeclaration.getJavadoc());
 	}
 
-	/**
-	 *
-	 */
 	public void test0056() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter15" , "src", "test0056", "X.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		ASTNode result = runJLS8Conversion(sourceUnit, true, true);

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter15Test.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter15Test.java
@@ -1818,9 +1818,6 @@ public class ASTConverter15Test extends ConverterTestSetup {
 		assertNotNull("No javadoc", annotationTypeDeclaration.getJavadoc());
 	}
 
-	/**
-	 *
-	 */
 	public void test0056() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter15" , "src", "test0056", "X.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		ASTNode result = runJLS3Conversion(sourceUnit, true, true);

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter17Test.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter17Test.java
@@ -801,8 +801,6 @@ public class ASTConverter17Test extends ConverterTestSetup {
 	}
 	/**
      * https://bugs.eclipse.org/bugs/show_bug.cgi?id=402673
-     *
-     * @throws JavaModelException
      */
     public void test402673a() throws JavaModelException {
             String contents = "package test402673;"
@@ -831,8 +829,6 @@ public class ASTConverter17Test extends ConverterTestSetup {
     }
     /**
      * https://bugs.eclipse.org/bugs/show_bug.cgi?id=402673
-     *
-     * @throws JavaModelException
      */
     public void test402673b() throws JavaModelException {
             String contents = "package test402673;"
@@ -865,8 +861,6 @@ public class ASTConverter17Test extends ConverterTestSetup {
     }
 	/**
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=402674
-	 *
-	 * @throws JavaModelException
 	 */
 	public void test403444() throws JavaModelException {
 		this.workingCopy = getWorkingCopy("/Converter18/src/test403444/X.java",

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter18Test.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter18Test.java
@@ -166,8 +166,6 @@ public class ASTConverter18Test extends ConverterTestSetup {
 	/**
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=395886 tests annotations on
 	 * QTR in multiple scenarios of occurrence.
-	 *
-	 * @throws JavaModelException
 	 */
 	public void test0002() throws JavaModelException {
 		this.workingCopy = getWorkingCopy("/Converter18/src/test0002/X.java",
@@ -268,8 +266,6 @@ public class ASTConverter18Test extends ConverterTestSetup {
 	/**
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=395886 tests the
 	 * representation of type annotations on a possible JAVA 7 and 8 place.
-	 *
-	 * @throws JavaModelException
 	 */
 	public void test0003() throws JavaModelException {
 		this.workingCopy = getWorkingCopy("/Converter18/src/test0003/X.java",
@@ -306,8 +302,6 @@ public class ASTConverter18Test extends ConverterTestSetup {
 	/**
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=395886 tests QTR with
 	 * annotations
-	 *
-	 * @throws JavaModelException
 	 */
 	public void test0004() throws JavaModelException {
 		this.workingCopy = getWorkingCopy("/Converter18/src/test0004/X.java",
@@ -355,8 +349,6 @@ public class ASTConverter18Test extends ConverterTestSetup {
 	/**
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=395886 tests QTR with
 	 * annotations
-	 *
-	 * @throws JavaModelException
 	 */
 	public void test0005() throws JavaModelException {
 		this.workingCopy = getWorkingCopy("/Converter18/src/test0005/X.java",
@@ -455,8 +447,6 @@ public class ASTConverter18Test extends ConverterTestSetup {
 	/**
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=395886 tests PQTR with
 	 * annotations part
-	 *
-	 * @throws JavaModelException
 	 */
 	public void test0006() throws JavaModelException {
 		this.workingCopy = getWorkingCopy("/Converter18/src/test0006/X.java",
@@ -1290,8 +1280,6 @@ public class ASTConverter18Test extends ConverterTestSetup {
 	}
 	/**
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=399768
-	 *
-	 * @throws JavaModelException
 	 */
 	public void test0013() throws JavaModelException {
 		this.workingCopy = getWorkingCopy("/Converter18/src/test0010/X.java",
@@ -1336,8 +1324,6 @@ public class ASTConverter18Test extends ConverterTestSetup {
 
 	/**
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=399768
-	 *
-	 * @throws JavaModelException
 	 */
 	public void test0014() throws JavaModelException {
 		this.workingCopy = getWorkingCopy("/Converter18/src/test0011/X.java",
@@ -1392,8 +1378,6 @@ public class ASTConverter18Test extends ConverterTestSetup {
 
 	/**
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=399768
-	 *
-	 * @throws JavaModelException
 	 */
 	public void test0015() throws JavaModelException {
 		this.workingCopy = getWorkingCopy("/Converter18/src/test0012/X.java",
@@ -1567,8 +1551,6 @@ public class ASTConverter18Test extends ConverterTestSetup {
 
 	/**
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=399793
-	 *
-	 * @throws JavaModelException
 	 */
 	public void test399793a() throws JavaModelException {
 		this.workingCopy = getWorkingCopy("/Converter18/src/test399793/X.java",
@@ -1604,8 +1586,6 @@ public class ASTConverter18Test extends ConverterTestSetup {
 
 	/**
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=399793
-	 *
-	 * @throws JavaModelException
 	 */
 	public void test399793b() throws JavaModelException {
 		this.workingCopy = getWorkingCopy("/Converter18/src/test399793/X.java",
@@ -1637,8 +1617,6 @@ public class ASTConverter18Test extends ConverterTestSetup {
 
 	/**
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=399793
-	 *
-	 * @throws JavaModelException
 	 */
 	public void test399793c() throws JavaModelException {
 		this.workingCopy = getWorkingCopy("/Converter18/src/test399793/X.java",
@@ -1672,8 +1650,6 @@ public class ASTConverter18Test extends ConverterTestSetup {
 
 	/**
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=399793
-	 *
-	 * @throws JavaModelException
 	 */
 	public void test399793d() throws JavaModelException {
 		this.workingCopy = getWorkingCopy("/Converter18/src/test399793/X.java",
@@ -1712,8 +1688,6 @@ public class ASTConverter18Test extends ConverterTestSetup {
 	/**
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=399794
 	 * ReferenceExpression Family Tests
-	 *
-	 * @throws JavaModelException
 	 */
 	public void test399794() throws JavaModelException {
 		this.workingCopy = getWorkingCopy("/Converter18/src/test399794/X.java",
@@ -1932,8 +1906,6 @@ public class ASTConverter18Test extends ConverterTestSetup {
 
 	/**
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=399793
-	 *
-	 * @throws JavaModelException
 	 */
 	public void test399793e() throws JavaModelException {
 		this.workingCopy = getWorkingCopy("/Converter18/src/test399793/X.java",
@@ -1965,8 +1937,6 @@ public class ASTConverter18Test extends ConverterTestSetup {
 
 	/**
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=402665
-	 *
-	 * @throws JavaModelException
 	 */
 	public void test402665a() throws JavaModelException {
 		this.workingCopy = getWorkingCopy("/Converter18/src/test402665/X.java",
@@ -2152,8 +2122,6 @@ public class ASTConverter18Test extends ConverterTestSetup {
 	}
 	/**
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=402674
-	 *
-	 * @throws JavaModelException
 	 */
 	public void test402674() throws JavaModelException {
 		this.workingCopy = getWorkingCopy("/Converter18/src/test402674/X.java",
@@ -2687,8 +2655,6 @@ public class ASTConverter18Test extends ConverterTestSetup {
 	/**
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=406505
 	 * tests the source range issue that resulted in bad ast node.
-	 *
-	 * @throws JavaModelException
 	 */
 	public void testBug406505() throws JavaModelException {
 		this.workingCopy = getWorkingCopy("/Converter18/src/test406505/X.java",
@@ -2759,8 +2725,6 @@ public class ASTConverter18Test extends ConverterTestSetup {
 	}
 	/**
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=417017
-	 *
-	 * @throws JavaModelException
 	 */
 	public void test417017a() throws JavaModelException {
 		this.workingCopy = getWorkingCopy("/Converter18/src/test417017/X.java",
@@ -2791,8 +2755,6 @@ public class ASTConverter18Test extends ConverterTestSetup {
 	}
 	/**
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=417017
-	 *
-	 * @throws JavaModelException
 	 */
 	public void test417017b() throws JavaModelException {
 		this.workingCopy = getWorkingCopy("/Converter18/src/test417017/X.java",
@@ -2823,8 +2785,6 @@ public class ASTConverter18Test extends ConverterTestSetup {
 	}
 	/**
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=417017
-	 *
-	 * @throws JavaModelException
 	 */
 	public void test417017c() throws JavaModelException {
 		this.workingCopy = getWorkingCopy("/Converter18/src/test417017/X.java",
@@ -2855,8 +2815,6 @@ public class ASTConverter18Test extends ConverterTestSetup {
 	}
 	/**
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=417017
-	 *
-	 * @throws JavaModelException
 	 */
 	public void test417017d() throws JavaModelException {
 		this.workingCopy = getWorkingCopy("/Converter18/src/test399794/X.java",
@@ -2887,8 +2845,6 @@ public class ASTConverter18Test extends ConverterTestSetup {
 
 	/**
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=417017
-	 *
-	 * @throws JavaModelException
 	 */
 	public void test417017e() throws JavaModelException {
 		this.workingCopy = getWorkingCopy("/Converter18/src/test399794/X.java",
@@ -2914,8 +2870,6 @@ public class ASTConverter18Test extends ConverterTestSetup {
 
 	/**
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=417017
-	 *
-	 * @throws JavaModelException
 	 */
 	public void test417017f() throws JavaModelException {
 		this.workingCopy = getWorkingCopy("/Converter18/src/test399794/X.java",
@@ -4346,8 +4300,6 @@ public void testBug425183a() throws JavaModelException {
 }
 /**
  * https://bugs.eclipse.org/bugs/show_bug.cgi?id=432051
- *
- * @throws JavaModelException
  */
 public void testBug432051() throws JavaModelException {
 	String contents =
@@ -4382,8 +4334,6 @@ public void testBug432051() throws JavaModelException {
 }
 /**
  * https://bugs.eclipse.org/bugs/show_bug.cgi?id=426977
- *
- * @throws JavaModelException
  */
 public void testBug426977() throws JavaModelException {
 	String contents =
@@ -4919,8 +4869,6 @@ public void testBug432614() throws JavaModelException {
 }
 /**
  * https://bugs.eclipse.org/bugs/show_bug.cgi?id=447062
- *
- * @throws JavaModelException
  */
 public void testBug447062() throws JavaModelException {
 	String contents =
@@ -4951,8 +4899,6 @@ public void testBug447062() throws JavaModelException {
 }
 /**
  * https://bugs.eclipse.org/bugs/show_bug.cgi?id=399793
- *
- * @throws JavaModelException
  */
 public void testBug425601_001() throws JavaModelException {
 	this.workingCopy = getWorkingCopy("/Converter18/src/testBug425601_001/Outer.java",
@@ -4996,8 +4942,6 @@ public void testBug425601_001() throws JavaModelException {
 
 /**
  * https://bugs.eclipse.org/bugs/show_bug.cgi?id=399793
- *
- * @throws JavaModelException
  */
 public void testBug425601_002() throws JavaModelException {
 	this.workingCopy = getWorkingCopy("/Converter18/src/testBug425601_002/Outer.java",
@@ -5043,7 +4987,6 @@ public void testBug425601_002() throws JavaModelException {
  * https://bugs.eclipse.org/bugs/show_bug.cgi?id=44000
  *
  * @bug Bug 440000 [1.8][dom] MethodReference#resolveMethodBinding() API should return null for CreationReference of an ArrayType
- * @throws JavaModelException
  */
 public void testBug440000_001() throws JavaModelException {
 	String contents =
@@ -5067,8 +5010,6 @@ public void testBug440000_001() throws JavaModelException {
 }
 /**
  * https://bugs.eclipse.org/bugs/show_bug.cgi?id=459344
- *
- * @throws JavaModelException
  */
 public void testBug459344_001() throws JavaModelException {
 	this.workingCopy = getWorkingCopy("/Converter18/src/test459344/X.java",
@@ -5097,7 +5038,6 @@ public void testBug459344_001() throws JavaModelException {
 /**
  * https://bugs.eclipse.org/bugs/show_bug.cgi?id=460186
  * @bug Bug 460186 IAE in ASTNode.setSourceRange with broken code case 2
- * @throws JavaModelException
  */
 public void testBug460186() throws JavaModelException {
 	String contents =
@@ -5120,7 +5060,6 @@ public void testBug460186() throws JavaModelException {
 /**
  * https://bugs.eclipse.org/bugs/show_bug.cgi?id=443232
  * @bug Bug 443232 IAE in ASTNode.setSourceRange with broken code
- * @throws JavaModelException
  */
 public void testBug443232() throws JavaModelException {
 	String contents =
@@ -5147,8 +5086,6 @@ public void testBug443232() throws JavaModelException {
 }
 /**
  * https://bugs.eclipse.org/bugs/show_bug.cgi?id=429813
- *
- * @throws JavaModelException
  */
 public void test429813() throws JavaModelException {
 	this.workingCopy = getWorkingCopy("/Converter18/src/test429813/Snippet.java",

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter9Test.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter9Test.java
@@ -1421,7 +1421,6 @@ public class ASTConverter9Test extends ConverterTestSetup {
 	}
 	/**
 	 * @deprecated
-	 * @throws Exception
 	 */
 	public void testBug542795() throws Exception {
 		IJavaProject p =  createJavaProject("Foo", new String[] {"src"}, new String[] {jcl9lib}, "bin", "11");

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterAST3Test.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterAST3Test.java
@@ -45,8 +45,6 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	/**
 	 * Internal access method to VariableDeclarationFragment#setExtraDimensions() for avoiding deprecated warnings.
 	 *
-	 * @param node
-	 * @param dimensions
 	 * @deprecated
 	 */
 	private void internalSetExtraDimensions(VariableDeclarationFragment node, int dimensions) {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterAST4Test.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterAST4Test.java
@@ -45,8 +45,6 @@ public class ASTConverterAST4Test extends ConverterTestSetup {
 	/**
 	 * Internal access method to VariableDeclarationFragment#setExtraDimensions() for avoiding deprecated warnings.
 	 *
-	 * @param node
-	 * @param dimensions
 	 * @deprecated
 	 */
 	private void internalSetExtraDimensions(VariableDeclarationFragment node, int dimensions) {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterBindingsTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterBindingsTest.java
@@ -504,9 +504,6 @@ public class ASTConverterBindingsTest extends ConverterTestSetup {
 		checkBindingEqualityForProject("Converter15");
 	}
 
-	/**
-	 * @throws JavaModelException
-	 */
 	private void checkBindingEqualityForProject(String projectName) throws JavaModelException {
 		IJavaProject javaProject = getJavaProject(projectName);
 		IPackageFragment[] packageFragments = javaProject.getPackageFragments();

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterJavadocTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterJavadocTest.java
@@ -141,18 +141,11 @@ public class ASTConverterJavadocTest extends ConverterTestSetup {
 	protected boolean stopOnFailure = true;
 	Map savedOptions = null;
 
-	/**
-	 * @param name
-	 * @param support
-	 */
 	public ASTConverterJavadocTest(String name, String support, String unix) {
 		super(name);
 		this.docCommentSupport = support;
 		this.unix = "true".equals(unix);
 	}
-	/**
-	 * @param name
-	 */
 	public ASTConverterJavadocTest(String name) {
 		this(name.substring(0, name.indexOf(" - ")),
 				name.substring(name.indexOf(" - Doc ") + 7, name.lastIndexOf("abled") + 5),
@@ -3503,7 +3496,6 @@ public class ASTConverterJavadocTest extends ConverterTestSetup {
 	}
 	/**
 	 *
-	 * @throws JavaModelException
 	 * @deprecated
 	 */
 	public void testBug206345b() throws JavaModelException {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterJavadocTest_15.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterJavadocTest_15.java
@@ -125,18 +125,11 @@ public class ASTConverterJavadocTest_15 extends ConverterTestSetup {
 
 
 
-	/**
-	 * @param name
-	 * @param support
-	 */
 	public ASTConverterJavadocTest_15(String name, String support, String unix) {
 		super(name);
 		this.docCommentSupport = support;
 		this.unix = "true".equals(unix);
 	}
-	/**
-	 * @param name
-	 */
 	public ASTConverterJavadocTest_15(String name) {
 		this(name.substring(0, name.indexOf(" - ")),
 				name.substring(name.indexOf(" - Doc ") + 7, name.lastIndexOf("abled") + 5),

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterJavadocTest_18.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterJavadocTest_18.java
@@ -110,9 +110,6 @@ public class ASTConverterJavadocTest_18 extends ConverterTestSetup {
 
 	private static String SNIPPET_TAG = '@' + new String(JavadocTagConstants.TAG_SNIPPET);
 
-	/**
-	 * @param name
-	 */
 	public ASTConverterJavadocTest_18(String name) {
 		super(name);
 	}

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterTest2.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterTest2.java
@@ -2768,8 +2768,6 @@ public class ASTConverterTest2 extends ConverterTestSetup {
 		checkSourceRange(componentType, "Class", source);
 	}
 
-	/**
-	 */
 	public void test0498() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0498", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		ASTNode result = runConversion(sourceUnit, true);
@@ -2809,7 +2807,6 @@ public class ASTConverterTest2 extends ConverterTestSetup {
 	 * Test for bug 45436 fix.
 	 * When this bug happened, the first assertion was false (2 problems found).
 	 * @see <a href="http://bugs.eclipse.org/bugs/show_bug.cgi?id=45436">bug 45436</a>
-	 * @throws JavaModelException
 	 */
 	public void test0500() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0500", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterTestAST3_2.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterTestAST3_2.java
@@ -2852,8 +2852,6 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 		checkSourceRange(componentType, "Class", source);
 	}
 
-	/**
-	 */
 	public void test0498() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0498", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
@@ -2893,7 +2891,6 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 * Test for bug 45436 fix.
 	 * When this bug happened, the first assertion was false (2 problems found).
 	 * @see <a href="http://bugs.eclipse.org/bugs/show_bug.cgi?id=45436">bug 45436</a>
-	 * @throws JavaModelException
 	 */
 	public void test0500() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0500", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterTestAST4_2.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterTestAST4_2.java
@@ -2849,8 +2849,6 @@ public class ASTConverterTestAST4_2 extends ConverterTestSetup {
 		checkSourceRange(componentType, "Class", source);
 	}
 
-	/**
-	 */
 	public void test0498() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0498", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		ASTNode result = runConversion(getJLS4(), sourceUnit, true);
@@ -2890,7 +2888,6 @@ public class ASTConverterTestAST4_2 extends ConverterTestSetup {
 	 * Test for bug 45436 fix.
 	 * When this bug happened, the first assertion was false (2 problems found).
 	 * @see <a href="http://bugs.eclipse.org/bugs/show_bug.cgi?id=45436">bug 45436</a>
-	 * @throws JavaModelException
 	 */
 	public void test0500() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0500", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterTestAST8_2.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterTestAST8_2.java
@@ -2879,8 +2879,6 @@ public class ASTConverterTestAST8_2 extends ConverterTestSetup {
 		checkSourceRange(type, "Class", source);
 	}
 
-	/**
-	 */
 	public void test0498() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0498", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		ASTNode result = runConversion(getJLS8(), sourceUnit, true);
@@ -2920,7 +2918,6 @@ public class ASTConverterTestAST8_2 extends ConverterTestSetup {
 	 * Test for bug 45436 fix.
 	 * When this bug happened, the first assertion was false (2 problems found).
 	 * @see <a href="http://bugs.eclipse.org/bugs/show_bug.cgi?id=45436">bug 45436</a>
-	 * @throws JavaModelException
 	 */
 	public void test0500() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0500", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
@@ -10786,7 +10783,6 @@ public class ASTConverterTestAST8_2 extends ConverterTestSetup {
 	}
 	/**
 	 * @deprecated
-	 * @throws JavaModelException
 	 */
 	public void testBug443942() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "org.eclipse.swt.internal.gtk", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter_15Test.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter_15Test.java
@@ -124,7 +124,6 @@ public class ASTConverter_15Test extends ConverterTestSetup {
 
 	/**
 	 * Added for Bug 561193 - [14]record keyword inside method not colored correctly
-	 * @throws CoreException
 	 */
 	public void _testRecord002() throws CoreException {
 		if (!isJRE15) {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter_16Test.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter_16Test.java
@@ -109,7 +109,6 @@ public class ASTConverter_16Test extends ConverterTestSetup {
 
 	/**
 	 * Added for Bug 561193 - [14]record keyword inside method not colored correctly
-	 * @throws CoreException
 	 */
 	public void testRecord002() throws CoreException {
 		if (!isJRE16) {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTMatcherTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTMatcherTest.java
@@ -133,7 +133,6 @@ public class ASTMatcherTest extends org.eclipse.jdt.core.tests.junit.extension.T
 	/**
 	 * @deprecated (not really - just suppressing the warnings
 	 * that come from testing Javadoc.getComment())
-	 *
 	 */
 	protected void setUp() throws Exception {
 		super.setUp();
@@ -1047,7 +1046,6 @@ public class ASTMatcherTest extends org.eclipse.jdt.core.tests.junit.extension.T
 	/**
 	 * @deprecated (not really - just suppressing the warnings
 	 * that come from testing Javadoc.getComment())
-	 *
 	 */
 	public void testJavadoc() {
 		Javadoc x1 = this.ast.newJavadoc();

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTTest.java
@@ -805,7 +805,6 @@ public class ASTTest extends org.eclipse.jdt.core.tests.junit.extension.TestCase
 	/**
 	 * Internal access method to VariableDeclarationFragment#setExtraDimensions for avoiding deprecated warnings.
 	 *
-	 * @param node
 	 * @deprecated
 	 */
 	private void setExtraDimensions(VariableDeclarationFragment node, int dimensions) {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTVisitorTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTVisitorTest.java
@@ -155,7 +155,6 @@ public class ASTVisitorTest extends org.eclipse.jdt.core.tests.junit.extension.T
 	/**
 	 * @deprecated (not really - just suppressing the warnings
 	 * that come from testing Javadoc.getComment())
-	 *
 	 */
 	protected void setUp() throws Exception {
 		super.setUp();
@@ -687,7 +686,6 @@ public class ASTVisitorTest extends org.eclipse.jdt.core.tests.junit.extension.T
 		/**
 		 * @deprecated (not really - just suppressing the warnings
 		 * that come from testing Javadoc.getComment())
-		 *
 		 */
 		public boolean visit(Javadoc node) {
 			ASTVisitorTest.this.b.append("(JD"); //$NON-NLS-1$
@@ -704,7 +702,6 @@ public class ASTVisitorTest extends org.eclipse.jdt.core.tests.junit.extension.T
 		/**
 		 * @deprecated (not really - just suppressing the warnings
 		 * that come from testing Javadoc.getComment())
-		 *
 		 */
 		public void endVisit(Javadoc node) {
 			ASTVisitorTest.this.b.append("JD)"); //$NON-NLS-1$
@@ -1697,7 +1694,6 @@ public class ASTVisitorTest extends org.eclipse.jdt.core.tests.junit.extension.T
 	/**
 	 * @deprecated (not really - just suppressing the warnings
 	 * that come from testing Javadoc.getComment())
-	 *
 	 */
 	public void testJavadoc() {
 		Javadoc x1 = this.ast.newJavadoc();

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ProfilingASTConvertionTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ProfilingASTConvertionTest.java
@@ -99,10 +99,6 @@ public class ProfilingASTConvertionTest extends AbstractJavaModelTests {
 		return String.valueOf(buffer);
 	}
 
-	/**
-	 * @param array
-	 * @param increment
-	 */
 	private void printDistribution(long[] array, int increment) {
 		int bound = increment;
 		int counter = 0;
@@ -132,10 +128,6 @@ public class ProfilingASTConvertionTest extends AbstractJavaModelTests {
 		printRange(counter, bound, increment, totalCounter, length, numberOfFiguresForRange, numberOfFiguresForCounter);
 	}
 
-	/**
-	 * @param counter
-	 * @param bound
-	 */
 	private void printRange(int counter, int bound, int increment, int totalCounter, int length, int numberOfFiguresForRange, int numberOfFiguresForCounters) {
 		if (counter != 0) {
 			StringBuffer buffer = new StringBuffer();
@@ -157,10 +149,6 @@ public class ProfilingASTConvertionTest extends AbstractJavaModelTests {
 	}
 
 	/**
-	 * @param totalTime
-	 * @param length
-	 * @param times
-	 * @param arrayList
 	 * @deprecated using deprecated code
 	 */
 	private void reportResults(int apiLevel, long totalTime, int length, long[] times, ArrayList arrayList) {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/formatter/FormatterRegressionTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/formatter/FormatterRegressionTests.java
@@ -2104,8 +2104,6 @@ public class FormatterRegressionTests extends AbstractJavaModelTests {
 		runTest(codeFormatter, "test185", "A.java", CodeFormatter.K_COMPILATION_UNIT);//$NON-NLS-1$ //$NON-NLS-2$
 	}
 
-	/**
-	 */
 	public void _test186() {
 		DefaultCodeFormatterOptions preferences = new DefaultCodeFormatterOptions(DefaultCodeFormatterConstants.getEclipse21Settings());
 		preferences.tab_char = DefaultCodeFormatterOptions.TAB;
@@ -2146,8 +2144,6 @@ public class FormatterRegressionTests extends AbstractJavaModelTests {
 		runTest(codeFormatter, "test189", "A.java", CodeFormatter.K_COMPILATION_UNIT);//$NON-NLS-1$ //$NON-NLS-2$
 	}
 
-	/**
-	 */
 	public void test190() {
 		Map options = DefaultCodeFormatterConstants.getEclipse21Settings();
 		options.put(DefaultCodeFormatterConstants.FORMATTER_NUMBER_OF_EMPTY_LINES_TO_PRESERVE, "1");
@@ -2157,8 +2153,6 @@ public class FormatterRegressionTests extends AbstractJavaModelTests {
 		runTest(codeFormatter, "test190", "A.java", CodeFormatter.K_COMPILATION_UNIT);//$NON-NLS-1$ //$NON-NLS-2$
 	}
 
-	/**
-	 */
 	public void test191() {
 		DefaultCodeFormatterOptions preferences = new DefaultCodeFormatterOptions(DefaultCodeFormatterConstants.getEclipse21Settings());
 		preferences.number_of_empty_lines_to_preserve = 0;

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AbstractJavaModelTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AbstractJavaModelTests.java
@@ -301,7 +301,6 @@ public abstract class AbstractJavaModelTests extends SuiteOfTestCases {
 	protected static final int AST_INTERNAL_JLS21 = AST.JLS21;
 	/**
 	 * Internal synonym for the latest AST level.
-	 *
 	 */
 	protected static final int AST_INTERNAL_LATEST = AST.getJLSLatest();
 
@@ -598,7 +597,6 @@ public abstract class AbstractJavaModelTests extends SuiteOfTestCases {
 	/**
 	 * See buildModelTestSuite(Class evaluationTestClass) for more information.
 	 *
-	 * @param evaluationTestClass
 	 * @param minCompliance minimum compliance level required to run this test suite
 	 * @return a test suite ({@link Test})
 	 */
@@ -618,7 +616,6 @@ public abstract class AbstractJavaModelTests extends SuiteOfTestCases {
 	 * This test suite differ from this computed in {@link TestCase} in the fact that this is
 	 * a {@link SuiteOfTestCases.Suite} instead of a simple framework {@link TestSuite}.
 	 *
-	 * @param evaluationTestClass
 	 * @return a test suite ({@link Test})
 	 */
 	public static Test buildModelTestSuite(Class evaluationTestClass) {
@@ -635,7 +632,6 @@ public abstract class AbstractJavaModelTests extends SuiteOfTestCases {
 	 * This test suite differ from this computed in {@link TestCase} in the fact that this is
 	 * a {@link SuiteOfTestCases.Suite} instead of a simple framework {@link TestSuite}.
 	 *
-	 * @param evaluationTestClass
 	 * @param ordering kind of sort use for the list (see {@link #ORDERING} for possible values)
 	 * @return a test suite ({@link Test})
 	 */
@@ -3203,10 +3199,7 @@ public abstract class AbstractJavaModelTests extends SuiteOfTestCases {
 
 	/**
 	 * Select a field in a compilation unit identified with the first occurence in the source of a given selection.
-	 * @param unit
-	 * @param selection
 	 * @return IField
-	 * @throws JavaModelException
 	 */
 	protected IField selectField(ICompilationUnit unit, String selection) throws JavaModelException {
 		return selectField(unit, selection, 1);
@@ -3214,11 +3207,7 @@ public abstract class AbstractJavaModelTests extends SuiteOfTestCases {
 
 	/**
 	 * Select a field in a compilation unit identified with the nth occurence in the source of a given selection.
-	 * @param unit
-	 * @param selection
-	 * @param occurences
 	 * @return IField
-	 * @throws JavaModelException
 	 */
 	protected IField selectField(ICompilationUnit unit, String selection, int occurences) throws JavaModelException {
 		return (IField) selectJavaElement(unit, selection, occurences, IJavaElement.FIELD);
@@ -3226,10 +3215,7 @@ public abstract class AbstractJavaModelTests extends SuiteOfTestCases {
 
 	/**
 	 * Select a local variable in a compilation unit identified with the first occurence in the source of a given selection.
-	 * @param unit
-	 * @param selection
 	 * @return IType
-	 * @throws JavaModelException
 	 */
 	protected ILocalVariable selectLocalVariable(ICompilationUnit unit, String selection) throws JavaModelException {
 		return selectLocalVariable(unit, selection, 1);
@@ -3237,11 +3223,7 @@ public abstract class AbstractJavaModelTests extends SuiteOfTestCases {
 
 	/**
 	 * Select a local variable in a compilation unit identified with the nth occurence in the source of a given selection.
-	 * @param unit
-	 * @param selection
-	 * @param occurences
 	 * @return IType
-	 * @throws JavaModelException
 	 */
 	protected ILocalVariable selectLocalVariable(ICompilationUnit unit, String selection, int occurences) throws JavaModelException {
 		return (ILocalVariable) selectJavaElement(unit, selection, occurences, IJavaElement.LOCAL_VARIABLE);
@@ -3249,10 +3231,7 @@ public abstract class AbstractJavaModelTests extends SuiteOfTestCases {
 
 	/**
 	 * Select a method in a compilation unit identified with the first occurence in the source of a given selection.
-	 * @param unit
-	 * @param selection
 	 * @return IMethod
-	 * @throws JavaModelException
 	 */
 	protected IMethod selectMethod(ICompilationUnit unit, String selection) throws JavaModelException {
 		return selectMethod(unit, selection, 1);
@@ -3260,11 +3239,7 @@ public abstract class AbstractJavaModelTests extends SuiteOfTestCases {
 
 	/**
 	 * Select a method in a compilation unit identified with the nth occurence in the source of a given selection.
-	 * @param unit
-	 * @param selection
-	 * @param occurences
 	 * @return IMethod
-	 * @throws JavaModelException
 	 */
 	protected IMethod selectMethod(ICompilationUnit unit, String selection, int occurences) throws JavaModelException {
 		return (IMethod) selectJavaElement(unit, selection, occurences, IJavaElement.METHOD);
@@ -3272,10 +3247,7 @@ public abstract class AbstractJavaModelTests extends SuiteOfTestCases {
 
 	/**
 	 * Select a parameterized source method in a compilation unit identified with the first occurence in the source of a given selection.
-	 * @param unit
-	 * @param selection
 	 * @return ParameterizedSourceMethod
-	 * @throws JavaModelException
 	 */
 	protected ResolvedSourceMethod selectParameterizedMethod(ICompilationUnit unit, String selection) throws JavaModelException {
 		return selectParameterizedMethod(unit, selection, 1);
@@ -3283,11 +3255,7 @@ public abstract class AbstractJavaModelTests extends SuiteOfTestCases {
 
 	/**
 	 * Select a parameterized source method in a compilation unit identified with the nth occurence in the source of a given selection.
-	 * @param unit
-	 * @param selection
-	 * @param occurences
 	 * @return ParameterizedSourceMethod
-	 * @throws JavaModelException
 	 */
 	protected ResolvedSourceMethod selectParameterizedMethod(ICompilationUnit unit, String selection, int occurences) throws JavaModelException {
 		IMethod type = selectMethod(unit, selection, occurences);
@@ -3297,10 +3265,7 @@ public abstract class AbstractJavaModelTests extends SuiteOfTestCases {
 
 	/**
 	 * Select a parameterized source type in a compilation unit identified with the first occurence in the source of a given selection.
-	 * @param unit
-	 * @param selection
 	 * @return ParameterizedSourceType
-	 * @throws JavaModelException
 	 */
 	protected ResolvedSourceType selectParameterizedType(ICompilationUnit unit, String selection) throws JavaModelException {
 		return selectParameterizedType(unit, selection, 1);
@@ -3308,11 +3273,7 @@ public abstract class AbstractJavaModelTests extends SuiteOfTestCases {
 
 	/**
 	 * Select a parameterized source type in a compilation unit identified with the nth occurence in the source of a given selection.
-	 * @param unit
-	 * @param selection
-	 * @param occurences
 	 * @return ParameterizedSourceType
-	 * @throws JavaModelException
 	 */
 	protected ResolvedSourceType selectParameterizedType(ICompilationUnit unit, String selection, int occurences) throws JavaModelException {
 		IType type = selectType(unit, selection, occurences);
@@ -3322,10 +3283,7 @@ public abstract class AbstractJavaModelTests extends SuiteOfTestCases {
 
 	/**
 	 * Select a type in a compilation unit identified with the first occurence in the source of a given selection.
-	 * @param unit
-	 * @param selection
 	 * @return IType
-	 * @throws JavaModelException
 	 */
 	protected IType selectType(ICompilationUnit unit, String selection) throws JavaModelException {
 		return selectType(unit, selection, 1);
@@ -3333,11 +3291,7 @@ public abstract class AbstractJavaModelTests extends SuiteOfTestCases {
 
 	/**
 	 * Select a type in a compilation unit identified with the nth occurence in the source of a given selection.
-	 * @param unit
-	 * @param selection
-	 * @param occurences
 	 * @return IType
-	 * @throws JavaModelException
 	 */
 	protected IType selectType(ICompilationUnit unit, String selection, int occurences) throws JavaModelException {
 		return (IType) selectJavaElement(unit, selection, occurences, IJavaElement.TYPE);
@@ -3345,10 +3299,7 @@ public abstract class AbstractJavaModelTests extends SuiteOfTestCases {
 
 	/**
 	 * Select a type parameter in a compilation unit identified with the first occurence in the source of a given selection.
-	 * @param unit
-	 * @param selection
 	 * @return IType
-	 * @throws JavaModelException
 	 */
 	protected ITypeParameter selectTypeParameter(ICompilationUnit unit, String selection) throws JavaModelException {
 		return selectTypeParameter(unit, selection, 1);
@@ -3356,11 +3307,7 @@ public abstract class AbstractJavaModelTests extends SuiteOfTestCases {
 
 	/**
 	 * Select a type parameter in a compilation unit identified with the nth occurence in the source of a given selection.
-	 * @param unit
-	 * @param selection
-	 * @param occurences
 	 * @return IType
-	 * @throws JavaModelException
 	 */
 	protected ITypeParameter selectTypeParameter(ICompilationUnit unit, String selection, int occurences) throws JavaModelException {
 		return (ITypeParameter) selectJavaElement(unit, selection, occurences, IJavaElement.TYPE_PARAMETER);

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AttachedJavadocTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AttachedJavadocTests.java
@@ -605,7 +605,6 @@ public class AttachedJavadocTests extends ModifyingResourceTests {
 	 * to that entry
 	 *
 	 * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=304394"
-	 * @throws Exception
 	 */
 	public void testBug304394() throws Exception {
 		setJavadocLocationAttribute("specialDoc");
@@ -658,7 +657,6 @@ public class AttachedJavadocTests extends ModifyingResourceTests {
 	 * contain the javadoc location attrribute.
 	 *
 	 * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=304394"
-	 * @throws Exception
 	 */
 	public void testBug304394a() throws Exception {
 		setJavadocLocationAttribute("specialDoc");

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ClasspathInitializerTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ClasspathInitializerTests.java
@@ -1643,7 +1643,6 @@ public void testUserLibraryInitializer1() throws Exception {
 }
 /**
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=346002"
- * @throws Exception
  */
 public void testBug346002() throws Exception {
 	ClasspathContainerInitializer initializer = JavaCore.getClasspathContainerInitializer(JavaCore.USER_LIBRARY_CONTAINER_ID);

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ClasspathTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ClasspathTests.java
@@ -6031,7 +6031,6 @@ public void testForceNullArgumentsToEmptySet5() throws CoreException {
  *
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=276373"
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=280497"
- * @throws Exception
  */
 public void testBug276373() throws Exception {
 	File libDir = null;
@@ -6238,7 +6237,6 @@ public void testBug300136a() throws Exception {
  * Test that duplicate entries are not added to the resolved classpath
  *
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=294360"
- * @throws Exception
  */
 public void testBug294360a() throws Exception {
 	try {
@@ -6289,7 +6287,6 @@ public void testBug294360a() throws Exception {
  * 			 5) referenced libraries and their attributes are persisted in the .classpath file
  *
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=252431"
- * @throws Exception
  */
 public void testBug252341a() throws Exception {
 	try {
@@ -6407,7 +6404,6 @@ public void testBug252341a() throws Exception {
  * 4) Passing an empty array as referencedEntries clears the earlier referenced entries
  *
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=252431"
- * @throws Exception
  */
 public void testBug252341b() throws Exception {
 	try {
@@ -6538,7 +6534,6 @@ public void testBug252341b() throws Exception {
  * {@link IJavaProject#setRawClasspath(IClasspathEntry[], IClasspathEntry[], IPath, IProgressMonitor)}
  *
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=252431"
- * @throws Exception
  */
 public void testBug252341c() throws Exception {
 	try {
@@ -6603,7 +6598,6 @@ public void testBug252341c() throws Exception {
  * for the referenced classpath entries.
  *
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=304081"
- * @throws Exception
  */
 public void testBug304081() throws Exception {
 	File libDir = null;
@@ -6654,7 +6648,6 @@ public void testBug304081() throws Exception {
  * for the referenced classpath entries.
  *
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=304081"
- * @throws Exception
  */
 public void testBug304081a() throws Exception {
 	try {
@@ -6696,7 +6689,6 @@ public void testBug304081a() throws Exception {
  * 3) when a project is deleted, the non-chaining jar cache is reset.
  *
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=305122"
- * @throws Exception
  */
 public void testBug305122() throws Exception {
 	try {
@@ -6756,7 +6748,6 @@ public void testBug305122() throws Exception {
  * create any exceptions and is NOT added to the resolved classpath.
  *
  *  @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=308150"
- * @throws Exception
  */
 public void testBug308150() throws Exception {
 	try {
@@ -6790,7 +6781,6 @@ public void testBug308150() throws Exception {
  * and can be retrieved
  *
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=305037"
- * @throws Exception
  */
 public void testBug305037() throws Exception {
 	File libDir = null;
@@ -6843,7 +6833,6 @@ public void testBug305037() throws Exception {
  * for JARs from containers are resolved.
  *
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=313965"
- * @throws Exception
  */
 public void testBug313965() throws Exception {
 	try {
@@ -6886,7 +6875,6 @@ public void testBug313965() throws Exception {
  * the referenced libraries for JARs from containers are NOT resolved or added to the project's classpath.
  *
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=313965"
- * @throws Exception
  */
 public void testBug313965a() throws Exception {
 	try {
@@ -6940,7 +6928,6 @@ public void testBug321170() throws Exception {
  * Test that an invalid archive (JAR) creates a buildpath error
  *
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=229042"
- * @throws Exception
  */
 public void testBug229042() throws Exception {
 	try {
@@ -6976,7 +6963,6 @@ public void testBug229042() throws Exception {
  * Test that for an external project, relative paths are resolve relative to the project location.
  *
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=274737"
- * @throws Exception
  */
 public void testBug274737() throws Exception {
 	try {
@@ -7291,7 +7277,6 @@ public void testBug396299() throws Exception {
  * 3) when a project is deleted, the external files cache is reset.
  *
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=411423"
- * @throws Exception
  */
 public void testBug411423() throws Exception {
 	try {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests.java
@@ -20294,7 +20294,6 @@ public void test201762() throws JavaModelException {
 
 /**
  * An inner/member class should not be offered as completion suggestion.
- * @throws JavaModelException
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=270437"
  */
 public void test270437a() throws JavaModelException {
@@ -20322,7 +20321,6 @@ public void test270437a() throws JavaModelException {
 
 /**
  * An inner/member interface should not be offered as completion suggestion.
- * @throws JavaModelException
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=270437"
  */
 public void test270437b() throws JavaModelException {
@@ -20350,7 +20348,6 @@ public void test270437b() throws JavaModelException {
 
 /**
  * An inner/member interface should not be offered as completion suggestion.
- * @throws JavaModelException
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=270437"
  */
 public void test270437c() throws JavaModelException {
@@ -26231,7 +26228,6 @@ public void testBug574982() throws JavaModelException {
 }
 /**
  * https://bugs.eclipse.org/bugs/show_bug.cgi?id=578815
- * @throws IOException
  */
 public void testCompletionConstructorsForSubTypes() throws JavaModelException, IOException {
 	ICompilationUnit cu= getCompilationUnit("Completion", "src", "", "CompletionConstructorsForSubTypes.java");

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests18.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests18.java
@@ -3001,7 +3001,6 @@ public void test492947b() throws JavaModelException {
 }
 /**
  * Bug - No proposal yet for types on lambda arguments
- * @throws JavaModelException
  */
 public void _test492947c() throws JavaModelException {
 	this.workingCopies = new ICompilationUnit[1];

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CopyMoveResourcesTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CopyMoveResourcesTests.java
@@ -26,8 +26,6 @@ import org.eclipse.jdt.core.*;
 import org.eclipse.jdt.internal.core.util.Util;
 
 public class CopyMoveResourcesTests extends CopyMoveTests {
-/**
- */
 public CopyMoveResourcesTests(String name) {
 	super(name);
 }

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ExclusionPatternsTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ExclusionPatternsTests.java
@@ -483,7 +483,6 @@ public void testIsOnClasspath4() throws CoreException {
 /*
  * Ensures that an excluded nested source folder doesn't appear as a non-java resource of the outer folder.
  * (regression test for bug 28115 Ubiquitous resource in the JavaModel)
- *
  */
 public void testNestedSourceFolder1() throws CoreException {
 	setClasspath(new String[] {"/P/src1", "src2/**", "/P/src1/src2", ""});

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/HierarchyOnWorkingCopiesTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/HierarchyOnWorkingCopiesTests.java
@@ -54,8 +54,6 @@ protected void setUp() throws Exception {
 	super.setUp();
 }
 
-/**
- */
 public void testSimpleSubTypeHierarchy() throws CoreException {
 	String newContents =
 		"package x.y;\n" +
@@ -88,8 +86,6 @@ public void testSimpleSubTypeHierarchy() throws CoreException {
 		}
 	}
 }
-/**
- */
 public void testSimpleSuperTypeHierarchy() throws CoreException {
 	String newContents =
 		"package x.y;\n" +

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/InclusionPatternsTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/InclusionPatternsTests.java
@@ -630,7 +630,6 @@ public void testMoveFolderContainingPackage2() throws CoreException {
 }
 /*
  * Ensures that a non-included nested source folder doesn't appear as a non-java resource of the outer folder.
- *
  */
 public void testNestedSourceFolder1() throws CoreException {
 	setClasspath(new String[] {"/P/src1", "**/A.java", "/P/src1/src2", ""});

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaElementDeltaTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaElementDeltaTests.java
@@ -1406,7 +1406,6 @@ public void testCUNotOnClasspath() throws CoreException {
  * Ensure that deleting a jar that is in a folder and that is on the classpath reports
  * a removed  pkg fragment root delta.
  * (regression test for bug 27068 Elements in the Package Explorer are displayed but don't more exist [package explorer])
- *
  */
 public void testDeleteInnerJar() throws CoreException {
 	try {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchBugs14SwitchExpressionTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchBugs14SwitchExpressionTests.java
@@ -32,7 +32,6 @@ import junit.framework.Test;
  * Moved from JavaSearchBugs13Tests
  * All preview option disabled
  * @author vikchand
- *
  */
 public class JavaSearchBugs14SwitchExpressionTests extends AbstractJavaSearchTests {
 

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchBugs8Tests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchBugs8Tests.java
@@ -1686,7 +1686,6 @@ public void testBug427677() throws CoreException {
  * @test tests search for Reference expression - super:: form, without type arguments
  *
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=400904"
- *
  */
 public void testBug400904_0001() throws CoreException {
 	this.workingCopies = new ICompilationUnit[1];
@@ -1751,7 +1750,6 @@ public void testBug400904_0001a() throws CoreException {
  * @test tests search for Reference expression - super:: form, with type arguments
  *
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=400904"
- *
  */
 public void testBug400904_0002() throws CoreException {
 	this.workingCopies = new ICompilationUnit[1];
@@ -1787,7 +1785,6 @@ public void testBug400904_0002() throws CoreException {
  * @test tests search for Reference expression - SimpleName:: form, without type arguments.
  *
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=400904"
- *
  */
 public void testBug400904_0003() throws CoreException {
 	this.workingCopies = new ICompilationUnit[1];
@@ -1826,7 +1823,6 @@ public void testBug400904_0003() throws CoreException {
  * @test tests search for Reference expression - SimpleName:: form, with type arguments.
  *
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=400904"
- *
  */
 public void testBug400904_0004() throws CoreException {
 	this.workingCopies = new ICompilationUnit[1];
@@ -1859,7 +1855,6 @@ public void testBug400904_0004() throws CoreException {
  * @test tests search for Reference expression - QualifiedName:: form, without type arguments.
  *
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=400904"
- *
  */
 public void testBug400904_0005() throws CoreException {
 	this.workingCopies = new ICompilationUnit[1];
@@ -1894,7 +1889,6 @@ public void testBug400904_0005() throws CoreException {
  * @test tests search for Reference expression - QualifiedName:: form, with type arguments.
  *
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=400904"
- *
  */
 public void testBug400904_0006() throws CoreException {
 	this.workingCopies = new ICompilationUnit[1];
@@ -1929,7 +1923,6 @@ public void testBug400904_0006() throws CoreException {
  * @test tests search for Reference expression - Primary:: form, without type arguments.
  *
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=400904"
- *
  */
 public void testBug400904_0007() throws CoreException {
 	this.workingCopies = new ICompilationUnit[1];
@@ -1962,7 +1955,6 @@ public void testBug400904_0007() throws CoreException {
  * @test tests search for Reference expression - Primary:: form, with type arguments.
  *
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=400904"
- *
  */
 public void testBug400904_0008() throws CoreException {
 	this.workingCopies = new ICompilationUnit[1];
@@ -1995,7 +1987,6 @@ public void testBug400904_0008() throws CoreException {
  * @test tests search for Reference expression - X<T>:: form, without type arguments
  *
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=400904"
- *
  */
 public void testBug400904_0009() throws CoreException {
 	this.workingCopies = new ICompilationUnit[1];
@@ -2035,7 +2026,6 @@ public void testBug400904_0009() throws CoreException {
  * @test tests search for Reference expression - X<T>:: form, with type arguments
  *
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=400904"
- *
  */
 public void testBug400904_0010() throws CoreException {
 	this.workingCopies = new ICompilationUnit[1];
@@ -2074,7 +2064,6 @@ public void testBug400904_0010() throws CoreException {
  * @test tests search for Reference expression - X<T>.Name :: form, without type arguments
  *
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=400904"
- *
  */
 public void testBug400904_0011() throws CoreException {
 	this.workingCopies = new ICompilationUnit[1];
@@ -2112,7 +2101,6 @@ public void testBug400904_0011() throws CoreException {
  * @test tests search for Reference expression - X<T>.Name :: form, with type arguments
  *
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=400904"
- *
  */
 public void testBug400904_0012() throws CoreException {
 	this.workingCopies = new ICompilationUnit[1];
@@ -2150,7 +2138,6 @@ public void testBug400904_0012() throws CoreException {
  * @test tests search for Reference expression - X<T>.Y<K> :: form, without type arguments
  *
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=400904"
- *
  */
 public void testBug400904_0013() throws CoreException {
 	this.workingCopies = new ICompilationUnit[1];
@@ -2187,7 +2174,6 @@ public void testBug400904_0013() throws CoreException {
  * @test tests search for Reference expression - X<T>.Y<K> :: form, with type arguments
  *
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=400904"
- *
  */
 public void testBug400904_0014() throws CoreException {
 	this.workingCopies = new ICompilationUnit[1];
@@ -2224,7 +2210,6 @@ public void testBug400904_0014() throws CoreException {
  * @test tests search for Reference expression - X<T>.Y<K> :: new form, with type arguments
  *
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=400904"
- *
  */
 public void testBug400904_0015() throws CoreException {
 	this.workingCopies = new ICompilationUnit[1];
@@ -2262,7 +2247,6 @@ public void testBug400904_0015() throws CoreException {
  * @test lambda expression search on a) field b)parameter
  *
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=400905"
- *
  */
 public void testBug400905_0001() throws CoreException {
 	this.workingCopies = new ICompilationUnit[1];
@@ -2294,7 +2278,6 @@ public void testBug400905_0001() throws CoreException {
  * interface declaration and usage being in different files.
  *
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=400905"
- *
  */
 public void testBug400905_0002() throws CoreException {
 	this.workingCopies = new ICompilationUnit[3];
@@ -2337,7 +2320,6 @@ public void testBug400905_0002() throws CoreException {
  * interface declaration and usage being in different files.
  *
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=400905"
- *
  */
 public void testBug400905_0003() throws CoreException {
 	this.workingCopies = new ICompilationUnit[3];
@@ -2374,7 +2356,6 @@ public void testBug400905_0003() throws CoreException {
  * interface declaration and usage being in different files.
  *
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=400905"
- *
  */
 public void testBug400905_0004() throws CoreException {
 	this.workingCopies = new ICompilationUnit[3];
@@ -2412,7 +2393,6 @@ public void testBug400905_0004() throws CoreException {
  * interface declaration and usage being in different files.
  *
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=400905"
- *
  */
 public void testBug400905_0005() throws CoreException {
 	this.workingCopies = new ICompilationUnit[3];
@@ -2446,7 +2426,6 @@ public void testBug400905_0005() throws CoreException {
  * interface declaration and usage being in different files.
  *
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=400905"
- *
  */
 public void testBug400905_0006() throws CoreException {
 	boolean indexState = isIndexDisabledForTest();
@@ -2493,7 +2472,6 @@ public void testBug400905_0006() throws CoreException {
  * interface declaration and usage being in different files.
  *
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=400905"
- *
  */
 public void testBug400905_0007() throws CoreException {
 	boolean indexState = isIndexDisabledForTest();
@@ -3701,7 +3679,6 @@ public void test430159d() throws CoreException {
  * @test tests search for Reference expression - super:: form, without type arguments
  *
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=429012"
- *
  */
 public void testBug429012_0001() throws CoreException {
 	this.workingCopies = new ICompilationUnit[1];
@@ -3738,7 +3715,6 @@ public void testBug429012_0001() throws CoreException {
  * @test tests search for Reference expression - super:: form, with type arguments
  *
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=429012"
- *
  */
 public void testBug429012_0002() throws CoreException {
 	this.workingCopies = new ICompilationUnit[1];
@@ -3775,7 +3751,6 @@ public void testBug429012_0002() throws CoreException {
  * @test tests search for Reference expression - SimpleName:: form, without type arguments.
  *
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=429012"
- *
  */
 public void testBug429012_0003() throws CoreException {
 	this.workingCopies = new ICompilationUnit[1];
@@ -3813,7 +3788,6 @@ public void testBug429012_0003() throws CoreException {
  * @test tests search for Reference expression - SimpleName:: form, with type arguments.
  *
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=429012"
- *
  */
 public void testBug429012_0004() throws CoreException {
 	this.workingCopies = new ICompilationUnit[1];
@@ -3847,7 +3821,6 @@ public void testBug429012_0004() throws CoreException {
  * @test tests search for Reference expression - QualifiedName:: form, without type arguments.
  *
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=429012"
- *
  */
 public void testBug429012_0005() throws CoreException {
 	this.workingCopies = new ICompilationUnit[1];
@@ -3883,7 +3856,6 @@ public void testBug429012_0005() throws CoreException {
  * @test tests search for Reference expression - QualifiedName:: form, with type arguments.
  *
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=429012"
- *
  */
 public void testBug429012_0006() throws CoreException {
 	this.workingCopies = new ICompilationUnit[1];
@@ -3919,7 +3891,6 @@ public void testBug429012_0006() throws CoreException {
  * @test tests search for Reference expression - Primary:: form, without type arguments.
  *
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=429012"
- *
  */
 public void testBug429012_0007() throws CoreException {
 	this.workingCopies = new ICompilationUnit[1];
@@ -3953,7 +3924,6 @@ public void testBug429012_0007() throws CoreException {
  * @test tests search for Reference expression - Primary:: form, with type arguments.
  *
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=429012"
- *
  */
 public void testBug429012_0008() throws CoreException {
 	this.workingCopies = new ICompilationUnit[1];
@@ -3987,7 +3957,6 @@ public void testBug429012_0008() throws CoreException {
  * @test tests search for Reference expression - X<T>:: form, without type arguments
  *
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=429012"
- *
  */
 public void testBug429012_0009() throws CoreException {
 	this.workingCopies = new ICompilationUnit[1];
@@ -4028,7 +3997,6 @@ public void testBug429012_0009() throws CoreException {
  * @test tests search for Reference expression - X<T>:: form, with type arguments
  *
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=429012"
- *
  */
 public void testBug429012_0010() throws CoreException {
 	this.workingCopies = new ICompilationUnit[1];
@@ -4068,7 +4036,6 @@ public void testBug429012_0010() throws CoreException {
  * @test tests search for Reference expression - X<T>.Name :: form, without type arguments
  *
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=429012"
- *
  */
 public void testBug429012_0011() throws CoreException {
 	this.workingCopies = new ICompilationUnit[1];
@@ -4107,7 +4074,6 @@ public void testBug429012_0011() throws CoreException {
  * @test tests search for Reference expression - X<T>.Name :: form, with type arguments
  *
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=429012"
- *
  */
 public void testBug429012_0012() throws CoreException {
 	this.workingCopies = new ICompilationUnit[1];
@@ -4146,7 +4112,6 @@ public void testBug429012_0012() throws CoreException {
  * @test tests search for Reference expression - X<T>.Y<K> :: form, without type arguments
  *
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=429012"
- *
  */
 public void testBug429012_0013() throws CoreException {
 	this.workingCopies = new ICompilationUnit[1];
@@ -4184,7 +4149,6 @@ public void testBug429012_0013() throws CoreException {
  * @test tests search for Reference expression - X<T>.Y<K> :: form, with type arguments
  *
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=429012"
- *
  */
 public void testBug429012_0014() throws CoreException {
 	this.workingCopies = new ICompilationUnit[1];
@@ -4222,7 +4186,6 @@ public void testBug429012_0014() throws CoreException {
  * @test tests search for Reference expression - X<T>.Y<K> :: new form, with type arguments
  *
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=429012"
- *
  */
 public void testBug429012_0015() throws CoreException {
 	this.workingCopies = new ICompilationUnit[1];

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchBugsTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchBugsTests.java
@@ -9024,7 +9024,6 @@ public void testBug195489d() throws CoreException {
  * @test 1) That potential match are now well found while searching for implementors
  * 			2) That there's a workaround for this problem
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=196339"
- * @throws CoreException
  */
 public void testBug196339() throws CoreException {
 	this.workingCopies = new ICompilationUnit[1];
@@ -9113,7 +9112,6 @@ public void testBug196339b() throws CoreException {
  * 			2) That only match outside system libraries are returned when SYSTEM_LIBRARIES is NOT used in scope
  * 			3) That match in system libraries are returned when no mask is used in scope
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=199004"
- * @throws CoreException
  */
 public void testBug199004_SystemLibraries() throws CoreException {
 	DefaultContainerInitializer intializer = new DefaultContainerInitializer(new String[] {"JavaSearchBugs", "/JavaSearchBugs/lib/b199004.jar"}) {
@@ -12577,8 +12575,6 @@ public void testBug324109() throws CoreException {
  * that IMethod#isContructor returns correct value
  *
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=329727"
- * @throws CoreException
- * @throws IOException
  */
 public void testBug329727() throws CoreException, IOException {
 	IJavaProject project = getJavaProject("JavaSearchBugs");

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchBugsTests2.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchBugsTests2.java
@@ -670,7 +670,6 @@ public class JavaSearchBugsTests2 extends AbstractJavaSearchTests {
 	 * @bug 342393: Anonymous class' occurrence count is incorrect when two methods in a class have the same name.
 	 * @test Search for Enumerators with anonymous types
 	 *
-	 * @throws CoreException
 	 * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=342393"
 	 */
 	public void testBug342393() throws CoreException {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchGenericConstructorEquivalentTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchGenericConstructorEquivalentTests.java
@@ -26,9 +26,6 @@ import junit.framework.TestSuite;
 @SuppressWarnings("rawtypes")
 public class JavaSearchGenericConstructorEquivalentTests extends JavaSearchGenericConstructorTests {
 
-	/**
-	 * @param name
-	 */
 	public JavaSearchGenericConstructorEquivalentTests(String name) {
 		super(name, EQUIVALENT_RULE);
 	}

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchGenericConstructorExactTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchGenericConstructorExactTests.java
@@ -26,9 +26,6 @@ import junit.framework.TestSuite;
 @SuppressWarnings({"rawtypes"})
 public class JavaSearchGenericConstructorExactTests extends JavaSearchGenericConstructorTests {
 
-	/**
-	 * @param name
-	 */
 	public JavaSearchGenericConstructorExactTests(String name) {
 		super(name, EXACT_RULE);
 	}

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchGenericMethodEquivalentTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchGenericMethodEquivalentTests.java
@@ -27,9 +27,6 @@ import junit.framework.TestSuite;
 @SuppressWarnings("rawtypes")
 public class JavaSearchGenericMethodEquivalentTests extends JavaSearchGenericMethodTests {
 
-	/**
-	 * @param name
-	 */
 	public JavaSearchGenericMethodEquivalentTests(String name) {
 		super(name, EQUIVALENT_RULE);
 	}

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchGenericMethodExactTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchGenericMethodExactTests.java
@@ -26,9 +26,6 @@ import junit.framework.TestSuite;
 @SuppressWarnings("rawtypes")
 public class JavaSearchGenericMethodExactTests extends JavaSearchGenericMethodTests {
 
-	/**
-	 * @param name
-	 */
 	public JavaSearchGenericMethodExactTests(String name) {
 		super(name, EXACT_RULE);
 	}

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchGenericTypeEquivalentTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchGenericTypeEquivalentTests.java
@@ -29,9 +29,6 @@ public class JavaSearchGenericTypeEquivalentTests extends JavaSearchGenericTypeT
 
 //	static char[] RESULT_ERASURE_MATCH = "*] ERASURE_*".toCharArray();
 
-	/**
-	 * @param name
-	 */
 	public JavaSearchGenericTypeEquivalentTests(String name) {
 		super(name, EQUIVALENT_RULE);
 	}

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchGenericTypeExactTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchGenericTypeExactTests.java
@@ -27,9 +27,6 @@ import junit.framework.TestSuite;
 @SuppressWarnings("rawtypes")
 public class JavaSearchGenericTypeExactTests extends JavaSearchGenericTypeTests {
 
-	/**
-	 * @param name
-	 */
 	public JavaSearchGenericTypeExactTests(String name) {
 		super(name, EXACT_RULE);
 	}

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchJavadocTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchJavadocTests.java
@@ -32,9 +32,6 @@ public class JavaSearchJavadocTests extends JavaSearchTests {
 
 	Map<String, String> originalOptions;
 
-	/**
-	 * @param name
-	 */
 	public JavaSearchJavadocTests(String name) {
 		super(name);
 	}
@@ -648,7 +645,6 @@ public class JavaSearchJavadocTests extends JavaSearchTests {
 	/**
 	 * Test fix for bug 47909.
 	 * @see <a href="http://bugs.eclipse.org/bugs/show_bug.cgi?id=47909">47909</a>
-	 * @throws CoreException
 	 */
 	public void testBug47909() throws CoreException {
 		IType type = getCompilationUnit("JavaSearch", "src", "j3", "Y.java").getType("Y");
@@ -667,7 +663,6 @@ public class JavaSearchJavadocTests extends JavaSearchTests {
 	/**
 	 * Test fix for bug 47968.
 	 * @see <a href="http://bugs.eclipse.org/bugs/show_bug.cgi?id=47968">47968</a>
-	 * @throws CoreException
 	 */
 	public void testBug47968type() throws CoreException {
 		IType type = getCompilationUnit("JavaSearch", "src", "j2", "Bug47968.java").getType("Bug47968");
@@ -750,7 +745,6 @@ public class JavaSearchJavadocTests extends JavaSearchTests {
 	/**
 	 * Test fix for bug 47209.
 	 * @see <a href="http://bugs.eclipse.org/bugs/show_bug.cgi?id=47209">47209</a>
-	 * @throws CoreException
 	 */
 	public void testBug47209type() throws CoreException {
 		setJavadocOptions();
@@ -824,7 +818,6 @@ public class JavaSearchJavadocTests extends JavaSearchTests {
 	/**
 	 * Test fix for bug 49994.
 	 * @see <a href="http://bugs.eclipse.org/bugs/show_bug.cgi?id=49994">49994</a>
-	 * @throws CoreException
 	 */
 	public void testBug49994() throws CoreException {
 		setJavadocOptions();
@@ -890,7 +883,6 @@ public class JavaSearchJavadocTests extends JavaSearchTests {
 	/**
 	 * Test fix for bug 71267: [Search][Javadoc] SearchMatch in class javadoc reported with element of type IImportDeclaration
 	 * @see <a href="http://bugs.eclipse.org/bugs/show_bug.cgi?id=71267">71267</a>
-	 * @throws CoreException
 	 */
 	public void testBug71267() throws CoreException {
 		setJavadocOptions();

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavadocModuleCompletionTests15.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavadocModuleCompletionTests15.java
@@ -41,7 +41,6 @@ public class JavadocModuleCompletionTests15 extends AbstractJavaModelCompletionT
 
 	/**
 	 * ContentAssist for Module Javadoc support is available for java 15 and above Modular projects
-	 * @throws Exception
 	 */
 	public void test566060_001() throws Exception {
 		IJavaProject project1 = createJavaProject("Completion15_0", new String[] {"src"}, new String[] {"JCL14_LIB"}, "bin", "15");
@@ -113,7 +112,6 @@ public class JavadocModuleCompletionTests15 extends AbstractJavaModelCompletionT
 
 	/**
 	 * ContentAssist for Module Javadoc support is available for java 15 and above Modular projects
-	 * @throws Exception
 	 */
 	public void test566060_002() throws Exception {
 		IJavaProject project1 = createJavaProject("Completion15_1", new String[] {"src"}, new String[] {"JCL14_LIB"}, "bin", "15");
@@ -199,7 +197,6 @@ public class JavadocModuleCompletionTests15 extends AbstractJavaModelCompletionT
 
 	/**
 	 * ContentAssist for Module Javadoc support is available for java 15 and above Modular projects for jre modules
-	 * @throws Exception
 	 */
 	public void test566060_003() throws Exception {
 		IJavaProject project1 = createJavaProject("Completion15_0", new String[] {"src"}, new String[] {"JCL14_LIB"}, "bin", "15");
@@ -253,7 +250,6 @@ public class JavadocModuleCompletionTests15 extends AbstractJavaModelCompletionT
 
 	/**
 	 * ContentAssist for Module Javadoc support is available for java 15 and above non-modular projects for default modules provided by jre.
-	 * @throws Exception
 	 */
 	public void test566060_004() throws Exception {
 		IJavaProject project1 = createJavaProject("Completion15_0", new String[] {"src"}, new String[] {"JCL14_LIB"}, "bin", "15");
@@ -300,7 +296,6 @@ public class JavadocModuleCompletionTests15 extends AbstractJavaModelCompletionT
 
 	/**
 	 * Negative case. Module Javadoc support is not available for java 14 and below modular projects.
-	 * @throws Exception
 	 */
 	public void test566060_005() throws Exception {
 		IJavaProject project1 = createJavaProject("Completion14_0", new String[] {"src"}, new String[] {"JCL14_LIB"}, "bin", "14");
@@ -370,7 +365,6 @@ public class JavadocModuleCompletionTests15 extends AbstractJavaModelCompletionT
 
 	/**
 	 * Negative case. Module Javadoc support is not available for java 14 and below non-modular projects.
-	 * @throws Exception
 	 */
 	public void test566060_006() throws Exception {
 		IJavaProject project1 = createJavaProject("Completion14_2", new String[] {"src"}, new String[] {"JCL14_LIB"}, "bin", "14");
@@ -412,7 +406,6 @@ public class JavadocModuleCompletionTests15 extends AbstractJavaModelCompletionT
 
 	/**
 	 * ContentAssist for Module Javadoc support is available for java 15 and above Modular projects
-	 * @throws Exception
 	 */
 	public void test566060_007() throws Exception {
 		IJavaProject project1 = createJavaProject("Completion15_1", new String[] {"src"}, new String[] {"JCL14_LIB"}, "bin", "15");
@@ -499,7 +492,6 @@ public class JavadocModuleCompletionTests15 extends AbstractJavaModelCompletionT
 
 	/**
 	 * ContentAssist for Module Javadoc support is available for java 15 and above Modular projects
-	 * @throws Exception
 	 */
 	public void test566060_008() throws Exception {
 		IJavaProject project1 = createJavaProject("Completion15_1", new String[] {"src"}, new String[] {"JCL14_LIB"}, "bin", "15");
@@ -585,7 +577,6 @@ public class JavadocModuleCompletionTests15 extends AbstractJavaModelCompletionT
 
 	/**
 	 * ContentAssist for Module Javadoc support is available for java 15 and above Modular projects
-	 * @throws Exception
 	 */
 	public void test566060_009() throws Exception {
 		IJavaProject project1 = createJavaProject("Completion15_0", new String[] {"src"}, new String[] {"JCL14_LIB"}, "bin", "15");
@@ -657,7 +648,6 @@ public class JavadocModuleCompletionTests15 extends AbstractJavaModelCompletionT
 
 	/**
 	 * ContentAssist for Module Javadoc support is available for java 15 and above Modular projects
-	 * @throws Exception
 	 */
 	public void test566060_010() throws Exception {
 		IJavaProject project1 = createJavaProject("Completion15_0", new String[] {"src"}, new String[] {"JCL14_LIB"}, "bin", "15");
@@ -727,7 +717,6 @@ public class JavadocModuleCompletionTests15 extends AbstractJavaModelCompletionT
 
 	/**
 	 * ContentAssist for Module Javadoc support is available for java 15 and above Modular projects
-	 * @throws Exception
 	 */
 	public void test566060_011() throws Exception {
 		IJavaProject project1 = createJavaProject("Completion15_1", new String[] {"src"}, new String[] {"JCL14_LIB"}, "bin", "15");

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ModelTestsUtil.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ModelTestsUtil.java
@@ -123,9 +123,6 @@ static public IClassFile getClassFile(IJavaProject project, String rootPath, Str
 
 /**
  * Returns compilation unit with given name in given project and package.
- * @param javaProject
- * @param packageName
- * @param unitName
  * @return org.eclipse.jdt.core.ICompilationUnit
  */
 static public ICompilationUnit getCompilationUnit(IJavaProject javaProject, String packageName, String unitName) throws JavaModelException {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ModuleBuilderTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ModuleBuilderTests.java
@@ -279,7 +279,6 @@ public class ModuleBuilderTests extends ModifyingResourceTests {
 	/*
 	 * Two Java projects, each with one module. P2 has P1 in its build path but
 	 * module M2 has no 'requires' M1. Should report unresolved type, import etc.
-	 *
 	 */
 	public void test007() throws Exception {
 		try {
@@ -310,7 +309,6 @@ public class ModuleBuilderTests extends ModifyingResourceTests {
 	 * module M2 'requires' M1. Should report unresolved type, import etc. But M1
 	 * does not export the package that is used by M2. Test that M2 does not see
 	 * the types in unexported packages.
-	 *
 	 */
 	public void test008() throws Exception {
 		try {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ReconcilerStatementsRecoveryTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ReconcilerStatementsRecoveryTests.java
@@ -55,8 +55,6 @@ public class ReconcilerStatementsRecoveryTests extends ModifyingResourceTests {
 		}
 	}
 
-/**
- */
 public ReconcilerStatementsRecoveryTests(String name) {
 	super(name);
 }

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ReconcilerTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ReconcilerTests.java
@@ -153,8 +153,6 @@ public class ReconcilerTests extends ModifyingResourceTests {
 			}
 		}
 	}
-/**
- */
 public ReconcilerTests(String name) {
 	super(name);
 }
@@ -2906,7 +2904,6 @@ public void testNoChanges2() throws JavaModelException {
  * to reconcile is the same as the current contents,
  * no ast is requested, no problem is requested and problem requestor is not active.
  * (regression test for bug 179258 simple reconcile starts problem finder - main thread waiting)
- *
  */
 public void testNoChanges3() throws JavaModelException {
 	setWorkingCopyContents(this.workingCopy.getSource());
@@ -3892,7 +3889,6 @@ public void testVarargs() throws CoreException {
 /**
  * Bug 114338:[javadoc] Reconciler reports wrong javadoc warning (missing return type)
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=114338"
- *
  */
 public void testBug114338() throws CoreException {
 	// Set initial CU content

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ReconcilerTests16.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ReconcilerTests16.java
@@ -35,8 +35,6 @@ public class ReconcilerTests16 extends ModifyingResourceTests {
 	/*package*/ @SuppressWarnings("deprecation")
 	static final int JLS_LATEST = AST.JLS16;
 
-/**
- */
 public ReconcilerTests16(String name) {
 	super(name);
 }

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ReconcilerTests9.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ReconcilerTests9.java
@@ -44,8 +44,6 @@ public class ReconcilerTests9 extends ModifyingResourceTests {
 
 	/*package*/ static final int JLS_LATEST = AST.getJLSLatest();
 
-/**
- */
 public ReconcilerTests9(String name) {
 	super(name);
 }

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/RenameTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/RenameTests.java
@@ -26,8 +26,6 @@ import org.eclipse.jdt.core.*;
 
 public class RenameTests extends CopyMoveTests {
 	ICompilationUnit cu;
-/**
- */
 public RenameTests(String name) {
 	super(name);
 }
@@ -322,9 +320,6 @@ public void testRenameConstructor() {
 	renameNegative(constructor, "newName", false, IJavaModelStatusConstants.NAME_COLLISION);
 }
 
-/**
- *
- */
 public void testRenameCU1() throws CoreException {
 	this.cu.rename("NewX.java", false, null);
 	assertTrue("Original CU should not exist", !this.cu.exists());

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ResolveTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ResolveTests.java
@@ -2322,7 +2322,6 @@ public void testSingleNameInImport() throws JavaModelException {
 }
 /**
  * Bug 120350: [model] Secondary type not found by code resolve
- * @throws JavaModelException
  */
 public void testSecondaryTypes() throws JavaModelException {
 	waitUntilIndexesReady();

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/TypeHierarchyNotificationTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/TypeHierarchyNotificationTests.java
@@ -1380,7 +1380,6 @@ public void testOwner() throws CoreException {
  * result in a type hierarchy changed event.
  *
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=316654"
- * @throws CoreException
  */
 public void testBug316654() throws CoreException {
 	IJavaProject project = getJavaProject("TypeHierarchyNotification");
@@ -1402,7 +1401,6 @@ public void testBug316654() throws CoreException {
  * change event.
  *
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=316654"
- * @throws CoreException
  */
 public void testBug316654_a() throws CoreException {
 	IJavaProject project = getJavaProject("TypeHierarchyNotification");
@@ -1427,7 +1425,6 @@ public void testBug316654_a() throws CoreException {
  * change event.
  *
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=316654"
- * @throws CoreException
  */
 public void testBug316654_b() throws CoreException {
 	IJavaProject project = getJavaProject("TypeHierarchyNotification");
@@ -1456,7 +1453,6 @@ public void testBug316654_b() throws CoreException {
  * change event.
  *
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=316654"
- * @throws CoreException
  */
 public void testBug316654_c() throws CoreException {
 	IJavaProject project = getJavaProject("TypeHierarchyNotification");

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/TypeHierarchyTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/TypeHierarchyTests.java
@@ -2493,8 +2493,6 @@ public void testBug288698() throws JavaModelException {
  * @bug  329663:[type hierarchy] Interfaces duplicated in type hierarchy on two packages from multiple projects
  * @test that when two selected regions contains the same interface, it's not reported twice in the hierarchy.
  *
- * @throws JavaModelException
- * @throws CoreException
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=329663"
  */
 public void _testBug329663() throws JavaModelException, CoreException {
@@ -2540,8 +2538,6 @@ public void _testBug329663() throws JavaModelException, CoreException {
  * @test that when two selected regions contains interfaces with same name but different, they are reported individually
  * in the hierarchy.
  *
- * @throws JavaModelException
- * @throws CoreException
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=329663"
  */
 public void _testBug329663a() throws JavaModelException, CoreException {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/TypeResolveTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/TypeResolveTests.java
@@ -716,7 +716,6 @@ public void testParamAnnotations8() throws CoreException, IOException {
 	}
 }
 /**
- * @throws IOException
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=375568"
  */
 public void testParamAnnotations9() throws CoreException, IOException {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/WorkingCopyTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/WorkingCopyTests.java
@@ -110,8 +110,6 @@ public void testCancelMakeConsistent() throws JavaModelException {
 	assertTrue("Working copy should be opened", this.copy.isOpen());
 }
 
-/**
- */
 public void testChangeContent() throws CoreException {
 	String newContents =
 		"package x.y;\n" +
@@ -437,24 +435,18 @@ public void testGetPrimaryInitializer() {
 	IJavaElement primary= type.getInitializer(1).getPrimaryElement();
 	assertTrue("Element should exist", primary.exists());
 }
-/**
- */
 public void testGetPrimaryInnerField() {
 	IType innerType = this.copy.getType("A").getType("Inner");
 	IJavaElement primary = innerType.getField("innerField").getPrimaryElement();
 	assertTrue("Element is not a field", primary instanceof IField);
 	assertTrue("Element should exist", primary.exists());
 }
-/**
- */
 public void testGetPrimaryInnerMethod() throws JavaModelException {
 	IType innerType = this.copy.getType("A").getType("Inner");
 	IJavaElement primary = innerType.getMethods()[0].getPrimaryElement();
 	assertTrue("Element is not a method", primary instanceof IMethod);
 	assertTrue("Element should exist", primary.exists());
 }
-/**
- */
 public void testGetPrimaryInnerType() {
 	IType innerInnerType = this.copy.getType("A").getType("Inner").getType("InnerInner");
 	IJavaElement primary = innerInnerType.getPrimaryElement();

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/rewrite/describing/ASTRewritingReferenceExpressionTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/rewrite/describing/ASTRewritingReferenceExpressionTest.java
@@ -41,7 +41,6 @@ public class ASTRewritingReferenceExpressionTest extends ASTRewritingTest {
 
 	/**
 	 * tests various aspects of CreationReference (Constructor Method Reference) with ClassType as lhs
-	 * @throws Exception
 	 */
 	public void testReferenceExpressions_test001_since_8() throws Exception {
 		IPackageFragment pack1= this.sourceFolder.createPackageFragment("test407131", false, null);
@@ -180,7 +179,6 @@ public class ASTRewritingReferenceExpressionTest extends ASTRewritingTest {
 
 	/**
 	 * tests various aspects of CreationReference (Constructor Method Reference) with ArrayType as lhs
-	 * @throws Exception
 	 */
 	public void testReferenceExpressions_test002_since_8() throws Exception {
 		IPackageFragment pack1= this.sourceFolder.createPackageFragment("test407131", false, null);
@@ -230,7 +228,6 @@ public class ASTRewritingReferenceExpressionTest extends ASTRewritingTest {
 
 	/**
 	 * tests various aspects of {@link ExpressionMethodReference}
-	 * @throws Exception
 	 */
 	public void testReferenceExpressions_test003_since_8() throws Exception {
 		IPackageFragment pack1= this.sourceFolder.createPackageFragment("test407131", false, null);
@@ -311,7 +308,6 @@ public class ASTRewritingReferenceExpressionTest extends ASTRewritingTest {
 
 	/**
 	 * tests various aspects of {@link TypeMethodReference}
-	 * @throws Exception
 	 */
 	public void testReferenceExpressions_test004_since_8() throws Exception {
 		IPackageFragment pack1= this.sourceFolder.createPackageFragment("test407131", false, null);
@@ -401,7 +397,6 @@ public class ASTRewritingReferenceExpressionTest extends ASTRewritingTest {
 
 	/**
 	 * tests various aspects of SuperMethodReference
-	 * @throws Exception
 	 */
 	public void testReferenceExpressions_test005_since_8() throws Exception {
 		IPackageFragment pack1= this.sourceFolder.createPackageFragment("test407131", false, null);
@@ -477,7 +472,6 @@ public class ASTRewritingReferenceExpressionTest extends ASTRewritingTest {
 	}
 	/**
 	 * tests cross rewriting - changing from one member of reference expressions to another type.
-	 * @throws Exception
 	 */
 	public void testReferenceExpressions_test006_since_8() throws Exception {
 		IPackageFragment pack1= this.sourceFolder.createPackageFragment("test407131", false, null);

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/rewrite/describing/ASTRewritingTrackingTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/rewrite/describing/ASTRewritingTrackingTest.java
@@ -46,8 +46,6 @@ public class ASTRewritingTrackingTest extends ASTRewritingTest {
 	/**
 	 * Internal access method to VariableDeclarationFragment#setExtraDimensions() for avoiding deprecated warnings
 	 *
-	 * @param node
-	 * @param dimensions
 	 * @deprecated
 	 */
 	private void internalSetExtraDimensions(VariableDeclarationFragment node, int dimensions) {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/rewrite/describing/LineCommentOffsetsTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/rewrite/describing/LineCommentOffsetsTest.java
@@ -42,9 +42,6 @@ import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 import org.eclipse.jdt.core.dom.rewrite.ListRewrite;
 import org.eclipse.jdt.internal.core.dom.rewrite.LineCommentEndOffsets;
 
-/**
- *
- */
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class LineCommentOffsetsTest extends ASTRewritingTest {
 

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/rewrite/describing/SourceModifierTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/rewrite/describing/SourceModifierTest.java
@@ -23,9 +23,6 @@ import org.eclipse.jface.text.Document;
 import org.eclipse.text.edits.MultiTextEdit;
 import org.eclipse.text.edits.ReplaceEdit;
 
-/**
- *
- */
 public class SourceModifierTest extends AbstractJavaModelTests {
 
 	public SourceModifierTest(String name) {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/rewrite/describing/StringAsserts.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/rewrite/describing/StringAsserts.java
@@ -21,14 +21,8 @@ import java.util.Arrays;
 
 import junit.framework.TestCase;
 
-/**
- *
- */
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class StringAsserts {
-	/**
-	 *
-	 */
 	public StringAsserts() {
 		super();
 	}

--- a/org.eclipse.jdt.core.tests.performance/src/org/eclipse/jdt/core/tests/performance/FullSourceWorkspaceASTTests.java
+++ b/org.eclipse.jdt.core.tests.performance/src/org/eclipse/jdt/core/tests/performance/FullSourceWorkspaceASTTests.java
@@ -103,8 +103,6 @@ import org.eclipse.jdt.core.dom.WhileStatement;
 
 import junit.framework.Test;
 
-/**
- */
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class FullSourceWorkspaceASTTests extends FullSourceWorkspaceTests {
 	/**
@@ -122,9 +120,6 @@ public class FullSourceWorkspaceASTTests extends FullSourceWorkspaceTests {
     // Log files
     private static PrintStream[] LOG_STREAMS = new PrintStream[DIM_NAMES.length];
 
-	/**
-	 * @param name
-	 */
 	public FullSourceWorkspaceASTTests(String name) {
 		super(name);
 	}
@@ -817,8 +812,6 @@ public class FullSourceWorkspaceASTTests extends FullSourceWorkspaceTests {
 
 	/**
 	 * Create AST nodes tree for all compilation units in JUnit project.
-	 *
-	 * @throws JavaModelException
 	 */
 	public void testDomAstCreationProjectJLS3() throws JavaModelException {
 		tagAsSummary("DOM AST tree for project files (JLS3)", true); // put in fingerprint

--- a/org.eclipse.jdt.core.tests.performance/src/org/eclipse/jdt/core/tests/performance/FullSourceWorkspaceBuildTests.java
+++ b/org.eclipse.jdt.core.tests.performance/src/org/eclipse/jdt/core/tests/performance/FullSourceWorkspaceBuildTests.java
@@ -117,9 +117,6 @@ public class FullSourceWorkspaceBuildTests extends FullSourceWorkspaceTests {
 		"search"
 	};
 
-	/**
-	 * @param name
-	 */
 	public FullSourceWorkspaceBuildTests(String name) {
 		super(name);
 	}
@@ -434,9 +431,6 @@ public class FullSourceWorkspaceBuildTests extends FullSourceWorkspaceTests {
 	 * Test performance for a parser on one file.
 	 * Parse is executed many times ({@link #ITERATIONS_COUNT}) to have significant time for execution.
 	 * This test is repeated several times ({@link #MEASURES_COUNT}) to average time measuring.
-	 *
-	 * @throws InvalidInputException
-	 * @throws IOException
 	 */
 	void parseParserFile(final int kind) throws InvalidInputException, IOException, CoreException {
 
@@ -586,9 +580,6 @@ public class FullSourceWorkspaceBuildTests extends FullSourceWorkspaceTests {
 	 * Test performance for Scanner on one file.
 	 * Scan is executed many times ({@link #SCAN_REPEAT}) to have significant time for execution.
 	 * This test is repeated several times ({@link #ITERATIONS_COUNT}) to average time measuring.
-	 *
-	 * @throws InvalidInputException
-	 * @throws IOException
 	 */
 	public void testScanner() throws InvalidInputException, IOException, CoreException {
 
@@ -624,9 +615,6 @@ public class FullSourceWorkspaceBuildTests extends FullSourceWorkspaceTests {
 	 * Test performance for Parser on one file.
 	 * Parse is executed many times ({@link #ITERATIONS_COUNT}) to have significant time for execution.
 	 * This test is repeated several times ({@link #MEASURES_COUNT}) to average time measuring.
-	 *
-	 * @throws InvalidInputException
-	 * @throws IOException
 	 */
 	public void testParser() throws InvalidInputException, IOException, CoreException {
 		parseParserFile(0); // Parser kind
@@ -640,9 +628,6 @@ public class FullSourceWorkspaceBuildTests extends FullSourceWorkspaceTests {
 	 * Note: This test has been temporarily removed as there's unexplicable difference between
 	 * HEAD and 3.0 versions for CPU Time results (10% faster) and Elapsed process (25% slower)...
 	 * TODO (frederic) Put back when platform-releng will have stabilized performance results process.
-	 *
-	 * @throws InvalidInputException
-	 * @throws IOException
 	 */
 	public void _testSourceParser() throws InvalidInputException, IOException, CoreException {
 		parseParserFile(1); // SourceElementParser kind
@@ -655,9 +640,6 @@ public class FullSourceWorkspaceBuildTests extends FullSourceWorkspaceTests {
 	 * 	This test must be and _ever_ stay at first position as it build the entire workspace.
 	 * 	It also cannot be removed as it's a Global fingerprint!
 	 * 	Move it would have great consequence on all other tests results...
-	 *
-	 * @throws CoreException
-	 * @throws IOException
 	 */
 	public void testFullBuildDefault() throws CoreException, IOException {
 		tagAsSummary("Build entire workspace", false); // do NOT put in fingerprint
@@ -667,8 +649,6 @@ public class FullSourceWorkspaceBuildTests extends FullSourceWorkspaceTests {
 	/**
 	 * JDT/Core project full build with no warning.
 	 *
-	 * @throws CoreException
-	 * @throws IOException
 	 * @since 3.2 M6
 	 */
 	public void testFullBuildProjectNoWarning() throws CoreException, IOException {
@@ -679,8 +659,6 @@ public class FullSourceWorkspaceBuildTests extends FullSourceWorkspaceTests {
 	/**
 	 * JDT/Core project full build with JavaCore default options.
 	 *
-	 * @throws CoreException
-	 * @throws IOException
 	 * @since 3.2 M6
 	 */
 	public void testFullBuildProjectDefault() throws CoreException, IOException {
@@ -691,8 +669,6 @@ public class FullSourceWorkspaceBuildTests extends FullSourceWorkspaceTests {
 	/**
 	 * JDT/Core project full build with all warnings.
 	 *
-	 * @throws CoreException
-	 * @throws IOException
 	 * @since 3.2 M6
 	 */
 	public void testFullBuildProjectAllWarnings() throws CoreException, IOException {
@@ -705,8 +681,6 @@ public class FullSourceWorkspaceBuildTests extends FullSourceWorkspaceTests {
 	 *
 	 * Not calling tagAsSummary means that this test is currently evaluated
 	 * before put it in builds performance results.
-	 *
-	 * @throws IOException
 	 */
 	public void testBatchCompilerNoWarning() throws IOException, CoreException {
 		tagAsSummary("Compile folders using cmd line (no warn)", false); // do NOT put in fingerprint
@@ -715,8 +689,6 @@ public class FullSourceWorkspaceBuildTests extends FullSourceWorkspaceTests {
 
 	/**
 	 * Compile JDT/Core project with default warnings
-	 *
-	 * @throws IOException
 	 */
 	public void testCompileJDTCoreProjectNoWarning() throws IOException, CoreException {
 		tagAsSummary("Compile JDT/Core with cmd line (no warn)", false); // do NOT put in fingerprint
@@ -725,8 +697,6 @@ public class FullSourceWorkspaceBuildTests extends FullSourceWorkspaceTests {
 
 	/**
 	 * Compile JDT/Core project with default warnings
-	 *
-	 * @throws IOException
 	 */
 	public void testCompileJDTCoreProjectDefault() throws IOException, CoreException {
 		tagAsSummary("Compile JDT/Core with command line", true); // put in fingerprint
@@ -735,8 +705,6 @@ public class FullSourceWorkspaceBuildTests extends FullSourceWorkspaceTests {
 
 	/**
 	 * Compile JDT/Core project with default javadoc warnings
-	 *
-	 * @throws IOException
 	 */
 	public void testCompileJDTCoreProjectJavadoc() throws IOException, CoreException {
 		tagAsSummary("Compile JDT/Core with cmd line (javadoc)", false); // do NOT put in fingerprint
@@ -746,7 +714,6 @@ public class FullSourceWorkspaceBuildTests extends FullSourceWorkspaceTests {
 	/**
 	 * Compile JDT/Core project with all warnings
 	 *
-	 * @throws IOException
 	 * @since 3.2 M6
 	 */
 	public void testCompileJDTCoreProjectAllWarnings() throws IOException, CoreException {
@@ -757,7 +724,6 @@ public class FullSourceWorkspaceBuildTests extends FullSourceWorkspaceTests {
 	/**
 	 * Compile JDT/Core project with default warnings
 	 *
-	 * @throws IOException
 	 * @since 3.2 M6
 	 */
 	public void testCompileSWTProjectDefault() throws IOException, CoreException {

--- a/org.eclipse.jdt.core.tests.performance/src/org/eclipse/jdt/core/tests/performance/FullSourceWorkspaceCompleteSearchTests.java
+++ b/org.eclipse.jdt.core.tests.performance/src/org/eclipse/jdt/core/tests/performance/FullSourceWorkspaceCompleteSearchTests.java
@@ -99,9 +99,6 @@ private static void verifyVmArguments() {
 	}
 }
 
-/**
- * @param name
- */
 public FullSourceWorkspaceCompleteSearchTests(String name) {
 	super(name);
 }

--- a/org.eclipse.jdt.core.tests.performance/src/org/eclipse/jdt/core/tests/performance/FullSourceWorkspaceCompletionTests.java
+++ b/org.eclipse.jdt.core.tests.performance/src/org/eclipse/jdt/core/tests/performance/FullSourceWorkspaceCompletionTests.java
@@ -23,8 +23,6 @@ import org.eclipse.jdt.core.JavaModelException;
 
 import junit.framework.Test;
 
-/**
- */
 @SuppressWarnings("rawtypes")
 public class FullSourceWorkspaceCompletionTests extends FullSourceWorkspaceTests {
 

--- a/org.eclipse.jdt.core.tests.performance/src/org/eclipse/jdt/core/tests/performance/FullSourceWorkspaceFormatterTests.java
+++ b/org.eclipse.jdt.core.tests.performance/src/org/eclipse/jdt/core/tests/performance/FullSourceWorkspaceFormatterTests.java
@@ -24,8 +24,6 @@ import org.eclipse.jdt.core.formatter.CodeFormatter;
 import org.eclipse.jdt.core.tests.util.Util;
 import org.eclipse.jdt.internal.formatter.DefaultCodeFormatter;
 
-/**
- */
 @SuppressWarnings("rawtypes")
 public class FullSourceWorkspaceFormatterTests extends FullSourceWorkspaceTests {
 
@@ -41,9 +39,6 @@ public class FullSourceWorkspaceFormatterTests extends FullSourceWorkspaceTests 
 	static IPath FORMAT_TYPE_PATH;
 	static String FORMAT_TYPE_SOURCE;
 
-/**
- * @param name
- */
 public FullSourceWorkspaceFormatterTests(String name) {
 	super(name);
 }

--- a/org.eclipse.jdt.core.tests.performance/src/org/eclipse/jdt/core/tests/performance/FullSourceWorkspaceModelTests.java
+++ b/org.eclipse.jdt.core.tests.performance/src/org/eclipse/jdt/core/tests/performance/FullSourceWorkspaceModelTests.java
@@ -70,8 +70,6 @@ import org.eclipse.test.performance.Performance;
 
 import junit.framework.Test;
 
-/**
- */
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class FullSourceWorkspaceModelTests extends FullSourceWorkspaceTests implements IJavaSearchConstants {
 
@@ -96,9 +94,6 @@ public class FullSourceWorkspaceModelTests extends FullSourceWorkspaceTests impl
 	static IPath BIG_PROJECT_TYPE_PATH;
 	static ICompilationUnit WORKING_COPY;
 
-/**
- * @param name
- */
 public FullSourceWorkspaceModelTests(String name) {
 	super(name);
 }
@@ -651,7 +646,6 @@ public void testProjectFindUnknownType() throws CoreException {
 /*
  * Performance tests for model: Find Unknown type after resetting the classpath
  * (regression test for https://bugs.eclipse.org/bugs/show_bug.cgi?id=217059 )
- *
  */
 public void testProjectFindUnknownTypeAfterSetClasspath() throws CoreException {
 	tagAsSummary("Find unknown type in project after resetting classpath", false); // do NOT put in fingerprint

--- a/org.eclipse.jdt.core.tests.performance/src/org/eclipse/jdt/core/tests/performance/FullSourceWorkspaceSearchTests.java
+++ b/org.eclipse.jdt.core.tests.performance/src/org/eclipse/jdt/core/tests/performance/FullSourceWorkspaceSearchTests.java
@@ -28,8 +28,6 @@ import org.eclipse.jdt.internal.core.search.processing.IJob;
 
 import junit.framework.Test;
 
-/**
- */
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class FullSourceWorkspaceSearchTests extends FullSourceWorkspaceTests implements IJavaSearchConstants {
 
@@ -44,9 +42,6 @@ public class FullSourceWorkspaceSearchTests extends FullSourceWorkspaceTests imp
 	// Formats
 	private final static NumberFormat INT_FORMAT = NumberFormat.getIntegerInstance();
 
-	/**
-	 * @param name
-	 */
 	public FullSourceWorkspaceSearchTests(String name) {
 		super(name);
 	}

--- a/org.eclipse.jdt.core.tests.performance/src/org/eclipse/jdt/core/tests/performance/FullSourceWorkspaceTests.java
+++ b/org.eclipse.jdt.core.tests.performance/src/org/eclipse/jdt/core/tests/performance/FullSourceWorkspaceTests.java
@@ -242,7 +242,6 @@ public abstract class FullSourceWorkspaceTests extends TestCase {
 	 * following options:
 	 *		-DPerformanceMeterFactory=org.eclipse.jdt.core.tests.performance:org.eclipse.jdt.core.tests.performance.util.JdtCorePerformanceMeterFactory
 	 *		-DlogDir=directory where you want to write log files (for example d:/usr/OTI/tests/perfs/stats)
-	 *
 	 */
 	// Store directory where to put files
 	private final static File INVALID_DIR = new File("Invalid");
@@ -361,9 +360,6 @@ public abstract class FullSourceWorkspaceTests extends TestCase {
 		LOG_DIR = dir;
 	}
 
-	/**
-	 * @param name
-	 */
 	public FullSourceWorkspaceTests(String name) {
 		super(name);
 	}
@@ -1024,9 +1020,6 @@ public abstract class FullSourceWorkspaceTests extends TestCase {
 
 	/**
 	 * Returns compilation unit with given name in given project and package.
-	 * @param projectName
-	 * @param packageName
-	 * @param unitName
 	 * @return org.eclipse.jdt.core.ICompilationUnit
 	 */
 	protected ICompilationUnit getCompilationUnit(String projectName, String packageName, String unitName) throws JavaModelException {
@@ -1101,7 +1094,6 @@ public abstract class FullSourceWorkspaceTests extends TestCase {
 
 	/**
 	 * Returns project corresponding to given name or null if none is found.
-	 * @param projectName
 	 * @return IJavaProject
 	 */
 	protected IJavaProject getProject(String projectName) {

--- a/org.eclipse.jdt.core.tests.performance/src/org/eclipse/jdt/core/tests/performance/FullSourceWorkspaceTypeHierarchyTests.java
+++ b/org.eclipse.jdt.core.tests.performance/src/org/eclipse/jdt/core/tests/performance/FullSourceWorkspaceTypeHierarchyTests.java
@@ -22,8 +22,6 @@ import org.eclipse.jdt.core.*;
 import org.eclipse.jdt.core.search.*;
 import org.eclipse.test.performance.Performance;
 
-/**
- */
 @SuppressWarnings("rawtypes")
 public class FullSourceWorkspaceTypeHierarchyTests extends FullSourceWorkspaceTests implements IJavaSearchConstants {
 
@@ -37,9 +35,6 @@ public class FullSourceWorkspaceTypeHierarchyTests extends FullSourceWorkspaceTe
 	// Formats
 	private final static NumberFormat INT_FORMAT = NumberFormat.getIntegerInstance();
 
-	/**
-	 * @param name
-	 */
 	public FullSourceWorkspaceTypeHierarchyTests(String name) {
 		super(name);
 	}

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/CompletionEngine.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/CompletionEngine.java
@@ -865,7 +865,6 @@ public final class CompletionEngine
 	 * all elements found matches the expected type, the completion proposals will not contains the calculated expected type
 	 * relevance. This is done to keep the overloaded method suggestions always on top in this mode as a fix for
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=575149
-	 *
 	 */
 	private boolean strictMatchForExtepectedType = false;
 
@@ -13737,7 +13736,6 @@ public final class CompletionEngine
 	}
 	/**
 	 * Returns completion string inserted inside a specified inline tag.
-	 * @param completionName
 	 * @return char[] Completion text inclunding specified inline tag
 	 */
 	private char[] inlineTagCompletion(char[] completionName, char[] inlineTag) {

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/InternalCompletionProposal.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/InternalCompletionProposal.java
@@ -135,7 +135,6 @@ public class InternalCompletionProposal extends CompletionProposal {
 	 * in the context.
 	 *
 	 * Defaults to null if not set.
-	 *
 	 */
 	private char[][] declarationTypeVariables = null;
 

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/ThrownExceptionFinder.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/ThrownExceptionFinder.java
@@ -45,8 +45,6 @@ public class ThrownExceptionFinder extends ASTVisitor {
 	 * Exception is already caught even if its super type is being caught. Also computes, separately,
 	 * a list comprising of (a)those exceptions that have been caught already and (b)those exceptions that are thrown
 	 * by the method and whose super type has been caught already.
-	 * @param tryStatement
-	 * @param scope
 	 */
 	public void processThrownExceptions(TryStatement tryStatement, BlockScope scope) {
 		this.thrownExceptions = new SimpleSet();

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionJavadoc.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionJavadoc.java
@@ -37,8 +37,6 @@ public class CompletionJavadoc extends Javadoc {
 	/**
 	 * Resolve selected node if not null and throw exception to let clients know
 	 * that it has been found.
-	 *
-	 * @throws CompletionNodeFound
 	 */
 	private void internalResolve(Scope scope) {
 		if (this.completionNode != null) {
@@ -161,8 +159,6 @@ public class CompletionJavadoc extends Javadoc {
 	/**
 	 * Resolve completion node if not null and throw exception to let clients know
 	 * that it has been found.
-	 *
-	 * @throws CompletionNodeFound
 	 */
 	@Override
 	public void resolve(ClassScope scope) {
@@ -173,8 +169,6 @@ public class CompletionJavadoc extends Javadoc {
 	/**
 	 * Resolve completion node if not null and throw exception to let clients know
 	 * that it has been found.
-	 *
-	 * @throws CompletionNodeFound
 	 */
 	@Override
 	public void resolve(CompilationUnitScope scope) {
@@ -184,8 +178,6 @@ public class CompletionJavadoc extends Javadoc {
 	/**
 	 * Resolve completion node if not null and throw exception to let clients know
 	 * that it has been found.
-	 *
-	 * @throws CompletionNodeFound
 	 */
 	@Override
 	public void resolve(MethodScope scope) {

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnParameterizedQualifiedTypeReference.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnParameterizedQualifiedTypeReference.java
@@ -44,21 +44,10 @@ public class CompletionOnParameterizedQualifiedTypeReference extends Parameteriz
 
 	private int kind = K_TYPE;
 	public char[] completionIdentifier;
-	/**
-	 * @param tokens
-	 * @param typeArguments
-	 * @param positions
-	 */
 	public CompletionOnParameterizedQualifiedTypeReference(char[][] tokens,	TypeReference[][] typeArguments, char[] completionIdentifier, long[] positions) {
 		this(tokens, typeArguments, completionIdentifier, positions, K_TYPE);
 	}
 
-	/**
-	 * @param tokens
-	 * @param typeArguments
-	 * @param positions
-	 * @param kind
-	 */
 	public CompletionOnParameterizedQualifiedTypeReference(char[][] tokens,	TypeReference[][] typeArguments, char[] completionIdentifier, long[] positions, int kind) {
 		super(tokens, typeArguments, 0, positions);
 		this.completionIdentifier = completionIdentifier;

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionScanner.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionScanner.java
@@ -74,7 +74,6 @@ protected boolean isAtAssistIdentifier() {
 /*
  * Truncate the current identifier if it is containing the cursor location. Since completion is performed
  * on an identifier prefix.
- *
  */
 @Override
 public char[] getCurrentIdentifierSource() {

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/impl/AssistParser.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/impl/AssistParser.java
@@ -18,7 +18,6 @@ import java.util.Arrays;
 
 /*
  * Parser extension for code assist task
- *
  */
 
 import java.util.HashSet;
@@ -197,7 +196,6 @@ public Object becomeSimpleParser() {
 }
 /**
  * Restore the parser as an assist parser
- * @param parserState
  */
 public void restoreAssistParser(Object parserState) {
 	//Do nothing

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionJavadoc.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionJavadoc.java
@@ -72,8 +72,6 @@ public class SelectionJavadoc extends Javadoc {
 	/**
 	 * Resolve selected node if not null and throw exception to let clients know
 	 * that it has been found.
-	 *
-	 * @throws SelectionNodeFound
 	 */
 	private void internalResolve(Scope scope) {
 		if (this.selectedNode != null) {
@@ -125,8 +123,6 @@ public class SelectionJavadoc extends Javadoc {
 	/**
 	 * Resolve selected node if not null and throw exception to let clients know
 	 * that it has been found.
-	 *
-	 * @throws SelectionNodeFound
 	 */
 	@Override
 	public void resolve(ClassScope scope) {
@@ -136,8 +132,6 @@ public class SelectionJavadoc extends Javadoc {
 	/**
 	 * Resolve selected node if not null and throw exception to let clients know
 	 * that it has been found.
-	 *
-	 * @throws SelectionNodeFound
 	 */
 	@Override
 	public void resolve(MethodScope scope) {

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnExplicitConstructorCall.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnExplicitConstructorCall.java
@@ -29,7 +29,6 @@ package org.eclipse.jdt.internal.codeassist.select;
  *           <SelectOnExplicitConstructorCall:Y.super(1, 2)>
  *         }
  *       }
- *
  */
 
 import org.eclipse.jdt.internal.compiler.ast.*;

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnFieldReference.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnFieldReference.java
@@ -29,7 +29,6 @@ package org.eclipse.jdt.internal.codeassist.select;
  *           <SelectOnFieldReference:bar().fred>
  *         }
  *       }
- *
  */
 
 import org.eclipse.jdt.internal.compiler.ast.FieldReference;

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnImportReference.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnImportReference.java
@@ -29,7 +29,6 @@ package org.eclipse.jdt.internal.codeassist.select;
  *         void foo() {
  *         }
  *       }
- *
  */
 
 import org.eclipse.jdt.internal.compiler.ast.ImportReference;

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnMessageSend.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnMessageSend.java
@@ -29,7 +29,6 @@ package org.eclipse.jdt.internal.codeassist.select;
  *           <SelectOnMessageSend:this.bar(1, 2)>
  *         }
  *       }
- *
  */
 
 import org.eclipse.jdt.internal.compiler.ast.MessageSend;

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnPackageReference.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnPackageReference.java
@@ -29,7 +29,6 @@ package org.eclipse.jdt.internal.codeassist.select;
  *         void foo() {
  *         }
  *       }
- *
  */
 
 import org.eclipse.jdt.internal.compiler.ast.ImportReference;

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnPackageVisibilityReference.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnPackageVisibilityReference.java
@@ -29,7 +29,6 @@ import org.eclipse.jdt.internal.compiler.ast.ImportReference;
  *	module myModule {
  *	---> <SelectionOnExport:packageo>
  *  }
- *
  */
 public class SelectionOnPackageVisibilityReference extends ImportReference {
 

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnQualifiedAllocationExpression.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnQualifiedAllocationExpression.java
@@ -31,7 +31,6 @@ package org.eclipse.jdt.internal.codeassist.select;
  *           <SelectOnAllocationExpression:new Bar(1, 2)>
  *         }
  *       }
- *
  */
 
 import org.eclipse.jdt.internal.compiler.ast.ConstructorDeclaration;

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnQualifiedNameReference.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnQualifiedNameReference.java
@@ -31,7 +31,6 @@ package org.eclipse.jdt.internal.codeassist.select;
  *           <SelectOnName:y.fred.ba>
  *         }
  *       }
- *
  */
 
 import org.eclipse.jdt.core.compiler.CharOperation;

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnQualifiedSuperReference.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnQualifiedSuperReference.java
@@ -33,7 +33,6 @@ package org.eclipse.jdt.internal.codeassist.select;
  *           }
  *         }
  *       }
- *
  */
 
 import org.eclipse.jdt.internal.compiler.ast.QualifiedSuperReference;

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnQualifiedTypeReference.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnQualifiedTypeReference.java
@@ -22,7 +22,6 @@ package org.eclipse.jdt.internal.codeassist.select;
  *	class X extends java.lang.[start]Object[end]
  *
  *	---> class X extends <SelectOnType:java.lang.Object>
- *
  */
 
 import org.eclipse.jdt.core.compiler.CharOperation;

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnSingleNameReference.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnSingleNameReference.java
@@ -29,7 +29,6 @@ package org.eclipse.jdt.internal.codeassist.select;
  *           <SelectOnName:ba>
  *         }
  *       }
- *
  */
 
 import org.eclipse.jdt.internal.compiler.ast.SingleNameReference;

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnSingleTypeReference.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnSingleTypeReference.java
@@ -22,7 +22,6 @@ package org.eclipse.jdt.internal.codeassist.select;
  *	class X extends [start]Object[end]
  *
  *	---> class X extends <SelectOnType:Object>
- *
  */
 import org.eclipse.jdt.internal.compiler.ast.SingleTypeReference;
 import org.eclipse.jdt.internal.compiler.lookup.Binding;

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnSuperReference.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnSuperReference.java
@@ -33,7 +33,6 @@ package org.eclipse.jdt.internal.codeassist.select;
  *           }
  *         }
  *       }
- *
  */
 
 import org.eclipse.jdt.internal.compiler.ast.SuperReference;

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionScanner.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionScanner.java
@@ -28,7 +28,6 @@ public class SelectionScanner extends Scanner {
 /*
  * Truncate the current identifier if it is containing the cursor location. Since completion is performed
  * on an identifier prefix.
- *
  */
 
 public SelectionScanner(long sourceLevel, boolean previewEnabled) {

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ASTConverter.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ASTConverter.java
@@ -448,8 +448,6 @@ class ASTConverter {
 	}
 	/**
 	 * Internal access method to SwitchCase#setExpression() for avoiding deprecated warnings
-	 * @param switchCase
-	 * @param exp
 	 * @deprecated
 	 */
 	private static void internalSetExpression(SwitchCase switchCase, Expression exp) {
@@ -458,8 +456,6 @@ class ASTConverter {
 	/**
 	 * Internal access method to SingleVariableDeclaration#setExtraDimensions() for avoiding deprecated warnings
 	 *
-	 * @param node
-	 * @param dimensions
 	 * @deprecated
 	 */
 	private static void internalSetExtraDimensions(SingleVariableDeclaration node, int dimensions) {
@@ -468,8 +464,6 @@ class ASTConverter {
 	/**
 	 * Internal access method to VariableDeclarationFragment#setExtraDimensions() for avoiding deprecated warnings
 	 *
-	 * @param node
-	 * @param dimensions
 	 * @deprecated
 	 */
 	private static void internalSetExtraDimensions(VariableDeclarationFragment node, int dimensions) {
@@ -478,8 +472,6 @@ class ASTConverter {
 	/**
 	 * Internal access method to MethodDeclaration#setExtraDimension() for avoiding deprecated warnings
 	 *
-	 * @param node
-	 * @param dimensions
 	 * @deprecated
 	 */
 	private static void internalSetExtraDimensions(MethodDeclaration node, int dimensions) {
@@ -488,17 +480,12 @@ class ASTConverter {
 	/**
 	 * Internal access method to MethodDeclaration#thrownExceptions() for avoiding deprecated warnings
 	 *
-	 * @param node
 	 * @deprecated
 	 */
 	private static List internalThownExceptions(MethodDeclaration node) {
 		return node.thrownExceptions();
 	}
 
-	/**
-	 * @param compilationUnit
-	 * @param comments
-	 */
 	void buildCommentsTable(CompilationUnit compilationUnit, int[][] comments) {
 		// Build comment table
 		this.commentsTable = new Comment[comments.length];
@@ -5762,9 +5749,6 @@ class ASTConverter {
 		this.setModifiers(annotationTypeMemberDecl, annotationTypeMemberDeclaration.annotations, annotationTypeMemberDeclaration.sourceStart);
 	}
 
-	/**
-	 * @param bodyDeclaration
-	 */
 	protected void setModifiers(BodyDeclaration bodyDeclaration, org.eclipse.jdt.internal.compiler.ast.Annotation[] annotations, int modifiersEnd) {
 		setModifiers(bodyDeclaration.modifiers(), annotations, modifiersEnd);
 	}
@@ -5870,10 +5854,6 @@ class ASTConverter {
 		}
 	}
 
-	/**
-	 * @param fieldDeclaration
-	 * @param fieldDecl
-	 */
 	protected void setModifiers(FieldDeclaration fieldDeclaration, org.eclipse.jdt.internal.compiler.ast.FieldDeclaration fieldDecl) {
 		switch(this.ast.apiLevel) {
 			case AST.JLS2_INTERNAL :
@@ -5888,10 +5868,6 @@ class ASTConverter {
 		}
 	}
 
-	/**
-	 * @param initializer
-	 * @param oldInitializer
-	 */
 	protected void setModifiers(Initializer initializer, org.eclipse.jdt.internal.compiler.ast.Initializer oldInitializer) {
 		switch(this.ast.apiLevel) {
 			case AST.JLS2_INTERNAL:
@@ -5905,10 +5881,6 @@ class ASTConverter {
 				this.setModifiers(initializer, oldInitializer.annotations, oldInitializer.bodyStart);
 		}
 	}
-	/**
-	 * @param methodDecl
-	 * @param methodDeclaration
-	 */
 	protected void setModifiers(MethodDeclaration methodDecl, AbstractMethodDeclaration methodDeclaration) {
 		switch(this.ast.apiLevel) {
 			case AST.JLS2_INTERNAL :
@@ -5934,10 +5906,6 @@ class ASTConverter {
 			moduleDecl.annotations().add(ie);
 		}
 	}
-	/**
-	 * @param variableDecl
-	 * @param argument
-	 */
 	protected void setModifiers(SingleVariableDeclaration variableDecl, Argument argument) {
 		switch(this.ast.apiLevel) {
 			case AST.JLS2_INTERNAL :
@@ -6089,7 +6057,6 @@ class ASTConverter {
 	}
 
 	/**
-	 * @param variableDecl
 	 * @param component
 	 *
 	 * TODO: just plain copy of sM(SVD, Argument) - need to cut the flab here.
@@ -6168,10 +6135,6 @@ class ASTConverter {
 				}
 		}
 	}
-	/**
-	 * @param typeDecl
-	 * @param typeDeclaration
-	 */
 	protected void setModifiers(TypeDeclaration typeDecl, org.eclipse.jdt.internal.compiler.ast.TypeDeclaration typeDeclaration) {
 		switch(this.ast.apiLevel) {
 			case AST.JLS2_INTERNAL :
@@ -6189,10 +6152,6 @@ class ASTConverter {
 		}
 	}
 
-	/**
-	 * @param variableDeclarationExpression
-	 * @param localDeclaration
-	 */
 	protected void setModifiers(VariableDeclarationExpression variableDeclarationExpression, LocalDeclaration localDeclaration) {
 		switch(this.ast.apiLevel) {
 			case AST.JLS2_INTERNAL :
@@ -6270,10 +6229,6 @@ class ASTConverter {
 		}
 	}
 
-	/**
-	 * @param variableDeclarationStatement
-	 * @param localDeclaration
-	 */
 	protected void setModifiers(VariableDeclarationStatement variableDeclarationStatement, LocalDeclaration localDeclaration) {
 		switch(this.ast.apiLevel) {
 			case AST.JLS2_INTERNAL :
@@ -6520,8 +6475,6 @@ class ASTConverter {
 
 	/** extracts the subArrayType for a given declaration for AST levels less
 	 * @param arrayType parent type
-	 * @param remainingDimensions
-	 * @param dimensionsToRemove
 	 * @return an ArrayType
 	 */
 	private ArrayType extractSubArrayType(ArrayType arrayType, int remainingDimensions, int dimensionsToRemove) {

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/AbstractTextElement.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/AbstractTextElement.java
@@ -33,7 +33,6 @@ public abstract class AbstractTextElement extends ASTNode implements IDocElement
 
 	/**
 	 * The "text" structural property of this node type (type: {@link String}).
-	 *
 	 */
 	public static final SimplePropertyDescriptor internalTextPropertyFactory(Class nodeClass) {
 		return new SimplePropertyDescriptor(nodeClass, "text", String.class, MANDATORY); //$NON-NLS-1$

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/BindingComparator.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/BindingComparator.java
@@ -36,8 +36,6 @@ import org.eclipse.jdt.internal.compiler.lookup.WildcardBinding;
 @SuppressWarnings({"rawtypes", "unchecked"})
 class BindingComparator {
 	/**
-	 * @param bindings
-	 * @param otherBindings
 	 * @return true if both parameters are equals, false otherwise
 	 */
 	static boolean isEqual(TypeVariableBinding[] bindings, TypeVariableBinding[] otherBindings) {
@@ -63,8 +61,6 @@ class BindingComparator {
 	}
 
 	/**
-	 * @param declaringElement
-	 * @param declaringElement2
 	 * @return true if both parameters are equals, false otherwise
 	 */
 	static boolean isEqual(Binding declaringElement, Binding declaringElement2, HashSet visitedTypes) {
@@ -163,16 +159,12 @@ class BindingComparator {
 	}
 
 	/**
-	 * @param bindings
-	 * @param otherBindings
 	 * @return true if both parameters are equals, false otherwise
 	 */
 	static boolean isEqual(org.eclipse.jdt.internal.compiler.lookup.TypeBinding[] bindings, org.eclipse.jdt.internal.compiler.lookup.TypeBinding[] otherBindings) {
 		return isEqual(bindings, otherBindings, new HashSet());
 	}
 	/**
-	 * @param bindings
-	 * @param otherBindings
 	 * @return true if both parameters are equals, false otherwise
 	 */
 	static boolean isEqual(org.eclipse.jdt.internal.compiler.lookup.TypeBinding[] bindings, org.eclipse.jdt.internal.compiler.lookup.TypeBinding[] otherBindings, HashSet visitedTypes) {
@@ -320,8 +312,6 @@ class BindingComparator {
 		}
 	}
 	/**
-	 * @param typeBinding
-	 * @param typeBinding2
 	 * @return true if both parameters are equals, false otherwise
 	 */
 	static boolean isEqual(org.eclipse.jdt.internal.compiler.lookup.TypeBinding typeBinding, org.eclipse.jdt.internal.compiler.lookup.TypeBinding typeBinding2) {

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/BindingResolver.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/BindingResolver.java
@@ -165,7 +165,6 @@ class BindingResolver {
 	 *
 	 * @param moduleBinding the old module binding
 	 * @return the new module binding
-	 *
 	 */
 	IModuleBinding getModuleBinding(org.eclipse.jdt.internal.compiler.lookup.ModuleBinding moduleBinding) {
 		return null;
@@ -313,7 +312,6 @@ class BindingResolver {
 	 * The default implementation of this method does nothing.
 	 * Subclasses may reimplement.
 	 * </p>
-	 * @param astNode
 	 */
 	void recordScope(ASTNode astNode, BlockScope blockScope) {
 		// default implementation: do nothing

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/DefaultASTVisitor.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/DefaultASTVisitor.java
@@ -11,19 +11,11 @@
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
 package org.eclipse.jdt.core.dom;
-/**
- */
 class DefaultASTVisitor extends ASTVisitor {
-	/**
-	 *
-	 */
 	public DefaultASTVisitor() {
 		super();
 	}
 
-	/**
-	 *
-	 */
 	public DefaultASTVisitor(boolean visitDocTags) {
 		super(visitDocTags);
 	}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/DefaultCommentMapper.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/DefaultCommentMapper.java
@@ -187,7 +187,6 @@ class DefaultCommentMapper {
 	/**
 	 * Return index of first leading comment of a given node.
 	 *
-	 * @param node
 	 * @return index of first leading comment or -1 if node has no leading comment
 	 */
 	int firstLeadingCommentIndex(ASTNode node) {
@@ -204,7 +203,6 @@ class DefaultCommentMapper {
 	/**
 	 * Return index of last trailing comment of a given node.
 	 *
-	 * @param node
 	 * @return index of last trailing comment or -1 if node has no trailing comment
 	 */
 	int lastTrailingCommentIndex(ASTNode node) {

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/GuardedPattern.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/GuardedPattern.java
@@ -239,7 +239,6 @@ public class GuardedPattern extends Pattern{
 
 	/**
 	 * Sets the pattern of this switch case.
-	 * @param pattern
 	 * @noreference This method is not intended to be referenced by clients.
 	 * @exception UnsupportedOperationException if this operation is used not for JLS18
 	 * @exception UnsupportedOperationException if this operation is used without previewEnabled

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/JavaDocRegion.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/JavaDocRegion.java
@@ -231,7 +231,6 @@ public class JavaDocRegion extends AbstractTagElement{
 
 	/**
 	 * Sets the value of dummyRegion property.
-	 * @param dummyRegion
 	 * @exception UnsupportedOperationException if this operation is used below JLS18
 	 */
 	public void setDummyRegion(boolean dummyRegion) {
@@ -253,7 +252,6 @@ public class JavaDocRegion extends AbstractTagElement{
 
 	/**
 	 * Sets the value of validSnippet property.
-	 * @param validSnippet
 	 * @exception UnsupportedOperationException if this operation is used below JLS18
 	 */
 	public void setValidSnippet(boolean validSnippet) {

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ModuleDeclaration.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ModuleDeclaration.java
@@ -104,7 +104,6 @@ public class ModuleDeclaration extends ASTNode {
 	/**
 	 * The annotations (element type: {@link Annotation}).
 	 * Defaults to an empty list.
-	 *
 	 */
 	private final ASTNode.NodeList annotations = new ASTNode.NodeList(ANNOTATIONS_PROPERTY);
 

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ModuleQualifiedName.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ModuleQualifiedName.java
@@ -31,7 +31,6 @@ import java.util.List;
  *
  * @noinstantiate This class is not intended to be instantiated by clients.
  * @since 3.24
- *
  */
 @SuppressWarnings("rawtypes")
 public class ModuleQualifiedName extends Name {

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/RecordDeclaration.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/RecordDeclaration.java
@@ -99,7 +99,6 @@ public class RecordDeclaration extends AbstractTypeDeclaration {
 	private int restrictedIdentifierStartPosition = -1;
 
 	/**
-	 * @param restrictedIdentifierStartPosition
 	 * @since 3.26
 	 */
 	public void setRestrictedIdentifierStartPosition(int restrictedIdentifierStartPosition) {

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/TagProperty.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/TagProperty.java
@@ -240,7 +240,6 @@ public class TagProperty extends ASTNode implements IDocElement{
 	/**
 	 * Sets the name of this tag property.
 	 *
-	 * @param name
 	 * @exception UnsupportedOperationException if this operation is used below JLS18
 	 */
 	public void setName(String name) {
@@ -252,7 +251,6 @@ public class TagProperty extends ASTNode implements IDocElement{
 
 	/**
 	 * Sets the string value of this tag property.
-	 * @param value
 	 * @exception UnsupportedOperationException if this operation is used below JLS18
 	 */
 	public void setStringValue(String value) {
@@ -264,7 +262,6 @@ public class TagProperty extends ASTNode implements IDocElement{
 
 	/**
 	 * Sets the node value of this tag property.
-	 * @param value
 	 * @exception UnsupportedOperationException if this operation is used below JLS18
 	 */
 	public void setNodeValue(ASTNode value) {

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/TypeDeclaration.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/TypeDeclaration.java
@@ -252,7 +252,6 @@ public class TypeDeclaration extends AbstractTypeDeclaration {
 	 * The superinterface names (element type: {@link Name}).
 	 * JLS2 only; defaults to an empty list. Not used in JLS3.
 	 * (see constructor).
-	 *
 	 */
 	private ASTNode.NodeList superInterfaceNames = null;
 

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/SourceRangeVerifier.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/SourceRangeVerifier.java
@@ -40,7 +40,6 @@ public class SourceRangeVerifier extends ASTVisitor {
 	 * nodes never overlap.
 	 * </p>
 	 *
-	 * @param node
 	 * @return <code>null</code> if everything is OK; a list of errors otherwise
 	 */
 	public String process(ASTNode node) {

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/ASTRewriteFormatter.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/ASTRewriteFormatter.java
@@ -247,7 +247,6 @@ public final class ASTRewriteFormatter {
 	 * Creates edits that describe how to format the given string. Returns <code>null</code> if the code could not be formatted for the given kind.
 	 * @param node Node describing the type of the string
 	 * @param str The unformatted string
-	 * @param indentationLevel
 	 * @return Returns the edit representing the result of the formatter
 	 * @throws IllegalArgumentException If the offset and length are not inside the string, a
 	 *  IllegalArgumentException is thrown.

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/LineInformation.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/LineInformation.java
@@ -18,9 +18,6 @@ import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
 
-/**
- *
- */
 public abstract class LineInformation {
 
 	public static LineInformation create(final IDocument doc) {

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/ListRewriteEvent.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/ListRewriteEvent.java
@@ -18,9 +18,6 @@ import java.util.List;
 
 import org.eclipse.jdt.core.dom.ASTNode;
 
-/**
- *
- */
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class ListRewriteEvent extends RewriteEvent {
 

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/NodeInfoStore.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/NodeInfoStore.java
@@ -30,9 +30,6 @@ import org.eclipse.jdt.core.dom.VariableDeclarationStatement;
 
 import org.eclipse.jdt.internal.core.dom.rewrite.RewriteEventStore.CopySourceInfo;
 
-/**
- *
- */
 @SuppressWarnings({"rawtypes", "unchecked"})
 public final class NodeInfoStore {
 	private final AST ast;
@@ -159,9 +156,6 @@ public final class NodeInfoStore {
 		}
 	}
 
-	/**
-	 *
-	 */
 	public void clear() {
 		this.placeholderNodes= null;
 		this.collapsedNodes= null;

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/NodeRewriteEvent.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/NodeRewriteEvent.java
@@ -15,9 +15,6 @@ package org.eclipse.jdt.internal.core.dom.rewrite;
 
 
 
-/**
- *
- */
 public class NodeRewriteEvent extends RewriteEvent {
 
 	private final Object originalValue;

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/RewriteEvent.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/RewriteEvent.java
@@ -14,9 +14,6 @@
 package org.eclipse.jdt.internal.core.dom.rewrite;
 
 
-/**
- *
- */
 public abstract class RewriteEvent {
 
 	/**

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/RewriteEventStore.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/RewriteEventStore.java
@@ -477,8 +477,6 @@ public final class RewriteEventStore {
 
 	/**
 	 * Kind is either ORIGINAL, NEW, or BOTH
-	 * @param value
-	 * @param kind
 	 * @return Returns the event with the given value of <code>null</code>.
 	 */
 	public RewriteEvent findEvent(Object value, int kind) {

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/TrackedNodePosition.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/TrackedNodePosition.java
@@ -20,9 +20,6 @@ import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.rewrite.ITrackedNodePosition;
 import org.eclipse.jface.text.IRegion;
 
-/**
- *
- */
 public class TrackedNodePosition implements ITrackedNodePosition {
 
 	private final TextEditGroup group;

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/util/DOMASTUtil.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/util/DOMASTUtil.java
@@ -212,7 +212,6 @@ public class DOMASTUtil {
 	 * Calculates the JavaCore Option value string corresponding to the input ast level.
 	 * AST Level 4 is used for Java versions 1.4 to 1.7 and is converted to compliance level 7
 	 * if input ast level is out of boundary, latest compliance will be returned
-	 * @param astLevel
 	 * @return JavaCore Option value string corresponding to the ast level
 	 */
 	public static String getCompliance(int astLevel) {

--- a/org.eclipse.jdt.core/eval/org/eclipse/jdt/internal/eval/CodeSnippetReturnStatement.java
+++ b/org.eclipse.jdt.core/eval/org/eclipse/jdt/internal/eval/CodeSnippetReturnStatement.java
@@ -53,7 +53,6 @@ public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext, Fl
 
 /**
  * Dump the suitable return bytecode for a return statement
- *
  */
 @Override
 public void generateReturnBytecode(CodeStream codeStream) {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/core/ICodeAssist.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/core/ICodeAssist.java
@@ -257,7 +257,6 @@ public interface ICodeAssist {
 	 *  <li> The range specified is not within this element's
 	 *      source range (INDEX_OUT_OF_BOUNDS)
 	 * </ul>
-	 *
 	 */
 	IJavaElement[] codeSelect(int offset, int length) throws JavaModelException;
 	/**

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/core/IField.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/core/IField.java
@@ -94,7 +94,6 @@ boolean isResolved();
  * Returns whether this field represents a record component.
  *
  * @return whether this field represents a record component.
- * @throws JavaModelException
  * @since 3.26
  */
 boolean isRecordComponent() throws JavaModelException;

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/core/IJavaProject.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/core/IJavaProject.java
@@ -638,7 +638,6 @@ public interface IJavaProject extends IParent, IJavaElement, IOpenable {
 	 * @return the {@link IModuleDescription} this project owns.
 	 * @exception JavaModelException if this element does not exist or if an
 	 *		exception occurs while accessing its corresponding resource
-	 * @throws JavaModelException
 	 * @since 3.20
 	 */
 	IModuleDescription getOwnModuleDescription() throws JavaModelException;
@@ -1150,7 +1149,6 @@ public interface IJavaProject extends IParent, IJavaElement, IOpenable {
 	 * {@link #setRawClasspath(IClasspathEntry[], IClasspathEntry[], IPath, IProgressMonitor)}
 	 * If the client has not stored any referenced entries for this project, an empty array is returned.
 	 *
-	 * @throws JavaModelException
 	 * @return an array of referenced classpath entries stored for this java project or an empty array if none
 	 * 			stored earlier.
 	 * @since 3.6
@@ -1248,7 +1246,6 @@ public interface IJavaProject extends IParent, IJavaElement, IOpenable {
 	 * @param path
 	 *            IPath
 	 * @return the classpath entry or <code>null</code>.
-	 * @throws JavaModelException
 	 * @since 3.14
 	 */
 	IClasspathEntry getClasspathEntryFor(IPath path) throws JavaModelException;

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/core/IModularClassFile.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/core/IModularClassFile.java
@@ -24,7 +24,6 @@ public interface IModularClassFile extends IClassFile {
 	 * Returns the module description contained in this type root.
 	 * An error-free {@link IModularClassFile} should always have a module.
 	 *
-	 * @throws JavaModelException
 	 * @return the module description contained in the type root.
 	 */
 	@Override

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/core/IModuleDescription.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/core/IModuleDescription.java
@@ -41,7 +41,6 @@ public interface IModuleDescription extends IMember, IAnnotatable {
 	 * Get provided service names for this module.
 	 *
 	 * @return a non-null array of provided service names
-	 * @throws JavaModelException
 	 * @since 3.18
 	 */
 	String[] getProvidedServiceNames() throws JavaModelException;
@@ -50,7 +49,6 @@ public interface IModuleDescription extends IMember, IAnnotatable {
 	 * Get used service names for this module.
 	 *
 	 * @return a non-null array of used service names
-	 * @throws JavaModelException
 	 * @since 3.18
 	 */
 	String[] getUsedServiceNames() throws JavaModelException;
@@ -60,7 +58,6 @@ public interface IModuleDescription extends IMember, IAnnotatable {
 	 *
 	 * @param targetModule filter the result to include only packages exported to the given module, unless {@code null}.
 	 * @return a non-null array of exported package names
-	 * @throws JavaModelException
 	 * @since 3.18
 	 */
 	String[] getExportedPackageNames(IModuleDescription targetModule) throws JavaModelException;
@@ -70,7 +67,6 @@ public interface IModuleDescription extends IMember, IAnnotatable {
 	 *
 	 * @param targetModule filter the result to include only packages opened to the given module, unless {@code null}.
 	 * @return a non-null array of opened package names
-	 * @throws JavaModelException
 	 * @since 3.18
 	 */
 	String[] getOpenedPackageNames(IModuleDescription targetModule) throws JavaModelException;

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/core/ITypeRoot.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/core/ITypeRoot.java
@@ -41,7 +41,6 @@ IType findPrimaryType();
  * in this type root.
  * <p>Only subtype {@link IModularClassFile} promises to return non-null.</p>
  *
- * @throws JavaModelException
  * @since 3.14
  * @return the module description contained in the type root or null.
  */

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/core/JavaCore.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/core/JavaCore.java
@@ -4001,7 +4001,6 @@ public final class JavaCore extends Plugin {
 	/**
 	 * Returns deprecation message of a given classpath variable.
 	 *
-	 * @param variableName
 	 * @return A string if the classpath variable is deprecated, <code>null</code> otherwise.
 	 * @since 3.3
 	 */
@@ -4784,7 +4783,6 @@ public final class JavaCore extends Plugin {
 	/**
 	 * Returns whether a given classpath variable is read-only or not.
 	 *
-	 * @param variableName
 	 * @return <code>true</code> if the classpath variable is read-only,
 	 * 	<code>false</code> otherwise.
 	 * @since 3.3
@@ -5884,7 +5882,6 @@ public final class JavaCore extends Plugin {
 	 *
 	 * @param monitor a progress monitor, or <code>null</code> if progress
 	 *    reporting and cancellation are not desired
-	 * @throws CoreException
 	 * @since 3.13
 	 */
 	public static void rebuildIndex(IProgressMonitor monitor) throws CoreException {
@@ -6019,7 +6016,6 @@ public final class JavaCore extends Plugin {
 	 * @param affectedProjects - the set of projects for which this container is being bound
 	 * @param respectiveContainers - the set of respective containers for the affected projects
 	 * @param monitor a monitor to report progress
-	 * @throws JavaModelException
 	 * @see ClasspathContainerInitializer
 	 * @see #getClasspathContainer(IPath, IJavaProject)
 	 * @see IClasspathContainer
@@ -6057,7 +6053,6 @@ public final class JavaCore extends Plugin {
 	 *
 	 * @param variableName the name of the classpath variable
 	 * @param path the path
-	 * @throws JavaModelException
 	 * @see #getClasspathVariable(String)
 	 *
 	 * @deprecated Use {@link #setClasspathVariable(String, IPath, IProgressMonitor)} instead
@@ -6086,7 +6081,6 @@ public final class JavaCore extends Plugin {
 	 * @param variableName the name of the classpath variable
 	 * @param path the path
 	 * @param monitor a monitor to report progress
-	 * @throws JavaModelException
 	 * @see #getClasspathVariable(String)
 	 */
 	public static void setClasspathVariable(
@@ -6125,7 +6119,6 @@ public final class JavaCore extends Plugin {
 	 * @param paths an array of path updates for the modified classpath variables (null
 	 *       meaning that the corresponding value will be removed
 	 * @param monitor a monitor to report progress
-	 * @throws JavaModelException
 	 * @see #getClasspathVariable(String)
 	 * @since 2.0
 	 */
@@ -6314,7 +6307,6 @@ public final class JavaCore extends Plugin {
 	 * @param project
 	 *            the project whose referenced modules to be computed
 	 * @return an array of String containing module names
-	 * @throws CoreException
 	 * @since 3.14
 	 */
 	public static String[] getReferencedModules(IJavaProject project) throws CoreException {
@@ -6332,7 +6324,6 @@ public final class JavaCore extends Plugin {
 	 *
 	 * @return the <code>IModuleDescription</code> representing this java element as an automatic module,
 	 * 		never <code>null</code>.
-	 * @throws JavaModelException
 	 * @throws IllegalArgumentException if the provided element is neither <code>IPackageFragmentRoot</code>
 	 * 	nor <code>IJavaProject</code>
 	 * @since 3.14
@@ -6382,7 +6373,6 @@ public final class JavaCore extends Plugin {
 	 * @param classFileAttributes map of attribute names and values to be used during class file generation
 	 * @return the compiled byte code
 	 *
-	 * @throws JavaModelException
 	 * @throws IllegalArgumentException if the map of classFileAttributes contains an unsupported key.
 	 * @since 3.14
 	 */
@@ -6481,7 +6471,6 @@ public final class JavaCore extends Plugin {
 	 * Registers the JavaModelManager as a resource changed listener and save participant.
 	 * Starts the background indexing, and restore saved classpath variable values.
 	 * </p>
-	 * @throws Exception
 	 * @see org.eclipse.core.runtime.Plugin#start(BundleContext)
 	 */
 	@Override

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/core/provisional/JavaModelAccess.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/core/provisional/JavaModelAccess.java
@@ -48,7 +48,6 @@ public class JavaModelAccess {
 	 *
 	 * @return the <code>IModuleDescription</code> representing this java element as an automatic module,
 	 * 		never <code>null</code>.
-	 * @throws JavaModelException
 	 * @throws IllegalArgumentException if the provided element is neither <code>IPackageFragmentRoot</code>
 	 * 	nor <code>IJavaProject</code>
 	 * @since 3.14

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/compiler/IDocumentElementRequestor.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/compiler/IDocumentElementRequestor.java
@@ -97,7 +97,6 @@ void acceptInitializer(
  * of the parse action, so as to allow computation of normalized ranges.
  *
  * A line separator might corresponds to several characters in the source,
- *
  */
 void acceptLineSeparatorPositions(int[] positions);
 /**

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/compiler/ISourceElementRequestor.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/compiler/ISourceElementRequestor.java
@@ -191,7 +191,6 @@ public interface ISourceElementRequestor {
 	 * the parse action, so as to allow computation of normalized ranges.
 	 *
 	 * A line separator might corresponds to several characters in the source,
-	 *
 	 */
 	void acceptLineSeparatorPositions(int[] positions);
 

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/compiler/parser/SourceTypeConverter.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/compiler/parser/SourceTypeConverter.java
@@ -26,7 +26,6 @@ package org.eclipse.jdt.internal.compiler.parser;
  * | not take advantage of remote field constant inlining.
  * | Given the intended purpose of the conversion is to resolve references, this is not
  * | a problem.
- *
  */
 
 import org.eclipse.jdt.core.IAnnotatable;

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/CompilationUnitStructureRequestor.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/CompilationUnitStructureRequestor.java
@@ -179,7 +179,6 @@ public void acceptImport(int declarationStart, int declarationEnd, int nameSourc
  * of the parse action, so as to allow computation of normalized ranges.
  *
  * A line separator might corresponds to several characters in the source,
- *
  */
 @Override
 public void acceptLineSeparatorPositions(int[] positions) {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/CopyElementsOperation.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/CopyElementsOperation.java
@@ -60,7 +60,6 @@ import org.eclipse.jdt.internal.core.util.Messages;
  *
  *    <li>This operation only copies elements contained within compilation units.
  * </ul>
- *
  */
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class CopyElementsOperation extends MultiOperation implements SuffixConstants {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/CopyResourceElementsOperation.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/CopyResourceElementsOperation.java
@@ -85,7 +85,6 @@ import org.eclipse.text.edits.TextEditGroup;
  *    <li>This operation only copies compilation units and package fragments.
  *    It does not copy package fragment roots - a platform operation must be used for that.
  * </ul>
- *
  */
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class CopyResourceElementsOperation extends MultiOperation implements SuffixConstants {
@@ -300,7 +299,6 @@ public class CopyResourceElementsOperation extends MultiOperation implements Suf
 	 *			<li>one rooted in the destination project
 	 * <li> When a CU is being overwritten, the delta on the destination will be of type F_CONTENT </ul></ul>
 	 * If the operation is rooted in a single project, the delta is rooted in that project
-	 *
 	 */
 	protected void prepareDeltas(IJavaElement sourceElement, IJavaElement destinationElement, boolean isMove, boolean overWriteCU) {
 		if (Util.isExcluded(sourceElement) || Util.isExcluded(destinationElement)) return;

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/CreateElementInCUOperation.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/CreateElementInCUOperation.java
@@ -41,7 +41,6 @@ import org.eclipse.text.edits.TextEdit;
  * element in the compilation unit via the methods <code>#createAfter</code>
  * and <code>#createBefore</code>. By default, the new element is positioned
  * as the last child of its parent element.
- *
  */
 public abstract class CreateElementInCUOperation extends JavaModelOperation {
 	/**

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ImportContainer.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ImportContainer.java
@@ -92,8 +92,6 @@ public ISourceRange getSourceRange() throws JavaModelException {
 	SourceRange range= new SourceRange(firstRange.getOffset(), lastRange.getOffset() + lastRange.getLength() - firstRange.getOffset());
 	return range;
 }
-/**
- */
 @Override
 public String readableName() {
 

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ImportDeclaration.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ImportDeclaration.java
@@ -105,8 +105,6 @@ public JavaElement getPrimaryElement(boolean checkOwner) {
 public boolean isOnDemand() {
 	return this.isOnDemand;
 }
-/**
- */
 @Override
 public String readableName() {
 

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/Initializer.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/Initializer.java
@@ -68,8 +68,6 @@ protected char getHandleMementoDelimiter() {
 public int hashCode() {
 	return Util.combineHashCodes(this.getParent().hashCode(), this.occurrenceCount);
 }
-/**
- */
 @Override
 public String readableName() {
 

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaCorePreferenceModifyListener.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaCorePreferenceModifyListener.java
@@ -67,7 +67,6 @@ public class JavaCorePreferenceModifyListener extends PreferenceModifyListener {
 	 * Returns whether a java project referenced in property key
 	 * is still longer accessible or not.
 	 *
-	 * @param propertyName
 	 * @return true if a project is referenced in given key and this project
 	 * 	is still accessible, false otherwise.
 	 */

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaElement.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaElement.java
@@ -141,7 +141,6 @@ public abstract class JavaElement extends PlatformObject implements IJavaElement
 	 *
 	 * @exception IllegalArgumentException if the type is not one of the valid
 	 *		Java element type constants
-	 *
 	 */
 	protected JavaElement(JavaElement parent) throws IllegalArgumentException {
 		this.setParent(parent);
@@ -602,8 +601,6 @@ public abstract class JavaElement extends PlatformObject implements IJavaElement
 		}
 		return info;
 	}
-	/**
-	 */
 	public String readableName() {
 		return getElementName();
 	}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelManager.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelManager.java
@@ -1468,7 +1468,6 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 		 * Reads the classpath and caches the entries. Returns a two-dimensional array, where the number of elements in the row is fixed to 2.
 		 * The first element is an array of raw classpath entries and the second element is an array of referenced entries that may have been stored
 		 * by the client earlier. See {@link IJavaProject#getReferencedClasspathEntries()} for more details.
-		 *
 		 */
 		public synchronized IClasspathEntry[][] readAndCacheClasspath(JavaProject javaProject) {
 			// read file entries and update status

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaProject.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaProject.java
@@ -424,7 +424,6 @@ public class JavaProject
 	 * Detect cycles in the classpath of the workspace's projects
 	 * and create markers if necessary.
 	 * @param preferredClasspaths Map
-	 * @throws JavaModelException
 	 */
 	public static void validateCycles(Map preferredClasspaths) throws JavaModelException {
 		//long start = System.currentTimeMillis();
@@ -580,7 +579,6 @@ public class JavaProject
 	/**
 	 * Internal computation of an expanded classpath. It will eliminate duplicates, and produce copies
 	 * of exported or restricted classpath entries to avoid possible side-effects ever after.
-	 * @param excludeTestCode
 	 */
 	private void computeExpandedClasspath(
 		ClasspathEntry referringEntry,
@@ -699,7 +697,6 @@ public class JavaProject
 	 * @param rootIDs HashSet
 	 * @param referringEntry the CP entry (project) referring to this entry, or null if initial project
 	 * @param retrieveExportedRoots boolean
-	 * @throws JavaModelException
 	 */
 	public void computePackageFragmentRoots(
 		IClasspathEntry resolvedEntry,
@@ -723,7 +720,6 @@ public class JavaProject
 	 * @param filterModuleRoots if true, roots corresponding to modules will be filtered if applicable:
 	 *    if a limit-modules attribute exists, this is used, otherwise system modules will be filtered
 	 *    according to the rules of root modules per JEP 261.
-	 * @throws JavaModelException
 	 */
 	public void computePackageFragmentRoots(
 		IClasspathEntry resolvedEntry,
@@ -1035,7 +1031,6 @@ public class JavaProject
 	 *    if a limit-modules attribute exists, this is used, otherwise system modules will be filtered
 	 *    according to the rules of root modules per JEP 261.
 	 * @return IPackageFragmentRoot[]
-	 * @throws JavaModelException
 	 */
 	public IPackageFragmentRoot[] computePackageFragmentRoots(
 					IClasspathEntry[] resolvedClasspath,
@@ -1084,7 +1079,6 @@ public class JavaProject
 	 * @param filterModuleRoots if true, roots corresponding to modules will be filtered if applicable:
 	 *    if a limit-modules attribute exists, this is used, otherwise system modules will be filtered
 	 *    according to the rules of root modules per JEP 261.
-	 * @throws JavaModelException
 	 */
 	public void computePackageFragmentRoots(
 		IClasspathEntry[] resolvedClasspath,
@@ -1308,7 +1302,6 @@ public class JavaProject
 	 * Reads and decode an XML classpath string. Returns a two-dimensional array, where the number of elements in the row is fixed to 2.
 	 * The first element is an array of raw classpath entries and the second element is an array of referenced entries that may have been stored
 	 * by the client earlier. See {@link IJavaProject#getReferencedClasspathEntries()} for more details.
-	 *
 	 */
 	public IClasspathEntry[][] decodeClasspath(String xmlClasspath, Map unknownElements) throws IOException, ClasspathEntry.AssertionFailedException {
 
@@ -2041,7 +2034,6 @@ public class JavaProject
 	 * where all classpath variable entries have been resolved and substituted with their final target entries.
 	 * All project exports have been appended to project entries.
 	 * @return IClasspathEntry[]
-	 * @throws JavaModelException
 	 */
 	public IClasspathEntry[] getExpandedClasspath()	throws JavaModelException {
 		return getExpandedClasspath(false);
@@ -2595,7 +2587,6 @@ public class JavaProject
 	 * @param key String
 	 * @see JavaProject#setSharedProperty(String, String)
 	 * @return String
-	 * @throws CoreException
 	 */
 	public String getSharedProperty(String key) throws CoreException {
 
@@ -3465,7 +3456,6 @@ public class JavaProject
 	 * @param newClasspath IClasspathEntry[]
 	 * @param newOutputLocation IPath
 	 * @return boolean Return whether the .classpath file was modified.
-	 * @throws JavaModelException
 	 */
 	public boolean writeFileEntries(IClasspathEntry[] newClasspath, IClasspathEntry[] referencedEntries, IPath newOutputLocation) throws JavaModelException {
 
@@ -3717,7 +3707,6 @@ public class JavaProject
 	 * @param key String
 	 * @param value String
 	 * @see JavaProject#getSharedProperty(String key)
-	 * @throws CoreException
 	 */
 	public void setSharedProperty(String key, String value) throws CoreException {
 

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/Member.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/Member.java
@@ -444,8 +444,6 @@ private boolean isStringArrayParameter(String paramType) {
 public boolean isReadOnly() {
 	return getClassFile() != null;
 }
-/**
- */
 @Override
 public String readableName() {
 

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ModuleUpdater.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ModuleUpdater.java
@@ -55,7 +55,6 @@ public class ModuleUpdater {
 	 * Detects any ADD_EXPORTS or ADD_READS classpath attributes, parses the value,
 	 * and collects the resulting module updates.
 	 * @param entry a classpath entry of the current project.
-	 * @throws JavaModelException
 	 */
 	public void computeModuleUpdates(IClasspathEntry entry) throws JavaModelException {
 		for (IClasspathAttribute attribute : entry.getExtraAttributes()) {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/NameLookup.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/NameLookup.java
@@ -67,7 +67,6 @@ import org.eclipse.jdt.internal.core.util.Util;
  * package.  The other set of methods all begin with <code>seek*</code>.  These methods
  * do comprehensive searches of the <code>IJavaProject</code> returning hits
  * in real time through an <code>IJavaElementRequestor</code>.
- *
  */
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class NameLookup implements SuffixConstants {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/OverflowingLRUCache.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/OverflowingLRUCache.java
@@ -107,7 +107,6 @@ public OverflowingLRUCache(int size, int overflow) {
  *
  * <p>NOTE: this triggers an external remove from the cache
  * by closing the object.
- *
  */
 protected abstract boolean close(LRUCacheEntry<K, V> entry);
 	/**

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/PackageFragmentInfo.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/PackageFragmentInfo.java
@@ -28,8 +28,6 @@ class PackageFragmentInfo extends OpenableElementInfo {
 public PackageFragmentInfo() {
 	this.nonJavaResources = null;
 }
-/**
- */
 boolean containsJavaResources() {
 	return this.children.length != 0;
 }

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/PackageFragmentRoot.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/PackageFragmentRoot.java
@@ -341,7 +341,6 @@ protected int determineKind(IResource underlyingResource) throws JavaModelExcept
  * Compares two objects for equality;
  * for <code>PackageFragmentRoot</code>s, equality is having the
  * same parent, same resources, and occurrence count.
- *
  */
 @Override
 public boolean equals(Object o) {
@@ -892,7 +891,6 @@ protected void verifyAttachSource(IPath sourcePath) throws JavaModelException {
  * to directly under the root. It is the responsibility of such package fragment roots to
  * provide the custom behavior.
  *
- * @param classname
  * @return the relative path for the class file within the archive
  */
 public String getClassFilePath(String classname) {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ProjectEntry.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ProjectEntry.java
@@ -26,7 +26,6 @@ import org.eclipse.jdt.internal.compiler.env.IModulePathEntry;
 
 /**
  * Represents a project
- *
  */
 public class ProjectEntry implements IModulePathEntry {
 

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ReconcileWorkingCopyOperation.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ReconcileWorkingCopyOperation.java
@@ -125,9 +125,6 @@ public class ReconcileWorkingCopyOperation extends JavaModelOperation {
 
 	/**
 	 * Report working copy problems to a given requestor.
-	 *
-	 * @param workingCopy
-	 * @param problemRequestor
 	 */
 	private void reportProblems(CompilationUnit workingCopy, IProblemRequestor problemRequestor) {
 		try {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SortElementsOperation.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SortElementsOperation.java
@@ -67,9 +67,6 @@ public class SortElementsOperation extends JavaModelOperation {
 	 * Constructor for SortElementsOperation.
      *
      * @param level the AST API level; one of the AST LEVEL constants
-	 * @param elements
-	 * @param positions
-	 * @param comparator
 	 */
 	public SortElementsOperation(int level, IJavaElement[] elements, int[] positions, Comparator comparator) {
 		super(elements);
@@ -122,7 +119,6 @@ public class SortElementsOperation extends JavaModelOperation {
 
 	/**
 	 * Calculates the required text edits to sort the <code>unit</code>
-	 * @param group
 	 * @return the edit or null if no sorting is required
 	 */
 	public TextEdit calculateEdit(org.eclipse.jdt.core.dom.CompilationUnit unit, TextEditGroup group) throws JavaModelException {
@@ -151,8 +147,6 @@ public class SortElementsOperation extends JavaModelOperation {
 
 	/**
 	 * Method processElement.
-	 * @param unit
-	 * @param source
 	 */
 	private String processElement(ICompilationUnit unit, char[] source) {
 		Document document = new Document(new String(source));

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SourceMethod.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SourceMethod.java
@@ -272,8 +272,6 @@ public boolean isSimilar(IMethod method) {
 			null);
 }
 
-/**
- */
 @Override
 public String readableName() {
 

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SourceType.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SourceType.java
@@ -357,7 +357,6 @@ public String getFullyQualifiedParameterizedName() throws JavaModelException {
 }
 /*
  * For source types, the occurrence count is the one computed in the context of the immediately enclosing type.
- *
  */
 @Override
 protected String getOccurrenceCountSignature() {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/TypeVector.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/TypeVector.java
@@ -84,9 +84,6 @@ public boolean contains(IType element) {
 			return true;
 	return false;
 }
-/**
- *
- */
 private void constructElementSetIfNecessary() {
 	if (this.elementSet == null && this.size >= MIN_ELEMENTS_FOR_HASHSET) {
 		this.elementSet = new HashMap<>();

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/UserLibraryClasspathContainer.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/UserLibraryClasspathContainer.java
@@ -19,9 +19,6 @@ import org.eclipse.jdt.core.IClasspathContainer;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.JavaCore;
 
-/**
- *
- */
 public class UserLibraryClasspathContainer implements IClasspathContainer {
 
 	private final String name;

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/UserLibraryClasspathContainerInitializer.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/UserLibraryClasspathContainerInitializer.java
@@ -20,9 +20,6 @@ import org.eclipse.jdt.core.IClasspathContainer;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 
-/**
- *
- */
 public class UserLibraryClasspathContainerInitializer extends ClasspathContainerInitializer {
 
 	@Override

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/UserLibraryManager.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/UserLibraryManager.java
@@ -31,9 +31,6 @@ import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.internal.core.util.Util;
 import org.osgi.service.prefs.BackingStoreException;
 
-/**
- *
- */
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class UserLibraryManager {
 

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/hierarchy/HierarchyResolver.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/hierarchy/HierarchyResolver.java
@@ -109,8 +109,6 @@ public HierarchyResolver(LookupEnvironment lookupEnvironment, HierarchyBuilder b
 
 /**
  * Add an additional binary type
- * @param binaryType
- * @param packageBinding
  */
 @Override
 public void accept(IBinaryType binaryType, PackageBinding packageBinding, AccessRestriction accessRestriction) {
@@ -137,7 +135,6 @@ private void sanitizeBinaryType(IGenericType binaryType) {
 
 /**
  * Add an additional compilation unit.
- * @param sourceUnit
  */
 @Override
 public void accept(ICompilationUnit sourceUnit, AccessRestriction accessRestriction) {
@@ -169,8 +166,6 @@ private Parser basicParser() {
 
 /**
  * Add additional source types
- * @param sourceTypes
- * @param packageBinding
  */
 @Override
 public void accept(ISourceType[] sourceTypes, PackageBinding packageBinding, AccessRestriction accessRestriction) {
@@ -626,7 +621,6 @@ private void reset(){
  * Resolve the supertypes for the supplied source type.
  * Inform the requestor of the resolved supertypes using:
  *    connect(ISourceType suppliedType, IGenericType superclass, IGenericType[] superinterfaces)
- * @param suppliedType
  */
 public void resolve(IGenericType suppliedType) {
 	try {
@@ -683,9 +677,6 @@ public void resolve(IGenericType suppliedType) {
  * Also inform the requestor of the supertypes of each
  * additional requested super type which is also a source type
  * instead of a binary type.
- * @param openables
- * @param localTypes
- * @param monitor
  */
 public void resolve(Openable[] openables, HashSet localTypes, IProgressMonitor monitor) {
 	SubMonitor subMonitor = SubMonitor.convert(monitor, 3);

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/hierarchy/IndexBasedHierarchyBuilder.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/hierarchy/IndexBasedHierarchyBuilder.java
@@ -473,12 +473,6 @@ private String[] determinePossibleSubTypes(final HashSet localTypes, IProgressMo
  * hierarchy.
  * The match locator is not used here to narrow down the results, the type hierarchy
  * resolver is rather used to compute the whole hierarchy at once.
- * @param type
- * @param scope
- * @param binariesFromIndexMatches
- * @param pathRequestor
- * @param waitingPolicy
- * @param monitor
  */
 public static void searchAllPossibleSubTypes(
 	IType type,

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/hierarchy/TypeHierarchy.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/hierarchy/TypeHierarchy.java
@@ -451,8 +451,6 @@ private IType[] getAllSubtypesForType(IType type) {
 	subTypes.toArray(subClasses);
 	return subClasses;
 }
-/**
- */
 private void getAllSubtypesForType0(IType type, ArrayList<IType> subs) {
 	IType[] subTypes = getSubtypesForType(type);
 	if (subTypes.length != 0) {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/jdom/DOMBuilder.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/jdom/DOMBuilder.java
@@ -190,9 +190,6 @@ public IDOMField createField(char[] sourceCode) {
 	this.fNode.normalize(this);
 	return (IDOMField)this.fNode;
 }
-/**
- *
- */
 public IDOMField[] createFields(char[] sourceCode) {
 	initializeBuild(sourceCode, false, false, false);
 	this.fFields= new ArrayList();

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/jdom/DOMMethod.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/jdom/DOMMethod.java
@@ -732,8 +732,6 @@ public void setReturnType(String name) throws IllegalArgumentException {
 protected void setReturnTypeAltered(boolean typeAltered) {
 	setMask(MASK_RETURN_TYPE_ALTERED, typeAltered);
 }
-/**
- */
 @Override
 protected void setSourceRangeEnd(int end) {
 	super.setSourceRangeEnd(end);

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/jdom/DOMNode.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/jdom/DOMNode.java
@@ -281,7 +281,6 @@ public void addChild(IDOMNode child) throws IllegalArgumentException, DOMExcepti
  * using the original document and indicies as a form for the current
  * attribute values of this node. If this node not fragmented, the
  * contents can be obtained from the document.
- *
  */
 protected void appendContents(CharArrayBuffer buffer) {
 	if (isFragmented()) {
@@ -296,7 +295,6 @@ protected void appendContents(CharArrayBuffer buffer) {
  *
  * <p>This algorithm used minimizes String generation by merging
  * adjacent unfragmented children into one substring operation.
- *
  */
 protected void appendContentsOfChildren(CharArrayBuffer buffer) {
 	DOMNode child= this.fFirstChild;

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/jdom/SimpleDOMBuilder.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/jdom/SimpleDOMBuilder.java
@@ -93,8 +93,6 @@ protected void enterAbstractMethod(MethodInfo methodInfo) {
 
 	// type parameters not supported by JDOM
 }
-/**
- */
 @Override
 public void enterConstructor(MethodInfo methodInfo) {
 	/* see 1FVIIQZ */
@@ -105,8 +103,6 @@ public void enterConstructor(MethodInfo methodInfo) {
 
 	enterAbstractMethod(methodInfo);
 }
-/**
- */
 @Override
 public void enterField(FieldInfo fieldInfo) {
 
@@ -121,9 +117,6 @@ public void enterField(FieldInfo fieldInfo) {
 	addChild(this.fNode);
 	this.fStack.push(this.fNode);
 }
-/**
-
- */
 @Override
 public void enterInitializer(int declarationSourceStart, int modifiers) {
 	int[] sourceRange = {declarationSourceStart, -1};
@@ -131,14 +124,10 @@ public void enterInitializer(int declarationSourceStart, int modifiers) {
 	addChild(this.fNode);
 	this.fStack.push(this.fNode);
 }
-/**
- */
 @Override
 public void enterMethod(MethodInfo methodInfo) {
 	enterAbstractMethod(methodInfo);
 }
-/**
- */
 @Override
 public void enterType(TypeInfo typeInfo) {
 	if (this.fBuildingType) {
@@ -162,14 +151,10 @@ public void enterType(TypeInfo typeInfo) {
 public void exitConstructor(int declarationEnd) {
 	exitMember(declarationEnd);
 }
-/**
- */
 @Override
 public void exitField(int initializationStart, int declarationEnd, int declarationSourceEnd) {
 	exitMember(declarationEnd);
 }
-/**
- */
 @Override
 public void exitInitializer(int declarationEnd) {
 	exitMember(declarationEnd);
@@ -185,8 +170,6 @@ protected void exitMember(int declarationEnd) {
 	m.setSourceRangeEnd(declarationEnd);
 	this.fNode = m;
 }
-/**
- */
 @Override
 public void exitMethod(int declarationEnd, Expression defaultValue) {
 	exitMember(declarationEnd);

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/Annotation.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/Annotation.java
@@ -35,11 +35,6 @@ public class Annotation extends ClassFileStruct implements IAnnotation {
 
 	/**
 	 * Constructor for Annotation.
-	 *
-	 * @param classFileBytes
-	 * @param constantPool
-	 * @param offset
-	 * @throws ClassFormatException
 	 */
 	public Annotation(
 			byte[] classFileBytes,

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/AnnotationDefaultAttribute.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/AnnotationDefaultAttribute.java
@@ -31,10 +31,6 @@ public class AnnotationDefaultAttribute extends ClassFileAttribute
 
 	/**
 	 * Constructor for AnnotationDefaultAttribute.
-	 * @param classFileBytes
-	 * @param constantPool
-	 * @param offset
-	 * @throws ClassFormatException
 	 */
 	public AnnotationDefaultAttribute(
 			byte[] classFileBytes,

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/BootstrapMethodsAttribute.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/BootstrapMethodsAttribute.java
@@ -29,10 +29,6 @@ public class BootstrapMethodsAttribute extends ClassFileAttribute implements IBo
 
 	/**
 	 * Constructor for BootstrapMethodsAttribute.
-	 * @param classFileBytes
-	 * @param constantPool
-	 * @param offset
-	 * @throws ClassFormatException
 	 */
 	public BootstrapMethodsAttribute(
 			byte[] classFileBytes,

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/CommentRecorderParser.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/CommentRecorderParser.java
@@ -36,10 +36,6 @@ public class CommentRecorderParser extends Parser {
 	int commentPtr = -1; // no comment test with commentPtr value -1
 	protected final static int CommentIncrement = 100;
 
-	/**
-	 * @param problemReporter
-	 * @param optimizeStringLiterals
-	 */
 	public CommentRecorderParser(ProblemReporter problemReporter, boolean optimizeStringLiterals) {
 		super(problemReporter, optimizeStringLiterals);
 	}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/DefaultStackMapFrame.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/DefaultStackMapFrame.java
@@ -33,11 +33,6 @@ public class DefaultStackMapFrame extends ClassFileStruct implements IStackMapFr
 
 	/**
 	 * Constructor for StackMapFrame.
-	 *
-	 * @param classFileBytes
-	 * @param constantPool
-	 * @param offset
-	 * @throws ClassFormatException
 	 */
 	public DefaultStackMapFrame(
 			byte[] classFileBytes,

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/ExtendedAnnotation.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/ExtendedAnnotation.java
@@ -79,11 +79,6 @@ public class ExtendedAnnotation extends ClassFileStruct implements IExtendedAnno
 
 	/**
 	 * Constructor for ExtendedAnnotation, builds an annotation from the supplied bytestream.
-	 *
-	 * @param classFileBytes
-	 * @param constantPool
-	 * @param offset
-	 * @throws ClassFormatException
 	 */
 	public ExtendedAnnotation(
 			byte[] classFileBytes,

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/InnerClassesAttribute.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/InnerClassesAttribute.java
@@ -28,10 +28,6 @@ public class InnerClassesAttribute extends ClassFileAttribute implements IInnerC
 	private IInnerClassesAttributeEntry[] entries;
 	/**
 	 * Constructor for InnerClassesAttribute.
-	 * @param classFileBytes
-	 * @param constantPool
-	 * @param offset
-	 * @throws ClassFormatException
 	 */
 	public InnerClassesAttribute(
 		byte[] classFileBytes,

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/LineNumberAttribute.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/LineNumberAttribute.java
@@ -30,10 +30,6 @@ public class LineNumberAttribute
 
 	/**
 	 * Constructor for LineNumberAttribute.
-	 * @param classFileBytes
-	 * @param constantPool
-	 * @param offset
-	 * @throws ClassFormatException
 	 */
 	public LineNumberAttribute(
 		byte[] classFileBytes,

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/LocalVariableAttribute.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/LocalVariableAttribute.java
@@ -31,10 +31,6 @@ public class LocalVariableAttribute
 
 	/**
 	 * Constructor for LocalVariableAttribute.
-	 * @param classFileBytes
-	 * @param constantPool
-	 * @param offset
-	 * @throws ClassFormatException
 	 */
 	public LocalVariableAttribute(
 		byte[] classFileBytes,

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/LocalVariableReferenceInfo.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/LocalVariableReferenceInfo.java
@@ -28,11 +28,6 @@ public class LocalVariableReferenceInfo extends ClassFileStruct implements ILoca
 
 	/**
 	 * Constructor for LocalVariableTableEntry.
-	 *
-	 * @param classFileBytes
-	 * @param constantPool
-	 * @param offset
-	 * @throws ClassFormatException
 	 */
 	public LocalVariableReferenceInfo(
 			byte[] classFileBytes,

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/LocalVariableTableEntry.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/LocalVariableTableEntry.java
@@ -34,11 +34,6 @@ public class LocalVariableTableEntry extends ClassFileStruct implements ILocalVa
 
 	/**
 	 * Constructor for LocalVariableTableEntry.
-	 *
-	 * @param classFileBytes
-	 * @param constantPool
-	 * @param offset
-	 * @throws ClassFormatException
 	 */
 	public LocalVariableTableEntry(
 		byte[] classFileBytes,

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/LocalVariableTypeAttribute.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/LocalVariableTypeAttribute.java
@@ -31,10 +31,6 @@ public class LocalVariableTypeAttribute
 
 	/**
 	 * Constructor for LocalVariableTypeAttribute.
-	 * @param classFileBytes
-	 * @param constantPool
-	 * @param offset
-	 * @throws ClassFormatException
 	 */
 	public LocalVariableTypeAttribute(
 		byte[] classFileBytes,

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/LocalVariableTypeTableEntry.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/LocalVariableTypeTableEntry.java
@@ -34,11 +34,6 @@ public class LocalVariableTypeTableEntry extends ClassFileStruct implements ILoc
 
 	/**
 	 * Constructor for LocalVariableTypeTableEntry.
-	 *
-	 * @param classFileBytes
-	 * @param constantPool
-	 * @param offset
-	 * @throws ClassFormatException
 	 */
 	public LocalVariableTypeTableEntry(
 		byte[] classFileBytes,

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/ModuleMainClassAttribute.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/ModuleMainClassAttribute.java
@@ -29,10 +29,6 @@ public class ModuleMainClassAttribute extends ClassFileAttribute implements IMod
 
 	/**
 	 * Constructor for ModuleMainClassAttribute.
-	 * @param classFileBytes
-	 * @param constantPool
-	 * @param offset
-	 * @throws ClassFormatException
 	 */
 	public ModuleMainClassAttribute(	byte[] classFileBytes,	IConstantPool constantPool,	int offset)	throws ClassFormatException {
 		super(classFileBytes, constantPool, offset);

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/ModulePackagesAttribute.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/ModulePackagesAttribute.java
@@ -32,10 +32,6 @@ public class ModulePackagesAttribute extends ClassFileAttribute implements IModu
 
 	/**
 	 * Constructor for ModulePackagesAttribute.
-	 * @param classFileBytes
-	 * @param constantPool
-	 * @param offset
-	 * @throws ClassFormatException
 	 */
 	public ModulePackagesAttribute(	byte[] classFileBytes,	IConstantPool constantPool,	int offset)	throws ClassFormatException {
 		super(classFileBytes, constantPool, offset);

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/NestMembersAttribute.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/NestMembersAttribute.java
@@ -26,10 +26,6 @@ public class NestMembersAttribute extends ClassFileAttribute implements INestMem
 
 	/**
 	 * Constructor for NestMembersAttribute.
-	 * @param classFileBytes
-	 * @param constantPool
-	 * @param offset
-	 * @throws ClassFormatException
 	 */
 	public NestMembersAttribute(
 		byte[] classFileBytes,

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/ParameterAnnotation.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/ParameterAnnotation.java
@@ -31,11 +31,6 @@ public class ParameterAnnotation extends ClassFileStruct implements IParameterAn
 
 	/**
 	 * Constructor for Annotation.
-	 *
-	 * @param classFileBytes
-	 * @param constantPool
-	 * @param offset
-	 * @throws ClassFormatException
 	 */
 	public ParameterAnnotation(
 			byte[] classFileBytes,

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/PermittedSubclassesAttribute.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/PermittedSubclassesAttribute.java
@@ -29,10 +29,6 @@ public class PermittedSubclassesAttribute extends ClassFileAttribute implements 
 
 	/**
 	 * Constructor for PermittedSubclassesAttribute.
-	 * @param classFileBytes
-	 * @param constantPool
-	 * @param offset
-	 * @throws ClassFormatException
 	 */
 	public PermittedSubclassesAttribute(
 		byte[] classFileBytes,

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/RuntimeInvisibleAnnotationsAttribute.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/RuntimeInvisibleAnnotationsAttribute.java
@@ -31,10 +31,6 @@ public class RuntimeInvisibleAnnotationsAttribute
 
 	/**
 	 * Constructor for RuntimeInvisibleAnnotations.
-	 * @param classFileBytes
-	 * @param constantPool
-	 * @param offset
-	 * @throws ClassFormatException
 	 */
 	public RuntimeInvisibleAnnotationsAttribute(
 			byte[] classFileBytes,

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/RuntimeInvisibleParameterAnnotationsAttribute.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/RuntimeInvisibleParameterAnnotationsAttribute.java
@@ -31,10 +31,6 @@ public class RuntimeInvisibleParameterAnnotationsAttribute
 
 	/**
 	 * Constructor for RuntimeVisibleParameterAnnotations.
-	 * @param classFileBytes
-	 * @param constantPool
-	 * @param offset
-	 * @throws ClassFormatException
 	 */
 	public RuntimeInvisibleParameterAnnotationsAttribute(
 		byte[] classFileBytes,

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/RuntimeInvisibleTypeAnnotationsAttribute.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/RuntimeInvisibleTypeAnnotationsAttribute.java
@@ -33,10 +33,6 @@ public class RuntimeInvisibleTypeAnnotationsAttribute
 
 	/**
 	 * Constructor for RuntimeInvisibleTypeAnnotations.
-	 * @param classFileBytes
-	 * @param constantPool
-	 * @param offset
-	 * @throws ClassFormatException
 	 */
 	public RuntimeInvisibleTypeAnnotationsAttribute(
 			byte[] classFileBytes,

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/RuntimeVisibleAnnotationsAttribute.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/RuntimeVisibleAnnotationsAttribute.java
@@ -31,10 +31,6 @@ public class RuntimeVisibleAnnotationsAttribute
 
 	/**
 	 * Constructor for RuntimeVisibleAnnotations.
-	 * @param classFileBytes
-	 * @param constantPool
-	 * @param offset
-	 * @throws ClassFormatException
 	 */
 	public RuntimeVisibleAnnotationsAttribute(
 		byte[] classFileBytes,

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/RuntimeVisibleParameterAnnotationsAttribute.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/RuntimeVisibleParameterAnnotationsAttribute.java
@@ -31,10 +31,6 @@ public class RuntimeVisibleParameterAnnotationsAttribute
 
 	/**
 	 * Constructor for RuntimeVisibleParameterAnnotations.
-	 * @param classFileBytes
-	 * @param constantPool
-	 * @param offset
-	 * @throws ClassFormatException
 	 */
 	public RuntimeVisibleParameterAnnotationsAttribute(
 		byte[] classFileBytes,

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/RuntimeVisibleTypeAnnotationsAttribute.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/RuntimeVisibleTypeAnnotationsAttribute.java
@@ -33,10 +33,6 @@ public class RuntimeVisibleTypeAnnotationsAttribute
 
 	/**
 	 * Constructor for RuntimeVisibleTypeAnnotations.
-	 * @param classFileBytes
-	 * @param constantPool
-	 * @param offset
-	 * @throws ClassFormatException
 	 */
 	public RuntimeVisibleTypeAnnotationsAttribute(
 			byte[] classFileBytes,

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/SourceFileAttribute.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/SourceFileAttribute.java
@@ -31,10 +31,6 @@ public class SourceFileAttribute
 
 	/**
 	 * Constructor for SourceFileAttribute.
-	 * @param classFileBytes
-	 * @param constantPool
-	 * @param offset
-	 * @throws ClassFormatException
 	 */
 	public SourceFileAttribute(
 		byte[] classFileBytes,

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/StackMapAttribute.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/StackMapAttribute.java
@@ -35,10 +35,6 @@ public class StackMapAttribute
 
 	/**
 	 * Constructor for LineNumberAttribute.
-	 * @param classFileBytes
-	 * @param constantPool
-	 * @param offset
-	 * @throws ClassFormatException
 	 */
 	public StackMapAttribute(
 			byte[] classFileBytes,
@@ -79,8 +75,6 @@ public class StackMapAttribute
 		return this.frames;
 	}
 
-	/**
-	 */
 	public byte[] getBytes() {
 		return this.bytes;
 	}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/StackMapFrame.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/StackMapFrame.java
@@ -34,11 +34,6 @@ public class StackMapFrame extends ClassFileStruct implements IStackMapFrame {
 
 	/**
 	 * Constructor for StackMapFrame.
-	 *
-	 * @param classFileBytes
-	 * @param constantPool
-	 * @param offset
-	 * @throws ClassFormatException
 	 */
 	public StackMapFrame(
 			byte[] classFileBytes,

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/StackMapTableAttribute.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/StackMapTableAttribute.java
@@ -35,10 +35,6 @@ public class StackMapTableAttribute
 
 	/**
 	 * Constructor for LineNumberAttribute.
-	 * @param classFileBytes
-	 * @param constantPool
-	 * @param offset
-	 * @throws ClassFormatException
 	 */
 	public StackMapTableAttribute(
 			byte[] classFileBytes,
@@ -79,8 +75,6 @@ public class StackMapTableAttribute
 		return this.frames;
 	}
 
-	/**
-	 */
 	public byte[] getBytes() {
 		return this.bytes;
 	}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/Util.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/Util.java
@@ -1656,7 +1656,6 @@ public class Util {
 
 	/**
 	 * Returns whether the given resource is read-only or not.
-	 * @param resource
 	 * @return <code>true</code> if the resource is read-only, <code>false</code> if it is not or
 	 * 	if the file system does not support the read-only attribute.
 	 */
@@ -3329,7 +3328,6 @@ public class Util {
 	 * @param paramTypeSignatures the type signatures of the method arguments
 	 * @param isConstructor whether we're looking for a constructor
 	 * @return an IMethod if found, otherwise null
-	 * @throws JavaModelException
 	 */
 	public static IMethod findMethod(IType type, char[] selector, String[] paramTypeSignatures, boolean isConstructor) throws JavaModelException {
 		IMethod method = null;

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/core/search/MethodNameMatch.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/core/search/MethodNameMatch.java
@@ -40,7 +40,6 @@ public abstract class MethodNameMatch {
 	 * 		{@link IAccessRule#K_ACCESSIBLE}, {@link IAccessRule#K_DISCOURAGED}
 	 * 		or {@link IAccessRule#K_NON_ACCESSIBLE}.
 	 * 		The default returned value is {@link IAccessRule#K_ACCESSIBLE}.
-	 *
 	 */
 	public abstract int getAccessibility();
 

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/core/search/MethodNameRequestor.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/core/search/MethodNameRequestor.java
@@ -23,7 +23,6 @@ package org.eclipse.jdt.core.search;
   * This class may be subclassed by clients
   * </p>
  * @since 3.12
-  *
   */
 public abstract class MethodNameRequestor {
 

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/core/search/SearchEngine.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/core/search/SearchEngine.java
@@ -381,7 +381,6 @@ public class SearchEngine {
 	 * files of this package fragment will be included. Subpackages will NOT be
 	 * included.</p>
 	 *
-	 * @param excludeTestCode
 	 * @param elements the Java elements the scope is limited to
 	 * @param includeMask the bit-wise OR of all include types of interest
 	 * @return a new Java search scope

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/core/search/SearchPattern.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/core/search/SearchPattern.java
@@ -2802,7 +2802,6 @@ private static int validateMatchRule(String stringPattern, int searchFor, int li
 
 /*
  * Validate pattern for a camel case match rule
- * @return
  */
 private static boolean validateCamelCasePattern(String stringPattern) {
 	if (stringPattern == null) return true;

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/core/search/SearchRequestor.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/core/search/SearchRequestor.java
@@ -38,7 +38,6 @@ public abstract class SearchRequestor {
 	 * Accepts the given search match.
 	 *
 	 * @param match the found match
-	 * @throws CoreException
 	 */
 	public abstract void acceptSearchMatch(SearchMatch match) throws CoreException;
 

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/index/Index.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/index/Index.java
@@ -209,8 +209,6 @@ public void remove(String containerRelativePath) {
 }
 /**
  * Reset memory and disk indexes.
- *
- * @throws IOException
  */
 public void reset() throws IOException {
 	this.memoryIndex = new MemoryIndex();

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/index/IndexLocation.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/index/IndexLocation.java
@@ -30,7 +30,6 @@ import org.eclipse.jdt.internal.core.util.Util;
  *
  * This is an abstract class to allow different implementation for a jar entry and a file
  * on the disk. Some of these functions could mean different for a jar entry or a file
- *
  */
 public abstract class IndexLocation {
 
@@ -104,7 +103,6 @@ public abstract class IndexLocation {
 	/**
 	 * Creates a new file for the given index location
 	 * @return true if the file is created
-	 * @throws IOException
 	 */
 	public abstract boolean createNewFile() throws IOException;
 

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/index/MetaIndex.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/index/MetaIndex.java
@@ -68,7 +68,6 @@ public class MetaIndex {
 	 *
 	 * @param indexes all indexes as a {@link SimpleLookupTable} where key is {@link IndexLocation} and value is {@link Index}
 	 * @return index names which are not part of or empty.
-	 * @throws IOException
 	 */
 	public Set<String> getIndexesNotInMeta(SimpleLookupTable indexes) throws IOException {
 		// this method is accessed in a single thread

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/nd/java/model/BinaryModuleFactory.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/nd/java/model/BinaryModuleFactory.java
@@ -85,8 +85,6 @@ public class BinaryModuleFactory {
 	 * the file on disk, the type is read from the index. Otherwise the type is read from disk. Returns null if
 	 * no such type exists.
 	 * <strong>caveat</strong> modules are not yet supported in the index.
-	 *
-	 * @throws ClassFormatException
 	 */
 	public static IBinaryModule readModule(BinaryModuleDescriptor descriptor, IProgressMonitor monitor) throws JavaModelException, ClassFormatException {
 // FIXME: support module in the new index

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/nd/java/model/BinaryTypeFactory.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/nd/java/model/BinaryTypeFactory.java
@@ -110,7 +110,6 @@ public class BinaryTypeFactory {
 	 * Reads the given binary type. If the type can be found in the index with a fingerprint that exactly matches
 	 * the file on disk, the type is read from the index. Otherwise the type is read from disk. Returns null if
 	 * no such type exists.
-	 * @throws ClassFormatException
 	 */
 	public static IBinaryType readType(BinaryTypeDescriptor descriptor, IProgressMonitor monitor) throws JavaModelException, ClassFormatException {
 		return rawReadType(descriptor, true);
@@ -203,7 +202,6 @@ public class BinaryTypeFactory {
 	 * the field descriptor points to any other type, this returns the empty string. The field descriptor may optionally
 	 * contain a trailing ';'.
 	 *
-	 * @param fieldDescriptor
 	 * @return ""
 	 */
 	public static char[] fieldDescriptorToBinaryName(char[] fieldDescriptor) {

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/nd/util/CharArrayUtils.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/nd/util/CharArrayUtils.java
@@ -250,7 +250,6 @@ public class CharArrayUtils {
 	/**
 	 * Answers a new array which is the concatenation of all the given arrays.
 	 *
-	 * @param toCatenate
 	 * @since 3.12
 	 */
 	public static char[] concat(char[]... toCatenate) {
@@ -452,11 +451,6 @@ public class CharArrayUtils {
 		return subarray(array, pos + separator.length, array.length);
 	}
 
-    /**
-     * @param buff
-     * @param i
-     * @param charImage
-     */
     public static void overWrite(char[] buff, int i, char[] charImage) {
         if (buff.length < i + charImage.length)
             return;

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/BasicSearchEngine.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/BasicSearchEngine.java
@@ -275,9 +275,6 @@ public class BasicSearchEngine {
 		return new JavaSearchParticipant();
 	}
 
-	/**
-	 * @param matchRule
-	 */
 	public static String getMatchRuleString(final int matchRule) {
 		if (matchRule == 0) {
 			return "R_EXACT_MATCH"; //$NON-NLS-1$
@@ -321,8 +318,6 @@ public class BasicSearchEngine {
 
 	/**
 	 * Return kind of search corresponding to given value.
-	 *
-	 * @param searchFor
 	 */
 	public static String getSearchForString(final int searchFor) {
 		switch (searchFor) {

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/JavaSearchMethodNameMatch.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/JavaSearchMethodNameMatch.java
@@ -19,7 +19,6 @@ import org.eclipse.jdt.core.search.MethodNameMatch;
 
 /**
  * Java Search concrete class for a method name match.
- *
  */
 public class JavaSearchMethodNameMatch extends MethodNameMatch {
 

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/MethodNameRequestorWrapper.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/MethodNameRequestorWrapper.java
@@ -46,7 +46,6 @@ import org.eclipse.jdt.internal.compiler.env.AccessRestriction;
  * MethodNameRequestor methodRequestor,
  * int waitingPolicy,
  * IProgressMonitor progressMonitor)}.
- *
  */
 public class MethodNameRequestorWrapper implements IRestrictedAccessMethodRequestor {
 

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/FieldLocator.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/FieldLocator.java
@@ -260,7 +260,6 @@ protected void matchReportReference(ASTNode reference, IJavaElement element, IJa
 /* (non-Javadoc)
  * Overridden to reject unexact matches.
  * @see org.eclipse.jdt.internal.core.search.matching.PatternLocator#updateMatch(org.eclipse.jdt.internal.compiler.lookup.ParameterizedTypeBinding, char[][][], org.eclipse.jdt.internal.core.search.matching.MatchLocator)
- *
  */
 @Override
 protected void updateMatch(ParameterizedTypeBinding parameterizedBinding, char[][][] patternTypeArguments, MatchLocator locator) {

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/JavaSearchNameEnvironment.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/JavaSearchNameEnvironment.java
@@ -596,7 +596,6 @@ private static boolean isComplianceJava9OrHigher(IJavaProject javaProject) {
 
 /**
  * Computes matching module for given {@link PackageFragmentRoot}
- * @param root
  * @param defaultModule project module or {@code null}
  * @return may return {@code null}
  */

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/JavaSearchPattern.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/JavaSearchPattern.java
@@ -95,9 +95,6 @@ public class JavaSearchPattern extends SearchPattern implements IIndexConstants,
 		this.matchMode = rule & MATCH_MODE_MASK;
 	}
 
-	/**
-	 * @param fineGrain
-	 */
 	public static String getFineGrainFlagString(final int fineGrain) {
 		if (fineGrain == 0) {
 			return "none"; //$NON-NLS-1$
@@ -281,8 +278,6 @@ public class JavaSearchPattern extends SearchPattern implements IIndexConstants,
 	 * Note that obvious compatibility values as equals and {@link IIndexConstants#TYPE_SUFFIX}
 	 * has to be tested by caller to avoid unnecessary method call...
 	 *
-	 * @param typeSuffix
-	 * @param patternSuffix
 	 * @return true if suffixes are compatible, false otherwise
 	 */
 	boolean matchDifferentTypeSuffixes(int typeSuffix, int patternSuffix) {

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/PatternLocator.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/PatternLocator.java
@@ -278,8 +278,6 @@ protected boolean matchesName(char[] pattern, char[] name) {
  * Return how the given name matches the given pattern.
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=79866"
  *
- * @param pattern
- * @param name
  * @return Possible values are:
  * <ul>
  * 	<li> {@link #ACCURATE_MATCH}</li>

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/TypeParameterPattern.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/TypeParameterPattern.java
@@ -49,12 +49,6 @@ public class TypeParameterPattern extends JavaSearchPattern {
 	protected char[] methodDeclaringClassName;
 	protected char[][] methodArgumentTypes;
 
-	/**
-	 * @param findDeclarations
-	 * @param findReferences
-	 * @param typeParameter
-	 * @param matchRule
-	 */
 	public TypeParameterPattern(boolean findDeclarations, boolean findReferences, ITypeParameter typeParameter, int matchRule) {
 		super(TYPE_PARAM_PATTERN, matchRule);
 

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/processing/JobManager.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/processing/JobManager.java
@@ -260,7 +260,6 @@ public abstract class JobManager {
 	 * 		IJobConstants.ForceImmediateSearch
 	 * 		IJobConstants.CancelIfNotReadyToSearch
 	 * 		IJobConstants.WaitUntilReadyToSearch
-	 *
 	 */
 	public boolean performConcurrentJob(IJob searchJob, int waitingPolicy, IProgressMonitor monitor) {
 		if (VERBOSE) {

--- a/org.eclipse.jdt.tests.latestBREE/src/org/eclipse/jdt/core/tests/model/CompletionTests13.java
+++ b/org.eclipse.jdt.tests.latestBREE/src/org/eclipse/jdt/core/tests/model/CompletionTests13.java
@@ -1130,7 +1130,6 @@ public class CompletionTests13 extends AbstractJavaModelCompletionTests {
 	}
 	/*
 	 * Try completion for yield with value inside switch - positive
-	 * 
 	 */
 	public void test025() throws JavaModelException {
 		this.workingCopies = new ICompilationUnit[1];


### PR DESCRIPTION
Remove blank Javadoc

This commit cleans up Javadoc that does not add information. 
It resolves ecj warnings:
 `Javadoc: Description expected after ...`
It helps to prevent future empty javadoc by disabling 
missingJavaDoc warnings. This resolves
 `Javadoc: Missing ...`

The modification is a result of regular expression search&replace:

in files `*.java` (exclude org.eclipse.jdt.core.tests.model/workspace)
 `^[\s]*\*[\s]*(@return|@param[\s]*[^\s]+|@throws[\s]*[^\s]+)\R([\s]*\*[\s]*@|[\s]*\*/\R)`
 ->`$2`
 `^([\s]*\*[\s]*\R)([\s]*\*/\R)`
 ->`$2`
 `^[\S\t]*/\*\*\R[\s]*\*/\R`
 ->``

in files `org.eclipse.jdt.core.prefs`
 `org\.eclipse\.jdt\.core\.compiler\.problem\.missingJavadoc(Comments|Tags)\=[^\s]*`
 ->`org\.eclipse\.jdt\.core\.compiler\.problem\.missingJavadoc$1\=ignore`
