### PR TITLE
Removing type arguments reported to be redundant leads to type mismatch error

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ASTNode.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ASTNode.java
@@ -63,6 +63,7 @@ import org.eclipse.jdt.internal.compiler.lookup.AnnotationBinding;
 import org.eclipse.jdt.internal.compiler.lookup.ArrayBinding;
 import org.eclipse.jdt.internal.compiler.lookup.Binding;
 import org.eclipse.jdt.internal.compiler.lookup.BlockScope;
+import org.eclipse.jdt.internal.compiler.lookup.ClassScope;
 import org.eclipse.jdt.internal.compiler.lookup.ExtraCompilerModifiers;
 import org.eclipse.jdt.internal.compiler.lookup.FieldBinding;
 import org.eclipse.jdt.internal.compiler.lookup.InferenceContext18;
@@ -730,6 +731,16 @@ public abstract class ASTNode implements TypeConstants, TypeIds {
 	 * @return either the original method or a problem method
 	 */
 	public static MethodBinding resolvePolyExpressionArguments(Invocation invocation, MethodBinding method, TypeBinding[] argumentTypes, BlockScope scope) {
+		ClassScope cScope = scope.enclosingClassScope();
+		boolean resolvingPolyExpressionArguments = cScope.resolvingPolyExpressionArguments;
+		try {
+			cScope.resolvingPolyExpressionArguments = true;
+			return resolvePolyExpressionArguments0(invocation, method, argumentTypes, scope);
+		} finally {
+			cScope.resolvingPolyExpressionArguments = resolvingPolyExpressionArguments;
+		}
+	}
+	private static MethodBinding resolvePolyExpressionArguments0(Invocation invocation, MethodBinding method, TypeBinding[] argumentTypes, BlockScope scope) {
 		MethodBinding candidateMethod = method.isValidBinding() ? method : method instanceof ProblemMethodBinding ? ((ProblemMethodBinding) method).closestMatch : null;
 		if (candidateMethod == null)
 			return method;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AllocationExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AllocationExpression.java
@@ -662,6 +662,8 @@ public TypeBinding[] inferElidedTypes(ParameterizedTypeBinding parameterizedType
 }
 
 public void checkTypeArgumentRedundancy(ParameterizedTypeBinding allocationType, final BlockScope scope) {
+	if (scope.enclosingClassScope().resolvingPolyExpressionArguments) // express arguments may end up influencing the target type
+		return;                                                       // so, conservatively shut off diagnostic.
 	if ((scope.problemReporter().computeSeverity(IProblem.RedundantSpecificationOfTypeArguments) == ProblemSeverities.Ignore) || scope.compilerOptions().sourceLevel < ClassFileConstants.JDK1_7) return;
 	if (allocationType.arguments == null) return;  // raw binding
 	if (this.genericTypeArguments != null) return; // diamond can't occur with explicit type args for constructor

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ClassScope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ClassScope.java
@@ -67,6 +67,7 @@ public class ClassScope extends Scope {
 	public TypeDeclaration referenceContext;
 	public TypeReference superTypeReference;
 	java.util.ArrayList<TypeReference> deferredBoundChecks;
+	public boolean resolvingPolyExpressionArguments = false;
 
 	public ClassScope(Scope parent, TypeDeclaration context) {
 		super(Scope.CLASS_SCOPE, parent);

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_1_8.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_1_8.java
@@ -10543,4 +10543,59 @@ public void testBug508834_comment0() {
 				"""
 			});
 	}
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1794
+	// Remove redundant type arguments in lambda expressions leads to type mismatch error
+	public void testGH1794() {
+		Map customOptions = getCompilerOptions();
+		customOptions.put(CompilerOptions.OPTION_ReportRedundantSpecificationOfTypeArguments, CompilerOptions.ERROR);
+		runNegativeTest(
+			false /*skipJavac */,
+			JavacTestOptions.Excuse.EclipseWarningConfiguredAsError,
+			new String[] {
+				"TypeArgumentsTest.java",
+				"""
+				import java.util.ArrayList;
+				import java.util.List;
+				import java.util.stream.Collectors;
+
+				public class TypeArgumentsTest {
+					public static void main(String[] args) {
+						List<String> strings = List.of("string1", "string2");
+						ArrayList<ArrayList<String>> collectedStrings = strings.stream()
+								.map(s -> new ArrayList<String>())
+								.collect(Collectors.toCollection(() -> new ArrayList<>(strings.size())));
+						System.out.println(collectedStrings);
+					}
+				}
+				"""
+			},
+			"",
+			null, true, customOptions);
+	}
+	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=576002
+	// Mandatory Void Type gets eliminated
+	public void testBug576002() {
+		Map customOptions = getCompilerOptions();
+		customOptions.put(CompilerOptions.OPTION_ReportRedundantSpecificationOfTypeArguments, CompilerOptions.ERROR);
+		runNegativeTest(
+			false /*skipJavac */,
+			JavacTestOptions.Excuse.EclipseWarningConfiguredAsError,
+			new String[] {
+				"Test.java",
+				"""
+				import java.util.ArrayList;
+				import java.util.List;
+				import java.util.concurrent.FutureTask;
+				import java.util.stream.Collectors;
+
+				public class Test {
+					List<FutureTask<Void>> tasks = new ArrayList<>().stream().map(e -> new FutureTask<Void>(() -> {
+						return null;
+					})).collect(Collectors.toList());
+				}
+				"""
+			},
+			"",
+			null, true, customOptions);
+	}
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_1_8.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_1_8.java
@@ -10598,4 +10598,88 @@ public void testBug508834_comment0() {
 			"",
 			null, true, customOptions);
 	}
+	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=550864
+	// [1.8][inference] Removing "redundant" type argument results in compile error
+	public void testBug550864() {
+		Map customOptions = getCompilerOptions();
+		customOptions.put(CompilerOptions.OPTION_ReportRedundantSpecificationOfTypeArguments, CompilerOptions.ERROR);
+		runNegativeTest(
+			false /*skipJavac */,
+			JavacTestOptions.Excuse.EclipseWarningConfiguredAsError,
+			new String[] {
+				"TypeArgBug.java",
+				"""
+				import java.util.Comparator;
+				import java.util.List;
+
+				public class TypeArgBug {
+
+				  public static void main(String[] args) {
+
+				    // Allowed (with type specification in lambda)
+				    List<Order<Descriptor>> x = List.of(
+				      new Order<>(
+				        "best",
+				        Comparator.comparing((Item<Descriptor> item) -> ((Basket)item.getData()).getWeaveCount())
+				      )
+				    );
+
+				    // Allowed, but gives warning (redundant type argument for Order<Descriptor>)
+				    List<Order<Descriptor>> y = List.of(
+				      new Order<Descriptor>(
+				        "best",
+				        Comparator.comparing(item -> ((Basket)item.getData()).getWeaveCount())
+				      )
+				    );
+
+				    // Compiler error after removing redundant argument...
+				    List<Order<Descriptor>> z = List.of(
+				      new Order<>(
+				        "best",
+				        Comparator.comparing(item -> ((Basket)item.getData()).getWeaveCount())
+				      )
+				    );
+				  }
+
+				  public interface Descriptor {
+				  }
+
+				  public static class Order<T extends Descriptor> {
+				    public final String resourceKey;
+				    public final Comparator<Item<T>> comparator;
+
+				    public <G extends Comparable<G>> Order(String resourceKey, Comparator<Item<T>> comparator) {
+				      this.resourceKey = resourceKey;
+				      this.comparator = comparator;
+				    }
+				  }
+
+				  public static class Item<T extends Descriptor> {
+				    private final T data;
+
+				    public Item(T data) {
+				      this.data = data;
+				    }
+
+				    public T getData() {
+				      return data;
+				    }
+				  }
+
+				  public static class Basket implements Descriptor {
+				    public int getWeaveCount() {
+				      return 5;
+				    }
+				  }
+				}
+				"""
+			},
+			"----------\n" +
+			"1. ERROR in TypeArgBug.java (at line 18)\n" +
+			"	new Order<Descriptor>(\n" +
+			"	    ^^^^^\n" +
+			"Redundant specification of type arguments <TypeArgBug.Descriptor>\n" +
+			"----------\n",
+			null, true, customOptions);
+	}
 }


### PR DESCRIPTION

## What it does
Accommodate for express type arguments influencing the target type in the context where the enclosing expression occurs and conservatively skip the diagnosis.

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
