### PR TITLE
Using Simplify lambda expression and method reference syntax cleanup on

### DIFF
--- a/org.eclipse.jdt.apt.pluggable.tests/src/org/eclipse/jdt/apt/pluggable/tests/processors/buildertester/Bug341298Processor.java
+++ b/org.eclipse.jdt.apt.pluggable.tests/src/org/eclipse/jdt/apt/pluggable/tests/processors/buildertester/Bug341298Processor.java
@@ -66,8 +66,8 @@ public class Bug341298Processor extends AbstractProcessor {
 		JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
 		StandardJavaFileManager fileManager = compiler.getStandardFileManager(null, null, null);
 
-		List<String> options = opts.entrySet().stream().filter((e) -> !e.getKey().equals("phase"))
-				.flatMap((e) -> Arrays.asList("-" + e.getKey(), e.getValue()).stream()).collect(toList());
+		List<String> options = opts.entrySet().stream().filter(e -> !e.getKey().equals("phase"))
+				.flatMap(e -> Arrays.asList("-" + e.getKey(), e.getValue()).stream()).collect(toList());
 
 		Iterable<? extends JavaFileObject> objects = fileManager
 				.getJavaFileObjectsFromFiles(Arrays.asList(new File(sourceFile.toUri())));

--- a/org.eclipse.jdt.compiler.apt.tests/processors8/org/eclipse/jdt/compiler/apt/tests/processors/elements/Java12ElementProcessor.java
+++ b/org.eclipse.jdt.compiler.apt.tests/processors8/org/eclipse/jdt/compiler/apt/tests/processors/elements/Java12ElementProcessor.java
@@ -161,8 +161,8 @@ public class Java12ElementProcessor extends BaseProcessor {
 				mod3 = mod;
 			}
 		}
-		Collections.sort(types, (x, y) -> x.compareTo(y)); //unused as of now
-		Collections.sort(modules, (x, y) -> x.compareTo(y));
+		Collections.sort(types, String::compareTo); //unused as of now
+		Collections.sort(modules, String::compareTo);
 		assertEquals("incorrect no of modules in root elements in in "+ this.mode + " mode", 3, modules.size());
 		assertEquals("incorrect modules among root elements in "+ this.mode + " mode", "[module.main, module.readable.one, module.readable.two]", modules.toString());
 		assertNotNull("module should not be null in "+ this.mode + " mode", mod1);
@@ -208,8 +208,8 @@ public class Java12ElementProcessor extends BaseProcessor {
 				mod3 = mod;
 			}
 		}
-		Collections.sort(types, (x, y) -> x.compareTo(y)); //unused as of now
-		Collections.sort(modules, (x, y) -> x.compareTo(y));
+		Collections.sort(types, String::compareTo); //unused as of now
+		Collections.sort(modules, String::compareTo);
 		assertEquals("incorrect no of modules in root elements in "+ this.mode + " mode", this.isBinaryMode ? 2 : 3, modules.size());
 		assertEquals("incorrect modules among root elements in "+ this.mode + " mode", "[module.main, module.readable.one" +
 							(this.isBinaryMode ? "" : ", module.readable.two") + "]", modules.toString());
@@ -257,8 +257,8 @@ public class Java12ElementProcessor extends BaseProcessor {
 				mod3 = mod;
 			}
 		}
-		Collections.sort(types, (x, y) -> x.compareTo(y)); //unused as of now
-		Collections.sort(modules, (x, y) -> x.compareTo(y));
+		Collections.sort(types, String::compareTo); //unused as of now
+		Collections.sort(modules, String::compareTo);
 		assertEquals("incorrect no of modules in root elements in "+ this.mode + " mode", 3, modules.size());
 		assertEquals("incorrect modules among root elements in "+ this.mode + " mode", "[module.main, module.readable.one, module.readable.two]", modules.toString());
 		assertNotNull("module should not be null in "+ this.mode + " mode", mod1);

--- a/org.eclipse.jdt.compiler.apt.tests/processors8/org/eclipse/jdt/compiler/apt/tests/processors/elements/Java9ElementProcessor.java
+++ b/org.eclipse.jdt.compiler.apt.tests/processors8/org/eclipse/jdt/compiler/apt/tests/processors/elements/Java9ElementProcessor.java
@@ -236,8 +236,8 @@ public class Java9ElementProcessor extends BaseProcessor {
 				assertFalse("should be a named module", ((ModuleElement) root).isUnnamed());
 			}
 		}
-		Collections.sort(types, (x, y) -> x.compareTo(y));
-		Collections.sort(modules, (x, y) -> x.compareTo(y));
+		Collections.sort(types, String::compareTo);
+		Collections.sort(modules, String::compareTo);
 		assertEquals("incorrect no of modules in root elements", 2, moduleCount);
 		assertEquals("incorrect modules among root elements", "[mod.a, mod.b]", modules.toString());
 		assertEquals("incorrect no of types in root elements", 5, typeCount);

--- a/org.eclipse.jdt.compiler.apt.tests/processors8/org/eclipse/jdt/compiler/apt/tests/processors/elements/RecordElementProcessor.java
+++ b/org.eclipse.jdt.compiler.apt.tests/processors8/org/eclipse/jdt/compiler/apt/tests/processors/elements/RecordElementProcessor.java
@@ -305,8 +305,8 @@ public class RecordElementProcessor extends BaseElementProcessor {
 		recordComponent = (RecordComponentElement) element;
 		verifyAnnotations(recordComponent, new String[]{});
 		List<ExecutableElement> methodsIn = ElementFilter.methodsIn(enclosedElements);
-		List<String> actualMethodNames = methodsIn.stream().filter((m) -> m.getSimpleName().toString().startsWith("comp"))
-																	.map((m) -> m.getSimpleName().toString())
+		List<String> actualMethodNames = methodsIn.stream().filter(m -> m.getSimpleName().toString().startsWith("comp"))
+																	.map(m -> m.getSimpleName().toString())
 																	.collect(Collectors.toList());
 		assertEquals("incorrect method", 6, actualMethodNames.size());
 		for (ExecutableElement method : methodsIn) {
@@ -428,8 +428,8 @@ public class RecordElementProcessor extends BaseElementProcessor {
             assertEquals("expected enclosed Record Components mismatch", expRecComps.get(key), actRecComp.asType().getKind());
         }
 
-        List<String> actualMethodNames = methods.stream().map((m) -> m.getSimpleName().toString()).collect(Collectors.toList());
-        List<String> actualRecordCompNames = actRecComps.stream().map((m) -> m.getSimpleName().toString()).collect(Collectors.toList());
+        List<String> actualMethodNames = methods.stream().map(m -> m.getSimpleName().toString()).collect(Collectors.toList());
+        List<String> actualRecordCompNames = actRecComps.stream().map(m -> m.getSimpleName().toString()).collect(Collectors.toList());
 
         //checking the size
         assertEquals("expected enclosed Record Components size mismatch", expMethodNames.size(), actualMethodNames.size());
@@ -465,7 +465,7 @@ public class RecordElementProcessor extends BaseElementProcessor {
             assertEquals("expected enclosed Record Components mismatch", expRecComps.get(key), actRecComp.asType().getKind());
         }
 
-        List<String> actualRecordCompNames = actRecComps.stream().map((m) -> m.getSimpleName().toString()).collect(Collectors.toList());
+        List<String> actualRecordCompNames = actRecComps.stream().map(m -> m.getSimpleName().toString()).collect(Collectors.toList());
 
         if (!actualRecordCompNames.containsAll(expRecComppNames)) {
         	fail(" expected enclosed record components mismatch - expected at least : " + expRecComppNames + " " +

--- a/org.eclipse.jdt.compiler.apt.tests/src/org/eclipse/jdt/compiler/apt/tests/Java9ElementsTests.java
+++ b/org.eclipse.jdt.compiler.apt.tests/src/org/eclipse/jdt/compiler/apt/tests/Java9ElementsTests.java
@@ -434,7 +434,7 @@ public class Java9ElementsTests extends TestCase {
 		JavaCompiler compiler = BatchTestUtils.getEclipseCompiler();
 		final String autoModuleJar = BatchTestUtils.setupProcessorJar("lib/lib.x.jar", BatchTestUtils._tmpFolder);
 		internalTest(compiler, MODULE_PROC, "testBug572673", null, "bug572673", true, 
-				(options) -> {
+				options -> {
 					options.add("--module-path");
 					options.add(BatchTestUtils._jls8ProcessorJarPath + 
 							File.pathSeparator + autoModuleJar);

--- a/org.eclipse.jdt.compiler.tool.tests/src/org/eclipse/jdt/compiler/tool/tests/CompilerToolJava9Tests.java
+++ b/org.eclipse.jdt.compiler.tool.tests/src/org/eclipse/jdt/compiler/tool/tests/CompilerToolJava9Tests.java
@@ -256,7 +256,7 @@ public class CompilerToolJava9Tests extends TestCase {
 		if (this.isJREBelow9) return;
 		JavaCompiler compiler = this.compilers[1];
 		StandardJavaFileManager standardManager = compiler.getStandardFileManager(null, Locale.getDefault(), Charset.defaultCharset());
-		Consumer<JavaFileManager> cons = (manager) -> {
+		Consumer<JavaFileManager> cons = manager -> {
 			String tmpFolder = _tmpFolder;
 			File inputFile = new File(tmpFolder, "X.java");
 			try (Writer writer = new BufferedWriter(new FileWriter(inputFile))) {
@@ -318,7 +318,7 @@ public class CompilerToolJava9Tests extends TestCase {
 		if (this.isJREBelow9) return;
 		JavaCompiler compiler = this.compilers[1];
 		StandardJavaFileManager standardManager = compiler.getStandardFileManager(null, Locale.getDefault(), Charset.defaultCharset());
-		Consumer<JavaFileManager> cons = (manager) -> {
+		Consumer<JavaFileManager> cons = manager -> {
 			String tmpFolder = _tmpFolder;
 			File inputFile = new File(tmpFolder, "X.java");
 			try (Writer writer = new BufferedWriter(new FileWriter(inputFile))){
@@ -381,7 +381,7 @@ public class CompilerToolJava9Tests extends TestCase {
 		if (this.isJREBelow9) return;
 		JavaCompiler compiler = this.compilers[1];
 		StandardJavaFileManager standardManager = compiler.getStandardFileManager(null, Locale.getDefault(), Charset.defaultCharset());
-		Consumer<JavaFileManager> cons = (manager) -> {
+		Consumer<JavaFileManager> cons = manager -> {
 			String tmpFolder = _tmpFolder;
 			File inputFile = new File(tmpFolder, "X.java");
 			try (Writer writer = new BufferedWriter(new FileWriter(inputFile))){
@@ -431,7 +431,7 @@ public class CompilerToolJava9Tests extends TestCase {
 		if (this.isJREBelow9) return;
 		JavaCompiler compiler = this.compilers[1];
 		StandardJavaFileManager standardManager = compiler.getStandardFileManager(null, Locale.getDefault(), Charset.defaultCharset());
-		Consumer<JavaFileManager> cons = (manager) -> {
+		Consumer<JavaFileManager> cons = manager -> {
 			String tmpFolder = _tmpFolder;
 			File inputFile = new File(tmpFolder, "X.java");
 			try (Writer writer = new BufferedWriter(new FileWriter(inputFile))) {
@@ -520,7 +520,7 @@ public class CompilerToolJava9Tests extends TestCase {
 		if (this.isJREBelow12) return;
 		JavaCompiler compiler = this.compilers[1];
 		StandardJavaFileManager standardManager = compiler.getStandardFileManager(null, Locale.getDefault(), Charset.defaultCharset());
-		Consumer<JavaFileManager> cons = (manager) -> {
+		Consumer<JavaFileManager> cons = manager -> {
 			String tmpFolder = _tmpFolder;
 			File inputFile = new File(tmpFolder, "X.java");
 			try (Writer writer = new BufferedWriter(new FileWriter(inputFile))){
@@ -564,7 +564,7 @@ public class CompilerToolJava9Tests extends TestCase {
 		if (this.isJREBelow12) return;
 		JavaCompiler compiler = this.compilers[1];
 		StandardJavaFileManager standardManager = compiler.getStandardFileManager(null, Locale.getDefault(), Charset.defaultCharset());
-		Consumer<JavaFileManager> cons = (manager) -> {
+		Consumer<JavaFileManager> cons = manager -> {
 			String tmpFolder = _tmpFolder;
 			File inputFile = new File(tmpFolder, "X.java");
 			try (Writer writer = new BufferedWriter(new FileWriter(inputFile))){

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ClassFile.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ClassFile.java
@@ -621,7 +621,7 @@ public class ClassFile implements TypeConstants, TypeIds {
 						int size = allTypeAnnotationContexts.size();
 						attributesNumber = completeRuntimeTypeAnnotations(attributesNumber,
 								null,
-								(node) -> size > 0,
+								node -> size > 0,
 								() -> allTypeAnnotationContexts);
 					}
 				} finally {
@@ -674,7 +674,7 @@ public class ClassFile implements TypeConstants, TypeIds {
 				int size = allTypeAnnotationContexts.size();
 				attributesNumber = completeRuntimeTypeAnnotations(attributesNumber,
 																	null,
-																	(node) -> size > 0,
+																	node -> size > 0,
 																	() -> allTypeAnnotationContexts);
 
 			}
@@ -1763,7 +1763,7 @@ public class ClassFile implements TypeConstants, TypeIds {
 		int size = allTypeAnnotationContexts.size();
 		attributesNumber = completeRuntimeTypeAnnotations(attributesNumber,
 															null,
-															(node) -> size > 0,
+															node -> size > 0,
 															() -> allTypeAnnotationContexts);
 		return attributesNumber;
 	}
@@ -2475,7 +2475,7 @@ public class ClassFile implements TypeConstants, TypeIds {
 			int size = allTypeAnnotationContexts.size();
 			attributesNumber = completeRuntimeTypeAnnotations(attributesNumber,
 											null,
-											(node) -> size > 0,
+											node -> size > 0,
 											() -> allTypeAnnotationContexts);
 		}
 		if ((this.produceAttributes & ClassFileConstants.ATTR_METHOD_PARAMETERS) != 0 ||
@@ -3840,7 +3840,7 @@ public class ClassFile implements TypeConstants, TypeIds {
 		String names =
 			Arrays.stream(recordComponents)
 			.map(f -> new String(f.name))
-			.reduce((s1, s2) -> { return s1 + ";" + s2;}) //$NON-NLS-1$
+			.reduce((s1, s2) -> (s1 + ";" + s2)) //$NON-NLS-1$
 			.orElse(Util.EMPTY_STRING);
 		int namesIndex = this.constantPool.literalIndex(names);
 		this.contents[localContentsOffset++] = (byte) (namesIndex >> 8);
@@ -4437,7 +4437,7 @@ public class ClassFile implements TypeConstants, TypeIds {
 							int size = allTypeAnnotationContexts.size();
 							attributesNumber = completeRuntimeTypeAnnotations(attributesNumber,
 									null,
-									(node) -> size > 0,
+									node -> size > 0,
 									() -> allTypeAnnotationContexts);
 						}
 					}
@@ -5888,7 +5888,7 @@ public class ClassFile implements TypeConstants, TypeIds {
 		int size = allTypeAnnotationContexts.size();
 		attributesNumber = completeRuntimeTypeAnnotations(attributesNumber,
 				null,
-				(node) -> size > 0,
+				node -> size > 0,
 				() -> allTypeAnnotationContexts);
 		return attributesNumber;
 	}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/NameReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/NameReference.java
@@ -111,9 +111,7 @@ public abstract char[][] getName();
      (this.bits & ASTNode.IsCapturedOuterLocal) != 0
 */
 public boolean checkEffectiveFinality(VariableBinding localBinding, Scope scope) {
-	Predicate<VariableBinding> test = (local) -> {
-		return (!localBinding.isFinal() && !localBinding.isEffectivelyFinal());
-	};
+	Predicate<VariableBinding> test = local -> (!localBinding.isFinal() && !localBinding.isEffectivelyFinal());
 	if ((this.bits & ASTNode.IsCapturedOuterLocal) != 0) {
 		if (test.test(localBinding)) {
 			scope.problemReporter().cannotReferToNonEffectivelyFinalOuterLocal(localBinding, this);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/RecordPattern.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/RecordPattern.java
@@ -367,7 +367,7 @@ public class RecordPattern extends TypePattern {
 		if (currentScope == null || labels == null || labels.isEmpty())
 			return;
 		Predicate<Scope> pred = codeStream.patternCatchStack.isEmpty() ?
-			 s -> s instanceof MethodScope :
+			 MethodScope.class::isInstance :
 				 s -> s == codeStream.patternCatchStack.firstElement();
 
 		Scope scope = currentScope;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
@@ -1241,7 +1241,7 @@ public class SwitchStatement extends Expression {
 								this.scope.problemReporter().patternDominatedByAnother(c.e);
 							}
 							for (int j = 0; j < counter; j++) {
-								IntPredicate check = (idx) -> {
+								IntPredicate check = idx -> {
 									Constant c2 = this.otherConstants[idx].c;
 									if (con.typeID() == TypeIds.T_JavaLangString) {
 										return c2.stringValue().equals(con.stringValue());

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/FileSystem.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/FileSystem.java
@@ -652,7 +652,7 @@ public boolean hasCompilationUnit(char[][] qualifiedPackageName, char[] moduleNa
 	String moduleNameString = String.valueOf(moduleName);
 	LookupStrategy strategy = LookupStrategy.get(moduleName);
 	Parser parser = checkCUs ? getParser() : null;
-	Function<CompilationUnit, String> pkgNameExtractor = (sourceUnit) -> {
+	Function<CompilationUnit, String> pkgNameExtractor = sourceUnit -> {
 		String pkgName = null;
 		CompilationResult compilationResult = new CompilationResult(sourceUnit, 0, 0, 1);
 		char[][] name = parser.parsePackageDeclaration(sourceUnit.getContents(), compilationResult);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/CodeStream.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/CodeStream.java
@@ -7861,7 +7861,7 @@ public void addPatternAccessorExceptionHandler(BlockScope scope, boolean addTarg
 		this.exitUserScope(scope);
 	}
 	pushExceptionOnStack(TypeBinding.wellKnownType(scope, TypeIds.T_JavaLangThrowable));
-	patternExceptionLabels.forEach(e -> e.place());
+	patternExceptionLabels.forEach(ExceptionLabel::place);
 
 	LocalVariableBinding catchVar = this.scopeToCatchVar.get(scope);
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/CompilationUnitScope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/CompilationUnitScope.java
@@ -257,7 +257,7 @@ void checkAndSetImports() {
 		index = 2;
 	}
 
-	Predicate<ImportReference> isStaticImport = i -> i.isStatic();
+	Predicate<ImportReference> isStaticImport = ImportReference::isStatic;
 	Predicate<ImportReference> isNotStaticImport = Predicate.not(isStaticImport);
 
 	// GitHub 269: resolve non-static imports first, so that cyclic static imports can be resolved correctly

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SourceTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SourceTypeBinding.java
@@ -907,7 +907,7 @@ public List<MethodBinding> checkAndAddSyntheticRecordComponentAccessors(MethodBi
 	// and no accessor should be created (essentially in a recovered code if there are errors) - if there are no
 	// errors then filteredComponents equals components.
 	List<String> filteredComponents = Arrays.stream(this.fields) // initialize with all the record components
-			.filter(f -> f.isRecordComponent())
+			.filter(FieldBinding::isRecordComponent)
 			.map(f -> new String(f.name))
 			.collect(Collectors.toList());
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SyntheticMethodBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SyntheticMethodBinding.java
@@ -390,10 +390,10 @@ public class SyntheticMethodBinding extends MethodBinding {
 		this.tagBits |= (TagBits.AnnotationResolved | TagBits.DeprecatedAnnotationResolved) | (lambda.binding.tagBits & TagBits.HasParameterAnnotations);
 	    this.returnType = lambda.binding.returnType;
 	    this.parameters = lambda.binding.parameters;
-        if (this.returnType.isNonDenotable() || Stream.of(this.parameters).anyMatch(p -> p.isNonDenotable())) {
+        if (this.returnType.isNonDenotable() || Stream.of(this.parameters).anyMatch(TypeBinding::isNonDenotable)) {
         	this.modifiers &= ~ExtraCompilerModifiers.AccGenericSignature;
         }
-	    TypeVariableBinding[] vars = Stream.of(this.parameters).filter(param -> param.isTypeVariable()).toArray(TypeVariableBinding[]::new);
+	    TypeVariableBinding[] vars = Stream.of(this.parameters).filter(TypeBinding::isTypeVariable).toArray(TypeVariableBinding[]::new);
 	    if (vars != null && vars.length > 0)
 	    	this.typeVariables = vars;
 	    this.thrownExceptions = lambda.binding.thrownExceptions;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/tool/JrtFileSystem.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/tool/JrtFileSystem.java
@@ -92,7 +92,7 @@ public class JrtFileSystem extends Archive {
     	Path resolve = mPath.resolve(packageName);
     	java.util.List<Path> files = null;
         try (Stream<Path> p = Files.list(resolve)) {
-            files = p.filter((path) -> {
+            files = p.filter(path -> {
             	if (Files.isDirectory(path))
             		return false;
             	else

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/util/CharArrayHashMap.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/util/CharArrayHashMap.java
@@ -38,7 +38,7 @@ public final class CharArrayHashMap<V> implements CharArrayMapper<V>, Serializab
 
 	@Override
 	public Collection<char[]> keys() {
-		return this.map.keySet().stream().map(s -> s.getKey()).collect(Collectors.toList());
+		return this.map.keySet().stream().map(CharArray::getKey).collect(Collectors.toList());
 	}
 
 	@Override

--- a/org.eclipse.jdt.core.tests.builder/src/org/eclipse/jdt/core/tests/builder/CompressedWriterTest.java
+++ b/org.eclipse.jdt.core.tests.builder/src/org/eclipse/jdt/core/tests/builder/CompressedWriterTest.java
@@ -107,10 +107,10 @@ public class CompressedWriterTest extends BuilderTests {
 		String[] strings = new String[] { "nix", "xx", "xxxy", "xyz", "", "xxy", "z", "z", "xyz", "xu", "-".repeat(254),
 				"-".repeat(255), "-".repeat(256), "-".repeat(257), "-".repeat(60000) };
 		char[][] chars = Arrays.stream(strings).map(String::toCharArray).toArray(char[][]::new);
-		assertSame(strings, (w, v) -> w.writeStringUsingDictionary(v), r -> r.readStringUsingDictionary());
-		assertSame(chars, (w, v) -> w.writeChars(v), r -> r.readChars());
-		assertSame(chars, (w, v) -> w.writeCharsUsingLast(v), r -> r.readCharsUsingLast());
-		assertSame(strings, (w, v) -> w.writeStringUsingLast(v), r -> r.readStringUsingLast());
+		assertSame(strings, CompressedWriter::writeStringUsingDictionary, CompressedReader::readStringUsingDictionary);
+		assertSame(chars, CompressedWriter::writeChars, CompressedReader::readChars);
+		assertSame(chars, CompressedWriter::writeCharsUsingLast, CompressedReader::readCharsUsingLast);
+		assertSame(strings, CompressedWriter::writeStringUsingLast, CompressedReader::readStringUsingLast);
 	}
 
 	@FunctionalInterface

--- a/org.eclipse.jdt.core.tests.builder/src/org/eclipse/jdt/core/tests/builder/ReferenceCollectionTest.java
+++ b/org.eclipse.jdt.core.tests.builder/src/org/eclipse/jdt/core/tests/builder/ReferenceCollectionTest.java
@@ -317,11 +317,11 @@ public class ReferenceCollectionTest extends BuilderTests {
 	}
 
 	private static String[] toStringArray(char[][][] qualifiedNameReferences) {
-		return Arrays.stream(qualifiedNameReferences).map(a -> CharOperation.toString(a)).toArray(String[]::new);
+		return Arrays.stream(qualifiedNameReferences).map(CharOperation::toString).toArray(String[]::new);
 	}
 
 	private static String[] toStringArray(char[][] qualifiedNameReferences) {
-		return Arrays.stream(qualifiedNameReferences).map(a -> CharOperation.charToString(a)).toArray(String[]::new);
+		return Arrays.stream(qualifiedNameReferences).map(CharOperation::charToString).toArray(String[]::new);
 	}
 
 	public void testRegression01() {

--- a/org.eclipse.jdt.core.tests.builder/src/org/eclipse/jdt/core/tests/builder/StateTest.java
+++ b/org.eclipse.jdt.core.tests.builder/src/org/eclipse/jdt/core/tests/builder/StateTest.java
@@ -317,11 +317,11 @@ public class StateTest extends BuilderTests {
 	}
 
 	private static String[] toStringArray(char[][][] qualifiedNameReferences) {
-		return Arrays.stream(qualifiedNameReferences).map(a -> CharOperation.toString(a)).toArray(String[]::new);
+		return Arrays.stream(qualifiedNameReferences).map(CharOperation::toString).toArray(String[]::new);
 	}
 
 	private static String[] toStringArray(char[][] qualifiedNameReferences) {
-		return Arrays.stream(qualifiedNameReferences).map(a -> CharOperation.charToString(a)).toArray(String[]::new);
+		return Arrays.stream(qualifiedNameReferences).map(CharOperation::charToString).toArray(String[]::new);
 	}
 
 	char[][][] getQualifiedNameReferences(ReferenceCollection collection) {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/InMemoryNameEnvironment9.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/InMemoryNameEnvironment9.java
@@ -95,7 +95,7 @@ public class InMemoryNameEnvironment9 extends InMemoryNameEnvironment implements
 
 	@Override
 	public char[][] getAllAutomaticModules() {
-		return collect(env -> env.getAllAutomaticModules(), char[][]::new);
+		return collect(IModuleAwareNameEnvironment::getAllAutomaticModules, char[][]::new);
 	}
 
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PublicScannerTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PublicScannerTest.java
@@ -302,7 +302,7 @@ public class PublicScannerTest extends AbstractRegressionTest {
 
 		Field[] tsFields = ITerminalSymbols.class.getFields();
 		Set<String> ttNames = nameToValue.keySet();
-		Set<String> tsSet = Arrays.asList(tsFields).stream().map(x -> x.getName()).collect(Collectors.toSet());
+		Set<String> tsSet = Arrays.asList(tsFields).stream().map(Field::getName).collect(Collectors.toSet());
 		StringBuilder sb = new StringBuilder();
 		String ident = "\t\t\t";
 		for (String ttName : ttNames) {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests18.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests18.java
@@ -6594,9 +6594,7 @@ public void testBug578817() throws JavaModelException {
 	requestor = new CompletionTestsRequestor2(true);
 	requestor.setAllowsRequiredProposals(CompletionProposal.TYPE_REF, CompletionProposal.TYPE_REF, true);
 	requestor.setAllowsRequiredProposals(CompletionProposal.CONSTRUCTOR_INVOCATION, CompletionProposal.TYPE_REF, true);
-	requestor.setTypeProposalFilter((typeName) -> {
-		return typeName.startsWith("java.util.");
-	});
+	requestor.setTypeProposalFilter(typeName -> typeName.startsWith("java.util."));
 	this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner, new NullProgressMonitor());
 	result = requestor.getResults();
 	assertResults("", result);


### PR DESCRIPTION
all plug-ins except core

Using the JDT UI "Simplify lambda expression and method reference syntax" clean-up on all plug-ins except jdt.core.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
