### PR TITLE
Javadoc format fixes (part 2)

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/core/JavaCore.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/core/JavaCore.java
@@ -1530,7 +1530,7 @@ public final class JavaCore extends Plugin {
 	 * Compiler option ID: Reporting a resource that may not be closed properly.
 	 * <p>When enabled, the compiler will issue an error or a warning if
 	 *    a local variable holds a value of type <code>java.lang.AutoCloseable</code> (compliance>=1.7)
-	 *    or a value of type <code>java.io.Closeable</code> (compliance<=1.6) and if
+	 *    or a value of type <code>java.io.Closeable</code> (compliance&lt;=1.6) and if
 	 *    flow analysis shows that the method <code>close()</code> is
 	 *    not invoked locally on that value for all execution paths.</p>
 	 * <dl>
@@ -2934,7 +2934,7 @@ public final class JavaCore extends Plugin {
 	 *    one of the proposed suffixes.</p>
 	 * <dl>
 	 * <dt>Option id:</dt><dd><code>"org.eclipse.jdt.core.codeComplete.staticFinalFieldSuffixes"</code></dd>
-	 * <dt>Possible values:</dt><dd>{@code "<suffix>[<suffix>]*" }< where {@code <suffix>} is a String without any wild-card</dd>
+	 * <dt>Possible values:</dt><dd>{@code "<suffix>[<suffix>]*" }&lt; where {@code <suffix>} is a String without any wild-card</dd>
 	 * <dt>Default:</dt><dd><code>""</code></dd>
 	 * </dl>
 	 * @since 3.5

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/core/Signature.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/core/Signature.java
@@ -42,11 +42,11 @@ import org.eclipse.jdt.internal.compiler.util.Util;
  * with J2SE 1.4 or earlier, involved only <i>simple</i> signatures.
  * </p>
  * <p>
- * Note that the "Q", "!", "|" and "&" formats are specific to Eclipse; the remainder
+ * Note that the "Q", "!", "|" and "&amp;" formats are specific to Eclipse; the remainder
  * are specified in the JVM spec.
  * </p>
  * <p>
- * Due to historical reasons Eclipse uses "|" format for Intersection and "&" for Union
+ * Due to historical reasons Eclipse uses "|" format for Intersection and "&amp;" for Union
  * which is opposite to their usage in source code.
  * </p>
  * <p>
@@ -150,7 +150,7 @@ import org.eclipse.jdt.internal.compiler.util.Util;
  * <ul>
  *   <li><code>"X:"</code> denotes <code>X</code></li>
  *   <li><code>"X:QReader;"</code> denotes <code>X extends Reader</code> in source code</li>
- *   <li><code>"X:QReader;:QSerializable;"</code> denotes <code>X extends Reader & Serializable</code> in source code</li>
+ *   <li><code>"X:QReader;:QSerializable;"</code> denotes <code>X extends Reader &amp; Serializable</code> in source code</li>
  * </ul>
  * <p>
  * This class provides static methods and constants only.

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/core/jdom/IDOMType.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/core/jdom/IDOMType.java
@@ -163,7 +163,7 @@ public void setAnnotation(boolean b);
  * Sets the formal type parameters for this type.
  * <p>Formal type parameters are given as they appear in the source
  * code; for example:
- * <code>"X extends List&lt;String&gt; &amp Serializable"</code>.
+ * <code>"X extends List&lt;String&gt; &amp; Serializable"</code>.
  * </p>
  *
  * @param typeParameters the formal type parameters of this type,


### PR DESCRIPTION
Contributes to
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/1531. It's a pity that this takes multiple cycles but fixing one thing from the log uncovers the next.

