### PR TITLE
Fix one too many pops arising from string concat invoke dynamic

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AbstractMethodDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AbstractMethodDeclaration.java
@@ -378,9 +378,6 @@ public abstract class AbstractMethodDeclaration
 				throw new AbortMethod(this.scope.referenceCompilationUnit().compilationResult, null);
 			}
 			attributeNumber++;
-			if (!codeStream.switchSaveTypeBindings.isEmpty()) {
-				throw new AssertionError("Stack not drained"); //$NON-NLS-1$
-			}
 		} else {
 			checkArgumentsSize();
 		}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AbstractMethodDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AbstractMethodDeclaration.java
@@ -378,6 +378,9 @@ public abstract class AbstractMethodDeclaration
 				throw new AbortMethod(this.scope.referenceCompilationUnit().compilationResult, null);
 			}
 			attributeNumber++;
+			if (!codeStream.switchSaveTypeBindings.isEmpty()) {
+				throw new AssertionError("Stack not drained"); //$NON-NLS-1$
+			}
 		} else {
 			checkArgumentsSize();
 		}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/CodeStream.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/CodeStream.java
@@ -2614,12 +2614,18 @@ public void generateReturnBytecode(Expression expression) {
 public void invokeDynamicForStringConcat(StringBuilder recipe, List<TypeBinding> arguments) {
 	int invokeDynamicNumber = this.classFile.recordBootstrapMethod(recipe.toString());
 	StringBuilder signature = new StringBuilder("("); //$NON-NLS-1$
-	for(int i = 0; i < arguments.size(); i++) {
-		signature.append(arguments.get(i).signature());
+	int argsSize = 0;
+	for(TypeBinding argument : arguments) {
+		signature.append(argument.signature());
+		if (TypeIds.getCategory(argument.id) == 2) {
+			argsSize += 2;
+		} else {
+			argsSize++;
+		}
 	}
 	signature.append(")Ljava/lang/String;"); //$NON-NLS-1$
 	this.invokeDynamic(invokeDynamicNumber,
-			1,
+			argsSize,
 			1, // int
 			ConstantPool.ConcatWithConstants,
 			signature.toString().toCharArray(),

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/CodeStream.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/CodeStream.java
@@ -2615,13 +2615,9 @@ public void invokeDynamicForStringConcat(StringBuilder recipe, List<TypeBinding>
 	int invokeDynamicNumber = this.classFile.recordBootstrapMethod(recipe.toString());
 	StringBuilder signature = new StringBuilder("("); //$NON-NLS-1$
 	int argsSize = 0;
-	for(TypeBinding argument : arguments) {
+	for (TypeBinding argument : arguments) {
 		signature.append(argument.signature());
-		if (TypeIds.getCategory(argument.id) == 2) {
-			argsSize += 2;
-		} else {
-			argsSize++;
-		}
+		argsSize += TypeIds.getCategory(argument.id);
 	}
 	signature.append(")Ljava/lang/String;"); //$NON-NLS-1$
 	this.invokeDynamic(invokeDynamicNumber,

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/CodeStream.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/CodeStream.java
@@ -2619,7 +2619,7 @@ public void invokeDynamicForStringConcat(StringBuilder recipe, List<TypeBinding>
 	}
 	signature.append(")Ljava/lang/String;"); //$NON-NLS-1$
 	this.invokeDynamic(invokeDynamicNumber,
-			2,
+			1,
 			1, // int
 			ConstantPool.ConcatWithConstants,
 			signature.toString().toCharArray(),

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ConstantTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ConstantTest.java
@@ -435,7 +435,7 @@ public void test009() throws Exception {
 
 	String expectedOutput9OrLater =
 			"  // Method descriptor #15 ([Ljava/lang/String;)V\n" +
-			"  // Stack: 2, Locals: 4\n" +
+			"  // Stack: 3, Locals: 4\n" +
 			"  public static void main(java.lang.String[] args);\n" +
 			"     0  getstatic java.lang.System.out : java.io.PrintStream [16]\n" +
 			"     3  ldc <String \"1\"> [22]\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericTypeTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericTypeTest.java
@@ -36615,7 +36615,7 @@ public void test1066() throws Exception {
 	// 	check presence of checkcast
 	String expectedOutput;
 	if (this.complianceLevel >= ClassFileConstants.JDK9) {
-		expectedOutput = "  // Stack: 3, Locals: 8\n" +
+		expectedOutput = "  // Stack: 4, Locals: 8\n" +
 				"  public static void main(java.lang.String[] args);\n" +
 				"      0  new X [1]\n" +
 				"      3  dup\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/StringConcatTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/StringConcatTest.java
@@ -89,7 +89,7 @@ public class StringConcatTest extends AbstractComparableTest {
 				},
 				"one=1, two=2.0, three=3.0, four=4, five=5, six=6, seven=, boolean b=false."
 			);
-		String expectedOutput = "  // Stack: 11, Locals: 12\n" +
+		String expectedOutput = "  // Stack: 13, Locals: 12\n" +
 				"  public static void main(java.lang.String[] args);\n" +
 				"     0  iconst_1\n" +
 				"     1  istore_1 [one]\n" +
@@ -144,7 +144,7 @@ public class StringConcatTest extends AbstractComparableTest {
 				},
 				"one=1"
 			);
-		String expectedOutput = "  // Stack: 2, Locals: 3\n" +
+		String expectedOutput = "  // Stack: 3, Locals: 3\n" +
 				"  public void foo();\n" +
 				"     0  iconst_1\n" +
 				"     1  istore_1 [one]\n" +
@@ -277,7 +277,7 @@ public class StringConcatTest extends AbstractComparableTest {
 				},
 				"X 0 a 11 a 11 X 1 b 42 b 42 b 42 b 42"
 				);
-		String expectedOutput = "  // Stack: 7, Locals: 4\n"
+		String expectedOutput = "  // Stack: 8, Locals: 4\n"
 				+ "  public static void main(java.lang.String[] args);\n"
 				+ "     0  bipush 11\n"
 				+ "     2  istore_1 [first]\n"

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/StringConcatTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/StringConcatTest.java
@@ -89,7 +89,7 @@ public class StringConcatTest extends AbstractComparableTest {
 				},
 				"one=1, two=2.0, three=3.0, four=4, five=5, six=6, seven=, boolean b=false."
 			);
-		String expectedOutput = "  // Stack: 13, Locals: 12\n" +
+		String expectedOutput = "  // Stack: 11, Locals: 12\n" +
 				"  public static void main(java.lang.String[] args);\n" +
 				"     0  iconst_1\n" +
 				"     1  istore_1 [one]\n" +
@@ -277,7 +277,7 @@ public class StringConcatTest extends AbstractComparableTest {
 				},
 				"X 0 a 11 a 11 X 1 b 42 b 42 b 42 b 42"
 				);
-		String expectedOutput = "  // Stack: 8, Locals: 4\n"
+		String expectedOutput = "  // Stack: 7, Locals: 4\n"
 				+ "  public static void main(java.lang.String[] args);\n"
 				+ "     0  bipush 11\n"
 				+ "     2  istore_1 [first]\n"

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchExpressionsYieldTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchExpressionsYieldTest.java
@@ -6412,7 +6412,7 @@ public class SwitchExpressionsYieldTest extends AbstractRegressionTest {
 				"				\n" +
 				"			}\n" +
 				"		}\n" +
-				"		default -> throw new RuntimeException(\"\" + x);\n" +
+				"		default -> throw new RuntimeException(\"\" + x + \" \".toLowerCase());\n" +
 				"		};\n" +
 				"	}\n" +
 				"	public static void main(String[] args) {\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchExpressionsYieldTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchExpressionsYieldTest.java
@@ -6329,4 +6329,123 @@ public class SwitchExpressionsYieldTest extends AbstractRegressionTest {
 			"m cannot be resolved\n" +
 			"----------\n");
 	}
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1394
+	// switch statement with yield and try/catch produces EmptyStackException
+	public void testGHI1394() {
+		Map<String, String> options = getCompilerOptions();
+		options.put(CompilerOptions.OPTION_UseStringConcatFactory, CompilerOptions.ENABLED);
+		this.runConformTest(
+				new String[] {
+				"X.java",
+				"public class X {\n"
+				+ "	protected static int switchWithYield() {\n"
+				+ "		String myStringNumber = \"1\";\n"
+				+ "		return switch (myStringNumber) {\n"
+				+ "		case \"1\" -> {\n"
+				+ "			try {\n"
+				+ "				yield Integer.parseInt(myStringNumber);\n"
+				+ "			} catch (NumberFormatException e) {\n"
+				+ "				throw new RuntimeException(\"Failed parsing number\", e); //$NON-NLS-1$\n"
+				+ "			}\n"
+				+ "		}\n"
+				+ "		default -> throw new IllegalArgumentException(\"Unexpected value: \" + myStringNumber);\n"
+				+ "		};\n"
+				+ "	}\n"
+				+ "	public static void main(String[] args) {\n"
+				+ "		System.out.println(switchWithYield());\n"
+				+ "	}\n"
+				+ "} "
+				},
+				"1",
+				options);
+	}
+	public void testGHI1394_2() {
+		Map<String, String> options = getCompilerOptions();
+		options.put(CompilerOptions.OPTION_UseStringConcatFactory, CompilerOptions.ENABLED);
+		this.runConformTest(
+				new String[] {
+				"X.java",
+				"public class X {\n"
+				+ "	static String myStringNumber = \"1\";\n"
+				+ "	protected static int switchWithYield() {\n"
+				+ "		return switch (myStringNumber) {\n"
+				+ "		case \"10\" -> {\n"
+				+ "			try {\n"
+				+ "				yield Integer.parseInt(myStringNumber);\n"
+				+ "			} catch (NumberFormatException e) {\n"
+				+ "				throw new RuntimeException(\"Failed parsing number\", e); //$NON-NLS-1$\n"
+				+ "			}\n"
+				+ "		}\n"
+				+ "		default -> throw new IllegalArgumentException(\"Unexpected value: \" + myStringNumber);\n"
+				+ "		};\n"
+				+ "	}\n"
+				+ "	public static void main(String[] args) {\n"
+				+ "     try {\n"
+				+ "		    System.out.println(switchWithYield());\n"
+				+ "     } catch(IllegalArgumentException iae) {\n"
+				+ "         if (!iae.getMessage().equals(\"Unexpected value: \" + myStringNumber))\n"
+				+ "             throw iae;\n"
+				+ "     }\n"
+				+ "     System.out.println(\"Done\");\n"
+				+ "	}\n"
+				+ "} "
+				},
+				"Done",
+				options);
+	}
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1394
+	// switch statement with yield and try/catch produces EmptyStackException
+	public void testGHI1394_min() {
+		Map<String, String> options = getCompilerOptions();
+		options.put(CompilerOptions.OPTION_UseStringConcatFactory, CompilerOptions.ENABLED);
+		this.runConformTest(
+				new String[] {
+				"X.java",
+				"public class X {\n" +
+				"	static int foo() {\n" +
+				"		int x = 1;\n" +
+				"		return switch (x) {\n" +
+				"		case 1 -> {\n" +
+				"			try {\n" +
+				"				yield x;\n" +
+				"			} finally  {\n" +
+				"				\n" +
+				"			}\n" +
+				"		}\n" +
+				"		default -> throw new RuntimeException(\"\" + x);\n" +
+				"		};\n" +
+				"	}\n" +
+				"	public static void main(String[] args) {\n" +
+				"		System.out.println(foo());\n" +
+				"	}\n" +
+				"}\n"
+				},
+				"1",
+				options);
+	}
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1727
+	// Internal compiler error: java.util.EmptyStackException
+	public void testGHI1727() {
+		if (this.complianceLevel < ClassFileConstants.JDK21)
+			return;
+		this.runConformTest(
+				new String[] {
+				"X.java",
+				"class X {\n" +
+				"	private Object foo(Object value) {\n" +
+				"		return switch (value) {\n" +
+				"			case String string -> {\n" +
+				"				try {\n" +
+				"					yield string;\n" +
+				"				} catch (IllegalArgumentException exception) {\n" +
+				"					yield string;\n" +
+				"				}\n" +
+				"			}\n" +
+				"			default -> throw new IllegalArgumentException(\"Argument of type \" + value.getClass());\n" +
+				"		};\n" +
+				"	}\n" +
+				"}\n"
+				},
+				"");
+	}
 }


### PR DESCRIPTION
## What it does

Fixes ECJ behavior to ensure we don't pop more than pushed.
Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1394

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
