### PR TITLE
Switch to make some operations rely on DOM instead of ECJ

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter15Test.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter15Test.java
@@ -27,6 +27,7 @@ import junit.framework.Test;
 
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.BindingKey;
 import org.eclipse.jdt.core.IAnnotation;
@@ -7866,13 +7867,13 @@ public class ASTConverter15Test extends ConverterTestSetup {
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=173338
 	 */
 	public void test0238_2() throws JavaModelException {
-		this.workingCopy = getWorkingCopy("/Converter15/src/test0238/X.java", true/*resolve*/);
-		String contents =
-			"package test0238;\n" +
-			"public class X extends A {\n" +
-			"}";
+		this.workingCopy = getWorkingCopy("/Converter15/src/test0238/X.java",
+			"""
+			package test0238;
+			public class X extends A {
+			}""", true/*resolve*/);
 		ASTNode node = buildAST(
-				contents,
+				this.workingCopy.getSource(),
 				this.workingCopy,
 				false,
 				false,
@@ -7888,6 +7889,29 @@ public class ASTConverter15Test extends ConverterTestSetup {
 		typeBinding = typeBinding.getSuperclass();
 		IMethodBinding[] methodBindings = typeBinding.getDeclaredMethods();
 		assertNotNull("No method bindings", methodBindings);
+		assertEquals("wrong size", 2, methodBindings.length);
+	}
+
+	/*
+	 * https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1915
+	 */
+	public void test0238_ASTParser() throws JavaModelException, CoreException {
+		this.workingCopy = getWorkingCopy("/Converter15/src/test0238/X.java",
+			"""
+			package test0238;
+			public class X extends A {
+			}
+			""", true /*resolve*/);
+		ASTParser parser = ASTParser.newParser(AST.getJLSLatest());
+		parser.setBindingsRecovery(true);
+		parser.setResolveBindings(true);
+		parser.setStatementsRecovery(true);
+		parser.setSource(this.workingCopy);
+		parser.setProject(JavaCore.create(ResourcesPlugin.getWorkspace().getRoot().getProject("Converter15")));
+		CompilationUnit unit = (CompilationUnit) parser.createAST(null);
+		TypeDeclaration typeDeclaration = (TypeDeclaration) unit.types().get(0);
+		ITypeBinding superTypeBinding = typeDeclaration.resolveBinding().getSuperclass();
+		IMethodBinding[] methodBindings = superTypeBinding.getDeclaredMethods();
 		assertEquals("wrong size", 2, methodBindings.length);
 	}
 

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/CompilationUnitResolver.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/CompilationUnitResolver.java
@@ -1261,6 +1261,9 @@ class CompilationUnitResolver extends Compiler {
 				if (unit == null) {
 					unit = this.unitsToProcess[0]; // fall back to old behavior
 				}
+				if (this.totalUnits == 1 && this.lookupEnvironment.unitBeingCompleted == null) {
+					this.lookupEnvironment.unitBeingCompleted = unit;
+				}
 			} else {
 				// initial type binding creation
 				this.lookupEnvironment.buildTypeBindings(unit, null /*no access restriction*/);

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ASTHolderCUInfo.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ASTHolderCUInfo.java
@@ -19,7 +19,7 @@ import org.eclipse.jdt.core.compiler.CategorizedProblem;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 
 public class ASTHolderCUInfo extends CompilationUnitElementInfo {
-	int astLevel;
+	public int astLevel;
 	boolean resolveBindings;
 	int reconcileFlags;
 	Map<String, CategorizedProblem[]> problems = null;

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/CompilationUnit.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/CompilationUnit.java
@@ -24,6 +24,16 @@ import org.eclipse.core.runtime.*;
 import org.eclipse.jdt.core.*;
 import org.eclipse.jdt.core.compiler.*;
 import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.FieldAccess;
+import org.eclipse.jdt.core.dom.IBinding;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.MethodInvocation;
+import org.eclipse.jdt.core.dom.Name;
+import org.eclipse.jdt.core.dom.NodeFinder;
+import org.eclipse.jdt.core.dom.Type;
+import org.eclipse.jdt.core.dom.VariableDeclaration;
 import org.eclipse.jdt.internal.compiler.IProblemFactory;
 import org.eclipse.jdt.internal.compiler.SourceElementParser;
 import org.eclipse.jdt.internal.compiler.ast.CompilationUnitDeclaration;
@@ -46,10 +56,22 @@ import org.eclipse.text.edits.UndoEdit;
  * @see ICompilationUnit
  */
 public class CompilationUnit extends Openable implements ICompilationUnit, org.eclipse.jdt.internal.compiler.env.ICompilationUnit, SuffixConstants {
+	/**
+	 * Internal synonym for deprecated constant AST.JSL2
+	 * to alleviate deprecation warnings.
+	 * @deprecated
+	 */
+	/*package*/ static final int JLS2_INTERNAL = AST.JLS2;
+
+	public static boolean DOM_BASED_OPERATIONS = Boolean.getBoolean(CompilationUnit.class.getSimpleName() + ".DOM_BASED_OPERATIONS"); //$NON-NLS-1$
+	public static boolean DOM_BASED_COMPLETION = Boolean.getBoolean(CompilationUnit.class.getSimpleName() + ".codeComplete.DOM_BASED_OPERATIONS"); //$NON-NLS-1$
+
 	private static final IImportDeclaration[] NO_IMPORTS = new IImportDeclaration[0];
 
 	protected final String name;
 	public final WorkingCopyOwner owner;
+
+	private org.eclipse.jdt.core.dom.CompilationUnit ast;
 
 /**
  * Constructs a handle to a compilation unit with the given name in the
@@ -101,36 +123,13 @@ public void becomeWorkingCopy(IProgressMonitor monitor) throws JavaModelExceptio
 protected boolean buildStructure(OpenableElementInfo info, final IProgressMonitor pm, Map<IJavaElement, IElementInfo> newElements, IResource underlyingResource) throws JavaModelException {
 	CompilationUnitElementInfo unitInfo = (CompilationUnitElementInfo) info;
 
-	// ensure buffer is opened
-	IBuffer buffer = getBufferManager().getBuffer(CompilationUnit.this);
-	if (buffer == null) {
-		openBuffer(pm, unitInfo); // open buffer independently from the info, since we are building the info
-	}
-
 	// generate structure and compute syntax problems if needed
-	CompilationUnitStructureRequestor requestor = new CompilationUnitStructureRequestor(this, unitInfo, newElements);
 	JavaModelManager.PerWorkingCopyInfo perWorkingCopyInfo = getPerWorkingCopyInfo();
 	IJavaProject project = getJavaProject();
-
-	boolean createAST;
-	boolean resolveBindings;
-	int reconcileFlags;
-	Map<String, CategorizedProblem[]> problems;
-	if (info instanceof ASTHolderCUInfo) {
-		ASTHolderCUInfo astHolder = (ASTHolderCUInfo) info;
-		createAST = astHolder.astLevel != NO_AST;
-		resolveBindings = astHolder.resolveBindings;
-		reconcileFlags = astHolder.reconcileFlags;
-		problems = astHolder.problems;
-	} else {
-		createAST = false;
-		resolveBindings = false;
-		reconcileFlags = 0;
-		problems = null;
-	}
-
+	boolean createAST = info instanceof ASTHolderCUInfo astHolder ? astHolder.astLevel != NO_AST : false;
+	boolean resolveBindings = info instanceof ASTHolderCUInfo astHolder ? astHolder.resolveBindings : false;
+	int reconcileFlags = info instanceof ASTHolderCUInfo astHolder ? astHolder.reconcileFlags : 0;
 	boolean computeProblems = perWorkingCopyInfo != null && perWorkingCopyInfo.isActive() && project != null && JavaProject.hasJavaNature(project.getProject());
-	IProblemFactory problemFactory = new DefaultProblemFactory();
 	Map<String, String> options = this.getOptions(true);
 	if (!computeProblems) {
 		// disable task tags checking to speed up parsing
@@ -138,67 +137,106 @@ protected boolean buildStructure(OpenableElementInfo info, final IProgressMonito
 	}
 	CompilerOptions compilerOptions = new CompilerOptions(options);
 	compilerOptions.ignoreMethodBodies = (reconcileFlags & ICompilationUnit.IGNORE_METHOD_BODIES) != 0;
-	SourceElementParser parser = new SourceElementParser(
-		requestor,
-		problemFactory,
-		compilerOptions,
-		true/*report local declarations*/,
-		!createAST /*optimize string literals only if not creating a DOM AST*/);
-	parser.reportOnlyOneSyntaxError = !computeProblems;
-	parser.setMethodsFullRecovery(true);
-	parser.setStatementsRecovery((reconcileFlags & ICompilationUnit.ENABLE_STATEMENTS_RECOVERY) != 0);
-
-	if (!computeProblems && !resolveBindings && !createAST) // disable javadoc parsing if not computing problems, not resolving and not creating ast
-		parser.javadocParser.checkDocComment = false;
-	requestor.parser = parser;
 
 	// update timestamp (might be IResource.NULL_STAMP if original does not exist)
 	if (underlyingResource == null) {
 		underlyingResource = getResource();
 	}
 	// underlying resource is null in the case of a working copy on a class file in a jar
-	if (underlyingResource != null)
+	if (underlyingResource != null) {
 		unitInfo.timestamp = ((IFile)underlyingResource).getModificationStamp();
+	}
 
-	// compute other problems if needed
-	CompilationUnitDeclaration compilationUnitDeclaration = null;
-	CompilationUnit source = cloneCachingContents();
-	try {
-		if (computeProblems) {
-			if (problems == null) {
-				// report problems to the problem requestor
-				problems = new HashMap<>();
-				compilationUnitDeclaration = CompilationUnitProblemFinder.process(source, parser, this.owner, problems, createAST, reconcileFlags, pm);
+	// ensure buffer is opened
+	IBuffer buffer = getBufferManager().getBuffer(CompilationUnit.this);
+	if (buffer == null) {
+		openBuffer(pm, unitInfo); // open buffer independently from the info, since we are building the info
+	}
+
+	if (DOM_BASED_OPERATIONS) {
+		ASTParser astParser = ASTParser.newParser(info instanceof ASTHolderCUInfo astHolder && astHolder.astLevel > 0 ? astHolder.astLevel : AST.getJLSLatest());
+		astParser.setWorkingCopyOwner(getOwner());
+		astParser.setSource(this);
+		astParser.setProject(getJavaProject());
+		astParser.setStatementsRecovery((reconcileFlags & ICompilationUnit.ENABLE_STATEMENTS_RECOVERY) != 0);
+		astParser.setResolveBindings(resolveBindings);
+		astParser.setBindingsRecovery((reconcileFlags & ICompilationUnit.ENABLE_BINDINGS_RECOVERY) != 0);
+		if (astParser.createAST(pm) instanceof org.eclipse.jdt.core.dom.CompilationUnit newAST) {
+			if (perWorkingCopyInfo != null) {
 				try {
 					perWorkingCopyInfo.beginReporting();
-					for (Iterator<CategorizedProblem[]> iteraror = problems.values().iterator(); iteraror.hasNext();) {
-						CategorizedProblem[] categorizedProblems = iteraror.next();
-						if (categorizedProblems == null) continue;
-						for (int i = 0, length = categorizedProblems.length; i < length; i++) {
-							perWorkingCopyInfo.acceptProblem(categorizedProblems[i]);
-						}
+					for (IProblem problem : newAST.getProblems()) {
+						perWorkingCopyInfo.acceptProblem(problem);
 					}
 				} finally {
 					perWorkingCopyInfo.endReporting();
 				}
-			} else {
-				// collect problems
-				compilationUnitDeclaration = CompilationUnitProblemFinder.process(source, parser, this.owner, problems, createAST, reconcileFlags, pm);
 			}
-		} else {
-			compilationUnitDeclaration = parser.parseCompilationUnit(source, true /*full parse to find local elements*/, pm);
+			if (info instanceof ASTHolderCUInfo astHolder) {
+				astHolder.ast = newAST;
+			}
+			newAST.accept(new DOMToModelPopulator(newElements, this, unitInfo));
+			// unitInfo.setModule();
+			// unitInfo.setSourceLength(newSourceLength);
+			unitInfo.setIsStructureKnown(true);
 		}
+	} else {
+		CompilationUnitStructureRequestor requestor = new CompilationUnitStructureRequestor(this, unitInfo, newElements);
+		Map<String, CategorizedProblem[]> problems = info instanceof ASTHolderCUInfo astHolder ? astHolder.problems : null;
+		IProblemFactory problemFactory = new DefaultProblemFactory();
+		SourceElementParser parser = new SourceElementParser(
+			requestor,
+			problemFactory,
+			compilerOptions,
+			true/*report local declarations*/,
+			!createAST /*optimize string literals only if not creating a DOM AST*/);
+		parser.reportOnlyOneSyntaxError = !computeProblems;
+		parser.setMethodsFullRecovery(true);
+		parser.setStatementsRecovery((reconcileFlags & ICompilationUnit.ENABLE_STATEMENTS_RECOVERY) != 0);
 
-		if (createAST) {
-			int astLevel = ((ASTHolderCUInfo) info).astLevel;
-			org.eclipse.jdt.core.dom.CompilationUnit cu = AST.convertCompilationUnit(astLevel, compilationUnitDeclaration, options, computeProblems, source, reconcileFlags, pm);
-			((ASTHolderCUInfo) info).ast = cu;
+		if (!computeProblems && !resolveBindings && !createAST) // disable javadoc parsing if not computing problems, not resolving and not creating ast
+			parser.javadocParser.checkDocComment = false;
+		requestor.parser = parser;
+
+		// compute other problems if needed
+		CompilationUnitDeclaration compilationUnitDeclaration = null;
+		CompilationUnit source = cloneCachingContents();
+		try {
+			if (computeProblems) {
+				if (problems == null) {
+					// report problems to the problem requestor
+					problems = new HashMap<>();
+					compilationUnitDeclaration = CompilationUnitProblemFinder.process(source, parser, this.owner, problems, createAST, reconcileFlags, pm);
+					try {
+						perWorkingCopyInfo.beginReporting();
+						for (CategorizedProblem[] categorizedProblems : problems.values()) {
+							if (categorizedProblems == null) continue;
+							for (CategorizedProblem categorizedProblem : categorizedProblems) {
+								perWorkingCopyInfo.acceptProblem(categorizedProblem);
+							}
+						}
+					} finally {
+						perWorkingCopyInfo.endReporting();
+					}
+				} else {
+					// collect problems
+					compilationUnitDeclaration = CompilationUnitProblemFinder.process(source, parser, this.owner, problems, createAST, reconcileFlags, pm);
+				}
+			} else {
+				compilationUnitDeclaration = parser.parseCompilationUnit(source, true /*full parse to find local elements*/, pm);
+			}
+
+			if (createAST) {
+				int astLevel = ((ASTHolderCUInfo) info).astLevel;
+				org.eclipse.jdt.core.dom.CompilationUnit cu = AST.convertCompilationUnit(astLevel, compilationUnitDeclaration, options, computeProblems, source, reconcileFlags, pm);
+				((ASTHolderCUInfo) info).ast = cu;
+			}
+		} finally {
+		    if (compilationUnitDeclaration != null) {
+		    	unitInfo.hasFunctionalTypes = compilationUnitDeclaration.hasFunctionalTypes();
+		        compilationUnitDeclaration.cleanUp();
+		    }
 		}
-	} finally {
-	    if (compilationUnitDeclaration != null) {
-	    	unitInfo.hasFunctionalTypes = compilationUnitDeclaration.hasFunctionalTypes();
-	        compilationUnitDeclaration.cleanUp();
-	    }
 	}
 
 	return unitInfo.isStructureKnown();
@@ -357,6 +395,10 @@ public void codeComplete(int offset, CompletionRequestor requestor, WorkingCopyO
 
 @Override
 public void codeComplete(int offset, CompletionRequestor requestor, WorkingCopyOwner workingCopyOwner, IProgressMonitor monitor) throws JavaModelException {
+	if (DOM_BASED_COMPLETION) {
+		new DOMCompletionEngine(offset, getOrBuildAST(workingCopyOwner), requestor, monitor).run();
+		return;
+	}
 	codeComplete(
 			this,
 			isWorkingCopy() ? (org.eclipse.jdt.internal.compiler.env.ICompilationUnit) getOriginalElement() : this,
@@ -379,8 +421,67 @@ public IJavaElement[] codeSelect(int offset, int length) throws JavaModelExcepti
  */
 @Override
 public IJavaElement[] codeSelect(int offset, int length, WorkingCopyOwner workingCopyOwner) throws JavaModelException {
-	return super.codeSelect(this, offset, length, workingCopyOwner);
+	if (DOM_BASED_OPERATIONS) {
+		org.eclipse.jdt.core.dom.CompilationUnit currentAST = getOrBuildAST(workingCopyOwner);
+		if (currentAST == null) {
+			return new IJavaElement[0];
+		}
+		ASTNode node = NodeFinder.perform(currentAST, offset, length);
+		IBinding binding = resolveBinding(node);
+		if (binding != null) {
+			return new IJavaElement[] { binding.getJavaElement() };
+		}
+		return new IJavaElement[0];
+	} else {
+		return super.codeSelect(this, offset, length, workingCopyOwner);
+	}
 }
+static IBinding resolveBinding(ASTNode node) {
+	if (node instanceof MethodDeclaration decl) {
+		return decl.resolveBinding();
+	}
+	if (node instanceof MethodInvocation invocation) {
+		return invocation.resolveMethodBinding();
+	}
+	if (node instanceof VariableDeclaration decl) {
+		return decl.resolveBinding();
+	}
+	if (node instanceof FieldAccess access) {
+		return access.resolveFieldBinding();
+	}
+	if (node instanceof Type type) {
+		return type.resolveBinding();
+	}
+	if (node instanceof Name aName) {
+		IBinding res = aName.resolveBinding();
+		if (res != null) {
+			return res;
+		}
+		return resolveBinding(aName.getParent());
+	}
+	if (node instanceof org.eclipse.jdt.core.dom.TypeParameter typeParameter) {
+		return typeParameter.resolveBinding();
+	}
+	return null;
+}
+
+
+private org.eclipse.jdt.core.dom.CompilationUnit getOrBuildAST(WorkingCopyOwner workingCopyOwner) {
+	if (this.ast == null) {
+		ASTParser parser = ASTParser.newParser(AST.getJLSLatest()); // TODO use Java project info
+		parser.setSource(this);
+		// greedily enable everything assuming the AST will be used extensively for edition
+		parser.setResolveBindings(true);
+		parser.setStatementsRecovery(true);
+		parser.setBindingsRecovery(true);
+		if (parser.createAST(null) instanceof org.eclipse.jdt.core.dom.CompilationUnit newAST) {
+			this.ast = newAST;
+		}
+	}
+	return this.ast;
+}
+
+
 /**
  * @see IWorkingCopy#commit(boolean, IProgressMonitor)
  * @deprecated
@@ -1137,7 +1238,7 @@ public org.eclipse.jdt.core.dom.CompilationUnit makeConsistent(int astLevel, boo
 			openWhenClosed(info, true, monitor);
 			org.eclipse.jdt.core.dom.CompilationUnit result = info.ast;
 			info.ast = null;
-			return result;
+			return astLevel != NO_AST ? result : null;
 		} else {
 			openWhenClosed(createElementInfo(), true, monitor);
 			return null;

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/DOMCompletionEngine.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/DOMCompletionEngine.java
@@ -1,0 +1,188 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jdt.internal.core;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.CompletionContext;
+import org.eclipse.jdt.core.CompletionProposal;
+import org.eclipse.jdt.core.CompletionRequestor;
+import org.eclipse.jdt.core.Signature;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.Block;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.FieldAccess;
+import org.eclipse.jdt.core.dom.IBinding;
+import org.eclipse.jdt.core.dom.IMethodBinding;
+import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.IVariableBinding;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.NodeFinder;
+import org.eclipse.jdt.core.dom.Statement;
+import org.eclipse.jdt.core.dom.TypeDeclaration;
+import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
+import org.eclipse.jdt.core.dom.VariableDeclarationStatement;
+
+class DOMCompletionEngine implements Runnable {
+
+	private final int offset;
+	private final CompilationUnit unit;
+	private CompletionRequestor requestor;
+
+	DOMCompletionEngine(int offset, CompilationUnit unit, CompletionRequestor requestor, IProgressMonitor monitor) {
+		this.offset = offset;
+		this.unit = unit;
+		this.requestor = requestor;
+	}
+
+	private static Collection<? extends IBinding> visibleBindings(ASTNode node, int offset) {
+		if (node instanceof Block block) {
+			return ((List<Statement>)block.statements()).stream()
+				.filter(statement -> statement.getStartPosition() < offset)
+				.filter(VariableDeclarationStatement.class::isInstance)
+				.map(VariableDeclarationStatement.class::cast)
+				.flatMap(decl -> ((List<VariableDeclarationFragment>)decl.fragments()).stream())
+				.map(VariableDeclarationFragment::resolveBinding)
+				.toList();
+		} else if (node instanceof MethodDeclaration method) {
+			return Stream.of((List<ASTNode>)method.parameters(), (List<ASTNode>)method.typeParameters())
+				.flatMap(List::stream)
+				.map(org.eclipse.jdt.internal.core.CompilationUnit::resolveBinding)
+				.filter(Objects::nonNull)
+				.toList();
+		} else if (node instanceof TypeDeclaration type) {
+			VariableDeclarationFragment[] fields = Arrays.stream(type.getFields())
+				.map(decl -> (List<VariableDeclarationFragment>)decl.fragments())
+				.flatMap(List::stream)
+				.toArray(VariableDeclarationFragment[]::new);
+			return Stream.of(fields, type.getMethods(), type.getTypes())
+				.flatMap(Arrays::stream)
+				.map(org.eclipse.jdt.internal.core.CompilationUnit::resolveBinding)
+				.filter(Objects::nonNull)
+				.toList();
+		}
+		return List.of();
+	}
+
+	@Override
+	public void run() {
+		this.requestor.beginReporting();
+		this.requestor.acceptContext(new CompletionContext());
+		ASTNode toComplete = NodeFinder.perform(this.unit, this.offset, 0);
+		if (toComplete instanceof FieldAccess fieldAccess) {
+			processMembers(fieldAccess.resolveTypeBinding());
+		} else if (toComplete.getParent() instanceof FieldAccess fieldAccess) {
+			processMembers(fieldAccess.getExpression().resolveTypeBinding());
+		}
+		Collection<IBinding> scope = new HashSet<>();
+		ASTNode current = toComplete;
+		while (current != null) {
+			scope.addAll(visibleBindings(current, this.offset));
+			current = current.getParent();
+		}
+		// TODO also include other visible content: classpath, static methods...
+		scope.stream().map(this::toProposal).forEach(this.requestor::accept);
+		this.requestor.endReporting();
+	}
+
+	private void processMembers(ITypeBinding typeBinding) {
+		if (typeBinding == null) {
+			return;
+		}
+		Arrays.stream(typeBinding.getDeclaredFields()).map(this::toProposal).forEach(this.requestor::accept);
+		Arrays.stream(typeBinding.getDeclaredMethods()).map(this::toProposal).forEach(this.requestor::accept);
+		if (typeBinding.getInterfaces() != null) {
+			Arrays.stream(typeBinding.getInterfaces()).forEach(this::processMembers);
+		}
+		processMembers(typeBinding.getSuperclass());
+	}
+
+	private CompletionProposal toProposal(IBinding binding) {
+		int kind = 
+			binding instanceof ITypeBinding ? CompletionProposal.TYPE_REF :
+			binding instanceof IMethodBinding ? CompletionProposal.METHOD_REF :
+			binding instanceof IVariableBinding variableBinding ? CompletionProposal.LOCAL_VARIABLE_REF :
+			-1;
+		CompletionProposal res = new CompletionProposal() {
+			@Override
+			public int getKind() {
+				return kind;
+			}
+			@Override
+			public char[] getName() {
+				return binding.getName().toCharArray();
+			}
+			@Override
+			public char[] getCompletion() {
+				return binding.getName().toCharArray();
+			}
+			@Override
+			public char[] getSignature() {
+				if (binding instanceof IMethodBinding methodBinding) {
+					return Signature.createMethodSignature(
+							Arrays.stream(methodBinding.getParameterTypes())
+								.map(ITypeBinding::getName)
+								.map(String::toCharArray)
+								.map(type -> Signature.createTypeSignature(type, true).toCharArray())
+								.toArray(char[][]::new),
+							Signature.createTypeSignature(methodBinding.getReturnType().getQualifiedName().toCharArray(), true).toCharArray());
+				}
+				if (binding instanceof IVariableBinding variableBinding) {
+					return Signature.createTypeSignature(variableBinding.getType().getQualifiedName().toCharArray(), true).toCharArray();
+				}
+				if (binding instanceof ITypeBinding typeBinding) {
+					return Signature.createTypeSignature(typeBinding.getQualifiedName().toCharArray(), true).toCharArray();
+				}
+				return new char[] {};
+			}
+			@Override
+			public int getReplaceStart() {
+				return DOMCompletionEngine.this.offset;
+			}
+			@Override
+			public int getReplaceEnd() {
+				return getReplaceStart();
+			}
+			@Override
+			public int getFlags() {
+				return 0; //TODO
+			}
+			@Override
+			public char[] getReceiverSignature() {
+				if (binding instanceof IMethodBinding method) {
+					return Signature.createTypeSignature(method.getDeclaredReceiverType().getQualifiedName().toCharArray(), true).toCharArray();
+				}
+				if (binding instanceof IVariableBinding variable && variable.isField()) {
+					return Signature.createTypeSignature(variable.getDeclaringClass().getQualifiedName().toCharArray(), true).toCharArray();
+				}
+				return new char[]{};
+			}
+			@Override
+			public char[] getDeclarationSignature() {
+				if (binding instanceof IMethodBinding method) {
+					return Signature.createTypeSignature(method.getDeclaringClass().getQualifiedName().toCharArray(), true).toCharArray();
+				}
+				if (binding instanceof IVariableBinding variable && variable.isField()) {
+					return Signature.createTypeSignature(variable.getDeclaringClass().getQualifiedName().toCharArray(), true).toCharArray();
+				}
+				return new char[]{};
+			}
+		};
+		return res;
+	}
+
+}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/DOMToModelPopulator.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/DOMToModelPopulator.java
@@ -1,0 +1,700 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jdt.internal.core;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.Stack;
+import java.util.AbstractMap.SimpleEntry;
+import java.util.Map.Entry;
+
+import org.eclipse.core.runtime.ILog;
+import org.eclipse.jdt.core.IAnnotation;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IMemberValuePair;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.Signature;
+import org.eclipse.jdt.core.compiler.InvalidInputException;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ASTVisitor;
+import org.eclipse.jdt.core.dom.AnnotationTypeDeclaration;
+import org.eclipse.jdt.core.dom.AnnotationTypeMemberDeclaration;
+import org.eclipse.jdt.core.dom.ArrayInitializer;
+import org.eclipse.jdt.core.dom.BooleanLiteral;
+import org.eclipse.jdt.core.dom.CharacterLiteral;
+import org.eclipse.jdt.core.dom.EnumDeclaration;
+import org.eclipse.jdt.core.dom.ExportsDirective;
+import org.eclipse.jdt.core.dom.Expression;
+import org.eclipse.jdt.core.dom.FieldDeclaration;
+import org.eclipse.jdt.core.dom.ImportDeclaration;
+import org.eclipse.jdt.core.dom.Initializer;
+import org.eclipse.jdt.core.dom.MarkerAnnotation;
+import org.eclipse.jdt.core.dom.MemberValuePair;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.ModuleDeclaration;
+import org.eclipse.jdt.core.dom.Name;
+import org.eclipse.jdt.core.dom.NormalAnnotation;
+import org.eclipse.jdt.core.dom.NullLiteral;
+import org.eclipse.jdt.core.dom.NumberLiteral;
+import org.eclipse.jdt.core.dom.OpensDirective;
+import org.eclipse.jdt.core.dom.PackageDeclaration;
+import org.eclipse.jdt.core.dom.ProvidesDirective;
+import org.eclipse.jdt.core.dom.QualifiedName;
+import org.eclipse.jdt.core.dom.RecordDeclaration;
+import org.eclipse.jdt.core.dom.RequiresDirective;
+import org.eclipse.jdt.core.dom.SimpleName;
+import org.eclipse.jdt.core.dom.SingleMemberAnnotation;
+import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
+import org.eclipse.jdt.core.dom.StringLiteral;
+import org.eclipse.jdt.core.dom.TypeDeclaration;
+import org.eclipse.jdt.core.dom.TypeLiteral;
+import org.eclipse.jdt.core.dom.UsesDirective;
+import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
+import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
+import org.eclipse.jdt.internal.compiler.env.IElementInfo;
+import org.eclipse.jdt.internal.compiler.parser.RecoveryScanner;
+import org.eclipse.jdt.internal.compiler.parser.Scanner;
+import org.eclipse.jdt.internal.compiler.parser.TerminalTokens;
+import org.eclipse.jdt.internal.core.ModuleDescriptionInfo.ModuleReferenceInfo;
+import org.eclipse.jdt.internal.core.ModuleDescriptionInfo.PackageExportInfo;
+import org.eclipse.jdt.internal.core.ModuleDescriptionInfo.ServiceInfo;
+import org.eclipse.jdt.internal.core.util.Util;
+
+/**
+ * Process an AST to populate a tree of IJavaElement->JavaElementInfo.
+ * DOM-first approach to what legacy implements through ECJ parser and CompilationUnitStructureRequestor
+ */
+class DOMToModelPopulator extends ASTVisitor {
+
+	private final Map<IJavaElement, IElementInfo> toPopulate;
+	private final Stack<JavaElement> elements = new Stack<>();
+	private final Stack<JavaElementInfo> infos = new Stack<>();
+	private final Set<String> currentTypeParameters = new HashSet<>();
+	private final CompilationUnitElementInfo unitInfo;
+	private ImportContainer importContainer;
+	private final CompilationUnit root;
+
+	public DOMToModelPopulator(Map<IJavaElement, IElementInfo> newElements, CompilationUnit root, CompilationUnitElementInfo unitInfo) {
+		this.toPopulate = newElements;
+		this.elements.push(root);
+		this.infos.push(unitInfo);
+		this.root = root;
+		this.unitInfo = unitInfo;
+	}
+
+	private static void addAsChild(JavaElementInfo parentInfo, IJavaElement childElement) {
+		if (parentInfo instanceof AnnotatableInfo annotable && childElement instanceof IAnnotation annotation) {
+			IAnnotation[] newAnnotations = Arrays.copyOf(annotable.annotations, annotable.annotations.length + 1);
+			newAnnotations[newAnnotations.length - 1] = annotation;
+			annotable.annotations = newAnnotations;
+		} else if (parentInfo instanceof OpenableElementInfo openable) {
+			openable.addChild(childElement);
+		} else if (parentInfo instanceof SourceTypeElementInfo type) {
+			type.children = Arrays.copyOf(type.children, type.children.length + 1);
+			type.children[type.children.length - 1] = childElement;
+		} else if (parentInfo instanceof ImportContainerInfo importContainer && childElement instanceof org.eclipse.jdt.internal.core.ImportDeclaration importDecl) {
+			IJavaElement[] newImports = Arrays.copyOf(importContainer.getChildren(), importContainer.getChildren().length + 1);
+			newImports[newImports.length - 1] = importDecl;
+			importContainer.children = newImports;
+		}
+	}
+
+	@Override
+	public boolean visit(org.eclipse.jdt.core.dom.CompilationUnit node) {
+		this.unitInfo.setSourceLength(node.getLength());
+		return true;
+	}
+
+	@Override
+	public boolean visit(PackageDeclaration node) {
+		org.eclipse.jdt.internal.core.PackageDeclaration newElement = new org.eclipse.jdt.internal.core.PackageDeclaration(this.root, node.getName().toString());
+		this.elements.push(newElement);
+		addAsChild(this.infos.peek(), newElement);
+		AnnotatableInfo newInfo = new AnnotatableInfo();
+		newInfo.setSourceRangeStart(node.getStartPosition());
+		newInfo.setSourceRangeEnd(node.getStartPosition() + node.getLength() - 1);
+		newInfo.setNameSourceStart(node.getName().getStartPosition());
+		newInfo.setNameSourceEnd(node.getName().getStartPosition() + node.getName().getLength() - 1);
+		this.infos.push(newInfo);
+		this.toPopulate.put(newElement, newInfo);
+		return true;
+	}
+	@Override
+	public void endVisit(PackageDeclaration decl) {
+		this.elements.pop();
+		this.infos.pop();
+	}
+
+	@Override
+	public boolean visit(ImportDeclaration node) {
+		if (this.importContainer == null) {
+			this.importContainer = this.root.getImportContainer();
+			ImportContainerInfo importContainerInfo = new ImportContainerInfo();
+			JavaElementInfo parentInfo = this.infos.peek();
+			addAsChild(parentInfo, this.importContainer);
+			this.toPopulate.put(this.importContainer, importContainerInfo);
+		}
+		org.eclipse.jdt.internal.core.ImportDeclaration newElement = new org.eclipse.jdt.internal.core.ImportDeclaration(this.importContainer, node.getName().toString(), node.isOnDemand());
+		this.elements.push(newElement);
+		addAsChild(this.infos.peek(), newElement);
+		AnnotatableInfo newInfo = new AnnotatableInfo();
+		newInfo.setSourceRangeStart(node.getStartPosition());
+		newInfo.setSourceRangeEnd(node.getStartPosition() + node.getLength() - 1);
+		newInfo.setNameSourceStart(node.getName().getStartPosition());
+		newInfo.setNameSourceEnd(node.getName().getStartPosition() + node.getName().getLength() - 1);
+		this.infos.push(newInfo);
+		this.toPopulate.put(newElement, newInfo);
+		return true;
+	}
+	@Override
+	public void endVisit(ImportDeclaration decl) {
+		this.elements.pop();
+		this.infos.pop();
+	}
+
+	@Override
+	public boolean visit(TypeDeclaration node) {
+		if (node.getAST().apiLevel() > 2) {
+			((List<org.eclipse.jdt.core.dom.TypeParameter>)node.typeParameters())
+				.stream()
+				.map(org.eclipse.jdt.core.dom.TypeParameter::getName)
+				.map(Name::getFullyQualifiedName)
+				.forEach(this.currentTypeParameters::add);
+		}
+		SourceType newElement = new SourceType(this.elements.peek(), node.getName().toString());
+		this.elements.push(newElement);
+		addAsChild(this.infos.peek(), newElement);
+		SourceTypeElementInfo newInfo = new SourceTypeElementInfo();
+		newInfo.setSourceRangeStart(node.getStartPosition());
+		newInfo.setSourceRangeEnd(node.getStartPosition() + node.getLength() - 1);
+		newInfo.setFlags(node.getFlags() | (node.isInterface() ? ClassFileConstants.AccInterface : 0));
+		newInfo.setHandle(newElement);
+		newInfo.setNameSourceStart(node.getName().getStartPosition());
+		newInfo.setNameSourceEnd(node.getName().getStartPosition() + node.getName().getLength() - 1);
+		this.infos.push(newInfo);
+		this.toPopulate.put(newElement, newInfo);
+		return true;
+	}
+	@Override
+	public void endVisit(TypeDeclaration decl) {
+		this.elements.pop();
+		this.infos.pop();
+		if (decl.getAST().apiLevel() > 2) {
+			((List<org.eclipse.jdt.core.dom.TypeParameter>)decl.typeParameters())
+				.stream()
+				.map(org.eclipse.jdt.core.dom.TypeParameter::getName)
+				.map(Name::getFullyQualifiedName)
+				.forEach(this.currentTypeParameters::remove);
+		}
+	}
+
+	@Override
+	public boolean visit(AnnotationTypeDeclaration node) {
+		SourceType newElement = new SourceType(this.elements.peek(), node.getName().toString());
+		this.elements.push(newElement);
+		addAsChild(this.infos.peek(), newElement);
+		SourceTypeElementInfo newInfo = new SourceTypeElementInfo();
+		newInfo.setSourceRangeStart(node.getStartPosition());
+		newInfo.setSourceRangeEnd(node.getStartPosition() + node.getLength() - 1);
+		newInfo.setFlags(node.getFlags());
+		newInfo.setHandle(newElement);
+		newInfo.setNameSourceStart(node.getName().getStartPosition());
+		newInfo.setNameSourceEnd(node.getName().getStartPosition() + node.getName().getLength() - 1);
+		this.infos.push(newInfo);
+		this.toPopulate.put(newElement, newInfo);
+		return true;
+	}
+
+	@Override
+	public void endVisit(AnnotationTypeDeclaration decl) {
+		this.elements.pop();
+		this.infos.pop();
+	}
+
+	@Override
+	public boolean visit(EnumDeclaration node) {
+		SourceType newElement = new SourceType(this.elements.peek(), node.getName().toString());
+		this.elements.push(newElement);
+		addAsChild(this.infos.peek(), newElement);
+		SourceTypeElementInfo newInfo = new SourceTypeElementInfo();
+		newInfo.setSourceRangeStart(node.getStartPosition());
+		newInfo.setSourceRangeEnd(node.getStartPosition() + node.getLength() - 1);
+		newInfo.setFlags(node.getFlags());
+		newInfo.setHandle(newElement);
+		newInfo.setNameSourceStart(node.getName().getStartPosition());
+		newInfo.setNameSourceEnd(node.getName().getStartPosition() + node.getName().getLength() - 1);
+		this.infos.push(newInfo);
+		this.toPopulate.put(newElement, newInfo);
+		return true;
+	}
+	@Override
+	public void endVisit(EnumDeclaration decl) {
+		this.elements.pop();
+		this.infos.pop();
+	}
+
+//	@Override
+//	public boolean visit(EnumConstantDeclaration node) {
+//		SourceField newElement = new SourceField(this.elements.peek(), node.getName().toString());
+//		this.elements.push(newElement);
+//		addAsChild(this.infos.peek(), newElement);
+//		SourceFieldElementInfo info = new SourceFieldElementInfo();
+//		info.setSourceRangeStart(node.getStartPosition());
+//		info.setSourceRangeEnd(node.getStartPosition() + node.getLength() - 1);
+//		info.setFlags(node.getFlags());
+//		info.setNameSourceStart(node.getName().getStartPosition());
+//		info.setNameSourceEnd(node.getName().getStartPosition() + node.getName().getLength() - 1);
+//		// TODO populate info
+//		this.infos.push(info);
+//		this.toPopulate.put(newElement, info);
+//		return true;
+//	}
+//	@Override
+//	public void endVisit(EnumConstantDeclaration decl) {
+//		this.elements.pop();
+//		this.infos.pop();
+//	}
+
+	@Override
+	public boolean visit(RecordDeclaration node) {
+		SourceType newElement = new SourceType(this.elements.peek(), node.getName().toString());
+		this.elements.push(newElement);
+		addAsChild(this.infos.peek(), newElement);
+		SourceTypeElementInfo newInfo = new SourceTypeElementInfo();
+		newInfo.setSourceRangeStart(node.getStartPosition());
+		newInfo.setSourceRangeEnd(node.getStartPosition() + node.getLength() - 1);
+		newInfo.setFlags(node.getFlags());
+		newInfo.setHandle(newElement);
+		newInfo.setNameSourceStart(node.getName().getStartPosition());
+		newInfo.setNameSourceEnd(node.getName().getStartPosition() + node.getName().getLength() - 1);
+		this.infos.push(newInfo);
+		this.toPopulate.put(newElement, newInfo);
+		return true;
+	}
+	@Override
+	public void endVisit(RecordDeclaration decl) {
+		this.elements.pop();
+		this.infos.pop();
+	}
+
+
+	@Override
+	public boolean visit(MethodDeclaration method) {
+		if (method.getAST().apiLevel() > 2) {
+			((List<org.eclipse.jdt.core.dom.TypeParameter>)method.typeParameters())
+				.stream()
+				.map(org.eclipse.jdt.core.dom.TypeParameter::getName)
+				.map(Name::getFullyQualifiedName)
+				.forEach(this.currentTypeParameters::add);
+		}
+		SourceMethod newElement = new SourceMethod(this.elements.peek(),
+			method.getName().getIdentifier(),
+			((List<SingleVariableDeclaration>)method.parameters()).stream()
+				.map(this::createSignature)
+				.toArray(String[]::new));
+		this.elements.push(newElement);
+		addAsChild(this.infos.peek(), newElement);
+		SourceMethodInfo info = new SourceMethodInfo();
+		info.setArgumentNames(((List<SingleVariableDeclaration>)method.parameters()).stream().map(param -> param.getName().toString().toCharArray()).toArray(char[][]::new));
+		info.arguments = ((List<SingleVariableDeclaration>)method.parameters()).stream()
+			.map(this::toLocalVariable)
+			.toArray(LocalVariable[]::new);
+		if (method.getAST().apiLevel() > 2 && method.getReturnType2() != null) {
+			info.setReturnType(method.getReturnType2().toString().toCharArray());
+		}
+		info.setSourceRangeStart(method.getStartPosition());
+		info.setSourceRangeEnd(method.getStartPosition() + method.getLength() - 1);
+		info.setFlags(method.getFlags());
+		info.setNameSourceStart(method.getName().getStartPosition());
+		info.setNameSourceEnd(method.getName().getStartPosition() + method.getName().getLength() - 1);
+		this.infos.push(info);
+		this.toPopulate.put(newElement, info);
+		return true;
+	}
+	@Override
+	public void endVisit(MethodDeclaration decl) {
+		this.elements.pop();
+		this.infos.pop();
+		if (decl.getAST().apiLevel() > 2) {
+			((List<org.eclipse.jdt.core.dom.TypeParameter>)decl.typeParameters())
+				.stream()
+				.map(org.eclipse.jdt.core.dom.TypeParameter::getName)
+				.map(Name::getFullyQualifiedName)
+				.forEach(this.currentTypeParameters::remove);
+		}
+	}
+
+	@Override
+	public boolean visit(AnnotationTypeMemberDeclaration method) {
+		SourceMethod newElement = new SourceMethod(this.elements.peek(),
+			method.getName().getIdentifier(),
+			new String[0]);
+		this.elements.push(newElement);
+		addAsChild(this.infos.peek(), newElement);
+		SourceMethodInfo info = new SourceMethodInfo();
+		info.setReturnType(method.getType().toString().toCharArray());
+		info.setSourceRangeStart(method.getStartPosition());
+		info.setSourceRangeEnd(method.getStartPosition() + method.getLength() - 1);
+		info.setFlags(method.getFlags());
+		info.setNameSourceStart(method.getName().getStartPosition());
+		info.setNameSourceEnd(method.getName().getStartPosition() + method.getName().getLength() - 1);
+		this.infos.push(info);
+		this.toPopulate.put(newElement, info);
+		return true;
+	}
+	@Override
+	public void endVisit(AnnotationTypeMemberDeclaration decl) {
+		this.elements.pop();
+		this.infos.pop();
+	}
+
+	@Override
+	public boolean visit(org.eclipse.jdt.core.dom.TypeParameter typeParam) {
+		TypeParameter newElement = new TypeParameter(this.elements.peek(), typeParam.getName().getFullyQualifiedName());
+		this.elements.push(newElement);
+		addAsChild(this.infos.peek(), newElement);
+		TypeParameterElementInfo info = new TypeParameterElementInfo();
+		info.setSourceRangeStart(typeParam.getStartPosition());
+		info.setSourceRangeEnd(typeParam.getStartPosition() + typeParam.getLength());
+		this.infos.push(info);
+		return true;
+	}
+	@Override
+	public void endVisit(org.eclipse.jdt.core.dom.TypeParameter typeParam) {
+		this.elements.pop();
+		this.infos.pop();
+	}
+
+	@Override
+	public boolean visit(NormalAnnotation node) {
+		Annotation newElement = new Annotation(this.elements.peek(), node.getTypeName().toString());
+		this.elements.push(newElement);
+		addAsChild(this.infos.peek(), newElement);
+		AnnotationInfo newInfo = new AnnotationInfo();
+		newInfo.setSourceRangeStart(node.getStartPosition());
+		newInfo.setSourceRangeEnd(node.getStartPosition() + node.getLength() - 1);
+		newInfo.nameStart = node.getTypeName().getStartPosition();
+		newInfo.nameEnd = node.getTypeName().getStartPosition() + node.getTypeName().getLength() - 1;
+		newInfo.members = ((List<org.eclipse.jdt.core.dom.MemberValuePair>)node.values())
+			.stream()
+			.map(domMemberValuePair -> {
+				Entry<Object, Integer> value = memberValue(domMemberValuePair.getValue());
+				return new org.eclipse.jdt.internal.core.MemberValuePair(domMemberValuePair.getName().toString(), value.getKey(), value.getValue());
+			})
+			.toArray(IMemberValuePair[]::new);
+		this.infos.push(newInfo);
+		this.toPopulate.put(newElement, newInfo);
+		return true;
+	}
+	@Override
+	public void endVisit(NormalAnnotation decl) {
+		this.elements.pop();
+		this.infos.pop();
+	}
+
+	@Override
+	public boolean visit(MarkerAnnotation node) {
+		Annotation newElement = new Annotation(this.elements.peek(), node.getTypeName().toString());
+		this.elements.push(newElement);
+		addAsChild(this.infos.peek(), newElement);
+		AnnotationInfo newInfo = new AnnotationInfo();
+		newInfo.setSourceRangeStart(node.getStartPosition());
+		newInfo.setSourceRangeEnd(node.getStartPosition() + node.getLength() - 1);
+		newInfo.members = new IMemberValuePair[0];
+		this.infos.push(newInfo);
+		this.toPopulate.put(newElement, newInfo);
+		return true;
+	}
+	@Override
+	public void endVisit(MarkerAnnotation decl) {
+		this.elements.pop();
+		this.infos.pop();
+	}
+
+	@Override
+	public boolean visit(SingleMemberAnnotation node) {
+		Annotation newElement = new Annotation(this.elements.peek(), node.getTypeName().toString());
+		this.elements.push(newElement);
+		addAsChild(this.infos.peek(), newElement);
+		AnnotationInfo newInfo = new AnnotationInfo();
+		newInfo.setSourceRangeStart(node.getStartPosition());
+		newInfo.setSourceRangeEnd(node.getStartPosition() + node.getLength() - 1);
+		Entry<Object, Integer> value = memberValue(node.getValue());
+		newInfo.members = new IMemberValuePair[] { new org.eclipse.jdt.internal.core.MemberValuePair("value", value.getKey(), value.getValue()) }; //$NON-NLS-1$
+		this.infos.push(newInfo);
+		this.toPopulate.put(newElement, newInfo);
+		return true;
+	}
+	@Override
+	public void endVisit(SingleMemberAnnotation decl) {
+		this.elements.pop();
+		this.infos.pop();
+	}
+
+	public Entry<Object, Integer> memberValue(Expression dom) {
+		if (dom == null ||
+			dom instanceof NullLiteral nullLiteral ||
+			(dom instanceof SimpleName name && (
+				"MISSING".equals(name.getIdentifier()) || //$NON-NLS-1$ // better compare with internal SimpleName.MISSING
+				Arrays.equals(RecoveryScanner.FAKE_IDENTIFIER, name.getIdentifier().toCharArray())))) {
+			return new SimpleEntry<>(null, IMemberValuePair.K_UNKNOWN);
+		}
+		if (dom instanceof StringLiteral stringValue) {
+			return new SimpleEntry<>(stringValue.getLiteralValue(), IMemberValuePair.K_STRING);
+		}
+		if (dom instanceof BooleanLiteral booleanValue) {
+			return new SimpleEntry<>(booleanValue.booleanValue(), IMemberValuePair.K_BOOLEAN);
+		}
+		if (dom instanceof CharacterLiteral charValue) {
+			return new SimpleEntry<>(charValue.charValue(), IMemberValuePair.K_CHAR);
+		}
+		if (dom instanceof TypeLiteral typeLiteral) {
+			return new SimpleEntry<>(typeLiteral.getType(), IMemberValuePair.K_CLASS);
+		}
+		if (dom instanceof SimpleName simpleName) {
+			return new SimpleEntry<>(simpleName.toString(), IMemberValuePair.K_SIMPLE_NAME);
+		}
+		if (dom instanceof QualifiedName qualifiedName) {
+			return new SimpleEntry<>(qualifiedName.toString(), IMemberValuePair.K_QUALIFIED_NAME);
+		}
+		if (dom instanceof org.eclipse.jdt.core.dom.Annotation annotation) {
+			return new SimpleEntry<>(toModelAnnotation(annotation), IMemberValuePair.K_ANNOTATION);
+		}
+		if (dom instanceof ArrayInitializer arrayInitializer) {
+			var values = ((List<Expression>)arrayInitializer.expressions()).stream().map(this::memberValue).toList();
+			var types = values.stream().map(Entry::getValue).distinct().toList();
+			return new SimpleEntry<>(values.stream().map(Entry::getKey).toArray(), types.size() == 1 ? types.get(0) : IMemberValuePair.K_UNKNOWN);
+		}
+		if (dom instanceof NumberLiteral number) {
+			String token = number.getToken();
+			int type = toAnnotationValuePairType(token);
+			Object value = token;
+			if ((type == IMemberValuePair.K_LONG && token.endsWith("L")) || //$NON-NLS-1$
+				(type == IMemberValuePair.K_FLOAT && token.endsWith("f"))) { //$NON-NLS-1$
+				value = token.substring(0, token.length() - 1);
+			}
+			if (value instanceof String valueString) {
+				value = switch (type) {
+					case IMemberValuePair.K_INT -> Integer.parseInt(valueString);
+					case IMemberValuePair.K_LONG -> Long.parseLong(valueString);
+					case IMemberValuePair.K_SHORT -> Short.parseShort(valueString);
+					case IMemberValuePair.K_BYTE -> Byte.parseByte(valueString);
+					case IMemberValuePair.K_FLOAT -> Float.parseFloat(valueString);
+					case IMemberValuePair.K_DOUBLE -> Double.parseDouble(valueString);
+					default -> throw new IllegalArgumentException("Type not (yet?) supported"); //$NON-NLS-1$
+				};
+			}
+			return new SimpleEntry<>(value, type);
+		}
+		return new SimpleEntry<>(null, IMemberValuePair.K_UNKNOWN);
+	}
+
+	private int toAnnotationValuePairType(String token) {
+		// inspired by NumberLiteral.setToken
+		Scanner scanner = new Scanner();
+		scanner.setSource(token.toCharArray());
+		try {
+			int tokenType = scanner.getNextToken();
+			return switch(tokenType) {
+				case TerminalTokens.TokenNameDoubleLiteral -> IMemberValuePair.K_DOUBLE;
+				case TerminalTokens.TokenNameIntegerLiteral -> IMemberValuePair.K_INT;
+				case TerminalTokens.TokenNameFloatingPointLiteral -> IMemberValuePair.K_FLOAT;
+				case TerminalTokens.TokenNameLongLiteral -> IMemberValuePair.K_LONG;
+				case TerminalTokens.TokenNameMINUS ->
+					switch (scanner.getNextToken()) {
+						case TerminalTokens.TokenNameDoubleLiteral -> IMemberValuePair.K_DOUBLE;
+						case TerminalTokens.TokenNameIntegerLiteral -> IMemberValuePair.K_INT;
+						case TerminalTokens.TokenNameFloatingPointLiteral -> IMemberValuePair.K_FLOAT;
+						case TerminalTokens.TokenNameLongLiteral -> IMemberValuePair.K_LONG;
+						default -> throw new IllegalArgumentException("Invalid number literal : >" + token + "<"); //$NON-NLS-1$//$NON-NLS-2$
+					};
+				default -> throw new IllegalArgumentException("Invalid number literal : >" + token + "<"); //$NON-NLS-1$//$NON-NLS-2$
+			};
+		} catch (InvalidInputException ex) {
+			ILog.get().error(ex.getMessage(), ex);
+			return IMemberValuePair.K_UNKNOWN;
+		}
+	}
+
+	private Annotation toModelAnnotation(org.eclipse.jdt.core.dom.Annotation domAnnotation) {
+		IMemberValuePair[] members;
+		if (domAnnotation instanceof NormalAnnotation normalAnnotation) {
+			members = ((List<MemberValuePair>)normalAnnotation.values()).stream().map(domMemberValuePair -> {
+				Entry<Object, Integer> value = memberValue(domMemberValuePair.getValue());
+				return new org.eclipse.jdt.internal.core.MemberValuePair(domMemberValuePair.getName().toString(), value.getKey(), value.getValue());
+			}).toArray(IMemberValuePair[]::new);
+		} else if (domAnnotation instanceof SingleMemberAnnotation single) {
+			Entry<Object, Integer> value = memberValue(single.getValue());
+			members = new IMemberValuePair[] { new org.eclipse.jdt.internal.core.MemberValuePair("value", value.getKey(), value.getValue())}; //$NON-NLS-1$
+		} else {
+			members = new IMemberValuePair[0];
+		}
+		return new Annotation(null, domAnnotation.getTypeName().toString()) {
+			@Override
+			public IMemberValuePair[] getMemberValuePairs() {
+				return members;
+			}
+		};
+	}
+
+	private LocalVariable toLocalVariable(SingleVariableDeclaration parameter) {
+		return new LocalVariable(this.elements.peek(),
+				parameter.getName().getIdentifier(),
+				parameter.getStartPosition(),
+				parameter.getStartPosition() + parameter.getLength(),
+				parameter.getName().getStartPosition(),
+				parameter.getName().getStartPosition() + parameter.getName().getLength(),
+				parameter.getType().toString(),
+				null, // TODO
+				parameter.getFlags(),
+				parameter.getParent() instanceof MethodDeclaration);
+	}
+
+	@Override
+	public boolean visit(FieldDeclaration field) {
+		for (VariableDeclarationFragment fragment : (Collection<VariableDeclarationFragment>) field.fragments()) {
+			SourceField newElement = new SourceField(this.elements.peek(), fragment.getName().toString());
+			this.elements.push(newElement);
+			addAsChild(this.infos.peek(), newElement);
+			SourceFieldElementInfo info = new SourceFieldElementInfo();
+			info.setTypeName(field.getType().toString().toCharArray());
+			info.setSourceRangeStart(field.getStartPosition());
+			info.setSourceRangeEnd(field.getStartPosition() + field.getLength() - 1);
+			info.setFlags(field.getFlags());
+			info.setNameSourceStart(fragment.getName().getStartPosition());
+			info.setNameSourceEnd(fragment.getName().getStartPosition() + fragment.getName().getLength() - 1);
+			// TODO populate info
+			this.infos.push(info);
+			this.toPopulate.put(newElement, info);
+		}
+		return true;
+	}
+	@Override
+	public void endVisit(FieldDeclaration decl) {
+		this.elements.pop();
+		this.infos.pop();
+	}
+
+	private String createSignature(SingleVariableDeclaration decl) {
+		String initialSignature = Util.getSignature(decl.getType());
+		int extraDimensions = decl.getExtraDimensions();
+		if (decl.isVarargs()) {
+			extraDimensions++;
+		}
+		return Signature.createArraySignature(initialSignature, extraDimensions);
+	}
+
+	@Override
+	public boolean visit(Initializer node) {
+		org.eclipse.jdt.internal.core.Initializer newElement = new org.eclipse.jdt.internal.core.Initializer(this.elements.peek(), 1);
+		this.elements.push(newElement);
+		addAsChild(this.infos.peek(), newElement);
+		InitializerElementInfo newInfo = new InitializerElementInfo();
+		newInfo.setSourceRangeStart(node.getStartPosition());
+		newInfo.setSourceRangeEnd(node.getStartPosition() + node.getLength() - 1);
+		newInfo.setFlags(node.getFlags());
+		this.infos.push(newInfo);
+		this.toPopulate.put(newElement, newInfo);
+		return true;
+	}
+	@Override
+	public void endVisit(Initializer decl) {
+		this.elements.pop();
+		this.infos.pop();
+	}
+
+	@Override
+	public boolean visit(ModuleDeclaration node) {
+		SourceModule newElement = new SourceModule(this.elements.peek(), node.getName().toString());
+		this.elements.push(newElement);
+		addAsChild(this.infos.peek(), newElement);
+		this.unitInfo.setModule(newElement);
+		try {
+			this.root.getJavaProject().setModuleDescription(newElement);
+		} catch (JavaModelException e) {
+			ILog.get().error(e.getMessage(), e);
+		}
+		ModuleDescriptionInfo newInfo = new ModuleDescriptionInfo();
+		newInfo.setHandle(newElement);
+		newInfo.name = node.getName().toString().toCharArray();
+		newInfo.setNameSourceStart(node.getName().getStartPosition());
+		newInfo.setNameSourceEnd(node.getName().getStartPosition() + node.getName().getLength() - 1);
+		newInfo.setSourceRangeStart(node.getStartPosition());
+		newInfo.setSourceRangeEnd(node.getStartPosition() + node.getLength() - 1);
+		newInfo.setFlags(node.getFlags());
+		List<?> moduleStatements = node.moduleStatements();
+		newInfo.requires = moduleStatements.stream()
+			.filter(RequiresDirective.class::isInstance)
+			.map(RequiresDirective.class::cast)
+			.map(this::toModuleReferenceInfo)
+			.toArray(ModuleReferenceInfo[]::new);
+		newInfo.exports = moduleStatements.stream()
+			.filter(ExportsDirective.class::isInstance)
+			.map(ExportsDirective.class::cast)
+			.map(req -> toPackageExportInfo(req, req.getName(), req.getFlags()))
+			.toArray(PackageExportInfo[]::new);
+		newInfo.opens = moduleStatements.stream()
+			.filter(OpensDirective.class::isInstance)
+			.map(OpensDirective.class::cast)
+			.map(req -> toPackageExportInfo(req, req.getName(), req.getFlags()))
+			.toArray(PackageExportInfo[]::new);
+		newInfo.usedServices = moduleStatements.stream()
+			.filter(UsesDirective.class::isInstance)
+			.map(UsesDirective.class::cast)
+			.map(UsesDirective::getName)
+			.map(Name::toString)
+			.map(String::toCharArray)
+			.toArray(char[][]::new);
+		newInfo.services = moduleStatements.stream()
+			.filter(ProvidesDirective.class::isInstance)
+			.map(ProvidesDirective.class::cast)
+			.map(this::toServiceInfo)
+			.toArray(ServiceInfo[]::new);
+		this.infos.push(newInfo);
+		this.toPopulate.put(newElement, newInfo);
+		return true;
+	}
+	@Override
+	public void endVisit(ModuleDeclaration decl) {
+		this.elements.pop();
+		this.infos.pop();
+	}
+
+	private ModuleReferenceInfo toModuleReferenceInfo(RequiresDirective node) {
+		ModuleReferenceInfo res = new ModuleReferenceInfo();
+		res.modifiers = node.getModifiers();
+		res.name = node.getName().toString().toCharArray();
+		res.setSourceRangeStart(node.getStartPosition());
+		res.setSourceRangeEnd(node.getStartPosition() + node.getLength() - 1);
+		return res;
+	}
+	private PackageExportInfo toPackageExportInfo(ASTNode node, Name name, int flags) {
+		PackageExportInfo res = new PackageExportInfo();
+		res.flags = flags;
+		res.pack = name.toString().toCharArray();
+		res.setSourceRangeStart(node.getStartPosition());
+		res.setSourceRangeEnd(node.getStartPosition() + node.getLength() - 1);
+		return res;
+	}
+	private ServiceInfo toServiceInfo(ProvidesDirective node) {
+		ServiceInfo res = new ServiceInfo();
+		res.flags = node.getFlags();
+		res.serviceName = node.getName().toString().toCharArray();
+		res.implNames = ((List<Name>)node.implementations()).stream().map(Name::toString).map(String::toCharArray).toArray(char[][]::new);
+		res.setSourceRangeStart(node.getStartPosition());
+		res.setSourceRangeEnd(node.getStartPosition() + node.getLength() - 1);
+		return res;
+	}
+}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/DOMToModelPopulator.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/DOMToModelPopulator.java
@@ -311,8 +311,12 @@ class DOMToModelPopulator extends ASTVisitor {
 		info.arguments = ((List<SingleVariableDeclaration>)method.parameters()).stream()
 			.map(this::toLocalVariable)
 			.toArray(LocalVariable[]::new);
-		if (method.getAST().apiLevel() > 2 && method.getReturnType2() != null) {
-			info.setReturnType(method.getReturnType2().toString().toCharArray());
+		if (method.getAST().apiLevel() > 2) {
+			if (method.getReturnType2() != null) {
+				info.setReturnType(method.getReturnType2().toString().toCharArray());
+			} else {
+				info.setReturnType("void".toCharArray()); //$NON-NLS-1$
+			}
 		}
 		info.setSourceRangeStart(method.getStartPosition());
 		info.setSourceRangeEnd(method.getStartPosition() + method.getLength() - 1);

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ReconcileWorkingCopyOperation.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ReconcileWorkingCopyOperation.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.core;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -25,6 +26,8 @@ import org.eclipse.jdt.core.compiler.CategorizedProblem;
 import org.eclipse.jdt.core.compiler.CompilationParticipant;
 import org.eclipse.jdt.core.compiler.ReconcileContext;
 import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.PrimitiveType;
 import org.eclipse.jdt.internal.compiler.ast.CompilationUnitDeclaration;
 import org.eclipse.jdt.internal.core.util.Messages;
 import org.eclipse.jdt.internal.core.util.Util;
@@ -175,7 +178,6 @@ public class ReconcileWorkingCopyOperation extends JavaModelOperation {
 		if (this.ast != null)
 			return this.ast; // no need to recompute AST if known already
 
-		CompilationUnitDeclaration unit = null;
 		try {
 			JavaModelManager.getJavaModelManager().abortOnMissingSource.set(Boolean.TRUE);
 			CompilationUnit source = workingCopy.cloneCachingContents();
@@ -183,33 +185,60 @@ public class ReconcileWorkingCopyOperation extends JavaModelOperation {
 			if (JavaProject.hasJavaNature(workingCopy.getJavaProject().getProject())
 					&& (this.reconcileFlags & ICompilationUnit.FORCE_PROBLEM_DETECTION) != 0) {
 				this.resolveBindings = this.requestorIsActive;
-				if (this.problems == null)
+				if (this.problems == null) {
 					this.problems = new HashMap<>();
-				unit =
-					CompilationUnitProblemFinder.process(
-						source,
-						this.workingCopyOwner,
-						this.problems,
-						this.astLevel != ICompilationUnit.NO_AST/*creating AST if level is not NO_AST */,
-						this.reconcileFlags,
-						this.progressMonitor);
-				if (this.progressMonitor != null) this.progressMonitor.worked(1);
-			}
-
-			// create AST if needed
-			if (this.astLevel != ICompilationUnit.NO_AST
-					&& unit !=null/*unit is null if working copy is consistent && (problem detection not forced || non-Java project) -> don't create AST as per API*/) {
+				}
 				Map<String, String> options = workingCopy.getJavaProject().getOptions(true);
-				// convert AST
-				this.ast =
-					AST.convertCompilationUnit(
-						this.astLevel,
-						unit,
-						options,
-						this.resolveBindings,
-						source,
-						this.reconcileFlags,
-						this.progressMonitor);
+				if (CompilationUnit.DOM_BASED_OPERATIONS) {
+					ASTParser parser = ASTParser.newParser(this.astLevel >= 0 ? this.astLevel : AST.getJLSLatest());
+					parser.setResolveBindings(this.resolveBindings || (this.reconcileFlags & ICompilationUnit.FORCE_PROBLEM_DETECTION) != 0);
+					parser.setCompilerOptions(options);
+					parser.setSource(source);
+					org.eclipse.jdt.core.dom.CompilationUnit newAST = (org.eclipse.jdt.core.dom.CompilationUnit) parser.createAST(this.progressMonitor);
+					if ((this.reconcileFlags & ICompilationUnit.FORCE_PROBLEM_DETECTION) != 0 && newAST != null) {
+						newAST.getAST().resolveWellKnownType(PrimitiveType.BOOLEAN.toString()); //trigger resolution and analysis
+					}
+					CategorizedProblem[] newProblems = Arrays.stream(newAST.getProblems())
+						.filter(CategorizedProblem.class::isInstance)
+						.map(CategorizedProblem.class::cast)
+						.toArray(CategorizedProblem[]::new);
+					this.problems.put(Integer.toString(CategorizedProblem.CAT_UNSPECIFIED), newProblems); // TODO better category
+					if (this.astLevel != ICompilationUnit.NO_AST) {
+						this.ast = newAST;
+					}
+				} else {
+					CompilationUnitDeclaration unit = null; 
+					try {
+						unit = CompilationUnitProblemFinder.process(
+								source,
+								this.workingCopyOwner,
+								this.problems,
+								this.astLevel != ICompilationUnit.NO_AST/*creating AST if level is not NO_AST */,
+								this.reconcileFlags,
+								this.progressMonitor);
+						if (this.progressMonitor != null) this.progressMonitor.worked(1);
+		
+						// create AST if needed
+						if (this.astLevel != ICompilationUnit.NO_AST
+								&& unit !=null/*unit is null if working copy is consistent && (problem detection not forced || non-Java project) -> don't create AST as per API*/) {
+							// convert AST
+							this.ast =
+								AST.convertCompilationUnit(
+									this.astLevel,
+									unit,
+									options,
+									this.resolveBindings,
+									source,
+									this.reconcileFlags,
+									this.progressMonitor);
+						}
+					} finally {
+						if (unit != null) {
+							unit.cleanUp();
+						}
+					}
+				}
+
 				if (this.ast != null) {
 					if (this.deltaBuilder.delta == null) {
 						this.deltaBuilder.delta = new JavaElementDelta(workingCopy);
@@ -225,9 +254,6 @@ public class ReconcileWorkingCopyOperation extends JavaModelOperation {
 	    	// (see https://bugs.eclipse.org/bugs/show_bug.cgi?id=100919)
 	    } finally {
 			JavaModelManager.getJavaModelManager().abortOnMissingSource.remove();
-	        if (unit != null) {
-	            unit.cleanUp();
-	        }
 	    }
 		return this.ast;
 	}

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/JavaSearchDocument.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/JavaSearchDocument.java
@@ -87,7 +87,7 @@ public class JavaSearchDocument extends SearchDocument {
 		}
 		return null;
 	}
-	private IFile getFile() {
+	public IFile getFile() {
 		if (this.file == null)
 			this.file = ResourcesPlugin.getWorkspace().getRoot().getFile(new Path(getPath()));
 		return this.file;

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/DOMToIndexVisitor.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/DOMToIndexVisitor.java
@@ -1,0 +1,134 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jdt.internal.core.search.indexing;
+
+import java.util.List;
+
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ASTVisitor;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.FieldDeclaration;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.PrimitiveType;
+import org.eclipse.jdt.core.dom.RecordDeclaration;
+import org.eclipse.jdt.core.dom.SimpleName;
+import org.eclipse.jdt.core.dom.SimpleType;
+import org.eclipse.jdt.core.dom.SingleVariableDeclaration;
+import org.eclipse.jdt.core.dom.Type;
+import org.eclipse.jdt.core.dom.TypeDeclaration;
+import org.eclipse.jdt.core.dom.VariableDeclaration;
+import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
+
+class DOMToIndexVisitor extends ASTVisitor {
+
+	private SourceIndexer sourceIndexer;
+
+	public DOMToIndexVisitor(SourceIndexer sourceIndexer) {
+		this.sourceIndexer = sourceIndexer;
+	}
+
+	@Override
+	public boolean visit(TypeDeclaration type) {
+		if (type.isInterface()) {
+			this.sourceIndexer.addInterfaceDeclaration(type.getModifiers(), getPackage(type), type.getName().toString().toCharArray(), null, ((List<Type>)type.superInterfaceTypes()).stream().map(superInterface -> superInterface.toString().toCharArray()).toArray(char[][]::new), null, false);
+		} else {
+			this.sourceIndexer.addClassDeclaration(type.getModifiers(), getPackage(type), type.getName().toString().toCharArray(), null, type.getSuperclassType() == null ? null : type.getSuperclassType().toString().toCharArray(),
+				((List<Type>)type.superInterfaceTypes()).stream().map(superInterface -> superInterface.toString().toCharArray()).toArray(char[][]::new), null, isSecondary(type));
+		}
+		// TODO other types
+		return true;
+	}
+
+	private boolean isSecondary(TypeDeclaration type) {
+		return type.getParent() instanceof CompilationUnit unit &&
+			unit.types().size() > 1 &&
+			unit.types().indexOf(type) > 0;
+			// TODO: check name?
+	}
+
+	private char[] getPackage(ASTNode node) {
+		while (node != null && !(node instanceof CompilationUnit)) {
+			node = node.getParent();
+		}
+		return node == null ? null :
+			node instanceof CompilationUnit unit && unit.getPackage() != null ? unit.getPackage().getName().toString().toCharArray() :
+			null; 
+	}
+
+	@Override
+	public boolean visit(RecordDeclaration recordDecl) {
+		// copied processing of TypeDeclaration
+		this.sourceIndexer.addClassDeclaration(recordDecl.getModifiers(), getPackage(recordDecl), recordDecl.getName().toString().toCharArray(), null, null,
+				((List<Type>)recordDecl.superInterfaceTypes()).stream().map(type -> type.toString().toCharArray()).toArray(char[][]::new), null, false);
+		return true;
+	}
+
+	@Override
+	public boolean visit(MethodDeclaration method) {
+		char[] methodName = method.getName().toString().toCharArray();
+		char[][] parameterTypes = ((List<VariableDeclaration>)method.parameters()).stream()
+			.filter(SingleVariableDeclaration.class::isInstance)
+			.map(SingleVariableDeclaration.class::cast)
+			.map(SingleVariableDeclaration::getType)
+			.map(Type::toString)
+			.map(String::toCharArray)
+			.toArray(char[][]::new);
+		char[] returnType = null;
+		if (method.getReturnType2() instanceof SimpleType simple) {
+			returnType = simple.getName().toString().toCharArray();
+		} else if (method.getReturnType2() instanceof PrimitiveType primitive) {
+			returnType = primitive.getPrimitiveTypeCode().toString().toCharArray();
+		} else if (method.getReturnType2() == null) {
+			// do nothing
+		} else {
+			returnType = method.getReturnType2().toString().toCharArray();
+		}
+		char[][] exceptionTypes = ((List<Type>)method.thrownExceptionTypes()).stream()
+			.map(Type::toString)
+			.map(String::toCharArray)
+			.toArray(char[][]::new);
+		this.sourceIndexer.addMethodDeclaration(methodName, parameterTypes, returnType, exceptionTypes);
+		char[][] parameterNames = ((List<VariableDeclaration>)method.parameters()).stream()
+			.map(VariableDeclaration::getName)
+			.map(SimpleName::toString)
+			.map(String::toCharArray)
+			.toArray(char[][]::new);
+		this.sourceIndexer.addMethodDeclaration(null,
+			null /* TODO: fully qualified name of enclosing type? */,
+			methodName,
+			parameterTypes.length,
+			null,
+			parameterTypes,
+			parameterNames,
+			returnType,
+			method.getModifiers(),
+			getPackage(method),
+			0 /* TODO What to put here? */,
+			exceptionTypes,
+			0 /* TODO ExtraFlags.IsLocalType ? */);
+		return true;
+	}
+
+	@Override
+	public boolean visit(FieldDeclaration field) {
+		char[] typeName = field.getType().toString().toCharArray();
+		for (VariableDeclarationFragment fragment: (List<VariableDeclarationFragment>)field.fragments()) {
+			this.sourceIndexer.addFieldDeclaration(typeName, fragment.getName().toString().toCharArray());
+		}
+		return true;
+	}
+	
+	// TODO (cf SourceIndexer and SourceIndexerRequestor)
+	// * Module: addModuleDeclaration/addModuleReference/addModuleExportedPackages
+	// * Lambda: addIndexEntry/addClassDeclaration
+	// * addMethodReference
+	// * addConstructorReference
+}


### PR DESCRIPTION
Introduced 2 system property switches to control whether some IDE operations are using ECJ parser (legacy/default) or whether to make those operations powered by a full DOM.

* CompilationUnit.DOM_BASED_OPERATIONS will make codeSelect (hover, link to definition...), buildStructure (JDT Project element model), reconciler (code diagnostics feedback) and indexer
* CompilationUnit.DOM_BASED_COMPLETION controls completion (unlike other operations, completion based on DOM is far from being complete or straightforward)

The DOM-based operation can then allow to plug alternative compiler then ECJ and still get JDT functionalities working.