### PR TITLE
Touch bundles affected by the changed ecj version

### DIFF
--- a/org.eclipse.jdt.apt.core/forceQualifierUpdate.txt
+++ b/org.eclipse.jdt.apt.core/forceQualifierUpdate.txt
@@ -4,3 +4,4 @@ BUg 492759 - update jdtcompiler and eclipserun to RC2 level to produce RC3
 Bug 509973 - Comparator errors in I20170105-0320
 Bug 566471 - I20200828-0150 - Comparator Errors Found
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/org.eclipse.jdt.apt.pluggable.core/forceQualifierUpdate.txt
+++ b/org.eclipse.jdt.apt.pluggable.core/forceQualifierUpdate.txt
@@ -1,2 +1,3 @@
 # To force a version qualifier update add the bug here
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/org.eclipse.jdt.apt.pluggable.tests/forceQualifierUpdate.txt
+++ b/org.eclipse.jdt.apt.pluggable.tests/forceQualifierUpdate.txt
@@ -1,2 +1,3 @@
 # To force a version qualifier update add the bug here
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/org.eclipse.jdt.apt.tests/forceQualifierUpdate.txt
+++ b/org.eclipse.jdt.apt.tests/forceQualifierUpdate.txt
@@ -3,3 +3,4 @@ Several bundles changed and need to be touched
 Bug 420446 - APT tests don't run
 Bug 566471 - I20200828-0150 - Comparator Errors Found
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/org.eclipse.jdt.apt.ui/forceQualifierUpdate.txt
+++ b/org.eclipse.jdt.apt.ui/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 Bug 566471 - I20200828-0150 - Comparator Errors Found
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/org.eclipse.jdt.compiler.apt.tests/forceQualifierUpdate.txt
+++ b/org.eclipse.jdt.compiler.apt.tests/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 Bug 566471 - I20200828-0150 - Comparator Errors Found
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/org.eclipse.jdt.compiler.tool.tests/forceQualifierUpdate.txt
+++ b/org.eclipse.jdt.compiler.tool.tests/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update add the bug here
 Bug 566471 - I20200828-0150 - Comparator Errors Found
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/org.eclipse.jdt.core.tests.builder/forceQualifierUpdate.txt
+++ b/org.eclipse.jdt.core.tests.builder/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update, add the bug here
 Bug 480835 - Failures in build due to changes not being picked up by tests
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/org.eclipse.jdt.core.tests.model/forceQualifierUpdate.txt
+++ b/org.eclipse.jdt.core.tests.model/forceQualifierUpdate.txt
@@ -1,3 +1,4 @@
 # To force a version qualifier update, add the bug here
 Bug 489604 - should not override <timestampProvider>
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/org.eclipse.jdt.core.tests.performance/forceQualifierUpdate.txt
+++ b/org.eclipse.jdt.core.tests.performance/forceQualifierUpdate.txt
@@ -3,3 +3,4 @@ Bug 545608 - [comparator] 4.12 Comparator errors - I20190320-1800
 Bug 561237 - [comparator] Comparator errors I20200318-1800
 Bug 574551 - Comparator errors in Y20210629-0800
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659

--- a/org.eclipse.jdt.core/forceQualifierUpdate.txt
+++ b/org.eclipse.jdt.core/forceQualifierUpdate.txt
@@ -11,3 +11,4 @@ Bug 549687 - Local ecj build has a SHA-256 digest error for org/eclipse/jdt/inte
 Bug 566471 - I20200828-0150 - Comparator Errors Found
 Bug 573283 - don't include javax15api.jar in jdt binaries
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659


### PR DESCRIPTION
See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1394 
See https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
