### PR TITLE
Suggest 'var' type variables as auto-completion method arguments. Fix #228

### DIFF
--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/CompletionEngine.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/CompletionEngine.java
@@ -13220,7 +13220,7 @@ public final class CompletionEngine
 								continue next;
 
 							// https://bugs.eclipse.org/bugs/show_bug.cgi?id=328674
-							if (local.declaration.initialization != null && !local.declaration.type.isTypeNameVar(null)) {
+							if (local.declaration.initialization != null && !local.declaration.isTypeNameVar(local.declaringScope)) {
 								// proposal being asked inside field's initialization. Don't propose this field.
 								continue next;
 							}

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/InternalExtendedCompletionContext.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/InternalExtendedCompletionContext.java
@@ -251,6 +251,13 @@ public class InternalExtendedCompletionContext {
 		}
 		if (parent == null) return null;
 
+		String typeSig;
+ 		if (local.type == null || local.type.isTypeNameVar(binding.declaringScope)) {
+ 			typeSig = Signature.createTypeSignature(binding.type.signableName(), true);
+ 		} else {
+ 			typeSig = Util.typeSignature(local.type);
+ 		}
+
 		return new LocalVariable(
 				parent,
 				DeduplicationUtil.toString(local.name),
@@ -258,7 +265,7 @@ public class InternalExtendedCompletionContext {
 				local.declarationSourceEnd,
 				local.sourceStart,
 				local.sourceEnd,
-				local.type == null ? Signature.createTypeSignature(binding.type.signableName(), true) : Util.typeSignature(local.type),
+				typeSig,
 				binding.declaration.annotations,
 				local.modifiers,
 				local.getKind() == AbstractVariableDeclaration.PARAMETER);

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/InternalExtendedCompletionContext.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/InternalExtendedCompletionContext.java
@@ -742,7 +742,10 @@ public class InternalExtendedCompletionContext {
 						// then don't propose the local variable
 						if (local.declaration.initialization != null) {
 							/*(use this if-else block if it is found that local.declaration.initialization != null is not sufficient to
-							  guarantee that proposal is being asked inside a local variable declaration's initializer)
+							  guarantee that proposal is being asked inside a local variable declaration's initializer)*/
+
+							// use this to avoid matching with var declarations.
+							// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/228
 							 if(local.declaration.initialization.sourceEnd > 0) {
 								if (this.assistNode.sourceEnd <= local.declaration.initialization.sourceEnd
 										&& this.assistNode.sourceStart >= local.declaration.initialization.sourceStart) {
@@ -755,8 +758,7 @@ public class InternalExtendedCompletionContext {
 								if (detector.containsCompletionNode()) {
 									continue next;
 								}
-							}*/
-							continue next;
+							}
 						}
 						for (int f = 0; f < localsFound.size; f++) {
 							LocalVariableBinding otherLocal =

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/InternalExtendedCompletionContext.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/InternalExtendedCompletionContext.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008, 2014 IBM Corporation and others.
+ * Copyright (c) 2008, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
- Fixes #228

#### Uses existing logic which has been commented out.
The condition `local.declaration.initialization != null` matches with variables being initialized but also matches var declarations. Then var variables get out of completion candidates. Fortunately, there was [existing logic in code's comments](https://github.com/eclipse-jdt/eclipse.jdt.core/commit/cb53eff5db7d4f76eb24c91a2abecee1441f0bbc#diff-0e781fe5c69959e9da651b4c13022062c34e898f147a412c5cf6a8807a3f7f90R752-R758) that can deal with this problem.

This simple changes also fix this issue but are not perfect here. (The problem is that var variables being initialized will appear in proposals, but can this change be better choice?)
[78adf91f002a1a9b7d1838c24de08c2d5f608e25](https://github.com/eclipse-jdt/eclipse.jdt.core/commit/78adf91f002a1a9b7d1838c24de08c2d5f608e25#diff-8469e0f05a7f350e7047101a3e20fe0bf4d0f65df01fa0a18eb6378128c5de5aR12338)

#### Provides resolved types of var declarations.
When calculating auto-boxing scores, var is considered qualified class type whose name is var. Without the change, primitive type variables declared with var get bad scores; the auto-completion suggests 0 of literal instead of var variables. This change is same as: [3b1eade6257846b964d26359bdcfbc40d6c4bec4](https://github.com/eclipse-jdt/eclipse.jdt.core/commit/3b1eade6257846b964d26359bdcfbc40d6c4bec4#diff-2a561a84bd9c4008e33ec162133f1f0734636eada70d3367792b70a12d4d7b98R470-R483)

#### Uses the method with null checks and adds an argument.
I believe it should have null checks. `local.declaringScope` is used to tell whether var keyword is available at the version.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

[eclipse.jdt.ui/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/contentassist/MethodParameterGuessingCompletionTest10.java](https://github.com/eclipse-jdt/eclipse.jdt.core/files/13282131/MethodParameterGuessingCompletionTest10.java.txt)
[eclipse.jdt.ui/org.eclipse.jdt.text.tests/src/org/eclipse/jdt/text/tests/contentassist/CompletionTestSetup10.java](https://github.com/eclipse-jdt/eclipse.jdt.core/files/13282132/CompletionTestSetup10.java.txt)
These tests will have to be situated in eclipse.jdt.ui, what can I do?

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)

I'm open to changing expressions since I'm not good at English.
