### PR TITLE
Start position and length of Dimension node lost when cloned

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTTest.java
@@ -9575,5 +9575,19 @@ public class ASTTest extends org.eclipse.jdt.core.tests.junit.extension.TestCase
 		AST a = new AST(options);
 		assertEquals("Incorrect ast mapping", a.apiLevel(), AST.getJLSLatest());
 	}
+
+	@SuppressWarnings("deprecation")
+	public void testDimension() {
+		// Introduced with JSL8
+		if (this.ast.apiLevel() < AST.JLS8) {
+			return;
+		}
+		Dimension dimension = this.ast.newDimension();
+		dimension.setSourceRange(1, 2);
+
+		Dimension copy = (Dimension) ASTNode.copySubtree(this.ast, dimension);
+		assertEquals(copy.getStartPosition(), 1);
+		assertEquals(copy.getLength(), 2);
+	}
 }
 

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/Dimension.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/Dimension.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2014 IBM Corporation and others.
+ * Copyright (c) 2013, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -114,6 +114,7 @@ public class Dimension extends ASTNode {
 	@Override
 	ASTNode clone0(AST target) {
 		Dimension result = new Dimension(target);
+		result.setSourceRange(getStartPosition(), getLength());
 		result.annotations().addAll(
 				ASTNode.copySubtrees(target, annotations()));
 		return result;


### PR DESCRIPTION
## What it does

When a Dimension node is cloned, the start position and length of the node needs to be explicitly set. Otherwise this information is lost.

## How to test

Execute ASTTest#testDimension().

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
