### PR TITLE
CompilationUnitResolver: Name the CU that causes Exception

### DIFF
--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/CompilationUnitResolver.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/CompilationUnitResolver.java
@@ -1004,9 +1004,12 @@ class CompilationUnitResolver extends Compiler {
 						ast.setDefaultNodeFlag(0);
 						ast.setOriginalModificationCount(ast.modificationCount());
 
-						// pass it to requestor
-						astRequestor.acceptAST(source, compilationUnit);
-
+						try {
+							// pass it to requestor
+							astRequestor.acceptAST(source, compilationUnit);
+						} catch (RuntimeException e) {
+							throw new RuntimeException("Error on " + source.getPath(), e); //$NON-NLS-1$
+						}
 						worked(1);
 
 						// remove at the end so that we don't resolve twice if a source and a key for the same file name have been requested


### PR DESCRIPTION
for example during Cleanup
https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/950

![image](https://github.com/eclipse-jdt/eclipse.jdt.core/assets/51790620/6f0dcefd-1725-494a-87f4-011c7dbb9408)
