### PR TITLE
Touch test bundle affected by TypeHierarchy code change

### DIFF
--- a/org.eclipse.jdt.core.tests.model/forceQualifierUpdate.txt
+++ b/org.eclipse.jdt.core.tests.model/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 489604 - should not override <timestampProvider>
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1704


### PR DESCRIPTION
See https://github.com/eclipse-jdt/eclipse.jdt.core/pull/1783 
See https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1704
