### PR TITLE
Too many compiler regression tests on Java 21 SDK build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,7 @@ pipeline {
 					-Ptest-on-javase-21 -Pbree-libs -Papi-check \
 					-Dcompare-version-with-baselines.skip=false \
 					-Djava.io.tmpdir=$WORKSPACE/tmp -Dproject.build.sourceEncoding=UTF-8 \
-					-Dtycho.surefire.argLine="--add-modules ALL-SYSTEM -Dcompliance=1.8,11,17,19,21 -Djdt.performance.asserts=disabled" \
+					-Dtycho.surefire.argLine="--add-modules ALL-SYSTEM -Dcompliance=1.8,11,17,20,21 -Djdt.performance.asserts=disabled" \
 					-DDetectVMInstallationsJob.disabled=true \
 					-Dtycho.apitools.debug \
 					-Dcbi-ecj-version=99.99

--- a/org.eclipse.jdt.core.tests.compiler/test.xml
+++ b/org.eclipse.jdt.core.tests.compiler/test.xml
@@ -57,7 +57,7 @@
       <property name="classname" 
                 value="org.eclipse.jdt.core.tests.compiler.regression.TestAll"/>
       <property name="vmargs" 
-      	value="-Dcompliance.jre.11=1.8,9,10,11 -Dcompliance.jre.16=1.8,11,15,16 -Dcompliance.jre.17=1.8,11,16,17"
+      	value="-Dcompliance.jre.17=1.7,1.8,11,17 -Dcompliance.jre.21=1.8,11,17,20,21 -Dcompliance.jre.22=1.8,11,17,21,22 -Dcompliance.jre.23=1.8,11,17,21,23"
       />
     </ant>
 


### PR DESCRIPTION
For SDK tests:
- Defined dedicated compliance.jre from 21 to 23, removed unused
- SDK tests will run on Java 21 tests for 1.8,11,17,20,21 JLS
- Changed compliance.jre.17 to 1.3,1.8,11,17 (added 1.3, omitted 16)

For Jenkins (github validation):
- Changed compliance to 1.8,11,17,20,21 (replaced 19 with 20)

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1605
