### PR TITLE
Use Use lazy logical operator (&& and ||)

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LambdaExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LambdaExpression.java
@@ -509,7 +509,7 @@ public class LambdaExpression extends FunctionalExpression implements IPolyExpre
 		if (this.original == this) {
 			this.committed = true; // the original has been resolved
 		}
-		return (argumentsHaveErrors|parametersHaveErrors) ? null : this.resolvedType;
+		return (argumentsHaveErrors || parametersHaveErrors) ? null : this.resolvedType;
 	}
 
 	// check if the given types are parameterized types and if their type arguments

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
@@ -12014,7 +12014,7 @@ protected CompilationUnitDeclaration endParse(int act) {
 		}
 		this.currentElement.topElement().updateParseTree();
 	} else {
-		if (this.diet & VERBOSE_RECOVERY){
+		if (this.diet && VERBOSE_RECOVERY){
 			System.out.print(Messages.parser_regularParse);
 			System.out.println("--------------------------");	 //$NON-NLS-1$
 			System.out.println(this.compilationUnit);

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/CompletionEngine.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/CompletionEngine.java
@@ -10396,7 +10396,7 @@ public final class CompletionEngine
 					if (receiverType != null) {
 						receiverSourceName = receiverType.sourceName;
 					}
-					if( enclosingSourceName !=null & receiverSourceName !=null)
+					if( enclosingSourceName !=null && receiverSourceName !=null)
 						isEqual = Arrays.equals(enclosingSourceName, receiverSourceName);
 					if(isEqual) {
 						findKeywords(token, new char[][] { Keywords.THIS }, true, false);


### PR DESCRIPTION
Running the performance clean-up "Use lazy logical operator (&& and ||)" on JDT core

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
