### PR TITLE
ECJ should not proceed to code generation with missing types in picture

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/RecordPattern.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/RecordPattern.java
@@ -227,7 +227,7 @@ public class RecordPattern extends TypePattern {
 		return this.resolvedType != null && this.resolvedType.isRawType();
 	}
 	private void infuseInferredType(Scope currentScope, TypePattern tp, RecordComponentBinding componentBinding) {
-		SingleTypeReference ref = new SingleTypeReference(componentBinding.type.sourceName(),
+		SingleTypeReference ref = new SingleTypeReference(tp.local.type.getTypeName()[0],
 				tp.local.type.sourceStart,
 				tp.local.type.sourceEnd) {
 			@Override

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchPatternTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchPatternTest.java
@@ -7121,4 +7121,93 @@ public class SwitchPatternTest extends AbstractRegressionTest9 {
 				+ "shape : 100.0\n"
 				+ "NULL");
 	}
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1856
+	// [switch][record patterns] NPE: Cannot invoke "org.eclipse.jdt.internal.compiler.lookup.MethodBinding.isStatic()"
+	public void testGHI1856() {
+		this.runNegativeTest(
+				new String[] {
+					"X.java",
+					"""
+					public class X {
+
+						public class Data {
+						    String name;
+						}
+
+						record WrapperRec(ExhaustiveSwitch.Data data) {}
+
+
+						public static void main(String[] args) {
+						    switch (new Object()) {
+						        case WrapperRec(var data) when data.name.isEmpty() -> { }
+						        default -> {}
+						    }
+						}
+					}
+					""",
+				},
+				"----------\n"
+				+ "1. ERROR in X.java (at line 1)\n"
+				+ "	public class X {\n"
+				+ "	^\n"
+				+ "Data cannot be resolved to a type\n"
+				+ "----------\n"
+				+ "2. ERROR in X.java (at line 7)\n"
+				+ "	record WrapperRec(ExhaustiveSwitch.Data data) {}\n"
+				+ "	                  ^^^^^^^^^^^^^^^^\n"
+				+ "ExhaustiveSwitch cannot be resolved to a type\n"
+				+ "----------\n"
+				+ "3. ERROR in X.java (at line 12)\n"
+				+ "	case WrapperRec(var data) when data.name.isEmpty() -> { }\n"
+				+ "	                ^^^\n"
+				+ "Data cannot be resolved to a type\n"
+				+ "----------\n");
+	}
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1856
+	// [switch][record patterns] NPE: Cannot invoke "org.eclipse.jdt.internal.compiler.lookup.MethodBinding.isStatic()"
+	public void testGHI1856_2() {
+		this.runNegativeTest(
+				new String[] {
+					"X.java",
+					"""
+					public class X {
+
+						public class Data {
+						    String name;
+						}
+
+						record WrapperRec(ExhaustiveSwitch.Data data) {}
+
+
+						public static void main(String[] args) {
+						    switch (new Object()) {
+						        case WrapperRec(ExhaustiveSwitch.Data data) when data.name.isEmpty() -> { }
+						        default -> {}
+						    }
+						}
+					}
+					""",
+				},
+				"----------\n"
+				+ "1. ERROR in X.java (at line 1)\n"
+				+ "	public class X {\n"
+				+ "	^\n"
+				+ "Data cannot be resolved to a type\n"
+				+ "----------\n"
+				+ "2. ERROR in X.java (at line 7)\n"
+				+ "	record WrapperRec(ExhaustiveSwitch.Data data) {}\n"
+				+ "	                  ^^^^^^^^^^^^^^^^\n"
+				+ "ExhaustiveSwitch cannot be resolved to a type\n"
+				+ "----------\n"
+				+ "3. ERROR in X.java (at line 12)\n"
+				+ "	case WrapperRec(ExhaustiveSwitch.Data data) when data.name.isEmpty() -> { }\n"
+				+ "	                ^^^^^^^^^^^^^^^^\n"
+				+ "ExhaustiveSwitch cannot be resolved to a type\n"
+				+ "----------\n"
+				+ "4. ERROR in X.java (at line 12)\n"
+				+ "	case WrapperRec(ExhaustiveSwitch.Data data) when data.name.isEmpty() -> { }\n"
+				+ "	                ^^^^^^^^^^^^^^^^^^^^^^^^^^\n"
+				+ "Record component with type Data is not compatible with type ExhaustiveSwitch.Data\n"
+				+ "----------\n");
+	}
 }


### PR DESCRIPTION

## What it does

Prevents crash in code generation - we should not be attempting to generate code with missing types in picture.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1856


## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
