### PR TITLE
ECJ 3.36.0 regression: The type 'E extends java.lang.Exception' is not a valid substitute for the type parameter 'E extends java.lang.@NonNull Exception'

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Scope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Scope.java
@@ -986,8 +986,8 @@ public abstract class Scope {
 				nextBound: for (int j = 0, boundLength = boundRefs.length; j < boundLength; j++) {
 					typeRef = boundRefs[j];
 					superType = this.kind == METHOD_SCOPE
-						? typeRef.resolveType((BlockScope)this, false)
-						: typeRef.resolveType((ClassScope)this);
+						? typeRef.resolveType((BlockScope)this, false, Binding.DefaultLocationTypeBound)
+						: typeRef.resolveType((ClassScope)this, Binding.DefaultLocationTypeBound);
 					if (superType == null) {
 						typeVariable.tagBits |= TagBits.HierarchyHasProblems;
 						continue nextBound;

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TestAll.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TestAll.java
@@ -235,7 +235,7 @@ public static Test suite() {
 	 since_21.add(SwitchPatternTest.class);
 	 since_21.add(RecordPatternTest.class);
 //	 since_21.add(UnnammedPatternsAndVarsTest.class); Enable after implementation.
-	 since_21.add(NullAnnotationTests18.class);
+	 since_21.add(NullAnnotationTests21.class);
 	 since_21.add(StringTemplateTest.class);
 
 	 // Build final test suite

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/RunOnlyJava19Tests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/RunOnlyJava19Tests.java
@@ -18,7 +18,7 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 
-import org.eclipse.jdt.core.tests.compiler.regression.NullAnnotationTests18;
+import org.eclipse.jdt.core.tests.compiler.regression.NullAnnotationTests21;
 import org.eclipse.jdt.core.tests.compiler.regression.RecordPatternTest;
 import org.eclipse.jdt.core.tests.compiler.regression.SwitchPatternTest;
 import org.eclipse.jdt.core.tests.dom.ConverterTestSetup;
@@ -36,7 +36,7 @@ public class RunOnlyJava19Tests extends TestCase {
 	public static Class[] getAllTestClasses() {
 		return new Class[] {
 			RecordPatternTest.class,
-			NullAnnotationTests18.class,
+			NullAnnotationTests21.class,
 			SwitchPatternTest.class
 		};
 	}


### PR DESCRIPTION
fixes #1691


## What it does

Resolve a TODO from #1413 whereby bounds of type parameters have not been fully updated with annotations.

+ also slightly updates NullAnnotationTests18 as NullAnnotationTests21

## How to test
JUnits included

