### PR TITLE
Bump bundle dependencies to trigger a rebuild / fix SDK build error

### DIFF
--- a/org.eclipse.jdt.core.tests.performance/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.tests.performance/META-INF/MANIFEST.MF
@@ -7,15 +7,15 @@ Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jdt.core.tests.performance,
  org.eclipse.jdt.core.tests.performance.util
-Require-Bundle: org.eclipse.core.resources;bundle-version="[3.2.0,4.0.0)",
- org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
- org.eclipse.jdt.core;bundle-version="[3.36.0,4.0.0)",
- org.eclipse.jdt.core.tests.builder;bundle-version="[3.4.0,4.0.0)",
- org.eclipse.jdt.core.tests.compiler;bundle-version="[3.4.0,4.0.0)",
- org.eclipse.jdt.core.tests.model;bundle-version="[3.4.0,4.0.0)",
+Require-Bundle: org.eclipse.core.resources;bundle-version="[3.20.100,4.0.0)",
+ org.eclipse.core.runtime;bundle-version="[3.30.100,4.0.0)",
+ org.eclipse.jdt.core;bundle-version="[3.37.0,4.0.0)",
+ org.eclipse.jdt.core.tests.builder;bundle-version="[3.12.300,4.0.0)",
+ org.eclipse.jdt.core.tests.compiler;bundle-version="[3.13.300,4.0.0)",
+ org.eclipse.jdt.core.tests.model;bundle-version="[3.12.300,4.0.0)",
  org.junit;bundle-version="3.8.1",
- org.eclipse.test.performance;bundle-version="[3.1.0,4.0.0)",
- org.eclipse.text;bundle-version="[3.1.0,4.0.0)"
+ org.eclipse.test.performance;bundle-version="[3.20.0,4.0.0)",
+ org.eclipse.text;bundle-version="[3.13.0,4.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Eclipse-BundleShape: dir
 Automatic-Module-Name: org.eclipse.jdt.core.tests.performance


### PR DESCRIPTION
The change in bytecode of FullSourceWorkspaceBuildTests is due the constant value change of
o.e.jdt.internal.compiler.parser.TerminalTokens.TokenNameEOF coming from #1513.

Fixes https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1617
