### PR TITLE
NullReferenceTest.testGH1667() test fails in 1.3/1.4 compliance levels

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullReferenceTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullReferenceTest.java
@@ -71,7 +71,7 @@ public NullReferenceTest(String name) {
 // Only the highest compliance level is run; add the VM argument
 // -Dcompliance=1.4 (for example) to lower it if needed
 static {
-//		TESTS_NAMES = new String[] { "testBug542707_1" };
+		TESTS_NAMES = new String[] { "testGH1667" };
 //		TESTS_NAMES = new String[] { "testBug384380" };
 //		TESTS_NAMES = new String[] { "testBug384380_b" };
 //		TESTS_NAMES = new String[] { "testBug321926a2" };
@@ -18540,6 +18540,8 @@ public void testGH1642_a() {
 			"""});
 }
 public void testGH1667() {
+	if (this.complianceLevel < ClassFileConstants.JDK1_5)
+		return; // uses foreach
 	runConformTest(
 		new String[] {
 			"Foo.java",

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullReferenceTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullReferenceTest.java
@@ -71,7 +71,7 @@ public NullReferenceTest(String name) {
 // Only the highest compliance level is run; add the VM argument
 // -Dcompliance=1.4 (for example) to lower it if needed
 static {
-		TESTS_NAMES = new String[] { "testGH1667" };
+//		TESTS_NAMES = new String[] { "testBug542707_1" };
 //		TESTS_NAMES = new String[] { "testBug384380" };
 //		TESTS_NAMES = new String[] { "testBug384380_b" };
 //		TESTS_NAMES = new String[] { "testBug321926a2" };


### PR DESCRIPTION

## What it does

 As test uses foreach loop, skip compliance levels below 1.5

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
