### PR TITLE
Code select fails to navigate to element variable of an enhanced for loop in some cases

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/parser/PatternMatchingSelectionTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/parser/PatternMatchingSelectionTest.java
@@ -194,7 +194,9 @@ public class PatternMatchingSelectionTest extends AbstractSelectionTest {
 									"  public static void foo(ColoredRectangle[] ar_ray) {\n" +
 									"    for (ColoredRectangle(int x_1, int y_1, Color col) : ar_ray) \n" +
 									"      {\n" +
+									"        int;\n" +
 									"        int per = <SelectOnName:x_1>;\n" +
+									"        <SelectOnName:x_1>;\n" +
 									"      }\n" +
 									"  }\n" +
 									"}\n" +
@@ -347,5 +349,64 @@ public class PatternMatchingSelectionTest extends AbstractSelectionTest {
 				completionIdentifier,
 				expectedReplacedSource,
 				testName);
+	}
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1568
+	// Current text selection cannot be opened in an editor #1568
+	public void testGH1568() {
+		if (this.complianceLevel < ClassFileConstants.JDK17)
+			return;
+		String string =  "@SuppressWarnings(\"preview\")\n"
+						+ "public class X {\n"
+						+ "    public static Object k_;\n"
+						+ "    public int val_;\n"
+						+ "    public static void foo(X[] ar_ray) {\n"
+						+ "       if (k instanceof String z_) {\n"
+						+ "           System.out.println(\"Some statement\");\n"
+						+ "           for(X x_ : ar_ray) {\n"
+						+ "    	          int per = x_.val_ * 2;\n"
+						+ "           }\n"
+						+ "       }\n"
+						+ "    }\n"
+						+ "}\n";
+
+		String selection = "x_";
+		String selectKey = "<SelectOnName:";
+		String expectedSelection = selectKey + selection + ">";
+
+		String selectionIdentifier = "x_";
+		String expectedUnitDisplayString =
+						"public @SuppressWarnings(\"preview\") class X {\n" +
+						"  public static Object k_;\n" +
+						"  public int val_;\n" +
+						"  <clinit>() {\n" +
+						"  }\n" +
+						"  public X() {\n" +
+						"  }\n" +
+						"  public static void foo(X[] ar_ray) {\n" +
+						"    {\n" +
+						"      {\n" +
+						"        if ((k instanceof String z_))\n" +
+						"            {\n" +
+			            "              System.out.println(\"Some statement\");\n" +
+						"              for (X x_ : ar_ray) \n" +
+						"                {\n" +
+						"                  int;\n" +
+						"                  int per;\n" +
+						"                  <SelectOnName:x_>;\n" +
+						"                }\n" +
+						"            }\n" +
+						"      }\n" +
+						"    }\n" +
+						"  }\n" +
+						"}\n";
+
+		String expectedReplacedSource = "x_";
+		String testName = "X.java";
+
+		int selectionStart = string.lastIndexOf(selection);
+		int selectionEnd = selectionStart + selection.length() - 1;
+
+		checkMethodParse(string.toCharArray(), selectionStart, selectionEnd, expectedSelection, expectedUnitDisplayString,
+				selectionIdentifier, expectedReplacedSource, testName);
 	}
 }

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ResolveTests12To15.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ResolveTests12To15.java
@@ -1525,4 +1525,181 @@ public void testGH860() throws JavaModelException {
 		elements
 	);
 }
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1568
+// Current text selection cannot be opened in an editor
+public void testGH1568() throws JavaModelException {
+	this.wc = getWorkingCopy("/Resolve15/src/RowRenderData.java",
+			"""
+			import java.util.ArrayList;
+			import java.util.List;
+
+			public class RowRenderData {
+
+			    private List<Object> cells = new ArrayList<>();
+
+			    public List<Object> getCells() {
+			        return cells;
+			    }
+
+			    public void setCells(List<Object> cells) {
+			        this.cells = cells;
+			    }
+
+			    public static void main(String[] args) {
+			        List<RowRenderData> rows = new ArrayList<>();
+			        if (true) {
+			            for (RowRenderData row : rows) {
+			                row.getCells();
+			            }
+			        }
+			    }
+			}
+			""");
+	String str = this.wc.getSource();
+	String selection = "row";
+	int start = str.lastIndexOf(selection);
+	int length = selection.length();
+	IJavaElement[] elements = this.wc.codeSelect(start, length);
+	assertElementsEqual(
+		"Unexpected elements",
+		"row [in main(String[]) [in RowRenderData [in [Working copy] RowRenderData.java [in <default> [in src [in Resolve15]]]]]]",
+		elements
+	);
+}
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1568
+// Current text selection cannot be opened in an editor
+public void testGH1568_2() throws JavaModelException {
+	this.wc = getWorkingCopy("/Resolve15/src/X.java",
+			"""
+			public class X {
+				Integer abcdef = 10;
+			    public void main(String argv[]) {
+			        Object o = argv;
+			        if (!(o instanceof String [] abcdef)) {
+			        	if (abcdef == null) {
+
+			        	}
+			        } else {
+			        	if (abcdef.length > 0) {
+
+			        	}
+			        }
+			    }
+			}
+			""");
+	String str = this.wc.getSource();
+	String selection = "abcdef";
+	int start = str.lastIndexOf(selection);
+	int length = selection.length();
+	IJavaElement[] elements = this.wc.codeSelect(start, length);
+	assertElementsEqual(
+		"Unexpected elements",
+		"abcdef [in main(String[]) [in X [in [Working copy] X.java [in <default> [in src [in Resolve15]]]]]]",
+		elements
+	);
+}
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1568
+// Current text selection cannot be opened in an editor
+public void testGH1568_3() throws JavaModelException {
+	this.wc = getWorkingCopy("/Resolve15/src/X.java",
+			"""
+			public class X {
+
+				public void main(String argv[]) {
+					Object o = argv;
+					if (o instanceof String[] abcdef) {
+						if (o != null) {
+							if (argv[0] instanceof String str) {
+							}
+						} else {
+							if (abcdef.length > 0) {
+
+
+							}
+						}
+					}
+				}
+			}
+			""");
+	String str = this.wc.getSource();
+	String selection = "abcdef";
+	int start = str.lastIndexOf(selection);
+	int length = selection.length();
+	IJavaElement[] elements = this.wc.codeSelect(start, length);
+	assertElementsEqual(
+		"Unexpected elements",
+		"abcdef [in main(String[]) [in X [in [Working copy] X.java [in <default> [in src [in Resolve15]]]]]]",
+		elements
+	);
+}
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1568
+// Current text selection cannot be opened in an editor
+public void testGH1568_4() throws JavaModelException {
+	this.wc = getWorkingCopy("/Resolve15/src/X.java",
+			"""
+			public class X {
+				Integer abcdef = 10;
+			    public void main(String argv[]) {
+			        Object o = argv;
+			        if (!(o instanceof String [] abcdef)) {
+			        	if (abcdef == null) {
+
+			        	}
+			        } else {
+			        }
+			    }
+			}
+			""");
+	String str = this.wc.getSource();
+	String selection = "abcdef";
+	int start = str.lastIndexOf(selection);
+	int length = selection.length();
+	IJavaElement[] elements = this.wc.codeSelect(start, length);
+	assertElementsEqual(
+		"Unexpected elements",
+		"abcdef [in X [in [Working copy] X.java [in <default> [in src [in Resolve15]]]]]",
+		elements
+	);
+}
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1568
+// Current text selection cannot be opened in an editor
+public void testGH1568_5() throws JavaModelException {
+	this.wc = getWorkingCopy("/Resolve15/src/X.java",
+			"""
+			import java.util.ArrayList;
+			import java.util.List;
+
+			public class RowRenderData {
+
+			    private List<Object> cells = new ArrayList<>();
+
+			    public List<Object> getCells() {
+			        return cells;
+			    }
+
+			    public void setCells(List<Object> cells) {
+			        this.cells = cells;
+			    }
+
+			    public static void main(String[] args) {
+			        List<RowRenderData> rows = new ArrayList<>();
+			        if (true) {
+			            for (RowRenderData row = new RowRenderData(); row != null;) {
+			                row.getCells();
+			            }
+			        }
+			    }
+			}
+			""");
+	String str = this.wc.getSource();
+	String selection = "row";
+	int start = str.lastIndexOf(selection);
+	int length = selection.length();
+	IJavaElement[] elements = this.wc.codeSelect(start, length);
+	assertElementsEqual(
+		"Unexpected elements",
+		"row [in main(String[]) [in RowRenderData [in [Working copy] X.java [in <default> [in src [in Resolve15]]]]]]",
+		elements
+	);
+}
 }

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionParser.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionParser.java
@@ -43,6 +43,7 @@ import org.eclipse.jdt.internal.compiler.ast.EmptyStatement;
 import org.eclipse.jdt.internal.compiler.ast.ExplicitConstructorCall;
 import org.eclipse.jdt.internal.compiler.ast.Expression;
 import org.eclipse.jdt.internal.compiler.ast.FieldReference;
+import org.eclipse.jdt.internal.compiler.ast.ForeachStatement;
 import org.eclipse.jdt.internal.compiler.ast.GuardedPattern;
 import org.eclipse.jdt.internal.compiler.ast.IfStatement;
 import org.eclipse.jdt.internal.compiler.ast.ImportReference;
@@ -103,6 +104,8 @@ public class SelectionParser extends AssistParser {
 	protected static final int K_INSIDE_STATEMENT_SWITCH = SELECTION_PARSER + 11; // whether we are in a switch statement
 	protected static final int K_INSIDE_EXPRESSION_SWITCH = SELECTION_PARSER + 12; // whether we are in an expression switch
 	protected static final int K_INSIDE_WHEN = SELECTION_PARSER + 13; // whether we are in the guard
+
+	protected static final int K_INSIDE_FOR_EACH = SELECTION_PARSER + 14; // whether we are in a for each statement
 
 
 
@@ -213,6 +216,7 @@ private void buildMoreCompletionContext(Expression expression) {
 			case K_INSIDE_ELSE:
 			case K_INSIDE_STATEMENT_SWITCH:
 			case K_INSIDE_EXPRESSION_SWITCH:
+			case K_INSIDE_FOR_EACH:
 				int newAstPtr = (int) this.elementObjectInfoStack[i];
 				int length = this.astPtr - newAstPtr;
 				Statement[] statements = new Statement[length + (orphan != null ? 1 : 0)];
@@ -236,6 +240,11 @@ private void buildMoreCompletionContext(Expression expression) {
 					case K_INSIDE_ELSE:
 						elseStat = b;
 						orphan = null; // orphan subsumed into the dangling else
+						break;
+					case K_INSIDE_FOR_EACH:
+						ForeachStatement forEach = (ForeachStatement)this.astStack[this.astPtr--];
+						forEach.action = b;
+						orphan = forEach;
 						break;
 					case K_POST_WHILE_EXPRESSION:
 						whileBody = b;
@@ -912,6 +921,19 @@ protected void consumeStatementWhile() {
 		popUntilElement(K_INSIDE_WHILE);
 		popElement(K_INSIDE_WHILE);
 	}
+}
+
+@Override
+protected void consumeEnhancedForStatementHeader() {
+	super.consumeEnhancedForStatementHeader();
+	pushOnElementStack(K_INSIDE_FOR_EACH, this.expressionPtr, this.astPtr);
+}
+
+@Override
+protected void consumeEnhancedForStatement() {
+	super.consumeEnhancedForStatement();
+	popUntilElement(K_INSIDE_FOR_EACH);
+	popElement(K_INSIDE_FOR_EACH);
 }
 
 @Override


### PR DESCRIPTION

## What it does
Recover the body of the enhanced for loop properly so code select works correctly and allows navigation to declaration of the element variable.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1568

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
