### PR TITLE
Version bumps for 4.31 stream

### DIFF
--- a/org.eclipse.jdt.apt.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.apt.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.apt.core; singleton:=true
-Bundle-Version: 3.8.200.qualifier
+Bundle-Version: 3.8.300.qualifier
 Bundle-Localization: plugin
 Export-Package: com.sun.mirror.apt,
  com.sun.mirror.declaration,

--- a/org.eclipse.jdt.apt.core/pom.xml
+++ b/org.eclipse.jdt.apt.core/pom.xml
@@ -17,6 +17,6 @@
     <version>4.31.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.eclipse.jdt.apt.core</artifactId>
-  <version>3.8.200-SNAPSHOT</version>
+  <version>3.8.300-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.eclipse.jdt.apt.pluggable.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.apt.pluggable.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.apt.pluggable.core;singleton:=true
-Bundle-Version: 1.4.200.qualifier
+Bundle-Version: 1.4.300.qualifier
 Bundle-Activator: org.eclipse.jdt.internal.apt.pluggable.core.Apt6Plugin
 Bundle-Vendor: %providerName
 Require-Bundle: org.eclipse.core.runtime,

--- a/org.eclipse.jdt.apt.pluggable.core/pom.xml
+++ b/org.eclipse.jdt.apt.pluggable.core/pom.xml
@@ -17,6 +17,6 @@
     <version>4.31.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.eclipse.jdt.apt.pluggable.core</artifactId>
-  <version>1.4.200-SNAPSHOT</version>
+  <version>1.4.300-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>


### PR DESCRIPTION
Should have been part of
https://github.com/eclipse-jdt/eclipse.jdt.core/pull/1620
