### PR TITLE
reduce usage of raw Object

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/env/IBinaryAnnotation.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/env/IBinaryAnnotation.java
@@ -16,7 +16,7 @@ package org.eclipse.jdt.internal.compiler.env;
 /**
  * This represents class file information about an annotation instance.
  */
-public interface IBinaryAnnotation {
+public interface IBinaryAnnotation extends IBinaryInfo {
 
 /**
  * @return the signature of the annotation type.

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/env/IBinaryField.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/env/IBinaryField.java
@@ -17,7 +17,7 @@ package org.eclipse.jdt.internal.compiler.env;
 
 import org.eclipse.jdt.internal.compiler.impl.Constant;
 
-public interface IBinaryField extends IGenericField {
+public interface IBinaryField extends IGenericField, IBinaryInfo {
 /**
  * Answer the runtime visible and invisible annotations for this field or null if none.
  */

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/env/IBinaryInfo.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/env/IBinaryInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2023 GK Software AG, and others.
+ * Copyright (c) 2024 Joerg Kubitz and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -8,16 +8,9 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     Stephan Herrmann - initial API and implementation
  *******************************************************************************/
 package org.eclipse.jdt.internal.compiler.env;
 
-import java.net.URI;
-
-public interface IBinaryModule extends IModule, IBinaryInfo {
-	public IBinaryAnnotation[] getAnnotations();
-
-	public long getTagBits();
-	public URI getURI();
+public interface IBinaryInfo extends IElementInfo {
+	// empty marker interface
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/env/IBinaryMethod.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/env/IBinaryMethod.java
@@ -25,7 +25,7 @@ import org.eclipse.jdt.internal.compiler.util.Util;
 // member type) is also ignored by the compiler, BUT in this case it must be included
 // in the constructor's signature.
 
-public interface IBinaryMethod extends IGenericMethod {
+public interface IBinaryMethod extends IGenericMethod, IBinaryInfo {
 
 /**
  * Answer the runtime visible and invisible annotations for this method or null if none.

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/env/IBinaryType.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/env/IBinaryType.java
@@ -23,7 +23,7 @@ import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.internal.compiler.lookup.BinaryTypeBinding.ExternalAnnotationStatus;
 import org.eclipse.jdt.internal.compiler.lookup.LookupEnvironment;
 
-public interface IBinaryType extends IGenericType {
+public interface IBinaryType extends IGenericType, IBinaryInfo {
 
 	char[][] NoInterface = CharOperation.NO_CHAR_CHAR;
 	IBinaryNestedType[] NoNestedType = new IBinaryNestedType[0];

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/env/IElementInfo.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/env/IElementInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2023 GK Software AG, and others.
+ * Copyright (c) 2024 Joerg Kubitz and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -8,16 +8,9 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
- * Contributors:
- *     Stephan Herrmann - initial API and implementation
  *******************************************************************************/
 package org.eclipse.jdt.internal.compiler.env;
 
-import java.net.URI;
-
-public interface IBinaryModule extends IModule, IBinaryInfo {
-	public IBinaryAnnotation[] getAnnotations();
-
-	public long getTagBits();
-	public URI getURI();
+public interface IElementInfo {
+	// empty marker interface
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
@@ -218,7 +218,6 @@ import org.eclipse.jdt.internal.compiler.util.Messages;
 import org.eclipse.jdt.internal.compiler.util.Util;
 
 /** See contract of {@link #close()}. */
-@SuppressWarnings("rawtypes")
 public class ProblemReporter extends ProblemHandler implements AutoCloseable {
 
 	public ReferenceContext referenceContext;
@@ -4867,12 +4866,12 @@ public void invalidType(ASTNode location, TypeBinding type) {
 		}
 
 		if (type.isParameterizedType()) {
-			List missingTypes = type.collectMissingTypes(null);
+			List<TypeBinding> missingTypes = type.collectMissingTypes(null);
 			if (missingTypes != null) {
 				ReferenceContext savedContext = this.referenceContext;
-				for (Iterator iterator = missingTypes.iterator(); iterator.hasNext(); ) {
+				for (Iterator<TypeBinding> iterator = missingTypes.iterator(); iterator.hasNext(); ) {
 					try {
-						invalidType(location, (TypeBinding) iterator.next());
+						invalidType(location, iterator.next());
 					} finally {
 						this.referenceContext = savedContext; // nested reporting will have reset referenceContext
 					}
@@ -6920,12 +6919,12 @@ public void missingSynchronizedOnInheritedMethod(MethodBinding currentMethod, Me
 			currentMethod.sourceEnd());
 }
 public void missingTypeInConstructor(ASTNode location, MethodBinding constructor) {
-	List missingTypes = constructor.collectMissingTypes(null);
+	List<TypeBinding> missingTypes = constructor.collectMissingTypes(null);
 	if (missingTypes == null) {
 		System.err.println("The constructor " + constructor + " is wrongly tagged as containing missing types"); //$NON-NLS-1$ //$NON-NLS-2$
 		return;
 	}
-	TypeBinding missingType = (TypeBinding) missingTypes.get(0);
+	TypeBinding missingType = missingTypes.get(0);
 	int start = location.sourceStart;
 	int end = location.sourceEnd;
 	if (location instanceof QualifiedAllocationExpression) {
@@ -6953,12 +6952,12 @@ public void missingTypeInConstructor(ASTNode location, MethodBinding constructor
 public void missingTypeInLambda(LambdaExpression lambda, MethodBinding method) {
 	int nameSourceStart = lambda.sourceStart();
 	int nameSourceEnd = lambda.diagnosticsSourceEnd();
-	List missingTypes = method.collectMissingTypes(null);
+	List<TypeBinding> missingTypes = method.collectMissingTypes(null);
 	if (missingTypes == null) {
 		System.err.println("The lambda expression " + method + " is wrongly tagged as containing missing types"); //$NON-NLS-1$ //$NON-NLS-2$
 		return;
 	}
-	TypeBinding missingType = (TypeBinding) missingTypes.get(0);
+	TypeBinding missingType = missingTypes.get(0);
 	this.handle(
 			IProblem.MissingTypeInLambda,
 			new String[] {
@@ -6980,12 +6979,12 @@ public void missingTypeInMethod(ASTNode astNode, MethodBinding method) {
 		nameSourceStart = astNode.sourceStart;
 		nameSourceEnd = astNode.sourceEnd;
 	}
-	List missingTypes = method.collectMissingTypes(null);
+	List<TypeBinding> missingTypes = method.collectMissingTypes(null);
 	if (missingTypes == null) {
 		System.err.println("The method " + method + " is wrongly tagged as containing missing types"); //$NON-NLS-1$ //$NON-NLS-2$
 		return;
 	}
-	TypeBinding missingType = (TypeBinding) missingTypes.get(0);
+	TypeBinding missingType = missingTypes.get(0);
 	this.handle(
 			IProblem.MissingTypeInMethod,
 			new String[] {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/OverflowingCacheTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/OverflowingCacheTests.java
@@ -23,8 +23,25 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Path;
-import org.eclipse.jdt.core.*;
-import org.eclipse.jdt.internal.core.*;
+import org.eclipse.jdt.core.IBuffer;
+import org.eclipse.jdt.core.IBufferChangedListener;
+import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IOpenable;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.WorkingCopyOwner;
+import org.eclipse.jdt.internal.compiler.env.IElementInfo;
+import org.eclipse.jdt.internal.core.BufferCache;
+import org.eclipse.jdt.internal.core.BufferManager;
+import org.eclipse.jdt.internal.core.ElementCache;
+import org.eclipse.jdt.internal.core.JavaElementInfo;
+import org.eclipse.jdt.internal.core.JavaModelCache;
+import org.eclipse.jdt.internal.core.Openable;
+import org.eclipse.jdt.internal.core.OpenableElementInfo;
+import org.eclipse.jdt.internal.core.PackageFragmentRoot;
 import org.eclipse.jdt.internal.core.util.LRUCache.LRUCacheEntry;
 import org.eclipse.jdt.internal.core.util.MementoTokenizer;
 
@@ -197,7 +214,7 @@ public class OverflowingCacheTests extends ModifyingResourceTests {
 			open(null);
 		}
 
-		protected boolean buildStructure(OpenableElementInfo info, IProgressMonitor pm, Map newElements, IResource underlyingResource) {
+		protected boolean buildStructure(OpenableElementInfo info, IProgressMonitor pm, Map<IJavaElement, IElementInfo> newElements, IResource underlyingResource) {
 			return false;
 		}
 

--- a/org.eclipse.jdt.core/antadapter/org/eclipse/jdt/core/CheckDebugAttributes.java
+++ b/org.eclipse.jdt.core/antadapter/org/eclipse/jdt/core/CheckDebugAttributes.java
@@ -40,7 +40,6 @@ import org.eclipse.jdt.internal.antadapter.AntAdapterMessages;
  * This is not intended to be subclassed by users.
  * @since 2.0
  */
-@SuppressWarnings("rawtypes")
 public final class CheckDebugAttributes extends Task {
 
 	private String file;
@@ -61,8 +60,8 @@ public final class CheckDebugAttributes extends Task {
 				hasDebugAttributes = checkClassFile(classFileReader);
 			} else {
 				try (ZipFile jarFile = new ZipFile(this.file)) {
-					for (Enumeration entries = jarFile.entries(); !hasDebugAttributes && entries.hasMoreElements(); ) {
-						ZipEntry entry = (ZipEntry) entries.nextElement();
+					for (Enumeration<? extends ZipEntry> entries = jarFile.entries(); !hasDebugAttributes && entries.hasMoreElements(); ) {
+						ZipEntry entry = entries.nextElement();
 						if (org.eclipse.jdt.internal.compiler.util.Util.isClassFileName(entry.getName())) {
 							IClassFileReader classFileReader = ToolFactory.createDefaultClassFileReader(this.file, entry.getName(), IClassFileReader.ALL);
 							hasDebugAttributes = checkClassFile(classFileReader);

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/CompletionUnitStructureRequestor.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/CompletionUnitStructureRequestor.java
@@ -17,6 +17,7 @@ import java.util.Map;
 
 import org.eclipse.jdt.core.IAnnotation;
 import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IMemberValuePair;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.internal.codeassist.complete.CompletionOnMarkerAnnotationName;
@@ -42,6 +43,7 @@ import org.eclipse.jdt.internal.compiler.ast.MemberValuePair;
 import org.eclipse.jdt.internal.compiler.ast.ParameterizedQualifiedTypeReference;
 import org.eclipse.jdt.internal.compiler.ast.ParameterizedSingleTypeReference;
 import org.eclipse.jdt.internal.compiler.ast.TypeReference;
+import org.eclipse.jdt.internal.compiler.env.IElementInfo;
 import org.eclipse.jdt.internal.compiler.lookup.Binding;
 import org.eclipse.jdt.internal.compiler.parser.Parser;
 import org.eclipse.jdt.internal.core.AnnotatableInfo;
@@ -60,7 +62,6 @@ import org.eclipse.jdt.internal.core.SourceMethod;
 import org.eclipse.jdt.internal.core.SourceType;
 import org.eclipse.jdt.internal.core.TypeParameter;
 
-@SuppressWarnings({"rawtypes"})
 public class CompletionUnitStructureRequestor extends CompilationUnitStructureRequestor {
 	private final ASTNode assistNode;
 
@@ -76,7 +77,7 @@ public class CompletionUnitStructureRequestor extends CompilationUnitStructureRe
 			Map<JavaElement, Binding> bindingCache,
 			Map<Binding, JavaElement> elementCache,
 			Map<ASTNode, JavaElement> elementWithProblemCache,
-			Map newElements) {
+			Map<IJavaElement, IElementInfo> newElements) {
 		super(unit, unitInfo, newElements);
 		this.parser = parser;
 		this.assistNode = assistNode;

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/InternalCompletionProposal.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/InternalCompletionProposal.java
@@ -260,7 +260,7 @@ public class InternalCompletionProposal extends CompletionProposal {
 							// map source and try to find parameter names
 							if(paramNames == null) {
 								if (!packageFragmentRoot.isArchive()) this.completionEngine.openedBinaryTypes++;
-								IBinaryType info = (IBinaryType) ((BinaryType) type).getElementInfo();
+								IBinaryType info = ((BinaryType) type).getElementInfo();
 								char[] source = mapper.findSource(type, info);
 								if (source != null){
 									mapper.mapSource((NamedMember) type, source, info);

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/InternalExtendedCompletionContext.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/InternalExtendedCompletionContext.java
@@ -43,6 +43,7 @@ import org.eclipse.jdt.internal.compiler.ast.TypeDeclaration;
 import org.eclipse.jdt.internal.compiler.ast.TypeParameter;
 import org.eclipse.jdt.internal.compiler.ast.TypeReference;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
+import org.eclipse.jdt.internal.compiler.env.IElementInfo;
 import org.eclipse.jdt.internal.compiler.env.ITypeAnnotationWalker;
 import org.eclipse.jdt.internal.compiler.impl.ReferenceContext;
 import org.eclipse.jdt.internal.compiler.lookup.BinaryTypeBinding;
@@ -70,7 +71,6 @@ import org.eclipse.jdt.internal.core.JavaElement;
 import org.eclipse.jdt.internal.core.LocalVariable;
 import org.eclipse.jdt.internal.core.util.Util;
 
-@SuppressWarnings({"rawtypes"})
 public class InternalExtendedCompletionContext {
 	private static Util.BindingsToNodesMap EmptyNodeMap = new Util.BindingsToNodesMap() {
 		@Override
@@ -135,9 +135,9 @@ public class InternalExtendedCompletionContext {
 			HashMap<JavaElement, Binding> handleToBinding = new HashMap<>();
 			HashMap<Binding, JavaElement> bindingToHandle = new HashMap<>();
 			HashMap<ASTNode, JavaElement> nodeWithProblemToHandle = new HashMap<>();
-			HashMap<ICompilationUnit, CompilationUnitElementInfo> handleToInfo = new HashMap<>();
+			Map<IJavaElement, IElementInfo> handleToInfo = new HashMap<>();
 
-			org.eclipse.jdt.core.ICompilationUnit handle = new AssistCompilationUnit(original, this.owner, handleToBinding, handleToInfo);
+			AssistCompilationUnit handle = new AssistCompilationUnit(original, this.owner, handleToBinding, handleToInfo);
 			CompilationUnitElementInfo info = new CompilationUnitElementInfo();
 
 			handleToInfo.put(handle, info);
@@ -165,7 +165,7 @@ public class InternalExtendedCompletionContext {
 					this.compilationUnitDeclaration.sourceEnd,
 					false,
 					this.parser.sourceEnds,
-					new HashMap());
+					new HashMap<>());
 
 			this.bindingsToHandles = bindingToHandle;
 			this.nodesWithProblemsToHandles = nodeWithProblemToHandle;

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionNodeDetector.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionNodeDetector.java
@@ -46,8 +46,8 @@ public class CompletionNodeDetector extends ASTVisitor {
 		return visitor.found;
 	}
 
-	@SuppressWarnings("serial")
-	static class StopTraversal extends RuntimeException { /* no details */}
+	static class StopTraversal extends RuntimeException {
+		private static final long serialVersionUID = 1L; /* no details */}
 
 	private final ASTNode searchedNode;
 	private ASTNode parent;

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/impl/AssistAnnotation.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/impl/AssistAnnotation.java
@@ -16,20 +16,22 @@ package org.eclipse.jdt.internal.codeassist.impl;
 import java.util.Map;
 
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.internal.compiler.env.IElementInfo;
 import org.eclipse.jdt.internal.core.Annotation;
 import org.eclipse.jdt.internal.core.JavaElement;
 
-@SuppressWarnings("rawtypes")
 public class AssistAnnotation extends Annotation {
-	private final Map infoCache;
-	public AssistAnnotation(JavaElement parent, String name, Map infoCache) {
+	private final Map<IJavaElement, IElementInfo> infoCache;
+
+	public AssistAnnotation(JavaElement parent, String name, Map<IJavaElement, IElementInfo> infoCache) {
 		super(parent, name);
 		this.infoCache = infoCache;
 	}
 
 	@Override
-	public Object getElementInfo(IProgressMonitor monitor) throws JavaModelException {
+	public IElementInfo getElementInfo(IProgressMonitor monitor) throws JavaModelException {
 		return this.infoCache.get(this);
 	}
 }

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/impl/AssistCompilationUnit.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/impl/AssistCompilationUnit.java
@@ -17,28 +17,32 @@ import java.util.Map;
 
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.WorkingCopyOwner;
+import org.eclipse.jdt.internal.compiler.env.IElementInfo;
+import org.eclipse.jdt.internal.compiler.lookup.Binding;
 import org.eclipse.jdt.internal.core.CompilationUnit;
+import org.eclipse.jdt.internal.core.CompilationUnitElementInfo;
 import org.eclipse.jdt.internal.core.ImportContainer;
+import org.eclipse.jdt.internal.core.JavaElement;
 import org.eclipse.jdt.internal.core.JavaElementInfo;
 import org.eclipse.jdt.internal.core.PackageDeclaration;
 import org.eclipse.jdt.internal.core.PackageFragment;
 
-@SuppressWarnings("rawtypes")
 public class AssistCompilationUnit extends CompilationUnit {
-	private final Map infoCache;
-	private final Map bindingCache;
-	public AssistCompilationUnit(ICompilationUnit compilationUnit, WorkingCopyOwner owner, Map bindingCache, Map infoCache) {
+	private final Map<IJavaElement, IElementInfo> infoCache;
+	private final Map<JavaElement, Binding> bindingCache;
+	public AssistCompilationUnit(ICompilationUnit compilationUnit, WorkingCopyOwner owner, Map<JavaElement, Binding> bindingCache, Map<IJavaElement, IElementInfo> infoCache) {
 		super((PackageFragment)compilationUnit.getParent(), compilationUnit.getElementName(), owner);
 		this.bindingCache = bindingCache;
 		this.infoCache = infoCache;
 	}
 
 	@Override
-	public Object getElementInfo(IProgressMonitor monitor) throws JavaModelException {
-		return this.infoCache.get(this);
+	public CompilationUnitElementInfo getElementInfo(IProgressMonitor monitor) throws JavaModelException {
+		return (CompilationUnitElementInfo) this.infoCache.get(this);
 	}
 
 	@Override

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/impl/AssistImportContainer.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/impl/AssistImportContainer.java
@@ -16,21 +16,23 @@ package org.eclipse.jdt.internal.codeassist.impl;
 import java.util.Map;
 
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.internal.compiler.env.IElementInfo;
 import org.eclipse.jdt.internal.core.CompilationUnit;
 import org.eclipse.jdt.internal.core.ImportContainer;
 import org.eclipse.jdt.internal.core.ImportDeclaration;
 
-@SuppressWarnings("rawtypes")
 public class AssistImportContainer extends ImportContainer {
-	private final Map infoCache;
-	public AssistImportContainer(CompilationUnit parent, Map infoCache) {
+	private final Map<IJavaElement, IElementInfo> infoCache;
+
+	public AssistImportContainer(CompilationUnit parent, Map<IJavaElement, IElementInfo> infoCache) {
 		super(parent);
 		this.infoCache = infoCache;
 	}
 
 	@Override
-	public Object getElementInfo(IProgressMonitor monitor) throws JavaModelException {
+	public IElementInfo getElementInfo(IProgressMonitor monitor) throws JavaModelException {
 		return this.infoCache.get(this);
 	}
 

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/impl/AssistImportDeclaration.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/impl/AssistImportDeclaration.java
@@ -16,20 +16,22 @@ package org.eclipse.jdt.internal.codeassist.impl;
 import java.util.Map;
 
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.internal.compiler.env.IElementInfo;
 import org.eclipse.jdt.internal.core.ImportContainer;
 import org.eclipse.jdt.internal.core.ImportDeclaration;
 
-@SuppressWarnings("rawtypes")
 public class AssistImportDeclaration extends ImportDeclaration {
-	private final Map infoCache;
-	public AssistImportDeclaration(ImportContainer parent, String name, boolean isOnDemand, Map infoCache) {
+	private final Map<IJavaElement, IElementInfo> infoCache;
+
+	public AssistImportDeclaration(ImportContainer parent, String name, boolean isOnDemand, Map<IJavaElement, IElementInfo> infoCache) {
 		super(parent, name, isOnDemand);
 		this.infoCache = infoCache;
 	}
 
 	@Override
-	public Object getElementInfo(IProgressMonitor monitor) throws JavaModelException {
+	public IElementInfo getElementInfo(IProgressMonitor monitor) throws JavaModelException {
 		return this.infoCache.get(this);
 	}
 }

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/impl/AssistInitializer.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/impl/AssistInitializer.java
@@ -16,23 +16,25 @@ package org.eclipse.jdt.internal.codeassist.impl;
 import java.util.Map;
 
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.internal.compiler.env.IElementInfo;
+import org.eclipse.jdt.internal.compiler.lookup.Binding;
 import org.eclipse.jdt.internal.core.Initializer;
 import org.eclipse.jdt.internal.core.JavaElement;
 
-@SuppressWarnings("rawtypes")
 public class AssistInitializer extends Initializer {
-	private final Map bindingCache;
-	private final Map infoCache;
-	public AssistInitializer(JavaElement parent, int count, Map bindingCache, Map infoCache) {
+	private final Map<JavaElement, Binding> bindingCache;
+	private final Map<IJavaElement, IElementInfo> infoCache;
+	public AssistInitializer(JavaElement parent, int count, Map<JavaElement, Binding> bindingCache, Map<IJavaElement, IElementInfo> infoCache) {
 		super(parent, count);
 		this.bindingCache = bindingCache;
 		this.infoCache = infoCache;
 	}
 
 	@Override
-	public Object getElementInfo(IProgressMonitor monitor) throws JavaModelException {
+	public IElementInfo getElementInfo(IProgressMonitor monitor) throws JavaModelException {
 		return this.infoCache.get(this);
 	}
 

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/impl/AssistOptions.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/impl/AssistOptions.java
@@ -18,7 +18,6 @@ import java.util.Map;
 
 import org.eclipse.jdt.core.compiler.CharOperation;
 
-@SuppressWarnings("rawtypes")
 public class AssistOptions {
 	/**
 	 * Option IDs
@@ -95,171 +94,141 @@ public class AssistOptions {
 	/**
 	 * Initializing the assist options with external settings
 	 */
-	public AssistOptions(Map settings) {
+	public AssistOptions(Map<String, String> settings) {
 		if (settings == null)
 			return;
 
 		set(settings);
 	}
-	public void set(Map optionsMap) {
 
-		Object optionValue;
-		if ((optionValue = optionsMap.get(OPTION_PerformVisibilityCheck)) != null) {
-			if (ENABLED.equals(optionValue)) {
+	public void set(Map<String, String> optionsMap) {
+		String value;
+		if ((value = optionsMap.get(OPTION_PerformVisibilityCheck)) != null) {
+			if (ENABLED.equals(value)) {
 				this.checkVisibility = true;
-			} else if (DISABLED.equals(optionValue)) {
+			} else if (DISABLED.equals(value)) {
 				this.checkVisibility = false;
 			}
 		}
-		if ((optionValue = optionsMap.get(OPTION_ForceImplicitQualification)) != null) {
-			if (ENABLED.equals(optionValue)) {
+		if ((value = optionsMap.get(OPTION_ForceImplicitQualification)) != null) {
+			if (ENABLED.equals(value)) {
 				this.forceImplicitQualification = true;
-			} else if (DISABLED.equals(optionValue)) {
+			} else if (DISABLED.equals(value)) {
 				this.forceImplicitQualification = false;
 			}
 		}
-		if ((optionValue = optionsMap.get(OPTION_FieldPrefixes)) != null) {
-			if (optionValue instanceof String) {
-				String stringValue = (String) optionValue;
-				if (stringValue.length() > 0){
-					this.fieldPrefixes = splitAndTrimOn(',', stringValue.toCharArray());
-				} else {
-					this.fieldPrefixes = null;
-				}
+		if ((value = optionsMap.get(OPTION_FieldPrefixes)) != null) {
+			if (value.length() > 0) {
+				this.fieldPrefixes = splitAndTrimOn(',', value.toCharArray());
+			} else {
+				this.fieldPrefixes = null;
 			}
 		}
-		if ((optionValue = optionsMap.get(OPTION_StaticFieldPrefixes)) != null) {
-			if (optionValue instanceof String) {
-				String stringValue = (String) optionValue;
-				if (stringValue.length() > 0){
-					this.staticFieldPrefixes = splitAndTrimOn(',', stringValue.toCharArray());
-				} else {
-					this.staticFieldPrefixes = null;
-				}
+		if ((value = optionsMap.get(OPTION_StaticFieldPrefixes)) != null) {
+			if (value.length() > 0) {
+				this.staticFieldPrefixes = splitAndTrimOn(',', value.toCharArray());
+			} else {
+				this.staticFieldPrefixes = null;
 			}
 		}
-		if ((optionValue = optionsMap.get(OPTION_StaticFinalFieldPrefixes)) != null) {
-			if (optionValue instanceof String) {
-				String stringValue = (String) optionValue;
-				if (stringValue.length() > 0){
-					this.staticFinalFieldPrefixes = splitAndTrimOn(',', stringValue.toCharArray());
-				} else {
-					this.staticFinalFieldPrefixes = null;
-				}
+		if ((value = optionsMap.get(OPTION_StaticFinalFieldPrefixes)) != null) {
+			if (value.length() > 0) {
+				this.staticFinalFieldPrefixes = splitAndTrimOn(',', value.toCharArray());
+			} else {
+				this.staticFinalFieldPrefixes = null;
 			}
 		}
-		if ((optionValue = optionsMap.get(OPTION_LocalPrefixes)) != null) {
-			if (optionValue instanceof String) {
-				String stringValue = (String) optionValue;
-				if (stringValue.length() > 0){
-					this.localPrefixes = splitAndTrimOn(',', stringValue.toCharArray());
-				} else {
-					this.localPrefixes = null;
-				}
+		if ((value = optionsMap.get(OPTION_LocalPrefixes)) != null) {
+			if (value.length() > 0) {
+				this.localPrefixes = splitAndTrimOn(',', value.toCharArray());
+			} else {
+				this.localPrefixes = null;
 			}
 		}
-		if ((optionValue = optionsMap.get(OPTION_ArgumentPrefixes)) != null) {
-			if (optionValue instanceof String) {
-				String stringValue = (String) optionValue;
-				if (stringValue.length() > 0){
-					this.argumentPrefixes = splitAndTrimOn(',', stringValue.toCharArray());
-				} else {
-					this.argumentPrefixes = null;
-				}
+		if ((value = optionsMap.get(OPTION_ArgumentPrefixes)) != null) {
+			if (value.length() > 0) {
+				this.argumentPrefixes = splitAndTrimOn(',', value.toCharArray());
+			} else {
+				this.argumentPrefixes = null;
 			}
 		}
-		if ((optionValue = optionsMap.get(OPTION_FieldSuffixes)) != null) {
-			if (optionValue instanceof String) {
-				String stringValue = (String) optionValue;
-				if (stringValue.length() > 0){
-					this.fieldSuffixes = splitAndTrimOn(',', stringValue.toCharArray());
-				} else {
-					this.fieldSuffixes = null;
-				}
+		if ((value = optionsMap.get(OPTION_FieldSuffixes)) != null) {
+			if (value.length() > 0) {
+				this.fieldSuffixes = splitAndTrimOn(',', value.toCharArray());
+			} else {
+				this.fieldSuffixes = null;
 			}
 		}
-		if ((optionValue = optionsMap.get(OPTION_StaticFieldSuffixes)) != null) {
-			if (optionValue instanceof String) {
-				String stringValue = (String) optionValue;
-				if (stringValue.length() > 0){
-					this.staticFieldSuffixes = splitAndTrimOn(',', stringValue.toCharArray());
-				} else {
-					this.staticFieldSuffixes = null;
-				}
+		if ((value = optionsMap.get(OPTION_StaticFieldSuffixes)) != null) {
+			if (value.length() > 0) {
+				this.staticFieldSuffixes = splitAndTrimOn(',', value.toCharArray());
+			} else {
+				this.staticFieldSuffixes = null;
 			}
 		}
-		if ((optionValue = optionsMap.get(OPTION_StaticFinalFieldSuffixes)) != null) {
-			if (optionValue instanceof String) {
-				String stringValue = (String) optionValue;
-				if (stringValue.length() > 0){
-					this.staticFinalFieldSuffixes = splitAndTrimOn(',', stringValue.toCharArray());
-				} else {
-					this.staticFinalFieldSuffixes = null;
-				}
+		if ((value = optionsMap.get(OPTION_StaticFinalFieldSuffixes)) != null) {
+			if (value.length() > 0) {
+				this.staticFinalFieldSuffixes = splitAndTrimOn(',', value.toCharArray());
+			} else {
+				this.staticFinalFieldSuffixes = null;
 			}
 		}
-		if ((optionValue = optionsMap.get(OPTION_LocalSuffixes)) != null) {
-			if (optionValue instanceof String) {
-				String stringValue = (String) optionValue;
-				if (stringValue.length() > 0){
-					this.localSuffixes = splitAndTrimOn(',', stringValue.toCharArray());
-				} else {
-					this.localSuffixes = null;
-				}
+		if ((value = optionsMap.get(OPTION_LocalSuffixes)) != null) {
+			if (value.length() > 0) {
+				this.localSuffixes = splitAndTrimOn(',', value.toCharArray());
+			} else {
+				this.localSuffixes = null;
 			}
 		}
-		if ((optionValue = optionsMap.get(OPTION_ArgumentSuffixes)) != null) {
-			if (optionValue instanceof String) {
-				String stringValue = (String) optionValue;
-				if (stringValue.length() > 0){
-					this.argumentSuffixes = splitAndTrimOn(',', stringValue.toCharArray());
-				} else {
-					this.argumentSuffixes = null;
-				}
+		if ((value = optionsMap.get(OPTION_ArgumentSuffixes)) != null) {
+			if (value.length() > 0) {
+				this.argumentSuffixes = splitAndTrimOn(',', value.toCharArray());
+			} else {
+				this.argumentSuffixes = null;
 			}
 		}
-		if ((optionValue = optionsMap.get(OPTION_PerformForbiddenReferenceCheck)) != null) {
-			if (ENABLED.equals(optionValue)) {
+		if ((value = optionsMap.get(OPTION_PerformForbiddenReferenceCheck)) != null) {
+			if (ENABLED.equals(value)) {
 				this.checkForbiddenReference = true;
-			} else if (DISABLED.equals(optionValue)) {
+			} else if (DISABLED.equals(value)) {
 				this.checkForbiddenReference = false;
 			}
 		}
-		if ((optionValue = optionsMap.get(OPTION_PerformDiscouragedReferenceCheck)) != null) {
-			if (ENABLED.equals(optionValue)) {
+		if ((value = optionsMap.get(OPTION_PerformDiscouragedReferenceCheck)) != null) {
+			if (ENABLED.equals(value)) {
 				this.checkDiscouragedReference = true;
-			} else if (DISABLED.equals(optionValue)) {
+			} else if (DISABLED.equals(value)) {
 				this.checkDiscouragedReference = false;
 			}
 		}
-		if ((optionValue = optionsMap.get(OPTION_CamelCaseMatch)) != null) {
-			if (ENABLED.equals(optionValue)) {
+		if ((value = optionsMap.get(OPTION_CamelCaseMatch)) != null) {
+			if (ENABLED.equals(value)) {
 				this.camelCaseMatch = true;
-			} else if (DISABLED.equals(optionValue)) {
+			} else if (DISABLED.equals(value)) {
 				this.camelCaseMatch = false;
 			}
 		}
-		if ("false".equals(System.getProperty(PROPERTY_SubstringMatch))) {  //$NON-NLS-1$
+		if ("false".equals(System.getProperty(PROPERTY_SubstringMatch))) { //$NON-NLS-1$
 			this.substringMatch = false;
 		}
-		if ((optionValue = optionsMap.get(OPTION_SubwordMatch)) != null) {
-			if (ENABLED.equals(optionValue)) {
+		if ((value = optionsMap.get(OPTION_SubwordMatch)) != null) {
+			if (ENABLED.equals(value)) {
 				this.subwordMatch = true;
-			} else if (DISABLED.equals(optionValue)) {
+			} else if (DISABLED.equals(value)) {
 				this.subwordMatch = false;
 			}
 		}
-		if ((optionValue = optionsMap.get(OPTION_PerformDeprecationCheck)) != null) {
-			if (ENABLED.equals(optionValue)) {
+		if ((value = optionsMap.get(OPTION_PerformDeprecationCheck)) != null) {
+			if (ENABLED.equals(value)) {
 				this.checkDeprecation = true;
-			} else if (DISABLED.equals(optionValue)) {
+			} else if (DISABLED.equals(value)) {
 				this.checkDeprecation = false;
 			}
 		}
-		if ((optionValue = optionsMap.get(OPTION_SuggestStaticImports)) != null) {
-			if (ENABLED.equals(optionValue)) {
+		if ((value = optionsMap.get(OPTION_SuggestStaticImports)) != null) {
+			if (ENABLED.equals(value)) {
 				this.suggestStaticImport = true;
-			} else if (DISABLED.equals(optionValue)) {
+			} else if (DISABLED.equals(value)) {
 				this.suggestStaticImport = false;
 			}
 		}

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/impl/AssistPackageDeclaration.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/impl/AssistPackageDeclaration.java
@@ -17,20 +17,21 @@ import java.util.Map;
 
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.core.IAnnotation;
+import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.internal.compiler.env.IElementInfo;
 import org.eclipse.jdt.internal.core.CompilationUnit;
 import org.eclipse.jdt.internal.core.PackageDeclaration;
 
-@SuppressWarnings("rawtypes")
 public class AssistPackageDeclaration extends PackageDeclaration {
-	private final Map infoCache;
-	public AssistPackageDeclaration(CompilationUnit parent, String name, Map infoCache) {
+	private final Map<IJavaElement, IElementInfo> infoCache;
+	public AssistPackageDeclaration(CompilationUnit parent, String name, Map<IJavaElement, IElementInfo> infoCache) {
 		super(parent, name);
 		this.infoCache = infoCache;
 	}
 
 	@Override
-	public Object getElementInfo(IProgressMonitor monitor) throws JavaModelException {
+	public IElementInfo getElementInfo(IProgressMonitor monitor) throws JavaModelException {
 		return this.infoCache.get(this);
 	}
 

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/impl/AssistSourceField.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/impl/AssistSourceField.java
@@ -17,35 +17,36 @@ import java.util.Map;
 
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.core.IAnnotation;
+import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.internal.compiler.env.IElementInfo;
 import org.eclipse.jdt.internal.compiler.lookup.Binding;
 import org.eclipse.jdt.internal.core.JavaElement;
 import org.eclipse.jdt.internal.core.ResolvedSourceField;
 
-@SuppressWarnings("rawtypes")
 public class AssistSourceField extends ResolvedSourceField {
-	private final Map bindingCache;
-	private final Map infoCache;
+	private final Map<JavaElement, Binding> bindingCache;
+	private final Map<IJavaElement, IElementInfo> infoCache;
 
 	private String uniqueKey;
 	private boolean isResolved;
 
-	public AssistSourceField(JavaElement parent, String name, Map bindingCache, Map infoCache) {
+	public AssistSourceField(JavaElement parent, String name, Map<JavaElement, Binding> bindingCache, Map<IJavaElement, IElementInfo> infoCache) {
 		super(parent, name, null);
 		this.bindingCache = bindingCache;
 		this.infoCache = infoCache;
 	}
 
 	@Override
-	public Object getElementInfo(IProgressMonitor monitor) throws JavaModelException {
+	public IElementInfo getElementInfo(IProgressMonitor monitor) throws JavaModelException {
 		return this.infoCache.get(this);
 	}
 
 	@Override
 	public String getKey() {
 		if (this.uniqueKey == null) {
-			Binding binding = (Binding) this.bindingCache.get(this);
+			Binding binding = this.bindingCache.get(this);
 			if (binding != null) {
 				this.isResolved = true;
 				this.uniqueKey = new String(binding.computeUniqueKey());

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/impl/AssistSourceMethod.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/impl/AssistSourceMethod.java
@@ -17,36 +17,37 @@ import java.util.Map;
 
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.core.IAnnotation;
+import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.ITypeParameter;
 import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.internal.compiler.env.IElementInfo;
 import org.eclipse.jdt.internal.compiler.lookup.Binding;
 import org.eclipse.jdt.internal.core.JavaElement;
 import org.eclipse.jdt.internal.core.ResolvedSourceMethod;
 
-@SuppressWarnings("rawtypes")
 public class AssistSourceMethod extends ResolvedSourceMethod {
-	private final Map bindingCache;
-	private final Map infoCache;
+	private final Map<JavaElement, Binding> bindingCache;
+	private final Map<IJavaElement, IElementInfo> infoCache;
 
 	private String uniqueKey;
 	private boolean isResolved;
 
-	public AssistSourceMethod(JavaElement parent, String name, String[] parameterTypes, Map bindingCache, Map infoCache) {
+	public AssistSourceMethod(JavaElement parent, String name, String[] parameterTypes, Map<JavaElement, Binding> bindingCache, Map<IJavaElement, IElementInfo> infoCache) {
 		super(parent, name, parameterTypes, null);
 		this.bindingCache = bindingCache;
 		this.infoCache = infoCache;
 	}
 
 	@Override
-	public Object getElementInfo(IProgressMonitor monitor) throws JavaModelException {
+	public IElementInfo getElementInfo(IProgressMonitor monitor) throws JavaModelException {
 		return this.infoCache.get(this);
 	}
 
 	@Override
 	public String getKey() {
 		if (this.uniqueKey == null) {
-			Binding binding = (Binding) this.bindingCache.get(this);
+			Binding binding = this.bindingCache.get(this);
 			if (binding != null) {
 				this.isResolved = true;
 				this.uniqueKey = new String(binding.computeUniqueKey());

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/impl/AssistSourceType.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/impl/AssistSourceType.java
@@ -19,30 +19,31 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.core.IAnnotation;
 import org.eclipse.jdt.core.IField;
 import org.eclipse.jdt.core.IInitializer;
+import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.ITypeParameter;
 import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.internal.compiler.env.IElementInfo;
 import org.eclipse.jdt.internal.compiler.lookup.Binding;
 import org.eclipse.jdt.internal.core.JavaElement;
 import org.eclipse.jdt.internal.core.ResolvedSourceType;
 
-@SuppressWarnings("rawtypes")
 public class AssistSourceType extends ResolvedSourceType {
-	private final Map bindingCache;
-	private final Map infoCache;
+	private final Map<JavaElement, Binding> bindingCache;
+	private final Map<IJavaElement, IElementInfo> infoCache;
 
 	private String uniqueKey;
 	private boolean isResolved;
 
-	public AssistSourceType(JavaElement parent, String name, Map bindingCache, Map infoCache) {
+	public AssistSourceType(JavaElement parent, String name, Map<JavaElement, Binding> bindingCache, Map<IJavaElement, IElementInfo> infoCache) {
 		super(parent, name, null);
 		this.bindingCache = bindingCache;
 		this.infoCache = infoCache;
 	}
 
 	@Override
-	public Object getElementInfo(IProgressMonitor monitor) throws JavaModelException {
+	public IElementInfo getElementInfo(IProgressMonitor monitor) throws JavaModelException {
 		return this.infoCache.get(this);
 	}
 
@@ -57,7 +58,7 @@ public class AssistSourceType extends ResolvedSourceType {
 	@Override
 	public String getKey() {
 		if (this.uniqueKey == null) {
-			Binding binding = (Binding) this.bindingCache.get(this);
+			Binding binding = this.bindingCache.get(this);
 			if (binding != null) {
 				this.isResolved = true;
 				this.uniqueKey = new String(binding.computeUniqueKey());

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/impl/AssistTypeParameter.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/impl/AssistTypeParameter.java
@@ -16,20 +16,21 @@ package org.eclipse.jdt.internal.codeassist.impl;
 import java.util.Map;
 
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.internal.compiler.env.IElementInfo;
 import org.eclipse.jdt.internal.core.JavaElement;
 import org.eclipse.jdt.internal.core.TypeParameter;
 
-@SuppressWarnings("rawtypes")
 public class AssistTypeParameter extends TypeParameter {
-	private final Map infoCache;
-	public AssistTypeParameter(JavaElement parent, String name, Map infoCache) {
+	private final Map<IJavaElement, IElementInfo> infoCache;
+	public AssistTypeParameter(JavaElement parent, String name, Map<IJavaElement, IElementInfo> infoCache) {
 		super(parent, name);
 		this.infoCache = infoCache;
 	}
 
 	@Override
-	public Object getElementInfo(IProgressMonitor monitor) throws JavaModelException {
+	public IElementInfo getElementInfo(IProgressMonitor monitor) throws JavaModelException {
 		return this.infoCache.get(this);
 	}
 }

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ASTParser.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ASTParser.java
@@ -1185,7 +1185,7 @@ public class ASTParser {
 							BinaryType type = (BinaryType) this.typeRoot.findPrimaryType();
 							String fileNameString = null;
 							if (type != null) {
-								IBinaryType binaryType = (IBinaryType) type.getElementInfo();
+								IBinaryType binaryType = type.getElementInfo();
 								// file name is used to recreate the Java element, so it has to be the toplevel .class file name
 								char[] fileName = binaryType.getFileName();
 

--- a/org.eclipse.jdt.core/eval/org/eclipse/jdt/internal/eval/Evaluator.java
+++ b/org.eclipse.jdt.core/eval/org/eclipse/jdt/internal/eval/Evaluator.java
@@ -35,7 +35,6 @@ import org.eclipse.jdt.internal.core.util.Util;
  * If the compilation unit has problems, reports the problems using the
  * requestor.
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public abstract class Evaluator {
 	EvaluationContext context;
 	INameEnvironment environment;
@@ -88,7 +87,7 @@ protected EvaluationResult[] evaluationResultsForCompilationProblems(Compilation
  */
 ClassFile[] getClasses() {
 	final char[] source = getSource();
-	final ArrayList classDefinitions = new ArrayList();
+	final ArrayList<ClassFile> classDefinitions = new ArrayList<>();
 
 	// The requestor collects the class definitions and problems
 	class CompilerRequestor implements ICompilerRequestor {

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/core/formatter/DefaultCodeFormatterConstants.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/core/formatter/DefaultCodeFormatterConstants.java
@@ -31,7 +31,6 @@ import org.eclipse.jdt.internal.formatter.DefaultCodeFormatterOptions.Alignment;
  * @noinstantiate This class is not intended to be instantiated by clients.
  * @noextend This class is not intended to be subclassed by clients.
  */
-@SuppressWarnings("rawtypes")
 public class DefaultCodeFormatterConstants {
 
 	/**
@@ -5952,7 +5951,7 @@ public class DefaultCodeFormatterConstants {
 	 * @return the Eclipse 2.1 settings
 	 * @since 3.0
 	 */
-	public static Map getEclipse21Settings() {
+	public static Map<String, String> getEclipse21Settings() {
 		DefaultCodeFormatterOptions options = DefaultCodeFormatterOptions.getDefaultSettings();
 		options.page_width = 80; // changed with bug 356841
 		options.comment_count_line_length_from_starting_position = false;
@@ -5966,7 +5965,7 @@ public class DefaultCodeFormatterConstants {
 	 * @return the Eclipse default settings
 	 * @since 3.1
 	 */
-	public static Map getEclipseDefaultSettings() {
+	public static Map<String, String> getEclipseDefaultSettings() {
 		return DefaultCodeFormatterOptions.getEclipseDefaultSettings().getMap();
 	}
 

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/core/formatter/IndentManipulation.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/core/formatter/IndentManipulation.java
@@ -32,7 +32,6 @@ import org.eclipse.text.edits.ReplaceEdit;
  * @since 3.2
  * @noinstantiate This class is not intended to be instantiated by clients.
  */
-@SuppressWarnings({ "rawtypes", "unchecked" })
 public final class IndentManipulation {
 
 	private IndentManipulation() {
@@ -336,13 +335,13 @@ public final class IndentManipulation {
 			throw new IllegalArgumentException();
 		}
 
-		ArrayList result= new ArrayList();
+		ArrayList<ReplaceEdit> result= new ArrayList<>();
 		try {
 			ILineTracker tracker= new DefaultLineTracker();
 			tracker.set(source);
 			int nLines= tracker.getNumberOfLines();
 			if (nLines == 1)
-				return (ReplaceEdit[])result.toArray(new ReplaceEdit[result.size()]);
+				return result.toArray(ReplaceEdit[]::new);
 			for (int i= 1; i < nLines; i++) {
 				IRegion region= tracker.getLineInformation(i);
 				int offset= region.getOffset();
@@ -358,7 +357,7 @@ public final class IndentManipulation {
 		} catch (BadLocationException cannotHappen) {
 			// can not happen
 		}
-		return (ReplaceEdit[])result.toArray(new ReplaceEdit[result.size()]);
+		return result.toArray(ReplaceEdit[]::new);
 	}
 
 	/*
@@ -410,7 +409,7 @@ public final class IndentManipulation {
 	 * @return the tab width
 	 * @exception IllegalArgumentException if the given <code>options</code> is null
 	 */
-	public static int getTabWidth(Map options) {
+	public static int getTabWidth(Map<String, String> options) {
 		if (options == null) {
 			throw new IllegalArgumentException();
 		}
@@ -426,7 +425,7 @@ public final class IndentManipulation {
 	 * @return the indent width
 	 * @exception IllegalArgumentException if the given <code>options</code> is null
 	 */
-	public static int getIndentWidth(Map options) {
+	public static int getIndentWidth(Map<String, String> options) {
 		if (options == null) {
 			throw new IllegalArgumentException();
 		}
@@ -438,9 +437,9 @@ public final class IndentManipulation {
 		return tabWidth;
 	}
 
-	private static int getIntValue(Map options, String key, int def) {
+	private static int getIntValue(Map<String, String> options, String key, int def) {
 		try {
-			return Integer.parseInt((String) options.get(key));
+			return Integer.parseInt(options.get(key));
 		} catch (NumberFormatException e) {
 			return def;
 		}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/core/compiler/ReconcileContext.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/core/compiler/ReconcileContext.java
@@ -49,7 +49,6 @@ import org.eclipse.jdt.internal.core.ReconcileWorkingCopyOperation;
  * @noinstantiate This class is not intended to be instantiated by clients.
  * @noextend This class is not intended to be subclassed by clients.
  */
-@SuppressWarnings({"rawtypes"})
 public class ReconcileContext {
 
 	private final ReconcileWorkingCopyOperation operation;
@@ -247,7 +246,7 @@ public IJavaElementDelta getDelta() {
  */
 public CategorizedProblem[] getProblems(String markerType) {
 	if (this.operation.problems == null) return null;
-	return (CategorizedProblem[]) this.operation.problems.get(markerType);
+	return this.operation.problems.get(markerType);
 }
 
 /**
@@ -292,7 +291,7 @@ public void resetAST() {
  */
 public void putProblems(String markerType, CategorizedProblem[] problems) {
 	if (this.operation.problems == null)
-		this.operation.problems = new HashMap();
+		this.operation.problems = new HashMap<>();
 	this.operation.problems.put(markerType, problems);
 }
 

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/compiler/ISourceElementRequestor.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/compiler/ISourceElementRequestor.java
@@ -14,7 +14,9 @@
 package org.eclipse.jdt.internal.compiler;
 
 import java.util.HashMap;
+import java.util.Map;
 
+import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.compiler.CategorizedProblem;
 import org.eclipse.jdt.internal.compiler.ast.AbstractMethodDeclaration;
 import org.eclipse.jdt.internal.compiler.ast.AbstractVariableDeclaration;
@@ -48,7 +50,6 @@ import org.eclipse.jdt.internal.compiler.ast.TypeDeclaration;
  * other simpler elements (package, import) are read all at once: - accept
  * <Element>
  */
-@SuppressWarnings("rawtypes")
 public interface ISourceElementRequestor {
 
 	public static class ModuleInfo {
@@ -96,7 +97,7 @@ public interface ISourceElementRequestor {
 		public Annotation[] annotations;
 		public int extraFlags;
 		public TypeDeclaration node;
-		public HashMap childrenCategories = new HashMap();
+		public Map<IJavaElement, char[][]> childrenCategories = new HashMap<>();
 	}
 
 	public static class TypeParameterInfo {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ASTHolderCUInfo.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ASTHolderCUInfo.java
@@ -13,15 +13,15 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.core;
 
-import java.util.HashMap;
+import java.util.Map;
 
+import org.eclipse.jdt.core.compiler.CategorizedProblem;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 
-@SuppressWarnings("rawtypes")
 public class ASTHolderCUInfo extends CompilationUnitElementInfo {
 	int astLevel;
 	boolean resolveBindings;
 	int reconcileFlags;
-	HashMap problems = null;
+	Map<String, CategorizedProblem[]> problems = null;
 	CompilationUnit ast;
 }

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/AbstractClassFile.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/AbstractClassFile.java
@@ -123,7 +123,7 @@ public abstract class AbstractClassFile extends Openable implements IClassFile, 
 	 * Returns a new element info for this element.
 	 */
 	@Override
-	protected Object createElementInfo() {
+	protected ClassFileInfo createElementInfo() {
 		return new ClassFileInfo();
 	}
 	@Override

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/BinaryMethod.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/BinaryMethod.java
@@ -261,7 +261,7 @@ public String[] getParameterNames() throws JavaModelException {
 
 		// map source and try to find parameter names
 		if(paramNames == null) {
-			IBinaryType info = (IBinaryType) ((BinaryType) getDeclaringType()).getElementInfo();
+			IBinaryType info = ((BinaryType) getDeclaringType()).getElementInfo();
 			char[] source = mapper.findSource(type, info);
 			if (source != null) {
 				mapper.mapSource((NamedMember) type, source, info);

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/BinaryType.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/BinaryType.java
@@ -27,6 +27,7 @@ import org.eclipse.jdt.core.search.SearchEngine;
 import org.eclipse.jdt.internal.codeassist.CompletionEngine;
 import org.eclipse.jdt.internal.compiler.ast.TypeDeclaration;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
+import org.eclipse.jdt.internal.compiler.env.IElementInfo;
 import org.eclipse.jdt.internal.compiler.env.IBinaryAnnotation;
 import org.eclipse.jdt.internal.compiler.env.IBinaryType;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
@@ -181,7 +182,7 @@ public IMethod[] findMethods(IMethod method) {
 }
 @Override
 public IAnnotation[] getAnnotations() throws JavaModelException {
-	IBinaryType info = (IBinaryType) getElementInfo();
+	IBinaryType info = getElementInfo();
 	IBinaryAnnotation[] binaryAnnotations = info.getAnnotations();
 	return getAnnotations(binaryAnnotations, info.getTagBits());
 }
@@ -236,7 +237,7 @@ public IType getDeclaringType() {
 	IClassFile classFile = getClassFile();
 	if (classFile.isOpen()) {
 		try {
-			char[] enclosingTypeName = ((IBinaryType) getElementInfo()).getEnclosingTypeName();
+			char[] enclosingTypeName = getElementInfo().getEnclosingTypeName();
 			if (enclosingTypeName == null) {
 				return null;
 			}
@@ -281,9 +282,9 @@ public IType getDeclaringType() {
 	}
 }
 @Override
-public Object getElementInfo(IProgressMonitor monitor) throws JavaModelException {
+public IElementInfo getElementInfo(IProgressMonitor monitor) throws JavaModelException {
 	JavaModelManager manager = JavaModelManager.getJavaModelManager();
-	Object info = manager.getInfo(this);
+	IElementInfo info = manager.getInfo(this);
 	if (info != null && info != JavaModelCache.NON_EXISTING_JAR_TYPE_INFO) return info;
 	return openWhenClosed(createElementInfo(), false, monitor);
 }
@@ -350,7 +351,7 @@ public IField getRecordComponent(String compName) {
 }
 @Override
 public int getFlags() throws JavaModelException {
-	IBinaryType info = (IBinaryType) getElementInfo();
+	IBinaryType info = getElementInfo();
 	return info.getModifiers() & ~ClassFileConstants.AccSuper;
 }
 
@@ -519,7 +520,7 @@ public IPackageFragment getPackageFragment() {
  */
 @Override
 public String getSuperclassTypeSignature() throws JavaModelException {
-	IBinaryType info = (IBinaryType) getElementInfo();
+	IBinaryType info = getElementInfo();
 	char[] genericSignature = info.getGenericSignature();
 	if (genericSignature != null) {
 		int signatureLength = genericSignature.length;
@@ -555,7 +556,7 @@ public String getSuperclassTypeSignature() throws JavaModelException {
 public String getSourceFileName(IBinaryType info) {
 	if (info == null) {
 		try {
-			info = (IBinaryType) getElementInfo();
+			info = getElementInfo();
 		} catch (JavaModelException e) {
 			// default to using the outer most declaring type name
 			IType type = this;
@@ -572,7 +573,7 @@ public String getSourceFileName(IBinaryType info) {
 
 @Override
 public String getSuperclassName() throws JavaModelException {
-	IBinaryType info = (IBinaryType) getElementInfo();
+	IBinaryType info = getElementInfo();
 	char[] superclassName = info.getSuperclassName();
 	if (superclassName == null) {
 		return null;
@@ -582,7 +583,7 @@ public String getSuperclassName() throws JavaModelException {
 
 @Override
 public String[] getSuperInterfaceNames() throws JavaModelException {
-	IBinaryType info = (IBinaryType) getElementInfo();
+	IBinaryType info = getElementInfo();
 	char[][] names= info.getInterfaceNames();
 	int length;
 	if (names == null || (length = names.length) == 0) {
@@ -597,7 +598,7 @@ public String[] getSuperInterfaceNames() throws JavaModelException {
 }
 @Override
 public String[] getPermittedSubtypeNames() throws JavaModelException {
-	IBinaryType info = (IBinaryType) getElementInfo();
+	IBinaryType info = getElementInfo();
 	char[][] names= info.getPermittedSubtypeNames();
 	int length;
 	if (names == null || (length = names.length) == 0) {
@@ -617,7 +618,7 @@ public String[] getPermittedSubtypeNames() throws JavaModelException {
  */
 @Override
 public String[] getSuperInterfaceTypeSignatures() throws JavaModelException {
-	IBinaryType info = (IBinaryType) getElementInfo();
+	IBinaryType info = getElementInfo();
 	char[] genericSignature = info.getGenericSignature();
 	if (genericSignature != null) {
 		ArrayList interfaces = new ArrayList();
@@ -684,7 +685,7 @@ public ITypeParameter[] getTypeParameters() throws JavaModelException {
  */
 @Override
 public String[] getTypeParameterSignatures() throws JavaModelException {
-	IBinaryType info = (IBinaryType) getElementInfo();
+	IBinaryType info = getElementInfo();
 	char[] genericSignature = info.getGenericSignature();
 	if (genericSignature == null)
 		return CharOperation.NO_STRINGS;
@@ -734,13 +735,13 @@ public IType[] getTypes() throws JavaModelException {
 
 @Override
 public boolean isAnonymous() throws JavaModelException {
-	IBinaryType info = (IBinaryType) getElementInfo();
+	IBinaryType info = getElementInfo();
 	return info.isAnonymous();
 }
 
 @Override
 public boolean isClass() throws JavaModelException {
-	IBinaryType info = (IBinaryType) getElementInfo();
+	IBinaryType info = getElementInfo();
 	return TypeDeclaration.kind(info.getModifiers()) == TypeDeclaration.CLASS_DECL;
 
 }
@@ -751,7 +752,7 @@ public boolean isClass() throws JavaModelException {
  */
 @Override
 public boolean isEnum() throws JavaModelException {
-	IBinaryType info = (IBinaryType) getElementInfo();
+	IBinaryType info = getElementInfo();
 	return TypeDeclaration.kind(info.getModifiers()) == TypeDeclaration.ENUM_DECL;
 }
 
@@ -761,7 +762,7 @@ public boolean isEnum() throws JavaModelException {
  */
 @Override
 public boolean isRecord() throws JavaModelException {
-	IBinaryType info = (IBinaryType) getElementInfo();
+	IBinaryType info = getElementInfo();
 	return TypeDeclaration.kind(info.getModifiers()) == TypeDeclaration.RECORD_DECL;
 }
 /**
@@ -770,14 +771,14 @@ public boolean isRecord() throws JavaModelException {
  */
 @Override
 public boolean isSealed() throws JavaModelException {
-	IBinaryType info = (IBinaryType) getElementInfo();
+	IBinaryType info = getElementInfo();
 	char[][] names = info.getPermittedSubtypeNames();
 	return (names != null && names.length > 0);
 }
 
 @Override
 public boolean isInterface() throws JavaModelException {
-	IBinaryType info = (IBinaryType) getElementInfo();
+	IBinaryType info = getElementInfo();
 	switch (TypeDeclaration.kind(info.getModifiers())) {
 		case TypeDeclaration.INTERFACE_DECL:
 		case TypeDeclaration.ANNOTATION_TYPE_DECL: // annotation is interface too
@@ -791,19 +792,19 @@ public boolean isInterface() throws JavaModelException {
  */
 @Override
 public boolean isAnnotation() throws JavaModelException {
-	IBinaryType info = (IBinaryType) getElementInfo();
+	IBinaryType info = getElementInfo();
 	return TypeDeclaration.kind(info.getModifiers()) == TypeDeclaration.ANNOTATION_TYPE_DECL;
 }
 
 @Override
 public boolean isLocal() throws JavaModelException {
-	IBinaryType info = (IBinaryType) getElementInfo();
+	IBinaryType info = getElementInfo();
 	return info.isLocal();
 }
 
 @Override
 public boolean isMember() throws JavaModelException {
-	IBinaryType info = (IBinaryType) getElementInfo();
+	IBinaryType info = getElementInfo();
 	return info.isMember();
 }
 
@@ -1147,5 +1148,9 @@ private static boolean isComplianceJava11OrHigher(IJavaProject javaProject) {
 		return false;
 	}
 	return CompilerOptions.versionToJdkLevel(javaProject.getOption(JavaCore.COMPILER_COMPLIANCE, true)) >= ClassFileConstants.JDK11;
+}
+@Override
+public IBinaryType getElementInfo() throws JavaModelException {
+	return (IBinaryType) super.getElementInfo();
 }
 }

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ClassFileInfo.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ClassFileInfo.java
@@ -14,7 +14,7 @@
 package org.eclipse.jdt.internal.core;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Map;
 
 import org.eclipse.jdt.core.*;
 import org.eclipse.jdt.core.compiler.CharOperation;
@@ -25,6 +25,7 @@ import org.eclipse.jdt.internal.compiler.env.IBinaryField;
 import org.eclipse.jdt.internal.compiler.env.IBinaryMethod;
 import org.eclipse.jdt.internal.compiler.env.IBinaryNestedType;
 import org.eclipse.jdt.internal.compiler.env.IBinaryType;
+import org.eclipse.jdt.internal.compiler.env.IElementInfo;
 import org.eclipse.jdt.internal.compiler.env.IRecordComponent;
 import org.eclipse.jdt.internal.compiler.lookup.TagBits;
 import org.eclipse.jdt.internal.compiler.lookup.TypeConstants;
@@ -34,8 +35,7 @@ import org.eclipse.jdt.internal.compiler.util.SuffixConstants;
  * Element info for <code>ClassFile</code> handles.
  */
 
-@SuppressWarnings({"rawtypes", "unchecked"})
-/* package */ class ClassFileInfo extends OpenableElementInfo implements SuffixConstants {
+class ClassFileInfo extends OpenableElementInfo implements SuffixConstants {
 	/**
 	 * The children of the <code>BinaryType</code> corresponding to our
 	 * <code>ClassFile</code>. These are kept here because we don't have
@@ -47,14 +47,14 @@ import org.eclipse.jdt.internal.compiler.util.SuffixConstants;
 	 */
 	protected ITypeParameter[] typeParameters;
 
-private void generateAnnotationsInfos(JavaElement member, IBinaryAnnotation[] binaryAnnotations, long tagBits, HashMap newElements) {
+private void generateAnnotationsInfos(JavaElement member, IBinaryAnnotation[] binaryAnnotations, long tagBits, Map<IJavaElement, IElementInfo> newElements) {
 	generateAnnotationsInfos(member, null, binaryAnnotations, tagBits, newElements);
 }
 /**
  * Creates the handles and infos for the annotations of the given binary member.
  * Adds new handles to the given vector.
  */
-private void generateAnnotationsInfos(JavaElement member, char[] parameterName, IBinaryAnnotation[] binaryAnnotations, long tagBits, HashMap newElements) {
+private void generateAnnotationsInfos(JavaElement member, char[] parameterName, IBinaryAnnotation[] binaryAnnotations, long tagBits, Map<IJavaElement, IElementInfo> newElements) {
 	if (binaryAnnotations != null) {
 		for (int i = 0, length = binaryAnnotations.length; i < length; i++) {
 			IBinaryAnnotation annotationInfo = binaryAnnotations[i];
@@ -63,10 +63,10 @@ private void generateAnnotationsInfos(JavaElement member, char[] parameterName, 
 	}
 	generateStandardAnnotationsInfos(member, parameterName, tagBits, newElements);
 }
-private void generateAnnotationInfo(JavaElement parent, HashMap newElements, IBinaryAnnotation annotationInfo, String memberValuePairName) {
+private void generateAnnotationInfo(JavaElement parent, Map<IJavaElement, IElementInfo> newElements, IBinaryAnnotation annotationInfo, String memberValuePairName) {
 	generateAnnotationInfo(parent, null, newElements, annotationInfo, memberValuePairName);
 }
-private void generateAnnotationInfo(JavaElement parent, char[] parameterName, HashMap newElements, IBinaryAnnotation annotationInfo, String memberValuePairName) {
+private void generateAnnotationInfo(JavaElement parent, char[] parameterName, Map<IJavaElement, IElementInfo> newElements, IBinaryAnnotation annotationInfo, String memberValuePairName) {
 	char[] typeName = org.eclipse.jdt.core.Signature.toCharArray(CharOperation.replaceOnCopy(annotationInfo.getTypeName(), '/', '.'));
 	Annotation annotation = new Annotation(parent, new String(typeName), memberValuePairName);
 	while (newElements.containsKey(annotation)) {
@@ -90,7 +90,7 @@ private void generateAnnotationInfo(JavaElement parent, char[] parameterName, Ha
 		}
 	}
 }
-private void generateStandardAnnotationsInfos(JavaElement javaElement, char[] parameterName, long tagBits, HashMap newElements) {
+private void generateStandardAnnotationsInfos(JavaElement javaElement, char[] parameterName, long tagBits, Map<IJavaElement, IElementInfo> newElements) {
 	if ((tagBits & TagBits.AllStandardAnnotationsMask) == 0)
 		return;
 	if ((tagBits & TagBits.AnnotationRetentionMASK) != 0) {
@@ -114,7 +114,7 @@ private void generateStandardAnnotationsInfos(JavaElement javaElement, char[] pa
 	// note that JAVA_LANG_SUPPRESSWARNINGS and JAVA_LANG_OVERRIDE cannot appear in binaries
 }
 
-private void generateStandardAnnotation(JavaElement javaElement, char[][] typeName, IMemberValuePair[] members, HashMap newElements) {
+private void generateStandardAnnotation(JavaElement javaElement, char[][] typeName, IMemberValuePair[] members, Map<IJavaElement, IElementInfo> newElements) {
 	IAnnotation annotation = new Annotation(javaElement, new String(CharOperation.concatWith(typeName, '.')));
 	AnnotationInfo annotationInfo = new AnnotationInfo();
 	annotationInfo.members = members;
@@ -157,7 +157,7 @@ private IMemberValuePair[] getRetentionPolicy(long tagBits) {
  * Creates the handles and infos for the fields of the given binary type.
  * Adds new handles to the given vector.
  */
-private void generateFieldInfos(IType type, IBinaryType typeInfo, HashMap newElements, ArrayList childrenHandles) {
+private void generateFieldInfos(IType type, IBinaryType typeInfo, Map<IJavaElement, IElementInfo> newElements, ArrayList<JavaElement> childrenHandles) {
 	// Make the fields
 	IBinaryField[] fields = typeInfo.getFields();
 	if (fields == null) {
@@ -180,7 +180,7 @@ private void generateFieldInfos(IType type, IBinaryType typeInfo, HashMap newEle
  * Creates the handles and infos for the fields of the given binary type.
  * Adds new handles to the given vector.
  */
-private void generateRecordComponentInfos(IType type, IBinaryType typeInfo, HashMap newElements, ArrayList childrenHandles) {
+private void generateRecordComponentInfos(IType type, IBinaryType typeInfo, Map<IJavaElement, IElementInfo> newElements, ArrayList<JavaElement> childrenHandles) {
 	// Make the fields
 	IRecordComponent[] components = typeInfo.getRecordComponents();
 	if (components == null) {
@@ -204,7 +204,7 @@ private void generateRecordComponentInfos(IType type, IBinaryType typeInfo, Hash
  * Creates the handles for the inner types of the given binary type.
  * Adds new handles to the given vector.
  */
-private void generateInnerClassHandles(IType type, IBinaryType typeInfo, ArrayList childrenHandles) {
+private void generateInnerClassHandles(IType type, IBinaryType typeInfo, ArrayList<JavaElement> childrenHandles) {
 	// Add inner types
 	// If the current type is an inner type, innerClasses returns
 	// an extra entry for the current type.  This entry must be removed.
@@ -215,7 +215,7 @@ private void generateInnerClassHandles(IType type, IBinaryType typeInfo, ArrayLi
 		for (int i = 0, typeCount = innerTypes.length; i < typeCount; i++) {
 			IBinaryNestedType binaryType = innerTypes[i];
 			IClassFile parentClassFile= pkg.getClassFile(new String(ClassFile.unqualifiedName(binaryType.getName())) + SUFFIX_STRING_class);
-			IType innerType = new BinaryType((JavaElement) parentClassFile, ClassFile.simpleName(binaryType.getName()));
+			BinaryType innerType = new BinaryType((JavaElement) parentClassFile, ClassFile.simpleName(binaryType.getName()));
 			childrenHandles.add(innerType);
 		}
 	}
@@ -224,7 +224,7 @@ private void generateInnerClassHandles(IType type, IBinaryType typeInfo, ArrayLi
  * Creates the handles and infos for the methods of the given binary type.
  * Adds new handles to the given vector.
  */
-private void generateMethodInfos(IType type, IBinaryType typeInfo, HashMap newElements, ArrayList childrenHandles, ArrayList typeParameterHandles) {
+private void generateMethodInfos(IType type, IBinaryType typeInfo, Map<IJavaElement, IElementInfo> newElements, ArrayList<JavaElement> childrenHandles, ArrayList<ITypeParameter> typeParameterHandles) {
 	IBinaryMethod[] methods = typeInfo.getMethods();
 	if (methods == null) {
 		return;
@@ -347,7 +347,7 @@ private void generateMethodInfos(IType type, IBinaryType typeInfo, HashMap newEl
  * Creates the handles and infos for the type parameter of the given binary member.
  * Adds new handles to the given vector.
  */
-private void generateTypeParameterInfos(BinaryMember parent, char[] signature, HashMap newElements, ArrayList typeParameterHandles) {
+private void generateTypeParameterInfos(BinaryMember parent, char[] signature, Map<IJavaElement, IElementInfo> newElements, ArrayList<ITypeParameter> typeParameterHandles) {
 	if (signature == null) return;
 	char[][] typeParameterSignatures = Signature.getTypeParameters(signature);
 	for (int i = 0, typeParameterCount = typeParameterSignatures.length; i < typeParameterCount; i++) {
@@ -379,10 +379,10 @@ private void generateTypeParameterInfos(BinaryMember parent, char[] signature, H
  * <code>ClassFile</code> and adds them to the
  * <code>JavaModelManager</code>'s cache.
  */
-protected void readBinaryChildren(ClassFile classFile, HashMap newElements, IBinaryType typeInfo) {
-	ArrayList childrenHandles = new ArrayList();
+protected void readBinaryChildren(ClassFile classFile, Map<IJavaElement, IElementInfo> newElements, IBinaryType typeInfo) {
+	ArrayList<JavaElement> childrenHandles = new ArrayList<>();
 	BinaryType type = (BinaryType) classFile.getType();
-	ArrayList typeParameterHandles = new ArrayList();
+	ArrayList<ITypeParameter> typeParameterHandles = new ArrayList<>();
 	if (typeInfo != null) { //may not be a valid class file
 		generateAnnotationsInfos(type, typeInfo.getAnnotations(), typeInfo.getTagBits(), newElements);
 		generateTypeParameterInfos(type, typeInfo.getGenericSignature(), newElements, typeParameterHandles);

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ClassFileWorkingCopy.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ClassFileWorkingCopy.java
@@ -25,6 +25,7 @@ import org.eclipse.jdt.core.WorkingCopyOwner;
 import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.core.util.ClassFileBytesDisassembler;
 import org.eclipse.jdt.core.util.IClassFileReader;
+import org.eclipse.jdt.internal.compiler.env.IElementInfo;
 import org.eclipse.jdt.internal.compiler.lookup.TypeConstants;
 import org.eclipse.jdt.internal.core.util.Disassembler;
 import org.eclipse.jdt.internal.core.util.Util;
@@ -91,11 +92,8 @@ public IResource resource(PackageFragmentRoot root) {
 	return this.classFile.resource(root);
 }
 
-/**
- * @see Openable#openBuffer(IProgressMonitor, Object)
- */
 @Override
-protected IBuffer openBuffer(IProgressMonitor pm, Object info) throws JavaModelException {
+protected IBuffer openBuffer(IProgressMonitor pm, IElementInfo info) throws JavaModelException {
 
 	// create buffer
 	IBuffer buffer = BufferManager.createBuffer(this);

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/CompilationUnitProblemFinder.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/CompilationUnitProblemFinder.java
@@ -13,7 +13,6 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.core;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.core.runtime.IPath;
@@ -41,7 +40,6 @@ import org.eclipse.jdt.internal.core.util.Util;
  * Responsible for resolving types inside a compilation unit being reconciled,
  * reporting the discovered problems to a given IProblemRequestor.
  */
-@SuppressWarnings({ "rawtypes", "unchecked" })
 public class CompilationUnitProblemFinder extends Compiler {
 
 	/**
@@ -184,7 +182,7 @@ public class CompilationUnitProblemFinder extends Compiler {
 		}
 	}
 
-	protected static CompilerOptions getCompilerOptions(Map settings, boolean creatingAST, boolean statementsRecovery) {
+	protected static CompilerOptions getCompilerOptions(Map<String, String> settings, boolean creatingAST, boolean statementsRecovery) {
 		CompilerOptions compilerOptions = new CompilerOptions(settings);
 		compilerOptions.performMethodsFullRecovery = statementsRecovery;
 		compilerOptions.performStatementsRecovery = statementsRecovery;
@@ -240,7 +238,7 @@ public class CompilationUnitProblemFinder extends Compiler {
 			CompilationUnit unitElement,
 			SourceElementParser parser,
 			WorkingCopyOwner workingCopyOwner,
-			HashMap problems,
+			Map<String, CategorizedProblem[]> problems,
 			boolean creatingAST,
 			int reconcileFlags,
 			IProgressMonitor monitor)
@@ -339,7 +337,7 @@ public class CompilationUnitProblemFinder extends Compiler {
 	public static CompilationUnitDeclaration process(
 			CompilationUnit unitElement,
 			WorkingCopyOwner workingCopyOwner,
-			HashMap problems,
+			Map<String, CategorizedProblem[]> problems,
 			boolean creatingAST,
 			int reconcileFlags,
 			IProgressMonitor monitor)

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/CreateTypeMemberOperation.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/CreateTypeMemberOperation.java
@@ -138,7 +138,7 @@ protected ASTNode generateElementAST(ASTRewrite rewriter, ICompilationUnit cu) t
 }
 private String removeIndentAndNewLines(String code, ICompilationUnit cu) throws JavaModelException {
 	IJavaProject project = cu.getJavaProject();
-	Map options = project.getOptions(true/*inherit JavaCore options*/);
+	Map<String, String> options = project.getOptions(true/*inherit JavaCore options*/);
 	int tabWidth = IndentManipulation.getTabWidth(options);
 	int indentWidth = IndentManipulation.getIndentWidth(options);
 	int indent = IndentManipulation.measureIndentUnits(code, tabWidth, indentWidth);

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/DeltaProcessor.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/DeltaProcessor.java
@@ -41,6 +41,7 @@ import org.eclipse.core.runtime.*;
 import org.eclipse.jdt.core.*;
 import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.internal.compiler.SourceElementParser;
+import org.eclipse.jdt.internal.compiler.env.IElementInfo;
 import org.eclipse.jdt.internal.compiler.lookup.TypeConstants;
 import org.eclipse.jdt.internal.core.JavaModelManager.PerProjectInfo;
 import org.eclipse.jdt.internal.core.builder.JavaBuilder;
@@ -1802,7 +1803,7 @@ public class DeltaProcessor {
 	private void nonJavaResourcesChanged(Openable element, IResourceDelta delta) 	throws JavaModelException {
 		// reset non-java resources if element was open
 		if (element.isOpen()) {
-			JavaElementInfo info = (JavaElementInfo)element.getElementInfo();
+			IElementInfo info = element.getElementInfo();
 			switch (element.getElementType()) {
 				case IJavaElement.JAVA_MODEL :
 					((JavaModelInfo) info).setNonJavaResources(null);

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ExternalFolderChange.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ExternalFolderChange.java
@@ -23,7 +23,6 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.JavaModelException;
 
-@SuppressWarnings("rawtypes")
 public class ExternalFolderChange {
 
 	private final JavaProject project;
@@ -38,13 +37,13 @@ public class ExternalFolderChange {
 	 * Update external folders
 	 */
 	public void updateExternalFoldersIfNecessary(boolean refreshIfExistAlready, IProgressMonitor monitor) throws JavaModelException {
-		Set oldFolders = ExternalFoldersManager.getExternalFolders(this.oldResolvedClasspath);
+		Set<IPath> oldFolders = ExternalFoldersManager.getExternalFolders(this.oldResolvedClasspath);
 		IClasspathEntry[] newResolvedClasspath = this.project.getResolvedClasspath();
-		Set newFolders = ExternalFoldersManager.getExternalFolders(newResolvedClasspath);
+		Set<IPath> newFolders = ExternalFoldersManager.getExternalFolders(newResolvedClasspath);
 		if (newFolders == null)
 			return;
 		ExternalFoldersManager foldersManager = JavaModelManager.getExternalManager();
-		Iterator iterator = newFolders.iterator();
+		Iterator<IPath> iterator = newFolders.iterator();
 		while (iterator.hasNext()) {
 			Object folderPath = iterator.next();
 			if (oldFolders == null || !oldFolders.remove(folderPath) || foldersManager.removePendingFolder(folderPath)) {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JarPackageFragment.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JarPackageFragment.java
@@ -170,7 +170,7 @@ public ICompilationUnit createCompilationUnit(String cuName, String contents, bo
  * @see JavaElement
  */
 @Override
-protected Object createElementInfo() {
+protected JarPackageFragmentInfo createElementInfo() {
 	return new JarPackageFragmentInfo();
 }
 /**

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JarPackageFragmentRoot.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JarPackageFragmentRoot.java
@@ -208,7 +208,7 @@ public class JarPackageFragmentRoot extends PackageFragmentRoot {
 	 * Returns a new element info for this element.
 	 */
 	@Override
-	protected Object createElementInfo() {
+	protected JarPackageFragmentRootInfo createElementInfo() {
 		return new JarPackageFragmentRootInfo();
 	}
 	/**

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaElementInfo.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaElementInfo.java
@@ -14,12 +14,13 @@
 package org.eclipse.jdt.internal.core;
 
 import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.internal.compiler.env.IElementInfo;
 
 /**
  * Holds cached structure and properties for a Java element.
  * Subclassed to carry properties for specific kinds of elements.
  */
-public class JavaElementInfo implements Cloneable {
+public class JavaElementInfo implements Cloneable, IElementInfo {
 
 	/**
 	 * Shared empty collection used for efficiency.

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModel.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModel.java
@@ -118,7 +118,7 @@ public void copy(IJavaElement[] elements, IJavaElement[] containers, IJavaElemen
  * Returns a new element info for this element.
  */
 @Override
-protected Object createElementInfo() {
+protected JavaModelInfo createElementInfo() {
 	return new JavaModelInfo();
 }
 

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelCache.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelCache.java
@@ -23,6 +23,8 @@ import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
 import org.eclipse.jdt.core.ITypeRoot;
+import org.eclipse.jdt.internal.compiler.env.IBinaryInfo;
+import org.eclipse.jdt.internal.compiler.env.IElementInfo;
 import org.eclipse.jdt.internal.core.util.LRUCache;
 import org.eclipse.jdt.internal.core.util.Util;
 
@@ -41,7 +43,7 @@ public class JavaModelCache {
 	public static final String RATIO_PROPERTY = "org.eclipse.jdt.core.javamodelcache.ratio"; //$NON-NLS-1$
 	public static final String JAR_TYPE_RATIO_PROPERTY = "org.eclipse.jdt.core.javamodelcache.jartyperatio"; //$NON-NLS-1$
 
-	public static final Object NON_EXISTING_JAR_TYPE_INFO = new Object();
+	public static final IBinaryInfo NON_EXISTING_JAR_TYPE_INFO = new IBinaryInfo() {/*empty marker instance only*/};
 
 	/*
 	 * The memory ratio that should be applied to the above constants.
@@ -76,13 +78,13 @@ public class JavaModelCache {
 	/**
 	 * Cache of open children of openable Java Model Java elements
 	 */
-	protected Map<IJavaElement, Object> childrenCache;
+	protected Map<IJavaElement, IElementInfo> childrenCache;
 
 	/**
 	 * Cache of open binary type (inside a jar) that have a non-open parent
 	 * Values are either instance of IBinaryType or Object (see {@link #NON_EXISTING_JAR_TYPE_INFO})
 	 */
-	protected LRUCache<IJavaElement, Object> jarTypeCache;
+	protected LRUCache<IJavaElement, IElementInfo> jarTypeCache;
 
 public JavaModelCache() {
 	// set the size of the caches as a function of the maximum amount of memory available
@@ -127,7 +129,7 @@ private double getRatioForProperty(String propertyName) {
 /**
  *  Returns the info for the element.
  */
-public Object getInfo(IJavaElement element) {
+public IElementInfo getInfo(IJavaElement element) {
 	switch (element.getElementType()) {
 		case IJavaElement.JAVA_MODEL:
 			return this.modelInfo;
@@ -141,7 +143,7 @@ public Object getInfo(IJavaElement element) {
 		case IJavaElement.CLASS_FILE:
 			return this.openableCache.get((ITypeRoot) element);
 		case IJavaElement.TYPE:
-			Object result = this.jarTypeCache.get(element);
+			IElementInfo result = this.jarTypeCache.get(element);
 			if (result != null)
 				return result;
 			else
@@ -189,7 +191,7 @@ protected double getMemoryRatio() {
  *  Returns the info for this element without
  *  disturbing the cache ordering.
  */
-protected Object peekAtInfo(IJavaElement element) {
+protected IElementInfo peekAtInfo(IJavaElement element) {
 	switch (element.getElementType()) {
 		case IJavaElement.JAVA_MODEL:
 			return this.modelInfo;
@@ -203,7 +205,7 @@ protected Object peekAtInfo(IJavaElement element) {
 		case IJavaElement.CLASS_FILE:
 			return this.openableCache.peek((ITypeRoot) element);
 		case IJavaElement.TYPE:
-			Object result = this.jarTypeCache.peek(element);
+			IElementInfo result = this.jarTypeCache.peek(element);
 			if (result != null)
 				return result;
 			else
@@ -216,7 +218,7 @@ protected Object peekAtInfo(IJavaElement element) {
 /**
  * Remember the info for the element.
  */
-protected void putInfo(IJavaElement element, Object info) {
+protected void putInfo(IJavaElement element, IElementInfo info) {
 	if (DEBUG_CACHE_INSERTIONS) {
 		JavaModelManager.trace(Thread.currentThread() + " cache putInfo (" + getElementType(element) + " " + element.toString() + ", " + info + ")");  //$NON-NLS-1$//$NON-NLS-2$//$NON-NLS-3$//$NON-NLS-4$
 	}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelManager.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelManager.java
@@ -140,6 +140,7 @@ import org.eclipse.jdt.internal.compiler.AbstractAnnotationProcessorManager;
 import org.eclipse.jdt.internal.compiler.Compiler;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 import org.eclipse.jdt.internal.compiler.env.AccessRestriction;
+import org.eclipse.jdt.internal.compiler.env.IElementInfo;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jdt.internal.compiler.lookup.TypeConstants;
 import org.eclipse.jdt.internal.compiler.util.HashtableOfObjectToInt;
@@ -1262,7 +1263,7 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 	/*
 	 * Temporary cache of newly opened elements
 	 */
-	private final ThreadLocal<HashMap<IJavaElement, Object>> temporaryCache = new ThreadLocal<>();
+	private final ThreadLocal<HashMap<IJavaElement, IElementInfo>> temporaryCache = new ThreadLocal<>();
 
 	/**
 	 * Set of elements which are out of sync with their buffers.
@@ -2269,10 +2270,10 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 	/**
 	 *  Returns the info for the element.
 	 */
-	public synchronized Object getInfo(IJavaElement element) {
-		HashMap<IJavaElement, Object> tempCache = this.temporaryCache.get();
+	public synchronized IElementInfo getInfo(IJavaElement element) {
+		HashMap<IJavaElement, IElementInfo> tempCache = this.temporaryCache.get();
 		if (tempCache != null) {
-			Object result = tempCache.get(element);
+			IElementInfo result = tempCache.get(element);
 			if (result != null) {
 				return result;
 			}
@@ -2713,10 +2714,20 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 	 * Returns the temporary cache for newly opened elements for the current thread.
 	 * Creates it if not already created.
 	 */
-	public HashMap<IJavaElement, Object> getTemporaryCache() {
-		HashMap<IJavaElement, Object> result = this.temporaryCache.get();
+	public HashMap<IJavaElement, IElementInfo> getTemporaryCache() {
+		HashMap<IJavaElement, IElementInfo> result = this.temporaryCache.get();
 		if (result == null) {
-			result = new HashMap<>();
+			result = new HashMap<>() {
+				/**
+				 *
+				 */
+				private static final long serialVersionUID = 1L;
+
+				@Override
+				public IElementInfo put(IJavaElement key, IElementInfo value) {
+					return super.put(key, value);
+				}
+			};
 			this.temporaryCache.set(result);
 		}
 		return result;
@@ -4111,10 +4122,10 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 	 *  Returns the info for this element without
 	 *  disturbing the cache ordering.
 	 */
-	protected synchronized Object peekAtInfo(IJavaElement element) {
-		HashMap<IJavaElement, Object> tempCache = this.temporaryCache.get();
+	protected synchronized IElementInfo peekAtInfo(IJavaElement element) {
+		HashMap<IJavaElement, IElementInfo> tempCache = this.temporaryCache.get();
 		if (tempCache != null) {
-			Object result = tempCache.get(element);
+			IElementInfo result = tempCache.get(element);
 			if (result != null) {
 				return result;
 			}
@@ -4136,9 +4147,9 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 	 * If forceAdd is false it just returns the existing info and if true, this element and it's children are closed and then
 	 * this particular info is added to the cache.
 	 */
-	protected synchronized Object putInfos(IJavaElement openedElement, Object newInfo, boolean forceAdd, Map<IJavaElement, Object> newElements) {
+	protected synchronized IElementInfo putInfos(IJavaElement openedElement, IElementInfo newInfo, boolean forceAdd, Map<IJavaElement, IElementInfo> newElements) {
 		// remove existing children as the are replaced with the new children contained in newElements
-		Object existingInfo = this.cache.peekAtInfo(openedElement);
+		IElementInfo existingInfo = this.cache.peekAtInfo(openedElement);
 		if (existingInfo != null && !forceAdd) {
 			// If forceAdd is false, then it could mean that the particular element
 			// wasn't in cache at that point of time, but would have got added through
@@ -4162,19 +4173,19 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 		// Subsequent resolution against package in the jar would fail as a result.
 		// https://bugs.eclipse.org/bugs/show_bug.cgi?id=102422
 		// (theodora)
-		for(Iterator<Entry<IJavaElement, Object>> it = newElements.entrySet().iterator(); it.hasNext(); ) {
-			Entry<IJavaElement, Object> entry = it.next();
+		for(Iterator<Entry<IJavaElement, IElementInfo>> it = newElements.entrySet().iterator(); it.hasNext(); ) {
+			Entry<IJavaElement, IElementInfo> entry = it.next();
 			IJavaElement element = entry.getKey();
 			if (element instanceof JarPackageFragmentRoot) {
-				JavaElementInfo info = (JavaElementInfo) entry.getValue();
+				IElementInfo info = entry.getValue();
 				it.remove();
 				this.cache.putInfo(element, info);
 			}
 		}
 
-		Iterator<Entry<IJavaElement, Object>> iterator = newElements.entrySet().iterator();
+		Iterator<Entry<IJavaElement, IElementInfo>> iterator = newElements.entrySet().iterator();
 		while (iterator.hasNext()) {
-			Entry<IJavaElement, Object> entry = iterator.next();
+			Entry<IJavaElement, IElementInfo> entry = iterator.next();
 			this.cache.putInfo(entry.getKey(), entry.getValue());
 		}
 		return newInfo;
@@ -4203,7 +4214,7 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 	 * Remember the info for the jar binary type
 	 * @param info instanceof IBinaryType or {@link JavaModelCache#NON_EXISTING_JAR_TYPE_INFO}
 	 */
-	protected synchronized void putJarTypeInfo(IJavaElement type, Object info) {
+	protected synchronized void putJarTypeInfo(IJavaElement type, IElementInfo info) {
 		this.cache.jarTypeCache.put(type, info);
 	}
 

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaProject.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaProject.java
@@ -1294,7 +1294,7 @@ public class JavaProject
 	 * Returns a new element info for this element.
 	 */
 	@Override
-	protected Object createElementInfo() {
+	protected JavaProjectElementInfo createElementInfo() {
 		return new JavaProjectElementInfo();
 	}
 

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/LambdaExpression.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/LambdaExpression.java
@@ -170,7 +170,7 @@ public class LambdaExpression extends SourceType {
 	}
 
 	@Override
-	public Object getElementInfo(IProgressMonitor monitor) throws JavaModelException {
+	public SourceTypeElementInfo getElementInfo(IProgressMonitor monitor) throws JavaModelException {
 		return this.elementInfo;
 	}
 

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/LambdaMethod.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/LambdaMethod.java
@@ -74,7 +74,7 @@ public class LambdaMethod extends SourceMethod {
 	}
 
 	@Override
-	public Object getElementInfo(IProgressMonitor monitor) throws JavaModelException {
+	public SourceMethodElementInfo getElementInfo(IProgressMonitor monitor) throws JavaModelException {
 		return this.elementInfo;
 	}
 

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/LocalVariable.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/LocalVariable.java
@@ -15,7 +15,7 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.core;
 
-import java.util.HashMap;
+import java.util.Map;
 
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.IPath;
@@ -32,6 +32,7 @@ import org.eclipse.jdt.internal.compiler.ast.OperatorIds;
 import org.eclipse.jdt.internal.compiler.ast.QualifiedNameReference;
 import org.eclipse.jdt.internal.compiler.ast.SingleNameReference;
 import org.eclipse.jdt.internal.compiler.ast.UnaryExpression;
+import org.eclipse.jdt.internal.compiler.env.IElementInfo;
 import org.eclipse.jdt.internal.compiler.lookup.ExtraCompilerModifiers;
 import org.eclipse.jdt.internal.compiler.parser.RecoveryScanner;
 import org.eclipse.jdt.internal.core.util.MementoTokenizer;
@@ -105,7 +106,7 @@ public class LocalVariable extends SourceRefElement implements ILocalVariable {
 	}
 
 	@Override
-	protected Object createElementInfo() {
+	protected JavaElementInfo createElementInfo() {
 		// a local variable has no info
 		return null;
 	}
@@ -128,7 +129,7 @@ public class LocalVariable extends SourceRefElement implements ILocalVariable {
 	}
 
 	@Override
-	protected void generateInfos(Object info, HashMap newElements, IProgressMonitor pm) {
+	protected void generateInfos(IElementInfo info, Map<IJavaElement, IElementInfo> newElements, IProgressMonitor pm) {
 		// a local variable has no info
 	}
 

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ModularClassFile.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ModularClassFile.java
@@ -22,6 +22,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.core.*;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFormatException;
+import org.eclipse.jdt.internal.compiler.env.IElementInfo;
 import org.eclipse.jdt.internal.compiler.env.IBinaryModule;
 import org.eclipse.jdt.internal.compiler.env.IDependent;
 import org.eclipse.jdt.internal.compiler.env.IModule;
@@ -49,7 +50,7 @@ public class ModularClassFile extends AbstractClassFile implements IModularClass
 	 * @see Signature
 	 */
 	@Override
-	protected boolean buildStructure(OpenableElementInfo info, IProgressMonitor pm, Map newElements, IResource underlyingResource) throws JavaModelException {
+	protected boolean buildStructure(OpenableElementInfo info, IProgressMonitor pm, Map<IJavaElement, IElementInfo> newElements, IResource underlyingResource) throws JavaModelException {
 		IBinaryModule moduleInfo = getBinaryModuleInfo();
 		if (moduleInfo == null) {
 			// The structure of a class file is unknown if a class file format errors occurred
@@ -253,7 +254,7 @@ public class ModularClassFile extends AbstractClassFile implements IModularClass
 	 * @see Openable
 	 */
 	@Override
-	protected IBuffer openBuffer(IProgressMonitor pm, Object info) throws JavaModelException {
+	protected IBuffer openBuffer(IProgressMonitor pm, IElementInfo info) throws JavaModelException {
 		SourceMapper mapper = getSourceMapper();
 		if (mapper != null) {
 			return mapSource(mapper);

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/NameLookup.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/NameLookup.java
@@ -42,7 +42,6 @@ import org.eclipse.jdt.internal.compiler.ast.ASTNode;
 import org.eclipse.jdt.internal.compiler.ast.TypeDeclaration;
 import org.eclipse.jdt.internal.compiler.env.AccessRestriction;
 import org.eclipse.jdt.internal.compiler.env.AccessRuleSet;
-import org.eclipse.jdt.internal.compiler.env.IBinaryType;
 import org.eclipse.jdt.internal.compiler.env.IModule;
 import org.eclipse.jdt.internal.compiler.lookup.TypeConstants;
 import org.eclipse.jdt.internal.compiler.parser.ScannerHelper;
@@ -383,7 +382,7 @@ public class NameLookup implements SuffixConstants {
 		try {
 			int kind = isSourceType
 					? TypeDeclaration.kind(((SourceTypeElementInfo) ((SourceType) type).getElementInfo()).getModifiers())
-					: TypeDeclaration.kind(((IBinaryType) ((BinaryType) type).getElementInfo()).getModifiers());
+					: TypeDeclaration.kind(((BinaryType) type).getElementInfo().getModifiers());
 			switch (kind) {
 				case TypeDeclaration.CLASS_DECL :
 					return (acceptFlags & (ACCEPT_CLASSES | ACCEPT_RECORDS)) != 0;

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/PackageFragment.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/PackageFragment.java
@@ -168,7 +168,7 @@ public ICompilationUnit createCompilationUnit(String cuName, String contents, bo
  * @see JavaElement
  */
 @Override
-protected Object createElementInfo() {
+protected PackageFragmentInfo createElementInfo() {
 	return new PackageFragmentInfo();
 }
 /**

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/PackageFragmentRoot.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/PackageFragmentRoot.java
@@ -308,7 +308,7 @@ public void copy(
  * Returns a new element info for this element.
  */
 @Override
-protected Object createElementInfo() {
+protected PackageFragmentRootInfo createElementInfo() {
 	return new PackageFragmentRootInfo();
 }
 

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ReconcileWorkingCopyOperation.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ReconcileWorkingCopyOperation.java
@@ -45,13 +45,12 @@ import org.eclipse.jdt.internal.core.util.Util;
  * <li>notifies compilation participants of the reconcile allowing them to participate in this operation and report problems</li>
  * </ul>
  */
-@SuppressWarnings({"rawtypes"})
 public class ReconcileWorkingCopyOperation extends JavaModelOperation {
 	public static boolean PERF = false;
 
 	public int astLevel;
 	public boolean resolveBindings;
-	public HashMap problems;
+	public Map<String, CategorizedProblem[]>  problems;
 	public int reconcileFlags;
 	WorkingCopyOwner workingCopyOwner;
 	public org.eclipse.jdt.core.dom.CompilationUnit ast;
@@ -129,8 +128,8 @@ public class ReconcileWorkingCopyOperation extends JavaModelOperation {
 	private void reportProblems(CompilationUnit workingCopy, IProblemRequestor problemRequestor) {
 		try {
 			problemRequestor.beginReporting();
-			for (Iterator iteraror = this.problems.values().iterator(); iteraror.hasNext();) {
-				CategorizedProblem[] categorizedProblems = (CategorizedProblem[]) iteraror.next();
+			for (Iterator<CategorizedProblem[]> iteraror = this.problems.values().iterator(); iteraror.hasNext();) {
+				CategorizedProblem[] categorizedProblems = iteraror.next();
 				if (categorizedProblems == null) continue;
 				for (int i = 0, length = categorizedProblems.length; i < length; i++) {
 					CategorizedProblem problem = categorizedProblems[i];
@@ -165,7 +164,7 @@ public class ReconcileWorkingCopyOperation extends JavaModelOperation {
 	public org.eclipse.jdt.core.dom.CompilationUnit makeConsistent(CompilationUnit workingCopy) throws JavaModelException {
 		if (!workingCopy.isConsistent()) {
 			// make working copy consistent
-			if (this.problems == null) this.problems = new HashMap();
+			if (this.problems == null) this.problems = new HashMap<>();
 			this.resolveBindings = this.requestorIsActive;
 			this.ast = workingCopy.makeConsistent(this.astLevel, this.resolveBindings, this.reconcileFlags, this.problems, this.progressMonitor);
 			this.deltaBuilder.buildDeltas();
@@ -185,7 +184,7 @@ public class ReconcileWorkingCopyOperation extends JavaModelOperation {
 					&& (this.reconcileFlags & ICompilationUnit.FORCE_PROBLEM_DETECTION) != 0) {
 				this.resolveBindings = this.requestorIsActive;
 				if (this.problems == null)
-					this.problems = new HashMap();
+					this.problems = new HashMap<>();
 				unit =
 					CompilationUnitProblemFinder.process(
 						source,
@@ -200,7 +199,7 @@ public class ReconcileWorkingCopyOperation extends JavaModelOperation {
 			// create AST if needed
 			if (this.astLevel != ICompilationUnit.NO_AST
 					&& unit !=null/*unit is null if working copy is consistent && (problem detection not forced || non-Java project) -> don't create AST as per API*/) {
-				Map options = workingCopy.getJavaProject().getOptions(true);
+				Map<String, String> options = workingCopy.getJavaProject().getOptions(true);
 				// convert AST
 				this.ast =
 					AST.convertCompilationUnit(

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SearchableEnvironment.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SearchableEnvironment.java
@@ -245,7 +245,7 @@ public class SearchableEnvironment
 	private NameEnvironmentAnswer createAnswer(Answer lookupAnswer, String packageName, String typeName, BinaryType binaryType) {
 		char[] moduleName = lookupAnswer.module != null ? lookupAnswer.module.getElementName().toCharArray() : null;
 		try {
-			IBinaryType iBinaryType = (IBinaryType) binaryType.getElementInfo();
+			IBinaryType iBinaryType = binaryType.getElementInfo();
 			if (iBinaryType.getExternalAnnotationStatus() == ExternalAnnotationStatus.NOT_EEA_CONFIGURED
 					&& JavaCore.ENABLED.equals(this.project.getOption(JavaCore.CORE_JAVA_BUILD_EXTERNAL_ANNOTATIONS_FROM_ALL_LOCATIONS, true)))
 			{

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SourceRefElement.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SourceRefElement.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.core;
 
-import java.util.HashMap;
+import java.util.Map;
 
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.IPath;
@@ -21,6 +21,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.core.*;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.internal.compiler.env.IElementInfo;
 import org.eclipse.jdt.internal.core.util.DOMFinder;
 import org.eclipse.jdt.internal.core.util.MementoTokenizer;
 import org.eclipse.jdt.internal.core.util.Messages;
@@ -53,7 +54,7 @@ protected void closing(Object info) throws JavaModelException {
  * Returns a new element info for this element.
  */
 @Override
-protected Object createElementInfo() {
+protected JavaElementInfo createElementInfo() {
 	return null; // not used for source ref elements
 }
 /**
@@ -104,11 +105,11 @@ public ASTNode findNode(CompilationUnit ast) {
 }
 
 @Override
-protected void generateInfos(Object info, HashMap newElements, IProgressMonitor pm) throws JavaModelException {
+protected void generateInfos(IElementInfo info, Map<IJavaElement, IElementInfo> newElements, IProgressMonitor pm) throws JavaModelException {
 	Openable openableParent = (Openable)getOpenableParent();
 	if (openableParent == null) return;
 
-	JavaElementInfo openableParentInfo = (JavaElementInfo) JavaModelManager.getJavaModelManager().getInfo(openableParent);
+	IElementInfo openableParentInfo = JavaModelManager.getJavaModelManager().getInfo(openableParent);
 	if (openableParentInfo == null) {
 		openableParent.generateInfos(openableParent.createElementInfo(), newElements, pm);
 	}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/ClasspathJar.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/ClasspathJar.java
@@ -55,7 +55,6 @@ import org.eclipse.jdt.internal.compiler.util.SuffixConstants;
 import org.eclipse.jdt.internal.core.JavaModelManager;
 import org.eclipse.jdt.internal.core.util.Util;
 
-@SuppressWarnings("rawtypes")
 public class ClasspathJar extends ClasspathLocation {
 final boolean isOnModulePath;
 
@@ -110,8 +109,8 @@ protected SimpleSet findPackageSet() {
 }
 protected String readJarContent(final SimpleSet packageSet) {
 	String modInfo = null;
-	for (Enumeration e = this.zipFile.entries(); e.hasMoreElements(); ) {
-		String fileName = ((ZipEntry) e.nextElement()).getName();
+	for (Enumeration<? extends ZipEntry> e = this.zipFile.entries(); e.hasMoreElements(); ) {
+		String fileName = e.nextElement().getName();
 		if (fileName.startsWith("META-INF/")) //$NON-NLS-1$
 			continue;
 		if (modInfo == null) {

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/core/index/JavaIndexerApplication.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/core/index/JavaIndexerApplication.java
@@ -17,6 +17,7 @@ import java.io.File;
 import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.ArrayList;
+import java.util.List;
 
 import org.eclipse.equinox.app.IApplication;
 import org.eclipse.equinox.app.IApplicationContext;
@@ -36,7 +37,6 @@ import org.eclipse.osgi.util.NLS;
  * @noinstantiate This class is not intended to be instantiated by clients.
  * @noextend This class is not intended to be subclassed by clients.
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class JavaIndexerApplication implements IApplication {
 
 	private final static class Messages extends NLS {
@@ -92,7 +92,7 @@ public class JavaIndexerApplication implements IApplication {
 	}
 
 	private boolean processCommandLine(String[] argsArray) {
-		ArrayList args = new ArrayList();
+		List<String> args = new ArrayList<>();
 		for (int i = 0, max = argsArray.length; i < max; i++) {
 			args.add(argsArray[i]);
 		}

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/BasicSearchEngine.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/BasicSearchEngine.java
@@ -45,7 +45,6 @@ import org.eclipse.jdt.internal.core.util.Messages;
  * for detailed comment), now uses basic engine functionalities.
  * Note that search basic engine does not implement deprecated functionalities...
  */
-@SuppressWarnings({ "rawtypes", "unchecked" })
 public class BasicSearchEngine {
 
 	/*
@@ -154,11 +153,11 @@ public class BasicSearchEngine {
 	 * @see SearchEngine#createJavaSearchScope(boolean, IJavaElement[], int) for detailed comment.
 	 */
 	public static IJavaSearchScope createJavaSearchScope(boolean excludeTestCode, IJavaElement[] elements, int includeMask) {
-		HashSet projectsToBeAdded = new HashSet(2);
+		Set<JavaProject> projectsToBeAdded = new HashSet<>(2);
 		for (int i = 0, length = elements.length; i < length; i++) {
 			IJavaElement element = elements[i];
-			if (element instanceof JavaProject) {
-				projectsToBeAdded.add(element);
+			if (element instanceof JavaProject p) {
+				projectsToBeAdded.add(p);
 			}
 		}
 		JavaSearchScope scope = new JavaSearchScope(excludeTestCode);
@@ -374,7 +373,7 @@ public class BasicSearchEngine {
 				if (copies == null) {
 					copies = this.workingCopies;
 				} else {
-					HashMap pathToCUs = new HashMap();
+					Map<IPath, ICompilationUnit> pathToCUs = new HashMap<>();
 					for (int i = 0, length = copies.length; i < length; i++) {
 						ICompilationUnit unit = copies[i];
 						pathToCUs.put(unit.getPath(), unit);
@@ -664,7 +663,7 @@ public class BasicSearchEngine {
 					validatedTypeMatchRule);
 
 			// Get working copy path(s). Store in a single string in case of only one to optimize comparison in requestor
-			final HashSet workingCopyPaths = new HashSet();
+			final Set<String> workingCopyPaths = new HashSet<>();
 			String workingCopyPath = null;
 			ICompilationUnit[] copies = getWorkingCopies();
 			final int copiesLength = copies == null ? 0 : copies.length;
@@ -1008,7 +1007,7 @@ public class BasicSearchEngine {
 			final MethodDeclarationPattern pattern = new MethodDeclarationPattern(qualifier, methodName, methodMatchRule);
 
 			// Get working copy path(s). Store in a single string in case of only one to optimize comparison in requestor
-			final HashSet workingCopyPaths = new HashSet();
+			Set<String> workingCopyPaths = new HashSet<>();
 			String workingCopyPath = null;
 			ICompilationUnit[] copies = getWorkingCopies();
 			final int copiesLength = copies == null ? 0 : copies.length;
@@ -1278,7 +1277,7 @@ public class BasicSearchEngine {
 			final MethodDeclarationPattern pattern = new MethodDeclarationPattern(packageName, declaringQualification, declaringSimpleName, methodName, methodMatchRule);
 
 			// Get working copy path(s). Store in a single string in case of only one to optimize comparison in requestor
-			final HashSet workingCopyPaths = new HashSet();
+			Set<String> workingCopyPaths = new HashSet<>();
 			String workingCopyPath = null;
 			ICompilationUnit[] copies = getWorkingCopies();
 			final int copiesLength = copies == null ? 0 : copies.length;
@@ -1634,7 +1633,7 @@ public class BasicSearchEngine {
 			final TypeDeclarationPattern pattern = new SecondaryTypeDeclarationPattern();
 
 			// Get working copy path(s). Store in a single string in case of only one to optimize comparison in requestor
-			final HashSet workingCopyPaths = new HashSet();
+			Set<String> workingCopyPaths = new HashSet<>();
 			String workingCopyPath = null;
 			ICompilationUnit[] copies = getWorkingCopies();
 			final int copiesLength = copies == null ? 0 : copies.length;
@@ -1845,7 +1844,7 @@ public class BasicSearchEngine {
 					validatedTypeMatchRule);
 
 			// Get working copy path(s). Store in a single string in case of only one to optimize comparison in requestor
-			final HashSet workingCopyPaths = new HashSet();
+			Set<String> workingCopyPaths = new HashSet<>();
 			String workingCopyPath = null;
 			ICompilationUnit[] copies = getWorkingCopies();
 			final int copiesLength = copies == null ? 0 : copies.length;
@@ -2097,7 +2096,7 @@ public class BasicSearchEngine {
 			final MultiTypeDeclarationPattern pattern = new MultiTypeDeclarationPattern(qualifications, typeNames, typeSuffix, matchRule);
 
 			// Get working copy path(s). Store in a single string in case of only one to optimize comparison in requestor
-			final HashSet workingCopyPaths = new HashSet();
+			Set<String> workingCopyPaths = new HashSet<>();
 			String workingCopyPath = null;
 			ICompilationUnit[] copies = getWorkingCopies();
 			final int copiesLength = copies == null ? 0 : copies.length;

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/IndexSelector.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/IndexSelector.java
@@ -58,7 +58,6 @@ import org.eclipse.jdt.internal.core.search.processing.JobManager;
  * Selects the indexes that correspond to projects in a given search scope
  * and that are dependent on a given focus element.
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class IndexSelector {
 
 	//TODO: Bug 386113: "Search references" and "Type hierarchy" show inconsistent results with "External Plug-in Libraries" project
@@ -219,7 +218,7 @@ private void initializeIndexLocations() {
 	IPath[] projectsAndJars = this.searchScope.enclosingProjectsAndJars();
 	IndexManager manager = JavaModelManager.getIndexManager();
 	// use a linked set to preserve the order during search: see bug 348507
-	LinkedHashSet locations = new LinkedHashSet();
+	LinkedHashSet<IndexLocation> locations = new LinkedHashSet<>();
 	IJavaElement focus = this.pattern instanceof ModulePattern ? null : MatchLocator.projectOrJarFocus(this.pattern);
 	if (focus == null) {
 		for (int i = 0; i < projectsAndJars.length; i++) {
@@ -306,7 +305,7 @@ private void initializeIndexLocations() {
 	}
 
 	locations.remove(null); // Ensure no nulls
-	this.indexLocations = (IndexLocation[]) locations.toArray(new IndexLocation[locations.size()]);
+	this.indexLocations = locations.toArray(new IndexLocation[locations.size()]);
 }
 
 public IndexLocation[] getIndexLocations() {

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/JavaSearchParticipant.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/JavaSearchParticipant.java
@@ -32,10 +32,9 @@ import org.eclipse.jdt.internal.core.search.matching.MatchLocator;
  * index queries. It also can map a document path to an actual document (note that documents could live outside
  * the workspace or no exist yet, and thus aren't just resources).
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class JavaSearchParticipant extends SearchParticipant implements IParallelizable {
 
-	private final ThreadLocal indexSelector = new ThreadLocal();
+	private final ThreadLocal<IndexSelector> indexSelector = new ThreadLocal<>();
 
 	/**
 	 * The only reason this field exist is the unfortunate idea to share created source indexer
@@ -147,7 +146,7 @@ public class JavaSearchParticipant extends SearchParticipant implements IParalle
 	}
 
 	private IndexSelector getIndexSelector(SearchPattern pattern, IJavaSearchScope scope) {
-		IndexSelector selector = (IndexSelector) this.indexSelector.get();
+		IndexSelector selector = this.indexSelector.get();
 		if (selector == null) {
 			selector = new IndexSelector(scope, pattern);
 			this.indexSelector.set(selector);

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/JavaSearchScope.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/JavaSearchScope.java
@@ -16,6 +16,7 @@ package org.eclipse.jdt.internal.core.search;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
@@ -49,7 +50,6 @@ import org.eclipse.jdt.internal.core.util.Util;
 /**
  * A Java-specific scope for searching relative to one or more java elements.
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class JavaSearchScope extends AbstractJavaSearchScope {
 
 	private HashSet<IJavaElement> elements;
@@ -57,7 +57,7 @@ public class JavaSearchScope extends AbstractJavaSearchScope {
 	/**
 	 * The paths of the resources in this search scope (or the classpath entries' paths if the resources are projects)
 	 */
-	private ArrayList projectPaths = new ArrayList(); // container paths projects
+	private ArrayList<String> projectPaths = new ArrayList<>(); // container paths projects
 	private int[] projectIndexes; // Indexes of projects in list
 	private String[] containerPaths; // path to the container (e.g. /P/src, /P/lib.jar, c:\temp\mylib.jar)
 	private String[] relativePaths; // path relative to the container (e.g. x/y/Z.class, x/y, (empty))
@@ -99,10 +99,10 @@ private void addEnclosingProjectOrJar(IPath path) {
 
 /**
  * Add java project all fragment roots to current java search scope.
- * @see #add(JavaProject, IPath, int, HashSet, HashSet, IClasspathEntry)
+ * @see #add(JavaProject, IPath, int, Set, Set, IClasspathEntry)
  */
-public void add(JavaProject project, int includeMask, HashSet projectsToBeAdded) throws JavaModelException {
-	add(project, null, includeMask, projectsToBeAdded, new HashSet(2), null);
+public void add(JavaProject project, int includeMask, Set<JavaProject>  projectsToBeAdded) throws JavaModelException {
+	add(project, null, includeMask, projectsToBeAdded, new HashSet<>(2), null);
 }
 /**
  * Add a path to current java search scope or all project fragment roots if null.
@@ -116,7 +116,7 @@ public void add(JavaProject project, int includeMask, HashSet projectsToBeAdded)
  * @param referringEntry Project raw entry in referring project classpath
  * @throws JavaModelException May happen while getting java model info
  */
-void add(JavaProject javaProject, IPath pathToAdd, int includeMask, HashSet projectsToBeAdded, HashSet visitedProjects, IClasspathEntry referringEntry) throws JavaModelException {
+void add(JavaProject javaProject, IPath pathToAdd, int includeMask, Set<JavaProject> projectsToBeAdded, Set<IProject> visitedProjects, IClasspathEntry referringEntry) throws JavaModelException {
 	IProject project = javaProject.getProject();
 	if (!project.isAccessible() || !visitedProjects.add(project)) return;
 
@@ -147,9 +147,9 @@ void add(JavaProject javaProject, IPath pathToAdd, int includeMask, HashSet proj
 		switch (entry.getEntryKind()) {
 			case IClasspathEntry.CPE_LIBRARY:
 				IClasspathEntry rawEntry = null;
-				Map rootPathToRawEntries = perProjectInfo.rootPathToRawEntries;
+				Map<IPath, IClasspathEntry> rootPathToRawEntries = perProjectInfo.rootPathToRawEntries;
 				if (rootPathToRawEntries != null) {
-					rawEntry = (IClasspathEntry) rootPathToRawEntries.get(entry.getPath());
+					rawEntry = rootPathToRawEntries.get(entry.getPath());
 				}
 				if (rawEntry == null) break;
 				rawKind: switch (rawEntry.getEntryKind()) {
@@ -230,7 +230,7 @@ public void add(IJavaElement element) throws JavaModelException {
 			// a workspace sope should be used
 			break;
 		case IJavaElement.JAVA_PROJECT:
-			add((JavaProject)element, null, includeMask, new HashSet(2), new HashSet(2), null);
+			add((JavaProject)element, null, includeMask, new HashSet<>(2), new HashSet<>(2), null);
 			break;
 		case IJavaElement.PACKAGE_FRAGMENT_ROOT:
 			root = (PackageFragmentRoot)element;
@@ -529,7 +529,7 @@ protected void initialize(int size) {
 		extraRoom++;
 	this.relativePaths = new String[extraRoom];
 	this.containerPaths = new String[extraRoom];
-	this.projectPaths = new ArrayList();
+	this.projectPaths = new ArrayList<>();
 	this.projectIndexes = new int[extraRoom];
 	this.isPkgPath = new boolean[extraRoom];
 	this.pathRestrictions = null; // null to optimize case where no access rules are used

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/PathCollector.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/PathCollector.java
@@ -14,6 +14,7 @@
 package org.eclipse.jdt.internal.core.search;
 
 import java.util.HashSet;
+import java.util.Set;
 
 import org.eclipse.jdt.core.search.SearchParticipant;
 import org.eclipse.jdt.core.search.SearchPattern;
@@ -22,11 +23,10 @@ import org.eclipse.jdt.internal.compiler.env.AccessRuleSet;
 /**
  * Collects the resource paths reported by a client to this search requestor.
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class PathCollector extends IndexQueryRequestor {
 
 	/* a set of resource paths */
-	public HashSet paths = new HashSet(5);
+	public Set<String> paths = new HashSet<>(5);
 
 	@Override
 	public boolean acceptIndexMatch(String documentPath, SearchPattern indexRecord, SearchParticipant participant, AccessRuleSet access) {
@@ -38,6 +38,6 @@ public class PathCollector extends IndexQueryRequestor {
 	 * Returns the paths that have been collected.
 	 */
 	public String[] getPaths() {
-		return (String[]) this.paths.toArray(new String[this.paths.size()]);
+		return this.paths.toArray(String[]::new);
 	}
 }

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/AddJarFileToIndex.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/AddJarFileToIndex.java
@@ -47,7 +47,6 @@ import org.eclipse.jdt.internal.core.index.IndexLocation;
 import org.eclipse.jdt.internal.core.search.JavaSearchDocument;
 import org.eclipse.jdt.internal.core.search.processing.JobManager;
 
-@SuppressWarnings("rawtypes")
 class AddJarFileToIndex extends BinaryContainer {
 
 	private static final char JAR_SEPARATOR = IJavaSearchScope.JAR_FILE_ENTRY_SEPARATOR.charAt(0);
@@ -188,9 +187,9 @@ class AddJarFileToIndex extends BinaryContainer {
 					SimpleLookupTable indexedFileNames = new SimpleLookupTable(max == 0 ? 33 : max + 11);
 					for (int i = 0; i < max; i++)
 						indexedFileNames.put(paths[i], DELETED);
-					for (Enumeration e = zip.entries(); e.hasMoreElements();) {
+					for (Enumeration<? extends ZipEntry> e = zip.entries(); e.hasMoreElements();) {
 						// iterate each entry to index it
-						ZipEntry ze = (ZipEntry) e.nextElement();
+						ZipEntry ze = e.nextElement();
 						String zipEntryName = ze.getName();
 						if (Util.isClassFileName(zipEntryName) && isValidPackageNameForClassOrisModule(zipEntryName))
 								// the class file may not be there if the package name is not valid
@@ -231,7 +230,7 @@ class AddJarFileToIndex extends BinaryContainer {
 					indexPath = new Path(indexLocation.getCanonicalFilePath());
 				}
 				boolean hasModuleInfoClass = false;
-				for (Enumeration e = zip.entries(); e.hasMoreElements();) {
+				for (Enumeration<? extends ZipEntry> e = zip.entries(); e.hasMoreElements();) {
 					if (this.isCancelled) {
 						if (JobManager.VERBOSE)
 							trace("-> indexing of " + zip.getName() + " has been cancelled"); //$NON-NLS-1$ //$NON-NLS-2$
@@ -239,7 +238,7 @@ class AddJarFileToIndex extends BinaryContainer {
 					}
 
 					// iterate each entry to index it
-					ZipEntry ze = (ZipEntry) e.nextElement();
+					ZipEntry ze = e.nextElement();
 					String zipEntryName = ze.getName();
 					if (Util.isClassFileName(zipEntryName) &&
 							isValidPackageNameForClassOrisModule(zipEntryName)) {

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/DefaultJavaIndexer.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/DefaultJavaIndexer.java
@@ -30,7 +30,6 @@ import org.eclipse.jdt.internal.core.index.Index;
 import org.eclipse.jdt.internal.core.index.IndexLocation;
 import org.eclipse.jdt.internal.core.search.JavaSearchDocument;
 
-@SuppressWarnings("rawtypes")
 public class DefaultJavaIndexer {
 	private static final char JAR_SEPARATOR = IJavaSearchScope.JAR_FILE_ENTRY_SEPARATOR.charAt(0);
 
@@ -44,9 +43,9 @@ public class DefaultJavaIndexer {
 		SearchParticipant participant = SearchEngine.getDefaultSearchParticipant();
 		index.separator = JAR_SEPARATOR;
 		try (ZipFile zip = new ZipFile(pathToJar)) {
-			for (Enumeration e = zip.entries(); e.hasMoreElements();) {
+			for (Enumeration<? extends ZipEntry> e = zip.entries(); e.hasMoreElements();) {
 				// iterate each entry to index it
-				ZipEntry ze = (ZipEntry) e.nextElement();
+				ZipEntry ze = e.nextElement();
 				String zipEntryName = ze.getName();
 				if (Util.isClassFileName(zipEntryName)) {
 					final byte[] classFileBytes = org.eclipse.jdt.internal.compiler.util.Util.getZipEntryByteContent(ze, zip);

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/IndexAllProject.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/IndexAllProject.java
@@ -18,6 +18,7 @@ import static org.eclipse.jdt.internal.core.JavaModelManager.trace;
 import java.io.IOException;
 import java.net.URI;
 import java.util.HashSet;
+import java.util.Set;
 
 import org.eclipse.core.filesystem.EFS;
 import org.eclipse.core.resources.IFile;
@@ -39,7 +40,6 @@ import org.eclipse.jdt.internal.core.index.Index;
 import org.eclipse.jdt.internal.core.search.processing.JobManager;
 import org.eclipse.jdt.internal.core.util.Util;
 
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class IndexAllProject extends IndexRequest {
 	IProject project;
 
@@ -126,7 +126,7 @@ public class IndexAllProject extends IndexRequest {
 				if (sourceFolder != null) {
 
 					// collect output locations if source is project (see http://bugs.eclipse.org/bugs/show_bug.cgi?id=32041)
-					final HashSet outputs = new HashSet();
+					final Set<IPath> outputs = new HashSet<>();
 					if (sourceFolder.getType() == IResource.PROJECT) {
 						// Do not create marker while getting output location (see bug 41859)
 						outputs.add(javaProject.getOutputLocation());

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/IndexManager.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/IndexManager.java
@@ -85,7 +85,6 @@ import org.eclipse.jdt.internal.core.search.processing.JobManager;
 import org.eclipse.jdt.internal.core.util.Messages;
 import org.eclipse.jdt.internal.core.util.Util;
 
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class IndexManager extends JobManager implements IIndexConstants {
 	/**
 	 * Bug 178816:  In case the meta index is causing issue and needs to disable,
@@ -394,7 +393,7 @@ public synchronized void ensureIndexExists(IndexLocation indexLocation, IPath co
 }
 public SourceElementParser getSourceElementParser(IJavaProject project, ISourceElementRequestor requestor) {
 	// disable task tags to speed up parsing
-	Map options = project.getOptions(true);
+	Map<String, String> options = project.getOptions(true);
 	options.put(JavaCore.COMPILER_TASK_TAGS, ""); //$NON-NLS-1$
 
 	SourceElementParser parser = new IndexingParser(
@@ -1048,7 +1047,7 @@ public void removeIndexFamily(IPath path) {
 	// New index is disabled, see bug 544898
 	// this.indexer.makeWorkspacePathDirty(path);
 	// only finds cached index files... shutdown removes all non-cached index files
-	ArrayList toRemove = null;
+	List<IPath> toRemove = null;
 	synchronized (this) {
 		Object[] containerPaths = this.indexLocations.keyTable;
 		for (int i = 0, length = containerPaths.length; i < length; i++) {
@@ -1057,14 +1056,14 @@ public void removeIndexFamily(IPath path) {
 				continue;
 			if (path.isPrefixOf(containerPath)) {
 				if (toRemove == null)
-					toRemove = new ArrayList();
+					toRemove = new ArrayList<>();
 				toRemove.add(containerPath);
 			}
 		}
 	}
 	if (toRemove != null)
 		for (int i = 0, length = toRemove.size(); i < length; i++)
-			removeIndex((IPath) toRemove.get(i));
+			removeIndex(toRemove.get(i));
 }
 /**
  * Remove the content of the given source folder from the index.
@@ -1171,7 +1170,7 @@ public void saveIndex(Index index) throws IOException {
  */
 public void saveIndexes() {
 	// only save cached indexes... the rest were not modified
-	ArrayList toSave = new ArrayList();
+	List<Index> toSave = new ArrayList<>();
 	synchronized(this) {
 		Object[] valueTable = this.indexes.valueTable;
 		for (int i = 0, l = valueTable.length; i < l; i++) {
@@ -1183,7 +1182,7 @@ public void saveIndexes() {
 
 	boolean allSaved = true;
 	for (int i = 0, length = toSave.size(); i < length; i++) {
-		Index index = (Index) toSave.get(i);
+		Index index = toSave.get(i);
 		ReadWriteMonitor monitor = index.monitor;
 		if (monitor == null) continue; // index got deleted since acquired
 		try {

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/MatchLocator.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/MatchLocator.java
@@ -102,7 +102,6 @@ import org.eclipse.jdt.internal.core.util.ASTNodeFinder;
 import org.eclipse.jdt.internal.core.util.HandleFactory;
 import org.eclipse.jdt.internal.core.util.Util;
 
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class MatchLocator implements ITypeRequestor {
 
 public static final int MAX_AT_ONCE;
@@ -172,7 +171,7 @@ SimpleLookupTable bindings;
 
 HashtableOfIntValues inTypeOccurrencesCounts = new HashtableOfIntValues();
 // Cache for method handles
-HashSet methodHandles;
+HashSet<IMethod> methodHandles;
 private TypeBinding unitScopeTypeBinding = null; // cached
 
 private final boolean searchPackageDeclaration;
@@ -203,14 +202,14 @@ public static class WrappedCoreException extends RuntimeException {
 public static SearchDocument[] addWorkingCopies(SearchPattern pattern, SearchDocument[] indexMatches, org.eclipse.jdt.core.ICompilationUnit[] copies, SearchParticipant participant) {
 	if (copies == null) return indexMatches;
 	// working copies take precedence over corresponding compilation units
-	HashMap workingCopyDocuments = workingCopiesThatCanSeeFocus(copies, pattern, participant);
+	HashMap<String, WorkingCopyDocument> workingCopyDocuments = workingCopiesThatCanSeeFocus(copies, pattern, participant);
 	if (workingCopyDocuments.size() == 0) return indexMatches;
 	SearchDocument[] matches = null;
 	int length = indexMatches.length;
 	for (int i = 0; i < length; i++) {
 		SearchDocument searchDocument = indexMatches[i];
 		if (searchDocument.getParticipant() == participant) {
-			SearchDocument workingCopyDocument = (SearchDocument) workingCopyDocuments.remove(searchDocument.getPath());
+			SearchDocument workingCopyDocument = workingCopyDocuments.remove(searchDocument.getPath());
 			if (workingCopyDocument != null) {
 				if (matches == null) {
 					System.arraycopy(indexMatches, 0, matches = new SearchDocument[length], 0, length);
@@ -225,10 +224,10 @@ public static SearchDocument[] addWorkingCopies(SearchPattern pattern, SearchDoc
 	int remainingWorkingCopiesSize = workingCopyDocuments.size();
 	if (remainingWorkingCopiesSize != 0) {
 		System.arraycopy(matches, 0, matches = new SearchDocument[length+remainingWorkingCopiesSize], 0, length);
-		Iterator iterator = workingCopyDocuments.values().iterator();
+		Iterator<WorkingCopyDocument> iterator = workingCopyDocuments.values().iterator();
 		int index = length;
 		while (iterator.hasNext()) {
-			matches[index++] = (SearchDocument) iterator.next();
+			matches[index++] = iterator.next();
 		}
 	}
 	return matches;
@@ -249,9 +248,9 @@ public static void setIndexQualifierQuery(SearchPattern pattern, char[] queries)
 /*
  * Returns the working copies that can see the given focus.
  */
-private static HashMap workingCopiesThatCanSeeFocus(org.eclipse.jdt.core.ICompilationUnit[] copies, SearchPattern pattern, SearchParticipant participant) {
-	if (copies == null) return new HashMap();
-	HashMap result = new HashMap();
+private static HashMap<String, WorkingCopyDocument> workingCopiesThatCanSeeFocus(org.eclipse.jdt.core.ICompilationUnit[] copies, SearchPattern pattern, SearchParticipant participant) {
+	if (copies == null) return new HashMap<>();
+	HashMap<String, WorkingCopyDocument> result = new HashMap<>();
 	for (int i=0, length = copies.length; i<length; i++) {
 		org.eclipse.jdt.core.ICompilationUnit workingCopy = copies[i];
 		IPath projectOrJar = MatchLocator.getProjectOrJar(workingCopy).getPath();
@@ -899,7 +898,7 @@ private long findLastTypeArgumentInfo(TypeReference typeRef) {
 protected IBinaryType getBinaryInfo(ClassFile classFile, IResource resource) throws CoreException {
 	BinaryType binaryType = (BinaryType) classFile.getType();
 	if (classFile.isOpen())
-		return (IBinaryType) binaryType.getElementInfo(); // reuse the info from the java model cache
+		return binaryType.getElementInfo(); // reuse the info from the java model cache
 
 	// create a temporary info
 	IBinaryType info;
@@ -1256,7 +1255,7 @@ public void initialize(JavaProject project, int possibleMatchSize) throws JavaMo
 	this.nameEnvironment = JavaSearchNameEnvironment.createWithReferencedProjects(project, projects, this.workingCopies);
 
 	// create lookup environment
-	Map map = project.getOptions(true);
+	Map<String, String> map = project.getOptions(true);
 	map.put(CompilerOptions.OPTION_TaskTags, org.eclipse.jdt.internal.compiler.util.Util.EMPTY_STRING);
 	this.options = new CompilerOptions(map);
 	ProblemReporter problemReporter =
@@ -1435,7 +1434,7 @@ public void locateMatches(SearchDocument[] searchDocuments) throws CoreException
 	this.progressWorked = 0;
 
 	// extract working copies
-	ArrayList copies = new ArrayList();
+	ArrayList<org.eclipse.jdt.core.ICompilationUnit> copies = new ArrayList<>();
 	for (int i = 0; i < docsLength; i++) {
 		SearchDocument document = searchDocuments[i];
 		if (document instanceof WorkingCopyDocument) {
@@ -2831,7 +2830,7 @@ protected void reportMatching(CompilationUnitDeclaration unit, boolean mustResol
 	}
 
 	if (nodeSet.matchingNodes.elementSize == 0) return; // no matching nodes were found
-	this.methodHandles = new HashSet();
+	this.methodHandles = new HashSet<>();
 
 	boolean matchedUnitContainer = (this.matchContainer & PatternLocator.COMPILATION_UNIT_CONTAINER) != 0;
 

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/MatchingNodeSet.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/MatchingNodeSet.java
@@ -14,6 +14,7 @@
 package org.eclipse.jdt.internal.core.search.matching;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import org.eclipse.jdt.core.search.SearchMatch;
 import org.eclipse.jdt.core.search.SearchPattern;
@@ -26,7 +27,6 @@ import org.eclipse.jdt.internal.core.util.Util;
 /**
  * A set of matches and possible matches, which need to be resolved.
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class MatchingNodeSet {
 
 /**
@@ -136,19 +136,18 @@ protected boolean hasPossibleNodes(int start, int end) {
  * Returns the matching nodes that are in the given range in the source order.
  */
 protected ASTNode[] matchingNodes(int start, int end) {
-	ArrayList nodes = null;
+	List<ASTNode> nodes = null;
 	Object[] keyTable = this.matchingNodes.keyTable;
 	for (int i = 0, l = keyTable.length; i < l; i++) {
 		ASTNode node = (ASTNode) keyTable[i];
 		if (node != null && start <= node.sourceStart && node.sourceEnd <= end) {
-			if (nodes == null) nodes = new ArrayList();
+			if (nodes == null) nodes = new ArrayList<>();
 			nodes.add(node);
 		}
 	}
 	if (nodes == null) return null;
 
-	ASTNode[] result = new ASTNode[nodes.size()];
-	nodes.toArray(result);
+	ASTNode[] result = nodes.toArray(ASTNode[]::new);
 
 	// sort nodes by source starts
 	Util.Comparer comparer = new Util.Comparer() {

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/MethodLocator.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/MethodLocator.java
@@ -20,6 +20,7 @@ import static org.eclipse.jdt.internal.core.JavaModelManager.trace;
 
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Map;
 
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.*;
@@ -33,7 +34,6 @@ import org.eclipse.jdt.internal.compiler.util.SimpleSet;
 import org.eclipse.jdt.internal.core.BinaryMethod;
 import org.eclipse.jdt.internal.core.search.BasicSearchEngine;
 
-@SuppressWarnings({ "rawtypes", "unchecked" })
 public class MethodLocator extends PatternLocator {
 
 protected MethodPattern pattern;
@@ -51,7 +51,7 @@ private char[][][] samePkgSuperDeclaringTypeNames;
 
 private MatchLocator matchLocator;
 //method declarations which parameters verification fail
-private HashMap methodDeclarationsWithInvalidParam = new HashMap();
+private Map<ASTNode, Boolean> methodDeclarationsWithInvalidParam = new HashMap<>();
 
 
 public MethodLocator(MethodPattern pattern) {
@@ -65,7 +65,7 @@ public MethodLocator(MethodPattern pattern) {
  */
 @Override
 protected void clear() {
-	this.methodDeclarationsWithInvalidParam = new HashMap();
+	this.methodDeclarationsWithInvalidParam = new HashMap<>();
 }
 @Override
 protected int fineGrain() {
@@ -624,7 +624,7 @@ public SearchMatch newDeclarationMatch(ASTNode reference, IJavaElement element, 
 		// If method parameters verification was not valid, then try to see if method arguments can match a method in hierarchy
 		if (this.methodDeclarationsWithInvalidParam.containsKey(reference)) {
 			// First see if this reference has already been resolved => report match if validated
-			Boolean report = (Boolean) this.methodDeclarationsWithInvalidParam.get(reference);
+			Boolean report = this.methodDeclarationsWithInvalidParam.get(reference);
 			if (report != null) {
 				if (report.booleanValue()) {
 					return super.newDeclarationMatch(reference, element, elementBinding, accuracy, length, locator);

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/TypeReferenceLocator.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/TypeReferenceLocator.java
@@ -30,14 +30,13 @@ import org.eclipse.jdt.internal.compiler.lookup.*;
 import org.eclipse.jdt.internal.compiler.util.SimpleSet;
 import org.eclipse.jdt.internal.core.JavaElement;
 
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class TypeReferenceLocator extends PatternLocator {
 
 protected final TypeReferencePattern pattern;
 protected final boolean isDeclarationOfReferencedTypesPattern;
 
 private final int fineGrain;
-private final Map<QualifiedTypeReference, List<TypeBinding>> recordedResolutions = new HashMap();
+private final Map<QualifiedTypeReference, List<TypeBinding>> recordedResolutions = new HashMap<>();
 
 public TypeReferenceLocator(TypeReferencePattern pattern) {
 
@@ -827,10 +826,10 @@ protected int resolveLevelForTypeOrEnclosingTypes(char[] simpleNamePattern, char
 
 int resolveLevelForTypeOrQualifyingTypes(TypeReference typeRef, TypeBinding typeBinding) {
 	if (typeBinding == null || !typeBinding.isValidBinding()) return INACCURATE_MATCH;
-	List resolutionsList = this.recordedResolutions.get(typeRef);
+	List<TypeBinding> resolutionsList = this.recordedResolutions.get(typeRef);
 	if (resolutionsList != null) {
-		for (Iterator i = resolutionsList.iterator(); i.hasNext();) {
-			TypeBinding resolution = (TypeBinding) i.next();
+		for (Iterator<TypeBinding> i = resolutionsList.iterator(); i.hasNext();) {
+			TypeBinding resolution = i.next();
 			int level = resolveLevelForType(resolution);
 			if (level != IMPOSSIBLE_MATCH) return level;
 		}
@@ -841,7 +840,7 @@ int resolveLevelForTypeOrQualifyingTypes(TypeReference typeRef, TypeBinding type
 public void recordResolution(QualifiedTypeReference typeReference, TypeBinding resolution) {
 	List<TypeBinding> resolutionsForTypeReference = this.recordedResolutions.get(typeReference);
 	if (resolutionsForTypeReference == null) {
-		resolutionsForTypeReference = new ArrayList();
+		resolutionsForTypeReference = new ArrayList<>();
 	}
 	resolutionsForTypeReference.add(resolution);
 	this.recordedResolutions.put(typeReference, resolutionsForTypeReference);


### PR DESCRIPTION
reduces @SuppressWarnings("rawtypes")
removes some unnecessary type casts

JavaModelManager cache: use new common Interface "ElementInfo" for IBinaryType, JavaElementInfo instead of raw Object
