### PR TITLE
fix some ecj markers

### DIFF
--- a/JCL/converterJclMin9/src/java/lang/invoke/MethodHandle.java
+++ b/JCL/converterJclMin9/src/java/lang/invoke/MethodHandle.java
@@ -16,7 +16,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
-import java.lang.invoke.MethodType;
 
 public abstract class MethodHandle {
 	@Target(METHOD)

--- a/JCL/converterJclMin9/src/java/lang/invoke/MethodHandles.java
+++ b/JCL/converterJclMin9/src/java/lang/invoke/MethodHandles.java
@@ -1,5 +1,4 @@
 package java.lang.invoke;
-import java.lang.invoke.MethodType;
 
 public class MethodHandles {
 	public static final class Lookup {

--- a/org.eclipse.jdt.apt.tests/src/org/eclipse/jdt/apt/tests/MixedModeTesting.java
+++ b/org.eclipse.jdt.apt.tests/src/org/eclipse/jdt/apt/tests/MixedModeTesting.java
@@ -19,7 +19,6 @@ import junit.framework.Test;
 import junit.framework.TestSuite;
 
 import org.eclipse.core.resources.IProject;
-import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.jdt.apt.core.internal.util.FactoryContainer;
 import org.eclipse.jdt.apt.core.internal.util.FactoryPath;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/apt/dispatch/BatchAnnotationProcessorManager.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/apt/dispatch/BatchAnnotationProcessorManager.java
@@ -77,7 +77,7 @@ public class BatchAnnotationProcessorManager extends BaseAnnotationProcessorMana
 		}
 		BatchProcessingEnvImpl processingEnv = new BatchProcessingEnvImpl(this, (Main) batchCompiler, commandLineArguments);
 		this._processingEnv = processingEnv;
-		@SuppressWarnings("resource") // fileManager is not opened here
+		// @SuppressWarnings("resource") // fileManager is not opened here
 		JavaFileManager fileManager = processingEnv.getFileManager();
 		if (fileManager instanceof StandardJavaFileManager) {
 			Iterable<? extends File> location = null;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/apt/dispatch/HookedJavaFileObject.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/apt/dispatch/HookedJavaFileObject.java
@@ -209,13 +209,13 @@ public class HookedJavaFileObject extends
 		this._typeName = typeName;
 	}
 
-	@SuppressWarnings("resource") // ForwardingOutputStream forwards close() too
+	// @SuppressWarnings("resource") // ForwardingOutputStream forwards close() too
 	@Override
 	public OutputStream openOutputStream() throws IOException {
 		return new ForwardingOutputStream(super.openOutputStream());
 	}
 
-	@SuppressWarnings("resource") // ForwardingWriter forwards close() too
+	// @SuppressWarnings("resource") // ForwardingWriter forwards close() too
 	@Override
 	public Writer openWriter() throws IOException {
 		return new ForwardingWriter(super.openWriter());

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/tool/EclipseFileManager.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/tool/EclipseFileManager.java
@@ -163,7 +163,7 @@ public class EclipseFileManager implements StandardJavaFileManager {
 				}
 			}
 		} else if (isArchive(file)) {
-			@SuppressWarnings("resource") // cached archive is closed in EclipseFileManager.close()
+			// @SuppressWarnings("resource") // cached archive is closed in EclipseFileManager.close()
 			Archive archive = this.getArchive(file);
 			if (archive != Archive.UNKNOWN_ARCHIVE) {
 				String key = normalizedPackageName;
@@ -442,7 +442,7 @@ public class EclipseFileManager implements StandardJavaFileManager {
 		return null;
 	}
 
-	@SuppressWarnings("resource") // cached archive is closed in EclipseFileManager.close()
+	// @SuppressWarnings("resource") // cached archive is closed in EclipseFileManager.close()
 	private ArchiveFileObject getFileObject(File archiveFile, String normalizedFileName) {
 		Archive archive = getArchive(archiveFile);
 		if (archive == Archive.UNKNOWN_ARCHIVE) {
@@ -454,7 +454,7 @@ public class EclipseFileManager implements StandardJavaFileManager {
 		return null;
 	}
 
-	@SuppressWarnings("resource") // cached archive is closed in EclipseFileManager.close()
+	// @SuppressWarnings("resource") // cached archive is closed in EclipseFileManager.close()
 	private Boolean containsFileObject(File archiveFile, String normalizedFileName) {
 		Archive archive = getArchive(archiveFile);
 		if (archive == Archive.UNKNOWN_ARCHIVE) {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTMatcherTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTMatcherTest.java
@@ -1152,6 +1152,8 @@ public class ASTMatcherTest extends org.eclipse.jdt.core.tests.junit.extension.T
 		ParenthesizedExpression x1 = this.ast.newParenthesizedExpression();
 		basicMatch(x1);
 	}
+
+	@SuppressWarnings("deprecation")
 	public void testPatternInstanceofExpression() {
 		if (this.ast.apiLevel() < AST.JLS17) {
 			return;


### PR DESCRIPTION
Especially after moving files to compiler.batch - which has no resource warnings - the @SuppressWarnings("resource") is not used - leading to a marker
