### PR TITLE
Using Simplify lambda expression and method reference syntax cleanup on

### DIFF
--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/CompletionEngine.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/CompletionEngine.java
@@ -9858,8 +9858,8 @@ public final class CompletionEngine
 			arguments = ms.arguments;
 			candidates = StreamSupport.stream(methodsFound.spliterator(), false)
 					.filter(Objects::nonNull)
-					.filter(o -> o instanceof Object[]).map(o -> (Object[]) o)
-					.map(o -> o[0]).filter(o -> o instanceof MethodBinding).map(b -> (MethodBinding) b)
+					.filter(Object[].class::isInstance).map(o -> (Object[]) o)
+					.map(o -> o[0]).filter(MethodBinding.class::isInstance).map(b -> (MethodBinding) b)
 					.filter(b -> CharOperation.equals(ms.selector, b.selector)).findFirst()
 					.map(m -> new MethodBinding[] { m }).orElse(new MethodBinding[0]);
 		} else if (this.parser.assistNodeParent instanceof AllocationExpression ae) {
@@ -9869,8 +9869,8 @@ public final class CompletionEngine
 						true);
 			}
 			candidates = StreamSupport.stream(methodsFound.spliterator(), false).filter(Objects::nonNull)
-					.filter(o -> o instanceof Object[]).map(o -> (Object[]) o).map(o -> o[0])
-					.filter(o -> o instanceof MethodBinding).map(b -> (MethodBinding) b).filter(b -> b.isConstructor())
+					.filter(Object[].class::isInstance).map(o -> (Object[]) o).map(o -> o[0])
+					.filter(MethodBinding.class::isInstance).map(b -> (MethodBinding) b).filter(MethodBinding::isConstructor)
 					.toArray(MethodBinding[]::new);
 		} else {
 			return parameterName;

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnQualifiedNameReference.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnQualifiedNameReference.java
@@ -77,10 +77,8 @@ public TypeBinding resolveType(BlockScope scope) {
 
 		throw new CompletionNodeFound();
 	}
-
-	return new CompletionNodeFound(this, this.binding, scope).throwOrDeferAndReturn(() -> {
-		// probably not in the position to do useful resolution, just provide some binding
-		return this.resolvedType = new ProblemReferenceBinding(this.tokens, null, ProblemReasons.NotFound);
-	});
+	
+	// probably not in the position to do useful resolution, just provide some binding
+	return new CompletionNodeFound(this, this.binding, scope).throwOrDeferAndReturn(() -> (this.resolvedType = new ProblemReferenceBinding(this.tokens, null, ProblemReasons.NotFound)));
 }
 }

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaProject.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaProject.java
@@ -3724,7 +3724,7 @@ public class JavaProject
 		}
 
 		public static Optional<CycleInfo> findCycleContaining(Collection<List<CycleInfo>> infos, IPath path) {
-			return infos.stream().flatMap(l -> l.stream()).filter(c -> c.cycle.contains(path)).findAny();
+			return infos.stream().flatMap(List::stream).filter(c -> c.cycle.contains(path)).findAny();
 		}
 
 		public static void add(IPath project, List<IPath> prefix, List<IPath> cycle, Map<IPath, List<CycleInfo>> cyclesPerProject) {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SearchableEnvironment.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SearchableEnvironment.java
@@ -111,7 +111,7 @@ public class SearchableEnvironment
 			this.moduleUpdater = new ModuleUpdater(project);
 			if (!excludeTestCode) {
 				IClasspathEntry[] expandedClasspath = project.getExpandedClasspath();
-				if(Arrays.stream(expandedClasspath).anyMatch(e -> e.isTest())) {
+				if(Arrays.stream(expandedClasspath).anyMatch(IClasspathEntry::isTest)) {
 					this.moduleUpdater.addReadUnnamedForNonEmptyClasspath(project, expandedClasspath);
 				}
 			}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/ClasspathJrt.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/ClasspathJrt.java
@@ -273,7 +273,7 @@ protected Collection<String> selectModules(Set<String> keySet, Collection<String
 		result.retainAll(limitModules);
 		rootModules = result;
 	} else {
-		rootModules = JavaProject.internalDefaultRootModules(keySet, s -> s, m -> getModule(m));
+		rootModules = JavaProject.internalDefaultRootModules(keySet, s -> s, this::getModule);
 	}
 	Set<String> allModules = new HashSet<>(rootModules);
 	for (String mod : rootModules)

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/NameEnvironment.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/NameEnvironment.java
@@ -27,7 +27,6 @@ import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 import org.eclipse.jdt.internal.compiler.env.*;
 import org.eclipse.jdt.internal.compiler.env.IUpdatableModule.UpdateKind;
-import org.eclipse.jdt.internal.compiler.env.NameEnvironmentAnswer;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jdt.internal.compiler.problem.AbortCompilation;
 import org.eclipse.jdt.internal.compiler.util.SimpleLookupTable;
@@ -786,7 +785,7 @@ public IModule getModule(char[] name) {
 public char[][] getAllAutomaticModules() {
 	if (this.modulePathEntries == null)
 		return CharOperation.NO_CHAR_CHAR;
-	Set<char[]> set = this.modulePathEntries.values().stream().filter(m -> m.isAutomaticModule()).map(e -> e.getModule().name())
+	Set<char[]> set = this.modulePathEntries.values().stream().filter(IModulePathEntry::isAutomaticModule).map(e -> e.getModule().name())
 			.collect(Collectors.toSet());
 	return set.toArray(new char[set.size()][]);
 }

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/State.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/State.java
@@ -847,8 +847,8 @@ private void writeBinaryLocations(CompressedWriter out, ClasspathLocation[] loca
 					try {
 						out.writeChars(pkgName.toCharArray());
 						char[][] targetModules = entry.getValue().stream()
-								.map(addExport -> addExport.getTargetModules()).filter(targets -> targets != null)
-								.reduce((f, s) -> CharOperation.arrayConcat(f, s)).orElse(null);
+								.map(AddExports::getTargetModules).filter(targets -> targets != null)
+								.reduce(CharOperation::arrayConcat).orElse(null);
 						writeNames(targetModules, out);
 					} catch (IOException e) {
 						// ignore

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/JavaSearchNameEnvironment.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/JavaSearchNameEnvironment.java
@@ -99,7 +99,7 @@ public JavaSearchNameEnvironment(IJavaProject javaProject, org.eclipse.jdt.core.
 
 	// if there are working copies, we need to index their packages too
 	if(this.workingCopies.size() > 0) {
-		Optional<ClasspathLocation> firstSrcLocation = this.locationSet.stream().filter(cp -> cp instanceof ClasspathSourceDirectory).findFirst();
+		Optional<ClasspathLocation> firstSrcLocation = this.locationSet.stream().filter(ClasspathSourceDirectory.class::isInstance).findFirst();
 		if(!firstSrcLocation.isPresent()) {
 			/*
 			 * Specifying working copies but not providing a project with a source folder is not supported by the current implementation.
@@ -572,8 +572,8 @@ public IModule getModule(char[] moduleName) {
 public char[][] getAllAutomaticModules() {
 	if (this.moduleLocations == null || this.moduleLocations.size() == 0)
 		return CharOperation.NO_CHAR_CHAR;
-	Set<char[]> set = this.moduleLocations.values().stream().map(e -> e.getModule()).filter(m -> m != null && m.isAutomatic())
-			.map(m -> m.name()).collect(Collectors.toSet());
+	Set<char[]> set = this.moduleLocations.values().stream().map(ClasspathLocation::getModule).filter(m -> m != null && m.isAutomatic())
+			.map(IModule::name).collect(Collectors.toSet());
 	return set.toArray(new char[set.size()][]);
 }
 


### PR DESCRIPTION
core

Using the JDT UI "Simplify lambda expression and method reference syntax" clean-up on jdt.core.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
