### PR TITLE
Parameters of compact canonical constructor are not marked as mandated

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ClassFile.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ClassFile.java
@@ -5179,7 +5179,10 @@ public class ClassFile implements TypeConstants, TypeIds {
 			for (int i = 0, max = targetParameters.length, argumentsLength = arguments != null ? arguments.length : 0; i < max; i++) {
 				if (argumentsLength > i && arguments[i] != null) {
 					Argument argument = arguments[i];
-					length = writeArgumentName(argument.name, argument.binding.modifiers, length);
+					int modifiers = argument.binding.modifiers;
+					if (binding.isCompactConstructor())
+						modifiers |= ClassFileConstants.AccMandated;
+					length = writeArgumentName(argument.name, modifiers, length);
 				} else {
 					length = writeArgumentName(null, ClassFileConstants.AccSynthetic, length);
 				}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordsRestrictedClassTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordsRestrictedClassTest.java
@@ -2138,8 +2138,8 @@ public void testBug560569_001() throws Exception {
 			"        [pc: 0, pc: 15] local: model index: 1 type: java.lang.String\n" +
 			"        [pc: 0, pc: 15] local: year index: 2 type: int\n" +
 			"      Method Parameters:\n" +
-			"        model\n" +
-			"        year\n" +
+			"        mandated model\n" +
+			"        mandated year\n" +
 			"  \n";
 	RecordsRestrictedClassTest.verifyClassFile(expectedOutput, "Car.class", ClassFileBytesDisassembler.SYSTEM);
 }
@@ -9683,5 +9683,28 @@ public void testIssue1641_006() {
 		true,
 		options
 	);
+}
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1806
+// Parameters of compact canonical constructor are not marked as mandated
+public void testGH1806() {
+	runConformTest(
+			new String[] {
+					"MyRecord.java",
+					"""
+					public record MyRecord(int a) {
+
+						public static void main(String[] args) {
+							var ctor = MyRecord.class.getConstructors()[0];
+							System.out.println(ctor.getParameters()[0].isImplicit());
+						}
+
+						public MyRecord {
+
+						}
+
+					}
+					"""
+			},
+		"true");
 }
 }


### PR DESCRIPTION


## What it does
Mark parameters of compact constructor as mandated



## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
