### PR TITLE
break from loop within labeled block causes loss of nullness info

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/flow/LoopingFlowContext.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/flow/LoopingFlowContext.java
@@ -451,8 +451,10 @@ public void complainOnDeferredNullChecks(BlockScope scope, FlowInfo callerFlowIn
 	// propagate breaks
 	if(updateInitsOnBreak) {
 		this.initsOnBreak.addPotentialNullInfoFrom(incomingInfo);
+		this.initsOnBreak.acceptIncomingNullnessFrom(incomingInfo);
 		for (int i = 0; i < this.breakTargetsCount; i++) {
 			this.breakTargetContexts[i].initsOnBreak.addPotentialNullInfoFrom(incomingInfo);
+			this.breakTargetContexts[i].initsOnBreak.acceptIncomingNullnessFrom(incomingInfo);
 		}
 	}
 }


### PR DESCRIPTION
fixes #1659

## What it does

Any flows through an explicit `break` within a loop need to contribute to the flow info after the loop, but this info tends to be imprecise because ecj evaluates only "1.5 loop iterations". To improve analysis of loops, https://bugs.eclipse.org/453483 had introduced tracking of whether or not a previous null / nonnull would reach any given point without modification.

For the case of breaking from an enclosing labeled block, this information was not yet used, resulting in imprecise information (viz. potentially nonnull where it should be definitely nonnull).

This change adds logic in one more code location to force def null / nonnull information where this was the state before the loop and where the flags from https://bugs.eclipse.org/453483 indicate so. 

## How to test

JUnits included

Note that new logic regarding bits in `UnconditionalFlowInfo` should always be tested with `-Djdt.flow.test.extra=true` which I did locally (this challenges the implementation part using bits in `UnconditionalFlowInfo.extra` - space for variables beyond 64).