### PR TITLE
disjunction of instanceof checks should suffice to guard as non-null

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullReferenceTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullReferenceTest.java
@@ -18524,4 +18524,19 @@ public void testBug380786() {
 		"----------\n"
 			);
 }
+public void testGH1642_a() {
+	runConformTest(
+		new String[] {
+			"Bug.java",
+			"""
+			public class Bug {
+				void m(Object o) {
+					if (o == null)
+						System.out.println();
+					if (o instanceof String || o instanceof Integer)
+						o.toString();
+				}
+			}
+			"""});
+}
 }


### PR DESCRIPTION
fixes #1642


## What it does

Inside `OR_OR_Expression.analyseCode()` the logic for merging flowInfos was incorrect. As this piece of code had grown somewhat convoluted over time, the fix includes some mild clean-up and adds comments to document my today's understanding.

Two factors complicating the issue:
* lazy boolean operators actually span 3 different execution paths (a, (!a b), (!a !b)), which have to be merged into 2 resulting branch infos
* definite assignment analysis per JLS needs info even from some unreachable branches (see e.g. InitializationTests.test318020*), while the rest of the analysis wants to benefit from UNREACHABLE.

