### PR TITLE
ecj: Duplicate resource leak warnings

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ResourceLeakTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ResourceLeakTests.java
@@ -7054,4 +7054,59 @@ public void testGH1762() {
 		null);
 
 }
+public void testGH1867() {
+	Map options = getCompilerOptions();
+	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
+	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
+	options.put(CompilerOptions.OPTION_ReportExplicitlyClosedAutoCloseable, CompilerOptions.ERROR);
+	runLeakTest(
+		new String[] {
+			"X.java",
+			"""
+			class RC implements AutoCloseable {
+				void m() {}
+				public void close() {}
+			}
+			public class X {
+				RC get() { return null; }
+				void test(int sw) {
+					if (sw != -1) {
+						switch(sw) {
+						case 1:
+							get().m();
+							break;
+						case 2:
+							get().m();
+							System.out.println();
+							return;
+						case 3:
+							get().m();
+							break;
+						}
+						System.out.println();
+					}
+				}
+			}
+			"""
+		},
+		"""
+		----------
+		1. ERROR in X.java (at line 11)
+			get().m();
+			^^^^^
+		Potential resource leak: \'<unassigned Closeable value>\' may not be closed
+		----------
+		2. ERROR in X.java (at line 14)
+			get().m();
+			^^^^^
+		Potential resource leak: \'<unassigned Closeable value>\' may not be closed
+		----------
+		3. ERROR in X.java (at line 18)
+			get().m();
+			^^^^^
+		Potential resource leak: \'<unassigned Closeable value>\' may not be closed
+		----------
+		""",
+		options);
+}
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ResourceLeakTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ResourceLeakTests.java
@@ -7089,24 +7089,22 @@ public void testGH1867() {
 			}
 			"""
 		},
-		"""
-		----------
-		1. ERROR in X.java (at line 11)
-			get().m();
-			^^^^^
-		Potential resource leak: \'<unassigned Closeable value>\' may not be closed
-		----------
-		2. ERROR in X.java (at line 14)
-			get().m();
-			^^^^^
-		Potential resource leak: \'<unassigned Closeable value>\' may not be closed
-		----------
-		3. ERROR in X.java (at line 18)
-			get().m();
-			^^^^^
-		Potential resource leak: \'<unassigned Closeable value>\' may not be closed
-		----------
-		""",
+		"----------\n" +
+		"1. ERROR in X.java (at line 11)\n" +
+		"	get().m();\n" +
+		"	^^^^^\n" +
+		potentialOrDefiniteLeak("<unassigned Closeable value>") +
+		"----------\n" +
+		"2. ERROR in X.java (at line 14)\n" +
+		"	get().m();\n" +
+		"	^^^^^\n" +
+		potentialOrDefiniteLeak("<unassigned Closeable value>") +
+		"----------\n" +
+		"3. ERROR in X.java (at line 18)\n" +
+		"	get().m();\n" +
+		"	^^^^^\n" +
+		potentialOrDefiniteLeak("<unassigned Closeable value>") +
+		"----------\n",
 		options);
 }
 }


### PR DESCRIPTION
fixes #1867

In all the years, flow analysis for resources failed to handle switch statements like blocks, although both have a list of statements. Resource analysis needs to cleanup after each contained statement in both contexts alike.