### PR TITLE
Add test for reproducing #1654

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/CompilationUnitScope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/CompilationUnitScope.java
@@ -412,8 +412,13 @@ void connectTypeHierarchy() {
 void integrateAnnotationsInHierarchy() {
 	// Only now that all hierarchy information is built we're ready for ...
 	// ... integrating annotations
-	for (int i = 0, length = this.topLevelTypes.length; i < length; i++)
-		this.topLevelTypes[i].scope.referenceType().updateSupertypesWithAnnotations(Collections.emptyMap());
+	try {
+		this.environment.suppressImportErrors = true;
+		for (int i = 0, length = this.topLevelTypes.length; i < length; i++)
+			this.topLevelTypes[i].scope.referenceType().updateSupertypesWithAnnotations(Collections.emptyMap());
+	} finally {
+		this.environment.suppressImportErrors = false;
+	}
 	// ... checking on permitted types
 	connectPermittedTypes();
 	for (int i = 0, length = this.topLevelTypes.length; i < length; i++)


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
Add test for #1654, based on existing test_github844() method.
The breakage is caused by this combination:
- import some class generated by some annotation processor
- to some other annotation, pass a value that is defined right within the currently compiled project

Beyond the breakage this test also shows small code changes which cause the compiler not to break.

## How to test
Run `AnnotationProcessingCompilerToolTest.test_github1654()` as JUnit Plug-in Test

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
