### PR TITLE
[switch] Code generated for statement switch doesn't throw MatchException where it should

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
@@ -866,8 +866,8 @@ public class SwitchStatement extends Expression {
 					generateCodePatternCaseEpilogue(codeStream, typeSwitchIndex, caseStatement);
 				}
 			}
-			boolean enumInSwitchExpression =  resolvedType1.isEnum() && this instanceof SwitchExpression;
-			boolean isEnumSwitchWithoutDefaultCase = this.defaultCase == null && enumInSwitchExpression;
+
+			boolean isEnumSwitchWithoutDefaultCase = this.defaultCase == null && resolvedType1.isEnum() && (this instanceof SwitchExpression || this.containsNull);
 			CompilerOptions compilerOptions = this.scope != null ? this.scope.compilerOptions() : null;
 			boolean isPatternSwitchSealedWithoutDefaultCase = this.defaultCase == null
 							&& compilerOptions != null
@@ -925,7 +925,7 @@ public class SwitchStatement extends Expression {
 			}
 			// place the trailing labels (for break and default case)
 			this.breakLabel.place();
-			if (this.defaultCase == null && !(enumInSwitchExpression
+			if (this.defaultCase == null && !(isEnumSwitchWithoutDefaultCase
 					|| isPatternSwitchSealedWithoutDefaultCase
 					|| isRecordPatternSwitchWithoutDefault)) {
 				// we want to force an line number entry to get an end position after the switch statement
@@ -940,7 +940,7 @@ public class SwitchStatement extends Expression {
 				boolean optimizedGoto = codeStream.lastAbruptCompletion == -1;
 				// if the last bytecode was an optimized goto (value is already on the stack) or an enum switch without default case, then we need to adjust the
 				// stack depth to reflect the fact that there is an value on the stack (return type of the switch expression)
-				codeStream.recordExpressionType(switchResolveType, optimizedGoto ? 0 : 1, optimizedGoto || isEnumSwitchWithoutDefaultCase);
+				codeStream.recordExpressionType(switchResolveType, optimizedGoto ? 0 : 1, optimizedGoto || (isEnumSwitchWithoutDefaultCase && this instanceof SwitchExpression));
 			}
 			codeStream.recordPositionsFrom(pc, this.sourceStart);
 		} finally {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/BatchCompilerTest_21.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/BatchCompilerTest_21.java
@@ -1,0 +1,185 @@
+/*******************************************************************************
+* Copyright (c) 2023 Advantest Europe GmbH and others.
+*
+* This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Srikanth Sankaran - initial implementation
+*******************************************************************************/
+package org.eclipse.jdt.core.tests.compiler.regression;
+
+import java.io.File;
+
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.tests.util.Util;
+import junit.framework.Test;
+
+public class BatchCompilerTest_21 extends AbstractBatchCompilerTest {
+
+	/**
+	 * This test suite only needs to be run on one compliance.
+	 *
+	 * @see TestAll
+	 */
+	public static Test suite() {
+		return buildMinimalComplianceTestSuite(testClass(), F_21);
+	}
+
+	public static Class<BatchCompilerTest_21> testClass() {
+		return BatchCompilerTest_21.class;
+	}
+
+	public BatchCompilerTest_21(String name) {
+		super(name);
+	}
+
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1774
+	// [switch] Code generated for statement switch doesn't handle MatchException
+	public void testGHI1774_Expression() throws Exception {
+
+		String path = LIB_DIR;
+		String libPath = null;
+		if (path.endsWith(File.separator)) {
+			libPath = path + "lib.jar";
+		} else {
+			libPath = path + File.separator + "lib.jar";
+		}
+		Util.createJar(new String[] {
+			"p/Color.java",
+			"package p;\n" +
+			"public enum Color {\n" +
+			"	R, Y;\n" +
+			"	public static Color getColor() {\n" +
+			"		return R;\n" +
+			"	}\n" +
+			"}",
+		},
+		libPath,
+		JavaCore.VERSION_20);
+		this.runConformTest(
+			new String[] {
+				"src/p/X.java",
+				"package p;\n"
+				+ "import p.Color;\n"
+				+ "public class X {\n"
+				+ "	public static void main(String argv[]) {\n"
+				+ "		Color c = Color.getColor();\n"
+				+ "		try {\n"
+				+ "			int a = switch (c) {\n"
+				+ "             case null -> 0;\n"
+				+ "				case R -> 1;\n"
+				+ "				case Y -> 2;\n"
+				+ "			};\n"
+				+ "		} catch (MatchException e) {\n"
+				+ "			System.out.print(\"OK\");\n"
+				+ "		} catch (Exception e) {\n"
+				+ "			System.out.print(\"NOT OK: \" + e);\n"
+				+ "		}\n"
+				+ "			System.out.print(\"END\");\n"
+				+ "	}\n"
+				+ "}",
+			},
+			"\"" + OUTPUT_DIR +  File.separator + "src/p/X.java\""
+			+ " -cp \"" + LIB_DIR + File.separator + "lib.jar\""
+			+ " -sourcepath \"" + OUTPUT_DIR +  File.separator + "src\""
+			+ " -source 21 -warn:none"
+			+ " -d \"" + OUTPUT_DIR + File.separator + "bin\" ",
+			"",
+			"",
+			true);
+		this.verifier.execute("p.X", new String[] {OUTPUT_DIR + File.separator + "bin", libPath}, new String[0], new String[] {"--enable-preview"});
+		assertEquals("Incorrect output", "END", this.verifier.getExecutionOutput());
+		Util.createJar(new String[] {
+				"p/Color.java",
+				"package p;\n" +
+				"public enum Color {\n" +
+				"	R, Y, B;\n" +
+				"	public static Color getColor() {\n" +
+				"		return B;\n" +
+				"	}\n" +
+				"}",
+			},
+			libPath,
+			JavaCore.VERSION_20);
+		this.verifier.execute("p.X", new String[] {OUTPUT_DIR + File.separator + "bin", libPath}, new String[0], new String[] {"--enable-preview"});
+		assertEquals("Incorrect output", "OKEND", this.verifier.getExecutionOutput());
+	}
+
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1774
+	// [switch] Code generated for statement switch doesn't handle MatchException
+	public void testGHI1774_Statement() throws Exception {
+
+		String path = LIB_DIR;
+		String libPath = null;
+		if (path.endsWith(File.separator)) {
+			libPath = path + "lib.jar";
+		} else {
+			libPath = path + File.separator + "lib.jar";
+		}
+		Util.createJar(new String[] {
+			"p/Color.java",
+			"package p;\n" +
+			"public enum Color {\n" +
+			"	R, Y;\n" +
+			"	public static Color getColor() {\n" +
+			"		return R;\n" +
+			"	}\n" +
+			"}",
+		},
+		libPath,
+		JavaCore.VERSION_20);
+		this.runConformTest(
+			new String[] {
+				"src/p/X.java",
+				"package p;\n"
+				+ "import p.Color;\n"
+				+ "public class X {\n"
+				+ "	public static void main(String argv[]) {\n"
+				+ "		Color c = Color.getColor();\n"
+				+ "		try {\n"
+				+ "			switch (c) {\n"
+				+ "             case null -> System.out.println(\"Null\");\n"
+				+ "				case R -> System.out.print(\"R\");\n"
+				+ "				case Y -> System.out.println(\"Y\");\n"
+				+ "			};\n"
+				+ "		} catch (MatchException e) {\n"
+				+ "			System.out.print(\"OK!\");\n"
+				+ "		} catch (Exception e) {\n"
+				+ "			System.out.print(\"NOT OK: \" + e);\n"
+				+ "		}\n"
+				+ "			System.out.print(\"END\");\n"
+				+ "	}\n"
+				+ "}",
+			},
+			"\"" + OUTPUT_DIR +  File.separator + "src/p/X.java\""
+			+ " -cp \"" + LIB_DIR + File.separator + "lib.jar\""
+			+ " -sourcepath \"" + OUTPUT_DIR +  File.separator + "src\""
+			+ " -source 21 -warn:none"
+			+ " -d \"" + OUTPUT_DIR + File.separator + "bin\" ",
+			"",
+			"",
+			true);
+		this.verifier.execute("p.X", new String[] {OUTPUT_DIR + File.separator + "bin", libPath}, new String[0], new String[0]);
+		assertEquals("Incorrect output", "REND", this.verifier.getExecutionOutput());
+		Util.createJar(new String[] {
+				"p/Color.java",
+				"package p;\n" +
+				"public enum Color {\n" +
+				"	R, Y, B;\n" +
+				"	public static Color getColor() {\n" +
+				"		return B;\n" +
+				"	}\n" +
+				"}",
+			},
+			libPath,
+			JavaCore.VERSION_20);
+		this.verifier.execute("p.X", new String[] {OUTPUT_DIR + File.separator + "bin", libPath}, new String[0], new String[0]);
+		assertEquals("Incorrect output", "OK!END", this.verifier.getExecutionOutput());
+	}
+
+}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TestAll.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TestAll.java
@@ -237,6 +237,7 @@ public static Test suite() {
 //	 since_21.add(UnnammedPatternsAndVarsTest.class); Enable after implementation.
 	 since_21.add(NullAnnotationTests21.class);
 	 since_21.add(StringTemplateTest.class);
+	 since_21.add(BatchCompilerTest_21.class);
 
 	 // Build final test suite
 	TestSuite all = new TestSuite(TestAll.class.getName());


### PR DESCRIPTION
## What it does

Arrange to throw MatchException as needed for the indy enumSwitch path
Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1774


## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
