### PR TITLE
Bug 196547 - [formatter] Option to join or rewrap wrapped line comments

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/formatter/FormatterCommentsTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/formatter/FormatterCommentsTests.java
@@ -1404,4 +1404,81 @@ public void testSnippet06() {
 		"}"
 	);
 }
+public void testJoinLineComment01() {
+	this.formatterPrefs.join_line_comments = true;
+	String source =
+		"""
+		class A {
+		int a = 5; // one  two
+		            // three
+		}
+		""";
+	formatSource(source,
+		"""
+		class A {
+			int a = 5; // one two three
+		}
+		""");
+}
+public void testJoinLineComment02() {
+	this.formatterPrefs.join_line_comments = true;
+	String source =
+		"""
+		class A {
+		int a = 5; // one  two
+		// three
+		}
+		""";
+	formatSource(source,
+		"""
+		class A {
+			int a = 5; // one two
+		// three
+		}
+		""");
+}
+public void testJoinLineComment03() {
+	this.formatterPrefs.join_line_comments = true;
+	String source =
+		"""
+		class A {
+		 int a = 5; // one  two
+		 // three
+		}
+		""";
+	formatSource(source,
+		"""
+		class A {
+			int a = 5; // one two
+			// three
+		}
+		""");
+}
+public void testJoinLineComment04() {
+	this.formatterPrefs.join_line_comments = true;
+	String source =
+		"""
+		class A {
+			int a = 5; // one  two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen
+						// one  two three four five six seven
+						// eight nine ten eleven twelve
+						// thirteen fourteen fifteen sixteen
+						// seventeen eighteen nineteen
+						// one  two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen
+			// one  two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen
+		}
+		""";
+	formatSource(source,
+		"""
+		class A {
+			int a = 5; // one two three four five six seven eight nine ten eleven twelve thirteen
+						// fourteen fifteen sixteen seventeen eighteen nineteen one two three four five
+						// six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen
+						// seventeen eighteen nineteen one two three four five six seven eight nine ten
+						// eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen
+			// one two three four five six seven eight nine ten eleven twelve thirteen
+			// fourteen fifteen sixteen seventeen eighteen nineteen
+		}
+		""");
+}
 }

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/core/formatter/DefaultCodeFormatterConstants.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/core/formatter/DefaultCodeFormatterConstants.java
@@ -5272,6 +5272,16 @@ public class DefaultCodeFormatterConstants {
 	public static final String FORMATTER_JOIN_LINES_IN_COMMENTS = JavaCore.PLUGIN_ID + ".formatter.join_lines_in_comments";	//$NON-NLS-1$
 	/**
 	 * <pre>
+	 * FORMATTER / Option to specify whether the formatter can join consecutive line comments
+	 *     - option id:         "org.eclipse.jdt.core.formatter.join_line_comments"
+	 *     - possible values:   { TRUE, FALSE }
+	 *     - default:           FALSE
+	 * </pre>
+	 * @since 3.37
+	 */
+	public static final String FORMATTER_JOIN_LINE_COMMENTS = JavaCore.PLUGIN_ID + ".formatter.join_line_comments";	//$NON-NLS-1$
+	/**
+	 * <pre>
 	 * FORMATTER / Option to specify whether or not empty statement should be on a new line
 	 *     - option id:         "org.eclipse.jdt.core.formatter.put_empty_statement_on_new_line"
 	 *     - possible values:   { TRUE, FALSE }

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/CommentsPreparator.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/CommentsPreparator.java
@@ -204,10 +204,14 @@ public class CommentsPreparator extends ASTVisitor {
 
 		List<Token> structure = tokenizeLineComment(commentToken);
 		if (isContinuation) {
-			Token first = structure.get(0);
-			first.breakBefore();
-			first.setWrapPolicy(
-					new WrapPolicy(WrapMode.WHERE_NECESSARY, commentIndex - 1, this.lastLineCommentPosition));
+			if (this.options.join_line_comments) {
+				structure.remove(0);
+			} else {
+				Token first = structure.get(0);
+				first.breakBefore();
+				first.setWrapPolicy(
+						new WrapPolicy(WrapMode.WHERE_NECESSARY, commentIndex - 1, this.lastLineCommentPosition));
+			}
 
 			// merge previous and current line comment
 			Token previous = this.lastLineComment;

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/DefaultCodeFormatterOptions.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/DefaultCodeFormatterOptions.java
@@ -511,6 +511,7 @@ public class DefaultCodeFormatterOptions {
 	public int number_of_empty_lines_to_preserve;
 	public boolean join_wrapped_lines;
 	public boolean join_lines_in_comments;
+	public boolean join_line_comments;
 	public boolean put_empty_statement_on_new_line;
 	public int tab_size;
 	public int page_width;
@@ -945,6 +946,7 @@ public class DefaultCodeFormatterOptions {
 		options.put(DefaultCodeFormatterConstants.FORMATTER_NUMBER_OF_EMPTY_LINES_TO_PRESERVE, Integer.toString(this.number_of_empty_lines_to_preserve));
 		options.put(DefaultCodeFormatterConstants.FORMATTER_JOIN_WRAPPED_LINES, this.join_wrapped_lines ? DefaultCodeFormatterConstants.TRUE : DefaultCodeFormatterConstants.FALSE);
 		options.put(DefaultCodeFormatterConstants.FORMATTER_JOIN_LINES_IN_COMMENTS, this.join_lines_in_comments ? DefaultCodeFormatterConstants.TRUE : DefaultCodeFormatterConstants.FALSE);
+		options.put(DefaultCodeFormatterConstants.FORMATTER_JOIN_LINE_COMMENTS, this.join_line_comments ? DefaultCodeFormatterConstants.TRUE : DefaultCodeFormatterConstants.FALSE);
 		options.put(DefaultCodeFormatterConstants.FORMATTER_PUT_EMPTY_STATEMENT_ON_NEW_LINE, this.put_empty_statement_on_new_line ? DefaultCodeFormatterConstants.TRUE : DefaultCodeFormatterConstants.FALSE);
 		options.put(DefaultCodeFormatterConstants.FORMATTER_LINE_SPLIT, Integer.toString(this.page_width));
 		switch(this.tab_char) {
@@ -2514,6 +2516,8 @@ public class DefaultCodeFormatterOptions {
 		if (joinLinesInCommentsOption != null) {
 			this.join_lines_in_comments = DefaultCodeFormatterConstants.TRUE.equals(joinLinesInCommentsOption);
 		}
+		setBoolean(settings, DefaultCodeFormatterConstants.FORMATTER_JOIN_LINE_COMMENTS, DefaultCodeFormatterConstants.TRUE,
+				v -> this.join_line_comments = v);
 		final Object joinWrappedLinesOption = settings.get(DefaultCodeFormatterConstants.FORMATTER_JOIN_WRAPPED_LINES);
 		if (joinWrappedLinesOption != null) {
 			this.join_wrapped_lines = DefaultCodeFormatterConstants.TRUE.equals(joinWrappedLinesOption);
@@ -3333,6 +3337,7 @@ public class DefaultCodeFormatterOptions {
 		this.never_indent_line_comments_on_first_column = false;
 		this.number_of_empty_lines_to_preserve = 1;
 		this.join_lines_in_comments = true;
+		this.join_line_comments = false;
 		this.join_wrapped_lines = true;
 		this.put_empty_statement_on_new_line = false;
 		this.tab_size = 4;
@@ -3735,6 +3740,7 @@ public class DefaultCodeFormatterOptions {
 		this.never_indent_line_comments_on_first_column = false;
 		this.number_of_empty_lines_to_preserve = 1;
 		this.join_lines_in_comments = true;
+		this.join_line_comments = false;
 		this.join_wrapped_lines = true;
 		this.put_empty_statement_on_new_line = true;
 		this.tab_size = 8;


### PR DESCRIPTION
## What it does
Option to join line comments, as discussed in https://bugs.eclipse.org/bugs/show_bug.cgi?id=196547

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
