### PR TITLE
[performance] O(n) StringLiteral concatenation

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/CompilationUnitDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/CompilationUnitDeclaration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -712,7 +712,7 @@ private void reportNLSProblems() {
 			int i = 0;
 			stringLiteralsLoop: for (; i < stringLiteralsLength; i++) {
 				literal = this.stringLiterals[i];
-				final int literalLineNumber = literal instanceof TextBlock ? ((TextBlock)literal).endLineNumber : literal.lineNumber;
+				final int literalLineNumber = literal instanceof TextBlock ? ((TextBlock)literal).endLineNumber : literal.getLineNumber();
 				if (lastLineNumber != literalLineNumber) {
 					indexInLine = 1;
 					lastLineNumber = literalLineNumber;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ExtendedStringLiteral.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ExtendedStringLiteral.java
@@ -18,68 +18,17 @@ import org.eclipse.jdt.internal.compiler.lookup.BlockScope;
 
 public class ExtendedStringLiteral extends StringLiteral {
 
-	/**
-	 *  Build a string+char literal
-	 */
-	public ExtendedStringLiteral(StringLiteral str, CharLiteral character) {
-
-		super(str.source, str.sourceStart, str.sourceEnd, str.lineNumber);
-		extendWith(character);
-	}
-
-	/**
-	 * Build a two-strings literal
-	 * */
-	public ExtendedStringLiteral(StringLiteral str1, StringLiteral str2) {
-
-		super(str1.source, str1.sourceStart, str1.sourceEnd, str1.lineNumber);
-		extendWith(str2);
-	}
-
-	/**
-	 * Add the lit source to mine, just as if it was mine
-	 */
-	@Override
-	public ExtendedStringLiteral extendWith(CharLiteral lit) {
-
-		//update the source
-		int length = this.source.length;
-		System.arraycopy(this.source, 0, (this.source = new char[length + 1]), 0, length);
-		this.source[length] = lit.value;
-		//position at the end of all literals
-		this.sourceEnd = lit.sourceEnd;
-		return this;
-	}
-
-	/**
-	 *  Add the lit source to mine, just as if it was mine
-	 */
-	@Override
-	public ExtendedStringLiteral extendWith(StringLiteral lit) {
-
-		//uddate the source
-		int length = this.source.length;
-		System.arraycopy(
-			this.source,
-			0,
-			this.source = new char[length + lit.source.length],
-			0,
-			length);
-		System.arraycopy(lit.source, 0, this.source, length, lit.source.length);
-		//position at the end of all literals
-		this.sourceEnd = lit.sourceEnd;
-		return this;
+	public ExtendedStringLiteral(char[] token, int start, int end, int lineNumber) {
+		super(token, start, end, lineNumber);
 	}
 
 	@Override
 	public StringBuilder printExpression(int indent, StringBuilder output) {
-
-		return output.append("ExtendedStringLiteral{").append(this.source).append('}'); //$NON-NLS-1$
+		return output.append("ExtendedStringLiteral{").append(this.source()).append('}'); //$NON-NLS-1$
 	}
 
 	@Override
 	public void traverse(ASTVisitor visitor, BlockScope scope) {
-
 		visitor.visit(this, scope);
 		visitor.endVisit(this, scope);
 	}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ExtendedStringLiteral.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ExtendedStringLiteral.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2009 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -18,8 +18,8 @@ import org.eclipse.jdt.internal.compiler.lookup.BlockScope;
 
 public class ExtendedStringLiteral extends StringLiteral {
 
-	public ExtendedStringLiteral(char[] token, int start, int end, int lineNumber) {
-		super(token, start, end, lineNumber);
+	protected ExtendedStringLiteral(StringLiteral optionalHead, Object sourcesTail, int start, int end, int lineNumber) {
+		super(optionalHead, sourcesTail, start,  end,  lineNumber);
 	}
 
 	@Override

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/StringTemplate.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/StringTemplate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2023 IBM Corporation and others.
+ * Copyright (c) 2023, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -100,7 +100,7 @@ public class StringTemplate extends Expression {
 		if (this.isMultiline)
 			output.append("\"\"\n"); //$NON-NLS-1$
 		for (int i = 0; i < length; i++) {
-			char[] source = this.fragments[i].source;
+			char[] source = this.fragments[i].source();
 			for (int j = 0; j < source.length; j++) {
 				Util.appendEscapedChar(output, source[j], true);
 			}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TextBlock.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TextBlock.java
@@ -300,8 +300,8 @@ public class TextBlock extends StringLiteral {
 	@Override
 	public StringBuilder printExpression(int indent, StringBuilder output) {
 		output.append("\"\"\"\n"); //$NON-NLS-1$
-		for (int i = 0; i < this.source.length; i++) {
-			Util.appendEscapedChar(output, this.source[i], true);
+		for (char c:this.source()) {
+			Util.appendEscapedChar(output, c, true);
 		}
 		output.append("\"\"\""); //$NON-NLS-1$
 		return output;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypeDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypeDeclaration.java
@@ -1012,7 +1012,7 @@ private void addJUnitMethodSourceValues(SimpleSetOfCharArray junitMethodSourceVa
 
 private char[] getValueAsChars(Expression value) {
 	if (value instanceof StringLiteral) { // e.g. "someMethod"
-		return ((StringLiteral) value).source;
+		return ((StringLiteral) value).source();
 	} else if (value.constant instanceof StringConstant) { // e.g. SOME_CONSTANT + "value"
 		return ((StringConstant) value.constant).stringValue().toCharArray();
 	}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
@@ -10026,7 +10026,7 @@ protected void consumeTemplate(int token) {
 			StringLiteral literal = fragments[index];
 			char[][] lines = TextBlock.convertTextBlockToLines(fragments[index].source());
 			char[] formattedText = TextBlock.formatTextBlock(lines, textBlockIndent, index > 0, index+1 < fragments.length);
-			literal.source = formattedText;
+			literal.setSource(formattedText);
 		}
 	}
 	//	get rid of all the cached values

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/parser/StringLiteralTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/parser/StringLiteralTest.java
@@ -1,0 +1,51 @@
+package org.eclipse.jdt.core.tests.compiler.parser;
+
+import java.util.List;
+
+import org.eclipse.jdt.internal.compiler.ast.CharLiteral;
+import org.eclipse.jdt.internal.compiler.ast.ExtendedStringLiteral;
+import org.eclipse.jdt.internal.compiler.ast.StringLiteral;
+import org.eclipse.jdt.internal.compiler.ast.StringLiteralConcatenation;
+
+import junit.framework.TestCase;
+
+public class StringLiteralTest extends TestCase {
+	public void testAppend() {
+		StringLiteral l1 = new StringLiteral(new char[] { 'a' }, 2, 3, 4);
+		StringLiteral l2 = new StringLiteral(new char[] { 'b' }, 5, 6, 7);
+		StringLiteral l3 = new StringLiteral(new char[] { 'c' }, 8, 9, 10);
+		ExtendedStringLiteral extendWithString = l1.extendWith(l2).extendWith(l3);
+		ExtendedStringLiteral extendWithString2 = l1.extendWith(l2.extendWith(l3));
+		StringLiteralConcatenation extendsWithString = l1.extendsWith(l2).extendsWith(l3);
+		StringLiteralConcatenation extendsWithString23 = l2.extendsWith(l3);
+		StringLiteralConcatenation extendsWithString3 = l1.extendsWith(extendsWithString23);
+		ExtendedStringLiteral extendWithChar = l1.extendWith(new CharLiteral("'\\n'".toCharArray(), 5, 6))
+				.extendWith(new CharLiteral("'\\t'".toCharArray(), 8, 9));
+		List<StringLiteral> allLiterals = List.of(extendWithString, extendWithString2, extendsWithString, extendsWithString3);
+		for (StringLiteral l : allLiterals) {
+			String expected = (l == extendWithChar) ? "a\n\t" : "abc";
+			assertEquals(expected, new String(l.source()));
+			assertEquals(2, l.sourceStart);
+			assertEquals(9, l.sourceEnd);
+			assertEquals(4 - 1, l.getLineNumber());
+			l.computeConstant();
+			assertEquals(expected, l.constant.stringValue());
+		}
+
+		StringLiteralConcatenation extendsWithString2 = l1.extendsWith(l2);
+		StringLiteral[] literals2 = extendsWithString2.getLiterals();
+		assertEquals(2, literals2.length);
+		assertEquals(l1, literals2[0]);
+		assertEquals(l2, literals2[1]);
+		StringLiteral[] literals = extendsWithString.getLiterals();
+		assertEquals(3, literals.length);
+		assertEquals(l1, literals[0]);
+		assertEquals(l2, literals[1]);
+		assertEquals(l3, literals[2]);
+		StringLiteral[] literals3 = extendsWithString3.getLiterals();
+		// undocumented why extendsWith(StringLiteralConcatenation) does not flatten the StringLiteralConcatenation - just keep it as is:
+		assertEquals(2, literals3.length);
+		assertEquals(l1, literals3[0]);
+		assertEquals(extendsWithString23, literals3[1]);
+	}
+}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/parser/TestAll.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/parser/TestAll.java
@@ -54,7 +54,7 @@ public TestAll(String testName) {
 
 public static TestSuite getTestSuite(boolean addComplianceDiagnoseTest) {
 	ArrayList testClasses = new ArrayList();
-
+	testClasses.add(StringLiteralTest.class);
 	/* completion tests */
 	testClasses.addAll(RunCompletionParserTests.TEST_CLASSES);
 

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterTestAST3_2.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterTestAST3_2.java
@@ -20,8 +20,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import junit.framework.Test;
-
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.jdt.core.Flags;
@@ -114,6 +112,8 @@ import org.eclipse.jdt.core.tests.model.CancelCounter;
 import org.eclipse.jdt.core.tests.model.Canceler;
 import org.eclipse.jdt.core.tests.model.ReconcilerTests;
 import org.eclipse.jdt.core.tests.util.Util;
+
+import junit.framework.Test;
 
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class ASTConverterTestAST3_2 extends ConverterTestSetup {
@@ -5271,7 +5271,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	}
 
 	/**
-	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=70398
+	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=76277
 	 */
 	public void test0570() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0570", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterTestAST4_2.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterTestAST4_2.java
@@ -21,8 +21,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import junit.framework.Test;
-
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.jdt.core.Flags;
@@ -111,6 +109,8 @@ import org.eclipse.jdt.core.tests.model.CancelCounter;
 import org.eclipse.jdt.core.tests.model.Canceler;
 import org.eclipse.jdt.core.tests.model.ReconcilerTests;
 import org.eclipse.jdt.core.tests.util.Util;
+
+import junit.framework.Test;
 
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class ASTConverterTestAST4_2 extends ConverterTestSetup {
@@ -5268,7 +5268,7 @@ public class ASTConverterTestAST4_2 extends ConverterTestSetup {
 	}
 
 	/**
-	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=70398
+	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=76277
 	 */
 	public void test0570() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0570", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterTestAST8_2.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterTestAST8_2.java
@@ -21,8 +21,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import junit.framework.Test;
-
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.jdt.core.Flags;
@@ -112,6 +110,8 @@ import org.eclipse.jdt.core.tests.model.CancelCounter;
 import org.eclipse.jdt.core.tests.model.Canceler;
 import org.eclipse.jdt.core.tests.model.ReconcilerTests;
 import org.eclipse.jdt.core.tests.util.Util;
+
+import junit.framework.Test;
 
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class ASTConverterTestAST8_2 extends ConverterTestSetup {
@@ -5298,7 +5298,7 @@ public class ASTConverterTestAST8_2 extends ConverterTestSetup {
 	}
 
 	/**
-	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=70398
+	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=76277
 	 */
 	public void test0570() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0570", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnStringLiteral.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnStringLiteral.java
@@ -45,11 +45,6 @@ public class CompletionOnStringLiteral extends StringLiteral implements Completi
 		this.contentEnd = ce;
 	}
 
-	public CompletionOnStringLiteral(int s, int e, int cs, int ce) {
-		super(s,e);
-		this.contentStart = cs;
-		this.contentEnd = ce;
-	}
 	@Override
 	public TypeBinding resolveType(ClassScope scope) {
 		throw new CompletionNodeFound(this, null, scope);

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ASTConverter.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ASTConverter.java
@@ -1336,10 +1336,10 @@ class ASTConverter {
 				&& ((expression.left.bits & org.eclipse.jdt.internal.compiler.ast.ASTNode.ParenthesizedMASK) == 0)
 				&& (OperatorIds.PLUS == expressionOperatorID)) {
 			StringLiteralConcatenation literal = (StringLiteralConcatenation) expression.left;
-			final org.eclipse.jdt.internal.compiler.ast.Expression[] stringLiterals = literal.literals;
+			final org.eclipse.jdt.internal.compiler.ast.Expression[] stringLiterals = literal.getLiterals();
 			infixExpression.setLeftOperand(convert(stringLiterals[0]));
 			infixExpression.setRightOperand(convert(stringLiterals[1]));
-			for (int i = 2; i < literal.counter; i++) {
+			for (int i = 2; i < stringLiterals.length; i++) {
 				infixExpression.extendedOperands().add(convert(stringLiterals[i]));
 			}
 			infixExpression.extendedOperands().add(convert(expression.right));
@@ -2087,7 +2087,7 @@ class ASTConverter {
 		if (this.resolveBindings) {
 			this.recordNodes(literal, expression);
 		}
-		literal.internalSetEscapedValue(new String(expression.source));
+		literal.internalSetEscapedValue(new String(expression.source()));
 		literal.setSourceRange(expression.sourceStart, expression.sourceEnd - expression.sourceStart + 1);
 		return literal;
 	}
@@ -2719,10 +2719,10 @@ class ASTConverter {
 		expression.computeConstant();
 		final InfixExpression infixExpression = new InfixExpression(this.ast);
 		infixExpression.setOperator(InfixExpression.Operator.PLUS);
-		org.eclipse.jdt.internal.compiler.ast.Expression[] stringLiterals = expression.literals;
+		org.eclipse.jdt.internal.compiler.ast.Expression[] stringLiterals = expression.getLiterals();
 		infixExpression.setLeftOperand(convert(stringLiterals[0]));
 		infixExpression.setRightOperand(convert(stringLiterals[1]));
-		for (int i = 2; i < expression.counter; i++) {
+		for (int i = 2; i < stringLiterals.length; i++) {
 			infixExpression.extendedOperands().add(convert(stringLiterals[i]));
 		}
 		if (this.resolveBindings) {


### PR DESCRIPTION
ExtendedStringLiteral.extendWith(StringLiteral):65 had O(n^2) memory consumption.
Use a linked list implementation instead and defer char[] concatenation until needed.

https://bugs.eclipse.org/bugs/show_bug.cgi?id=574433
