### PR TITLE
3 new compiler test fails on I20240112-0200

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ResourceLeakAnnotatedTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ResourceLeakAnnotatedTests.java
@@ -1362,6 +1362,8 @@ public void testWrappingTwoResources() {
 		null);
 }
 public void testConsumingMethod_nok() {
+	if (this.complianceLevel < ClassFileConstants.JDK1_8)
+		return;
 	runLeakTestWithAnnotations(
 		new String[] {
 			"F.java",
@@ -1388,6 +1390,8 @@ public void testConsumingMethod_nok() {
 		null);
 }
 public void testConsumingMethodUse() {
+	if (this.complianceLevel < ClassFileConstants.JDK1_8)
+		return;
 	runLeakTestWithAnnotations(
 		new String[] {
 			"F.java",
@@ -1415,6 +1419,8 @@ public void testConsumingMethodUse() {
 		null);
 }
 public void testConsumingMethodUse_binary() {
+	if (this.complianceLevel < ClassFileConstants.JDK1_8)
+		return;
 	runLeakTestWithAnnotations(
 			new String[] {
 				"p1/F.java",


### PR DESCRIPTION
fixes #1855

Some tests require compliance 1.8, disable them below
