### PR TITLE
Stop skipping compare-with-baseline for jdt.annotation v2

### DIFF
--- a/org.eclipse.jdt.annotation/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.annotation/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-Localization: bundle
 Bundle-SymbolicName: org.eclipse.jdt.annotation
-Bundle-Version: 2.2.800.qualifier
+Bundle-Version: 2.2.900.qualifier
 Export-Package: org.eclipse.jdt.annotation
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Vendor: %providerName

--- a/org.eclipse.jdt.annotation/pom.xml
+++ b/org.eclipse.jdt.annotation/pom.xml
@@ -35,25 +35,6 @@
             </compilerArgs>
 		  </configuration>
 		</plugin>
-		<plugin>
-		  <groupId>org.eclipse.tycho.extras</groupId>
-		  <artifactId>tycho-p2-extras-plugin</artifactId>
-          <executions>
-            <execution> <!-- Checks versions are properly bumped from one stream to the other -->
-              <id>compare-attached-artifacts-with-release</id>
-              <goals>
-                <goal>compare-version-with-baselines</goal>
-              </goals>
-              <configuration>
-                <skip>true</skip>
-                <baselines>
-                  <baseline>${previous-release.baseline}</baseline>
-                </baselines>
-                <comparator>zip</comparator>
-              </configuration>
-            </execution>
-          </executions>
-        </plugin>
   	</plugins>
   </build>
 </project>

--- a/org.eclipse.jdt.annotation/pom.xml
+++ b/org.eclipse.jdt.annotation/pom.xml
@@ -17,7 +17,7 @@
     <version>4.31.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.eclipse.jdt.annotation</artifactId>
-  <version>2.2.800-SNAPSHOT</version>
+  <version>2.2.900-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <build>


### PR DESCRIPTION
One less thing that has to be manually tracked and done.

