### PR TITLE
Enhance resource leak analysis with additional annotation(s)

### DIFF
--- a/org.eclipse.jdt.annotation/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.annotation/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %bundleName
 Bundle-Localization: bundle
 Bundle-SymbolicName: org.eclipse.jdt.annotation
-Bundle-Version: 2.2.900.qualifier
+Bundle-Version: 2.3.0.qualifier
 Export-Package: org.eclipse.jdt.annotation
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Vendor: %providerName

--- a/org.eclipse.jdt.annotation/pom.xml
+++ b/org.eclipse.jdt.annotation/pom.xml
@@ -17,7 +17,7 @@
     <version>4.31.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.eclipse.jdt.annotation</artifactId>
-  <version>2.2.900-SNAPSHOT</version>
+  <version>2.3.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <build>

--- a/org.eclipse.jdt.annotation/src/org/eclipse/jdt/annotation/NotOwning.java
+++ b/org.eclipse.jdt.annotation/src/org/eclipse/jdt/annotation/NotOwning.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2024 GK Software SE and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Stephan Herrmann - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation allows to specify absence of responsibility for certain objects as they are passed from one method to another.
+ * <p>This annotation is the direct inverse of {@link Owning} and can be used in all locations, where that annotation is used.
+ *  {@code @NotOwning} can be used do specify a shared responsibility rather than the clear separation between sources
+ *  and sinks of resources given by {@link Owning}.
+ * </p>
+ * <p>
+ *  In particular the annotation {@code @NotOwning} makes explicit that absence of {@code @Owning} is by intention.
+ * </p>
+ * <p>Additionally, placing {@code @NotOwning} on a class that implements {@link AutoCloseable} specifies that instances of this
+ *  class do <em>not</em> hold any gc-resistant resources and therefore calling {@link AutoCloseable#close()} is not necessary.
+ * </p>
+ *
+ * @since 2.3
+ */
+@Retention(RetentionPolicy.CLASS)
+@Documented
+@Target({ ElementType.TYPE, ElementType.PARAMETER, ElementType.METHOD, ElementType.FIELD })
+public @interface NotOwning {
+	// no details
+}

--- a/org.eclipse.jdt.annotation/src/org/eclipse/jdt/annotation/Owning.java
+++ b/org.eclipse.jdt.annotation/src/org/eclipse/jdt/annotation/Owning.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2023 GK Software SE and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Stephan Herrmann - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation allows to specify responsibility for certain objects as they are passed from one method to another.
+ * <p>
+ * Based on this annotation, flow oriented analysis tools can be made more precise without the need to perform
+ * full-system analysis, as the {@code @Owning} annotation describes a contract, consisting of two sides that can be
+ * checked independently.
+ * </p>
+ * <p>
+ * The Eclipse Compiler for Java&trade; (version 3.37 and greater) interprets this annotation when placed on a value of
+ * type {@link AutoCloseable} or any subtype. This annotation is interpreted specifically in these locations:
+ * </p>
+ * <dl>
+ * <dt>Method parameter ({@link ElementType#PARAMETER}):</dt>
+ * <dd>Here {@link Owning} denotes that responsibility to close a resource passed into this parameter will lie with the
+ * receiving method, on this particular flow.
+ * </dd>
+ * <dt>Method ({@link ElementType#METHOD}) - as a way to refer to the method return value:</dt>
+ * <dd>Here {@link Owning} denotes that responsibility to close a resource received from a call to this method will lie
+ * with the receiving code.
+ * </dd></dd></dt>
+ * <p>Responsibility to close a resource may <strong>initially arise</strong> from these situations:</p>
+ * <ul>
+ * <li>Instantiating a class that is a subtype of {@link AutoCloseable}.</li>
+ * <li>Receiving a method argument via a parameter of type {@link AutoCloseable} (or subtype) that is marked as {@code @Owning}.</li>
+ * <li>Receiving a result from a call to method that is marked as {@code @Owning} and returns {@link AutoCloseable} (or a subtype).
+ * 	<ul><li>If the {@code @Owning} annotation is absent in this situation, the receiving method is <em>potentially responsible</em>.</li></ul>
+ * </li>
+ * <li>
+ * <p>Responsibility to close a resource may be <strong>fulfilled</strong> by ensuring any of these measures on every possible path:</p>
+ * <ul>
+ * <li>Invoking {@link AutoCloseable#close()}.
+ * <li>Passing the resource into a method where the receiving parameter has type {@link AutoCloseable} (or subtype)
+ *  and is marked as {@code @Owning}.</li>
+ * <li>Returning the resource to the caller, provided that the current method is marked as {@code @Owning} and has a declared return type
+ * 	of {@link AutoCloseable} (or a subtype).</li>
+ * </ul>
+ *
+ * @since 2.3
+ */
+@Retention(RetentionPolicy.CLASS)
+@Documented
+@Target({ ElementType.PARAMETER, ElementType.METHOD })
+public @interface Owning {
+	// no details
+}

--- a/org.eclipse.jdt.annotation/src/org/eclipse/jdt/annotation/Owning.java
+++ b/org.eclipse.jdt.annotation/src/org/eclipse/jdt/annotation/Owning.java
@@ -44,6 +44,10 @@ import java.lang.annotation.Target;
  *  enclosing object. In order to allow for precise analysis in this situation, it is recommended that the enclosing
  *  class of such a field implements {@link AutoCloseable}. In that case, it will be the responsibility of the class's
  *  {@code close()} implementation to also close all resources stored in {@code @Owning} fields.
+ * <dt>Method receiver (via {@link ElementType#TYPE_USE})</dt>
+ * <dd>Annotating a method receiver (explicit {@code this} parameter) as owning signals that the method is responsible
+ *  for closing all contained resources. The method will be treated as a "custom close method".<br/>
+ *  The annotation is not evaluated in any other TYPE_USE locations.
  * </dl>
  * <p><strong>Responsibility</strong> to close a resource may <strong>initially arise</strong> from these situations:</p>
  * <ul>
@@ -52,26 +56,27 @@ import java.lang.annotation.Target;
  * <li>Receiving a result from a call to method that is marked as {@code @Owning} and returns {@link AutoCloseable} (or a subtype).
  * 	<ul><li>If the {@code @Owning} annotation is absent in this situation, the receiving method is <em>potentially responsible</em>.</li></ul>
  * </li>
- * <li>Within the {@code close()} method of a class implementing {@link AutoCloseable}, each resource field annotations as {@code @Owning}
- * must be closed.</li>
+ * <li>Within the {@code close()} method of a class implementing {@link AutoCloseable}, and within each "custom close method",
+ *  each resource field annotated as {@code @Owning} must be closed.</li>
  * </ul>
  * <p><strong>Responsibility</strong> to close a resource may be <strong>fulfilled</strong> by ensuring any of these measures on every possible path:</p>
  * <ul>
- * <li>Invoking {@link AutoCloseable#close()}.
+ * <li>Invoking {@link AutoCloseable#close()} or a "custom close method".</li>
  * <li>Passing the resource into a method where the receiving parameter has type {@link AutoCloseable} (or subtype)
  *  and is marked as {@code @Owning}.</li>
  * <li>Returning the resource to the caller, provided that the current method is marked as {@code @Owning} and has a declared return type
  * 	of {@link AutoCloseable} (or a subtype).</li>
  * <li>Assigning the resource to a field annotated as {@code @Owning}.
- * <li>Within the {@code close()} method of a class implementing {@link AutoCloseable} (see above) closing the resource held by a field
- *  tagged as {@code @Owning} can happen either directly, or for inherited fields by invoking {@code super.close()}.
+ * <li>Within the {@code close()} method of a class implementing {@link AutoCloseable} and within a "custom close method"
+ *  closing the resource held by a field tagged as {@code @Owning} can happen either directly, or for inherited fields
+ *  by invoking {@code super.close()}, or the super version of a "custom close method".
  * </ul>
  *
  * @since 2.3
  */
 @Retention(RetentionPolicy.CLASS)
 @Documented
-@Target({ ElementType.PARAMETER, ElementType.METHOD, ElementType.FIELD })
+@Target({ ElementType.PARAMETER, ElementType.METHOD, ElementType.FIELD, ElementType.TYPE_USE })
 public @interface Owning {
 	// no details
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/core/compiler/IProblem.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/core/compiler/IProblem.java
@@ -2048,6 +2048,9 @@ void setSourceStart(int sourceStart);
 	/** @since 3.14 */
 	int DuplicateResource = Internal + 1251;
 
+	/** @since 3.37 */
+	int ShouldMarkMethodAsOwning = Internal + 1260;
+
 	// terminally
 	/** @since 3.14 */
 	int UsingTerminallyDeprecatedType = TypeRelated + 1400;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/core/compiler/IProblem.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/core/compiler/IProblem.java
@@ -2050,6 +2050,16 @@ void setSourceStart(int sourceStart);
 
 	/** @since 3.37 */
 	int ShouldMarkMethodAsOwning = Internal + 1260;
+	/** @since 3.37 */
+	int MandatoryCloseNotShown = Internal + 1261;
+	/** @since 3.37 */
+	int MandatoryCloseNotShownAtExit = Internal + 1262;
+	/** @since 3.37 */
+	int NotOwningResourceField = Internal + 1263;
+	/** @since 3.37 */
+	int OwningFieldInNonResourceClass = Internal + 1264;
+	/** @since 3.37 */
+	int OwningFieldShouldImplementClose = Internal + 1265;
 
 	// terminally
 	/** @since 3.14 */

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/core/compiler/IProblem.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/core/compiler/IProblem.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -2060,6 +2060,10 @@ void setSourceStart(int sourceStart);
 	int OwningFieldInNonResourceClass = Internal + 1264;
 	/** @since 3.37 */
 	int OwningFieldShouldImplementClose = Internal + 1265;
+	/** @since 3.37 */
+	int OverrideReducingParamterOwning = Internal + 1266;
+	/** @since 3.37 */
+	int OverrideAddingReturnOwning = Internal + 1267;
 
 	// terminally
 	/** @since 3.14 */

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AbstractMethodDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AbstractMethodDeclaration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -669,6 +669,15 @@ public abstract class AbstractMethodDeclaration
 
 		if (this.receiver.type.hasNullTypeAnnotation(AnnotationPosition.ANY)) {
 			this.scope.problemReporter().nullAnnotationUnsupportedLocation(this.receiver.type);
+		}
+		if (this.scope.compilerOptions().isAnnotationBasedResourceAnalysisEnabled && this.receiver.type.resolvedType != null) {
+			for (AnnotationBinding annotationBinding : this.receiver.type.resolvedType.getTypeAnnotations()) {
+				ReferenceBinding annotationType = annotationBinding.getAnnotationType();
+				if (annotationType != null && annotationType.hasTypeBit(TypeIds.BitOwningAnnotation)) {
+					this.binding.extendedTagBits = ExtendedTagBits.IsClosingMethod;
+					break;
+				}
+			}
 		}
 	}
 	public void resolveJavadoc() {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AbstractMethodDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AbstractMethodDeclaration.java
@@ -274,9 +274,11 @@ public abstract class AbstractMethodDeclaration
 				// tag parameters as being set:
 				flowInfo.markAsDefinitelyAssigned(local);
 
-				if (usesOwningAnnotations) {
+				if (usesOwningAnnotations && local.type.hasTypeBit(TypeIds.BitAutoCloseable|TypeIds.BitCloseable)) {
+					long owningTagBits = local.tagBits & TagBits.AnnotationOwningMASK;
 					int initialNullStatus = (local.tagBits & TagBits.AnnotationOwning) !=0 ? FlowInfo.NULL : FlowInfo.NON_NULL; // defaulting to not-owning
-					local.closeTracker = new FakedTrackingVariable(local, methodArguments[i], flowInfo, flowContext, initialNullStatus);
+					local.closeTracker = new FakedTrackingVariable(local, methodArguments[i], flowInfo, flowContext, initialNullStatus, usesOwningAnnotations);
+					local.closeTracker.owningState = FakedTrackingVariable.owningStateFromTagBits(owningTagBits, FakedTrackingVariable.NOT_OWNED_PER_DEFAULT);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AbstractMethodDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AbstractMethodDeclaration.java
@@ -35,6 +35,7 @@ import java.util.List;
 import org.eclipse.jdt.core.compiler.*;
 import org.eclipse.jdt.internal.compiler.*;
 import org.eclipse.jdt.internal.compiler.ast.TypeReference.AnnotationPosition;
+import org.eclipse.jdt.internal.compiler.flow.FlowContext;
 import org.eclipse.jdt.internal.compiler.flow.FlowInfo;
 import org.eclipse.jdt.internal.compiler.impl.*;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
@@ -113,6 +114,12 @@ public abstract class AbstractMethodDeclaration
 			for (int i = 0, length = arguments.length; i < length; i++) {
 				Argument argument = arguments[i];
 				binding.parameters[i] = argument.createBinding(scope, binding.parameters[i]);
+				if ((argument.binding.tagBits & TagBits.AnnotationOwning) != 0) {
+					if (binding.parameterOwning == null) {
+						binding.parameterOwning = new Boolean[arguments.length];
+					}
+					binding.parameterOwning[i] = Boolean.TRUE;
+				}
 				if (useTypeAnnotations)
 					continue; // no business with SE7 null annotations in the 1.8 case.
 				// createBinding() has resolved annotations, now transfer nullness info from the argument to the method:
@@ -215,36 +222,44 @@ public abstract class AbstractMethodDeclaration
 	/**
 	 * Feed null information from argument annotations into the analysis and mark arguments as assigned.
 	 */
-	static void analyseArguments(LookupEnvironment environment, FlowInfo flowInfo, Argument[] methodArguments, MethodBinding methodBinding) {
+	static void analyseArguments(LookupEnvironment environment, FlowInfo flowInfo, FlowContext flowContext, Argument[] methodArguments, MethodBinding methodBinding) {
 		if (methodArguments != null) {
 			boolean usesNullTypeAnnotations = environment.usesNullTypeAnnotations();
+			boolean usesOwningAnnotation = environment.usesOwningAnnotation();
+
 			int length = Math.min(methodBinding.parameters.length, methodArguments.length);
 			for (int i = 0; i < length; i++) {
+				TypeBinding parameterBinding = methodBinding.parameters[i];
+				LocalVariableBinding local = methodArguments[i].binding;
 				if (usesNullTypeAnnotations) {
 					// leverage null type annotations:
-					long tagBits = methodBinding.parameters[i].tagBits & TagBits.AnnotationNullMASK;
+					long tagBits = parameterBinding.tagBits & TagBits.AnnotationNullMASK;
 					if (tagBits == TagBits.AnnotationNonNull)
-						flowInfo.markAsDefinitelyNonNull(methodArguments[i].binding);
+						flowInfo.markAsDefinitelyNonNull(local);
 					else if (tagBits == TagBits.AnnotationNullable)
-						flowInfo.markPotentiallyNullBit(methodArguments[i].binding);
-					else if (methodBinding.parameters[i].isFreeTypeVariable())
-						flowInfo.markNullStatus(methodArguments[i].binding, FlowInfo.FREE_TYPEVARIABLE);
+						flowInfo.markPotentiallyNullBit(local);
+					else if (parameterBinding.isFreeTypeVariable())
+						flowInfo.markNullStatus(local, FlowInfo.FREE_TYPEVARIABLE);
 				} else {
 					if (methodBinding.parameterNonNullness != null) {
 						// leverage null-info from parameter annotations:
 						Boolean nonNullNess = methodBinding.parameterNonNullness[i];
 						if (nonNullNess != null) {
 							if (nonNullNess.booleanValue())
-								flowInfo.markAsDefinitelyNonNull(methodArguments[i].binding);
+								flowInfo.markAsDefinitelyNonNull(local);
 							else
-								flowInfo.markPotentiallyNullBit(methodArguments[i].binding);
+								flowInfo.markPotentiallyNullBit(local);
 						}
 					}
 				}
-				if (!flowInfo.hasNullInfoFor(methodArguments[i].binding))
-					flowInfo.markNullStatus(methodArguments[i].binding, FlowInfo.UNKNOWN); // ensure nullstatus is initialized
+				if (!flowInfo.hasNullInfoFor(local))
+					flowInfo.markNullStatus(local, FlowInfo.UNKNOWN); // ensure nullstatus is initialized
 				// tag parameters as being set:
-				flowInfo.markAsDefinitelyAssigned(methodArguments[i].binding);
+				flowInfo.markAsDefinitelyAssigned(local);
+
+				if (usesOwningAnnotation && (local.tagBits & TagBits.AnnotationOwning) !=0) {
+					local.closeTracker = new FakedTrackingVariable(local, methodArguments[i], flowInfo, flowContext, FlowInfo.NULL);
+				}
 			}
 		}
 	}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AllocationExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AllocationExpression.java
@@ -109,15 +109,17 @@ public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext, Fl
 				&& this.resolvedType instanceof ReferenceBinding
 				&& ((ReferenceBinding)this.resolvedType).hasTypeBit(TypeIds.BitWrapperCloseable);
 		for (int i = 0, count = this.arguments.length; i < count; i++) {
+			Expression argument = this.arguments[i];
 			flowInfo =
-				this.arguments[i]
+				argument
 					.analyseCode(currentScope, flowContext, flowInfo)
 					.unconditionalInits();
 			// if argument is an AutoCloseable insert info that it *may* be closed (by the target method, i.e.)
-			if (analyseResources && !hasResourceWrapperType) { // allocation of wrapped closeables is analyzed specially
-				flowInfo = FakedTrackingVariable.markPassedToOutside(currentScope, this.arguments[i], flowInfo, flowContext, false);
+			if (analyseResources) {
+				flowInfo = handleResourcePassedToInvocation(currentScope, this.binding, argument, i, flowContext, flowInfo,
+						hasResourceWrapperType);
 			}
-			this.arguments[i].checkNPEbyUnboxing(currentScope, flowContext, flowInfo);
+			argument.checkNPEbyUnboxing(currentScope, flowContext, flowInfo);
 		}
 		analyseArguments(currentScope, flowContext, flowInfo, this.binding, this.arguments);
 	}
@@ -139,7 +141,7 @@ public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext, Fl
 
 	// after having analysed exceptions above start tracking newly allocated resource:
 	if (currentScope.compilerOptions().analyseResourceLeaks && FakedTrackingVariable.isAnyCloseable(this.resolvedType))
-		FakedTrackingVariable.analyseCloseableAllocation(currentScope, flowInfo, this);
+		FakedTrackingVariable.analyseCloseableAllocation(currentScope, flowInfo, flowContext, this);
 
 	ReferenceBinding declaringClass = this.binding.declaringClass;
 	MethodScope methodScope = currentScope.methodScope();

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AllocationExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AllocationExpression.java
@@ -115,9 +115,8 @@ public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext, Fl
 					.analyseCode(currentScope, flowContext, flowInfo)
 					.unconditionalInits();
 			// if argument is an AutoCloseable insert info that it *may* be closed (by the target method, i.e.)
-			if (analyseResources) {
-				flowInfo = handleResourcePassedToInvocation(currentScope, this.binding, argument, i, flowContext, flowInfo,
-						hasResourceWrapperType);
+			if (analyseResources && !hasResourceWrapperType) { // allocation of wrapped closeables is analyzed specially
+				flowInfo = handleResourcePassedToInvocation(currentScope, this.binding, argument, i, flowContext, flowInfo);
 			}
 			argument.checkNPEbyUnboxing(currentScope, flowContext, flowInfo);
 		}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Annotation.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Annotation.java
@@ -441,6 +441,8 @@ public abstract class Annotation extends Expression {
 		if (compilerOptions.isAnnotationBasedResourceAnalysisEnabled) {
 			if (annotationType.hasTypeBit(TypeIds.BitOwningAnnotation)) {
 				tagBits |= TagBits.AnnotationOwning;
+			} else if (annotationType.hasTypeBit(TypeIds.BitNotOwningAnnotation)) {
+				tagBits |= TagBits.AnnotationNotOwning;
 			}
 		}
 		return tagBits;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Annotation.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Annotation.java
@@ -435,7 +435,9 @@ public abstract class Annotation extends Expression {
 		} else if (annotationType.hasNullBit(TypeIds.BitNonNullByDefaultAnnotation)) {
 			tagBits |= determineNonNullByDefaultTagBits(annotationType, valueAttribute);
 		}
-
+		if (annotationType.hasTypeBit(TypeIds.BitOwningAnnotation)) {
+			tagBits |= TagBits.AnnotationOwning;
+		}
 		return tagBits;
 	}
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Annotation.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Annotation.java
@@ -428,15 +428,20 @@ public abstract class Annotation extends Expression {
 				tagBits |= TagBits.AnnotationPolymorphicSignature;
 				break;
 		}
-		if (annotationType.hasNullBit(TypeIds.BitNullableAnnotation)) {
-			tagBits |= TagBits.AnnotationNullable;
-		} else if (annotationType.hasNullBit(TypeIds.BitNonNullAnnotation)) {
-			tagBits |= TagBits.AnnotationNonNull;
-		} else if (annotationType.hasNullBit(TypeIds.BitNonNullByDefaultAnnotation)) {
-			tagBits |= determineNonNullByDefaultTagBits(annotationType, valueAttribute);
+		CompilerOptions compilerOptions = scope.compilerOptions();
+		if (compilerOptions.isAnnotationBasedNullAnalysisEnabled) {
+			if (annotationType.hasNullBit(TypeIds.BitNullableAnnotation)) {
+				tagBits |= TagBits.AnnotationNullable;
+			} else if (annotationType.hasNullBit(TypeIds.BitNonNullAnnotation)) {
+				tagBits |= TagBits.AnnotationNonNull;
+			} else if (annotationType.hasNullBit(TypeIds.BitNonNullByDefaultAnnotation)) {
+				tagBits |= determineNonNullByDefaultTagBits(annotationType, valueAttribute);
+			}
 		}
-		if (annotationType.hasTypeBit(TypeIds.BitOwningAnnotation)) {
-			tagBits |= TagBits.AnnotationOwning;
+		if (compilerOptions.isAnnotationBasedResourceAnalysisEnabled) {
+			if (annotationType.hasTypeBit(TypeIds.BitOwningAnnotation)) {
+				tagBits |= TagBits.AnnotationOwning;
+			}
 		}
 		return tagBits;
 	}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Assignment.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Assignment.java
@@ -68,25 +68,38 @@ public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext, Fl
 
 	FlowInfo preInitInfo = null;
 	CompilerOptions compilerOptions = currentScope.compilerOptions();
-	boolean shouldAnalyseResource = local != null
-			&& flowInfo.reachMode() == FlowInfo.REACHABLE
+	boolean shouldAnalyseResource = false;
+	if (flowInfo.reachMode() == FlowInfo.REACHABLE
 			&& compilerOptions.analyseResourceLeaks
 			&& (FakedTrackingVariable.isAnyCloseable(this.expression.resolvedType)
-					|| this.expression.resolvedType == TypeBinding.NULL);
-	if (shouldAnalyseResource) {
+					|| this.expression.resolvedType == TypeBinding.NULL))
+	{
+		shouldAnalyseResource = local != null
+				|| ((this.lhs.bits & Binding.FIELD) != 0 & compilerOptions.isAnnotationBasedResourceAnalysisEnabled);
+	}
+
+	if (shouldAnalyseResource && local != null) {
 		preInitInfo = flowInfo.unconditionalCopy();
-		// analysis of resource leaks needs additional context while analyzing the RHS:
-		FakedTrackingVariable.preConnectTrackerAcrossAssignment(this, local, this.expression, flowInfo);
+		// analysis of resource leaks needs additional context while analyzing the RHS of assignment to local:
+		FakedTrackingVariable.preConnectTrackerAcrossAssignment(this, local, this.expression, flowInfo, compilerOptions.isAnnotationBasedResourceAnalysisEnabled);
 	}
 
 	flowInfo = ((Reference) this.lhs)
 		.analyseAssignment(currentScope, flowContext, flowInfo, this, false)
 		.unconditionalInits();
 
-	if (shouldAnalyseResource)
-		FakedTrackingVariable.handleResourceAssignment(currentScope, preInitInfo, flowInfo, flowContext, this, this.expression, local);
-	else
+	if (shouldAnalyseResource) {
+		if (local != null) {
+			// assignment to local
+			FakedTrackingVariable.handleResourceAssignment(currentScope, preInitInfo, flowInfo, flowContext, this, this.expression, local);
+		} else {
+			// assignment to field
+			FakedTrackingVariable.handleResourceFieldAssignment(currentScope, flowInfo, flowContext, this, this.expression);
+			FakedTrackingVariable.cleanUpAfterAssignment(currentScope, this.lhs.bits, this.expression);
+		}
+	} else {
 		FakedTrackingVariable.cleanUpAfterAssignment(currentScope, this.lhs.bits, this.expression);
+	}
 
 	int nullStatus = this.expression.nullStatus(flowInfo, flowContext);
 	if (local != null && (local.type.tagBits & TagBits.IsBaseType) == 0) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Block.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Block.java
@@ -55,7 +55,7 @@ public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext, Fl
 			flowContext.expireNullCheckedFieldInfo();
 		}
 		if (compilerOptions.analyseResourceLeaks) {
-			FakedTrackingVariable.cleanUpUnassigned(this.scope, stat, flowInfo);
+			FakedTrackingVariable.cleanUpUnassigned(this.scope, stat, flowInfo, null);
 		}
 	}
 	if (this.scope != currentScope) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Block.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Block.java
@@ -55,7 +55,7 @@ public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext, Fl
 			flowContext.expireNullCheckedFieldInfo();
 		}
 		if (compilerOptions.analyseResourceLeaks) {
-			FakedTrackingVariable.cleanUpUnassigned(this.scope, stat, flowInfo, null);
+			FakedTrackingVariable.cleanUpUnassigned(this.scope, stat, flowInfo, false);
 		}
 	}
 	if (this.scope != currentScope) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ConstructorDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ConstructorDeclaration.java
@@ -150,7 +150,7 @@ public void analyseCode(ClassScope classScope, InitializationFlowContext initial
 		}
 
 		// nullity and mark as assigned
-		analyseArguments(classScope.environment(), flowInfo, this.arguments, this.binding);
+		analyseArguments(classScope.environment(), flowInfo, initializerFlowContext, this.arguments, this.binding);
 
 		// propagate to constructor call
 		if (this.constructorCall != null) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ConstructorDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ConstructorDeclaration.java
@@ -185,7 +185,7 @@ public void analyseCode(ClassScope classScope, InitializationFlowContext initial
 					constructorContext.expireNullCheckedFieldInfo();
 				}
 				if (compilerOptions.analyseResourceLeaks) {
-					FakedTrackingVariable.cleanUpUnassigned(this.scope, stat, flowInfo, null);
+					FakedTrackingVariable.cleanUpUnassigned(this.scope, stat, flowInfo, false);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ConstructorDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ConstructorDeclaration.java
@@ -185,7 +185,7 @@ public void analyseCode(ClassScope classScope, InitializationFlowContext initial
 					constructorContext.expireNullCheckedFieldInfo();
 				}
 				if (compilerOptions.analyseResourceLeaks) {
-					FakedTrackingVariable.cleanUpUnassigned(this.scope, stat, flowInfo);
+					FakedTrackingVariable.cleanUpUnassigned(this.scope, stat, flowInfo, null);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ConstructorDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ConstructorDeclaration.java
@@ -149,7 +149,7 @@ public void analyseCode(ClassScope classScope, InitializationFlowContext initial
 			}
 		}
 
-		// nullity and mark as assigned
+		// nullity, owning and mark as assigned
 		analyseArguments(classScope.environment(), flowInfo, initializerFlowContext, this.arguments, this.binding);
 
 		// propagate to constructor call

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ExplicitConstructorCall.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ExplicitConstructorCall.java
@@ -107,7 +107,7 @@ public class ExplicitConstructorCall extends Statement implements Invocation {
 							.analyseCode(currentScope, flowContext, flowInfo)
 							.unconditionalInits();
 					if (analyseResources) {
-						flowInfo = handleResourcePassedToInvocation(currentScope, this.binding, this.arguments[i], i, flowContext, flowInfo, false);
+						flowInfo = handleResourcePassedToInvocation(currentScope, this.binding, this.arguments[i], i, flowContext, flowInfo);
 					}
 					this.arguments[i].checkNPEbyUnboxing(currentScope, flowContext, flowInfo);
 				}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ExplicitConstructorCall.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ExplicitConstructorCall.java
@@ -107,8 +107,7 @@ public class ExplicitConstructorCall extends Statement implements Invocation {
 							.analyseCode(currentScope, flowContext, flowInfo)
 							.unconditionalInits();
 					if (analyseResources) {
-						// if argument is an AutoCloseable insert info that it *may* be closed (by the target constructor, i.e.)
-						flowInfo = FakedTrackingVariable.markPassedToOutside(currentScope, this.arguments[i], flowInfo, flowContext, false);
+						flowInfo = handleResourcePassedToInvocation(currentScope, this.binding, this.arguments[i], i, flowContext, flowInfo, false);
 					}
 					this.arguments[i].checkNPEbyUnboxing(currentScope, flowContext, flowInfo);
 				}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/FakedTrackingVariable.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/FakedTrackingVariable.java
@@ -1518,9 +1518,7 @@ public class FakedTrackingVariable extends LocalDeclaration {
 		if ((this.globalClosingState & (TWR_EFFECTIVELY_FINAL|OWNED_BY_OUTSIDE|REPORTED_EXPLICIT_CLOSE|FOREACH_ELEMENT_VAR)) == 0) { // can't use t-w-r for OWNED_BY_OUTSIDE
 			if (this.originalFieldBinding != null && this.blockScope instanceof MethodScope) {
 				AbstractMethodDeclaration method = ((MethodScope) this.blockScope).referenceMethod();
-				if (CharOperation.equals(TypeConstants.CLOSE, method.selector)
-						&& method.binding != null
-						&& method.binding.declaringClass.hasTypeBit(TypeIds.BitCloseable|TypeIds.BitAutoCloseable)) {
+				if (method.binding != null && method.binding.isClosingMethod()) {
 					return; // this is the canonical close method, nothing to warn about.
 				}
 			}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/FakedTrackingVariable.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/FakedTrackingVariable.java
@@ -1056,10 +1056,8 @@ public class FakedTrackingVariable extends LocalDeclaration {
 				}
 				@Override
 				public boolean visit(AllocationExpression allocation, BlockScope skope) {
-					if (useAnnotations) {
-						if (handle(allocation.closeTracker, flowInfo, allocation, skope))
-							allocation.closeTracker = null;
-					}
+					if (handle(allocation.closeTracker, flowInfo, allocation, skope))
+						allocation.closeTracker = null;
 					return true;
 				}
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/FakedTrackingVariable.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/FakedTrackingVariable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 GK Software AG and others.
+ * Copyright (c) 2011, 2024 GK Software SE and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -22,11 +22,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.internal.compiler.ASTVisitor;
 import org.eclipse.jdt.internal.compiler.CompilationResult;
 import org.eclipse.jdt.internal.compiler.codegen.CodeStream;
+import org.eclipse.jdt.internal.compiler.codegen.ConstantPool;
 import org.eclipse.jdt.internal.compiler.flow.FinallyFlowContext;
 import org.eclipse.jdt.internal.compiler.flow.FlowContext;
 import org.eclipse.jdt.internal.compiler.flow.FlowInfo;
@@ -34,6 +37,7 @@ import org.eclipse.jdt.internal.compiler.impl.Constant;
 import org.eclipse.jdt.internal.compiler.impl.ReferenceContext;
 import org.eclipse.jdt.internal.compiler.lookup.Binding;
 import org.eclipse.jdt.internal.compiler.lookup.BlockScope;
+import org.eclipse.jdt.internal.compiler.lookup.FieldBinding;
 import org.eclipse.jdt.internal.compiler.lookup.LocalVariableBinding;
 import org.eclipse.jdt.internal.compiler.lookup.MethodBinding;
 import org.eclipse.jdt.internal.compiler.lookup.MethodScope;
@@ -53,7 +57,6 @@ import org.eclipse.jdt.internal.compiler.util.Util;
  *
  * See bug 349326 - [1.7] new warning for missing try-with-resources
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class FakedTrackingVariable extends LocalDeclaration {
 
 	private static final char[] UNASSIGNED_CLOSEABLE_NAME = "<unassigned Closeable value>".toCharArray(); //$NON-NLS-1$
@@ -93,28 +96,70 @@ public class FakedTrackingVariable extends LocalDeclaration {
 	 */
 	private int globalClosingState = 0;
 
+	private boolean useAnnotations = false;
+
+	public static final int NOT_OWNED = -2;
+	public static final int NOT_OWNED_PER_DEFAULT = -1;
+	public static final int OWNED_PER_DEFAULT = 1;
+	public static final int OWNED = 2;
+
+	static int owningStateFromTagBits(long owningTagBits, int defaultState) {
+		if (owningTagBits == TagBits.AnnotationOwning)
+			return OWNED;
+		if (owningTagBits == TagBits.AnnotationNotOwning)
+			return NOT_OWNED;
+		return defaultState;
+	}
+
+	/**
+	 * One of {@link #NOT_OWNED}, {@link #NOT_OWNED_PER_DEFAULT}, {@link #OWNED_PER_DEFAULT}, {@link #OWNED}.
+	 * A value of {@code 0} signals unknown state.
+	 */
+	public int owningState = 0;
+
 	public LocalVariableBinding originalBinding; // the real local being tracked, can be null for preliminary track vars for allocation expressions
+	public FieldBinding originalFieldBinding; // when tracking an @Owning field of resource type
 
 	public FakedTrackingVariable innerTracker; // chained tracking variable of a chained (wrapped) resource
 	public FakedTrackingVariable outerTracker; // inverse of 'innerTracker'
 
 	MethodScope methodScope; // designates the method declaring this variable
 
-	private HashMap recordedLocations; // initially null, ASTNode -> Integer
+	private HashMap<ASTNode,Integer> recordedLocations; // initially null, ASTNode -> Integer
 
 	// temporary storage while analyzing "res = new Res();":
 	private ASTNode currentAssignment; // temporarily store the assignment as the location for error reporting
 
 	// if tracking var was allocated from a finally context, record here the flow context of the corresponding try block
 	private FlowContext tryContext;
+	// designate the exact scope where this FTV was created
+	private BlockScope blockScope;
+	// within try blocks remember in which contexts the local was re-assigned
+	private Set<FlowContext> modificationContexts;
 
-	public FakedTrackingVariable(LocalVariableBinding original, ASTNode location, FlowInfo flowInfo, FlowContext flowContext, int nullStatus) {
-		super(original.name, location.sourceStart, location.sourceEnd);
+	public FakedTrackingVariable(LocalVariableBinding original, ASTNode location, FlowInfo flowInfo, FlowContext flowContext, int nullStatus, boolean useAnnotations) {
+		this(original.name, location, original.declaringScope, flowInfo, flowContext, nullStatus, useAnnotations);
+		this.methodScope = original.declaringScope.methodScope();
+		this.originalBinding = original;
+	}
+	public FakedTrackingVariable(LocalVariableBinding original, BlockScope scope, ASTNode location, FlowInfo flowInfo, FlowContext flowContext, int nullStatus, boolean useAnnotations) {
+		this(original.name, location, original.declaringScope, flowInfo, flowContext, nullStatus, useAnnotations);
+		this.methodScope = original.declaringScope.methodScope();
+		this.originalBinding = original;
+		this.blockScope = scope;
+	}
+	public FakedTrackingVariable(FieldBinding original, BlockScope scope, ASTNode location, FlowInfo flowInfo, FlowContext flowContext, int nullStatus, boolean useAnnotations) {
+		this(original.name, location, scope, flowInfo, flowContext, nullStatus, useAnnotations);
+		this.originalFieldBinding = original;
+		this.blockScope = scope;
+	}
+	private FakedTrackingVariable(char[] name, ASTNode location, BlockScope scope, FlowInfo flowInfo, FlowContext flowContext,
+			int nullStatus, boolean useAnnotations) {
+		super(name, location.sourceStart, location.sourceEnd);
 		this.type = new SingleTypeReference(
 				TypeConstants.OBJECT,
 				((long)this.sourceStart <<32)+this.sourceEnd);
-		this.methodScope = original.declaringScope.methodScope();
-		this.originalBinding = original;
+		this.useAnnotations = useAnnotations;
 		// inside a finally block?
 		while (flowContext != null) {
 			if (flowContext instanceof FinallyFlowContext) {
@@ -124,7 +169,7 @@ public class FakedTrackingVariable extends LocalDeclaration {
 			}
 			flowContext = flowContext.parent;
 		}
-		resolve(original.declaringScope);
+		resolve(scope);
 		if (nullStatus != 0)
 			flowInfo.markNullStatus(this.binding, nullStatus); // mark that this flow has seen the resource
 	}
@@ -137,6 +182,7 @@ public class FakedTrackingVariable extends LocalDeclaration {
 				((long)this.sourceStart <<32)+this.sourceEnd);
 		this.methodScope = scope.methodScope();
 		this.originalBinding = null;
+		this.useAnnotations = scope.compilerOptions().isAnnotationBasedResourceAnalysisEnabled;
 		resolve(scope);
 		if (nullStatus != 0)
 			flowInfo.markNullStatus(this.binding, nullStatus); // mark that this flow has seen the resource
@@ -167,6 +213,26 @@ public class FakedTrackingVariable extends LocalDeclaration {
 		this.binding.id = scope.registerTrackingVariable(this);
 	}
 
+	/** retrieve a closetracker for local that signifies a certain risk of resource leak in flowInfo. */
+	private static FakedTrackingVariable getRiskyCloseTrackerAt(LocalVariableBinding local, Scope scope, FlowInfo flowInfo) {
+		if (local.closeTracker == null) {
+			return null;
+		}
+		if (flowInfo.nullStatus(local.closeTracker.binding) != FlowInfo.UNKNOWN)
+			return local.closeTracker;
+		while (scope instanceof BlockScope) {
+			FakedTrackingVariable tracker = ((BlockScope) scope).getCloseTrackerFor(local);
+			if (tracker != null) {
+				if (tracker.riskyNullStatusAt(flowInfo) != 0)
+					return tracker;
+				if (tracker.hasDefinitelyNoResource(flowInfo))
+					return null;
+			}
+			scope = scope.parent;
+		}
+		return null;
+	}
+
 	/**
 	 * If expression resolves to a value of type AutoCloseable answer the variable that tracks closing of that local.
 	 * Covers two cases:
@@ -176,21 +242,18 @@ public class FakedTrackingVariable extends LocalDeclaration {
 	 * </ul>
 	 * @return a new {@link FakedTrackingVariable} or null.
 	 */
-	public static FakedTrackingVariable getCloseTrackingVariable(Expression expression, FlowInfo flowInfo, FlowContext flowContext) {
+	public static FakedTrackingVariable getCloseTrackingVariable(Expression expression, FlowInfo flowInfo, FlowContext flowContext, boolean useAnnotations) {
 		while (true) {
 			if (expression instanceof CastExpression)
 				expression = ((CastExpression) expression).expression;
 			else if (expression instanceof Assignment)
 				expression = ((Assignment) expression).expression;
 			else if (expression instanceof ConditionalExpression) {
-				FakedTrackingVariable falseTrackingVariable = getCloseTrackingVariable(((ConditionalExpression)expression).valueIfFalse, flowInfo, flowContext);
-				if (falseTrackingVariable != null) {
-					return falseTrackingVariable;
-				}
-				return getCloseTrackingVariable(((ConditionalExpression)expression).valueIfTrue, flowInfo, flowContext);
+				return getMoreUnsafeFromBranches((ConditionalExpression)expression, flowInfo,
+										branch -> getCloseTrackingVariable(branch, flowInfo, flowContext, useAnnotations));
 			} else if (expression instanceof SwitchExpression) {
 				for (Expression re : ((SwitchExpression) expression).resultExpressions) {
-					FakedTrackingVariable fakedTrackingVariable = getCloseTrackingVariable(re, flowInfo, flowContext);
+					FakedTrackingVariable fakedTrackingVariable = getCloseTrackingVariable(re, flowInfo, flowContext, useAnnotations);
 					if (fakedTrackingVariable != null) {
 						return fakedTrackingVariable;
 					}
@@ -200,26 +263,33 @@ public class FakedTrackingVariable extends LocalDeclaration {
 			else
 				break;
 		}
+		FieldBinding fieldBinding = null;
 		if (expression instanceof SingleNameReference) {
 			SingleNameReference name = (SingleNameReference) expression;
 			if (name.binding instanceof LocalVariableBinding) {
 				LocalVariableBinding local = (LocalVariableBinding)name.binding;
 				if (local.closeTracker != null)
 					return local.closeTracker;
-				if (!isAnyCloseable(expression.resolvedType))
+				if (!isCloseableNotWhiteListed(expression.resolvedType))
 					return null;
 				if ((local.tagBits & TagBits.IsResource) != 0)
 					return null;
 				// tracking var doesn't yet exist. This happens in finally block
 				// which is analyzed before the corresponding try block
 				Statement location = local.declaration;
-				local.closeTracker = new FakedTrackingVariable(local, location, flowInfo, flowContext, FlowInfo.UNKNOWN);
+				local.closeTracker = new FakedTrackingVariable(local, location, flowInfo, flowContext, FlowInfo.UNKNOWN, useAnnotations);
 				if (local.isParameter()) {
 					local.closeTracker.globalClosingState |= OWNED_BY_OUTSIDE;
 					// status of this tracker is now UNKNOWN
 				}
 				return local.closeTracker;
+			} else if (name.binding instanceof FieldBinding) {
+				fieldBinding = (FieldBinding) name.binding;
 			}
+		} else if (expression instanceof FieldReference) {
+			FieldReference fieldReference = (FieldReference) expression;
+			if (fieldReference.receiver.isThis())
+				fieldBinding = fieldReference.binding;
 		} else if (expression instanceof AllocationExpression) {
 			// return any preliminary tracking variable from analyseCloseableAllocation
 			return ((AllocationExpression) expression).closeTracker;
@@ -227,6 +297,8 @@ public class FakedTrackingVariable extends LocalDeclaration {
 			// return any preliminary tracking variable from analyseCloseableAcquisition
 			return ((MessageSend) expression).closeTracker;
 		}
+		if (fieldBinding != null)
+			return fieldBinding.closeTracker;
 		return null;
 	}
 
@@ -242,13 +314,13 @@ public class FakedTrackingVariable extends LocalDeclaration {
 	 * @param rhs the rhs of the assignment resp. the initialization of the local variable declaration.
 	 * 		<strong>Precondition:</strong> client has already checked that the resolved type of this expression is either a closeable type or NULL.
 	 */
-	public static FakedTrackingVariable preConnectTrackerAcrossAssignment(ASTNode location, LocalVariableBinding local, Expression rhs, FlowInfo flowInfo) {
+	public static FakedTrackingVariable preConnectTrackerAcrossAssignment(ASTNode location, LocalVariableBinding local, Expression rhs, FlowInfo flowInfo, boolean useAnnotations) {
 		FakedTrackingVariable closeTracker = null;
 		if (containsAllocation(rhs)) {
 			closeTracker = local.closeTracker;
 			if (closeTracker == null) {
 				if (rhs.resolvedType != TypeBinding.NULL) { // not NULL means valid closeable as per method precondition
-					closeTracker = new FakedTrackingVariable(local, location, flowInfo, null, FlowInfo.UNKNOWN);
+					closeTracker = new FakedTrackingVariable(local, location, flowInfo, null, FlowInfo.UNKNOWN, useAnnotations);
 					if (local.isParameter()) {
 						closeTracker.globalClosingState |= OWNED_BY_OUTSIDE;
 					}
@@ -256,17 +328,25 @@ public class FakedTrackingVariable extends LocalDeclaration {
 			}
 			if (closeTracker != null) {
 				closeTracker.currentAssignment = location;
-				preConnectTrackerAcrossAssignment(location, local, flowInfo, closeTracker, rhs);
+				preConnectTrackerAcrossAssignment(location, local, flowInfo, closeTracker, rhs, useAnnotations);
 			}
 		} else if (rhs instanceof MessageSend) {
+			MessageSend messageSend = (MessageSend) rhs;
 			closeTracker = local.closeTracker;
 			if (closeTracker != null) {
-				handleReassignment(flowInfo, closeTracker, location);
+				closeTracker = handleReassignment(flowInfo, closeTracker, location);
 			}
-			if (rhs.resolvedType != TypeBinding.NULL) { // not NULL means valid closeable as per method precondition
-				closeTracker = new FakedTrackingVariable(local, location, flowInfo, null, FlowInfo.UNKNOWN);
+			if (rhs.resolvedType != TypeBinding.NULL // not NULL means valid closeable as per method precondition
+					&& (!rhs.resolvedType.hasTypeBit(TypeIds.BitResourceFreeCloseable)
+						|| isBlacklistedMethod(rhs))) {
+				if (closeTracker == null)
+					closeTracker = new FakedTrackingVariable(local, location, flowInfo, null, FlowInfo.UNKNOWN, useAnnotations);
+				messageSend.closeTracker = closeTracker;
 				closeTracker.currentAssignment = location;
-				((MessageSend) rhs).closeTracker = closeTracker;
+			}
+			if (closeTracker != null) {
+				if (messageSend.binding != null && ((messageSend.binding.tagBits & TagBits.AnnotationNotOwning) == 0))
+					closeTracker.owningState = OWNED;
 			}
 		}
 		return closeTracker;
@@ -297,42 +377,45 @@ public class FakedTrackingVariable extends LocalDeclaration {
 	}
 
 	private static void preConnectTrackerAcrossAssignment(ASTNode location, LocalVariableBinding local, FlowInfo flowInfo,
-			FakedTrackingVariable closeTracker, Expression expression) {
+			FakedTrackingVariable closeTracker, Expression expression, boolean useAnnotations) {
 		if (expression instanceof AllocationExpression) {
-			preConnectTrackerAcrossAssignment(location, local, flowInfo, (AllocationExpression) expression, closeTracker);
+			preConnectTrackerAcrossAssignment(location, local, flowInfo, (AllocationExpression) expression, closeTracker, useAnnotations);
 		} else if (expression instanceof ConditionalExpression) {
-			preConnectTrackerAcrossAssignment(location, local, flowInfo, (ConditionalExpression) expression, closeTracker);
+			preConnectTrackerAcrossAssignment(location, local, flowInfo, (ConditionalExpression) expression, closeTracker, useAnnotations);
 		}  else if (expression instanceof SwitchExpression) {
-			preConnectTrackerAcrossAssignment(location, local, flowInfo, (SwitchExpression) expression, closeTracker);
+			preConnectTrackerAcrossAssignment(location, local, flowInfo, (SwitchExpression) expression, closeTracker, useAnnotations);
 		} else if (expression instanceof CastExpression) {
-			preConnectTrackerAcrossAssignment(location, local, ((CastExpression) expression).expression, flowInfo);
+			preConnectTrackerAcrossAssignment(location, local, ((CastExpression) expression).expression, flowInfo, useAnnotations);
 		} else if (expression instanceof MessageSend) {
 			if (isFluentMethod(((MessageSend) expression).binding))
-				preConnectTrackerAcrossAssignment(location, local, ((MessageSend) expression).receiver, flowInfo);
+				preConnectTrackerAcrossAssignment(location, local, ((MessageSend) expression).receiver, flowInfo, useAnnotations);
 		}
 	}
 
 	private static void preConnectTrackerAcrossAssignment(ASTNode location, LocalVariableBinding local, FlowInfo flowInfo,
-			ConditionalExpression conditional, FakedTrackingVariable closeTracker) {
-		preConnectTrackerAcrossAssignment(location, local, flowInfo, closeTracker, conditional.valueIfFalse);
-		preConnectTrackerAcrossAssignment(location, local, flowInfo, closeTracker, conditional.valueIfTrue);
+			ConditionalExpression conditional, FakedTrackingVariable closeTracker, boolean useAnnotations) {
+		preConnectTrackerAcrossAssignment(location, local, flowInfo, closeTracker, conditional.valueIfFalse, useAnnotations);
+		preConnectTrackerAcrossAssignment(location, local, flowInfo, closeTracker, conditional.valueIfTrue, useAnnotations);
 	}
 
 	private static void preConnectTrackerAcrossAssignment(ASTNode location, LocalVariableBinding local, FlowInfo flowInfo,
-			SwitchExpression se, FakedTrackingVariable closeTracker) {
+			SwitchExpression se, FakedTrackingVariable closeTracker, boolean useAnnotations) {
 		for (Expression re : se.resultExpressions) {
-			preConnectTrackerAcrossAssignment(location, local, flowInfo, closeTracker, re);
+			preConnectTrackerAcrossAssignment(location, local, flowInfo, closeTracker, re, useAnnotations);
 		}
 	}
 
 	private static void preConnectTrackerAcrossAssignment(ASTNode location, LocalVariableBinding local, FlowInfo flowInfo,
-			AllocationExpression allocationExpression, FakedTrackingVariable closeTracker) {
+			AllocationExpression allocationExpression, FakedTrackingVariable closeTracker, boolean useAnnotations) {
 		allocationExpression.closeTracker = closeTracker;
 		if (allocationExpression.arguments != null && allocationExpression.arguments.length > 0) {
 			// also push into nested allocations, see https://bugs.eclipse.org/368709
-			FakedTrackingVariable inner = preConnectTrackerAcrossAssignment(location, local, allocationExpression.arguments[0], flowInfo);
-			if (inner != closeTracker && closeTracker.innerTracker == null)
-				closeTracker.innerTracker = inner;
+			Expression firstArg = allocationExpression.arguments[0];
+			if (isCloseableNotWhiteListed(firstArg.resolvedType)) {
+				FakedTrackingVariable inner = preConnectTrackerAcrossAssignment(location, local, firstArg, flowInfo, useAnnotations);
+				if (inner != closeTracker && closeTracker.innerTracker == null)
+					closeTracker.innerTracker = inner;
+			}
 		}
 	}
 
@@ -340,7 +423,7 @@ public class FakedTrackingVariable extends LocalDeclaration {
 	 * Compute/assign a tracking variable for a freshly allocated closeable value, using information from our white lists.
 	 * See  Bug 358903 - Filter practically unimportant resource leak warnings
 	 */
-	public static void analyseCloseableAllocation(BlockScope scope, FlowInfo flowInfo, AllocationExpression allocation) {
+	public static void analyseCloseableAllocation(BlockScope scope, FlowInfo flowInfo, FlowContext flowContext, AllocationExpression allocation) {
 		// client has checked that the resolvedType is an AutoCloseable, hence the following cast is safe:
 		if (((ReferenceBinding)allocation.resolvedType).hasTypeBit(TypeIds.BitResourceFreeCloseable)) {
 			// remove unnecessary attempts (closeable is not relevant)
@@ -373,7 +456,7 @@ public class FakedTrackingVariable extends LocalDeclaration {
 						}
 					}
 					if (allocation.closeTracker.innerTracker != null && allocation.closeTracker.innerTracker != innerTracker) {
-						innerTracker = pickMoreUnsafe(allocation.closeTracker.innerTracker, innerTracker, scope, flowInfo);
+						innerTracker = pickMoreUnsafe(allocation.closeTracker.innerTracker, innerTracker, flowInfo);
 					}
 					allocation.closeTracker.innerTracker = innerTracker;
 					innerTracker.outerTracker = allocation.closeTracker;
@@ -405,10 +488,10 @@ public class FakedTrackingVariable extends LocalDeclaration {
 				}
 			} else {
 				// allocation does not provide a resource as the first argument -> don't treat as a wrapper
-				handleRegularResource(scope, flowInfo, allocation);
+				handleRegularResource(scope, flowInfo, flowContext, allocation);
 			}
 		} else { // regular resource
-			handleRegularResource(scope, flowInfo, allocation);
+			handleRegularResource(scope, flowInfo, flowContext, allocation);
 		}
 	}
 
@@ -423,7 +506,8 @@ public class FakedTrackingVariable extends LocalDeclaration {
 			return flowInfo;
 		}
 		// client has checked that the resolvedType is an AutoCloseable, hence the following cast is safe:
-		if (((ReferenceBinding)acquisition.resolvedType).hasTypeBit(TypeIds.BitResourceFreeCloseable)) {
+		if (((ReferenceBinding)acquisition.resolvedType).hasTypeBit(TypeIds.BitResourceFreeCloseable)
+				&& !isBlacklistedMethod(acquisition)) {
 			// remove unnecessary attempts (closeable is not relevant)
 			if (acquisition.closeTracker != null) {
 				acquisition.closeTracker.withdraw();
@@ -432,12 +516,17 @@ public class FakedTrackingVariable extends LocalDeclaration {
 			return flowInfo;
 		} else { // regular resource
 			FakedTrackingVariable tracker = acquisition.closeTracker;
-			if (isCallingOwningAnnotatedMethod(acquisition)) {
-				if (tracker != null) {
-					flowInfo.markAsDefinitelyNull(tracker.binding);
+			if (scope.compilerOptions().isAnnotationBasedResourceAnalysisEnabled) {
+				long owningTagBits = acquisition.binding.tagBits & TagBits.AnnotationOwningMASK;
+				int initialNullStatus = (owningTagBits == TagBits.AnnotationNotOwning) ? FlowInfo.NON_NULL : FlowInfo.NULL;
+				if (tracker == null) {
+					acquisition.closeTracker =
+							tracker = new FakedTrackingVariable(scope, acquisition, flowInfo, initialNullStatus); // no local available, closeable is unassigned
+					tracker.owningState = owningStateFromTagBits(owningTagBits, OWNED_PER_DEFAULT);
 				} else {
-					acquisition.closeTracker = new FakedTrackingVariable(scope, acquisition, flowInfo, FlowInfo.NULL); // no local available, closeable is unassigned
+					flowInfo.markNullStatus(tracker.binding, initialNullStatus);
 				}
+				tracker.acquisition = acquisition;
 				return flowInfo;
 			}
 			if (tracker != null) {
@@ -471,42 +560,111 @@ public class FakedTrackingVariable extends LocalDeclaration {
 		return false;
 	}
 
-	private static FakedTrackingVariable pickMoreUnsafe(FakedTrackingVariable tracker1, FakedTrackingVariable tracker2, BlockScope scope, FlowInfo info) {
+	private static FakedTrackingVariable getMoreUnsafeFromBranches(ConditionalExpression conditionalExpression,
+			FlowInfo flowInfo, Function<Expression,FakedTrackingVariable> retriever)
+	{
+		FakedTrackingVariable trackerIfTrue = retriever.apply(conditionalExpression.valueIfTrue);
+		FakedTrackingVariable trackerIfFalse = retriever.apply(conditionalExpression.valueIfFalse);
+		if (trackerIfTrue == null)
+			return trackerIfFalse;
+		if (trackerIfFalse == null)
+			return trackerIfTrue;
+		return pickMoreUnsafe(trackerIfTrue, trackerIfFalse, flowInfo);
+	}
+
+	private static FakedTrackingVariable pickMoreUnsafe(FakedTrackingVariable tracker1, FakedTrackingVariable tracker2, FlowInfo info) {
 		// whichever of the two trackers has stronger indication to be leaking will be returned,
 		// the other one will be removed from the scope (considered to be merged into the former).
 		int status1 = info.nullStatus(tracker1.binding);
 		int status2 = info.nullStatus(tracker2.binding);
-		if (status1 == FlowInfo.NULL || status2 == FlowInfo.NON_NULL) return pick(tracker1, tracker2, scope);
-		if (status1 == FlowInfo.NON_NULL || status2 == FlowInfo.NULL) return pick(tracker2, tracker1, scope);
-		if ((status1 & FlowInfo.POTENTIALLY_NULL) != 0) return pick(tracker1, tracker2, scope);
-		if ((status2 & FlowInfo.POTENTIALLY_NULL) != 0) return pick(tracker2, tracker1, scope);
-		return pick(tracker1, tracker2, scope);
+		if (status1 == FlowInfo.NULL || status2 == FlowInfo.NON_NULL) return pick(tracker1, tracker2);
+		if (status1 == FlowInfo.NON_NULL || status2 == FlowInfo.NULL) return pick(tracker2, tracker1);
+		if ((status1 & FlowInfo.POTENTIALLY_NULL) != 0) return pick(tracker1, tracker2);
+		if ((status2 & FlowInfo.POTENTIALLY_NULL) != 0) return pick(tracker2, tracker1);
+		return pick(tracker1, tracker2);
 	}
 
-	private static FakedTrackingVariable pick(FakedTrackingVariable tracker1, FakedTrackingVariable tracker2, BlockScope scope) {
+	private static FakedTrackingVariable pick(FakedTrackingVariable tracker1, FakedTrackingVariable tracker2) {
 		tracker2.withdraw();
 		return tracker1;
 	}
 
-	private static void handleRegularResource(BlockScope scope, FlowInfo flowInfo, AllocationExpression allocation) {
+	private static void handleRegularResource(BlockScope scope, FlowInfo flowInfo, FlowContext flowContext, AllocationExpression allocation) {
 		FakedTrackingVariable presetTracker = allocation.closeTracker;
+		LocalVariableBinding local = null;
 		if (presetTracker != null && presetTracker.originalBinding != null) {
-			// the current assignment forgets a previous resource in the LHS, may cause a leak
-			// report now because handleResourceAssignment can't distinguish this from a self-wrap situation
-			handleReassignment(flowInfo, presetTracker, presetTracker.currentAssignment);
+			if (presetTracker.isInFinallyBlockOf(flowContext) && presetTracker.recordFirstModification(flowContext)) {
+				// not a re-assignment after the one seen within finally, but this excuse is valid only once.
+			} else {
+				local = presetTracker.originalBinding;
+				// the current assignment forgets a previous resource in the LHS, may cause a leak
+				// report now because handleResourceAssignment can't distinguish this from a self-wrap situation
+				handleReassignment(flowInfo, presetTracker, presetTracker.currentAssignment);
+				if (local != null && !presetTracker.hasDefinitelyNoResource(flowInfo) && presetTracker.currentAssignment instanceof Assignment) {
+					boolean useAnnotations = scope.compilerOptions().isAnnotationBasedResourceAnalysisEnabled;
+					allocation.closeTracker =
+							local.closeTracker =
+							new FakedTrackingVariable(local, scope, presetTracker.currentAssignment, flowInfo, flowContext, FlowInfo.NULL, useAnnotations);
+					if (useAnnotations)
+						allocation.closeTracker.owningState = OWNED;
+					// if finally closes the given local, this may affect any resource bound to the same local
+					// (but re-assignment over an existing unclosed resource will be recorded (at-location) in handleReassignment() above).
+					FlowInfo enclosingFinallyInfo = null;
+					Scope current = scope;
+					while (current instanceof BlockScope && enclosingFinallyInfo == null) {
+						enclosingFinallyInfo = ((BlockScope) current).finallyInfo;
+						current = current.parent;
+					}
+					if (enclosingFinallyInfo != null) {
+						int finallyNullStatus = enclosingFinallyInfo.nullStatus(presetTracker.binding);
+						enclosingFinallyInfo.markNullStatus(local.closeTracker.binding, finallyNullStatus);
+					}
+					presetTracker.markUnknown(flowInfo, flowContext); // no longer relevant in this flow
+				}
+			}
 		} else {
 			allocation.closeTracker = new FakedTrackingVariable(scope, allocation, flowInfo, FlowInfo.UNKNOWN); // no local available, closeable is unassigned
 		}
 		flowInfo.markAsDefinitelyNull(allocation.closeTracker.binding);
 	}
 
-	private static void handleReassignment(FlowInfo flowInfo, FakedTrackingVariable existingTracker, ASTNode location) {
-		int closeStatus = flowInfo.nullStatus(existingTracker.binding);
-		if (closeStatus != FlowInfo.NON_NULL		// old resource was not closed
-				&& closeStatus != FlowInfo.UNKNOWN	// old resource had some flow information
-				&& !flowInfo.isDefinitelyNull(existingTracker.originalBinding)		// old resource was not null
+	/** Was this FTV created from the finally block of the current context? */
+	private boolean isInFinallyBlockOf(FlowContext flowContext) {
+		if (this.tryContext != null) {
+			do {
+				if (flowContext == this.tryContext)
+					return true;
+				flowContext = flowContext.parent;
+			} while (flowContext != null);
+		}
+		return false;
+	}
+
+	/** Try to remember flowContext as the first one where this FTV is being modified. */
+	private boolean recordFirstModification(FlowContext flowContext) {
+		if (this.modificationContexts == null) {
+			this.modificationContexts = new HashSet<>();
+			this.modificationContexts.add(flowContext);
+			return true;
+		}
+		FlowContext current = flowContext;
+		while (current != null) {
+			if (this.modificationContexts.contains(current))
+				return false;
+			current = current.parent;
+		}
+		return this.modificationContexts.add(flowContext);
+	}
+
+	private static FakedTrackingVariable handleReassignment(FlowInfo flowInfo, FakedTrackingVariable existingTracker, ASTNode location) {
+		int riskyStatus = existingTracker.riskyNullStatusAt(flowInfo);
+		if (riskyStatus != 0
 				&& !(location instanceof LocalDeclaration))	// forgetting old val in local decl is syntactically impossible
-			existingTracker.recordErrorLocation(location, closeStatus);
+		{
+			existingTracker.recordErrorLocation(location, riskyStatus);
+			return null; // stop using this tracker after re-assignment
+		}
+		return existingTracker;
 	}
 
 	/** Find an existing tracking variable for the argument of an allocation for a resource wrapper. */
@@ -551,25 +709,30 @@ public class FakedTrackingVariable extends LocalDeclaration {
 	public static void handleResourceAssignment(BlockScope scope, FlowInfo upstreamInfo, FlowInfo flowInfo, FlowContext flowContext, ASTNode location, Expression rhs, LocalVariableBinding local)
 	{
 		// does the LHS (local) already have a tracker, indicating we may leak a resource by the assignment?
-		FakedTrackingVariable previousTracker = null;
+		FakedTrackingVariable previousTracker = getRiskyCloseTrackerAt(local, scope, upstreamInfo);
 		FakedTrackingVariable disconnectedTracker = null;
-		if (local.closeTracker != null) {
+		if (previousTracker != null) {
 			// assigning to a variable already holding an AutoCloseable, has it been closed before?
-			previousTracker = local.closeTracker;
-			int nullStatus = upstreamInfo.nullStatus(local);
-			if (nullStatus != FlowInfo.NULL && nullStatus != FlowInfo.UNKNOWN) // only if previous value may be relevant
+			if (previousTracker.riskyNullStatusAt(upstreamInfo) != 0) // only if previous value may be relevant
 				disconnectedTracker = previousTracker; // report error below, unless we have a self-wrap assignment
+		} else {
+			previousTracker = local.closeTracker; // not yet risky, but may still be releavant below
 		}
+
+		boolean useAnnotations = scope.compilerOptions().isAnnotationBasedResourceAnalysisEnabled;
 
 		rhsAnalyis:
 		if (rhs.resolvedType != TypeBinding.NULL) {
 			// new value is AutoCloseable, start tracking, possibly re-using existing tracker var:
-			FakedTrackingVariable rhsTrackVar = getCloseTrackingVariable(rhs, flowInfo, flowContext);
+			FakedTrackingVariable rhsTrackVar = getCloseTrackingVariable(rhs, flowInfo, flowContext, useAnnotations);
 			if (rhsTrackVar != null) {								// 1. if RHS has a tracking variable...
 				if (local.closeTracker == null) {
 					// null shouldn't occur but let's play safe:
-					if (rhsTrackVar.originalBinding != null)
+					if (rhsTrackVar.originalBinding != null) {
 						local.closeTracker = rhsTrackVar;			//		a.: let fresh LHS share it
+					} else if (rhsTrackVar.originalFieldBinding != null) {
+						local.closeTracker = rhsTrackVar;
+					}
 					if (rhsTrackVar.currentAssignment == location) {
 						// pre-set tracker from lhs - passed from outside (or foreach)?
 						// now it's a fresh resource
@@ -580,10 +743,10 @@ public class FakedTrackingVariable extends LocalDeclaration {
 						if (rhsTrackVar == disconnectedTracker)
 							return;									// 		b.: self wrapper: res = new Wrap(res); -> done!
 						if (local.closeTracker == rhsTrackVar
-								&& ((rhsTrackVar.globalClosingState & OWNED_BY_OUTSIDE) != 0)) {
+								&& rhsTrackVar.isNotOwned()) {
 																	// 		c.: assigning a fresh resource (pre-connected alloc)
 																	//			to a local previously holding an alien resource -> start over
-							local.closeTracker = new FakedTrackingVariable(local, location, flowInfo, flowContext, FlowInfo.NULL);
+							local.closeTracker = new FakedTrackingVariable(local, scope, location, flowInfo, flowContext, FlowInfo.NULL, useAnnotations);
 							// still check disconnectedTracker below
 							break rhsAnalyis;
 						}
@@ -609,15 +772,17 @@ public class FakedTrackingVariable extends LocalDeclaration {
 					if ((previousTracker.globalClosingState & (SHARED_WITH_OUTSIDE|OWNED_BY_OUTSIDE|FOREACH_ELEMENT_VAR)) == 0
 							&& flowInfo.hasNullInfoFor(previousTracker.binding)) // avoid spilling info into a branch that doesn't see the corresponding resource
 						flowInfo.markAsDefinitelyNull(previousTracker.binding);
-					local.closeTracker = analyseCloseableExpression(flowInfo, flowContext, local, location, rhs, previousTracker);
+					local.closeTracker = analyseCloseableExpression(scope, flowInfo, flowContext, useAnnotations, local, location, rhs, previousTracker);
 				}
 			} else {												// 3. no re-use, create a fresh tracking variable:
-				rhsTrackVar = analyseCloseableExpression(flowInfo, flowContext, local, location, rhs, null);
+				rhsTrackVar = analyseCloseableExpression(scope, flowInfo, flowContext, useAnnotations, local, location, rhs, null);
 				if (rhsTrackVar != null) {
 					rhsTrackVar.attachTo(local);
-					// a fresh resource, mark as not-closed:
-					if ((rhsTrackVar.globalClosingState & (SHARED_WITH_OUTSIDE|OWNED_BY_OUTSIDE|FOREACH_ELEMENT_VAR)) == 0)
-						flowInfo.markAsDefinitelyNull(rhsTrackVar.binding);
+					if (!useAnnotations) {
+						// a fresh resource, mark as not-closed:
+						if ((rhsTrackVar.globalClosingState & (SHARED_WITH_OUTSIDE|OWNED_BY_OUTSIDE|FOREACH_ELEMENT_VAR)) == 0)
+							flowInfo.markAsDefinitelyNull(rhsTrackVar.binding);
+					}
 // TODO(stephan): this might be useful, but I could not find a test case for it:
 //					if (flowContext.initsOnFinally != null)
 //						flowContext.initsOnFinally.markAsDefinitelyNonNull(trackerBinding);
@@ -631,15 +796,71 @@ public class FakedTrackingVariable extends LocalDeclaration {
 				disconnectedTracker.innerTracker.outerTracker = null;
 				scope.pruneWrapperTrackingVar(disconnectedTracker);
 			} else {
-				int upstreamStatus = upstreamInfo.nullStatus(disconnectedTracker.binding);
-				if (upstreamStatus != FlowInfo.NON_NULL)
+				int upstreamStatus = disconnectedTracker.riskyNullStatusAt(upstreamInfo);
+				if (upstreamStatus != 0)
 					disconnectedTracker.recordErrorLocation(location, upstreamStatus);
+			}
+		}
+	}
+
+	public int riskyNullStatusAt(FlowInfo info) {
+		if (hasDefinitelyNoResource(info))
+			return 0;
+		int nullStatus = getNullStatusAggressively(this.binding, info);
+		if ((nullStatus & (FlowInfo.UNKNOWN | FlowInfo.NON_NULL)) == 0)
+			return nullStatus;
+		return 0;
+	}
+
+	/**
+	 * When assigning an rhs of an (Auto)Closeable type (or null) to a field, inspect annotations
+	 * to find out if the assignment assigns ownership to the instance (rather than current method).
+	 * @param scope scope containing the assignment
+	 * @param flowInfo info with analysis of the rhs, use this for recording resource status because this will be passed downstream
+	 * @param location where to report warnigs/errors against
+	 * @param rhs the right hand side of the assignment, this expression is to be analyzed.
+	 *			The caller has already checked that the rhs is either of a closeable type or null.
+	 */
+	public static void handleResourceFieldAssignment(BlockScope scope, FlowInfo flowInfo, FlowContext flowContext, ASTNode location, Expression rhs)
+	{
+		boolean useAnnotations = scope.compilerOptions().isAnnotationBasedResourceAnalysisEnabled;
+
+		if (rhs.resolvedType != TypeBinding.NULL) {
+			// new value is AutoCloseable, start tracking, possibly re-using existing tracker var:
+			FakedTrackingVariable rhsTrackVar = getCloseTrackingVariable(rhs, flowInfo, flowContext, useAnnotations);
+			if (rhsTrackVar != null) {
+				if (useAnnotations) {
+					if (location instanceof Assignment) {
+						Expression lhs = ((Assignment) location).lhs;
+						FieldBinding field = null;
+						// only consider access to field of the current instance:
+						if (lhs instanceof SingleNameReference) {
+							field = ((SingleNameReference) lhs).fieldBinding();
+						} else if (lhs instanceof FieldReference) {
+							FieldReference fieldReference = (FieldReference) lhs;
+							if (fieldReference.receiver.isThis())
+								field = fieldReference.binding;
+						}
+						if (field != null) {
+							if (!field.isStatic() && (field.tagBits & TagBits.AnnotationOwning) != 0) {
+								flowInfo.markAsDefinitelyNonNull(rhsTrackVar.binding);
+							} else {
+								rhsTrackVar.markAsShared();
+							}
+						}
+					}
+				}
+// TODO(stephan): this might be useful, but I could not find a test case for it:
+//					if (flowContext.initsOnFinally != null)
+//						flowContext.initsOnFinally.markAsDefinitelyNonNull(trackerBinding);
 			}
 		}
 	}
 	/**
 	 * Analyze structure of a closeable expression, matching (chained) resources against our white lists.
+	 * @param scope scope of the expression
 	 * @param flowInfo where to record close status
+	 * @param useAnnotations is annotation based resource analysis enabled
 	 * @param local local variable to which the closeable is being assigned
 	 * @param location where to flag errors/warnings against
 	 * @param expression expression to be analyzed
@@ -647,8 +868,8 @@ public class FakedTrackingVariable extends LocalDeclaration {
 	 *  		which we should then re-use
 	 * @return a tracking variable associated with local or null if no need to track
 	 */
-	private static FakedTrackingVariable analyseCloseableExpression(FlowInfo flowInfo, FlowContext flowContext, LocalVariableBinding local,
-									ASTNode location, Expression expression, FakedTrackingVariable previousTracker)
+	private static FakedTrackingVariable analyseCloseableExpression(BlockScope scope, FlowInfo flowInfo, FlowContext flowContext, boolean useAnnotations,
+									LocalVariableBinding local, ASTNode location, Expression expression, FakedTrackingVariable previousTracker)
 	{
 		// unwrap uninteresting nodes:
 		while (true) {
@@ -658,6 +879,26 @@ public class FakedTrackingVariable extends LocalDeclaration {
 				expression = ((CastExpression) expression).expression;
 			else
 				break;
+		}
+		if (expression instanceof Literal) {
+			return null;
+		}
+		// delegate to components:
+		if (expression instanceof ConditionalExpression) {
+			return getMoreUnsafeFromBranches((ConditionalExpression) expression, flowInfo,
+						branch -> analyseCloseableExpression(scope, flowInfo, flowContext, useAnnotations,
+																local, location, branch, previousTracker));
+		} else if (expression instanceof SwitchExpression) {
+			FakedTrackingVariable mostRisky = null;
+			for (Expression result : ((SwitchExpression) expression).resultExpressions) {
+				FakedTrackingVariable current = analyseCloseableExpression(scope, flowInfo, flowContext, useAnnotations,
+						local, location, result, previousTracker);
+				if (mostRisky == null)
+					mostRisky = current;
+				else
+					mostRisky = pickMoreUnsafe(mostRisky, current, flowInfo);
+			}
+			return mostRisky;
 		}
 
 		boolean isResourceProducer = false;
@@ -669,6 +910,27 @@ public class FakedTrackingVariable extends LocalDeclaration {
 				else
 					return null; // (a) resource-free closeable: -> null
 			}
+		}
+
+		if (local == null) {
+			FakedTrackingVariable tracker = null;
+			if (useAnnotations && (expression.bits & RestrictiveFlagMASK) == Binding.FIELD) {
+				// field read
+				FieldBinding fieldBinding = ((Reference) expression).lastFieldBinding();
+				long owningBits = 0;
+				if (fieldBinding != null) {
+					owningBits = fieldBinding.getAnnotationTagBits() & TagBits.AnnotationOwningMASK;
+				}
+				int status = FlowInfo.UNKNOWN;
+				if (owningBits == TagBits.AnnotationOwning) {
+					status = FlowInfo.NON_NULL;
+				} else if (owningBits == TagBits.AnnotationNotOwning) {
+					status = FlowInfo.POTENTIALLY_NULL;
+				}
+				tracker = new FakedTrackingVariable(local, scope, location, flowInfo, flowContext, status, useAnnotations);
+				tracker.owningState = NOT_OWNED;
+			}
+			return tracker;
 		}
 
 		// analyze by node type:
@@ -683,12 +945,18 @@ public class FakedTrackingVariable extends LocalDeclaration {
 		} else if (expression instanceof MessageSend
 				|| expression instanceof ArrayReference)
 		{
-			if (isCallingOwningAnnotatedMethod(expression)) {
-				return new FakedTrackingVariable(local, location, flowInfo, flowContext, FlowInfo.NULL);
+			int initialNullStatus = 0;
+			if (isBlacklistedMethod(expression)) {
+				initialNullStatus = FlowInfo.NULL;
+			} else if (useAnnotations) {
+				initialNullStatus = getNullStatusFromMessageSend(expression);
 			}
+			if (initialNullStatus != 0)
+				return new FakedTrackingVariable(local, location, flowInfo, flowContext, initialNullStatus, useAnnotations);
+
 			// we *might* be responsible for the resource obtained
-			FakedTrackingVariable tracker = new FakedTrackingVariable(local, location, flowInfo, flowContext, FlowInfo.POTENTIALLY_NULL); // shed some doubt
-			if (!isResourceProducer)
+			FakedTrackingVariable tracker = new FakedTrackingVariable(local, location, flowInfo, flowContext, FlowInfo.POTENTIALLY_NULL, useAnnotations); // shed some doubt
+			if (!isResourceProducer && !useAnnotations)
 				tracker.globalClosingState |= SHARED_WITH_OUTSIDE;
 			return tracker;
 		} else if (
@@ -696,17 +964,19 @@ public class FakedTrackingVariable extends LocalDeclaration {
 				||((expression instanceof QualifiedNameReference)
 						&& ((QualifiedNameReference) expression).isFieldAccess()))
 		{
-			// responsibility for this resource probably lies at a higher level
-			FakedTrackingVariable tracker = new FakedTrackingVariable(local, location, flowInfo, flowContext, FlowInfo.UNKNOWN);
-			tracker.globalClosingState |= OWNED_BY_OUTSIDE;
-			// leave state as UNKNOWN, the bit OWNED_BY_OUTSIDE will prevent spurious warnings
-			return tracker;
+			if (!useAnnotations) {
+				// responsibility for this resource probably lies at a higher level
+				FakedTrackingVariable tracker = new FakedTrackingVariable(local, location, flowInfo, flowContext, FlowInfo.UNKNOWN, useAnnotations);
+				tracker.globalClosingState |= OWNED_BY_OUTSIDE;
+				// leave state as UNKNOWN, the bit OWNED_BY_OUTSIDE will prevent spurious warnings
+				return tracker;
+			}
 		}
 
 		if (local.closeTracker != null)
 			// (c): inner has already been analyzed: -> re-use track var
 			return local.closeTracker;
-		FakedTrackingVariable newTracker = new FakedTrackingVariable(local, location, flowInfo, flowContext, FlowInfo.UNKNOWN);
+		FakedTrackingVariable newTracker = new FakedTrackingVariable(local, location, flowInfo, flowContext, FlowInfo.UNKNOWN, useAnnotations);
 		LocalVariableBinding rhsLocal = expression.localVariableBinding();
 		if (rhsLocal != null && rhsLocal.isParameter()) {
 			newTracker.globalClosingState |= OWNED_BY_OUTSIDE;
@@ -724,9 +994,14 @@ public class FakedTrackingVariable extends LocalDeclaration {
 		return false;
 	}
 
-	protected static boolean isCallingOwningAnnotatedMethod(Expression expression) {
-		return expression instanceof MessageSend
-				&& (((MessageSend) expression).binding.tagBits & TagBits.AnnotationOwning) != 0;
+	/* pre: usesOwningAnnotations. */
+	protected static int getNullStatusFromMessageSend(Expression expression) {
+		if (expression instanceof MessageSend) {
+			if ((((MessageSend) expression).binding.tagBits & TagBits.AnnotationNotOwning) != 0)
+				return FlowInfo.NON_NULL;
+			return FlowInfo.NULL; // per default assume responsibility to close
+		}
+		return 0;
 	}
 
 	public static void cleanUpAfterAssignment(BlockScope currentScope, int lhsBits, Expression expression) {
@@ -756,17 +1031,22 @@ public class FakedTrackingVariable extends LocalDeclaration {
 		} else {
 			// assignment passing a local into a field?
 			LocalVariableBinding local = expression.localVariableBinding();
-			if (local != null && local.closeTracker != null && ((lhsBits & Binding.FIELD) != 0))
+			if (local != null
+					&& ((lhsBits & Binding.FIELD) != 0)
+					&& !currentScope.compilerOptions().isAnnotationBasedResourceAnalysisEnabled
+					&& local.closeTracker != null) {
 				local.closeTracker.withdraw(); // TODO: may want to use local.closeTracker.markPassedToOutside(..,true)
+			}
 		}
 	}
 
-	/** Unassigned closeables are not visible beyond their enclosing statement, immediately report & remove after each statement.
-	 * @param returnOwning {@code TRUE} signals present {@code @Onwning} annotation on the method, {@code FALSE} absent annotation,
-	 * 	{@code null} signals not currently analysing a return statement (end of block / method).
+	/**
+	 * Unassigned closeables are not visible beyond their enclosing statement, immediately report & remove after each statement.
+	 * @param returnMissingOwning at a return statement this signals {@code true} when the enclosing method lacks an {@code @Owning} annotation.
 	 */
-	public static void cleanUpUnassigned(BlockScope scope, ASTNode location, FlowInfo flowInfo, Boolean returnOwning) {
+	public static void cleanUpUnassigned(BlockScope scope, ASTNode location, FlowInfo flowInfo, boolean returnMissingOwning) {
 		if (!scope.hasResourceTrackers()) return;
+		boolean useAnnotations = scope.compilerOptions().isAnnotationBasedResourceAnalysisEnabled;
 		location.traverse(new ASTVisitor() {
 				@Override
 				public boolean visit(MessageSend messageSend, BlockScope skope) {
@@ -776,23 +1056,27 @@ public class FakedTrackingVariable extends LocalDeclaration {
 				}
 				@Override
 				public boolean visit(AllocationExpression allocation, BlockScope skope) {
-					if (returnOwning != null)
-						handle(allocation.closeTracker, flowInfo, allocation, skope);
+					if (useAnnotations) {
+						if (handle(allocation.closeTracker, flowInfo, allocation, skope))
+							allocation.closeTracker = null;
+					}
 					return true;
 				}
 
-				protected void handle(FakedTrackingVariable closeTracker, FlowInfo flow, ASTNode loc, BlockScope skope) {
-					if (closeTracker != null) {
-						if (closeTracker.originalBinding == null) {
-							int nullStatus = flow.nullStatus(closeTracker.binding);
-							if ((nullStatus & (FlowInfo.POTENTIALLY_NULL | FlowInfo.NULL)) != 0) {
-								closeTracker.reportError(skope.problemReporter(), loc, nullStatus);
-							} else if (returnOwning == Boolean.FALSE) {
-								skope.problemReporter().shouldMarkMethodAsOwning(location);
-							}
-							closeTracker.withdraw();
+				/** @return has the tracker been withdrawn? */
+				protected boolean handle(FakedTrackingVariable closeTracker, FlowInfo flow, ASTNode loc, BlockScope skope) {
+					if (closeTracker != null && closeTracker.originalBinding == null && closeTracker.originalFieldBinding == null) {
+						int nullStatus = closeTracker.riskyNullStatusAt(flow);
+						if (nullStatus != 0) {
+							int reportFlag = closeTracker.reportError(skope.problemReporter(), loc, nullStatus);
+							closeTracker.markAllConnected(ftv -> ftv.globalClosingState |= reportFlag);
+						} else if (returnMissingOwning && useAnnotations) {
+							skope.problemReporter().shouldMarkMethodAsOwning(location);
 						}
+						closeTracker.withdraw();
+						return true;
 					}
+					return false;
 				}
 			},
 			scope);
@@ -802,6 +1086,16 @@ public class FakedTrackingVariable extends LocalDeclaration {
 	public static boolean isAnyCloseable(TypeBinding typeBinding) {
 		return typeBinding instanceof ReferenceBinding
 			&& ((ReferenceBinding)typeBinding).hasTypeBit(TypeIds.BitAutoCloseable|TypeIds.BitCloseable);
+	}
+
+	/** Answer wither the given type binding is a subtype of java.lang.AutoCloseable. */
+	public static boolean isCloseableNotWhiteListed(TypeBinding typeBinding) {
+		if (typeBinding instanceof ReferenceBinding) {
+			ReferenceBinding referenceBinding = (ReferenceBinding)typeBinding;
+			return referenceBinding.hasTypeBit(TypeIds.BitAutoCloseable|TypeIds.BitCloseable)
+					&& !referenceBinding.hasTypeBit(TypeIds.BitResourceFreeCloseable);
+		}
+		return false;
 	}
 
 	public int findMostSpecificStatus(FlowInfo flowInfo, BlockScope currentScope, BlockScope locationScope) {
@@ -861,7 +1155,7 @@ public class FakedTrackingVariable extends LocalDeclaration {
 			return FlowInfo.POTENTIALLY_NULL;
 		} else if (status == FlowInfo.UNKNOWN) {
 			// if unassigned resource (not having an originalBinding) is not withdrawn it is unclosed:
-			if (this.originalBinding == null)
+			if (this.originalBinding == null && this.originalFieldBinding == null)
 				return FlowInfo.NULL;
 		}
 		return status;
@@ -887,18 +1181,48 @@ public class FakedTrackingVariable extends LocalDeclaration {
 
 	/** Mark that this resource is closed locally. */
 	public void markClose(FlowInfo flowInfo, FlowContext flowContext) {
-		FakedTrackingVariable current = this;
-		do {
+		markAllConnected(current -> {
 			flowInfo.markAsDefinitelyNonNull(current.binding);
 			current.globalClosingState |= CLOSE_SEEN;
 			flowContext.markFinallyNullStatus(current.binding, FlowInfo.NON_NULL);
+		});
+	}
+
+	private void markUnknown(FlowInfo flowInfo, FlowContext flowContext) {
+		markAllConnected(current -> {
+			flowInfo.markAsDefinitelyUnknown(current.binding);
+			flowContext.markFinallyNullStatus(current.binding, FlowInfo.UNKNOWN);
+		});
+	}
+
+	public void markOwnedByOutside(FlowInfo flowInfo, FlowContext flowContext) {
+		markAllConnected(current -> {
+			flowInfo.markAsDefinitelyNonNull(current.binding);
+			flowContext.markFinallyNullStatus(current.binding, FlowInfo.NON_NULL);
+			current.globalClosingState = FakedTrackingVariable.OWNED_BY_OUTSIDE;
+		});
+	}
+
+	public void markAllConnected(Consumer<FakedTrackingVariable> operation) {
+		FakedTrackingVariable current = this;
+		do {
+			operation.accept(current);
 			current = current.innerTracker;
 		} while (current != null);
+		current = this.outerTracker;
+		while (current != null) {
+			operation.accept(current);
+			current = current.outerTracker;
+		}
 	}
 
 	/** Mark that this resource is closed from a nested method (inside a local class). */
 	public void markClosedInNestedMethod() {
 		this.globalClosingState |= CLOSED_IN_NESTED_METHOD;
+	}
+
+	public boolean isClosedInNestedMethod() {
+		return (this.globalClosingState & CLOSED_IN_NESTED_METHOD) != 0;
 	}
 
 	/** Mark that this resource is closed from a try-with-resource with the tracking variable being effectively final). */
@@ -913,17 +1237,18 @@ public class FakedTrackingVariable extends LocalDeclaration {
 	 */
 	public static FlowInfo markPassedToOutside(BlockScope scope, Expression expression, FlowInfo flowInfo, FlowContext flowContext, boolean owned) {
 
-		FakedTrackingVariable trackVar = getCloseTrackingVariable(expression, flowInfo, flowContext);
+		FakedTrackingVariable trackVar = getCloseTrackingVariable(expression, flowInfo, flowContext,
+				scope.compilerOptions().isAnnotationBasedResourceAnalysisEnabled);
 		if (trackVar != null) {
 			// insert info that the tracked resource *may* be closed (by the target method, i.e.)
 			FlowInfo infoResourceIsClosed = owned ? flowInfo : flowInfo.copy();
 			int flag = owned ? OWNED_BY_OUTSIDE : SHARED_WITH_OUTSIDE;
-			do {
-				trackVar.globalClosingState |= flag;
-				if (scope.methodScope() != trackVar.methodScope)
-					trackVar.globalClosingState |= CLOSED_IN_NESTED_METHOD;
-				infoResourceIsClosed.markAsDefinitelyNonNull(trackVar.binding);
-			} while ((trackVar = trackVar.innerTracker) != null);
+			trackVar.markAllConnected(ftv -> {
+				ftv.globalClosingState |= flag;
+				if (scope.methodScope() != ftv.methodScope)
+					ftv.globalClosingState |= CLOSED_IN_NESTED_METHOD;
+				infoResourceIsClosed.markAsDefinitelyNonNull(ftv.binding);
+			});
 			if (owned) {
 				return infoResourceIsClosed; // don't let downstream signal any problems on this flow
 			} else {
@@ -1064,6 +1389,11 @@ public class FakedTrackingVariable extends LocalDeclaration {
 			currentScope = (BlockScope) currentScope.parent;
 		}
 	}
+
+	public boolean isClosedInFinally() {
+		return this.blockScope != null && isClosedInFinallyOfEnclosing(this.blockScope);
+	}
+
 	/**
 	 * If current is the same as 'returnedResource' or a wrapper thereof,
 	 * mark as reported and return true, otherwise false.
@@ -1086,14 +1416,16 @@ public class FakedTrackingVariable extends LocalDeclaration {
 	public void withdraw() {
 		// must unregister at the declaringScope, note that twr resources are owned by the scope enclosing the twr
 		this.binding.declaringScope.removeTrackingVar(this);
+		if (this.acquisition != null && this.acquisition.closeTracker == this)
+			this.acquisition.closeTracker = null;
 	}
 
 	public void recordErrorLocation(ASTNode location, int nullStatus) {
-		if ((this.globalClosingState & OWNED_BY_OUTSIDE) != 0) {
+		if (isNotOwned()) {
 			return;
 		}
 		if (this.recordedLocations == null)
-			this.recordedLocations = new HashMap();
+			this.recordedLocations = new HashMap<>();
 		this.recordedLocations.put(location, Integer.valueOf(nullStatus));
 	}
 
@@ -1115,11 +1447,11 @@ public class FakedTrackingVariable extends LocalDeclaration {
 		}
 		boolean hasReported = false;
 		if (this.recordedLocations != null) {
-			Iterator locations = this.recordedLocations.entrySet().iterator();
+			Iterator<Map.Entry<ASTNode,Integer>> locations = this.recordedLocations.entrySet().iterator();
 			int reportFlags = 0;
 			while (locations.hasNext()) {
-				Map.Entry entry = (Entry) locations.next();
-				reportFlags |= reportError(scope.problemReporter(), (ASTNode)entry.getKey(), ((Integer)entry.getValue()).intValue());
+				Entry<ASTNode, Integer> entry = locations.next();
+				reportFlags |= reportError(scope.problemReporter(), entry.getKey(), entry.getValue().intValue());
 				hasReported = true;
 			}
 			if (reportFlags != 0) {
@@ -1133,6 +1465,10 @@ public class FakedTrackingVariable extends LocalDeclaration {
 		return hasReported;
 	}
 
+	public boolean hasRecordedLocations() {
+		return this.recordedLocations != null;
+	}
+
 	private boolean neverClosedAtLocations() {
 		if (this.recordedLocations != null) {
 			for (Object value : this.recordedLocations.values())
@@ -1143,7 +1479,7 @@ public class FakedTrackingVariable extends LocalDeclaration {
 	}
 
 	public int reportError(ProblemReporter problemReporter, ASTNode location, int nullStatus) {
-		if ((this.globalClosingState & OWNED_BY_OUTSIDE) != 0) {
+		if (isNotOwned()) {
 			return 0; // TODO: should we still propagate some flags??
 		}
 		// which degree of problem?
@@ -1171,16 +1507,25 @@ public class FakedTrackingVariable extends LocalDeclaration {
 		// propagate flag to inners:
 		int reportFlag = isPotentialProblem ? REPORTED_POTENTIAL_LEAK : REPORTED_DEFINITIVE_LEAK;
 		if (location == null) { // if location != null flags will be set after the loop over locations
-			FakedTrackingVariable current = this;
-			do {
-				current.globalClosingState |= reportFlag;
-			} while ((current = current.innerTracker) != null);
+			markAllConnected(current -> current.globalClosingState |= reportFlag);
 		}
 		return reportFlag;
 	}
 
 	public void reportExplicitClosing(ProblemReporter problemReporter) {
+		if (this.originalBinding != null && this.originalBinding.isParameter())
+			return;
+		if ((this.globalClosingState & CLOSE_SEEN) == 0)
+			return;
 		if ((this.globalClosingState & (TWR_EFFECTIVELY_FINAL|OWNED_BY_OUTSIDE|REPORTED_EXPLICIT_CLOSE|FOREACH_ELEMENT_VAR)) == 0) { // can't use t-w-r for OWNED_BY_OUTSIDE
+			if (this.originalFieldBinding != null && this.blockScope instanceof MethodScope) {
+				AbstractMethodDeclaration method = ((MethodScope) this.blockScope).referenceMethod();
+				if (CharOperation.equals(TypeConstants.CLOSE, method.selector)
+						&& method.binding != null
+						&& method.binding.declaringClass.hasTypeBit(TypeIds.BitCloseable|TypeIds.BitAutoCloseable)) {
+					return; // this is the canonical close method, nothing to warn about.
+				}
+			}
 			this.globalClosingState |= REPORTED_EXPLICIT_CLOSE;
 			problemReporter.explicitlyClosedAutoCloseable(this);
 		}
@@ -1201,6 +1546,25 @@ public class FakedTrackingVariable extends LocalDeclaration {
 				}
 			}
 		}
+		if (this.originalFieldBinding != null)
+			return String.valueOf(CharOperation.concat(ConstantPool.This, this.name, '.'));
 		return String.valueOf(this.name);
+	}
+
+	public void markAsShared() {
+		this.globalClosingState |= SHARED_WITH_OUTSIDE;
+	}
+
+	public boolean isShared() {
+		return (this.globalClosingState & SHARED_WITH_OUTSIDE) != 0;
+	}
+
+	protected boolean isNotOwned() {
+		if (this.useAnnotations)
+			return this.owningState < 0;
+		return (this.globalClosingState & OWNED_BY_OUTSIDE) != 0;
+	}
+	public boolean closeSeen() {
+		return (this.globalClosingState & CLOSE_SEEN) != 0;
 	}
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/FieldDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/FieldDeclaration.java
@@ -97,8 +97,8 @@ public FlowInfo analyseCode(MethodScope initializationScope, FlowContext flowCon
 				.unconditionalInits();
 		flowInfo.markAsDefinitelyAssigned(this.binding);
 	}
+	CompilerOptions options = initializationScope.compilerOptions();
 	if (this.initialization != null && this.binding != null) {
-		CompilerOptions options = initializationScope.compilerOptions();
 		if (options.isAnnotationBasedNullAnalysisEnabled) {
 			if (this.binding.isNonNull() || options.sourceLevel >= ClassFileConstants.JDK1_8) {
 				int nullStatus = this.initialization.nullStatus(flowInfo, flowContext);
@@ -106,6 +106,16 @@ public FlowInfo analyseCode(MethodScope initializationScope, FlowContext flowCon
 			}
 		}
 		this.initialization.checkNPEbyUnboxing(initializationScope, flowContext, flowInfo);
+	}
+	if (options.isAnnotationBasedResourceAnalysisEnabled
+			&& this.binding != null
+			&& this.binding.type.hasTypeBit(TypeIds.BitAutoCloseable|TypeIds.BitCloseable))
+	{
+		if ((this.binding.tagBits & TagBits.AnnotationOwning) == 0) {
+			initializationScope.problemReporter().shouldMarkFieldAsOwning(this);
+		} else if (!this.binding.declaringClass.hasTypeBit(TypeIds.BitAutoCloseable|TypeIds.BitCloseable)) {
+			initializationScope.problemReporter().shouldImplementAutoCloseable(this);
+		}
 	}
 	return flowInfo;
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Invocation.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Invocation.java
@@ -56,7 +56,7 @@ public interface Invocation extends InvocationSite {
 
 	/** Resource leak analysis: track the case that a resource is passed as an argument to an invocation. */
 	default FlowInfo handleResourcePassedToInvocation(BlockScope currentScope, MethodBinding methodBinding, Expression argument, int rank,
-			FlowContext flowContext, FlowInfo flowInfo, boolean constructingResourceWrapper) {
+			FlowContext flowContext, FlowInfo flowInfo) {
 		if (currentScope.compilerOptions().isAnnotationBasedResourceAnalysisEnabled) {
 			FakedTrackingVariable trackVar = FakedTrackingVariable.getCloseTrackingVariable(argument, flowInfo, flowContext, true);
 			if (trackVar != null) {
@@ -64,11 +64,11 @@ public interface Invocation extends InvocationSite {
 					trackVar.markOwnedByOutside(flowInfo, flowContext);
 				} else if (methodBinding.notownsParameter(rank)) {
 					// ignore, no relevant change
-				} else if (!constructingResourceWrapper) {
+				} else {
 					trackVar.markAsShared();
 				}
 			}
-		} else if (!constructingResourceWrapper) { // allocation of wrapped closeables is analyzed specially
+		} else {
 			// insert info that it *may* be closed (by the target constructor, i.e.)
 			return FakedTrackingVariable.markPassedToOutside(currentScope, argument, flowInfo, flowContext, false);
 		}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Invocation.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Invocation.java
@@ -13,6 +13,9 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.compiler.ast;
 
+import org.eclipse.jdt.internal.compiler.flow.FlowContext;
+import org.eclipse.jdt.internal.compiler.flow.FlowInfo;
+import org.eclipse.jdt.internal.compiler.lookup.BlockScope;
 import org.eclipse.jdt.internal.compiler.lookup.InferenceContext18;
 import org.eclipse.jdt.internal.compiler.lookup.InvocationSite;
 import org.eclipse.jdt.internal.compiler.lookup.MethodBinding;
@@ -51,4 +54,24 @@ public interface Invocation extends InvocationSite {
 	/** Record result against target type */
 	void registerResult(TypeBinding targetType, MethodBinding method);
 
+	/** Resource leak analysis: track the case that a resource is passed as an argument to an invocation. */
+	default FlowInfo handleResourcePassedToInvocation(BlockScope currentScope, MethodBinding methodBinding, Expression argument, int rank,
+			FlowContext flowContext, FlowInfo flowInfo, boolean constructingResourceWrapper) {
+		if (currentScope.compilerOptions().isAnnotationBasedResourceAnalysisEnabled) {
+			FakedTrackingVariable trackVar = FakedTrackingVariable.getCloseTrackingVariable(argument, flowInfo, flowContext, true);
+			if (trackVar != null) {
+				if (methodBinding.ownsParameter(rank)) {
+					trackVar.markOwnedByOutside(flowInfo, flowContext);
+				} else if (methodBinding.notownsParameter(rank)) {
+					// ignore, no relevant change
+				} else if (!constructingResourceWrapper) {
+					trackVar.markAsShared();
+				}
+			}
+		} else if (!constructingResourceWrapper) { // allocation of wrapped closeables is analyzed specially
+			// insert info that it *may* be closed (by the target constructor, i.e.)
+			return FakedTrackingVariable.markPassedToOutside(currentScope, argument, flowInfo, flowContext, false);
+		}
+		return flowInfo;
+	}
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LambdaExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LambdaExpression.java
@@ -602,7 +602,7 @@ public class LambdaExpression extends FunctionalExpression implements IPolyExpre
 
 		// nullity and mark as assigned
 		MethodBinding methodWithParameterDeclaration = argumentsTypeElided() ? this.descriptor : this.binding;
-		AbstractMethodDeclaration.analyseArguments(currentScope.environment(), lambdaInfo, this.arguments, methodWithParameterDeclaration);
+		AbstractMethodDeclaration.analyseArguments(currentScope.environment(), lambdaInfo, flowContext, this.arguments, methodWithParameterDeclaration);
 
 		if (this.arguments != null) {
 			for (int i = 0, count = this.arguments.length; i < count; i++) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LambdaExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LambdaExpression.java
@@ -600,7 +600,7 @@ public class LambdaExpression extends FunctionalExpression implements IPolyExpre
 						this.scope,
 						FlowInfo.DEAD_END);
 
-		// nullity and mark as assigned
+		// nullity, owning and mark as assigned
 		MethodBinding methodWithParameterDeclaration = argumentsTypeElided() ? this.descriptor : this.binding;
 		AbstractMethodDeclaration.analyseArguments(currentScope.environment(), lambdaInfo, flowContext, this.arguments, methodWithParameterDeclaration);
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LocalDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LocalDeclaration.java
@@ -82,14 +82,16 @@ public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext, Fl
 	this.initialization.checkNPEbyUnboxing(currentScope, flowContext, flowInfo);
 
 	FlowInfo preInitInfo = null;
+	CompilerOptions compilerOptions = currentScope.compilerOptions();
 	boolean shouldAnalyseResource = this.binding != null
 			&& flowInfo.reachMode() == FlowInfo.REACHABLE
-			&& currentScope.compilerOptions().analyseResourceLeaks
+			&& compilerOptions.analyseResourceLeaks
 			&& FakedTrackingVariable.isAnyCloseable(this.initialization.resolvedType);
 	if (shouldAnalyseResource) {
 		preInitInfo = flowInfo.unconditionalCopy();
 		// analysis of resource leaks needs additional context while analyzing the RHS:
-		FakedTrackingVariable.preConnectTrackerAcrossAssignment(this, this.binding, this.initialization, flowInfo);
+		FakedTrackingVariable.preConnectTrackerAcrossAssignment(this, this.binding, this.initialization, flowInfo,
+				compilerOptions.isAnnotationBasedResourceAnalysisEnabled);
 	}
 
 	flowInfo =
@@ -109,7 +111,7 @@ public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext, Fl
 		this.bits &= ~FirstAssignmentToLocal;  // int i = (i = 0);
 	}
 	flowInfo.markAsDefinitelyAssigned(this.binding);
-	if (currentScope.compilerOptions().isAnnotationBasedNullAnalysisEnabled) {
+	if (compilerOptions.isAnnotationBasedNullAnalysisEnabled) {
 		nullStatus = NullAnnotationMatching.checkAssignment(currentScope, flowContext, this.binding, flowInfo, nullStatus, this.initialization, this.initialization.resolvedType);
 	}
 	if ((this.binding.type.tagBits & TagBits.IsBaseType) == 0) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/MessageSend.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/MessageSend.java
@@ -245,7 +245,7 @@ public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext, Fl
 					flowInfo = argument.analyseCode(currentScope, flowContext, flowInfo).unconditionalInits();
 			}
 			if (analyseResources) {
-				flowInfo = handleResourcePassedToInvocation(currentScope, this.binding, argument, i, flowContext, flowInfo, false);
+				flowInfo = handleResourcePassedToInvocation(currentScope, this.binding, argument, i, flowContext, flowInfo);
 			}
 		}
 		analyseArguments(currentScope, flowContext, flowInfo, this.binding, this.arguments);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/MessageSend.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/MessageSend.java
@@ -264,7 +264,7 @@ public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext, Fl
 	}
 	// after having analysed exceptions above start tracking newly allocated resource:
 	if (analyseResources && FakedTrackingVariable.isAnyCloseable(this.resolvedType))
-		flowInfo = FakedTrackingVariable.analyseCloseableAcquisition(currentScope, flowInfo, this);
+		flowInfo = FakedTrackingVariable.analyseCloseableAcquisition(currentScope, flowInfo, flowContext, this);
 
 	manageSyntheticAccessIfNecessary(currentScope, flowInfo);
 	// account for pot. exceptions thrown by method execution

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/MessageSend.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/MessageSend.java
@@ -237,7 +237,14 @@ public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext, Fl
 			}
 			if (analyseResources) {
 				// if argument is an AutoCloseable insert info that it *may* be closed (by the target method, i.e.)
-				flowInfo = FakedTrackingVariable.markPassedToOutside(currentScope, argument, flowInfo, flowContext, false);
+				if (this.binding.ownsParameter(i)) {
+					FakedTrackingVariable trackVar = FakedTrackingVariable.getCloseTrackingVariable(argument, flowInfo, flowContext);
+					if (trackVar != null) {
+						flowInfo.markAsDefinitelyNonNull(trackVar.binding);
+					}
+				} else {
+					flowInfo = FakedTrackingVariable.markPassedToOutside(currentScope, argument, flowInfo, flowContext, false);
+				}
 			}
 		}
 		analyseArguments(currentScope, flowContext, flowInfo, this.binding, this.arguments);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/MethodDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/MethodDeclaration.java
@@ -115,7 +115,7 @@ public class MethodDeclaration extends AbstractMethodDeclaration {
 					FlowInfo.DEAD_END);
 
 			// nullity and mark as assigned
-			analyseArguments(classScope.environment(), flowInfo, this.arguments, this.binding);
+			analyseArguments(classScope.environment(), flowInfo, flowContext, this.arguments, this.binding);
 
 			BiPredicate<TypeBinding, ReferenceBinding> condition = (argType, declClass) -> {
 				ReferenceBinding enclosingType = argType.enclosingType();

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/MethodDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/MethodDeclaration.java
@@ -158,7 +158,7 @@ public class MethodDeclaration extends AbstractMethodDeclaration {
 						methodContext.expireNullCheckedFieldInfo();
 					}
 					if (compilerOptions.analyseResourceLeaks) {
-						FakedTrackingVariable.cleanUpUnassigned(this.scope, stat, flowInfo);
+						FakedTrackingVariable.cleanUpUnassigned(this.scope, stat, flowInfo, null);
 					}
 				}
 			} else {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/MethodDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/MethodDeclaration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -148,9 +148,7 @@ public class MethodDeclaration extends AbstractMethodDeclaration {
 			}
 			CompilerOptions compilerOptions = this.scope.compilerOptions();
 			if (compilerOptions.isAnnotationBasedResourceAnalysisEnabled
-					&& this.binding.declaringClass.hasTypeBit(TypeIds.BitAutoCloseable|TypeIds.BitCloseable)
-					&& CharOperation.equals(this.selector, TypeConstants.CLOSE)
-					&& this.arguments == null)
+					&& this.binding.isClosingMethod())
 			{
 				// implementation of AutoCloseable.close() should close all @Owning fields, create the obligation now:
 				ReferenceBinding currentClass = this.binding.declaringClass;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/MethodDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/MethodDeclaration.java
@@ -114,7 +114,7 @@ public class MethodDeclaration extends AbstractMethodDeclaration {
 					this.scope,
 					FlowInfo.DEAD_END);
 
-			// nullity and mark as assigned
+			// nullity, owning and mark as assigned
 			analyseArguments(classScope.environment(), flowInfo, flowContext, this.arguments, this.binding);
 
 			BiPredicate<TypeBinding, ReferenceBinding> condition = (argType, declClass) -> {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/QualifiedAllocationExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/QualifiedAllocationExpression.java
@@ -129,9 +129,8 @@ public class QualifiedAllocationExpression extends AllocationExpression {
 						&& ((ReferenceBinding)this.resolvedType).hasTypeBit(TypeIds.BitWrapperCloseable);
 			for (int i = 0, count = this.arguments.length; i < count; i++) {
 				flowInfo = this.arguments[i].analyseCode(currentScope, flowContext, flowInfo);
-				if (analyseResources) {
-					flowInfo = handleResourcePassedToInvocation(currentScope, this.binding, this.arguments[i], i,
-							flowContext, flowInfo, hasResourceWrapperType);
+				if (analyseResources && !hasResourceWrapperType) { // allocation of wrapped closeables is analyzed specially
+					flowInfo = handleResourcePassedToInvocation(currentScope, this.binding, this.arguments[i], i, flowContext, flowInfo);
 				}
 				this.arguments[i].checkNPEbyUnboxing(currentScope, flowContext, flowInfo);
 			}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/QualifiedAllocationExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/QualifiedAllocationExpression.java
@@ -129,9 +129,9 @@ public class QualifiedAllocationExpression extends AllocationExpression {
 						&& ((ReferenceBinding)this.resolvedType).hasTypeBit(TypeIds.BitWrapperCloseable);
 			for (int i = 0, count = this.arguments.length; i < count; i++) {
 				flowInfo = this.arguments[i].analyseCode(currentScope, flowContext, flowInfo);
-				if (analyseResources && !hasResourceWrapperType) { // allocation of wrapped closeables is analyzed specially
-					// if argument is an AutoCloseable insert info that it *may* be closed (by the target method, i.e.)
-					flowInfo = FakedTrackingVariable.markPassedToOutside(currentScope, this.arguments[i], flowInfo, flowContext, false);
+				if (analyseResources) {
+					flowInfo = handleResourcePassedToInvocation(currentScope, this.binding, this.arguments[i], i,
+							flowContext, flowInfo, hasResourceWrapperType);
 				}
 				this.arguments[i].checkNPEbyUnboxing(currentScope, flowContext, flowInfo);
 			}
@@ -160,7 +160,7 @@ public class QualifiedAllocationExpression extends AllocationExpression {
 
 		// after having analysed exceptions above start tracking newly allocated resource:
 		if (currentScope.compilerOptions().analyseResourceLeaks && FakedTrackingVariable.isAnyCloseable(this.resolvedType)) {
-			FakedTrackingVariable.analyseCloseableAllocation(currentScope, flowInfo, this);
+			FakedTrackingVariable.analyseCloseableAllocation(currentScope, flowInfo, flowContext, this);
 		}
 
 		manageEnclosingInstanceAccessIfNecessary(currentScope, flowInfo);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ReferenceExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ReferenceExpression.java
@@ -532,7 +532,8 @@ public class ReferenceExpression extends FunctionalExpression implements IPolyEx
 				}
 			}
 		}
-		if (currentScope.compilerOptions().isAnyEnabled(IrritantSet.UNLIKELY_ARGUMENT_TYPE) && this.binding.isValidBinding()
+		CompilerOptions compilerOptions = currentScope.compilerOptions();
+		if (compilerOptions.isAnyEnabled(IrritantSet.UNLIKELY_ARGUMENT_TYPE) && this.binding.isValidBinding()
 				&& this.binding != null && this.binding.parameters != null) {
 			if (this.binding.parameters.length == 1
 					&& this.descriptor.parameters.length == (this.receiverPrecedesParameters ? 2 : 1)
@@ -559,9 +560,9 @@ public class ReferenceExpression extends FunctionalExpression implements IPolyEx
 			}
 		}
 
-		if (currentScope.compilerOptions().analyseResourceLeaks) {
+		if (compilerOptions.analyseResourceLeaks) {
 			if (this.haveReceiver && CharOperation.equals(this.selector, TypeConstants.CLOSE)) {
-				FakedTrackingVariable trackingVariable = FakedTrackingVariable.getCloseTrackingVariable(this.lhs, flowInfo, flowContext);
+				FakedTrackingVariable trackingVariable = FakedTrackingVariable.getCloseTrackingVariable(this.lhs, flowInfo, flowContext, compilerOptions.isAnnotationBasedResourceAnalysisEnabled);
 				if (trackingVariable != null) { // null happens if target is not a local variable or not an AutoCloseable
 					trackingVariable.markClosedInNestedMethod(); // there is a close()-call, but we don't know if it will be invoked
 				}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ReturnStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ReturnStatement.java
@@ -92,21 +92,22 @@ public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext, Fl
 		if (flowInfo.reachMode() == FlowInfo.REACHABLE && currentScope.compilerOptions().isAnnotationBasedNullAnalysisEnabled)
 			checkAgainstNullAnnotation(currentScope, flowContext, flowInfo, this.expression);
 		if (currentScope.compilerOptions().analyseResourceLeaks) {
-			Boolean returnOwning = null;
-			FakedTrackingVariable trackingVariable = FakedTrackingVariable.getCloseTrackingVariable(this.expression, flowInfo, flowContext);
+			boolean returnWithoutOwning = false;
+			boolean useOwningAnnotations = currentScope.compilerOptions().isAnnotationBasedResourceAnalysisEnabled;
+			FakedTrackingVariable trackingVariable = FakedTrackingVariable.getCloseTrackingVariable(this.expression, flowInfo, flowContext, useOwningAnnotations);
 			if (trackingVariable != null) {
 				if (methodScope != trackingVariable.methodScope)
 					trackingVariable.markClosedInNestedMethod();
-				if (currentScope.compilerOptions().isAnnotationBasedResourceAnalysisEnabled) {
+				if (useOwningAnnotations) {
 					flowInfo.markAsDefinitelyNonNull(trackingVariable.binding);
-					returnOwning = (methodScope.referenceMethodBinding().tagBits & TagBits.AnnotationOwning) != 0;
+					returnWithoutOwning = (methodScope.referenceMethodBinding().tagBits & TagBits.AnnotationOwning) == 0;
 				} else {
 					// by returning the method passes the responsibility to the caller:
 					flowInfo = FakedTrackingVariable.markPassedToOutside(currentScope, this.expression, flowInfo, flowContext, true);
 				}
 			}
 			// don't wait till after this statement, because then flowInfo would be DEAD_END & thus cannot serve nullStatus any more:
-			FakedTrackingVariable.cleanUpUnassigned(currentScope, this.expression, flowInfo, returnOwning);
+			FakedTrackingVariable.cleanUpUnassigned(currentScope, this.expression, flowInfo, returnWithoutOwning);
 		}
 	}
 	this.initStateIndex =

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Statement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Statement.java
@@ -137,12 +137,12 @@ protected void analyseArguments(BlockScope currentScope, FlowContext flowContext
 		if (compilerOptions.sourceLevel >= ClassFileConstants.JDK1_7 && methodBinding.isPolymorphic())
 			return;
 		boolean considerTypeAnnotations = currentScope.environment().usesNullTypeAnnotations();
-		boolean hasJDK15NullAnnotations = methodBinding.parameterNonNullness != null;
+		boolean hasJDK15FlowAnnotations = methodBinding.parameterFlowBits != null;
 		int numParamsToCheck = methodBinding.parameters.length;
 		int varArgPos = -1;
 		TypeBinding varArgsType = null;
 		boolean passThrough = false;
-		if (considerTypeAnnotations || hasJDK15NullAnnotations) {
+		if (considerTypeAnnotations || hasJDK15FlowAnnotations) {
 			// check if varargs need special treatment:
 			if (methodBinding.isVarargs()) {
 				varArgPos = numParamsToCheck-1;
@@ -162,21 +162,21 @@ protected void analyseArguments(BlockScope currentScope, FlowContext flowContext
 		if (considerTypeAnnotations) {
 			for (int i=0; i<numParamsToCheck; i++) {
 				TypeBinding expectedType = methodBinding.parameters[i];
-				Boolean specialCaseNonNullness = hasJDK15NullAnnotations ? methodBinding.parameterNonNullness[i] : null;
+				Boolean specialCaseNonNullness = hasJDK15FlowAnnotations? methodBinding.getParameterNullness(i) : null;
 				analyseOneArgument18(currentScope, flowContext, flowInfo, expectedType, arguments[i],
 						specialCaseNonNullness, methodBinding.original().parameters[i]);
 			}
 			if (!passThrough && varArgsType instanceof ArrayBinding) {
 				TypeBinding expectedType = ((ArrayBinding) varArgsType).elementsType();
-				Boolean specialCaseNonNullness = hasJDK15NullAnnotations ? methodBinding.parameterNonNullness[varArgPos] : null;
+				Boolean specialCaseNonNullness = hasJDK15FlowAnnotations? methodBinding.getParameterNullness(varArgPos) : null;
 				for (int i = numParamsToCheck; i < arguments.length; i++) {
 					analyseOneArgument18(currentScope, flowContext, flowInfo, expectedType, arguments[i],
 							specialCaseNonNullness, methodBinding.original().parameters[varArgPos]);
 				}
 			}
-		} else if (hasJDK15NullAnnotations) {
+		} else if (hasJDK15FlowAnnotations) {
 			for (int i = 0; i < numParamsToCheck; i++) {
-				if (methodBinding.parameterNonNullness[i] == Boolean.TRUE) {
+				if ((methodBinding.parameterFlowBits[i] & MethodBinding.PARAM_NONNULL) != 0) {
 					TypeBinding expectedType = methodBinding.parameters[i];
 					Expression argument = arguments[i];
 					int nullStatus = argument.nullStatus(flowInfo, flowContext); // slight loss of precision: should also use the null info from the receiver.

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TryStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TryStatement.java
@@ -171,7 +171,9 @@ public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext, Fl
 					localVariableBinding = (LocalVariableBinding) ((NameReference) resource).binding;
 				}
 				resolvedType = ((Expression) resource).resolvedType;
-				recordCallingClose(currentScope, flowContext, tryInfo, (Expression)resource);
+				if (currentScope.compilerOptions().analyseResourceLeaks) {
+					recordCallingClose(currentScope, handlingContext, tryInfo, (Expression)resource);
+				}
 			}
 			if (localVariableBinding != null) {
 				localVariableBinding.useFlag = LocalVariableBinding.USED; // Is implicitly used anyways.

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TryStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TryStatement.java
@@ -384,7 +384,8 @@ public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext, Fl
 	}
 }
 private void recordCallingClose(BlockScope currentScope, FlowContext flowContext, FlowInfo flowInfo, Expression closeTarget) {
-	FakedTrackingVariable trackingVariable = FakedTrackingVariable.getCloseTrackingVariable(closeTarget, flowInfo, flowContext);
+	FakedTrackingVariable trackingVariable = FakedTrackingVariable.getCloseTrackingVariable(closeTarget, flowInfo, flowContext,
+			currentScope.compilerOptions().isAnnotationBasedResourceAnalysisEnabled);
 	if (trackingVariable != null) { // null happens if target is not a local variable or not an AutoCloseable
 		if (trackingVariable.methodScope == currentScope.methodScope()) {
 			trackingVariable.markClose(flowInfo, flowContext);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypeDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypeDeclaration.java
@@ -1924,6 +1924,9 @@ public void updateSupertypesWithAnnotations(Map<ReferenceBinding,ReferenceBindin
 			memberTypesDecl.updateSupertypesWithAnnotations(updates);
 		}
 	}
+	if (this.scope.compilerOptions().isAnnotationBasedResourceAnalysisEnabled) {
+		this.binding.detectWrapperResource(); // needs field an methods built
+	}
 }
 
 protected ReferenceBinding updateWithAnnotations(TypeReference typeRef, ReferenceBinding previousType,

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypeDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypeDeclaration.java
@@ -543,13 +543,13 @@ public MethodBinding createDefaultConstructorWithBinding(MethodBinding inherited
 			sourceType); //declaringClass
 	constructor.binding.tagBits |= (inheritedConstructorBinding.tagBits & TagBits.HasMissingType);
 	constructor.binding.modifiers |= ExtraCompilerModifiers.AccIsDefaultConstructor;
-	if (inheritedConstructorBinding.parameterNonNullness != null // this implies that annotation based null analysis is enabled
+	if (inheritedConstructorBinding.parameterFlowBits != null // this implies that annotation based null/resource analysis is enabled
 			&& argumentsLength > 0)
 	{
-		// copy nullness info from inherited constructor to the new constructor:
-		int len = inheritedConstructorBinding.parameterNonNullness.length;
-		System.arraycopy(inheritedConstructorBinding.parameterNonNullness, 0,
-				constructor.binding.parameterNonNullness = new Boolean[len], 0, len);
+		// copy flowbits from inherited constructor to the new constructor:
+		int len = inheritedConstructorBinding.parameterFlowBits.length;
+		System.arraycopy(inheritedConstructorBinding.parameterFlowBits, 0,
+				constructor.binding.parameterFlowBits = new byte[len], 0, len);
 	}
 	// TODO(stephan): do argument types already carry sufficient info about type annotations?
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/flow/FlowContext.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/flow/FlowContext.java
@@ -49,6 +49,7 @@ import org.eclipse.jdt.internal.compiler.codegen.BranchLabel;
 import org.eclipse.jdt.internal.compiler.lookup.Binding;
 import org.eclipse.jdt.internal.compiler.lookup.BlockScope;
 import org.eclipse.jdt.internal.compiler.lookup.CatchParameterBinding;
+import org.eclipse.jdt.internal.compiler.lookup.FieldBinding;
 import org.eclipse.jdt.internal.compiler.lookup.LocalVariableBinding;
 import org.eclipse.jdt.internal.compiler.lookup.ReferenceBinding;
 import org.eclipse.jdt.internal.compiler.lookup.Scope;
@@ -175,6 +176,25 @@ public void recordNullCheckedFieldReference(Reference reference, int timeToLive)
 		this.nullCheckedFieldReferences[len] = reference;
 		this.timesToLiveForNullCheckInfo[len] = timeToLive;
 	}
+}
+
+public FieldBinding[] nullCheckedFields() {
+	if (this.nullCheckedFieldReferences == null)
+		return Binding.NO_FIELDS;
+	int len = this.nullCheckedFieldReferences.length;
+	// insert into first empty slot:
+	int count = 0;
+	for (int i=0; i<len; i++) {
+		if (this.nullCheckedFieldReferences[i] != null)
+			count++;
+	}
+	FieldBinding[] result = new FieldBinding[count];
+	count = 0;
+	for (int i=0; i<len; i++) {
+		if (this.nullCheckedFieldReferences[i] != null)
+			result[count++] = this.nullCheckedFieldReferences[i].fieldBinding();
+	}
+	return result;
 }
 
 /** If a null checked field has been recorded recently, increase its time to live. */

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/flow/UnconditionalFlowInfo.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/flow/UnconditionalFlowInfo.java
@@ -1081,7 +1081,8 @@ final public boolean isPotentiallyAssigned(LocalVariableBinding local) {
 // TODO (Ayush) Check why this method does not return true for protected non null (1111)
 @Override
 final public boolean isPotentiallyNonNull(LocalVariableBinding local) {
-	if ((this.tagBits & NULL_FLAG_MASK) == 0 ||
+	if ((this.tagBits & UNREACHABLE) != 0 ||
+			(this.tagBits & NULL_FLAG_MASK) == 0 ||
 			(local.type.tagBits & TagBits.IsBaseType) != 0) {
 		return false;
 	}
@@ -1108,7 +1109,8 @@ final public boolean isPotentiallyNonNull(LocalVariableBinding local) {
 // TODO (Ayush) Check why this method does not return true for protected null
 @Override
 final public boolean isPotentiallyNull(LocalVariableBinding local) {
-	if ((this.tagBits & NULL_FLAG_MASK) == 0 ||
+	if ((this.tagBits & UNREACHABLE) != 0 ||
+			(this.tagBits & NULL_FLAG_MASK) == 0 ||
 			(local.type.tagBits & TagBits.IsBaseType) != 0) {
 		return false;
 	}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/impl/CompilerOptions.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/impl/CompilerOptions.java
@@ -172,7 +172,9 @@ public class CompilerOptions {
 	public static final String OPTION_ReportExplicitlyClosedAutoCloseable = "org.eclipse.jdt.core.compiler.problem.explicitlyClosedAutoCloseable"; //$NON-NLS-1$
 	public static final String OPTION_AnnotationBasedResourceAnalysis = "org.eclipse.jdt.core.compiler.annotation.resourceanalysis"; //$NON-NLS-1$
 	public static final String OPTION_OwningAnnotationName = "org.eclipse.jdt.core.compiler.annotation.owning"; //$NON-NLS-1$
+	public static final String OPTION_NotOwningAnnotationName = "org.eclipse.jdt.core.compiler.annotation.notowning"; //$NON-NLS-1$
 	static final char[][] DEFAULT_OWNING_ANNOTATION_NAME = CharOperation.splitOn('.', "org.eclipse.jdt.annotation.Owning".toCharArray()); //$NON-NLS-1$
+	static final char[][] DEFAULT_NOTOWNING_ANNOTATION_NAME = CharOperation.splitOn('.', "org.eclipse.jdt.annotation.NotOwning".toCharArray()); //$NON-NLS-1$
 
 	public static final String OPTION_ReportNullSpecViolation = "org.eclipse.jdt.core.compiler.problem.nullSpecViolation";  //$NON-NLS-1$
 	public static final String OPTION_ReportNullAnnotationInferenceConflict = "org.eclipse.jdt.core.compiler.problem.nullAnnotationInferenceConflict";  //$NON-NLS-1$
@@ -523,6 +525,8 @@ public class CompilerOptions {
 	public boolean isAnnotationBasedResourceAnalysisEnabled;
 	/** Name of the annotation which the resource leak analysis will use as 'owning' */
 	public char[][] owningAnnotationName;
+	/** Name of the annotation which the resource leak analysis will use as 'not-owning' */
+	public char[][] notOwningAnnotationName;
 	/** Should missing enum cases be reported even if a default case exists in the same switch? */
 	public boolean reportMissingEnumCaseDespiteDefault;
 
@@ -551,7 +555,7 @@ public class CompilerOptions {
 	/** Not directly configurable, derived from other options by LookupEnvironment.usesNullTypeAnnotations() */
 	public Boolean useNullTypeAnnotations = null;
 	/** Not directly configurable, derived from other options by LookupEnvironment.usesOwningAnnotation() */
-	public Boolean useOwningAnnotation;
+	public Boolean useOwningAnnotations;
 
 	/** Master flag to enabled/disable all preview features */
 	public boolean enablePreviewFeatures;
@@ -1037,6 +1041,7 @@ public class CompilerOptions {
 			OPTION_ReportExplicitlyClosedAutoCloseable,
 			OPTION_AnnotationBasedResourceAnalysis,
 			OPTION_OwningAnnotationName,
+			OPTION_NotOwningAnnotationName,
 			OPTION_AnnotationBasedNullAnalysis,
 			OPTION_NonNullAnnotationName,
 			OPTION_NullableAnnotationName,
@@ -1387,6 +1392,7 @@ public class CompilerOptions {
 		optionsMap.put(OPTION_ReportExplicitlyClosedAutoCloseable, getSeverityString(ExplicitlyClosedAutoCloseable));
 		optionsMap.put(OPTION_AnnotationBasedResourceAnalysis, this.isAnnotationBasedResourceAnalysisEnabled ? ENABLED : DISABLED);
 		optionsMap.put(OPTION_OwningAnnotationName, String.valueOf(CharOperation.concatWith(this.owningAnnotationName, '.')));
+		optionsMap.put(OPTION_NotOwningAnnotationName, String.valueOf(CharOperation.concatWith(this.notOwningAnnotationName, '.')));
 		optionsMap.put(OPTION_AnnotationBasedNullAnalysis, this.isAnnotationBasedNullAnalysisEnabled ? ENABLED : DISABLED);
 		optionsMap.put(OPTION_ReportNullSpecViolation, getSeverityString(NullSpecViolation));
 		optionsMap.put(OPTION_ReportNullAnnotationInferenceConflict, getSeverityString(NullAnnotationInferenceConflict));
@@ -1613,6 +1619,7 @@ public class CompilerOptions {
 		this.analyseResourceLeaks = true;
 		this.isAnnotationBasedResourceAnalysisEnabled = false;
 		this.owningAnnotationName = DEFAULT_OWNING_ANNOTATION_NAME;
+		this.notOwningAnnotationName = DEFAULT_NOTOWNING_ANNOTATION_NAME;
 
 		this.reportMissingEnumCaseDespiteDefault = false;
 
@@ -1949,6 +1956,9 @@ public class CompilerOptions {
 		}
 		if ((optionValue = optionsMap.get(OPTION_OwningAnnotationName)) != null) {
 			this.owningAnnotationName = CharOperation.splitAndTrimOn('.', optionValue.toCharArray());
+		}
+		if ((optionValue = optionsMap.get(OPTION_NotOwningAnnotationName)) != null) {
+			this.notOwningAnnotationName = CharOperation.splitAndTrimOn('.', optionValue.toCharArray());
 		}
 		if ((optionValue = optionsMap.get(OPTION_ReportAPILeak)) != null) updateSeverity(APILeak, optionValue);
 		if ((optionValue = optionsMap.get(OPTION_ReportUnstableAutoModuleName)) != null) updateSeverity(UnstableAutoModuleName, optionValue);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/impl/CompilerOptions.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/impl/CompilerOptions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -172,6 +172,7 @@ public class CompilerOptions {
 	public static final String OPTION_ReportPotentiallyUnclosedCloseable = "org.eclipse.jdt.core.compiler.problem.potentiallyUnclosedCloseable"; //$NON-NLS-1$
 	public static final String OPTION_ReportExplicitlyClosedAutoCloseable = "org.eclipse.jdt.core.compiler.problem.explicitlyClosedAutoCloseable"; //$NON-NLS-1$
 	public static final String OPTION_ReportInsufficientResourceManagement = "org.eclipse.jdt.core.compiler.problem.insufficientResourceAnalysis"; //$NON-NLS-1$
+	public static final String OPTION_ReportIncompatibleOwningContract = "org.eclipse.jdt.core.compiler.problem.incompatibleOwningContract"; //$NON-NLS-1$
 	public static final String OPTION_AnnotationBasedResourceAnalysis = "org.eclipse.jdt.core.compiler.annotation.resourceanalysis"; //$NON-NLS-1$
 	public static final String OPTION_OwningAnnotationName = "org.eclipse.jdt.core.compiler.annotation.owning"; //$NON-NLS-1$
 	public static final String OPTION_NotOwningAnnotationName = "org.eclipse.jdt.core.compiler.annotation.notowning"; //$NON-NLS-1$
@@ -374,6 +375,7 @@ public class CompilerOptions {
 
 	// group 3
 	public static final int InsufficientResourceManagement = IrritantSet.GROUP3 | ASTNode.Bit1;
+	public static final int IncompatibleOwningContract = IrritantSet.GROUP3 | ASTNode.Bit2;
 
 
 	// Severity level for handlers
@@ -803,6 +805,8 @@ public class CompilerOptions {
 				return OPTION_ReportExplicitlyClosedAutoCloseable;
 			case InsufficientResourceManagement:
 				return OPTION_ReportInsufficientResourceManagement;
+			case IncompatibleOwningContract:
+				return OPTION_ReportIncompatibleOwningContract;
 
 			// null analysis:
 			case NullSpecViolation :
@@ -1061,6 +1065,7 @@ public class CompilerOptions {
 			OPTION_ReportPotentiallyUnclosedCloseable,
 			OPTION_ReportExplicitlyClosedAutoCloseable,
 			OPTION_ReportInsufficientResourceManagement,
+			OPTION_ReportIncompatibleOwningContract,
 			OPTION_AnnotationBasedResourceAnalysis,
 			OPTION_OwningAnnotationName,
 			OPTION_NotOwningAnnotationName,
@@ -1419,6 +1424,7 @@ public class CompilerOptions {
 		optionsMap.put(OPTION_ReportPotentiallyUnclosedCloseable, getSeverityString(PotentiallyUnclosedCloseable));
 		optionsMap.put(OPTION_ReportExplicitlyClosedAutoCloseable, getSeverityString(ExplicitlyClosedAutoCloseable));
 		optionsMap.put(OPTION_ReportInsufficientResourceManagement, getSeverityString(InsufficientResourceManagement));
+		optionsMap.put(OPTION_ReportIncompatibleOwningContract, getSeverityString(IncompatibleOwningContract));
 		optionsMap.put(OPTION_AnnotationBasedResourceAnalysis, this.isAnnotationBasedResourceAnalysisEnabled ? ENABLED : DISABLED);
 		optionsMap.put(OPTION_OwningAnnotationName, String.valueOf(CharOperation.concatWith(this.owningAnnotationName, '.')));
 		optionsMap.put(OPTION_NotOwningAnnotationName, String.valueOf(CharOperation.concatWith(this.notOwningAnnotationName, '.')));
@@ -1971,6 +1977,7 @@ public class CompilerOptions {
 		if ((optionValue = optionsMap.get(OPTION_ReportPotentiallyUnclosedCloseable)) != null) updateSeverity(PotentiallyUnclosedCloseable, optionValue);
 		if ((optionValue = optionsMap.get(OPTION_ReportExplicitlyClosedAutoCloseable)) != null) updateSeverity(ExplicitlyClosedAutoCloseable, optionValue);
 		if ((optionValue = optionsMap.get(OPTION_ReportInsufficientResourceManagement)) != null) updateSeverity(InsufficientResourceManagement, optionValue);
+		if ((optionValue = optionsMap.get(OPTION_ReportIncompatibleOwningContract)) != null) updateSeverity(IncompatibleOwningContract, optionValue);
 		if (getSeverity(UnclosedCloseable) == ProblemSeverities.Ignore
 				&& getSeverity(PotentiallyUnclosedCloseable) == ProblemSeverities.Ignore
 				&& getSeverity(ExplicitlyClosedAutoCloseable) == ProblemSeverities.Ignore) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/impl/CompilerOptions.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/impl/CompilerOptions.java
@@ -167,9 +167,11 @@ public class CompilerOptions {
 	public static final String OPTION_ReportMethodCanBePotentiallyStatic = "org.eclipse.jdt.core.compiler.problem.reportMethodCanBePotentiallyStatic";  //$NON-NLS-1$
 	public static final String OPTION_ReportRedundantSpecificationOfTypeArguments =  "org.eclipse.jdt.core.compiler.problem.redundantSpecificationOfTypeArguments"; //$NON-NLS-1$
 
+	// resource leak analysis:
 	public static final String OPTION_ReportUnclosedCloseable = "org.eclipse.jdt.core.compiler.problem.unclosedCloseable"; //$NON-NLS-1$
 	public static final String OPTION_ReportPotentiallyUnclosedCloseable = "org.eclipse.jdt.core.compiler.problem.potentiallyUnclosedCloseable"; //$NON-NLS-1$
 	public static final String OPTION_ReportExplicitlyClosedAutoCloseable = "org.eclipse.jdt.core.compiler.problem.explicitlyClosedAutoCloseable"; //$NON-NLS-1$
+	public static final String OPTION_ReportInsufficientResourceManagement = "org.eclipse.jdt.core.compiler.problem.insufficientResourceAnalysis"; //$NON-NLS-1$
 	public static final String OPTION_AnnotationBasedResourceAnalysis = "org.eclipse.jdt.core.compiler.annotation.resourceanalysis"; //$NON-NLS-1$
 	public static final String OPTION_OwningAnnotationName = "org.eclipse.jdt.core.compiler.annotation.owning"; //$NON-NLS-1$
 	public static final String OPTION_NotOwningAnnotationName = "org.eclipse.jdt.core.compiler.annotation.notowning"; //$NON-NLS-1$
@@ -342,9 +344,14 @@ public class CompilerOptions {
 	public static final int MethodCanBeStatic = IrritantSet.GROUP2 | ASTNode.Bit5;
 	public static final int MethodCanBePotentiallyStatic = IrritantSet.GROUP2 | ASTNode.Bit6;
 	public static final int RedundantSpecificationOfTypeArguments = IrritantSet.GROUP2 | ASTNode.Bit7;
+
+	// resource leak analysis:
 	public static final int UnclosedCloseable = IrritantSet.GROUP2 | ASTNode.Bit8;
 	public static final int PotentiallyUnclosedCloseable = IrritantSet.GROUP2 | ASTNode.Bit9;
 	public static final int ExplicitlyClosedAutoCloseable = IrritantSet.GROUP2 | ASTNode.Bit10;
+	// see also InsufficientResourceManagement in group 3
+
+	// null analysis:
 	public static final int NullSpecViolation = IrritantSet.GROUP2 | ASTNode.Bit11;
 	public static final int NullAnnotationInferenceConflict = IrritantSet.GROUP2 | ASTNode.Bit12;
 	public static final int NullUncheckedConversion = IrritantSet.GROUP2 | ASTNode.Bit13;
@@ -364,6 +371,9 @@ public class CompilerOptions {
 	public static final int PreviewFeatureUsed = IrritantSet.GROUP2 | ASTNode.Bit27;
 	public static final int SuppressWarningsNotAnalysed = IrritantSet.GROUP2 | ASTNode.Bit28;
 	public static final int AnnotatedTypeArgumentToUnannotated = IrritantSet.GROUP2 | ASTNode.Bit29;
+
+	// group 3
+	public static final int InsufficientResourceManagement = IrritantSet.GROUP3 | ASTNode.Bit1;
 
 
 	// Severity level for handlers
@@ -519,6 +529,7 @@ public class CompilerOptions {
 	public String[] nonNullByDefaultAnnotationSecondaryNames = NO_STRINGS;
 	/** TagBits-encoded default for non-annotated types. */
 	public long intendedDefaultNonNullness; // 0 or TagBits#AnnotationNonNull
+
 	/** Should resources (objects of type Closeable) be analysed for matching calls to close()? */
 	public boolean analyseResourceLeaks;
 	/** Should an owning-annotation be evaluated for improved analysis of resource leaks? */
@@ -527,6 +538,7 @@ public class CompilerOptions {
 	public char[][] owningAnnotationName;
 	/** Name of the annotation which the resource leak analysis will use as 'not-owning' */
 	public char[][] notOwningAnnotationName;
+
 	/** Should missing enum cases be reported even if a default case exists in the same switch? */
 	public boolean reportMissingEnumCaseDespiteDefault;
 
@@ -781,12 +793,18 @@ public class CompilerOptions {
 				return OPTION_ReportMissingNonNullByDefaultAnnotation;
 			case RedundantSpecificationOfTypeArguments :
 				return OPTION_ReportRedundantSpecificationOfTypeArguments;
+
+			// resource leak analysis:
 			case UnclosedCloseable :
 				return OPTION_ReportUnclosedCloseable;
 			case PotentiallyUnclosedCloseable :
 				return OPTION_ReportPotentiallyUnclosedCloseable;
 			case ExplicitlyClosedAutoCloseable :
 				return OPTION_ReportExplicitlyClosedAutoCloseable;
+			case InsufficientResourceManagement:
+				return OPTION_ReportInsufficientResourceManagement;
+
+			// null analysis:
 			case NullSpecViolation :
 				return OPTION_ReportNullSpecViolation;
 			case NullAnnotationInferenceConflict :
@@ -803,6 +821,7 @@ public class CompilerOptions {
 				return OPTION_ReportNonNullTypeVariableFromLegacyInvocation;
 			case AnnotatedTypeArgumentToUnannotated:
 				return OPTION_ReportAnnotatedTypeArgumentToUnannotated;
+
 			case UnlikelyCollectionMethodArgumentType:
 				return OPTION_ReportUnlikelyCollectionMethodArgumentType;
 			case UnlikelyEqualsArgumentType:
@@ -1036,12 +1055,17 @@ public class CompilerOptions {
 			OPTION_ReportUnusedTypeArgumentsForMethodInvocation,
 			OPTION_ReportUnusedWarningToken,
 			OPTION_ReportVarargsArgumentNeedCast,
+
+			// resource leak analysis:
 			OPTION_ReportUnclosedCloseable,
 			OPTION_ReportPotentiallyUnclosedCloseable,
 			OPTION_ReportExplicitlyClosedAutoCloseable,
+			OPTION_ReportInsufficientResourceManagement,
 			OPTION_AnnotationBasedResourceAnalysis,
 			OPTION_OwningAnnotationName,
 			OPTION_NotOwningAnnotationName,
+
+			// null analysis:
 			OPTION_AnnotationBasedNullAnalysis,
 			OPTION_NonNullAnnotationName,
 			OPTION_NullableAnnotationName,
@@ -1056,6 +1080,7 @@ public class CompilerOptions {
 			OPTION_InheritNullAnnotations,
 			OPTION_ReportNonnullParameterAnnotationDropped,
 			OPTION_ReportAnnotatedTypeArgumentToUnannotated,
+
 			OPTION_ReportUnlikelyCollectionMethodArgumentType,
 			OPTION_ReportUnlikelyEqualsArgumentType,
 			OPTION_ReportAPILeak,
@@ -1149,6 +1174,7 @@ public class CompilerOptions {
 			case PotentiallyUnclosedCloseable:
 			case UnclosedCloseable:
 			case ExplicitlyClosedAutoCloseable:
+			case InsufficientResourceManagement:
 				return "resource"; //$NON-NLS-1$
 			case InvalidJavadoc :
 			case MissingJavadocComments :
@@ -1387,12 +1413,17 @@ public class CompilerOptions {
 		optionsMap.put(OPTION_ReportMethodCanBeStatic, getSeverityString(MethodCanBeStatic));
 		optionsMap.put(OPTION_ReportMethodCanBePotentiallyStatic, getSeverityString(MethodCanBePotentiallyStatic));
 		optionsMap.put(OPTION_ReportRedundantSpecificationOfTypeArguments, getSeverityString(RedundantSpecificationOfTypeArguments));
+
+		// resource leak analysis:
 		optionsMap.put(OPTION_ReportUnclosedCloseable, getSeverityString(UnclosedCloseable));
 		optionsMap.put(OPTION_ReportPotentiallyUnclosedCloseable, getSeverityString(PotentiallyUnclosedCloseable));
 		optionsMap.put(OPTION_ReportExplicitlyClosedAutoCloseable, getSeverityString(ExplicitlyClosedAutoCloseable));
+		optionsMap.put(OPTION_ReportInsufficientResourceManagement, getSeverityString(InsufficientResourceManagement));
 		optionsMap.put(OPTION_AnnotationBasedResourceAnalysis, this.isAnnotationBasedResourceAnalysisEnabled ? ENABLED : DISABLED);
 		optionsMap.put(OPTION_OwningAnnotationName, String.valueOf(CharOperation.concatWith(this.owningAnnotationName, '.')));
 		optionsMap.put(OPTION_NotOwningAnnotationName, String.valueOf(CharOperation.concatWith(this.notOwningAnnotationName, '.')));
+
+		// null analysis:
 		optionsMap.put(OPTION_AnnotationBasedNullAnalysis, this.isAnnotationBasedNullAnalysisEnabled ? ENABLED : DISABLED);
 		optionsMap.put(OPTION_ReportNullSpecViolation, getSeverityString(NullSpecViolation));
 		optionsMap.put(OPTION_ReportNullAnnotationInferenceConflict, getSeverityString(NullAnnotationInferenceConflict));
@@ -1935,15 +1966,11 @@ public class CompilerOptions {
 		if ((optionValue = optionsMap.get(OPTION_ReportMethodCanBeStatic)) != null) updateSeverity(MethodCanBeStatic, optionValue);
 		if ((optionValue = optionsMap.get(OPTION_ReportMethodCanBePotentiallyStatic)) != null) updateSeverity(MethodCanBePotentiallyStatic, optionValue);
 		if ((optionValue = optionsMap.get(OPTION_ReportRedundantSpecificationOfTypeArguments)) != null) updateSeverity(RedundantSpecificationOfTypeArguments, optionValue);
+		// resource leak analysis:
 		if ((optionValue = optionsMap.get(OPTION_ReportUnclosedCloseable)) != null) updateSeverity(UnclosedCloseable, optionValue);
 		if ((optionValue = optionsMap.get(OPTION_ReportPotentiallyUnclosedCloseable)) != null) updateSeverity(PotentiallyUnclosedCloseable, optionValue);
 		if ((optionValue = optionsMap.get(OPTION_ReportExplicitlyClosedAutoCloseable)) != null) updateSeverity(ExplicitlyClosedAutoCloseable, optionValue);
-		if ((optionValue = optionsMap.get(OPTION_ReportUnusedTypeParameter)) != null) updateSeverity(UnusedTypeParameter, optionValue);
-		if ((optionValue = optionsMap.get(OPTION_ReportUnlikelyCollectionMethodArgumentType)) != null) updateSeverity(UnlikelyCollectionMethodArgumentType, optionValue);
-		if ((optionValue = optionsMap.get(OPTION_ReportUnlikelyCollectionMethodArgumentTypeStrict)) != null) {
-			this.reportUnlikelyCollectionMethodArgumentTypeStrict = ENABLED.equals(optionValue);
-		}
-		if ((optionValue = optionsMap.get(OPTION_ReportUnlikelyEqualsArgumentType)) != null) updateSeverity(UnlikelyEqualsArgumentType, optionValue);
+		if ((optionValue = optionsMap.get(OPTION_ReportInsufficientResourceManagement)) != null) updateSeverity(InsufficientResourceManagement, optionValue);
 		if (getSeverity(UnclosedCloseable) == ProblemSeverities.Ignore
 				&& getSeverity(PotentiallyUnclosedCloseable) == ProblemSeverities.Ignore
 				&& getSeverity(ExplicitlyClosedAutoCloseable) == ProblemSeverities.Ignore) {
@@ -1960,6 +1987,13 @@ public class CompilerOptions {
 		if ((optionValue = optionsMap.get(OPTION_NotOwningAnnotationName)) != null) {
 			this.notOwningAnnotationName = CharOperation.splitAndTrimOn('.', optionValue.toCharArray());
 		}
+
+		if ((optionValue = optionsMap.get(OPTION_ReportUnusedTypeParameter)) != null) updateSeverity(UnusedTypeParameter, optionValue);
+		if ((optionValue = optionsMap.get(OPTION_ReportUnlikelyCollectionMethodArgumentType)) != null) updateSeverity(UnlikelyCollectionMethodArgumentType, optionValue);
+		if ((optionValue = optionsMap.get(OPTION_ReportUnlikelyCollectionMethodArgumentTypeStrict)) != null) {
+			this.reportUnlikelyCollectionMethodArgumentTypeStrict = ENABLED.equals(optionValue);
+		}
+		if ((optionValue = optionsMap.get(OPTION_ReportUnlikelyEqualsArgumentType)) != null) updateSeverity(UnlikelyEqualsArgumentType, optionValue);
 		if ((optionValue = optionsMap.get(OPTION_ReportAPILeak)) != null) updateSeverity(APILeak, optionValue);
 		if ((optionValue = optionsMap.get(OPTION_ReportUnstableAutoModuleName)) != null) updateSeverity(UnstableAutoModuleName, optionValue);
 		if ((optionValue = optionsMap.get(OPTION_AnnotationBasedNullAnalysis)) != null) {
@@ -2313,9 +2347,12 @@ public class CompilerOptions {
 		buf.append("\n\t- method can be static: ").append(getSeverityString(MethodCanBeStatic)); //$NON-NLS-1$
 		buf.append("\n\t- method can be potentially static: ").append(getSeverityString(MethodCanBePotentiallyStatic)); //$NON-NLS-1$
 		buf.append("\n\t- redundant specification of type arguments: ").append(getSeverityString(RedundantSpecificationOfTypeArguments)); //$NON-NLS-1$
+		// resource leak analysis:
 		buf.append("\n\t- resource is not closed: ").append(getSeverityString(UnclosedCloseable)); //$NON-NLS-1$
 		buf.append("\n\t- resource may not be closed: ").append(getSeverityString(PotentiallyUnclosedCloseable)); //$NON-NLS-1$
 		buf.append("\n\t- resource should be handled by try-with-resources: ").append(getSeverityString(ExplicitlyClosedAutoCloseable)); //$NON-NLS-1$
+		buf.append("\n\t- resource should be managed explicitly: ").append(getSeverityString(InsufficientResourceManagement)); //$NON-NLS-1$
+
 		buf.append("\n\t- Unused Type Parameter: ").append(getSeverityString(UnusedTypeParameter)); //$NON-NLS-1$
 		buf.append("\n\t- pessimistic null analysis for free type variables: ").append(getSeverityString(PessimisticNullAnalysisForFreeTypeVariables)); //$NON-NLS-1$
 		buf.append("\n\t- report unsafe nonnull return from legacy method: ").append(getSeverityString(NonNullTypeVariableFromLegacyInvocation)); //$NON-NLS-1$

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/impl/IrritantSet.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/impl/IrritantSet.java
@@ -34,14 +34,14 @@ public class IrritantSet {
 	// Reserve two high bits for selecting the right bit pattern
 	public final static int GROUP_MASK = ASTNode.Bit32 | ASTNode.Bit31 | ASTNode.Bit30;
 	public final static int GROUP_SHIFT = 29;
-	public final static int GROUP_MAX = 3; // can be increased up to 8
+	public final static int GROUP_MAX = 4; // can be increased up to 8
 
 	// Group prefix for irritants
 	public final static int GROUP0 = 0 << GROUP_SHIFT;
 	public final static int GROUP1 = 1 << GROUP_SHIFT;
 	public final static int GROUP2 = 2 << GROUP_SHIFT;
+	public final static int GROUP3 = 3 << GROUP_SHIFT;
 	// reveal subsequent groups as needed
-	// public final static int GROUP3 = 3 << GROUP_SHIFT;
 	// public final static int GROUP4 = 4 << GROUP_SHIFT;
 	// public final static int GROUP5 = 5 << GROUP_SHIFT;
 	// public final static int GROUP6 = 6 << GROUP_SHIFT;
@@ -138,7 +138,8 @@ public class IrritantSet {
 				|CompilerOptions.UsingTerminallyDeprecatedAPI
 				|CompilerOptions.APILeak
 				|CompilerOptions.UnstableAutoModuleName
-				|CompilerOptions.PreviewFeatureUsed);
+				|CompilerOptions.PreviewFeatureUsed)
+			.set(CompilerOptions.InsufficientResourceManagement);
 		// default errors IF AnnotationBasedNullAnalysis is enabled:
 		COMPILER_DEFAULT_ERRORS.set(
 				CompilerOptions.NullSpecViolation

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/impl/IrritantSet.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/impl/IrritantSet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -139,7 +139,8 @@ public class IrritantSet {
 				|CompilerOptions.APILeak
 				|CompilerOptions.UnstableAutoModuleName
 				|CompilerOptions.PreviewFeatureUsed)
-			.set(CompilerOptions.InsufficientResourceManagement);
+			.set(CompilerOptions.InsufficientResourceManagement
+				|CompilerOptions.IncompatibleOwningContract);
 		// default errors IF AnnotationBasedNullAnalysis is enabled:
 		COMPILER_DEFAULT_ERRORS.set(
 				CompilerOptions.NullSpecViolation

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BinaryModuleBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BinaryModuleBinding.java
@@ -160,7 +160,7 @@ public class BinaryModuleBinding extends ModuleBinding {
 				char[] annotationTypeName = annotations[i].getTypeName();
 				if (annotationTypeName[0] != Util.C_RESOLVED)
 					continue;
-				int typeBit = this.environment.getNullAnnotationBit(BinaryTypeBinding.signature2qualifiedTypeName(annotationTypeName));
+				int typeBit = this.environment.getAnalysisAnnotationBit(BinaryTypeBinding.signature2qualifiedTypeName(annotationTypeName));
 				if (typeBit == TypeIds.BitNonNullByDefaultAnnotation) {
 					// using NonNullByDefault we need to inspect the details of the value() attribute:
 					nullness |= BinaryTypeBinding.getNonNullByDefaultValue(annotations[i], this.environment);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BinaryTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BinaryTypeBinding.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BinaryTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BinaryTypeBinding.java
@@ -477,6 +477,9 @@ void cachePartsFrom(IBinaryType binaryType, boolean needFieldsAndMethods) {
 			// need annotations on the type before processing null annotations on members respecting any @NonNullByDefault:
 			scanTypeForNullDefaultAnnotation(binaryType, this.fPackage);
 		}
+		if (this.environment.globalOptions.isAnnotationBasedResourceAnalysisEnabled && binaryType.getAnnotations() != null) {
+			this.tagBits |= scanForOwningAnnotation(binaryType.getAnnotations());
+		}
 		ITypeAnnotationWalker walker = getTypeAnnotationWalker(binaryType.getTypeAnnotations(), Binding.NO_NULL_DEFAULT);
 		ITypeAnnotationWalker toplevelWalker = binaryType.enrichWithExternalAnnotationsFor(walker, null, this.environment);
 		this.externalAnnotationStatus = binaryType.getExternalAnnotationStatus();
@@ -2546,7 +2549,7 @@ public ReferenceBinding[] superInterfaces() {
 		}
 		this.typeBits |= (this.superInterfaces[i].typeBits & TypeIds.InheritableBits);
 		if ((this.typeBits & (TypeIds.BitAutoCloseable|TypeIds.BitCloseable)) != 0) // avoid the side-effects of hasTypeBit()!
-			this.typeBits |= applyCloseableInterfaceWhitelists();
+			this.typeBits |= applyCloseableInterfaceWhitelists(this.environment.globalOptions);
 	}
 	this.tagBits &= ~TagBits.HasUnresolvedSuperinterfaces;
 	return this.superInterfaces;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BinaryTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BinaryTypeBinding.java
@@ -768,7 +768,7 @@ private int getNullDefaultFrom(IBinaryAnnotation[] declAnnotations) {
 	if (declAnnotations != null) {
 		for (IBinaryAnnotation annotation : declAnnotations) {
 			char[][] typeName = signature2qualifiedTypeName(annotation.getTypeName());
-			if (this.environment.getNullAnnotationBit(typeName) == TypeIds.BitNonNullByDefaultAnnotation)
+			if (this.environment.getAnalysisAnnotationBit(typeName) == TypeIds.BitNonNullByDefaultAnnotation)
 				result |= getNonNullByDefaultValue(annotation, this.environment);
 		}
 	}
@@ -2043,7 +2043,7 @@ private void scanFieldForNullAnnotation(IBinaryField field, VariableBinding fiel
 			char[] annotationTypeName = annotations[i].getTypeName();
 			if (annotationTypeName[0] != Util.C_RESOLVED)
 				continue;
-			int typeBit = this.environment.getNullAnnotationBit(signature2qualifiedTypeName(annotationTypeName));
+			int typeBit = this.environment.getAnalysisAnnotationBit(signature2qualifiedTypeName(annotationTypeName));
 			if (typeBit == TypeIds.BitNonNullAnnotation) {
 				fieldBinding.tagBits |= TagBits.AnnotationNonNull;
 				explicitNullness = true;
@@ -2101,7 +2101,7 @@ private void scanMethodForNullAnnotation(IBinaryMethod method, MethodBinding met
 			char[] annotationTypeName = annotations[i].getTypeName();
 			if (annotationTypeName[0] != Util.C_RESOLVED)
 				continue;
-			int typeBit = this.environment.getNullAnnotationBit(signature2qualifiedTypeName(annotationTypeName));
+			int typeBit = this.environment.getAnalysisAnnotationBit(signature2qualifiedTypeName(annotationTypeName));
 			if (typeBit == TypeIds.BitNonNullByDefaultAnnotation) {
 				methodDefaultNullness |= getNonNullByDefaultValue(annotations[i], this.environment);
 			} else if (typeBit == TypeIds.BitNonNullAnnotation) {
@@ -2144,7 +2144,7 @@ private void scanMethodForNullAnnotation(IBinaryMethod method, MethodBinding met
 						char[] annotationTypeName = paramAnnotations[i].getTypeName();
 						if (annotationTypeName[0] != Util.C_RESOLVED)
 							continue;
-						int typeBit = this.environment.getNullAnnotationBit(signature2qualifiedTypeName(annotationTypeName));
+						int typeBit = this.environment.getAnalysisAnnotationBit(signature2qualifiedTypeName(annotationTypeName));
 						if (typeBit == TypeIds.BitNonNullAnnotation) {
 							if (methodBinding.parameterNonNullness == null)
 								methodBinding.parameterNonNullness = new Boolean[numVisibleParams];
@@ -2214,7 +2214,7 @@ private void scanTypeForNullDefaultAnnotation(IBinaryType binaryType, PackageBin
 			char[] annotationTypeName = annotations[i].getTypeName();
 			if (annotationTypeName[0] != Util.C_RESOLVED)
 				continue;
-			int typeBit = this.environment.getNullAnnotationBit(signature2qualifiedTypeName(annotationTypeName));
+			int typeBit = this.environment.getAnalysisAnnotationBit(signature2qualifiedTypeName(annotationTypeName));
 			if (typeBit == TypeIds.BitNonNullByDefaultAnnotation) {
 				// using NonNullByDefault we need to inspect the details of the value() attribute:
 				nullness |= getNonNullByDefaultValue(annotations[i], this.environment);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BinaryTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BinaryTypeBinding.java
@@ -2344,6 +2344,20 @@ private boolean scanMethodForOwningAnnotations(IBinaryMethod method, MethodBindi
 	// return:
 	methodBinding.tagBits |= scanForOwningAnnotation(method.getAnnotations());
 
+	// check for "@Owning MyType this":
+	IBinaryTypeAnnotation[] methodTypeAnnotations = method.getTypeAnnotations();
+	if (methodTypeAnnotations != null) {
+		ITypeAnnotationWalker walker = new TypeAnnotationWalker(methodTypeAnnotations).toReceiver();
+		IBinaryAnnotation[] receiverTypeAnnotations = walker.getAnnotationsAtCursor(0, false);
+		if (receiverTypeAnnotations != null) {
+			for (IBinaryAnnotation binaryAnnotation : receiverTypeAnnotations) {
+				int typeBit = this.environment.getAnalysisAnnotationBit(signature2qualifiedTypeName(binaryAnnotation.getTypeName()));
+				if ((typeBit & TypeIds.BitOwningAnnotation) != 0)
+					methodBinding.extendedTagBits |= ExtendedTagBits.IsClosingMethod;
+			}
+		}
+	}
+
 	// parameters:
 	TypeBinding[] parameters = methodBinding.parameters;
 	int numVisibleParams = parameters.length;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BinaryTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BinaryTypeBinding.java
@@ -2153,9 +2153,9 @@ private void scanMethodForNullAnnotation(IBinaryMethod method, MethodBinding met
 							continue;
 						int typeBit = this.environment.getAnalysisAnnotationBit(signature2qualifiedTypeName(annotationTypeName));
 						if (typeBit == TypeIds.BitNonNullAnnotation) {
-							if (methodBinding.parameterNonNullness == null)
-								methodBinding.parameterNonNullness = new Boolean[numVisibleParams];
-							methodBinding.parameterNonNullness[j] = Boolean.TRUE;
+							if (methodBinding.parameterFlowBits == null)
+								methodBinding.parameterFlowBits = new byte[numVisibleParams];
+							methodBinding.parameterFlowBits[j] |= MethodBinding.PARAM_NONNULL;
 							if (this.environment.usesNullTypeAnnotations()) {
 								if (methodBinding.parameters[j] != null
 										&& !methodBinding.parameters[j].hasNullTypeAnnotations()) {
@@ -2166,9 +2166,9 @@ private void scanMethodForNullAnnotation(IBinaryMethod method, MethodBinding met
 							}
 							break;
 						} else if (typeBit == TypeIds.BitNullableAnnotation) {
-							if (methodBinding.parameterNonNullness == null)
-								methodBinding.parameterNonNullness = new Boolean[numVisibleParams];
-							methodBinding.parameterNonNullness[j] = Boolean.FALSE;
+							if (methodBinding.parameterFlowBits == null)
+								methodBinding.parameterFlowBits = new byte[numVisibleParams];
+							methodBinding.parameterFlowBits[j] |= MethodBinding.PARAM_NULLABLE;
 							if (this.environment.usesNullTypeAnnotations()) {
 								if (methodBinding.parameters[j] != null
 										&& !methodBinding.parameters[j].hasNullTypeAnnotations()) {
@@ -2187,7 +2187,7 @@ private void scanMethodForNullAnnotation(IBinaryMethod method, MethodBinding met
 	if (useNullTypeAnnotations && this.externalAnnotationStatus.isPotentiallyUnannotatedLib()) {
 		if (methodBinding.returnType.hasNullTypeAnnotations()
 				|| (methodBinding.tagBits & TagBits.AnnotationNullMASK) != 0
-				|| methodBinding.parameterNonNullness != null) {
+				|| methodBinding.parameterFlowBits != null) {
 			this.externalAnnotationStatus = ExternalAnnotationStatus.TYPE_IS_ANNOTATED;
 		} else {
 			for (TypeBinding parameter : parameters) {
@@ -2335,9 +2335,9 @@ private void scanMethodForOwningAnnotation(IBinaryMethod method, MethodBinding m
 							continue;
 						int typeBit = this.environment.getAnalysisAnnotationBit(signature2qualifiedTypeName(annotationTypeName));
 						if (typeBit == TypeIds.BitOwningAnnotation) {
-							if (methodBinding.parameterOwning == null)
-								methodBinding.parameterOwning = new Boolean[numVisibleParams];
-							methodBinding.parameterOwning[j] = Boolean.TRUE;
+							if (methodBinding.parameterFlowBits == null)
+								methodBinding.parameterFlowBits = new byte[numVisibleParams];
+							methodBinding.parameterFlowBits[j] |= MethodBinding.PARAM_OWNING;
 							break;
 						}
 					}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BinaryTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BinaryTypeBinding.java
@@ -1681,14 +1681,16 @@ public boolean hasTypeBit(int bit) {
 	if (!isPrototype())
 		return this.prototype.hasTypeBit(bit);
 
-	// ensure hierarchy is resolved, which will propagate bits down to us
-	boolean wasToleratingMissingTypeProcessingAnnotations = this.environment.mayTolerateMissingType;
-	this.environment.mayTolerateMissingType = true;
-	try {
-		superclass();
-		superInterfaces();
-	} finally {
-		this.environment.mayTolerateMissingType = wasToleratingMissingTypeProcessingAnnotations;
+	if ((bit & TypeIds.InheritableBits) != 0) {
+		// ensure hierarchy is resolved, which will propagate bits down to us
+		boolean wasToleratingMissingTypeProcessingAnnotations = this.environment.mayTolerateMissingType;
+		this.environment.mayTolerateMissingType = true;
+		try {
+			superclass();
+			superInterfaces();
+		} finally {
+			this.environment.mayTolerateMissingType = wasToleratingMissingTypeProcessingAnnotations;
+		}
 	}
 	return (this.typeBits & bit) != 0;
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BlockScope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BlockScope.java
@@ -44,7 +44,6 @@ import org.eclipse.jdt.internal.compiler.flow.FlowInfo;
 import org.eclipse.jdt.internal.compiler.impl.Constant;
 import org.eclipse.jdt.internal.compiler.problem.ProblemReporter;
 
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class BlockScope extends Scope {
 
 	// Local variable management
@@ -1113,7 +1112,7 @@ public String toString(int tab) {
 	return s;
 }
 
-private List trackingVariables; // can be null if no resources are tracked
+private List<FakedTrackingVariable> trackingVariables; // can be null if no resources are tracked
 /** Used only during analyseCode and only for checking if a resource was closed in a finallyBlock. */
 public FlowInfo finallyInfo;
 
@@ -1122,7 +1121,7 @@ public FlowInfo finallyInfo;
  */
 public int registerTrackingVariable(FakedTrackingVariable fakedTrackingVariable) {
 	if (this.trackingVariables == null)
-		this.trackingVariables = new ArrayList(3);
+		this.trackingVariables = new ArrayList<>(3);
 	this.trackingVariables.add(fakedTrackingVariable);
 	MethodScope outerMethodScope = outerMostMethodScope();
 	return outerMethodScope.analysisIndex++;
@@ -1154,7 +1153,9 @@ public boolean hasResourceTrackers() {
  */
 public void checkUnclosedCloseables(FlowInfo flowInfo, FlowContext flowContext, ASTNode location, BlockScope locationScope) {
 	if (!compilerOptions().analyseResourceLeaks) return;
-	if (this.trackingVariables == null) {
+	if (this.trackingVariables == null
+			|| (!(this instanceof MethodScope) && location != null && locationScope != null && locationScope.isLastInMethod(null, location)))
+	{
 		// at a method return we also consider enclosing scopes
 		if (location != null && this.parent instanceof BlockScope && !isLambdaScope())
 			((BlockScope) this.parent).checkUnclosedCloseables(flowInfo, flowContext, location, locationScope);
@@ -1162,30 +1163,35 @@ public void checkUnclosedCloseables(FlowInfo flowInfo, FlowContext flowContext, 
 	}
 	if (location != null && flowInfo.reachMode() != 0) return;
 
-	FakedTrackingVariable returnVar = (location instanceof ReturnStatement) ?
-			FakedTrackingVariable.getCloseTrackingVariable(((ReturnStatement)location).expression, flowInfo, flowContext) : null;
-
-	boolean useOwningAnnotation = this.compilerOptions().isAnnotationBasedResourceAnalysisEnabled;
+	boolean useOwningAnnotations = this.compilerOptions().isAnnotationBasedResourceAnalysisEnabled;
+	FakedTrackingVariable returnVar = (location instanceof ReturnStatement)
+			? FakedTrackingVariable.getCloseTrackingVariable(((ReturnStatement)location).expression, flowInfo, flowContext, useOwningAnnotations)
+			: null;
 
 	// iterate variables according to the priorities defined in FakedTrackingVariable.IteratorForReporting.Stage
 	Iterator<FakedTrackingVariable> iterator = new FakedTrackingVariable.IteratorForReporting(this.trackingVariables, this, location != null);
 	while (iterator.hasNext()) {
 		FakedTrackingVariable trackingVar = iterator.next();
 
-		if (returnVar != null && trackingVar.isResourceBeingReturned(returnVar, useOwningAnnotation)) {
-			if (useOwningAnnotation) {
-				if ((methodScope().referenceMethodBinding().tagBits & TagBits.AnnotationOwning) == 0) {
+		if (returnVar != null && trackingVar.isResourceBeingReturned(returnVar, useOwningAnnotations)) {
+			if (useOwningAnnotations) {
+				long methodTagBits = methodScope().referenceMethodBinding().tagBits;
+				if ((methodTagBits & TagBits.AnnotationOwning) == 0) {
 					// returning resource against unannotated return type
 					LocalVariableBinding original = trackingVar.originalBinding;
 					if (original != null && original.isParameter() && (original.tagBits & TagBits.AnnotationOwning) == 0) {
 						// unannotated pass-through resource, remain quiet
-					} else {
+						trackingVar.markAsShared();
+					} else if ((methodTagBits & TagBits.AnnotationNotOwning) == 0) {
 						// resource is "probably owned", should delegate to caller
 						problemReporter().shouldMarkMethodAsOwning(location);
 						trackingVar.withdraw();
 					}
 					continue;
-				} // else proceed to precise analysis vis-a-vis @Owning below
+				} else {
+					trackingVar.markAsShared();
+				}
+				// else proceed to precise analysis vis-a-vis @Owning below
 			} else {
 				continue; // silent assumption that caller will handle it
 			}
@@ -1195,31 +1201,43 @@ public void checkUnclosedCloseables(FlowInfo flowInfo, FlowContext flowContext, 
 			continue; // reporting against a specific location, there is no resource at this flow, don't complain
 		}
 
-		if (location != null && flowContext != null && flowContext.recordExitAgainstResource(this, flowInfo, trackingVar, location)) {
+		ASTNode locToBlame = location;
+		if (location instanceof ReturnStatement && !trackingVar.isShared() && !trackingVar.closeSeen() && locationScope.isLastInMethod(null, location)) {
+			locToBlame = null; // at end of method there's no point in specifically blaming the final return (unless other returns may have seen a close)
+		}
+
+		if (locToBlame != null && flowContext != null && flowContext.recordExitAgainstResource(this, flowInfo, trackingVar, location)) {
 			continue; // handled by the flow context
+		}
+
+		if (!trackingVar.hasRecordedLocations() && trackingVar.isClosedInFinally()) {
+			continue;
 		}
 
 		// compute the most specific null status for this resource,
 		int status = trackingVar.findMostSpecificStatus(flowInfo, this, locationScope);
 
 		if (status == FlowInfo.NULL) {
-			// definitely unclosed: highest priority
-			reportResourceLeak(trackingVar, location, status);
-			continue;
+			if (trackingVar.isClosedInNestedMethod()) {
+				status = FlowInfo.POTENTIALLY_NULL;
+			} else {
+				// definitely unclosed: highest priority
+				reportResourceLeak(trackingVar, locToBlame, status);
+				continue;
+			}
 		}
-		if (location == null) // at end of block and not definitely unclosed
-		{
+		if (locToBlame == null) { // at end of block and not definitely unclosed
 			// problems at specific locations: medium priority
 			if (trackingVar.reportRecordedErrors(this, status, flowInfo.reachMode() != FlowInfo.REACHABLE)) // ... report previously recorded errors
 				continue;
 		}
 		if (status == FlowInfo.POTENTIALLY_NULL) {
 			// potentially unclosed: lower priority
-			reportResourceLeak(trackingVar, location, status);
+			reportResourceLeak(trackingVar, locToBlame, status);
 		} else if (status == FlowInfo.NON_NULL) {
 			// properly closed but not managed by t-w-r: lowest priority
 			if (environment().globalOptions.complianceLevel >= ClassFileConstants.JDK1_7)
-				trackingVar.reportExplicitClosing(problemReporter());
+				trackingVar.reportExplicitClosing(problemReporter()); // fixme: only for actual close calls, not return in @Owning
 		}
 	}
 	if (location == null) {
@@ -1230,8 +1248,66 @@ public void checkUnclosedCloseables(FlowInfo flowInfo, FlowContext flowContext, 
 	}
 }
 
+private boolean isLastInMethod(Block block, ASTNode location) {
+	Statement[] blockStatements = null;
+	if (block != null) {
+		blockStatements = block.statements;
+	} else if (this.referenceContext() instanceof AbstractMethodDeclaration method) {
+		blockStatements = method.statements;
+	}
+	if (blockStatements != null) {
+		Statement lastStatement = blockStatements[blockStatements.length-1];
+		if (lastStatement == location) {
+			Scope current = this;
+			Scope currentParent;
+			// at each level in the parent chain:
+			while (!(current instanceof MethodScope) && (currentParent = current.parent) instanceof BlockScope) {
+				Scope lastSubScope = ((BlockScope) currentParent).findLastRelevantSubScope();
+				// are we within that arm of the last relevant subScope?
+				if (lastSubScope != null && lastSubScope != current) {
+					return false;
+				}
+				current = currentParent;
+			}
+			return true;
+		} else if (lastStatement instanceof Block aBlock) {
+			return block.scope.isLastInMethod(aBlock, location);
+		} else if (lastStatement instanceof TryStatement tryStatement) {
+			// which block is last (try or finally)?
+			if (tryStatement.finallyBlock == null || tryStatement.finallyBlock.statements == null) {
+				return tryStatement.tryBlock.scope.isLastInMethod(tryStatement.tryBlock, location);
+			} else {
+				return tryStatement.finallyBlock.scope.isLastInMethod(tryStatement.finallyBlock, location);
+			}
+		}
+		// loops are trickier: would need to inspect every potential exit.
+	}
+	return false;
+}
+
+protected Scope findLastRelevantSubScope() {
+	int lastIdx = this.subscopeCount-1;
+	Scope lastSubScope = null;
+	while (lastIdx >= 0) {
+		lastSubScope = this.subscopes[lastIdx];
+		if (lastSubScope instanceof BlockScope blockSub && !blockSub.isSecretScope())
+			break;
+		lastIdx--;
+	}
+	return lastSubScope;
+}
+
+private boolean isSecretScope() {
+	if (this.locals != null && this.locals.length > 0) {
+		LocalVariableBinding local = this.locals[0];
+		if (local != null && CharOperation.prefixEquals(RecordPattern.SECRET_RECORD_PATTERN_THROWABLE_VARIABLE_NAME.toCharArray(), local.name))
+			return true;
+	}
+	return false;
+}
+
 private void reportResourceLeak(FakedTrackingVariable trackingVar, ASTNode location, int nullStatus) {
-	if (location != null)
+	if (location != null && trackingVar.originalBinding != null)
 		trackingVar.recordErrorLocation(location, nullStatus);
 	else
 		trackingVar.reportError(problemReporter(), null, nullStatus);
@@ -1260,7 +1336,7 @@ public void correlateTrackingVarsIfElse(FlowInfo thenFlowInfo, FlowInfo elseFlow
 	if (this.trackingVariables != null) {
 		int trackVarCount = this.trackingVariables.size();
 		for (int i=0; i<trackVarCount; i++) {
-			FakedTrackingVariable trackingVar = (FakedTrackingVariable) this.trackingVariables.get(i);
+			FakedTrackingVariable trackingVar = this.trackingVariables.get(i);
 			if (trackingVar.originalBinding == null) {
 				// avoid problem weakened to 'potential' if unassigned resource exists only in one branch:
 				boolean hasNullInfoInThen = thenFlowInfo.hasNullInfoFor(trackingVar.binding);
@@ -1289,7 +1365,7 @@ public void correlateTrackingVarsIfElse(FlowInfo thenFlowInfo, FlowInfo elseFlow
 					continue; // short cut
 
 				for (int j=i+1; j<trackVarCount; j++) {
-					FakedTrackingVariable var2 = ((FakedTrackingVariable) this.trackingVariables.get(j));
+					FakedTrackingVariable var2 = this.trackingVariables.get(j);
 					if (trackingVar.originalBinding == var2.originalBinding) {
 						// two tracking variables for the same original, merge info from both branches now:
 						boolean var1SeenInThen = thenFlowInfo.hasNullInfoFor(trackingVar.binding);
@@ -1316,6 +1392,20 @@ public void correlateTrackingVarsIfElse(FlowInfo thenFlowInfo, FlowInfo elseFlow
 	}
 	if (this.parent instanceof BlockScope)
 		((BlockScope) this.parent).correlateTrackingVarsIfElse(thenFlowInfo, elseFlowInfo);
+}
+
+/** Retrieve the nearest tracking variable for the given original binding. */
+public FakedTrackingVariable getCloseTrackerFor(LocalVariableBinding localVariable) {
+	if (this.trackingVariables != null) {
+		for (FakedTrackingVariable tracker : this.trackingVariables) {
+			if (tracker.originalBinding == localVariable)
+				return tracker;
+		}
+	}
+	if (this.parent instanceof BlockScope) {
+		return ((BlockScope) this.parent).getCloseTrackerFor(localVariable);
+	}
+	return null;
 }
 
 /** 15.12.3 (Java 8) "Compile-Time Step 3: Is the Chosen Method Appropriate?" */

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BlockScope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BlockScope.java
@@ -1257,7 +1257,7 @@ private boolean isLastInMethod(Block block, ASTNode location) {
 	} else if (this.referenceContext() instanceof AbstractMethodDeclaration method) {
 		blockStatements = method.statements;
 	}
-	if (blockStatements != null) {
+	if (blockStatements != null && blockStatements.length > 0) {
 		Statement lastStatement = blockStatements[blockStatements.length-1];
 		if (lastStatement == location) {
 			Scope current = this;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ClassScope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ClassScope.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ClassScope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ClassScope.java
@@ -1459,7 +1459,7 @@ public class ClassScope extends Scope {
 			sourceType.typeBits |= (superInterface.typeBits & TypeIds.InheritableBits);
 			// further analysis against white lists for the unlikely case we are compiling java.util.stream.Stream:
 			if ((sourceType.typeBits & (TypeIds.BitAutoCloseable|TypeIds.BitCloseable)) != 0)
-				sourceType.typeBits |= sourceType.applyCloseableInterfaceWhitelists();
+				sourceType.typeBits |= sourceType.applyCloseableInterfaceWhitelists(compilerOptions());
 			interfaceBindings[count++] = superInterface;
 		}
 		// hold onto all correctly resolved superinterfaces

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ExtendedTagBits.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ExtendedTagBits.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2020, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -17,7 +17,7 @@ import org.eclipse.jdt.internal.compiler.ast.ASTNode;
 
 public interface ExtendedTagBits {
 
-	int AreRecordComponentsComplete = ASTNode.Bit1;
+	int AreRecordComponentsComplete = ASTNode.Bit1; // type
 	int HasUnresolvedPermittedSubtypes = ASTNode.Bit2;
 
 	/** From Java 16
@@ -28,5 +28,8 @@ public interface ExtendedTagBits {
 	// Java 16 Records
 	int IsCanonicalConstructor = ASTNode.Bit4; // constructor
 	int isImplicit  = ASTNode.Bit5; // constructor and method
+
+	// @Owning / closing
+	int IsClosingMethod = ASTNode.Bit1; // method
 
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/FieldBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/FieldBinding.java
@@ -26,6 +26,7 @@ package org.eclipse.jdt.internal.compiler.lookup;
 import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.internal.compiler.IErrorHandlingPolicy;
 import org.eclipse.jdt.internal.compiler.ast.ASTNode;
+import org.eclipse.jdt.internal.compiler.ast.FakedTrackingVariable;
 import org.eclipse.jdt.internal.compiler.ast.FieldDeclaration;
 import org.eclipse.jdt.internal.compiler.ast.TypeDeclaration;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
@@ -35,6 +36,8 @@ import org.eclipse.jdt.internal.compiler.problem.ProblemReporter;
 public class FieldBinding extends VariableBinding {
 	public ReferenceBinding declaringClass;
 	public int compoundUseFlag = 0; // number or accesses via postIncrement or compoundAssignment
+
+	public FakedTrackingVariable closeTracker;
 
 protected FieldBinding() {
 	super(null, null, 0, null);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ImplicitNullAnnotationVerifier.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ImplicitNullAnnotationVerifier.java
@@ -345,10 +345,10 @@ public class ImplicitNullAnnotationVerifier {
 			length = currentArguments.length;
 		if (useTypeAnnotations) // need to look for type annotations on all parameters:
 			length = currentMethod.parameters.length;
-		else if (inheritedMethod.parameterNonNullness != null)
-			length = inheritedMethod.parameterNonNullness.length;
-		else if (currentMethod.parameterNonNullness != null)
-			length = currentMethod.parameterNonNullness.length;
+		else if (inheritedMethod.parameterFlowBits != null)
+			length = inheritedMethod.parameterFlowBits.length;
+		else if (currentMethod.parameterFlowBits != null)
+			length = currentMethod.parameterFlowBits.length;
 
 		parameterLoop:
 		for (int i = 0; i < length; i++) {
@@ -493,8 +493,8 @@ public class ImplicitNullAnnotationVerifier {
 			}
 			return null;
 		}
-		return (method.parameterNonNullness == null)
-						? null : method.parameterNonNullness[i];
+		return (method.parameterFlowBits == null)
+						? null : method.getParameterNullness(i);
 	}
 
 	private long getReturnTypeNullnessTagBits(MethodBinding method, boolean useTypeAnnotations) {
@@ -525,9 +525,13 @@ public class ImplicitNullAnnotationVerifier {
 
 	/* record declared nullness of a parameter into the method and into the argument (if present). */
 	void recordArgNonNullness(MethodBinding method, int paramCount, int paramIdx, Argument currentArgument, Boolean nonNullNess) {
-		if (method.parameterNonNullness == null)
-			method.parameterNonNullness = new Boolean[paramCount];
-		method.parameterNonNullness[paramIdx] = nonNullNess;
+		if (method.parameterFlowBits == null)
+			method.parameterFlowBits = new byte[paramCount];
+		if (nonNullNess == Boolean.TRUE) {
+			method.parameterFlowBits[paramIdx] |= MethodBinding.PARAM_NONNULL;
+		} else if (nonNullNess == Boolean.FALSE) {
+			method.parameterFlowBits[paramIdx] |= MethodBinding.PARAM_NULLABLE;
+		}
 		if (currentArgument != null) {
 			currentArgument.binding.tagBits |= nonNullNess.booleanValue() ?
 					TagBits.AnnotationNonNull : TagBits.AnnotationNullable;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/LookupEnvironment.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/LookupEnvironment.java
@@ -127,7 +127,9 @@ public class LookupEnvironment implements ProblemReasons, TypeConstants {
 	AnnotationBinding nonNullAnnotation;
 	AnnotationBinding nullableAnnotation;
 
-	Map<String,Integer> allNullAnnotations = null;
+	AnnotationBinding owningAnnotation;
+
+	Map<String,Integer> allAnalysisAnnotations = null;
 
 	final List<MethodBinding> deferredEnumMethods; // SHARED: during early initialization we cannot mark Enum-methods as nonnull.
 
@@ -1573,21 +1575,36 @@ public char[][] getNonNullByDefaultAnnotationName() {
 	return this.globalOptions.nonNullByDefaultAnnotationName;
 }
 
-int getNullAnnotationBit(char[][] qualifiedTypeName) {
-	if (this.allNullAnnotations == null) {
-		this.allNullAnnotations = new HashMap<>();
-		this.allNullAnnotations.put(CharOperation.toString(this.globalOptions.nonNullAnnotationName), TypeIds.BitNonNullAnnotation);
-		this.allNullAnnotations.put(CharOperation.toString(this.globalOptions.nullableAnnotationName), TypeIds.BitNullableAnnotation);
-		this.allNullAnnotations.put(CharOperation.toString(this.globalOptions.nonNullByDefaultAnnotationName), TypeIds.BitNonNullByDefaultAnnotation);
+public char[][] getOwningAnnotationName() {
+	return this.globalOptions.owningAnnotationName;
+}
+
+public AnnotationBinding getOwningAnnotation() {
+	if (this.owningAnnotation != null)
+		return this.owningAnnotation;
+	if (this.root != this) {
+		return this.owningAnnotation = this.root.getNonNullAnnotation();
+	}
+	ReferenceBinding owning = getResolvedType(this.globalOptions.owningAnnotationName, this.UnNamedModule, null, true);
+	return this.owningAnnotation = this.typeSystem.getAnnotationType(owning, true);
+}
+
+int getAnalysisAnnotationBit(char[][] qualifiedTypeName) {
+	if (this.allAnalysisAnnotations == null) {
+		this.allAnalysisAnnotations = new HashMap<>();
+		this.allAnalysisAnnotations.put(CharOperation.toString(this.globalOptions.nonNullAnnotationName), TypeIds.BitNonNullAnnotation);
+		this.allAnalysisAnnotations.put(CharOperation.toString(this.globalOptions.nullableAnnotationName), TypeIds.BitNullableAnnotation);
+		this.allAnalysisAnnotations.put(CharOperation.toString(this.globalOptions.nonNullByDefaultAnnotationName), TypeIds.BitNonNullByDefaultAnnotation);
+		this.allAnalysisAnnotations.put(CharOperation.toString(this.globalOptions.owningAnnotationName), TypeIds.BitOwningAnnotation);
 		for (String name : this.globalOptions.nullableAnnotationSecondaryNames)
-			this.allNullAnnotations.put(name, TypeIds.BitNullableAnnotation);
+			this.allAnalysisAnnotations.put(name, TypeIds.BitNullableAnnotation);
 		for (String name : this.globalOptions.nonNullAnnotationSecondaryNames)
-			this.allNullAnnotations.put(name, TypeIds.BitNonNullAnnotation);
+			this.allAnalysisAnnotations.put(name, TypeIds.BitNonNullAnnotation);
 		for (String name : this.globalOptions.nonNullByDefaultAnnotationSecondaryNames)
-			this.allNullAnnotations.put(name, TypeIds.BitNonNullByDefaultAnnotation);
+			this.allAnalysisAnnotations.put(name, TypeIds.BitNonNullByDefaultAnnotation);
 	}
 	String qualifiedTypeString = CharOperation.toString(qualifiedTypeName);
-	Integer typeBit = this.allNullAnnotations.get(qualifiedTypeString);
+	Integer typeBit = this.allAnalysisAnnotations.get(qualifiedTypeString);
 	return typeBit == null ? 0 : typeBit;
 }
 public boolean isNullnessAnnotationPackage(PackageBinding pkg) {
@@ -1643,6 +1660,46 @@ private void initializeUsesNullTypeAnnotation() {
 	if (nullableMetaBits == 0)
 		return;
 	this.globalOptions.useNullTypeAnnotations = Boolean.TRUE;
+}
+
+public boolean usesOwningAnnotation() {
+	if(this.root != this) {
+		return this.root.usesOwningAnnotation();
+	}
+	if (this.globalOptions.useOwningAnnotation != null)
+		return this.globalOptions.useOwningAnnotation;
+
+	initializeUsesOwningAnnotation();
+	for (MethodBinding enumMethod : this.deferredEnumMethods) {
+		int purpose = 0;
+		if (CharOperation.equals(enumMethod.selector, TypeConstants.VALUEOF)) {
+			purpose = SyntheticMethodBinding.EnumValueOf;
+		} else if (CharOperation.equals(enumMethod.selector, TypeConstants.VALUES)) {
+			purpose = SyntheticMethodBinding.EnumValues;
+		}
+		if (purpose != 0)
+			SyntheticMethodBinding.markNonNull(enumMethod, purpose, this);
+	}
+	this.deferredEnumMethods.clear();
+	return this.globalOptions.useOwningAnnotation;
+}
+
+private void initializeUsesOwningAnnotation() {
+	this.globalOptions.useOwningAnnotation = Boolean.FALSE;
+	if (!this.globalOptions.analyseResourceLeaks || this.globalOptions.originalSourceLevel < ClassFileConstants.JDK1_7)
+		return;
+	ReferenceBinding owning;
+	boolean origMayTolerateMissingType = this.mayTolerateMissingType;
+	this.mayTolerateMissingType = true;
+	try {
+		owning = this.owningAnnotation != null ? this.owningAnnotation.getAnnotationType()
+				: getType(this.getOwningAnnotationName(), this.UnNamedModule); // FIXME(SHMOD) module for null annotations??
+	} finally {
+		this.mayTolerateMissingType = origMayTolerateMissingType;
+	}
+	if (owning == null)
+		return;
+	this.globalOptions.useOwningAnnotation = Boolean.TRUE;
 }
 
 /* Answer the top level package named name if it exists in the cache.
@@ -2272,7 +2329,7 @@ public boolean containsNullTypeAnnotation(IBinaryAnnotation[] typeAnnotations) {
 		// typeName must be "Lfoo/X;"
 		if (typeName == null || typeName.length < 3 || typeName[0] != 'L') continue;
 		char[][] name = CharOperation.splitOn('/', typeName, 1, typeName.length-1);
-		if (getNullAnnotationBit(name) != 0)
+		if (getAnalysisAnnotationBit(name) != 0)
 			return true;
 	}
 	return false;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/LookupEnvironment.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/LookupEnvironment.java
@@ -1612,6 +1612,8 @@ public boolean isNullnessAnnotationPackage(PackageBinding pkg) {
 }
 
 public boolean usesNullTypeAnnotations() {
+	if (!this.globalOptions.isAnnotationBasedNullAnalysisEnabled)
+		return false;
 	if(this.root != this) {
 		return this.root.usesNullTypeAnnotations();
 	}
@@ -1663,6 +1665,9 @@ private void initializeUsesNullTypeAnnotation() {
 }
 
 public boolean usesOwningAnnotation() {
+	if (!this.globalOptions.isAnnotationBasedResourceAnalysisEnabled) {
+		return false;
+	}
 	if(this.root != this) {
 		return this.root.usesOwningAnnotation();
 	}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MethodBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MethodBinding.java
@@ -1475,6 +1475,12 @@ public boolean hasPolymorphicSignature(Scope scope) {
 
 	return false;
 }
+public boolean isClosingMethod() {
+	if (!this.declaringClass.hasTypeBit(TypeIds.BitAutoCloseable))
+		return false;
+	return (this.extendedTagBits & ExtendedTagBits.IsClosingMethod) != 0 // custom closing method with "@Owning MyType this"
+			|| (CharOperation.equals(this.selector, TypeConstants.CLOSE) && this.parameters == NO_PARAMETERS); // AutoCloseable.close()
+}
 public boolean ownsParameter(int i) {
 	if (this.parameterFlowBits != null)
 		return (this.parameterFlowBits[i] & PARAM_OWNING) != 0;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MethodBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MethodBinding.java
@@ -1478,6 +1478,9 @@ public boolean hasPolymorphicSignature(Scope scope) {
 public boolean ownsParameter(int i) {
 	if (this.parameterFlowBits != null)
 		return (this.parameterFlowBits[i] & PARAM_OWNING) != 0;
+	if (i == 0 && this.parameters.length > 0 && this.declaringClass.hasTypeBit(TypeIds.BitWrapperCloseable)) {
+		return this.parameters[0].hasTypeBit(TypeIds.BitAutoCloseable);
+	}
 	return false;
 }
 public boolean notownsParameter(int i) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MethodBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MethodBinding.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -1495,6 +1495,20 @@ public Boolean getParameterNullness(int idx) {
 			return Boolean.FALSE;
 	}
 	return null;
+}
+public void verifyOverrideCompatibility(MethodBinding inheritedMethod, ClassScope scope) {
+	int len = Math.min(this.parameters.length, inheritedMethod.parameters.length);
+	AbstractMethodDeclaration sourceMethod = sourceMethod();
+	for (int i=0; i<len; i++) {
+		if (inheritedMethod.ownsParameter(i)) {
+			if (!ownsParameter(i))
+				scope.problemReporter().overrideReducingParamterOwning(sourceMethod.arguments[i]);
+		}
+	}
+	if ((this.tagBits & TagBits.AnnotationOwning) != 0) {
+		if ((inheritedMethod.tagBits & TagBits.AnnotationOwning) == 0)
+			scope.problemReporter().overrideAddingReturnOwning(sourceMethod);
+	}
 }
 }
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MethodBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MethodBinding.java
@@ -73,6 +73,8 @@ public class MethodBinding extends Binding {
 	public Boolean[] parameterNonNullness;  // TRUE means @NonNull declared, FALSE means @Nullable declared, null means nothing declared
 	public int defaultNullness; // for null *type* annotations
 
+	public Boolean[] parameterOwning; // TRUE means @Owning declared, ...
+
 	/** Store parameter names from MethodParameters attribute (incl. applicable default). */
 	public char[][] parameterNames = Binding.NO_PARAMETER_NAMES;
 
@@ -1453,6 +1455,11 @@ public boolean hasPolymorphicSignature(Scope scope) {
 		}
 	}
 
+	return false;
+}
+public boolean ownsParameter(int i) {
+	if (this.parameterOwning != null)
+		return this.parameterOwning[i] == Boolean.TRUE;
 	return false;
 }
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MethodBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MethodBinding.java
@@ -78,6 +78,7 @@ public class MethodBinding extends Binding {
 	public static byte PARAM_NULLABLE = 2;
 	public static byte PARAM_NULLITY = (byte) (PARAM_NONNULL | PARAM_NULLABLE);
 	public static byte PARAM_OWNING = 4;
+	public static byte PARAM_NOTOWNING = 8;
 
 	public static byte flowBitFromAnnotationTagBit(long tagBit) {
 		if (tagBit == TagBits.AnnotationNonNull)
@@ -86,6 +87,8 @@ public class MethodBinding extends Binding {
 			return PARAM_NULLABLE;
 		if (tagBit == TagBits.AnnotationOwning)
 			return PARAM_OWNING;
+		if (tagBit == TagBits.AnnotationNotOwning)
+			return PARAM_NOTOWNING;
 		return 0;
 	}
 
@@ -1475,6 +1478,11 @@ public boolean hasPolymorphicSignature(Scope scope) {
 public boolean ownsParameter(int i) {
 	if (this.parameterFlowBits != null)
 		return (this.parameterFlowBits[i] & PARAM_OWNING) != 0;
+	return false;
+}
+public boolean notownsParameter(int i) {
+	if (this.parameterFlowBits != null)
+		return (this.parameterFlowBits[i] & PARAM_NOTOWNING) != 0;
 	return false;
 }
 /** @return TRUE means @NonNull declared, FALSE means @Nullable declared, null means nothing declared */

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MethodBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MethodBinding.java
@@ -1476,10 +1476,11 @@ public boolean hasPolymorphicSignature(Scope scope) {
 	return false;
 }
 public boolean isClosingMethod() {
-	if (!this.declaringClass.hasTypeBit(TypeIds.BitAutoCloseable))
-		return false;
-	return (this.extendedTagBits & ExtendedTagBits.IsClosingMethod) != 0 // custom closing method with "@Owning MyType this"
-			|| (CharOperation.equals(this.selector, TypeConstants.CLOSE) && this.parameters == NO_PARAMETERS); // AutoCloseable.close()
+	boolean isCloseMethod = CharOperation.equals(this.selector, TypeConstants.CLOSE) && this.parameters == NO_PARAMETERS;  // close()
+	isCloseMethod |= (this.extendedTagBits & ExtendedTagBits.IsClosingMethod) != 0; // "@Owning MyType this"
+	if (isCloseMethod)
+		return this.declaringClass.hasTypeBit(TypeIds.BitAutoCloseable);
+	return false;
 }
 public boolean ownsParameter(int i) {
 	if (this.parameterFlowBits != null)

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MethodVerifier.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MethodVerifier.java
@@ -146,6 +146,7 @@ void checkAgainstInheritedMethods(MethodBinding currentMethod, MethodBinding[] m
 				} else {
 					currentMethod.modifiers |= ExtraCompilerModifiers.AccImplementing | ExtraCompilerModifiers.AccOverriding;
 				}
+				currentMethod.verifyOverrideCompatibility(inheritedMethod, this.type.scope);
 //			with the above change an abstract method is tagged as implementing the inherited abstract method
 //			if (!currentMethod.isAbstract() && inheritedMethod.isAbstract()) {
 //				if ((currentMethod.modifiers & CompilerModifiers.AccOverriding) == 0)
@@ -166,6 +167,7 @@ void checkAgainstInheritedMethods(MethodBinding currentMethod, MethodBinding[] m
 						currentMethod.modifiers |= ExtraCompilerModifiers.AccImplementing;
 					else
 						currentMethod.modifiers |= ExtraCompilerModifiers.AccOverriding;
+					currentMethod.verifyOverrideCompatibility(inheritedMethod, this.type.scope);
 				}
 			}
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MostSpecificExceptionMethodBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MostSpecificExceptionMethodBinding.java
@@ -33,7 +33,7 @@ public class MostSpecificExceptionMethodBinding  extends MethodBinding {
 				mostSpecificExceptions,
 				originalMethod.declaringClass);
 		this.originalMethod = originalMethod;
-		this.parameterNonNullness = originalMethod.parameterNonNullness;
+		this.parameterFlowBits = originalMethod.parameterFlowBits;
 		this.defaultNullness = originalMethod.defaultNullness;
 	}
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/PackageBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/PackageBinding.java
@@ -103,9 +103,9 @@ void addType(ReferenceBinding element) {
 	if (priorType != null && priorType.isUnresolvedType() && !element.isUnresolvedType()) {
 		((UnresolvedReferenceBinding) priorType).setResolvedType(element, this.environment);
 	}
-	if (this.environment.globalOptions.isAnnotationBasedNullAnalysisEnabled)
+	if (this.environment.globalOptions.isAnnotationBasedNullAnalysisEnabled || this.environment.usesOwningAnnotation())
 		if (element.isAnnotationType() || element instanceof UnresolvedReferenceBinding) // unresolved types don't yet have the modifiers set
-			checkIfNullAnnotationType(element);
+			checkIfAnalysisAnnotationType(element);
 
 	if (!element.isUnresolvedType() && this.wrappingSplitPackageBindings != null) {
 		for (SplitPackageBinding splitPackageBinding : this.wrappingSplitPackageBindings) {
@@ -394,7 +394,7 @@ private boolean isPackageOfQualifiedTypeName(char[][] packageName, char[][] type
 	return true;
 }
 
-void checkIfNullAnnotationType(ReferenceBinding type) {
+void checkIfAnalysisAnnotationType(ReferenceBinding type) {
 	// check if type is one of the configured null annotation types
 	// if so mark as a well known type using the corresponding typeBit:
 	if (this.environment.nullableAnnotationPackage == this
@@ -413,7 +413,7 @@ void checkIfNullAnnotationType(ReferenceBinding type) {
 		if (!(type instanceof UnresolvedReferenceBinding)) // unresolved will need to check back for the resolved type
 			this.environment.nonnullByDefaultAnnotationPackage = null; // don't check again
 	} else {
-		type.typeBits |= this.environment.getNullAnnotationBit(type.compoundName);
+		type.typeBits |= this.environment.getAnalysisAnnotationBit(type.compoundName);
 	}
 }
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/PackageBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/PackageBinding.java
@@ -103,7 +103,7 @@ void addType(ReferenceBinding element) {
 	if (priorType != null && priorType.isUnresolvedType() && !element.isUnresolvedType()) {
 		((UnresolvedReferenceBinding) priorType).setResolvedType(element, this.environment);
 	}
-	if (this.environment.globalOptions.isAnnotationBasedNullAnalysisEnabled || this.environment.usesOwningAnnotation())
+	if (this.environment.globalOptions.isAnnotationBasedNullAnalysisEnabled || this.environment.globalOptions.isAnnotationBasedResourceAnalysisEnabled)
 		if (element.isAnnotationType() || element instanceof UnresolvedReferenceBinding) // unresolved types don't yet have the modifiers set
 			checkIfAnalysisAnnotationType(element);
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedGenericMethodBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedGenericMethodBinding.java
@@ -570,7 +570,7 @@ public class ParameterizedGenericMethodBinding extends ParameterizedMethodBindin
 	    									? originalMethod.returnType // no substitution if original was static
 	    									: Scope.substitute(rawType, originalMethod.returnType));
 	    this.wasInferred = false; // not resulting from method invocation inferrence
-	    this.parameterNonNullness = originalMethod.parameterNonNullness;
+	    this.parameterFlowBits = originalMethod.parameterFlowBits;
 	    this.defaultNullness = originalMethod.defaultNullness;
 	}
 
@@ -626,7 +626,7 @@ public class ParameterizedGenericMethodBinding extends ParameterizedMethodBindin
 			}
 		}
 	    this.wasInferred = true;// resulting from method invocation inferrence
-	    this.parameterNonNullness = originalMethod.parameterNonNullness;
+	    this.parameterFlowBits = originalMethod.parameterFlowBits;
 	    this.defaultNullness = originalMethod.defaultNullness;
 	    // special case: @NonNull for a parameter that is inferred to 'null' is encoded the old way
 	    // because we cannot (and don't want to) add type annotations to NullTypeBinding.
@@ -635,9 +635,9 @@ public class ParameterizedGenericMethodBinding extends ParameterizedMethodBindin
 	    	if (this.parameters[i] == TypeBinding.NULL) {
 	    		long nullBits = originalMethod.parameters[i].tagBits & TagBits.AnnotationNullMASK;
 	    		if (nullBits == TagBits.AnnotationNonNull) {
-	    			if (this.parameterNonNullness == null)
-	    				this.parameterNonNullness = new Boolean[len];
-	    			this.parameterNonNullness[i] = Boolean.TRUE;
+	    			if (this.parameterFlowBits == null)
+	    				this.parameterFlowBits = new byte[len];
+	    			this.parameterFlowBits[i] |= PARAM_NONNULL;
 	    		}
 	    	}
 	    }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedMethodBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedMethodBinding.java
@@ -50,7 +50,7 @@ public class ParameterizedMethodBinding extends MethodBinding {
 		 * is substituted by a raw type.
 		 */
 		this.tagBits = originalMethod.tagBits & ~TagBits.HasMissingType;
-		this.parameterNonNullness = originalMethod.parameterNonNullness;
+		this.parameterFlowBits = originalMethod.parameterFlowBits;
 		this.defaultNullness = originalMethod.defaultNullness;
 
 		final TypeVariableBinding[] originalVariables = originalMethod.typeVariables;
@@ -143,9 +143,9 @@ public class ParameterizedMethodBinding extends MethodBinding {
 				for (int i=0; i<parametersLen; i++) {
 					long paramTagBits = NullAnnotationMatching.validNullTagBits(this.parameters[i].tagBits);
 					if (paramTagBits != 0) {
-						if (this.parameterNonNullness == null)
-							this.parameterNonNullness = new Boolean[parametersLen];
-						this.parameterNonNullness[i] = Boolean.valueOf(paramTagBits == TagBits.AnnotationNonNull);
+						if (this.parameterFlowBits == null)
+							this.parameterFlowBits = new byte[parametersLen];
+						this.parameterFlowBits[i] |= flowBitFromAnnotationTagBit(paramTagBits);
 					}
 				}
 			}
@@ -189,7 +189,7 @@ public class ParameterizedMethodBinding extends MethodBinding {
 		 * is substituted by a raw type.
 		 */
 		this.tagBits = originalMethod.tagBits & ~TagBits.HasMissingType;
-		this.parameterNonNullness = originalMethod.parameterNonNullness;
+		this.parameterFlowBits = originalMethod.parameterFlowBits;
 		this.defaultNullness = originalMethod.defaultNullness;
 
 		final TypeVariableBinding[] originalVariables = originalMethod.typeVariables;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedTypeBinding.java
@@ -1533,7 +1533,7 @@ public class ParameterizedTypeBinding extends ReferenceBinding implements Substi
 	    		for (int i = this.superInterfaces.length; --i >= 0;) {
 	    			this.typeBits |= (this.superInterfaces[i].typeBits & TypeIds.InheritableBits);
 	    			if ((this.typeBits & (TypeIds.BitAutoCloseable|TypeIds.BitCloseable)) != 0) // avoid the side-effects of hasTypeBit()!
-	    				this.typeBits |= applyCloseableInterfaceWhitelists();
+	    				this.typeBits |= applyCloseableInterfaceWhitelists(this.environment.globalOptions);
 	    		}
     		}
 	    }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
@@ -2163,6 +2163,11 @@ protected int applyCloseableClassWhitelists(CompilerOptions options) {
 			return TypeIds.BitWrapperCloseable;
 	}
 	if (options.analyseResourceLeaks) {
+		if (options.isAnnotationBasedResourceAnalysisEnabled) {
+			if ((this.getAnnotationTagBits() & TagBits.AnnotationNotOwning) != 0) {
+				return TypeIds.BitResourceFreeCloseable;
+			}
+		}
 		ReferenceBinding mySuper = this.superclass();
 		if (mySuper != null && mySuper.id != TypeIds.T_JavaLangObject) {
 			if (hasMethodWithNumArgs(TypeConstants.CLOSE, 0))
@@ -2187,7 +2192,7 @@ protected boolean hasMethodWithNumArgs(char[] selector, int numArgs) {
  * If a type - known to be a Closeable - is mentioned in one of our white lists
  * answer the typeBit for the white list (BitWrapperCloseable or BitResourceFreeCloseable).
  */
-protected int applyCloseableInterfaceWhitelists() {
+protected int applyCloseableInterfaceWhitelists(CompilerOptions options) {
 	switch (this.compoundName.length) {
 		case 4:
 			if (CharOperation.equals(this.compoundName[0], TypeConstants.JAVA_UTIL_STREAM[0])) {
@@ -2214,6 +2219,11 @@ protected int applyCloseableInterfaceWhitelists() {
 				}
 			}
 			break;
+	}
+	if (options.isAnnotationBasedResourceAnalysisEnabled) {
+		if ((this.getAnnotationTagBits() & TagBits.AnnotationNotOwning) != 0) {
+			return TypeIds.BitResourceFreeCloseable;
+		}
 	}
 	return 0;
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TagBits.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TagBits.java
@@ -156,9 +156,10 @@ public interface TagBits {
 	long AnnotationNonNull = ASTNode.Bit57L;
 	/** @since 3.37 Owning annotation for resource leak analysis: */
 	long AnnotationOwning = ASTNode.Bit58L;
-	/** @since 3.8 canceling null-default annotation for PackageBinding or TypeBinding or MethodBinding: */
-	@Deprecated
-	long AnnotationNullUnspecifiedByDefault = ASTNode.Bit59L;
+	/** @since 3.37 NotOwning annotation for resource leak analysis */
+	long AnnotationNotOwning = ASTNode.Bit59L;
+	/** @since 3.37 Bit mask for owning  */
+	long AnnotationOwningMASK = AnnotationOwning | AnnotationNotOwning;
 	/** From Java 8 */
 	long AnnotationFunctionalInterface = ASTNode.Bit60L;
 	/** From Java 8 */
@@ -183,7 +184,7 @@ public interface TagBits {
 				| AnnotationNullable
 				| AnnotationNonNull
 				| AnnotationOwning
-				| AnnotationNullUnspecifiedByDefault
+				| AnnotationNotOwning
 				| AnnotationRepeatable;
 
 	long AnnotationNullMASK = AnnotationNullable | AnnotationNonNull;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TagBits.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TagBits.java
@@ -154,9 +154,8 @@ public interface TagBits {
 	long AnnotationNullable = ASTNode.Bit56L;
 	/** @since 3.8 null annotation for MethodBinding or LocalVariableBinding (argument): */
 	long AnnotationNonNull = ASTNode.Bit57L;
-	/** @since 3.8 null-default annotation for PackageBinding or TypeBinding or MethodBinding: */
-	@Deprecated
-	long AnnotationNonNullByDefault = ASTNode.Bit58L;
+	/** @since 3.37 Owning annotation for resource leak analysis: */
+	long AnnotationOwning = ASTNode.Bit58L;
 	/** @since 3.8 canceling null-default annotation for PackageBinding or TypeBinding or MethodBinding: */
 	@Deprecated
 	long AnnotationNullUnspecifiedByDefault = ASTNode.Bit59L;
@@ -183,7 +182,7 @@ public interface TagBits {
 				| AnnotationPolymorphicSignature
 				| AnnotationNullable
 				| AnnotationNonNull
-				| AnnotationNonNullByDefault
+				| AnnotationOwning
 				| AnnotationNullUnspecifiedByDefault
 				| AnnotationRepeatable;
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeConstants.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeConstants.java
@@ -305,8 +305,6 @@ public interface TypeConstants {
 		"ObjectOutputStream".toCharArray(), //$NON-NLS-1$
 		"FilterInputStream".toCharArray(), //$NON-NLS-1$
 		"FilterOutputStream".toCharArray(), //$NON-NLS-1$
-		"DataInputStream".toCharArray(), //$NON-NLS-1$
-		"DataOutputStream".toCharArray(), //$NON-NLS-1$
 		"PushbackInputStream".toCharArray(), //$NON-NLS-1$
 		"SequenceInputStream".toCharArray(), //$NON-NLS-1$
 		"PrintStream".toCharArray(), //$NON-NLS-1$

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeIds.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeIds.java
@@ -283,8 +283,11 @@ public interface TypeIds {
 	/** Mark subtypes of List to analyze dangerous indexOf. */
 	final int BitList = 1024;
 
-	/** Mark the type using as owning-annotation for resource analysis. */
+	/** Mark the type as owning-annotation for resource analysis. */
 	final int BitOwningAnnotation = 2048;
+
+	/** Mark the type as notowning-annotation for resource analysis. */
+	final int BitNotOwningAnnotation = 4096;
 
 	/**
 	 * Set of type bits that should be inherited by any sub types.

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeIds.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeIds.java
@@ -283,6 +283,9 @@ public interface TypeIds {
 	/** Mark subtypes of List to analyze dangerous indexOf. */
 	final int BitList = 1024;
 
+	/** Mark the type using as owning-annotation for resource analysis. */
+	final int BitOwningAnnotation = 2048;
+
 	/**
 	 * Set of type bits that should be inherited by any sub types.
 	 */

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -703,6 +703,9 @@ public static int getIrritant(int problemID) {
 		case IProblem.OwningFieldInNonResourceClass:
 		case IProblem.OwningFieldShouldImplementClose:
 			return CompilerOptions.InsufficientResourceManagement;
+		case IProblem.OverrideReducingParamterOwning:
+		case IProblem.OverrideAddingReturnOwning:
+			return CompilerOptions.IncompatibleOwningContract;
 
 		case IProblem.RedundantSpecificationOfTypeArguments:
 			return CompilerOptions.RedundantSpecificationOfTypeArguments;
@@ -787,6 +790,8 @@ public static int getProblemCategory(int severity, int problemID) {
 			case CompilerOptions.UnusedObjectAllocation :
 			case CompilerOptions.UnclosedCloseable :
 			case CompilerOptions.PotentiallyUnclosedCloseable :
+			case CompilerOptions.IncompatibleOwningContract:
+			case CompilerOptions.InsufficientResourceManagement:
 			case CompilerOptions.PessimisticNullAnalysisForFreeTypeVariables :
 			case CompilerOptions.NonNullTypeVariableFromLegacyInvocation :
 			case CompilerOptions.UnlikelyCollectionMethodArgumentType :
@@ -10320,6 +10325,29 @@ public void missingImplementationOfClose(FieldDeclaration fieldDeclaration) {
 		args,
 		fieldDeclaration.sourceStart,
 		fieldDeclaration.sourceEnd);
+}
+public void overrideReducingParamterOwning(Argument argument) {
+	char[] name = this.options.owningAnnotationName[this.options.owningAnnotationName.length-1];
+	String[] args = { String.valueOf(name) };
+	this.handle(
+		IProblem.OverrideReducingParamterOwning,
+		args,
+		args,
+		argument.sourceStart,
+		argument.sourceEnd);
+}
+
+public void overrideAddingReturnOwning(AbstractMethodDeclaration method) {
+	char[] name = this.options.owningAnnotationName[this.options.owningAnnotationName.length-1];
+	Annotation annotation = findAnnotation(method.annotations, TypeIds.BitOwningAnnotation);
+	ASTNode location = annotation != null ? annotation : method;
+	String[] args = { String.valueOf(name) };
+	this.handle(
+		IProblem.OverrideAddingReturnOwning,
+		args,
+		args,
+		location.sourceStart,
+		location.sourceEnd);
 }
 public void nullityMismatch(Expression expression, TypeBinding providedType, TypeBinding requiredType, int nullStatus, char[][] annotationName) {
 	if ((nullStatus & FlowInfo.NULL) != 0) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
@@ -693,6 +693,7 @@ public static int getIrritant(int problemID) {
 			return CompilerOptions.UnclosedCloseable;
 		case IProblem.PotentiallyUnclosedCloseable:
 		case IProblem.PotentiallyUnclosedCloseableAtExit:
+		case IProblem.ShouldMarkMethodAsOwning:
 			return CompilerOptions.PotentiallyUnclosedCloseable;
 		case IProblem.ExplicitlyClosedAutoCloseable:
 			return CompilerOptions.ExplicitlyClosedAutoCloseable;
@@ -10272,6 +10273,16 @@ public void explicitlyClosedAutoCloseable(FakedTrackingVariable trackVar) {
 		args,
 		trackVar.sourceStart,
 		trackVar.sourceEnd);
+}
+public void shouldMarkMethodAsOwning(ASTNode location) {
+	char[] name = this.options.owningAnnotationName[this.options.owningAnnotationName.length-1];
+	String[] args = { String.valueOf(name) };
+	this.handle(
+		IProblem.ShouldMarkMethodAsOwning,
+		args,
+		args,
+		location.sourceStart,
+		location.sourceEnd);
 }
 
 public void nullityMismatch(Expression expression, TypeBinding providedType, TypeBinding requiredType, int nullStatus, char[][] annotationName) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/messages.properties
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/messages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2000, 2023 IBM Corporation and others.
+# Copyright (c) 2000, 2024 IBM Corporation and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -916,6 +916,8 @@
 1263 = It is recommended to mark resource fields as ''@{0}'' to ensure proper closing
 1264 = Class with resource fields tagged as ''@{0}'' should implement AutoCloseable
 1265 = Class with resource fields tagged as ''@{0}'' should implement ''close()''
+1266 = Unsafe redefinition, super method tagged this parameter as ''@{0}''
+1267 = Unsafe redefinition, super method is not tagged as ''@{0}''
 
 # Java9 - Module declaration related
 1300 = {0} cannot be resolved to a module

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/messages.properties
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/messages.properties
@@ -909,6 +909,8 @@
 
 ### Autoclosable try
 1251 = Duplicate resource reference {0}
+### Annotation based resource analysis
+1260 = Enclosing method should be tagged as ''@{0}'' to pass the responsibility for the returned resource to the caller
 
 # Java9 - Module declaration related
 1300 = {0} cannot be resolved to a module

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/messages.properties
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/messages.properties
@@ -911,6 +911,11 @@
 1251 = Duplicate resource reference {0}
 ### Annotation based resource analysis
 1260 = Enclosing method should be tagged as ''@{0}'' to pass the responsibility for the returned resource to the caller
+1261 = Mandatory close of resource ''{0}'' has not been shown
+1262 = Mandatory close of resource ''{0}'' has not been shown at this location
+1263 = It is recommended to mark resource fields as ''@{0}'' to ensure proper closing
+1264 = Class with resource fields tagged as ''@{0}'' should implement AutoCloseable
+1265 = Class with resource fields tagged as ''@{0}'' should implement ''close()''
 
 # Java9 - Module declaration related
 1300 = {0} cannot be resolved to a module

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/BatchCompilerTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/BatchCompilerTest.java
@@ -1082,6 +1082,7 @@ public void test012b(){
 			"		<option key=\"org.eclipse.jdt.core.compiler.problem.hiddenCatchBlock\" value=\"warning\"/>\n" +
 			"		<option key=\"org.eclipse.jdt.core.compiler.problem.includeNullInfoFromAsserts\" value=\"disabled\"/>\n" +
 			"		<option key=\"org.eclipse.jdt.core.compiler.problem.incompatibleNonInheritedInterfaceMethod\" value=\"warning\"/>\n" +
+			"		<option key=\"org.eclipse.jdt.core.compiler.problem.incompatibleOwningContract\" value=\"warning\"/>\n" +
 			"		<option key=\"org.eclipse.jdt.core.compiler.problem.incompleteEnumSwitch\" value=\"warning\"/>\n" +
 			"		<option key=\"org.eclipse.jdt.core.compiler.problem.indirectStaticAccess\" value=\"ignore\"/>\n" +
 			"		<option key=\"org.eclipse.jdt.core.compiler.problem.insufficientResourceAnalysis\" value=\"warning\"/>\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/BatchCompilerTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/BatchCompilerTest.java
@@ -1038,6 +1038,8 @@ public void test012b(){
 			"		<option key=\"org.eclipse.jdt.core.compiler.annotation.nullable\" value=\"org.eclipse.jdt.annotation.Nullable\"/>\n" +
 			"		<option key=\"org.eclipse.jdt.core.compiler.annotation.nullable.secondary\" value=\"\"/>\n" +
 			"		<option key=\"org.eclipse.jdt.core.compiler.annotation.nullanalysis\" value=\"disabled\"/>\n" +
+			"		<option key=\"org.eclipse.jdt.core.compiler.annotation.owning\" value=\"org.eclipse.jdt.annotation.Owning\"/>\n" +
+			"		<option key=\"org.eclipse.jdt.core.compiler.annotation.resourceanalysis\" value=\"disabled\"/>\n" +
 			"		<option key=\"org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode\" value=\"disabled\"/>\n" +
 			"		<option key=\"org.eclipse.jdt.core.compiler.codegen.lambda.genericSignature\" value=\"do not generate\"/>\n" +
 			"		<option key=\"org.eclipse.jdt.core.compiler.codegen.methodParameters\" value=\"do not generate\"/>\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/BatchCompilerTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/BatchCompilerTest.java
@@ -1035,6 +1035,7 @@ public void test012b(){
 			"		<option key=\"org.eclipse.jdt.core.compiler.annotation.nonnull.secondary\" value=\"\"/>\n" +
 			"		<option key=\"org.eclipse.jdt.core.compiler.annotation.nonnullbydefault\" value=\"org.eclipse.jdt.annotation.NonNullByDefault\"/>\n" +
 			"		<option key=\"org.eclipse.jdt.core.compiler.annotation.nonnullbydefault.secondary\" value=\"\"/>\n" +
+			"		<option key=\"org.eclipse.jdt.core.compiler.annotation.notowning\" value=\"org.eclipse.jdt.annotation.NotOwning\"/>\n" +
 			"		<option key=\"org.eclipse.jdt.core.compiler.annotation.nullable\" value=\"org.eclipse.jdt.annotation.Nullable\"/>\n" +
 			"		<option key=\"org.eclipse.jdt.core.compiler.annotation.nullable.secondary\" value=\"\"/>\n" +
 			"		<option key=\"org.eclipse.jdt.core.compiler.annotation.nullanalysis\" value=\"disabled\"/>\n" +
@@ -1083,6 +1084,7 @@ public void test012b(){
 			"		<option key=\"org.eclipse.jdt.core.compiler.problem.incompatibleNonInheritedInterfaceMethod\" value=\"warning\"/>\n" +
 			"		<option key=\"org.eclipse.jdt.core.compiler.problem.incompleteEnumSwitch\" value=\"warning\"/>\n" +
 			"		<option key=\"org.eclipse.jdt.core.compiler.problem.indirectStaticAccess\" value=\"ignore\"/>\n" +
+			"		<option key=\"org.eclipse.jdt.core.compiler.problem.insufficientResourceAnalysis\" value=\"warning\"/>\n" +
 			"		<option key=\"org.eclipse.jdt.core.compiler.problem.invalidJavadoc\" value=\"ignore\"/>\n" +
 			"		<option key=\"org.eclipse.jdt.core.compiler.problem.invalidJavadocTags\" value=\"disabled\"/>\n" +
 			"		<option key=\"org.eclipse.jdt.core.compiler.problem.invalidJavadocTagsDeprecatedRef\" value=\"disabled\"/>\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/CompilerInvocationTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/CompilerInvocationTests.java
@@ -799,6 +799,8 @@ public void test011_problem_categories() {
 		expectedProblemAttributes.put("LocalVariableIsNeverUsed", new ProblemAttributes(CategorizedProblem.CAT_UNNECESSARY_CODE));
 		expectedProblemAttributes.put("LocalVariableMayBeNull", DEPRECATED);
 		expectedProblemAttributes.put("MaskedCatch", new ProblemAttributes(CategorizedProblem.CAT_POTENTIAL_PROGRAMMING_PROBLEM));
+		expectedProblemAttributes.put("MandatoryCloseNotShown", new ProblemAttributes(CategorizedProblem.CAT_POTENTIAL_PROGRAMMING_PROBLEM));
+		expectedProblemAttributes.put("MandatoryCloseNotShownAtExit", new ProblemAttributes(CategorizedProblem.CAT_POTENTIAL_PROGRAMMING_PROBLEM));
 		expectedProblemAttributes.put("MethodButWithConstructorName", new ProblemAttributes(CategorizedProblem.CAT_CODE_STYLE));
 		expectedProblemAttributes.put("MethodCanBePotentiallyStatic", new ProblemAttributes(CategorizedProblem.CAT_CODE_STYLE));
 		expectedProblemAttributes.put("MethodCanBeStatic", new ProblemAttributes(CategorizedProblem.CAT_CODE_STYLE));
@@ -887,6 +889,7 @@ public void test011_problem_categories() {
 		expectedProblemAttributes.put("NotExportedTypeInAPI", new ProblemAttributes(CategorizedProblem.CAT_POTENTIAL_PROGRAMMING_PROBLEM));
 		expectedProblemAttributes.put("ConflictingPackageFromModules", new ProblemAttributes(CategorizedProblem.CAT_MODULE));
 		expectedProblemAttributes.put("ConflictingPackageFromOtherModules", new ProblemAttributes(CategorizedProblem.CAT_MODULE));
+		expectedProblemAttributes.put("NotOwningResourceField", new ProblemAttributes(CategorizedProblem.CAT_INTERNAL));
 		expectedProblemAttributes.put("NotVisibleConstructor", new ProblemAttributes(CategorizedProblem.CAT_MEMBER));
 		expectedProblemAttributes.put("NotVisibleConstructorInDefaultConstructor", new ProblemAttributes(CategorizedProblem.CAT_MEMBER));
 		expectedProblemAttributes.put("NotVisibleConstructorInImplicitConstructorCall", new ProblemAttributes(CategorizedProblem.CAT_MEMBER));
@@ -924,6 +927,8 @@ public void test011_problem_categories() {
 		expectedProblemAttributes.put("OverridingTerminallyDeprecatedSinceVersionMethod", new ProblemAttributes(CategorizedProblem.CAT_DEPRECATION));
 		expectedProblemAttributes.put("OverridingMethodWithoutSuperInvocation", new ProblemAttributes(CategorizedProblem.CAT_POTENTIAL_PROGRAMMING_PROBLEM));
 		expectedProblemAttributes.put("OverridingNonVisibleMethod", new ProblemAttributes(CategorizedProblem.CAT_NAME_SHADOWING_CONFLICT));
+		expectedProblemAttributes.put("OwningFieldInNonResourceClass", new ProblemAttributes(CategorizedProblem.CAT_INTERNAL));
+		expectedProblemAttributes.put("OwningFieldShouldImplementClose", new ProblemAttributes(CategorizedProblem.CAT_INTERNAL));
 		expectedProblemAttributes.put("PackageCollidesWithType", new ProblemAttributes(CategorizedProblem.CAT_TYPE));
 		expectedProblemAttributes.put("PackageDoesNotExistOrIsEmpty", new ProblemAttributes(CategorizedProblem.CAT_MODULE));
 		expectedProblemAttributes.put("PackageIsNotExpectedPackage", new ProblemAttributes(CategorizedProblem.CAT_INTERNAL));
@@ -1022,7 +1027,7 @@ public void test011_problem_categories() {
 		expectedProblemAttributes.put("ServiceImplDefaultConstructorNotPublic", new ProblemAttributes(CategorizedProblem.CAT_TYPE));
 		expectedProblemAttributes.put("ServiceImplNotDefinedByModule", new ProblemAttributes(CategorizedProblem.CAT_TYPE));
 		expectedProblemAttributes.put("ShouldImplementHashcode", new ProblemAttributes(CategorizedProblem.CAT_POTENTIAL_PROGRAMMING_PROBLEM));
-		expectedProblemAttributes.put("ShouldMarkMethodAsOwning", new ProblemAttributes(CategorizedProblem.CAT_POTENTIAL_PROGRAMMING_PROBLEM));
+		expectedProblemAttributes.put("ShouldMarkMethodAsOwning", new ProblemAttributes(CategorizedProblem.CAT_INTERNAL));
 		expectedProblemAttributes.put("ShouldReturnValue", new ProblemAttributes(CategorizedProblem.CAT_MEMBER));
 		expectedProblemAttributes.put("ShouldReturnValueHintMissingDefault", new ProblemAttributes(CategorizedProblem.CAT_MEMBER));
 		expectedProblemAttributes.put("SpecdNonNullLocalVariableComparisonYieldsFalse", new ProblemAttributes(CategorizedProblem.CAT_POTENTIAL_PROGRAMMING_PROBLEM));
@@ -1900,6 +1905,8 @@ public void test012_compiler_problems_tuning() {
 		expectedProblemAttributes.put("LocalVariableIsNeverUsed", new ProblemAttributes(JavaCore.COMPILER_PB_UNUSED_LOCAL));
 		expectedProblemAttributes.put("LocalVariableMayBeNull", SKIP);
 		expectedProblemAttributes.put("MaskedCatch", new ProblemAttributes(JavaCore.COMPILER_PB_HIDDEN_CATCH_BLOCK));
+		expectedProblemAttributes.put("MandatoryCloseNotShown", new ProblemAttributes(JavaCore.COMPILER_PB_UNCLOSED_CLOSEABLE));
+		expectedProblemAttributes.put("MandatoryCloseNotShownAtExit", new ProblemAttributes(JavaCore.COMPILER_PB_UNCLOSED_CLOSEABLE));
 		expectedProblemAttributes.put("MethodButWithConstructorName", new ProblemAttributes(JavaCore.COMPILER_PB_METHOD_WITH_CONSTRUCTOR_NAME));
 		expectedProblemAttributes.put("MethodCanBePotentiallyStatic", new ProblemAttributes(JavaCore.COMPILER_PB_POTENTIALLY_MISSING_STATIC_ON_METHOD));
 		expectedProblemAttributes.put("MethodCanBeStatic", new ProblemAttributes(JavaCore.COMPILER_PB_MISSING_STATIC_ON_METHOD));
@@ -1988,6 +1995,7 @@ public void test012_compiler_problems_tuning() {
 		expectedProblemAttributes.put("NotExportedTypeInAPI", new ProblemAttributes(JavaCore.COMPILER_PB_API_LEAKS));
 		expectedProblemAttributes.put("ConflictingPackageFromModules", SKIP);
 		expectedProblemAttributes.put("ConflictingPackageFromOtherModules", SKIP);
+		expectedProblemAttributes.put("NotOwningResourceField", new ProblemAttributes(JavaCore.COMPILER_PB_RECOMMENDED_RESOURCE_MANAGEMENT));
 		expectedProblemAttributes.put("NotVisibleConstructor", SKIP);
 		expectedProblemAttributes.put("NotVisibleConstructorInDefaultConstructor", SKIP);
 		expectedProblemAttributes.put("NotVisibleConstructorInImplicitConstructorCall", SKIP);
@@ -2025,6 +2033,8 @@ public void test012_compiler_problems_tuning() {
 		expectedProblemAttributes.put("OverridingTerminallyDeprecatedSinceVersionMethod", new ProblemAttributes(JavaCore.COMPILER_PB_TERMINAL_DEPRECATION));
 		expectedProblemAttributes.put("OverridingMethodWithoutSuperInvocation", new ProblemAttributes(JavaCore.COMPILER_PB_OVERRIDING_METHOD_WITHOUT_SUPER_INVOCATION));
 		expectedProblemAttributes.put("OverridingNonVisibleMethod", new ProblemAttributes(JavaCore.COMPILER_PB_OVERRIDING_PACKAGE_DEFAULT_METHOD));
+		expectedProblemAttributes.put("OwningFieldInNonResourceClass", new ProblemAttributes(JavaCore.COMPILER_PB_RECOMMENDED_RESOURCE_MANAGEMENT));
+		expectedProblemAttributes.put("OwningFieldShouldImplementClose", new ProblemAttributes(JavaCore.COMPILER_PB_RECOMMENDED_RESOURCE_MANAGEMENT));
 		expectedProblemAttributes.put("PackageCollidesWithType", SKIP);
 		expectedProblemAttributes.put("PackageDoesNotExistOrIsEmpty", SKIP);
 		expectedProblemAttributes.put("PackageIsNotExpectedPackage", SKIP);
@@ -2124,7 +2134,7 @@ public void test012_compiler_problems_tuning() {
 		expectedProblemAttributes.put("ServiceImplDefaultConstructorNotPublic", SKIP);
 		expectedProblemAttributes.put("ServiceImplNotDefinedByModule", SKIP);
 		expectedProblemAttributes.put("ShouldImplementHashcode", new ProblemAttributes(JavaCore.COMPILER_PB_MISSING_HASHCODE_METHOD));
-		expectedProblemAttributes.put("ShouldMarkMethodAsOwning", new ProblemAttributes(JavaCore.COMPILER_PB_POTENTIALLY_UNCLOSED_CLOSEABLE));
+		expectedProblemAttributes.put("ShouldMarkMethodAsOwning", SKIP);
 		expectedProblemAttributes.put("ShouldReturnValue", SKIP);
 		expectedProblemAttributes.put("ShouldReturnValueHintMissingDefault", SKIP);
 		expectedProblemAttributes.put("SpecdNonNullLocalVariableComparisonYieldsFalse", new ProblemAttributes(JavaCore.COMPILER_PB_REDUNDANT_NULL_CHECK));

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/CompilerInvocationTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/CompilerInvocationTests.java
@@ -1022,6 +1022,7 @@ public void test011_problem_categories() {
 		expectedProblemAttributes.put("ServiceImplDefaultConstructorNotPublic", new ProblemAttributes(CategorizedProblem.CAT_TYPE));
 		expectedProblemAttributes.put("ServiceImplNotDefinedByModule", new ProblemAttributes(CategorizedProblem.CAT_TYPE));
 		expectedProblemAttributes.put("ShouldImplementHashcode", new ProblemAttributes(CategorizedProblem.CAT_POTENTIAL_PROGRAMMING_PROBLEM));
+		expectedProblemAttributes.put("ShouldMarkMethodAsOwning", new ProblemAttributes(CategorizedProblem.CAT_POTENTIAL_PROGRAMMING_PROBLEM));
 		expectedProblemAttributes.put("ShouldReturnValue", new ProblemAttributes(CategorizedProblem.CAT_MEMBER));
 		expectedProblemAttributes.put("ShouldReturnValueHintMissingDefault", new ProblemAttributes(CategorizedProblem.CAT_MEMBER));
 		expectedProblemAttributes.put("SpecdNonNullLocalVariableComparisonYieldsFalse", new ProblemAttributes(CategorizedProblem.CAT_POTENTIAL_PROGRAMMING_PROBLEM));
@@ -2123,6 +2124,7 @@ public void test012_compiler_problems_tuning() {
 		expectedProblemAttributes.put("ServiceImplDefaultConstructorNotPublic", SKIP);
 		expectedProblemAttributes.put("ServiceImplNotDefinedByModule", SKIP);
 		expectedProblemAttributes.put("ShouldImplementHashcode", new ProblemAttributes(JavaCore.COMPILER_PB_MISSING_HASHCODE_METHOD));
+		expectedProblemAttributes.put("ShouldMarkMethodAsOwning", new ProblemAttributes(JavaCore.COMPILER_PB_POTENTIALLY_UNCLOSED_CLOSEABLE));
 		expectedProblemAttributes.put("ShouldReturnValue", SKIP);
 		expectedProblemAttributes.put("ShouldReturnValueHintMissingDefault", SKIP);
 		expectedProblemAttributes.put("SpecdNonNullLocalVariableComparisonYieldsFalse", new ProblemAttributes(JavaCore.COMPILER_PB_REDUNDANT_NULL_CHECK));

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/CompilerInvocationTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/CompilerInvocationTests.java
@@ -889,7 +889,7 @@ public void test011_problem_categories() {
 		expectedProblemAttributes.put("NotExportedTypeInAPI", new ProblemAttributes(CategorizedProblem.CAT_POTENTIAL_PROGRAMMING_PROBLEM));
 		expectedProblemAttributes.put("ConflictingPackageFromModules", new ProblemAttributes(CategorizedProblem.CAT_MODULE));
 		expectedProblemAttributes.put("ConflictingPackageFromOtherModules", new ProblemAttributes(CategorizedProblem.CAT_MODULE));
-		expectedProblemAttributes.put("NotOwningResourceField", new ProblemAttributes(CategorizedProblem.CAT_INTERNAL));
+		expectedProblemAttributes.put("NotOwningResourceField", new ProblemAttributes(CategorizedProblem.CAT_POTENTIAL_PROGRAMMING_PROBLEM));
 		expectedProblemAttributes.put("NotVisibleConstructor", new ProblemAttributes(CategorizedProblem.CAT_MEMBER));
 		expectedProblemAttributes.put("NotVisibleConstructorInDefaultConstructor", new ProblemAttributes(CategorizedProblem.CAT_MEMBER));
 		expectedProblemAttributes.put("NotVisibleConstructorInImplicitConstructorCall", new ProblemAttributes(CategorizedProblem.CAT_MEMBER));
@@ -921,14 +921,16 @@ public void test011_problem_categories() {
 		expectedProblemAttributes.put("ObjectMustBeClass", new ProblemAttributes(CategorizedProblem.CAT_INTERNAL));
 		expectedProblemAttributes.put("OuterLocalMustBeEffectivelyFinal", new ProblemAttributes(CategorizedProblem.CAT_INTERNAL));
 		expectedProblemAttributes.put("OuterLocalMustBeFinal", new ProblemAttributes(CategorizedProblem.CAT_INTERNAL));
+		expectedProblemAttributes.put("OverrideAddingReturnOwning",  new ProblemAttributes(CategorizedProblem.CAT_POTENTIAL_PROGRAMMING_PROBLEM));
+		expectedProblemAttributes.put("OverrideReducingParamterOwning",  new ProblemAttributes(CategorizedProblem.CAT_POTENTIAL_PROGRAMMING_PROBLEM));
 		expectedProblemAttributes.put("OverridingDeprecatedMethod", new ProblemAttributes(CategorizedProblem.CAT_DEPRECATION));
 		expectedProblemAttributes.put("OverridingDeprecatedSinceVersionMethod", new ProblemAttributes(CategorizedProblem.CAT_DEPRECATION));
 		expectedProblemAttributes.put("OverridingTerminallyDeprecatedMethod", new ProblemAttributes(CategorizedProblem.CAT_DEPRECATION));
 		expectedProblemAttributes.put("OverridingTerminallyDeprecatedSinceVersionMethod", new ProblemAttributes(CategorizedProblem.CAT_DEPRECATION));
 		expectedProblemAttributes.put("OverridingMethodWithoutSuperInvocation", new ProblemAttributes(CategorizedProblem.CAT_POTENTIAL_PROGRAMMING_PROBLEM));
 		expectedProblemAttributes.put("OverridingNonVisibleMethod", new ProblemAttributes(CategorizedProblem.CAT_NAME_SHADOWING_CONFLICT));
-		expectedProblemAttributes.put("OwningFieldInNonResourceClass", new ProblemAttributes(CategorizedProblem.CAT_INTERNAL));
-		expectedProblemAttributes.put("OwningFieldShouldImplementClose", new ProblemAttributes(CategorizedProblem.CAT_INTERNAL));
+		expectedProblemAttributes.put("OwningFieldInNonResourceClass", new ProblemAttributes(CategorizedProblem.CAT_POTENTIAL_PROGRAMMING_PROBLEM));
+		expectedProblemAttributes.put("OwningFieldShouldImplementClose", new ProblemAttributes(CategorizedProblem.CAT_POTENTIAL_PROGRAMMING_PROBLEM));
 		expectedProblemAttributes.put("PackageCollidesWithType", new ProblemAttributes(CategorizedProblem.CAT_TYPE));
 		expectedProblemAttributes.put("PackageDoesNotExistOrIsEmpty", new ProblemAttributes(CategorizedProblem.CAT_MODULE));
 		expectedProblemAttributes.put("PackageIsNotExpectedPackage", new ProblemAttributes(CategorizedProblem.CAT_INTERNAL));
@@ -1027,7 +1029,7 @@ public void test011_problem_categories() {
 		expectedProblemAttributes.put("ServiceImplDefaultConstructorNotPublic", new ProblemAttributes(CategorizedProblem.CAT_TYPE));
 		expectedProblemAttributes.put("ServiceImplNotDefinedByModule", new ProblemAttributes(CategorizedProblem.CAT_TYPE));
 		expectedProblemAttributes.put("ShouldImplementHashcode", new ProblemAttributes(CategorizedProblem.CAT_POTENTIAL_PROGRAMMING_PROBLEM));
-		expectedProblemAttributes.put("ShouldMarkMethodAsOwning", new ProblemAttributes(CategorizedProblem.CAT_INTERNAL));
+		expectedProblemAttributes.put("ShouldMarkMethodAsOwning", new ProblemAttributes(CategorizedProblem.CAT_POTENTIAL_PROGRAMMING_PROBLEM));
 		expectedProblemAttributes.put("ShouldReturnValue", new ProblemAttributes(CategorizedProblem.CAT_MEMBER));
 		expectedProblemAttributes.put("ShouldReturnValueHintMissingDefault", new ProblemAttributes(CategorizedProblem.CAT_MEMBER));
 		expectedProblemAttributes.put("SpecdNonNullLocalVariableComparisonYieldsFalse", new ProblemAttributes(CategorizedProblem.CAT_POTENTIAL_PROGRAMMING_PROBLEM));
@@ -2027,6 +2029,8 @@ public void test012_compiler_problems_tuning() {
 		expectedProblemAttributes.put("ObjectMustBeClass", SKIP);
 		expectedProblemAttributes.put("OuterLocalMustBeEffectivelyFinal", SKIP);
 		expectedProblemAttributes.put("OuterLocalMustBeFinal", SKIP);
+		expectedProblemAttributes.put("OverrideAddingReturnOwning",  new ProblemAttributes(JavaCore.COMPILER_PB_INCOMPATIBLE_OWNING_CONTRACT));
+		expectedProblemAttributes.put("OverrideReducingParamterOwning",  new ProblemAttributes(JavaCore.COMPILER_PB_INCOMPATIBLE_OWNING_CONTRACT));
 		expectedProblemAttributes.put("OverridingDeprecatedMethod", new ProblemAttributes(JavaCore.COMPILER_PB_DEPRECATION));
 		expectedProblemAttributes.put("OverridingDeprecatedSinceVersionMethod", new ProblemAttributes(JavaCore.COMPILER_PB_DEPRECATION));
 		expectedProblemAttributes.put("OverridingTerminallyDeprecatedMethod", new ProblemAttributes(JavaCore.COMPILER_PB_TERMINAL_DEPRECATION));

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullReferenceTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullReferenceTest.java
@@ -6959,22 +6959,27 @@ public void test0576_try_with_resources() {
 		"	      ^^^^^^^^^^^\n" +
 		"The serializable class MyException does not declare a static final serialVersionUID field of type long\n" +
 		"----------\n" +
-		"2. ERROR in X.java (at line 13)\n" +
+		"2. WARNING in X.java (at line 12)\n" +
+		"	fis = new FileInputStream(\"\");\n" +
+		"	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
+		"Resource leak: \'fis\' is never closed\n" +
+		"----------\n" +
+		"3. ERROR in X.java (at line 13)\n" +
 		"	fis2.available();\n" +
 		"	^^^^\n" +
 		"Potential null pointer access: The variable fis2 may be null at this location\n" +
 		"----------\n" +
-		"3. ERROR in X.java (at line 14)\n" +
+		"4. ERROR in X.java (at line 14)\n" +
 		"	fis3.close();\n" +
 		"	^^^^\n" +
 		"Potential null pointer access: The variable fis3 may be null at this location\n" +
 		"----------\n" +
-		"4. ERROR in X.java (at line 15)\n" +
+		"5. ERROR in X.java (at line 15)\n" +
 		"	fis4.available();\n" +
 		"	^^^^\n" +
 		"Null pointer access: The variable fis4 can only be null at this location\n" +
 		"----------\n" +
-		"5. ERROR in X.java (at line 18)\n" +
+		"6. ERROR in X.java (at line 18)\n" +
 		"	fis.available();\n" +
 		"	^^^\n" +
 		"Potential null pointer access: The variable fis may be null at this location\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ResourceLeakAnnotatedTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ResourceLeakAnnotatedTests.java
@@ -1,0 +1,1019 @@
+/*******************************************************************************
+ * Copyright (c) 2023 GK Software SE.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Stephan Herrmann - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.core.tests.compiler.regression;
+
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.jdt.core.tests.util.AbstractCompilerTest;
+import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
+import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
+
+import junit.framework.Test;
+import junit.framework.TestSuite;
+
+public class ResourceLeakAnnotatedTests extends ResourceLeakTests {
+
+static {
+	TESTS_NAMES = null; // clear forgotten filter from super class
+//	TESTS_NAMES = new String[] { "test056l" };
+}
+public ResourceLeakAnnotatedTests(String name) {
+	super(name);
+}
+public static Test suite() {
+	TestSuite suite = new TestSuite(ResourceLeakAnnotatedTests.class.getName());
+	// argument 'inheritedDepth' is not exposed in original API, therefore these helpers are copied below with this arg added
+	buildMinimalComplianceTestSuite(F_1_7, 1, suite, ResourceLeakAnnotatedTests.class);
+	return suite;
+}
+
+private static void buildMinimalComplianceTestSuite(int minimalCompliance, int inheritedDepth, TestSuite suite, Class<?> evaluationTestClass) {
+	int complianceLevels = AbstractCompilerTest.getPossibleComplianceLevels();
+	for (int[] map : complianceTestLevelMapping) {
+		if ((complianceLevels & map[0]) != 0) {
+			long complianceLevelForJavaVersion = ClassFileConstants.getComplianceLevelForJavaVersion(map[1]);
+			checkCompliance(evaluationTestClass, minimalCompliance, suite, complianceLevels, inheritedDepth, map[0], map[1], getVersionString(complianceLevelForJavaVersion));
+		}
+	}
+}
+protected static void checkCompliance(Class<?> evaluationTestClass, int minimalCompliance, TestSuite suite, int complianceLevels,
+		int inheritedDepth, int abstractCompilerTestCompliance, int classFileConstantsVersion, String release) {
+	int lev = complianceLevels & abstractCompilerTestCompliance;
+	if (lev != 0) {
+		if (lev < minimalCompliance) {
+			System.err.println("Cannot run "+evaluationTestClass.getName()+" at compliance " + release + "!");
+		} else {
+			suite.addTest(buildUniqueComplianceTestSuite(evaluationTestClass, ClassFileConstants.getComplianceLevelForJavaVersion(classFileConstantsVersion), inheritedDepth));
+		}
+	}
+}
+public static Test buildUniqueComplianceTestSuite(Class<?> evaluationTestClass, long uniqueCompliance, int inheritedDepth) {
+	long highestLevel = highestComplianceLevels();
+	if (highestLevel < uniqueCompliance) {
+		String complianceString;
+		if (highestLevel == ClassFileConstants.JDK10)
+			complianceString = "10";
+		else if (highestLevel == ClassFileConstants.JDK9)
+			complianceString = "9";
+		else if (highestLevel == ClassFileConstants.JDK1_8)
+			complianceString = "1.8";
+		else if (highestLevel == ClassFileConstants.JDK1_7)
+			complianceString = "1.7";
+		else if (highestLevel == ClassFileConstants.JDK1_6)
+			complianceString = "1.6";
+		else if (highestLevel == ClassFileConstants.JDK1_5)
+			complianceString = "1.5";
+		else if (highestLevel == ClassFileConstants.JDK1_4)
+			complianceString = "1.4";
+		else if (highestLevel == ClassFileConstants.JDK1_3)
+			complianceString = "1.3";
+		else {
+			highestLevel = ClassFileConstants.getLatestJDKLevel();
+			if (highestLevel > 0) {
+				complianceString = CompilerOptions.versionFromJdkLevel(highestLevel);
+			} else {
+				complianceString = "unknown";
+			}
+
+		}
+
+		System.err.println("Cannot run "+evaluationTestClass.getName()+" at compliance "+complianceString+"!");
+		return new TestSuite();
+	}
+	TestSuite complianceSuite = new RegressionTestSetup(uniqueCompliance);
+	List<Test> tests = buildTestsList(evaluationTestClass, inheritedDepth);
+	for (int index=0, size=tests.size(); index<size; index++) {
+		complianceSuite.addTest(tests.get(index));
+	}
+	return complianceSuite;
+}
+
+
+@Override
+protected Map<String, String> getCompilerOptions() {
+	Map<String, String> options = super.getCompilerOptions();
+	options.put(CompilerOptions.OPTION_AnnotationBasedResourceAnalysis, CompilerOptions.ENABLED);
+	options.put(CompilerOptions.OPTION_ReportInsufficientResourceManagement, CompilerOptions.IGNORE);
+	return options;
+}
+
+protected static final String OWNING_JAVA = "org/eclipse/jdt/annotation/Owning.java";
+protected static final String OWNING_CONTENT =
+	"""
+	package org.eclipse.jdt.annotation;
+	import java.lang.annotation.*;
+	@Target({ElementType.PARAMETER, ElementType.METHOD, ElementType.FIELD})
+	public @interface Owning {}
+	""";
+protected static final String NOTOWNING_JAVA = "org/eclipse/jdt/annotation/NotOwning.java";
+protected static final String NOTOWNING_CONTENT =
+	"""
+	package org.eclipse.jdt.annotation;
+	import java.lang.annotation.*;
+	@Target({ElementType.PARAMETER, ElementType.METHOD, ElementType.FIELD})
+	public @interface NotOwning {}
+	""";
+
+@Override
+protected String potentialLeakOrCloseNotShown(String resourceName) {
+	// some leaks are considered as definite when annotations are used.
+	return "Mandatory close of resource '"+resourceName+"' has not been shown\n";
+}
+@Override
+protected String potentialLeakOrCloseNotShownAtExit(String resourceName) {
+	// some leaks are considered as definite when annotations are used - variant
+	// at-exit is irrelevant for unassigned closeables:
+	String suffix = resourceName.startsWith("<unassigned Closeable") ? "\n" : " at this location\n";
+	return "Mandatory close of resource '"+resourceName+"' has not been shown"+suffix;
+}
+@Override
+protected String potentialOrDefiniteLeak(String string) {
+	return "Resource leak: '"+string+"' is never closed\n";
+}
+
+private void runLeakTestWithAnnotations(String[] testFiles, String expectedProblems, Map<String, String> options) {
+	runLeakTestWithAnnotations(testFiles, expectedProblems, options, true);
+}
+
+private void runLeakTestWithAnnotations(String[] testFiles, String expectedProblems, Map<String,String> options, boolean shouldFlushOutputDirectory) {
+	if (options == null)
+		options = getCompilerOptions();
+	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
+	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
+	options.put(CompilerOptions.OPTION_ReportExplicitlyClosedAutoCloseable, CompilerOptions.INFO);
+	if (options.get(CompilerOptions.OPTION_ReportInsufficientResourceManagement).equals(CompilerOptions.IGNORE))
+		options.put(CompilerOptions.OPTION_ReportInsufficientResourceManagement, CompilerOptions.INFO);
+	int length = testFiles.length;
+	System.arraycopy(testFiles, 0, testFiles = new String[length+4], 4, length);
+	testFiles[0] = OWNING_JAVA;
+	testFiles[1] = OWNING_CONTENT;
+	testFiles[2] = NOTOWNING_JAVA;
+	testFiles[3] = NOTOWNING_CONTENT;
+	runLeakTest(testFiles, expectedProblems, options, shouldFlushOutputDirectory);
+}
+
+@Override
+protected String getTest056e_log() {
+	// error is more precise due to default of @Owning on method return
+	return	"""
+		----------
+		2. ERROR in X.java (at line 11)
+			FileReader reader = getReader("somefile");
+			           ^^^^^^
+		Resource leak: 'reader' is never closed
+		----------
+		""";
+}
+@Override
+protected String getTest056y_log() {
+	return """
+			----------
+			1. ERROR in X.java (at line 4)
+				final FileReader reader31 = new FileReader("file");
+				                 ^^^^^^^^
+			Mandatory close of resource 'reader31' has not been shown
+			----------
+			2. WARNING in X.java (at line 17)
+				final FileReader reader23 = new FileReader("file");
+				                 ^^^^^^^^
+			Potential resource leak: 'reader23' may not be closed
+			----------
+			""";
+}
+@Override
+protected String getTest061l2_log() {
+	return """
+		----------
+		1. ERROR in xy\\Leaks.java (at line 10)
+			FileInputStream fileInputStream= new FileInputStream(name);
+			                ^^^^^^^^^^^^^^^
+		Mandatory close of resource 'fileInputStream' has not been shown
+		----------
+		2. ERROR in xy\\Leaks.java (at line 18)
+			this(new FileInputStream("default")); // potential problem
+			     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+		Mandatory close of resource '<unassigned Closeable value>' has not been shown
+		----------
+		3. ERROR in xy\\Leaks.java (at line 25)
+			FileInputStream fileInputStream= new FileInputStream(name);
+			                ^^^^^^^^^^^^^^^
+		Mandatory close of resource 'fileInputStream' has not been shown
+		----------
+		""";
+}
+@Override
+protected String getTest063c_log() {
+	return """
+		----------
+		1. ERROR in X.java (at line 8)
+			BufferedInputStream bis = new BufferedInputStream(s);
+			                    ^^^
+		Mandatory close of resource 'bis' has not been shown
+		----------
+		""";
+}
+
+@Override
+protected String getTestBug440282_log() {
+	return
+		"----------\n" +
+		"1. ERROR in ResourceLeakFalseNegative.java (at line 36)\n" +
+		"	final FileInputStream in = new FileInputStream(\"/dev/null\");\n" +
+		"	                      ^^\n" +
+		"Resource leak: 'in' is never closed\n" +
+		"----------\n" +
+		"2. ERROR in ResourceLeakFalseNegative.java (at line 39)\n" +
+		"	return new Foo(reader).read();\n" +
+		"	       ^^^^^^^^^^^^^^^\n" +
+		"Resource leak: \'<unassigned Closeable value>\' is never closed\n" +
+		"----------\n";
+}
+
+public void testBug411098_comment19_annotated() {
+	runLeakTestWithAnnotations(
+		new String[] {
+			"A.java",
+			"import java.io.PrintWriter;\n" +
+			"import org.eclipse.jdt.annotation.Owning;\n" +
+			"public class A implements AutoCloseable {\n" +
+			"	@Owning PrintWriter fWriter;\n" +
+			"	boolean useField = false;\n" +
+			"	public void close() {\n" +
+			"		PrintWriter bug= useField ? fWriter : null;\n" +
+			"		System.out.println(bug);\n" +
+			"	}\n" +
+			"}"
+		},
+		"""
+		----------
+		1. ERROR in A.java (at line 6)
+			public void close() {
+			            ^^^^^^^
+		Mandatory close of resource 'this.fWriter' has not been shown
+		----------
+		""",
+		null);
+}
+
+public void testBug440282_annotated() {
+	runLeakTestWithAnnotations(
+		new String[] {
+			"ResourceLeakFalseNegative.java",
+			"import java.io.*;\n" +
+			"\n" +
+			"import org.eclipse.jdt.annotation.*;\n" +
+			"\n" +
+			"public final class ResourceLeakFalseNegative {\n" +
+			"\n" +
+			"  private static final class Foo implements AutoCloseable {\n" +
+			"    @Owning final InputStreamReader reader;\n" +
+			"\n" +
+			"    Foo(@Owning final InputStreamReader reader) {\n" +
+			"      this.reader = reader;\n" +
+			"    }\n" +
+			"    \n" +
+			"    public int read() throws IOException {\n" +
+			"      return reader.read();\n" +
+			"    }\n" +
+			"\n" +
+			"    public void close() throws IOException {\n" +
+			"      reader.close();\n" +
+			"    }\n" +
+			"  }\n" +
+			"\n" +
+			"  private static final class Bar {\n" +
+			"    final int read;\n" +
+			"\n" +
+			"    Bar(final InputStreamReader reader) throws IOException {\n" +
+			"      read = reader.read();\n" +
+			"    }\n" +
+			"    \n" +
+			"    public int read() {\n" +
+			"      return read;\n" +
+			"    }\n" +
+			"  }\n" +
+			"\n" +
+			"  public final static int foo() throws IOException {\n" +
+			"    final FileInputStream in = new FileInputStream(\"/dev/null\");\n" +
+			"    final InputStreamReader reader = new InputStreamReader(in);\n" +
+			"    try {\n" +
+			"      return new Foo(reader).read();\n" +
+			"    } finally {\n" +
+			"      // even though Foo is not closed, no potential resource leak is reported.\n" +
+			"    }\n" +
+			"  }\n" +
+			"\n" +
+			"  public final static int bar() throws IOException {\n" +
+			"    final FileInputStream in = new FileInputStream(\"/dev/null\");\n" +
+			"    final InputStreamReader reader = new InputStreamReader(in);\n" +
+			"    try {\n" +
+			"      final Bar bar = new Bar(reader);\n" +
+			"      return bar.read();\n" +
+			"    } finally {\n" +
+			"      // Removing the close correctly reports potential resource leak as a warning,\n" +
+			"      // because Bar does not implement AutoCloseable.\n" +
+			"      reader.close();\n" +
+			"    }\n" +
+			"  }\n" +
+			"\n" +
+			"  public static void main(String[] args) throws IOException {\n" +
+			"    for (;;) {\n" +
+			"      foo();\n" +
+			"      bar();\n" +
+			"    }\n" +
+			"  }\n" +
+			"}\n"
+		},
+		"----------\n" +
+		"1. ERROR in ResourceLeakFalseNegative.java (at line 39)\n" +
+		"	return new Foo(reader).read();\n" +
+		"	       ^^^^^^^^^^^^^^^\n" +
+		"Resource leak: \'<unassigned Closeable value>\' is never closed\n" +
+		"----------\n" +
+		"2. INFO in ResourceLeakFalseNegative.java (at line 46)\n" +
+		"	final FileInputStream in = new FileInputStream(\"/dev/null\");\n" +
+		"	                      ^^\n" +
+		"Resource \'in\' should be managed by try-with-resource\n" +
+		"----------\n" +
+		"3. INFO in ResourceLeakFalseNegative.java (at line 47)\n" +
+		"	final InputStreamReader reader = new InputStreamReader(in);\n" +
+		"	                        ^^^^^^\n" +
+		"Resource \'reader\' should be managed by try-with-resource\n" +
+		"----------\n",
+		null);
+}
+
+public void testOwningField_NOK1() {
+	runLeakTestWithAnnotations(
+		new String[] {
+			"A.java",
+			"""
+			import java.io.PrintWriter;
+			import org.eclipse.jdt.annotation.Owning;
+			import org.eclipse.jdt.annotation.NotOwning;
+			public class A implements AutoCloseable {
+				@Owning PrintWriter fWriter;
+				PrintWriter fOther;
+				boolean useField = false;
+				A(@Owning PrintWriter writer1, @Owning PrintWriter writer2) {
+					fWriter = writer1; // OK
+					fOther = writer2; // not sufficient
+				}
+				public void close() {
+					PrintWriter bug= useField ? fWriter : null;
+					println(bug);
+					new A(null, null).fWriter.close(); // closing fWriter of other instance is no good!
+				}
+				void println(@NotOwning AutoCloseable rc) { System.out.println(rc); }
+			}
+			"""
+		},
+		"""
+		----------
+		1. INFO in A.java (at line 6)
+			PrintWriter fOther;
+			            ^^^^^^
+		It is recommended to mark resource fields as '@Owning' to ensure proper closing
+		----------
+		2. ERROR in A.java (at line 8)
+			A(@Owning PrintWriter writer1, @Owning PrintWriter writer2) {
+			                                                   ^^^^^^^
+		Mandatory close of resource 'writer2' has not been shown
+		----------
+		3. ERROR in A.java (at line 12)
+			public void close() {
+			            ^^^^^^^
+		Resource leak: 'this.fWriter' is never closed
+		----------
+		4. ERROR in A.java (at line 15)
+			new A(null, null).fWriter.close(); // closing fWriter of other instance is no good!
+			^^^^^^^^^^^^^^^^^
+		Resource leak: '<unassigned Closeable value>' is never closed
+		----------
+		""",
+		null);
+}
+
+public void testOwningField_NOK2() {
+	runLeakTestWithAnnotations(
+		new String[] {
+			"A.java",
+			"""
+			import java.io.PrintWriter;
+			import org.eclipse.jdt.annotation.Owning;
+			class ASuper implements AutoCloseable {
+				public void close() { /* nothing */ }
+			}
+			public class A extends ASuper {
+				@Owning PrintWriter fWriter;
+				PrintWriter fOther;
+				boolean useField = false;
+				A(@Owning PrintWriter writer1, @Owning PrintWriter writer2) {
+					fWriter = writer1; // OK
+					fOther = writer2; // not sufficient
+				}
+			}
+			"""
+		},
+		"""
+		----------
+		1. INFO in A.java (at line 7)
+			@Owning PrintWriter fWriter;
+			                    ^^^^^^^
+		Class with resource fields tagged as '@Owning' should implement 'close()'
+		----------
+		2. INFO in A.java (at line 8)
+			PrintWriter fOther;
+			            ^^^^^^
+		It is recommended to mark resource fields as '@Owning' to ensure proper closing
+		----------
+		3. ERROR in A.java (at line 10)
+			A(@Owning PrintWriter writer1, @Owning PrintWriter writer2) {
+			                                                   ^^^^^^^
+		Mandatory close of resource 'writer2' has not been shown
+		----------
+		""",
+		null);
+}
+
+public void testOwningField_binaryField_lazyInit() {
+	runLeakTestWithAnnotations(
+		new String[] {
+			"A.java",
+			"""
+			import java.io.PrintWriter;
+			import org.eclipse.jdt.annotation.Owning;
+			public abstract class A implements AutoCloseable {
+				@Owning PrintWriter fWriter;
+				PrintWriter fOther;
+				boolean useField = false;
+			}
+			"""
+		},
+		"""
+		----------
+		1. INFO in A.java (at line 4)
+			@Owning PrintWriter fWriter;
+			                    ^^^^^^^
+		Class with resource fields tagged as '@Owning' should implement 'close()'
+		----------
+		2. INFO in A.java (at line 5)
+			PrintWriter fOther;
+			            ^^^^^^
+		It is recommended to mark resource fields as '@Owning' to ensure proper closing
+		----------
+		""",
+		null);
+	runLeakTestWithAnnotations(
+		new String[] {
+			"AImpl.java",
+			"""
+			import java.io.PrintWriter;
+			import org.eclipse.jdt.annotation.Owning;
+			public class AImpl extends A {
+				void init(@Owning PrintWriter writer1, @Owning PrintWriter writer2) {
+					fWriter = writer1; // OK
+					fOther = writer2; // not sufficient
+				}
+				public void close() {
+					// not closing any fields
+				}
+			}
+			"""
+		},
+		"""
+		----------
+		1. ERROR in AImpl.java (at line 4)
+			void init(@Owning PrintWriter writer1, @Owning PrintWriter writer2) {
+			                                                           ^^^^^^^
+		Mandatory close of resource 'writer2' has not been shown
+		----------
+		2. ERROR in AImpl.java (at line 8)
+			public void close() {
+			            ^^^^^^^
+		Resource leak: 'this.fWriter' is never closed
+		----------
+		""",
+		null,
+		false);
+}
+
+public void testOwningField_binaryField_lazyInit2() {
+	runLeakTestWithAnnotations(
+		new String[] {
+			"A.java",
+			"""
+			import java.io.PrintWriter;
+			import org.eclipse.jdt.annotation.Owning;
+			public class A implements AutoCloseable {
+				@Owning PrintWriter fWriter;
+				PrintWriter fOther;
+				boolean useField = false;
+				public void close() {
+					if (fWriter != null)
+						fWriter.close();
+				}
+			}
+			"""
+		},
+		"""
+		----------
+		1. INFO in A.java (at line 5)
+			PrintWriter fOther;
+			            ^^^^^^
+		It is recommended to mark resource fields as '@Owning' to ensure proper closing
+		----------
+		""",
+		null);
+	runLeakTestWithAnnotations(
+		new String[] {
+			"AImpl.java",
+			"""
+			import java.io.PrintWriter;
+			import org.eclipse.jdt.annotation.Owning;
+			public class AImpl extends A {
+				boolean should = false;
+				void init(@Owning PrintWriter writer1, @Owning PrintWriter writer2) {
+					fWriter = writer1; // OK
+					fOther = writer2; // not sufficient
+				}
+				public void close() {
+					if (should)
+						super.close();
+				}
+			}
+			"""
+		},
+		"""
+		----------
+		1. ERROR in AImpl.java (at line 5)
+			void init(@Owning PrintWriter writer1, @Owning PrintWriter writer2) {
+			                                                           ^^^^^^^
+		Mandatory close of resource 'writer2' has not been shown
+		----------
+		2. ERROR in AImpl.java (at line 9)
+			public void close() {
+			            ^^^^^^^
+		Potential resource leak: 'this.fWriter' may not be closed
+		----------
+		""",
+		null,
+		false);
+}
+
+public void testOwningField_OK() {
+	runLeakTestWithAnnotations(
+		new String[] {
+			"A.java",
+			"""
+			import java.io.PrintWriter;
+			import org.eclipse.jdt.annotation.Owning;
+			import org.eclipse.jdt.annotation.NotOwning;
+			public class A implements AutoCloseable {
+				@Owning PrintWriter fWriter;
+				@Owning PrintWriter fOther;
+				boolean useField = false;
+				A(@Owning PrintWriter writer1, @Owning PrintWriter writer2) {
+					fWriter = writer1;
+					this.fOther = writer2;
+				}
+				public void close() {
+					fWriter.close();
+					this.fOther.close();
+				}
+				void println(@NotOwning AutoCloseable rc) { System.out.println(rc); }
+			}
+			"""
+		},
+		"",
+		null);
+}
+
+public void testSharedField() {
+	Map<String, String> options = getCompilerOptions();
+	options.put(CompilerOptions.OPTION_ReportInsufficientResourceManagement, CompilerOptions.WARNING);
+	runLeakTestWithAnnotations(
+		new String[] {
+			"A.java",
+			"""
+			import java.io.PrintWriter;
+			import org.eclipse.jdt.annotation.Owning;
+			import org.eclipse.jdt.annotation.NotOwning;
+			public class A {
+				@NotOwning PrintWriter fWriter;
+				PrintWriter fOther;
+				@Owning PrintWriter fProper;
+				boolean useField = false;
+				A(PrintWriter writer1, PrintWriter writer2, @Owning PrintWriter writer3) {
+					fWriter = writer1;
+					fOther = writer2;
+					fProper = writer3;
+				}
+			}
+			"""
+		},
+		"""
+		----------
+		1. WARNING in A.java (at line 5)
+			@NotOwning PrintWriter fWriter;
+			                       ^^^^^^^
+		It is recommended to mark resource fields as '@Owning' to ensure proper closing
+		----------
+		2. WARNING in A.java (at line 6)
+			PrintWriter fOther;
+			            ^^^^^^
+		It is recommended to mark resource fields as '@Owning' to ensure proper closing
+		----------
+		3. WARNING in A.java (at line 7)
+			@Owning PrintWriter fProper;
+			                    ^^^^^^^
+		Class with resource fields tagged as '@Owning' should implement AutoCloseable
+		----------
+		""",
+		options
+		);
+}
+
+public void testOwning_receiving_parameter() {
+	if (this.complianceLevel < ClassFileConstants.JDK9)
+		return; // t-w-r with pre-declared local available since 9
+	runLeakTestWithAnnotations(
+		new String[] {
+			"X.java",
+			"""
+			import org.eclipse.jdt.annotation.Owning;
+			public class X {
+				void nok(@Owning AutoCloseable c) {
+					System.out.print(1);
+				}
+				void ok(@Owning AutoCloseable c) throws Exception {
+					try (c) {
+						System.out.print(2);
+					};
+				}
+			}
+			"""
+		},
+		"""
+		----------
+		1. ERROR in X.java (at line 3)
+			void nok(@Owning AutoCloseable c) {
+			                               ^
+		Resource leak: 'c' is never closed
+		----------
+		""",
+		null);
+}
+
+public void testOwning_sending() {
+	if (this.complianceLevel < ClassFileConstants.JDK9)
+		return; // t-w-r with pre-declared local available since 9
+	runLeakTestWithAnnotations(
+		new String[] {
+			"X.java",
+			"""
+			import org.eclipse.jdt.annotation.Owning;
+			class Rc implements AutoCloseable {
+				@Override public void close() {}
+			}
+			public class X {
+				void consume(@Owning Rc rc1) {
+					try (rc1) {
+						System.out.print(2);
+					};
+				}
+				void nok() {
+					Rc rc2 = new Rc();
+					System.out.print(rc2);
+				}
+				void unsafe(boolean f) {
+					Rc rc3 = new Rc();
+					if (f)
+						consume(rc3);
+				}
+				void leakAtReturn(boolean f) {
+					Rc rc4 = new Rc();
+					if (f)
+						return;
+					consume(rc4);
+				}
+				void ok(boolean f) {
+					Rc rc5 = new Rc();
+					if (f)
+						consume(rc5);
+					else
+						rc5.close();
+				}
+			}
+			"""
+		},
+		"""
+		----------
+		1. ERROR in X.java (at line 12)
+			Rc rc2 = new Rc();
+			   ^^^
+		Mandatory close of resource 'rc2' has not been shown
+		----------
+		2. ERROR in X.java (at line 16)
+			Rc rc3 = new Rc();
+			   ^^^
+		Potential resource leak: 'rc3' may not be closed
+		----------
+		3. ERROR in X.java (at line 23)
+			return;
+			^^^^^^^
+		Resource leak: 'rc4' is not closed at this location
+		----------
+		""",
+		null);
+}
+public void testOwning_sending_toBinary() {
+	if (this.complianceLevel < ClassFileConstants.JDK9)
+		return; // t-w-r with pre-declared local available since 9
+	runLeakTestWithAnnotations(
+		new String[] {
+			"p/Consume.java",
+			"""
+			package p;
+			import org.eclipse.jdt.annotation.Owning;
+			public class Consume {
+				public void consume(@Owning AutoCloseable rc1) {
+					try (rc1) {
+						System.out.print(2);
+					} catch (Exception e) {
+						// nothing
+					}
+				}
+			}
+			"""
+		},
+		"",
+		null);
+	runLeakTestWithAnnotations(
+		new String[] {
+			"X.java",
+			"""
+			class Rc implements AutoCloseable {
+				@Override public void close() {}
+			}
+			public class X {
+				p.Consume consumer;
+
+				void unsafe(boolean f) {
+					Rc rc3 = new Rc();
+					if (f)
+						consumer.consume(rc3);
+				}
+				void leakAtReturn(boolean f) {
+					Rc rc4 = new Rc();
+					if (f)
+						return;
+					consumer.consume(rc4);
+				}
+				void ok(boolean f) {
+					Rc rc5 = new Rc();
+					if (f)
+						consumer.consume(rc5);
+					else
+						rc5.close();
+				}
+			}
+			"""
+		},
+		"""
+		----------
+		1. ERROR in X.java (at line 8)
+			Rc rc3 = new Rc();
+			   ^^^
+		Potential resource leak: 'rc3' may not be closed
+		----------
+		2. ERROR in X.java (at line 15)
+			return;
+			^^^^^^^
+		Resource leak: 'rc4' is not closed at this location
+		----------
+		""",
+		null,
+		false);
+}
+
+public void testOwning_receiving_from_call() {
+	runLeakTestWithAnnotations(
+		new String[] {
+			"X.java",
+			"""
+			import org.eclipse.jdt.annotation.*;
+			import java.io.*;
+			public class X {
+				void err() {
+					AutoCloseable rc1 = provideOwned();
+					if (rc1 == null) System.out.print("null");
+				}
+				void warn() {
+					AutoCloseable rc2 = provideShared(); // not responsible
+					if (rc2 == null) System.out.print("null");
+				}
+				void err_without_local() {
+					if (provideOwned() == null) System.out.print("null");
+				}
+				String err_wrapped() {
+					BufferedInputStream bis = new BufferedInputStream(provideOwned());
+					return bis.toString();
+				}
+				void ok() throws Exception {
+					try (AutoCloseable c = provideOwned()) {
+						System.out.print(2);
+					};
+				}
+				@NotOwning AutoCloseable provideShared() {
+					return null;
+				}
+				@Owning InputStream provideOwned() {
+					return null;
+				}
+			}
+			"""
+		},
+		"""
+		----------
+		1. ERROR in X.java (at line 5)
+			AutoCloseable rc1 = provideOwned();
+			              ^^^
+		Resource leak: 'rc1' is never closed
+		----------
+		2. ERROR in X.java (at line 13)
+			if (provideOwned() == null) System.out.print("null");
+			    ^^^^^^^^^^^^^^
+		Resource leak: '<unassigned Closeable value>' is never closed
+		----------
+		3. ERROR in X.java (at line 16)
+			BufferedInputStream bis = new BufferedInputStream(provideOwned());
+			                    ^^^
+		Resource leak: 'bis' is never closed
+		----------
+		""",
+		null);
+
+}
+public void testOwning_receiving_from_binaryCall() {
+	runLeakTestWithAnnotations(
+		new String[] {
+			"p/Produce.java",
+			"""
+			package p;
+			import org.eclipse.jdt.annotation.*;
+			import java.io.*;
+			public class Produce {
+				public @NotOwning AutoCloseable provideShared() {
+					return null;
+				}
+				public @Owning InputStream provideOwned() {
+					return null;
+				}
+			}
+			"""
+		},
+		"",
+		null);
+	runLeakTestWithAnnotations(
+		new String[] {
+			"X.java",
+			"""
+			import java.io.*;
+			public class X {
+				p.Produce producer;
+				void err() {
+					AutoCloseable rc1 = producer.provideOwned();
+					if (rc1 == null) System.out.print("null");
+				}
+				void warn() {
+					AutoCloseable rc2 = producer.provideShared();
+					if (rc2 == null) System.out.print("null");
+				}
+				void err_without_local() {
+					if (producer.provideOwned() == null) System.out.print("null");
+				}
+				String err_wrapped() {
+					BufferedInputStream bis = new BufferedInputStream(producer.provideOwned());
+					return bis.toString();
+				}
+				void ok() throws Exception {
+					try (AutoCloseable c = producer.provideOwned()) {
+						System.out.print(2);
+					};
+				}
+			}
+			"""
+		},
+		"""
+		----------
+		1. ERROR in X.java (at line 5)
+			AutoCloseable rc1 = producer.provideOwned();
+			              ^^^
+		Resource leak: 'rc1' is never closed
+		----------
+		2. ERROR in X.java (at line 13)
+			if (producer.provideOwned() == null) System.out.print("null");
+			    ^^^^^^^^^^^^^^^^^^^^^^^
+		Resource leak: '<unassigned Closeable value>' is never closed
+		----------
+		3. ERROR in X.java (at line 16)
+			BufferedInputStream bis = new BufferedInputStream(producer.provideOwned());
+			                    ^^^
+		Resource leak: 'bis' is never closed
+		----------
+		""",
+		null,
+		false);
+
+}
+public void testOwning_return() {
+	runLeakTestWithAnnotations(
+		new String[] {
+			"X.java",
+			"""
+			import java.io.*;
+			import org.eclipse.jdt.annotation.Owning;
+			public class X {
+				@Owning AutoCloseable ok(String fn) throws IOException {
+					return new FileInputStream(fn);
+				}
+				@Owning AutoCloseable somePath(String fn) throws IOException {
+					FileInputStream fis = new FileInputStream(fn);
+					if (fn.length() > 1)
+						return fis;
+					return null;
+				}
+				@Owning AutoCloseable mixed(String fn) throws IOException {
+					FileInputStream fis = new FileInputStream(fn);
+					if (fn.length() > 1)
+						return new FileInputStream(fn);
+					return fis;
+				}
+			}
+			"""
+		},
+		"""
+		----------
+		1. ERROR in X.java (at line 11)
+			return null;
+			^^^^^^^^^^^^
+		Mandatory close of resource 'fis' has not been shown at this location
+		----------
+		2. ERROR in X.java (at line 16)
+			return new FileInputStream(fn);
+			^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+		Mandatory close of resource 'fis' has not been shown at this location
+		----------
+		""",
+		null);
+}
+public void testUnannotated_return() {
+	runLeakTestWithAnnotations(
+		new String[] {
+			"X.java",
+			"""
+			import java.io.*;
+			public class X {
+				AutoCloseable varReturn(String fn) throws IOException {
+					FileInputStream fis = new FileInputStream(fn);
+					return fis;
+				}
+				AutoCloseable unassignedReturn(String fn) throws IOException {
+					return new FileInputStream(fn);
+				}
+				AutoCloseable passThrough(AutoCloseable rc) {
+					return rc; // silent, since caller did not delegate responsibility to us
+				}
+			}
+			"""
+		},
+		"""
+		----------
+		1. INFO in X.java (at line 5)
+			return fis;
+			^^^^^^^^^^^
+		Enclosing method should be tagged as '@Owning' to pass the responsibility for the returned resource to the caller
+		----------
+		2. INFO in X.java (at line 8)
+			return new FileInputStream(fn);
+			       ^^^^^^^^^^^^^^^^^^^^^^^
+		Enclosing method should be tagged as '@Owning' to pass the responsibility for the returned resource to the caller
+		----------
+		""",
+		null);
+}
+
+}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ResourceLeakAnnotatedTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ResourceLeakAnnotatedTests.java
@@ -29,6 +29,10 @@ static {
 	TESTS_NAMES = null; // clear forgotten filter from super class
 //	TESTS_NAMES = new String[] { "test056l" };
 }
+
+// marker field that influences the call to buildTestsList():
+public static final int INHERITED_DEPTH = 1;
+
 public ResourceLeakAnnotatedTests(String name) {
 	super(name);
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ResourceLeakAnnotatedTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ResourceLeakAnnotatedTests.java
@@ -1337,4 +1337,28 @@ public void testSubclassingWrapperResource() {
 		""",
 		null);
 }
+public void testWrappingTwoResources() {
+	runLeakTestWithAnnotations(
+		new String[] {
+			"X.java",
+			"""
+			import java.io.*;
+			import org.eclipse.jdt.annotation.*;
+			public class X implements AutoCloseable {
+				private final @Owning DataInputStream fDataIn;
+				private final @Owning DataOutputStream fDataOut;
+				public X(@Owning InputStream in, @Owning OutputStream out) {
+					fDataIn = new DataInputStream(new BufferedInputStream(in));
+					fDataOut = new DataOutputStream(new BufferedOutputStream(out));
+				}
+				public void close() throws IOException {
+					fDataIn.close();
+					fDataOut.close();
+				}
+			}
+			"""
+		},
+		"",
+		null);
+}
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ResourceLeakAnnotatedTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ResourceLeakAnnotatedTests.java
@@ -1379,12 +1379,7 @@ public void testConsumingMethod_nok() {
 		},
 		"""
 		----------
-		1. INFO in F.java (at line 6)
-			public void consume(@Owning F this) throws Exception {
-			            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-		Resource 'rc1' should be managed by try-with-resource
-		----------
-		2. ERROR in F.java (at line 6)
+		1. ERROR in F.java (at line 6)
 			public void consume(@Owning F this) throws Exception {
 			            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 		Resource leak: 'this.rc2' is never closed

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TestAll.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TestAll.java
@@ -92,6 +92,7 @@ public static Test suite() {
 	standardTests.add(ManifestAnalyzerTest.class);
 	standardTests.add(InitializationTests.class);
 	standardTests.add(ResourceLeakTests.class);
+	standardTests.add(ResourceLeakAnnotatedTests.class);
 	standardTests.add(PackageBindingTest.class);
 
 	// add all javadoc tests

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/util/AbstractCompilerTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/util/AbstractCompilerTest.java
@@ -193,10 +193,15 @@ public class AbstractCompilerTest extends TestCase {
 		// add tests
 		for (int i=0, m=testClasses.size(); i<m ; i++) {
 			Class testClass = (Class)testClasses.get(i);
-			TestSuite suite = new TestSuite(testClass.getName());
-			List tests = buildTestsList(testClass);
-			for (int index=0, size=tests.size(); index<size; index++) {
-				suite.addTest((Test)tests.get(index));
+			TestSuite suite;
+			try {
+				suite = (TestSuite) testClass.getMethod("suite").invoke(null);
+			} catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException | NoSuchMethodException | SecurityException e) {
+				suite = new TestSuite(testClass.getName());
+				List tests = buildTestsList(testClass);
+				for (int index=0, size=tests.size(); index<size; index++) {
+					suite.addTest((Test)tests.get(index));
+				}
 			}
 			complianceSuite.addTest(suite);
 		}
@@ -224,7 +229,7 @@ public class AbstractCompilerTest extends TestCase {
 		}
 		return suite;
 	}
-	private static void checkCompliance(Class evaluationTestClass, int minimalCompliance, TestSuite suite,
+	protected static void checkCompliance(Class evaluationTestClass, int minimalCompliance, TestSuite suite,
 			int complianceLevels, int abstractCompilerTestCompliance, int classFileConstantsVersion, String release) {
 		int lev = complianceLevels & abstractCompilerTestCompliance;
 		if (lev != 0) {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/util/AbstractCompilerTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/util/AbstractCompilerTest.java
@@ -15,6 +15,7 @@ package org.eclipse.jdt.core.tests.util;
 
 import java.io.File;
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -193,15 +194,18 @@ public class AbstractCompilerTest extends TestCase {
 		// add tests
 		for (int i=0, m=testClasses.size(); i<m ; i++) {
 			Class testClass = (Class)testClasses.get(i);
-			TestSuite suite;
+			TestSuite suite = new TestSuite(testClass.getName());
+			int inheritedDepth = 0;
 			try {
-				suite = (TestSuite) testClass.getMethod("suite").invoke(null);
-			} catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException | NoSuchMethodException | SecurityException e) {
-				suite = new TestSuite(testClass.getName());
-				List tests = buildTestsList(testClass);
-				for (int index=0, size=tests.size(); index<size; index++) {
-					suite.addTest((Test)tests.get(index));
-				}
+				Field depthField = testClass.getDeclaredField("INHERITED_DEPTH");
+				if (depthField != null)
+					inheritedDepth = depthField.getInt(null);
+			} catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException e) {
+				// ignore
+			}
+			List tests = buildTestsList(testClass, inheritedDepth, ORDERING);
+			for (int index=0, size=tests.size(); index<size; index++) {
+				suite.addTest((Test)tests.get(index));
 			}
 			complianceSuite.addTest(suite);
 		}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/core/JavaCore.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/core/JavaCore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -1643,6 +1643,28 @@ public final class JavaCore extends Plugin {
 	 * @category CompilerOptionID
 	 */
 	public static final String COMPILER_PB_RECOMMENDED_RESOURCE_MANAGEMENT = PLUGIN_ID + ".compiler.problem.insufficientResourceAnalysis"; //$NON-NLS-1$
+
+	/**
+	 * Compiler option ID: Reporting when a method override incompatibly changes the owning contract.
+	 * <p>When enabled, the compiler will issue an error or a warning or an info if a method signature is incompatible
+	 *  with an overridden method from a super type in terms of resource ownership.</p>
+	 * <p>Incompatibility occurs if:</p>
+	 * <ul>
+	 * <li>A super parameter is tagged as owning ({@link #COMPILER_OWNING_ANNOTATION_NAME}) but the corresponding
+	 *  parameter of the current method does not repeat this annotation.</li>
+	 * <li>The current method is tagged as owning (affecting the method return), but an overridden super method does not
+	 *  have this annotation.</li>
+	 * </ul>
+	 * <p>This option only has an effect if the option {@link #COMPILER_ANNOTATION_RESOURCE_ANALYSIS} is enabled.</p>
+	 * <dl>
+	 * <dt>Option id:</dt><dd><code>"org.eclipse.jdt.core.compiler.problem.incompatibleOwningContract"</code></dd>
+	 * <dt>Possible values:</dt><dd><code>{ "error", "warning", "info", "ignore" }</code></dd>
+	 * <dt>Default:</dt><dd><code>"warning"</code></dd>
+	 * </dl>
+	 * @since 3.37
+	 * @category CompilerOptionID
+	 */
+	public static final String COMPILER_PB_INCOMPATIBLE_OWNING_CONTRACT = PLUGIN_ID + ".compiler.problem.incompatibleOwningContract";  //$NON-NLS-1$
 
 	/**
 	 * Compiler option ID: Reporting a method invocation providing an argument of an unlikely type.

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/core/JavaCore.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/core/JavaCore.java
@@ -1559,6 +1559,92 @@ public final class JavaCore extends Plugin {
 	public static final String COMPILER_PB_EXPLICITLY_CLOSED_AUTOCLOSEABLE = PLUGIN_ID + ".compiler.problem.explicitlyClosedAutoCloseable"; //$NON-NLS-1$
 
 	/**
+	 * Compiler option ID: Enable the use of specific annotations for more precise analysis of resource leaks.
+	 * <p>When enabled, the compiler will respect annotations by the names specified in {@link #COMPILER_OWNING_ANNOTATION_NAME}
+	 * and {@link #COMPILER_NOTOWNING_ANNOTATION_NAME}</p>
+	 * <dl>
+	 * <dt>Option id:</dt><dd><code>"org.eclipse.jdt.core.compiler.annotation.resourceanalysis"</code></dd>
+	 * <dt>Possible values:</dt><dd><code>{ "enabled", "disabled" }</code></dd>
+	 * <dt>Default:</dt><dd><code>"disabled"</code></dd>
+	 * </dl>
+	 * @since 3.37
+	 * @category CompilerOptionID
+	 */
+	public static final String COMPILER_ANNOTATION_RESOURCE_ANALYSIS = PLUGIN_ID + ".compiler.annotation.resourceanalysis"; //$NON-NLS-1$
+
+	/**
+	 * Compiler option ID: Name of annotation type for "owned" resource values.
+	 * <p>The annotation specified here should only be used on an element of type {@link AutoCloseable} or a subtype.
+	 *  It can be used in the following locations: </p>
+	 * <dl>
+	 * <dt>Method parameter</dt><dd>Signify that the receiving method is responsible for closing any resource value passed via this argument.
+	 * 	At the caller side, passing an unclosed resource into this parameter satisfies any responsibility for this resource.</dd>
+	 * <dt>Method</dt><dd>Signify that every caller is responsible for closing any resource values received as return from this method.
+	 * 	The method itself is entitled to return unclosed resources.</dd>
+	 * <dt>Field:</dt><dd>The enclosing class should implement {@link AutoCloseable}, and its {@link AutoCloseable#close()} method
+	 * 	should close each field thusly annotated.
+	 * 	Conversely, a constructor receiving an unclosed resource may satisfy its responsibility by assigning the resource
+	 * 	to a field marked with this annotation.</dd>
+	 * <p>This option only has an effect if the option {@link #COMPILER_ANNOTATION_RESOURCE_ANALYSIS} is enabled.</p>
+	 * <dl>
+	 * <dt>Option id:</dt><dd><code>"org.eclipse.jdt.core.compiler.annotation.owning"</code></dd>
+	 * <dt>Possible values:</dt><dd>A fully qualified name of an annotation declaration</dd>
+	 * <dt>Default:</dt><dd><code>"org.eclipse.jdt.annotation.Owning"</code></dd>
+	 * </dl>
+	 * @since 3.37
+	 * @category CompilerOptionID
+	 */
+	public static final String COMPILER_OWNING_ANNOTATION_NAME = PLUGIN_ID + ".compiler.annotation.owning"; //$NON-NLS-1$
+
+	/**
+	 * Compiler option ID: Name of annotation type for "not-owned" resource values.
+	 * 	This annotations is then inverse of {@link #COMPILER_OWNING_ANNOTATION_NAME}.
+	 * <p>The annotation specified here should only be used on an element of type {@link AutoCloseable} or a subtype.
+	 *  It can be used in the following locations: </p>
+	 * <dl>
+	 * <dt>Method parameter</dt><dd>Signify that passing a resource into this parameter does not affect the caller's responsibility
+	 * 	to close that resource. The receiving method has no obligations in this regard.</dd>
+	 * <dt>Method</dt><dd>Signify that returning a resource value from this method does not affect the responsibility to close.
+	 * 	Given that the method can not close the resource after returning, the resource should therefore be stored in a field,
+	 * 	for closing at a later point.</dd>
+	 * <dt>Field:</dt><dd>Storing a resource value in a field with this annotation does not affect responsibility to close.
+	 * 	Storing an unclosed resource does not satisfy the responsibility, reading from such field does not create
+	 * 	any responsibility.</dd>
+	 * <p>This option only has an effect if the option {@link #COMPILER_ANNOTATION_RESOURCE_ANALYSIS} is enabled.</p>
+	 * <dl>
+	 * <dt>Option id:</dt><dd><code>"org.eclipse.jdt.core.compiler.annotation.notowning"</code></dd>
+	 * <dt>Possible values:</dt><dd>A fully qualified name of an annotation declaration</dd>
+	 * <dt>Default:</dt><dd><code>"org.eclipse.jdt.annotation.NotOwning"</code></dd>
+	 * </dl>
+	 * @since 3.37
+	 * @category CompilerOptionID
+	 */
+	public static final String COMPILER_NOTOWNING_ANNOTATION_NAME = PLUGIN_ID + ".compiler.annotation.notowning"; //$NON-NLS-1$
+
+	/**
+	 * Compiler option ID: Reporting a resource that is not managed by recommended strategies.
+	 * <p>When enabled, the compiler will issue an error or a warning or an info if a value of type {@link AutoCloseable} or subtype
+	 * 	is managed in ways that impede static analysis.</p>
+	 * <p>The following recommendations apply:</p>
+	 * <ul>
+	 * <li>Any field of a resource type should be annotated as owning ({@link #COMPILER_OWNING_ANNOTATION_NAME}).</li>
+	 * <li>Any class declaring one or more fields annotated as owning should itself implement {@link AutoCloseable}.</li>
+	 * <li>Any class implementing {@link AutoCloseable} that declares one or more owned resource fields should implement
+	 * 	{@link AutoCloseable#close()} and ensure that each owned resource field is always closed when <code>close()</code> is executed.</li>
+	 * <li>A method returning a locally owned resource should be tagged as owning ({@link #COMPILER_OWNING_ANNOTATION_NAME}).</li>
+	 * </ul>
+	 * <p>This option only has an effect if the option {@link #COMPILER_ANNOTATION_RESOURCE_ANALYSIS} is enabled.</p>
+	 * <dl>
+	 * <dt>Option id:</dt><dd><code>"org.eclipse.jdt.core.compiler.problem.insufficientResourceAnalysis"</code></dd>
+	 * <dt>Possible values:</dt><dd><code>{ "error", "warning", "info", "ignore" }</code></dd>
+	 * <dt>Default:</dt><dd><code>"warning"</code></dd>
+	 * </dl>
+	 * @since 3.37
+	 * @category CompilerOptionID
+	 */
+	public static final String COMPILER_PB_RECOMMENDED_RESOURCE_MANAGEMENT = PLUGIN_ID + ".compiler.problem.insufficientResourceAnalysis"; //$NON-NLS-1$
+
+	/**
 	 * Compiler option ID: Reporting a method invocation providing an argument of an unlikely type.
 	 * <p>When enabled, the compiler will issue an error or warning when certain well-known Collection methods
 	 *    that take an 'Object', like e.g. {@link Map#get(Object)}, are used with an argument type


### PR DESCRIPTION
fixes #1530

## What it does

Demonstrate how evaluating one more annotations `@Owning` can enhance our resource leak analysis.

Most of the change is infra structure work to define new options, let the compiler detect that annotation and propagate that information to where it is needed.

Few semantically interesting code changes suffice to tell the existing analysis:
1. a method parameter of a closeable type and marked `@Owning` **must** be closed in, or on behalf of this method.
2. passing an unclosed closeable value into a method where the receiving parameter is marked `@Owning` delegates responsibility of closing to the receiving method.
3. returning an unclosing closeable value from a method annotated as `@Owning` delegates responsibility to the calling method.

The above can be mapped as equivalent to existing constructs:
1. corresponds to acquiring a fresh resource, e.g., by allocating a new instance.
2. corresponds to calling `close()` on the resource being sent to the other method
3. corresponds to calling `close()` on the resource being returned from the current method

## How to test

1. Ensure you have `org.eclipse.jdt.annotation` bundle on you buildpath (with addition in this PR)
2. Enter the following lines in the project's `.settings/org.eclipse.jdt.core.prefs`:
```
org.eclipse.jdt.core.compiler.annotation.resourceanalysis=enabled
org.eclipse.jdt.core.compiler.problem.potentiallyUnclosedCloseable=warning
org.eclipse.jdt.core.compiler.problem.unclosedCloseable=error
```

In particular the first option doesn't yet have UI. By specifying `org.eclipse.jdt.core.compiler.annotation.owning=your.Annot` you could optionally roll you own equivalent of `@org.eclipse.jdt.annotation.Owning`.

With this setup interested parties can play with the new analysis. Have a look at new tests or the following example for inspiration:

```
public class Producer {
	@Owning InputStream get() throws FileNotFoundException {
		return new FileInputStream("foo");
	}
}
```
```
public class Consumer {
	@Owning InputStream inspect(@Owning InputStream input) {
		if (input != null)
			System.out.println("ok");
		return input;
	}
	public void consume(@Owning AutoCloseable rc) {
		try (rc) {
			System.out.println("reading");
		} catch (Exception e) {
			e.printStackTrace();
		}
	}
}
```
```
public class Client {
	void ok(Producer p, Consumer c) throws IOException {
		InputStream is = p.get(); // *1*
		InputStream is2 = c.inspect(is); // *2* 
		c.consume(is2);  // *3*
	}
}
```
By commenting line \*3* and then \*2* you will see errors appear on the previous line. By removing the annotation from `Producer.get()` the error will disappear again. Etc. pp.
