### PR TITLE
Fix ECJ hang while computing available pattern binding

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Statement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Statement.java
@@ -501,30 +501,21 @@ public void addPatternVariablesWhenFalse(LocalVariableBinding[] vars) {
 	if (this.patternVarsWhenFalse == vars) return;
 	this.patternVarsWhenFalse = addPatternVariables(this.patternVarsWhenFalse, vars);
 }
-private LocalVariableBinding[] addPatternVariables(LocalVariableBinding[] current, LocalVariableBinding[] add) {
-	if (add == null || add.length == 0)
-		return current;
-	if (current == null) {
-		current = add;
-	} else {
-		for (LocalVariableBinding local : add) {
-			current = addPatternVariables(current, local);
+
+private LocalVariableBinding[] addPatternVariables(LocalVariableBinding[] current, LocalVariableBinding[] additions) {
+	if (additions != null && additions.length > 0) {
+		if (current == null)
+			current = new LocalVariableBinding[0];
+		nextVariable: for (LocalVariableBinding addition : additions) {
+			for (LocalVariableBinding existing : current) {
+				if (existing == addition)
+					continue nextVariable;
+			}
+			int oldLength = current.length;
+			System.arraycopy(current, 0, (current = new LocalVariableBinding[oldLength + 1]), 0, oldLength);
+			current[oldLength] = addition;
 		}
 	}
-	return current;
-}
-private LocalVariableBinding[] addPatternVariables(LocalVariableBinding[] current, LocalVariableBinding add) {
-	int oldSize = current.length;
-	// it's odd that we only look at the last element, but in most cases
-	// we will only have one in the array. In the unlikely case of having two
-	// distinct pattern variables, the cost is nothing but setting the same
-	// bit twice on the same object.
-	if (oldSize > 0 && current[oldSize - 1] == add) {
-		return current;
-	}
-	int newLength = current.length + 1;
-	System.arraycopy(current, 0, (current = new LocalVariableBinding[newLength]), 0, oldSize);
-	current[oldSize] = add;
 	return current;
 }
 public void promotePatternVariablesIfApplicable(LocalVariableBinding[] patternVariablesInScope, BooleanSupplier condition) {
@@ -583,3 +574,4 @@ protected MethodBinding findConstructorBinding(BlockScope scope, Invocation site
 	return resolvePolyExpressionArguments(site, ctorBinding, argumentTypes, scope);
 }
 }
+

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PatternMatching16Test.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PatternMatching16Test.java
@@ -4307,4 +4307,44 @@ public class PatternMatching16Test extends AbstractRegressionTest {
 				},
 				"test");
 	}
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1485
+	// ECJ hangs when pattern matching code is used in a nested conditional expression.
+	public void testGHI1485() {
+
+		runConformTest(
+				new String[] {
+						"X.java",
+						"""
+						public class X {
+						    static class PvsVariable {
+						    }
+
+						    static class PvsVariableNext_1 extends PvsVariable {
+						    }
+
+						    static class PvsVariableNext_2 extends PvsVariableNext_1 {
+						    }
+
+						    static class PvsVariableNext_3 extends PvsVariableNext_2 {
+						    }
+
+						    static class PvsVariableNext_4 extends PvsVariableNext_3 {
+						    }
+
+						    public static void main(String[] args) {
+						        final var pvsVariable = new PvsVariableNext_3();
+						        final Object origVar =
+						                pvsVariable instanceof PvsVariableNext_1 var_first
+						                    ? "PvsVariableNext_1"
+						                    : (pvsVariable instanceof PvsVariableNext_2 var_second &&
+						                       pvsVariable instanceof PvsVariableNext_3 var_three &&
+						                       true) ? "PvsVariableNext_2 && PvsVariableNext_3"
+						                                : "None";
+						        System.out.println(origVar);
+						    }
+						}
+						""",
+				},
+				"PvsVariableNext_1");
+	}
 }


### PR DESCRIPTION

## What it does
Maintain pattern variables array with "setness" to avoid runaway growth due to duplications
Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1485

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
