### PR TITLE
For classic string switch, emitted code wastes two local variable slots

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
@@ -1583,7 +1583,7 @@ public class SwitchStatement extends Expression {
 		TypeBinding eType = this.expression != null ? this.expression.resolvedType : null;
 		if (eType == null)
 			return false;
-		return !(eType.isPrimitiveOrBoxedPrimitiveType() || eType.isEnum());
+		return !(eType.isPrimitiveOrBoxedPrimitiveType() || eType.isEnum() || eType.id == TypeIds.T_JavaLangString); // classic selectors
 	}
 	private void addSecretPatternSwitchVariables(BlockScope upperScope) {
 		if (needPatternDispatchCopy()) {


### PR DESCRIPTION
## What it does

Ensure that we don't create needless secret variables for classic string switch
Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1782

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
