### PR TITLE
Mark CodeFormatter for removal

### DIFF
--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/old/CodeFormatter.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/old/CodeFormatter.java
@@ -30,6 +30,7 @@ import org.eclipse.text.edits.TextEdit;
  * @deprecated
 */
 @SuppressWarnings({ "rawtypes", "unchecked" })
+@Deprecated(forRemoval = true, since = "2024-03")
 public class CodeFormatter implements TerminalTokens, org.eclipse.jdt.core.ICodeFormatter {
 
 	private Map options;


### PR DESCRIPTION
Was deprecated in 2008, so we should mark it for removal (following the API removal process, that will allow us to remove it in 2 years)

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
