### PR TITLE
Touch bundles affected by changed compiler generation for switch

### DIFF
--- a/org.eclipse.jdt.core/forceQualifierUpdate.txt
+++ b/org.eclipse.jdt.core/forceQualifierUpdate.txt
@@ -12,3 +12,4 @@ Bug 566471 - I20200828-0150 - Comparator Errors Found
 Bug 573283 - don't include javax15api.jar in jdt binaries
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1686


### PR DESCRIPTION
See https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1686
