### PR TITLE
Compiler fails to recognize an exhaustive switch

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
@@ -1488,12 +1488,20 @@ public class SwitchStatement extends Expression {
 		this.switchBits |= SwitchStatement.Exhaustive;
 		return false;
 	}
-	private boolean isExhaustiveWithCaseTypes(List<ReferenceBinding> allallowedTypes,  List<TypeBinding> listedTypes) {
+	private boolean isExhaustiveWithCaseTypes(List<ReferenceBinding> allAllowedTypes,  List<TypeBinding> listedTypes) {
 		// first KISS (Keep It Simple Stupid)
-		int pendingTypes = allallowedTypes.size();
-		for (ReferenceBinding pt : allallowedTypes) {
+		int pendingTypes = allAllowedTypes.size();
+		for (ReferenceBinding pt : allAllowedTypes) {
+			/* Per JLS 14.11.1.1: A type T that names an abstract sealed class or sealed interface is covered
+			   if every permitted direct subclass or subinterface of it is covered. These subtypes are already
+			   added to allAllowedTypes and subject to cover test.
+			*/
+			if (pt.isAbstract() && pt.isSealed()) {
+				--pendingTypes;
+				continue;
+			}
 			for (TypeBinding type : listedTypes) {
-				if (pt.isAbstract() || pt.isCompatibleWith(type)) {
+				if (pt.isCompatibleWith(type)) {
 					--pendingTypes;
 					break;
 				}
@@ -1503,7 +1511,7 @@ public class SwitchStatement extends Expression {
 			return true;
 		// else - #KICKME (Keep It Complicated Keep Me Employed)"
 		List<TypeBinding> coveredTypes = new ArrayList<>(listedTypes);
-		List<ReferenceBinding> remainingTypes = new ArrayList<>(allallowedTypes);
+		List<ReferenceBinding> remainingTypes = new ArrayList<>(allAllowedTypes);
 		remainingTypes.removeAll(coveredTypes);
 
 		Map<TypeBinding, List<TypeBinding>> impliedTypes = new HashMap<>();
@@ -1511,7 +1519,7 @@ public class SwitchStatement extends Expression {
 		for (ReferenceBinding type : remainingTypes) {
 			impliedTypes.put(type, new ArrayList<>());
 			List<ReferenceBinding> typesToAdd = new ArrayList<>();
-			for (ReferenceBinding impliedType : allallowedTypes) {
+			for (ReferenceBinding impliedType : allAllowedTypes) {
 				if (impliedType.equals(type)) continue;
 				if (type.isClass()) {
 					if (impliedType.isAbstract() && type.superclass().equals(impliedType)) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
@@ -1491,9 +1491,9 @@ public class SwitchStatement extends Expression {
 	private boolean isExhaustiveWithCaseTypes(List<ReferenceBinding> allallowedTypes,  List<TypeBinding> listedTypes) {
 		// first KISS (Keep It Simple Stupid)
 		int pendingTypes = allallowedTypes.size();
-		for (TypeBinding pt : allallowedTypes) {
+		for (ReferenceBinding pt : allallowedTypes) {
 			for (TypeBinding type : listedTypes) {
-				if (pt.isCompatibleWith(type)) {
+				if (pt.isAbstract() || pt.isCompatibleWith(type)) {
 					--pendingTypes;
 					break;
 				}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PatternMatching16Test.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PatternMatching16Test.java
@@ -4150,4 +4150,88 @@ public class PatternMatching16Test extends AbstractRegressionTest {
 				"12341",
 				compilerOptions);
 	}
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1725
+	// [21] Wrongly needing a default case for a switch expression
+	public void testGH1725() {
+		if (this.complianceLevel < ClassFileConstants.JDK21)
+			return;
+		Map<String, String> compilerOptions = getCompilerOptions(true);
+		runConformTest(
+				new String[] {
+						"X.java",
+						"""
+						public class X {
+							public abstract sealed class A permits B, C {
+							}
+
+							public final class C extends A {
+							}
+
+							public abstract sealed class B extends A permits D {
+							}
+
+							public final class D extends B {
+							}
+
+							public String foo(A a) {
+								return switch (a) {
+									case D d -> "1234";
+									case C c -> "6789";
+								};
+							}
+							public static void main(String [] args) {
+								System.out.println(new X().foo(new X().new D()) + new X().foo(new X().new C()));
+							}
+						}
+						""",
+				},
+				"12346789",
+				compilerOptions);
+	}
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1725
+	// [21] Wrongly needing a default case for a switch expression
+	public void testGH1725_2() {
+		if (this.complianceLevel < ClassFileConstants.JDK21)
+			return;
+
+		runNegativeTest(
+				new String[] {
+						"X.java",
+						"""
+						public class X {
+							public abstract sealed class A permits B, C {
+							}
+
+							public final class C extends A {
+							}
+
+							public sealed class B extends A permits D {
+							}
+
+							public final class D extends B {
+							}
+
+							public String foo(A a) {
+								return switch (a) {
+									case D d -> "1234";
+									// case B b -> "blah";
+									case C c -> "6789";
+								};
+							}
+							public static void main(String [] args) {
+								System.out.println(new X().foo(new X().new D()) + new X().foo(new X().new C()));
+							}
+						}
+						""",
+				},
+				"""
+				----------
+				1. ERROR in X.java (at line 15)
+					return switch (a) {
+					               ^
+				A switch expression should have a default case
+				----------
+				""",
+				false);
+	}
 }


### PR DESCRIPTION
## What it does

Fix defect in exhaustiveness check for sealed classes
Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1725

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
