### PR TITLE
Remove unused PrintWriter local variable in ReadAnnotationTypeProcessor

### DIFF
--- a/org.eclipse.jdt.apt.tests/src-annotations/org/eclipse/jdt/apt/tests/annotations/readAnnotationType/ReadAnnotationTypeProcessor.java
+++ b/org.eclipse.jdt.apt.tests/src-annotations/org/eclipse/jdt/apt/tests/annotations/readAnnotationType/ReadAnnotationTypeProcessor.java
@@ -31,7 +31,6 @@ public class ReadAnnotationTypeProcessor extends BaseProcessor {
     }
 
     public void process() {
-        PrintWriter writer = null;
         try
         {
             Collection<Declaration> declarations = _env.getDeclarationsAnnotatedWith(_annotationType);
@@ -41,12 +40,6 @@ public class ReadAnnotationTypeProcessor extends BaseProcessor {
         {
             e.printStackTrace();
             _env.getMessager().printError(e.getMessage());
-        } finally
-        {
-            if (writer != null)
-            {
-                writer.close();
-            }
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
