### PR TITLE
Single async "Synchronizing projects" Job #419

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/DeltaProcessor.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/DeltaProcessor.java
@@ -888,7 +888,7 @@ public class DeltaProcessor {
 				}
 				if (projectsToTouch.length > 0) {
 					if (asynchronous){
-						this.manager.touchProjects(projectsToTouch, monitor);
+						this.manager.touchProjectsAsync(projectsToTouch);
 					}
 					else {
 						// touch the projects to force them to be recompiled while taking the workspace lock


### PR DESCRIPTION
Scheduling multiple times "while the job is running, the job will still only be rescheduled once" (javadoc) so there will be always only a single job running.
Using a Set prevents touching projects multiple times.

https://github.com/eclipse-jdt/eclipse.jdt.core/issues/419

Manually tested by changing Compiler Building options "Circular dependencies", which triggers a new build.
![image](https://github.com/eclipse-jdt/eclipse.jdt.core/assets/51790620/c0487177-5a96-4e4b-bbfa-dc617fc00abb)

