### PR TITLE
Handle type annotations on record type so as to maintain expression stack integrity

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
@@ -10953,12 +10953,36 @@ protected void consumeTypePattern() {
 	pushOnAstStack(aTypePattern);
 }
 protected void consumeRecordPattern() {
-	int length = this.astLengthPtr == -1 ? 0 : this.astLengthStack[this.astLengthPtr--];
-	this.astPtr -= length;
+
+	int length;
+	Annotation[] typeAnnotations = null;
+	if ((length = this.expressionLengthStack[this.expressionLengthPtr--]) != 0) {
+		System.arraycopy(
+			this.expressionStack,
+			(this.expressionPtr -= length) + 1,
+			typeAnnotations = new Annotation[length],
+			0,
+			length);
+	}
+
 	TypeReference type = getTypeReference(0);
+
+	if (typeAnnotations != null) {
+		int levels = type.getAnnotatableLevels();
+		if (type.annotations == null)
+			type.annotations = new Annotation[levels][];
+		type.annotations[0] = typeAnnotations;
+		type.sourceStart = type.annotations[0][0].sourceStart;
+		type.bits |= ASTNode.HasTypeAnnotations;
+	}
+
 	int sourceEnd = this.intStack[this.intPtr--];
 	this.intPtr--;
 	RecordPattern recPattern = new RecordPattern(type, type.sourceStart, sourceEnd);
+
+	length = this.astLengthPtr == -1 ? 0 : this.astLengthStack[this.astLengthPtr--];
+	this.astPtr -= length;
+
 	if (length != 0) {
 		Pattern[] patterns = new Pattern[length];
 		System.arraycopy(

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PatternMatching16Test.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PatternMatching16Test.java
@@ -4125,4 +4125,29 @@ public class PatternMatching16Test extends AbstractRegressionTest {
 				"true",
 				compilerOptions);
 	}
+	public void testGH1726() {
+		if (this.complianceLevel < ClassFileConstants.JDK21)
+			return;
+		Map<String, String> compilerOptions = getCompilerOptions(true);
+		runConformTest(
+				new String[] {
+						"X.java",
+						"""
+						public class X {
+							record A(int x) {
+							}
+
+							public static int foo(Object a) {
+								return a instanceof A(int x) ? x : 1;
+							}
+
+							public static void main(String [] args) {
+								System.out.println("" + foo(new A(1234)) + foo(args));
+							}
+						}
+						""",
+				},
+				"12341",
+				compilerOptions);
+	}
 }


### PR DESCRIPTION

## What it does
Handles type annotations on record type so as to maintain expression stack integrity.
Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1726

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
