### PR TITLE
Try-with-resource clean-up in JDT core

### DIFF
--- a/org.eclipse.jdt.apt.pluggable.tests/src/org/eclipse/jdt/apt/pluggable/tests/IdeTestUtils.java
+++ b/org.eclipse.jdt.apt.pluggable.tests/src/org/eclipse/jdt/apt/pluggable/tests/IdeTestUtils.java
@@ -143,18 +143,12 @@ public class IdeTestUtils {
 	private static byte[] read(java.io.File file) throws java.io.IOException {
 		int fileLength;
 		byte[] fileBytes = new byte[fileLength = (int) file.length()];
-		java.io.FileInputStream stream = null;
-		try {
-			stream = new java.io.FileInputStream(file);
+		try (java.io.FileInputStream stream = new java.io.FileInputStream(file)) {
 			int bytesRead = 0;
 			int lastReadSize = 0;
 			while ((lastReadSize != -1) && (bytesRead != fileLength)) {
 				lastReadSize = stream.read(fileBytes, bytesRead, fileLength - bytesRead);
 				bytesRead += lastReadSize;
-			}
-		} finally {
-			if (stream != null) {
-				stream.close();
 			}
 		}
 		return fileBytes;

--- a/org.eclipse.jdt.apt.pluggable.tests/src/org/eclipse/jdt/apt/pluggable/tests/processors/buildertester/Bug468893Processor.java
+++ b/org.eclipse.jdt.apt.pluggable.tests/src/org/eclipse/jdt/apt/pluggable/tests/processors/buildertester/Bug468893Processor.java
@@ -42,8 +42,7 @@ public class Bug468893Processor extends AbstractProcessor {
 			processingEnv.getMessager().printMessage(Kind.WARNING, "Processing over...");
 			try {
 				FileObject resource = processingEnv.getFiler().createSourceFile("generated.TypeIndex");
-				BufferedWriter w = new BufferedWriter(resource.openWriter());
-				try {
+				try (BufferedWriter w = new BufferedWriter(resource.openWriter())) {
 					w.append("package generated;");
 					w.newLine();
 					w.append("public interface TypeIndex {");
@@ -52,8 +51,6 @@ public class Bug468893Processor extends AbstractProcessor {
 					w.newLine();
 					w.append("}");
 					w.newLine();
-				} finally {
-					w.close();
 				}
 			} catch (IOException e) {
 				processingEnv.getMessager().printMessage(Kind.ERROR, "Could not create output " + e.getMessage());

--- a/org.eclipse.jdt.apt.pluggable.tests/src/org/eclipse/jdt/apt/pluggable/tests/processors/filertester/FilerTesterProc.java
+++ b/org.eclipse.jdt.apt.pluggable.tests/src/org/eclipse/jdt/apt/pluggable/tests/processors/filertester/FilerTesterProc.java
@@ -180,13 +180,8 @@ public class FilerTesterProc extends AbstractProcessor {
 	public void testCreateNonSourceFile(Element e, String pkg, String relName) throws Exception {
 		FileObject fo = _filer.createResource(StandardLocation.SOURCE_OUTPUT,
 				pkg, relName, e);
-		PrintWriter pw = null;
-		try {
-			pw = new PrintWriter(fo.openWriter());
+		try (PrintWriter pw = new PrintWriter(fo.openWriter())) {
 			pw.println("Hello world");
-		} finally {
-			if (pw != null)
-				pw.close();
 		}
 		String name = fo.getName().toString();
 		// JSR269 spec does not make strict requirements about what getName() returns,
@@ -241,52 +236,28 @@ public class FilerTesterProc extends AbstractProcessor {
 
 	public void testBug534979(Element e, String pkg, String relName) throws Exception {
 		JavaFileObject jfo = _filer.createSourceFile(pkg + "." + relName);
-		PrintWriter pw = null;
-		try {
-			pw = new PrintWriter(jfo.openWriter());
+		try (PrintWriter pw = new PrintWriter(jfo.openWriter())) {
 			pw.println("package " + pkg + ";\npublic class " + relName + "{ }");
-		}
-		finally {
-			if (pw != null)
-				pw.close();
 		}
 	}
 	public void testBug542090a(Element e, String pkg, String relName) throws Exception {
 		if (++roundNo > 1)
 			return;
 		JavaFileObject jfo = _filer.createSourceFile(pkg + "." + relName);
-		PrintWriter pw = null;
-		try {
-			pw = new PrintWriter(jfo.openWriter());
+		try (PrintWriter pw = new PrintWriter(jfo.openWriter())) {
 			pw.println("package " + pkg + ";\npublic class " + relName + "{ }");
-		}
-		finally {
-			if (pw != null)
-				pw.close();
 		}
 	}
 	public void testBug542090b(Element e, String pkg, String relName) throws Exception {
 		JavaFileObject jfo = _filer.createSourceFile(pkg + "." + relName);
-		PrintWriter pw = null;
-		try {
-			pw = new PrintWriter(jfo.openWriter());
+		try (PrintWriter pw = new PrintWriter(jfo.openWriter())) {
 			pw.println("package " + pkg + ";\npublic class " + relName + "{ }");
-		}
-		finally {
-			if (pw != null)
-				pw.close();
 		}
 	}
 	public void testBug534979InModule(Element e, String pkg, String relName) throws Exception {
 		JavaFileObject jfo = _filer.createSourceFile(pkg+"."+relName, e.getEnclosingElement());
-		PrintWriter pw = null;
-		try {
-			pw = new PrintWriter(jfo.openWriter());
+		try (PrintWriter pw = new PrintWriter(jfo.openWriter())) {
 			pw.println("package " + pkg + ";\npublic class " + relName + "{ }");
-		}
-		finally {
-			if (pw != null)
-				pw.close();
 		}
 	}
 	public void testCreateClass1(Element e, String pkg, String relName) throws Exception {
@@ -296,28 +267,20 @@ public class FilerTesterProc extends AbstractProcessor {
 				return;
 			if (roundNo == 2) {
 				JavaFileObject jfo = filer.createSourceFile("p/Test", e.getEnclosingElement());
-				PrintWriter pw = null;
-				try {
-					pw = new PrintWriter(jfo.openWriter());
+				try (PrintWriter pw = new PrintWriter(jfo.openWriter())) {
 					pw.write("package p;\n " +
 							"import org.eclipse.jdt.apt.pluggable.tests.annotations.FilerTestTrigger;\n" +
 							"@FilerTestTrigger(test = \"testCreateClass1\", arg0 = \"p\", arg1 = \"Test.java\")" +
 							"public class Test {}");
-				} finally {
-					pw.close();
 				}
 			} else if(roundNo == 3) {
 					if (classContent == null) {
 						throw new IOException("Class file should have been present");
 					}
 					IdeOutputClassFileObject jfo = (IdeOutputClassFileObject) filer.createClassFile("p/Trigger");
-					OutputStream out = null;
-					try {
-						out = jfo.openOutputStream();
+					try (OutputStream out = jfo.openOutputStream()) {
 						out.write(classContent);
 					} catch (Exception ex) {
-					} finally {
-						out.close();
 					}
 			}
 		} finally {
@@ -330,28 +293,20 @@ public class FilerTesterProc extends AbstractProcessor {
 				return;
 			if (roundNo == 2) {
 				JavaFileObject jfo = filer.createSourceFile("p/Test", e.getEnclosingElement());
-				PrintWriter pw = null;
-				try {
-					pw = new PrintWriter(jfo.openWriter());
+				try (PrintWriter pw = new PrintWriter(jfo.openWriter())) {
 					pw.write("package p;\n " +
 							"import org.eclipse.jdt.apt.pluggable.tests.annotations.FilerTestTrigger;\n" +
 							"@FilerTestTrigger(test = \"testCreateClass1\", arg0 = \"p\", arg1 = \"Test.java\")" +
 							"public class Test {}");
-				} finally {
-					pw.close();
 				}
 			} else if(roundNo == 3) {
 					if (classContent == null) {
 						throw new IOException("Class file should have been present");
 					}
 					IdeOutputClassFileObject jfo = (IdeOutputClassFileObject) filer.createClassFile("p.Trigger");
-					OutputStream out = null;
-					try {
-						out = jfo.openOutputStream();
+					try (OutputStream out = jfo.openOutputStream()) {
 						out.write(classContent);
 					} catch (Exception ex) {
-					} finally {
-						out.close();
 					}
 			}
 		} finally {
@@ -359,13 +314,8 @@ public class FilerTesterProc extends AbstractProcessor {
 	}
 
 	private void checkGenUri(FileObject fo, String name, String content, String category) throws Exception {
-		PrintWriter pw = null;
-		try {
-			pw = new PrintWriter(fo.openWriter());
+		try (PrintWriter pw = new PrintWriter(fo.openWriter())) {
 			pw.print(content);
-		} finally {
-			if (pw != null)
-				pw.close();
 		}
 		URI uri = fo.toUri();
 		if (!uri.toString().contains(name)) {

--- a/org.eclipse.jdt.apt.tests/src/org/eclipse/jdt/apt/tests/PerfTests.java
+++ b/org.eclipse.jdt.apt.tests/src/org/eclipse/jdt/apt/tests/PerfTests.java
@@ -69,12 +69,9 @@ public class PerfTests extends BuilderTests
 		File tempPath = fetchFromBinariesProject("perf-test-project.zip", 3_307_492);
 		
 		InputStream in = new FileInputStream(tempPath);
-		ZipInputStream zipIn = new ZipInputStream(in);
-		try {
+		
+		try (ZipInputStream zipIn = new ZipInputStream(in)) {
 			TestUtil.unzip(zipIn, destRoot);
-		}
-		finally {
-			zipIn.close();
 		}
 
 		// project will be deleted by super-class's tearDown() method

--- a/org.eclipse.jdt.apt.tests/src/org/eclipse/jdt/apt/tests/TestUtil.java
+++ b/org.eclipse.jdt.apt.tests/src/org/eclipse/jdt/apt/tests/TestUtil.java
@@ -297,20 +297,11 @@ public class TestUtil
 	public static void zip(String zipPath, Map<File, FileFilter> input)
 		throws IOException
 	{
-		ZipOutputStream zip = null;
-		try
+		try (ZipOutputStream zip = new ZipOutputStream( new FileOutputStream( zipPath ) ))
 		{
-			zip = new ZipOutputStream( new FileOutputStream( zipPath ) );
 			// +1 for last slash
 			for (Map.Entry<File, FileFilter> e : input.entrySet()) {
 				zip( zip, e.getKey(), e.getKey().getPath().length() + 1, e.getValue() );
-			}
-		}
-		finally
-		{
-			if( zip != null )
-			{
-				zip.close();
 			}
 		}
 	}

--- a/org.eclipse.jdt.compiler.apt.tests/processors8/org/eclipse/jdt/compiler/apt/tests/processors/elements/Java8ElementProcessor.java
+++ b/org.eclipse.jdt.compiler.apt.tests/processors8/org/eclipse/jdt/compiler/apt/tests/processors/elements/Java8ElementProcessor.java
@@ -1094,11 +1094,9 @@ public class Java8ElementProcessor extends BaseProcessor {
 	private void createPackageBinary() throws IOException {
 		String path = packageName.replace('.', '/');
 		ClassLoader loader = getClass().getClassLoader();
-		InputStream in = loader.getResourceAsStream(path + "/package-info.class");
-		try {
+		try (InputStream in = loader.getResourceAsStream(path + "/package-info.class")) {
 			Filer filer = processingEnv.getFiler();
-			OutputStream out = filer.createClassFile(packageName + ".package-info").openOutputStream();
-			try {
+			try (OutputStream out = filer.createClassFile(packageName + ".package-info").openOutputStream()) {
 				if (in != null && out != null) {
 					int c = in.read();
 					while (c != -1) {
@@ -1106,11 +1104,7 @@ public class Java8ElementProcessor extends BaseProcessor {
 						c = in.read();
 					}
 				}
-			} finally {
-				out.close();
 			}
-		} finally {
-			in.close();
 		}
 	}
 

--- a/org.eclipse.jdt.compiler.apt.tests/processors8/org/eclipse/jdt/compiler/apt/tests/processors/filer/Java8FilerProcessor.java
+++ b/org.eclipse.jdt.compiler.apt.tests/processors8/org/eclipse/jdt/compiler/apt/tests/processors/filer/Java8FilerProcessor.java
@@ -101,11 +101,9 @@ public class Java8FilerProcessor extends BaseProcessor {
 	private void createPackageBinary() throws IOException {
 		String path = packageName.replace('.', '/');
 		ClassLoader loader = getClass().getClassLoader();
-		InputStream in = loader.getResourceAsStream(path + "/package-info.class");
-		try {
+		try (InputStream in = loader.getResourceAsStream(path + "/package-info.class")) {
 			Filer filer = processingEnv.getFiler();
-			OutputStream out = filer.createClassFile(packageName + ".package-info").openOutputStream();
-			try {
+			try (OutputStream out = filer.createClassFile(packageName + ".package-info").openOutputStream()) {
 				if (in != null && out != null) {
 					int c = in.read();
 					while (c != -1) {
@@ -113,11 +111,7 @@ public class Java8FilerProcessor extends BaseProcessor {
 						c = in.read();
 					}
 				}
-			} finally {
-				out.close();
 			}
-		} finally {
-			in.close();
 		}
 	}
 }

--- a/org.eclipse.jdt.compiler.apt.tests/src/org/eclipse/jdt/compiler/apt/tests/BatchTestUtils.java
+++ b/org.eclipse.jdt.compiler.apt.tests/src/org/eclipse/jdt/compiler/apt/tests/BatchTestUtils.java
@@ -559,18 +559,12 @@ public class BatchTestUtils {
 	public static byte[] read(java.io.File file) throws java.io.IOException {
 		int fileLength;
 		byte[] fileBytes = new byte[fileLength = (int) file.length()];
-		java.io.FileInputStream stream = null;
-		try {
-			stream = new java.io.FileInputStream(file);
+		try (java.io.FileInputStream stream = new java.io.FileInputStream(file)) {
 			int bytesRead = 0;
 			int lastReadSize = 0;
 			while ((lastReadSize != -1) && (bytesRead != fileLength)) {
 				lastReadSize = stream.read(fileBytes, bytesRead, fileLength - bytesRead);
 				bytesRead += lastReadSize;
-			}
-		} finally {
-			if (stream != null) {
-				stream.close();
 			}
 		}
 		return fileBytes;
@@ -623,15 +617,9 @@ public class BatchTestUtils {
 			}
 		}
 		// write bytes to dest
-		FileOutputStream out = null;
-		try {
-			out = new FileOutputStream(dest);
+		try (FileOutputStream out = new FileOutputStream(dest)) {
 			out.write(srcBytes);
 			out.flush();
-		} finally {
-			if (out != null) {
-				out.close();
-			}
 		}
 	}
 

--- a/org.eclipse.jdt.compiler.tool.tests/src/org/eclipse/jdt/compiler/tool/tests/CompilerInvocationTests.java
+++ b/org.eclipse.jdt.compiler.tool.tests/src/org/eclipse/jdt/compiler/tool/tests/CompilerInvocationTests.java
@@ -996,14 +996,8 @@ public void test021_output_streams() throws IOException {
 		Arrays.asList("-v"), null, null);
 	assertTrue(task.call());
 	Properties properties = new Properties();
-	InputStream resourceAsStream = null;
-	try {
-		resourceAsStream = Main.class.getResourceAsStream("messages.properties");
+	try (InputStream resourceAsStream = Main.class.getResourceAsStream("messages.properties")) {
 		properties.load(resourceAsStream);
-	} finally {
-		if (resourceAsStream != null) {
-			resourceAsStream.close();
-		}
 	}
 	assertTrue(outBuffer.toString().startsWith(properties.getProperty("compiler.name")));
 	assertTrue(errBuffer.toString().isEmpty());

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/BatchCompilerTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/BatchCompilerTest.java
@@ -3030,8 +3030,7 @@ public void test052(){
 	try {
 		new File(OUTPUT_DIR).mkdirs();
 		File barFile = new File(OUTPUT_DIR +  File.separator + "Bar.java");
-		FileOutputStream barOutput = new FileOutputStream(barFile);
-		try {
+		try (FileOutputStream barOutput = new FileOutputStream(barFile)) {
 			String barContents =
 				"public class Bar	\n" +
 				"{	\n" +
@@ -3040,8 +3039,6 @@ public void test052(){
 				"  }	\n" +
 				"}\n";
 			barOutput.write(barContents.getBytes());
-		} finally {
-			barOutput.close();
 		}
 	} catch(IOException e) {
 		// do nothing, will fail below
@@ -10011,11 +10008,8 @@ public void test275_jar_ref_in_jar(){
 }
 private boolean analyzeManifestContents(ManifestAnalyzer manifestAnalyzer,
 		String string) throws IOException {
-	InputStream stream = new ByteArrayInputStream(string.getBytes());
-	try {
+	try (InputStream stream = new ByteArrayInputStream(string.getBytes())) {
 		return manifestAnalyzer.analyzeManifestContents(stream);
-	} finally {
-		stream.close();
 	}
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=97332 - jars pointed by jars

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ManifestAnalyzerTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ManifestAnalyzerTest.java
@@ -41,11 +41,8 @@ public class ManifestAnalyzerTest extends AbstractRegressionTest {
 	}
 
 	private void analyzeManifestContents(String contents) throws IOException {
-		InputStream stream = new ByteArrayInputStream(contents.getBytes());
-		try {
+		try (InputStream stream = new ByteArrayInputStream(contents.getBytes())) {
 			this.manifestAnalyzer.analyzeManifestContents(stream);
-		} finally {
-			stream.close();
 		}
 	}
 	public void testWithOneJarWithWiteSpace() throws IOException {
@@ -154,11 +151,8 @@ public class ManifestAnalyzerTest extends AbstractRegressionTest {
 	}
 
 	public void testWithOneJarUsingUTF8Name() throws IOException {
-		InputStream inputStream = ManifestAnalyzerTest.class.getResourceAsStream("MANIFEST.MF");
-		try {
+		try (InputStream inputStream = ManifestAnalyzerTest.class.getResourceAsStream("MANIFEST.MF")) {
 			this.manifestAnalyzer.analyzeManifestContents(inputStream);
-		} finally {
-			inputStream.close();
 		}
 		List jars = this.manifestAnalyzer.getCalledFileNames();
 		assertEquals("Wrong size", 1, jars.size());

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/eval/target/CodeSnippetRunner.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/eval/target/CodeSnippetRunner.java
@@ -502,14 +502,8 @@ private void writeClassOnDisk(String className, byte[] classDefinition) {
 		if (!parent.exists()) {
 			throw new IOException("Could not create directory " + parent.getPath());
 		}
-		FileOutputStream out = null;
-		try {
-			out = new FileOutputStream(classFile);
+		try (FileOutputStream out = new FileOutputStream(classFile)) {
 			out.write(classDefinition);
-		} finally {
-			if (out != null) {
-				out.close();
-			}
 		}
 	} catch (IOException e) {
 		e.printStackTrace();

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/util/Util.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/util/Util.java
@@ -429,11 +429,8 @@ public static void copy(String sourcePath, String destPath) {
     }
 }
 public static void createFile(String path, String contents) throws IOException {
-    FileOutputStream output = new FileOutputStream(path);
-    try {
+    try (FileOutputStream output = new FileOutputStream(path)) {
         output.write(contents.getBytes());
-    } finally {
-        output.close();
     }
 }
 public static void createClassFolder(String[] pathsAndContents, String folderPath, String compliance) throws IOException {
@@ -1516,8 +1513,7 @@ public static void zipFiles(File[] files, String zipPath) throws IOException {
 	} else {
 		zipFile.getParentFile().mkdirs();
 	}
-	ZipOutputStream zip = new ZipOutputStream(new FileOutputStream(zipFile));
-	try {
+	try (ZipOutputStream zip = new ZipOutputStream(new FileOutputStream(zipFile))) {
 		for (int i = 0, length = files.length; i < length; i++) {
 			File file = files[i];
 			ZipEntry entry = new ZipEntry(file.getName());
@@ -1525,8 +1521,6 @@ public static void zipFiles(File[] files, String zipPath) throws IOException {
 			zip.write(org.eclipse.jdt.internal.compiler.util.Util.getFileByteContent(file));
 			zip.closeEntry();
 		}
-	} finally {
-		zip.close();
 	}
 }
 /**

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/util/VerifyTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/util/VerifyTests.java
@@ -53,8 +53,7 @@ private static URL[] classPathToURLs(String[] classPath) throws MalformedURLExce
 }
 
 public void loadAndRun(String className, String[] classPath) throws Throwable {
-	URLClassLoader urlClassLoader = new URLClassLoader(classPathToURLs(classPath));
-	try {
+	try (URLClassLoader urlClassLoader = new URLClassLoader(classPathToURLs(classPath))) {
 		//System.out.println("Loading " + className + "...");
 		Class testClass = urlClassLoader.loadClass(className);
 		//System.out.println("Loaded " + className);
@@ -68,8 +67,6 @@ public void loadAndRun(String className, String[] classPath) throws Throwable {
 		} catch (InvocationTargetException e) {
 			throw e.getTargetException();
 		}
-	} finally {
-		urlClassLoader.close();
 	}
 }
 public static void main(String[] args) throws IOException {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/formatter/FormatterMassiveRegressionTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/formatter/FormatterMassiveRegressionTests.java
@@ -485,8 +485,7 @@ protected static Test suite(File inputDir, String profile, Map directories) {
 				listFileWriter.newLine();
 			} else {
 				System.out.print("stored list in "+listFile.getPath()+"...");
-				BufferedReader listFileReader = new BufferedReader(new InputStreamReader(new FileInputStream(listFile.getAbsolutePath())));
-				try {
+				try (BufferedReader listFileReader = new BufferedReader(new InputStreamReader(new FileInputStream(listFile.getAbsolutePath())))) {
 					// First line is the number of files
 					String line = listFileReader.readLine();
 					int maxFiles = Integer.parseInt(line);
@@ -506,9 +505,6 @@ protected static Test suite(File inputDir, String profile, Map directories) {
 				catch (IOException ioe) {
 					ioe.printStackTrace();
 					return null;
-				}
-				finally {
-					listFileReader.close();
 				}
 			}
 			directories.put(inputDir, allFiles);

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AbstractJavaModelTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AbstractJavaModelTests.java
@@ -1639,11 +1639,8 @@ public abstract class AbstractJavaModelTests extends SuiteOfTestCases {
 		}
 
 		// write bytes to dest
-		FileOutputStream out = new FileOutputStream(dest);
-		try {
+		try (FileOutputStream out = new FileOutputStream(dest)) {
 			out.write(srcBytes);
-		} finally {
-			out.close();
 		}
 	}
 

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ClasspathTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ClasspathTests.java
@@ -175,11 +175,8 @@ private void assertEncodeDecodeEntry(String projectName, String expectedEncoded,
 }
 protected File createFile(File parent, String name, String content) throws IOException {
 	File file = new File(parent, name);
-	FileOutputStream out = new FileOutputStream(file);
-	try {
+	try (FileOutputStream out = new FileOutputStream(file)) {
 		out.write(content.getBytes());
-	} finally {
-		out.close();
 	}
 	/*
 	 * Need to change the time stamp to realize that the file has been modified
@@ -2988,15 +2985,10 @@ public void testEncoding2() throws Exception {
 		IJavaProject p = createJavaProject("P", new String[] {"src"}, "bin");
 		IFile file = getFile("/P/.classpath");
 		byte[] contents = org.eclipse.jdt.internal.core.util.Util.getResourceContentsAsByteArray(file);
-		FileOutputStream output = null;
-		try {
-			output = new FileOutputStream(file.getLocation().toFile());
+		try (FileOutputStream output = new FileOutputStream(file.getLocation().toFile())) {
 			output.write(IContentDescription.BOM_UTF_8); // UTF-8 BOM
 			output.write(contents);
 			output.flush();
-		} finally {
-			if (output != null)
-				output.close();
 		}
 		file.refreshLocal(IResource.DEPTH_ONE, null);
 

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests2.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests2.java
@@ -196,11 +196,8 @@ public static Test suite() {
 
 static File createFile(File parent, String name, String content) throws IOException {
 	File file = new File(parent, name);
-	FileOutputStream out = new FileOutputStream(file);
-	try {
+	try (FileOutputStream out = new FileOutputStream(file)) {
 		out.write(content.getBytes());
-	} finally {
-		out.close();
 	}
 	return file;
 }

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionWithMissingTypesTests2.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionWithMissingTypesTests2.java
@@ -75,11 +75,8 @@ public static Test suite() {
 
 File createFile(File parent, String name, String content) throws IOException {
 	File file = new File(parent, name);
-	FileOutputStream out = new FileOutputStream(file);
-	try  {
+	try (FileOutputStream out = new FileOutputStream(file))  {
 		out.write(content.getBytes());
-	} finally {
-		out.close();
 	}
 	return file;
 }

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/EncodingTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/EncodingTests.java
@@ -707,8 +707,7 @@ public class EncodingTests extends ModifyingResourceTests {
 
 			// Read file using a transformation where a character is read and the next alphabetical character is
 			// automaticaly added
-			final InputStream fileStream = file.getContents();
-			try {
+			try (final InputStream fileStream = file.getContents()) {
 				InputStream in = new InputStream() {
 					int current = -1;
 					@Override
@@ -733,8 +732,6 @@ public class EncodingTests extends ModifyingResourceTests {
 					"abcdefghijklmn",
 					new String(result)
 				);
-			} finally {
-				fileStream.close();
 			}
 		} finally {
 			deleteFile("Encoding/Test34.txt");

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaProjectTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaProjectTests.java
@@ -1681,15 +1681,10 @@ public void testPackageFragmentRootNonJavaResources8() throws CoreException {
  */
 public void testPackageFragmentRootNonJavaResources9() throws Exception {
 	try {
-		ZipOutputStream zip = null;
-		try {
-			zip = new ZipOutputStream(new FileOutputStream(getExternalFile("lib.jar")));
+		try (ZipOutputStream zip = new ZipOutputStream(new FileOutputStream(getExternalFile("lib.jar")))) {
 			// the bug occurred only if META-INF/MANIFEST.MF was before META-INF in the ZIP file
 			// Altered the test for 534624. Usage of Zip file system for traversal no longer sees two different entries, but just the file.
 			zip.putNextEntry(new ZipEntry("META-INF/MANIFEST.MF"));
-		} finally {
-			if (zip != null)
-				zip.close();
 		}
 		createJavaProject("P", new String[0], new String[] {getExternalResourcePath("lib.jar")}, "");
 		waitForManualRefresh();

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ModelTestsUtil.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ModelTestsUtil.java
@@ -67,11 +67,8 @@ static public void copy(File src, File dest) throws IOException {
 	}
 
 	// write bytes to dest
-	FileOutputStream out = new FileOutputStream(dest);
-	try {
+	try (FileOutputStream out = new FileOutputStream(dest)) {
 		out.write(srcBytes);
-	} finally {
-		out.close();
 	}
 }
 

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ModifyingResourceTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ModifyingResourceTests.java
@@ -150,8 +150,7 @@ public static void generateClassFile(String className, String javaSource) throws
 	String cu = "d:/temp/" + className + ".java";
 	Util.createFile(cu, javaSource);
 	BatchCompiler.compile(cu + " -d d:/temp -classpath " + System.getProperty("java.home") + "/lib/rt.jar", new PrintWriter(System.out), new PrintWriter(System.err), null/*progress*/);
-	FileInputStream input = new FileInputStream("d:/temp/" + className + ".class");
-	try {
+	try (FileInputStream input = new FileInputStream("d:/temp/" + className + ".class")) {
 		System.out.println("{");
 		byte[] buffer = new byte[80];
 		int read = 0;
@@ -165,8 +164,6 @@ public static void generateClassFile(String className, String javaSource) throws
 			if (read != -1) System.out.println();
 		}
 		System.out.print("}");
-	} finally {
-		input.close();
 	}
 }
 

--- a/org.eclipse.jdt.core.tests.performance/src/org/eclipse/jdt/core/tests/performance/SecondaryTypesPerformanceTest.java
+++ b/org.eclipse.jdt.core.tests.performance/src/org/eclipse/jdt/core/tests/performance/SecondaryTypesPerformanceTest.java
@@ -163,11 +163,9 @@ public class SecondaryTypesPerformanceTest extends PerformanceTestCase {
 	}
 
 	private void writeFile(File aFile, String aSource) throws IOException {
-		FileWriter fileWriter = new FileWriter(aFile);
-		try {
+
+		try (FileWriter fileWriter = new FileWriter(aFile)) {
 			fileWriter.write(aSource);
-		} finally {
-			fileWriter.close();
 		}
 	}
 }


### PR DESCRIPTION
Using the JDT UI try-with-resource clean-up on core

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
