### PR TITLE
[formatter] Align arrows on column in switch statements/expressions

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/formatter/FormatterRegressionTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/formatter/FormatterRegressionTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -24,9 +24,7 @@ import java.util.Hashtable;
 import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
-
 import junit.framework.Test;
-
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspaceDescription;
 import org.eclipse.core.resources.IWorkspaceRoot;
@@ -16258,5 +16256,77 @@ public void testGH59() {
 		}
 		""");
 }
+/**
+ * https://github.com/eclipse-jdt/eclipse.jdt/pull/1817 - [formatter] Align arrows on column in switch statements/expressions
+ */
+public void testGH1817a() {
+	this.formatterPrefs.align_arrows_in_switch_on_columns = true;
+	String source =
+		"""
+		class A {
+			void foo(int i) {
+				switch(i){
+				case 0 -> theInt++;
+				case 1234567890 -> theInt--;
 
+				case theInt -> theInt = 0;
+				default -> theInt = -1;
+				}
+			}
+		}
+		""";
+	formatSource(source,
+		"""
+		class A {
+			void foo(int i) {
+				switch (i) {
+				case 0			-> theInt++;
+				case 1234567890	-> theInt--;
+
+				case theInt		-> theInt = 0;
+				default			-> theInt = -1;
+				}
+			}
+		}
+		""");
+}
+/**
+ * https://github.com/eclipse-jdt/eclipse.jdt/pull/1817 - [formatter] Align arrows on column in switch statements/expressions
+ */
+public void testGH1817b() {
+	setComplianceLevel(CompilerOptions.VERSION_14);
+	this.formatterPrefs.align_arrows_in_switch_on_columns = true;
+	this.formatterPrefs.align_fields_grouping_blank_lines = 1;
+	this.formatterPrefs.align_with_spaces = true;
+	String source =
+		"""
+		class A {
+			void foo(int i) {
+				int j = switch(i){
+				case 0 -> { yield theInt++; }
+				case 1234567890 -> theInt--;
+
+				case theInt -> theInt = 0;
+				default -> theInt = -1;
+				};
+			}
+		}
+		""";
+	formatSource(source,
+		"""
+		class A {
+			void foo(int i) {
+				int j = switch (i) {
+				case 0          -> {
+					yield theInt++;
+				}
+				case 1234567890 -> theInt--;
+
+				case theInt -> theInt = 0;
+				default     -> theInt = -1;
+				};
+			}
+		}
+		""");
+}
 }

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/core/formatter/DefaultCodeFormatterConstants.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/core/formatter/DefaultCodeFormatterConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -98,6 +98,19 @@ public class DefaultCodeFormatterConstants {
 	 * @since 3.15
 	 */
 	public static final String FORMATTER_ALIGN_ASSIGNMENT_STATEMENTS_ON_COLUMNS = JavaCore.PLUGIN_ID + ".formatter.align_assignment_statements_on_columns";	 //$NON-NLS-1$
+
+	/**
+	 * <pre>
+	 * FORMATTER / Option to align arrows in switch on column
+	 *     - option id:         "org.eclipse.jdt.core.formatter.align_arrows_in_switch_on_columns"
+	 *     - possible values:   { TRUE, FALSE }
+	 *     - default:           FALSE
+	 * </pre>
+	 * @see #TRUE
+	 * @see #FALSE
+	 * @since 3.37
+	 */
+	public static final String FORMATTER_ALIGN_ARROWS_IN_SWITCH_ON_COLUMNS = JavaCore.PLUGIN_ID + ".formatter.align_arrows_in_switch_on_columns";	 //$NON-NLS-1$
 
 	/**
 	 * <pre>

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/DefaultCodeFormatterOptions.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/DefaultCodeFormatterOptions.java
@@ -177,6 +177,7 @@ public class DefaultCodeFormatterOptions {
 	public boolean align_type_members_on_columns;
 	public boolean align_variable_declarations_on_columns;
 	public boolean align_assignment_statements_on_columns;
+	public boolean align_arrows_in_switch_on_columns;
 	public boolean align_with_spaces;
 	public int align_fields_grouping_blank_lines;
 
@@ -628,6 +629,7 @@ public class DefaultCodeFormatterOptions {
 		options.put(DefaultCodeFormatterConstants.FORMATTER_ALIGN_TYPE_MEMBERS_ON_COLUMNS, this.align_type_members_on_columns ? DefaultCodeFormatterConstants.TRUE : DefaultCodeFormatterConstants.FALSE);
 		options.put(DefaultCodeFormatterConstants.FORMATTER_ALIGN_VARIABLE_DECLARATIONS_ON_COLUMNS, this.align_variable_declarations_on_columns ? DefaultCodeFormatterConstants.TRUE : DefaultCodeFormatterConstants.FALSE);
 		options.put(DefaultCodeFormatterConstants.FORMATTER_ALIGN_ASSIGNMENT_STATEMENTS_ON_COLUMNS, this.align_assignment_statements_on_columns ? DefaultCodeFormatterConstants.TRUE : DefaultCodeFormatterConstants.FALSE);
+		options.put(DefaultCodeFormatterConstants.FORMATTER_ALIGN_ARROWS_IN_SWITCH_ON_COLUMNS, this.align_arrows_in_switch_on_columns ? DefaultCodeFormatterConstants.TRUE : DefaultCodeFormatterConstants.FALSE);
 		options.put(DefaultCodeFormatterConstants.FORMATTER_ALIGN_FIELDS_GROUPING_BLANK_LINES, Integer.toString(this.align_fields_grouping_blank_lines));
 		options.put(DefaultCodeFormatterConstants.FORMATTER_ALIGN_WITH_SPACES, this.align_with_spaces ? DefaultCodeFormatterConstants.TRUE : DefaultCodeFormatterConstants.FALSE);
 		options.put(DefaultCodeFormatterConstants.FORMATTER_BRACE_POSITION_FOR_ANNOTATION_TYPE_DECLARATION, this.brace_position_for_annotation_type_declaration);
@@ -1270,6 +1272,8 @@ public class DefaultCodeFormatterOptions {
 		if (alignAssignmentStatementsOnColumnsOption != null) {
 			this.align_assignment_statements_on_columns = DefaultCodeFormatterConstants.TRUE.equals(alignAssignmentStatementsOnColumnsOption);
 		}
+		setBoolean(settings, DefaultCodeFormatterConstants.FORMATTER_ALIGN_ARROWS_IN_SWITCH_ON_COLUMNS, DefaultCodeFormatterConstants.TRUE,
+				v -> this.align_arrows_in_switch_on_columns = v);
 		final Object alignGroupSepartionBlankLinesOption = settings.get(DefaultCodeFormatterConstants.FORMATTER_ALIGN_FIELDS_GROUPING_BLANK_LINES);
 		if (alignTypeMembersOnColumnsOption != null) {
 			try {
@@ -3023,6 +3027,7 @@ public class DefaultCodeFormatterOptions {
 		this.align_type_members_on_columns = false;
 		this.align_variable_declarations_on_columns = false;
 		this.align_assignment_statements_on_columns = false;
+		this.align_arrows_in_switch_on_columns = false;
 		this.align_with_spaces = false;
 		this.align_fields_grouping_blank_lines = Integer.MAX_VALUE;
 		this.brace_position_for_annotation_type_declaration = DefaultCodeFormatterConstants.END_OF_LINE;
@@ -3426,6 +3431,7 @@ public class DefaultCodeFormatterOptions {
 		this.align_type_members_on_columns = false;
 		this.align_variable_declarations_on_columns = false;
 		this.align_assignment_statements_on_columns = false;
+		this.align_arrows_in_switch_on_columns = false;
 		this.align_with_spaces = false;
 		this.align_fields_grouping_blank_lines = Integer.MAX_VALUE;
 		this.brace_position_for_annotation_type_declaration = DefaultCodeFormatterConstants.END_OF_LINE;

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/linewrap/WrapPreparator.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/linewrap/WrapPreparator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2023 Mateusz Matela and others.
+ * Copyright (c) 2014, 2024 Mateusz Matela and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -1150,6 +1150,7 @@ public class WrapPreparator extends ASTVisitor {
 		int rParen = this.tm.firstIndexAfter(node.getExpression(), TokenNameRPAREN);
 		handleParenthesesPositions(lParen, rParen, this.options.parenthesis_positions_in_switch_statement);
 		handleOneLineEnforcedSwitchCases(node, node.statements());
+		this.aligner.handleCaseStatementsAlign(node.statements());
 		return true;
 	}
 
@@ -1163,6 +1164,7 @@ public class WrapPreparator extends ASTVisitor {
 		List<Statement> caseStatements = statements.stream().filter(SwitchCase.class::isInstance).collect(toList());
 		handleOneLineEnforced(node, caseStatements);
 		handleOneLineEnforcedSwitchCases(node, statements);
+		this.aligner.handleCaseStatementsAlign(statements);
 		return true;
 	}
 


### PR DESCRIPTION
## What it does
Adds a new setting to align arrows on column in switch statements/expressions.

## How to test
Unit tests included

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
