### PR TITLE
Fixes incorrect Javadoc after StringBuffer to StringBuilder change

### DIFF
--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionJavadoc.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionJavadoc.java
@@ -101,9 +101,6 @@ public class CompletionJavadoc extends Javadoc {
 		}
 	}
 
-	/*
-	 * @see org.eclipse.jdt.internal.compiler.ast.ASTNode#print(int, java.lang.StringBuffer)
-	 */
 	@Override
 	public StringBuilder print(int indent, StringBuilder output) {
 		printIndent(indent, output).append("/**\n"); //$NON-NLS-1$

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/ASTRewriteFlattener.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/ASTRewriteFlattener.java
@@ -132,7 +132,7 @@ public class ASTRewriteFlattener extends ASTVisitor {
 	 * Appends the text representation of the given modifier flags, followed by a single space.
 	 *
 	 * @param modifiers the modifiers
-	 * @param buf The <code>StringBuffer</code> to write the result to.
+	 * @param buf The <code>StringBuilder</code> to write the result to.
 	 */
 	public static void printModifiers(int modifiers, StringBuilder buf) {
 		if (Modifier.isPublic(modifiers)) {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/BinaryMethod.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/BinaryMethod.java
@@ -211,9 +211,6 @@ public int getFlags() throws JavaModelException {
 		modifiers |= ExtraCompilerModifiers.AccDefaultMethod;
 	return modifiers;
 }
-/*
- * @see JavaElement#getHandleMemento(StringBuffer)
- */
 @Override
 protected void getHandleMemento(StringBuilder buff) {
 	getParent().getHandleMemento(buff);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
