### PR TITLE
Propagate pattern bindings to reference expression copy

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ReferenceExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ReferenceExpression.java
@@ -157,6 +157,8 @@ public class ReferenceExpression extends FunctionalExpression implements IPolyEx
 		copy.sourceStart = this.sourceStart;
 		copy.sourceEnd = this.sourceEnd;
 		copy.text = this.text;
+		copy.lhs.addPatternVariablesWhenTrue(this.lhs.getPatternVariablesWhenTrue());
+		copy.lhs.addPatternVariablesWhenFalse(this.lhs.getPatternVariablesWhenFalse());
 		return copy;
 	}
 

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PatternMatching16Test.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PatternMatching16Test.java
@@ -4234,4 +4234,77 @@ public class PatternMatching16Test extends AbstractRegressionTest {
 				""",
 				false);
 	}
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1759
+	// Pattern variable is not recognized in AND_AND_Expression
+	public void testGHI1759() {
+
+		runConformTest(
+				new String[] {
+						"X.java",
+						"""
+						import java.util.Arrays;
+						import java.util.List;
+						public class X {
+							public static void main(String [] args) {
+						        Object obj = "test";
+						        List<String> values = Arrays.asList("fail", "test", "pass");
+						        if (obj instanceof String str && values.stream().anyMatch(str::equalsIgnoreCase)) {
+						            System.out.println(str);
+						        }
+						    }
+
+						}
+						""",
+				},
+				"test");
+	}
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1759
+	// Pattern variable is not recognized in AND_AND_Expression
+	public void testGHI1759_2() {
+
+		runConformTest(
+				new String[] {
+						"X.java",
+						"""
+						import java.util.Arrays;
+						import java.util.List;
+						public class X {
+							public static void main(String [] args) {
+						        Object obj = "test";
+						        List<String> values = Arrays.asList("fail", "test", "pass");
+						        if (!(obj instanceof String str) || values.stream().anyMatch(str::equalsIgnoreCase)) {
+						            System.out.println(obj);
+						        }
+						    }
+
+						}
+						""",
+				},
+				"test");
+	}
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1759
+	// Pattern variable is not recognized in AND_AND_Expression
+	public void testGHI1759_3() {
+
+		runConformTest(
+				new String[] {
+						"X.java",
+						"""
+						import java.util.Arrays;
+						import java.util.List;
+						public class X {
+						    public static void main(String [] args) {
+						        Object obj = "test";
+						        List<String> values = Arrays.asList("fail", "test", "pass");
+						        if (obj instanceof String str) {
+						        	if (values.stream().anyMatch(str::equalsIgnoreCase)) {
+						        		System.out.println(str);
+						        	}
+						        }
+						    }
+						}
+						""",
+				},
+				"test");
+	}
 }


### PR DESCRIPTION

## What it does
Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1759

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
