### PR TITLE
Wrong placement of exception range closure call results in double closure

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TryStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TryStatement.java
@@ -995,6 +995,8 @@ public boolean generateSubRoutineInvocation(BlockScope currentScope, CodeStream 
 	switch(finallyMode) {
 		case FINALLY_DOES_NOT_COMPLETE :
 			if (this.switchExpression != null) {
+				exitAnyExceptionHandler();
+				exitDeclaredExceptionHandlers(codeStream);
 				this.finallyBlock.generateCode(currentScope, codeStream);
 				return true;
 			}
@@ -1002,9 +1004,7 @@ public boolean generateSubRoutineInvocation(BlockScope currentScope, CodeStream 
 			return true;
 
 		case NO_FINALLY :
-			if (this.switchExpression == null) { // already taken care at Yield
-				exitDeclaredExceptionHandlers(codeStream);
-			}
+			exitDeclaredExceptionHandlers(codeStream);
 			return false;
 	}
 	// optimize subroutine invocation sequences, using the targetLocation (if any)

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/YieldStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/YieldStatement.java
@@ -146,8 +146,6 @@ protected void generateExpressionResultCodeExpanded(BlockScope currentScope, Cod
 	if (this.subroutines != null){
 		for (int i = 0, max = this.subroutines.length; i < max; i++){
 			SubRoutineStatement sub = this.subroutines[i];
-			sub.exitAnyExceptionHandler();
-			sub.exitDeclaredExceptionHandlers(codeStream);
 			SwitchExpression se1 = sub.getSwitchExpression();
 			setSubroutineSwitchExpression(sub);
 			boolean didEscape = sub.generateSubRoutineInvocation(currentScope, codeStream, this.targetLabel, this.initStateIndex, null);

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchExpressionsYieldTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchExpressionsYieldTest.java
@@ -6448,4 +6448,61 @@ public class SwitchExpressionsYieldTest extends AbstractRegressionTest {
 				},
 				"");
 	}
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1686
+	// Switch statement with yield in synchronized and try-catch blocks results in ArrayIndexOutOfBoundsException
+	public void testGHI1686() {
+		this.runConformTest(
+				new String[] {
+				"X.java",
+				"""
+				public class X {
+
+					public String demo(String input) {
+						return switch (input) {
+							case "red" -> {
+								synchronized (this) {
+									yield "apple";
+								}
+							}
+							default -> {
+								try {
+									yield "banana";
+								}
+								catch (Exception ex) {
+									throw new IllegalStateException(ex);
+							    }
+						    }
+					    };
+				    }
+				}
+				"""
+				},
+				"");
+		}
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1686
+	// Switch statement with yield in synchronized and try-catch blocks results in ArrayIndexOutOfBoundsException
+	public void testGHI1686_works() {
+		this.runConformTest(
+				new String[] {
+				"X.java",
+				"""
+				public class X {
+
+					public String demo(String input) {
+						return switch (input) {
+							case "red" -> {
+								synchronized (this) {
+									yield "apple";
+								}
+							}
+							default -> {
+								yield "banana";
+						    }
+					    };
+				    }
+				}
+				"""
+				},
+				"");
+		}
 }


### PR DESCRIPTION

## What it does

Fixes AIOOB resulting from double closure of exception handling code range
Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1686


## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
