### PR TITLE
Moving the comment back in CompletionOnQualifiedNameReference

### DIFF
--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnQualifiedNameReference.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnQualifiedNameReference.java
@@ -77,8 +77,10 @@ public TypeBinding resolveType(BlockScope scope) {
 
 		throw new CompletionNodeFound();
 	}
-	
-	// probably not in the position to do useful resolution, just provide some binding
-	return new CompletionNodeFound(this, this.binding, scope).throwOrDeferAndReturn(() -> (this.resolvedType = new ProblemReferenceBinding(this.tokens, null, ProblemReasons.NotFound)));
+
+	return new CompletionNodeFound(this, this.binding, scope).throwOrDeferAndReturn(() -> {
+		// probably not in the position to do useful resolution, just provide some binding
+		return this.resolvedType = new ProblemReferenceBinding(this.tokens, null, ProblemReasons.NotFound);
+	});
 }
 }


### PR DESCRIPTION
Putting the comment above the return statement is confusing, so lets move it back inside the lambda.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
