### PR TITLE
NPE in org.eclipse.jdt.internal.compiler.ast.MessageSend.analyseCode

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LambdaExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LambdaExpression.java
@@ -252,6 +252,20 @@ public class LambdaExpression extends FunctionalExpression implements IPolyExpre
 		return super.kosherDescriptor(currentScope, sam, shouldChatter);
 	}
 
+	public void resolveWithPatternVariablesInScope(LocalVariableBinding[] patternVariablesInScope, BlockScope blockScope, boolean skipKosherCheck) {
+		if (patternVariablesInScope != null) {
+			for (LocalVariableBinding local : patternVariablesInScope) {
+				local.modifiers &= ~ExtraCompilerModifiers.AccPatternVariable;
+			}
+			this.resolveType(blockScope, skipKosherCheck);
+			for (LocalVariableBinding local : patternVariablesInScope) {
+				local.modifiers |= ExtraCompilerModifiers.AccPatternVariable;
+			}
+		} else {
+			resolveType(blockScope, skipKosherCheck);
+		}
+	}
+
 	/* This code is arranged so that we can continue with as much analysis as possible while avoiding
 	 * mine fields that would result in a slew of spurious messages. This method is a merger of:
 	 * @see org.eclipse.jdt.internal.compiler.lookup.MethodScope.createMethod(AbstractMethodDeclaration)

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/InstanceofPrimaryPatternTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/InstanceofPrimaryPatternTest.java
@@ -254,4 +254,34 @@ public class InstanceofPrimaryPatternTest extends AbstractRegressionTest {
 			"Syntax error, modifiers are not allowed here\n" +
 			"----------\n");
 	}
+
+	public void testGH1621() {
+		runConformTest(
+			new String[] {
+				"ConsumerEndpointSpec.java",
+				"""
+				import java.util.function.Consumer;
+
+				public class ConsumerEndpointSpec {
+					public void setNotPropagatedHeaders(String... headers) {
+						for (String s: headers) System.out.print(s);
+					}
+					void foo(Object h) {
+						if (h instanceof ConsumerEndpointSpec producingMessageHandler) {
+							acceptIfNotEmpty(new String[] {"OK"}, producingMessageHandler::setNotPropagatedHeaders);
+						}
+					}
+					public <T> void acceptIfNotEmpty(T[] value, Consumer<T[]> consumer) {
+						consumer.accept(value);
+					}
+					public static void main(String... args) {
+						ConsumerEndpointSpec obj = new ConsumerEndpointSpec();
+						obj.foo(obj);
+					}
+				}
+				"""
+			},
+			"OK",
+			getCompilerOptions());
+	}
 }


### PR DESCRIPTION
fixes #1621

## What it does
Fix resolving of a synthetic lambda representing a reference expression which depends on a pattern variable.

This resolving was broken, because the synthetic lambda AST has no information about the syntactic context which may declare pattern variables depending on flow.

This is fixed by temporarily resetting `AccPatternVariable` just like done in `Statement.resolveWithPatternVariablesInScope()`.