### PR TITLE
Issue #1703 - adding constant version_22 to CompilerOptions

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/impl/CompilerOptions.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/impl/CompilerOptions.java
@@ -243,6 +243,7 @@ public class CompilerOptions {
 	public static final String VERSION_19 = "19"; //$NON-NLS-1$
 	public static final String VERSION_20 = "20"; //$NON-NLS-1$
 	public static final String VERSION_21 = "21"; //$NON-NLS-1$
+	public static final String VERSION_22 = "21"; //$NON-NLS-1$
 	/*
 	 * Note: Whenever a new version is added, make sure getLatestVersion()
 	 * is updated with it.

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/impl/CompilerOptions.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/impl/CompilerOptions.java
@@ -243,7 +243,7 @@ public class CompilerOptions {
 	public static final String VERSION_19 = "19"; //$NON-NLS-1$
 	public static final String VERSION_20 = "20"; //$NON-NLS-1$
 	public static final String VERSION_21 = "21"; //$NON-NLS-1$
-	public static final String VERSION_22 = "21"; //$NON-NLS-1$
+	public static final String VERSION_22 = "22"; //$NON-NLS-1$
 	/*
 	 * Note: Whenever a new version is added, make sure getLatestVersion()
 	 * is updated with it.


### PR DESCRIPTION
Adding the version_22 constant as well to CompilerOptions for issue #1703 
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
