### PR TITLE
Performance : getMainTypeName in CompilationUnitDeclaration is called very often Fix #1747

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/CompilationResult.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/CompilationResult.java
@@ -64,7 +64,7 @@ public class CompilationResult {
 	public CategorizedProblem tasks[];
 	public int problemCount;
 	public int taskCount;
-	public ICompilationUnit compilationUnit;
+	public final ICompilationUnit compilationUnit;
 	private Map<CategorizedProblem, ReferenceContext> problemsMap;
 	private Set firstErrors;
 	private final int maxProblemPerUnit;
@@ -98,6 +98,7 @@ public class CompilationResult {
 
 public CompilationResult(char[] fileName, int unitIndex, int totalUnitsKnown, int maxProblemPerUnit){
 	this.fileName = fileName;
+	this.compilationUnit = null;
 	this.unitIndex = unitIndex;
 	this.totalUnitsKnown = totalUnitsKnown;
 	this.maxProblemPerUnit = maxProblemPerUnit;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/CompilationUnitDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/CompilationUnitDeclaration.java
@@ -80,7 +80,7 @@ public class CompilationUnitDeclaration extends ASTNode implements ProblemSeveri
 	public boolean ignoreMethodBodies = false;
 	public CompilationUnitScope scope;
 	public ProblemReporter problemReporter;
-	public CompilationResult compilationResult;
+	public final CompilationResult compilationResult;
 
 	public Map<Integer,LocalTypeBinding> localTypes = Collections.emptyMap();
 
@@ -101,6 +101,7 @@ public class CompilationUnitDeclaration extends ASTNode implements ProblemSeveri
 	int suppressWarningsCount;
 	public int functionalExpressionsCount;
 	public FunctionalExpression[] functionalExpressions;
+	private final char[] mainTypeName;
 
 public CompilationUnitDeclaration(ProblemReporter problemReporter, CompilationResult compilationResult, int sourceLength) {
 	this.problemReporter = problemReporter;
@@ -108,6 +109,7 @@ public CompilationUnitDeclaration(ProblemReporter problemReporter, CompilationRe
 	//by definition of a compilation unit....
 	this.sourceStart = 0;
 	this.sourceEnd = sourceLength - 1;
+	this.mainTypeName = computeMainTypeName();
 }
 
 /*
@@ -431,6 +433,13 @@ public char[] getFileName() {
 }
 
 public char[] getMainTypeName() {
+	return this.mainTypeName;
+}
+
+private char[] computeMainTypeName() {
+	if(this.compilationResult == null) {
+		return null;
+	}
 	if (this.compilationResult.compilationUnit == null) {
 		char[] fileName = this.compilationResult.getFileName();
 


### PR DESCRIPTION
add a cash to increase performance

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
