### PR TITLE
Using Integer.toString directly in Disassembler

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/Disassembler.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/Disassembler.java
@@ -1927,7 +1927,7 @@ public class Disassembler extends ClassFileBytesDisassembler {
 			ConstantPoolEntry constantPoolEntry =  (ConstantPoolEntry) constantPool.decodeEntry(bootstrapArguments[i]);
 			switch(constantPoolEntry.getKind()) {
 				case IConstantPoolConstant.CONSTANT_Integer:
-					arguments[i] = ((Integer) constantPoolEntry.getIntegerValue()).toString();
+					arguments[i] = Integer.toString(constantPoolEntry.getIntegerValue());
 					break;
 				case IConstantPoolConstant.CONSTANT_MethodHandle:
 					// http://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.4.8


### PR DESCRIPTION
It is also a JDT UI performance clean-up but this clean-up found only one occurrence.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
