### PR TITLE
Demonstrate "Make Static" refactoring on AbstractRegressionTest

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/parser/ComplianceDiagnoseTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/parser/ComplianceDiagnoseTest.java
@@ -442,8 +442,8 @@ public void test0009() {
 	if(this.complianceLevel < ClassFileConstants.JDK1_5) {
 		this.runNegativeTest(testFiles, expected13ProblemLog);
 	} else {
-		runConformTest(
-			true,
+		AbstractRegressionTest.runConformTest(
+			this, true,
 			testFiles,
 			expected15ProblemLog,
 			null, null,

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/parser/ParserTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/parser/ParserTest.java
@@ -265,8 +265,8 @@ public void _test011() {
 public void test012() {
 	Hashtable nls = new Hashtable();
 	nls.put(CompilerOptions.OPTION_ReportNonExternalizedStringLiteral, CompilerOptions.ERROR);
-	runNegativeTest(
-		true,
+	AbstractRegressionTest.runNegativeTest(
+		this, true,
 		new String[] {
 			"X.java",
 			"public class X {\n" +
@@ -296,8 +296,8 @@ public void test012() {
 public void test013() {
 	Hashtable nls = new Hashtable();
 	nls.put(CompilerOptions.OPTION_ReportNonExternalizedStringLiteral, CompilerOptions.ERROR);
-	runNegativeTest(
-		true,
+	AbstractRegressionTest.runNegativeTest(
+		this, true,
 		new String[] {
 			"X.java",
 			"public class X {\n" +
@@ -506,8 +506,8 @@ public void test021() {
 
 	Hashtable options = new Hashtable();
 	options.put(CompilerOptions.OPTION_MaxProblemPerUnit, "10");
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			buffer.toString()
 		},
@@ -573,8 +573,8 @@ public void test021() {
 public void test022() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportEmptyStatement, CompilerOptions.ERROR);
-	runNegativeTest(
-		true,
+	AbstractRegressionTest.runNegativeTest(
+		this, true,
 		new String[] {
 			"X.java",
 			"interface X {\n" +
@@ -596,8 +596,8 @@ public void test022() {
 public void test023() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportEmptyStatement, CompilerOptions.ERROR);
-	runNegativeTest(
-		true,
+	AbstractRegressionTest.runNegativeTest(
+		this, true,
 		new String[] {
 			"X.java",
 			"class X {\n" +
@@ -619,8 +619,8 @@ public void test023() {
 public void test024() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportEmptyStatement, CompilerOptions.ERROR);
-	runNegativeTest(
-		true,
+	AbstractRegressionTest.runNegativeTest(
+		this, true,
 		new String[] {
 			"X.java",
 			"interface X {\n" +
@@ -642,8 +642,8 @@ public void test024() {
 public void test025() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUndocumentedEmptyBlock, CompilerOptions.ERROR);
-	runNegativeTest(
-		true,
+	AbstractRegressionTest.runNegativeTest(
+		this, true,
 		new String[] {
 			"X.java",
 			"public class X {\n" +
@@ -675,8 +675,8 @@ public void test025() {
 public void test026() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUndocumentedEmptyBlock, CompilerOptions.ERROR);
-	runNegativeTest(
-		true,
+	AbstractRegressionTest.runNegativeTest(
+		this, true,
 		new String[] {
 			"X.java",
 			"public class X {\n" +
@@ -775,8 +775,8 @@ public void _test028() {
 			"----------\n";
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportNonExternalizedStringLiteral, CompilerOptions.ERROR);
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"class X {\n" +
 			"    public static void foo(String param) {\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractNullAnnotationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractNullAnnotationTest.java
@@ -132,8 +132,8 @@ public abstract class AbstractNullAnnotationTest extends AbstractComparableTest 
 	}
 	/** Test expecting a null-error from ecj, none from javac. */
 	protected void runNegativeNullTest(String[] sourceFiles, String expectedCompileError, String[] libs, boolean shouldFlush, Map options) {
-		runNegativeTest(
-				sourceFiles,
+		AbstractRegressionTest.runNegativeTest(
+				this, sourceFiles,
 				expectedCompileError,
 				libs,
 				shouldFlush,
@@ -163,8 +163,8 @@ public abstract class AbstractNullAnnotationTest extends AbstractComparableTest 
 	/** Test with JDT null annotations, expecting a null-error from ecj, none from javac. */
 	void runNegativeTestWithLibs(boolean shouldFlushOutputDirectory, String[] testFiles, Map customOptions,
 			String expectedErrorLog, boolean skipJavaC) {
-		runNegativeTest(
-				shouldFlushOutputDirectory,
+		AbstractRegressionTest.runNegativeTest(
+				this, shouldFlushOutputDirectory,
 				testFiles,
 				this.LIBS,
 				customOptions,
@@ -187,8 +187,8 @@ public abstract class AbstractNullAnnotationTest extends AbstractComparableTest 
 	}
 	void runConformTestWithLibs(boolean shouldFlushOutputDirectory, String[] testFiles, Map customOptions,
 								String expectedCompilerLog, String expectedOutput) {
-		runConformTest(
-				shouldFlushOutputDirectory,
+		AbstractRegressionTest.runConformTest(
+				this, shouldFlushOutputDirectory,
 				testFiles,
 				this.LIBS,
 				customOptions,
@@ -198,8 +198,8 @@ public abstract class AbstractNullAnnotationTest extends AbstractComparableTest 
 			    JavacTestOptions.DEFAULT);
 	}
 	void runConformTestWithLibs(boolean shouldFlushOutputDirectory, String[] testFiles, Map customOptions, String expectedCompilerLog) {
-		runConformTest(
-				shouldFlushOutputDirectory,
+		AbstractRegressionTest.runConformTest(
+				this, shouldFlushOutputDirectory,
 				testFiles,
 				this.LIBS,
 				customOptions,
@@ -217,8 +217,8 @@ public abstract class AbstractNullAnnotationTest extends AbstractComparableTest 
 	void runWarningTestWithLibs(boolean shouldFlushOutputDirectory, String[] testFiles,
 				Map customOptions, String expectedCompilerLog, String expectedOutput)
 	{
-		runConformTest(
-				shouldFlushOutputDirectory,
+		AbstractRegressionTest.runConformTest(
+				this, shouldFlushOutputDirectory,
 				testFiles,
 				this.LIBS,
 				customOptions,
@@ -228,8 +228,8 @@ public abstract class AbstractNullAnnotationTest extends AbstractComparableTest 
 				JavacTestOptions.Excuse.EclipseHasSomeMoreWarnings);
 	}
 	void runConformTest(String[] testFiles, Map customOptions, String expectedOutputString) {
-		runConformTest(
-				testFiles,
+		AbstractRegressionTest.runConformTest(
+				this, testFiles,
 				expectedOutputString,
 				null /*classLibraries*/,
 				true /*shouldFlushOutputDirectory*/,

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractRegressionTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractRegressionTest.java
@@ -139,7 +139,7 @@ public abstract class AbstractRegressionTest extends AbstractCompilerTest implem
 		ASTVisitor visitor;
 
 		protected void runConformTest() {
-			runTest(this.shouldFlushOutputDirectory,
+			AbstractRegressionTest.runTest(AbstractRegressionTest.this, this.shouldFlushOutputDirectory,
 					this.testFiles,
 					this.dependantFiles != null ? this.dependantFiles : new String[] {},
 					this.classLibraries,
@@ -164,7 +164,7 @@ public abstract class AbstractRegressionTest extends AbstractCompilerTest implem
 		}
 
 		protected void runNegativeTest() {
-			runTest(this.shouldFlushOutputDirectory,
+			AbstractRegressionTest.runTest(AbstractRegressionTest.this, this.shouldFlushOutputDirectory,
 					this.testFiles,
 					this.dependantFiles != null ? this.dependantFiles : new String[] {},
 					this.classLibraries,
@@ -189,7 +189,7 @@ public abstract class AbstractRegressionTest extends AbstractCompilerTest implem
 		}
 
 		protected void runWarningTest() {
-			runTest(this.shouldFlushOutputDirectory,
+			AbstractRegressionTest.runTest(AbstractRegressionTest.this, this.shouldFlushOutputDirectory,
 					this.testFiles,
 					this.dependantFiles != null ? this.dependantFiles : new String[] {},
 					this.classLibraries,
@@ -1315,19 +1315,19 @@ protected static class JavacTestOptions {
 	public AbstractRegressionTest(String name) {
 		super(name);
 	}
-	protected boolean checkPreviewAllowed() {
-		return this.complianceLevel == ClassFileConstants.getLatestJDKLevel();
+	protected static boolean checkPreviewAllowed(AbstractRegressionTest abstractRegressionTest) {
+		return abstractRegressionTest.complianceLevel == ClassFileConstants.getLatestJDKLevel();
 	}
-	protected void checkClassFile(String className, String source, String expectedOutput) throws ClassFormatException, IOException {
-		this.checkClassFile("", className, source, expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+	protected static void checkClassFile(AbstractRegressionTest abstractRegressionTest, String className, String source, String expectedOutput) throws ClassFormatException, IOException {
+		AbstractRegressionTest.checkClassFile(abstractRegressionTest, "", className, source, expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
-	protected void checkClassFile(String className, String source, String expectedOutput, int mode) throws ClassFormatException, IOException {
-		this.checkClassFile("", className, source, expectedOutput, mode);
+	protected static void checkClassFile(AbstractRegressionTest abstractRegressionTest, String className, String source, String expectedOutput, int mode) throws ClassFormatException, IOException {
+		AbstractRegressionTest.checkClassFile(abstractRegressionTest, "", className, source, expectedOutput, mode);
 	}
-	protected void checkClassFile(String directoryName, String className, String disassembledClassName, String source, String expectedOutput,
+	protected static void checkClassFile(AbstractRegressionTest abstractRegressionTest, String directoryName, String className, String disassembledClassName, String source, String expectedOutput,
 			int mode, boolean suppressConsole) throws ClassFormatException, IOException
 	{
-		compileAndDeploy(source, directoryName, className, suppressConsole);
+		AbstractRegressionTest.compileAndDeploy(abstractRegressionTest, source, directoryName, className, suppressConsole);
 		try {
 			File directory = new File(EVAL_DIRECTORY, directoryName);
 			if (!directory.exists()) {
@@ -1364,16 +1364,16 @@ protected static class JavacTestOptions {
 				}
 			}
 		} finally {
-			removeTempClass(className);
+			AbstractRegressionTest.removeTempClass(className);
 		}
 	}
 
-	protected void checkClassFile(String directoryName, String className, String source, String expectedOutput, int mode) throws ClassFormatException, IOException {
-		this.checkClassFile(directoryName, className, className, source, expectedOutput, mode, false);
+	protected static void checkClassFile(AbstractRegressionTest abstractRegressionTest, String directoryName, String className, String source, String expectedOutput, int mode) throws ClassFormatException, IOException {
+		AbstractRegressionTest.checkClassFile(abstractRegressionTest, directoryName, className, className, source, expectedOutput, mode, false);
 	}
 
-	protected ClassFileReader getInternalClassFile(String directoryName, String className, String disassembledClassName, String source) throws ClassFormatException, IOException {
-		compileAndDeploy(source, directoryName, className, true);
+	protected static ClassFileReader getInternalClassFile(AbstractRegressionTest abstractRegressionTest, String directoryName, String className, String disassembledClassName, String source) throws ClassFormatException, IOException {
+		AbstractRegressionTest.compileAndDeploy(abstractRegressionTest, source, directoryName, className, true);
 		try {
 			File directory = new File(EVAL_DIRECTORY, directoryName);
 			if (!directory.exists()) {
@@ -1402,14 +1402,14 @@ protected static class JavacTestOptions {
 			}
 			return classFileReader;
 		} finally {
-			removeTempClass(className);
+			AbstractRegressionTest.removeTempClass(className);
 		}
 	}
 
-	protected void checkDisassembledClassFile(String fileName, String className, String expectedOutput) throws Exception {
-		this.checkDisassembledClassFile(fileName, className, expectedOutput, ClassFileBytesDisassembler.DETAILED);
+	protected static void checkDisassembledClassFile(AbstractRegressionTest abstractRegressionTest, String fileName, String className, String expectedOutput) throws Exception {
+		AbstractRegressionTest.checkDisassembledClassFile(fileName, className, expectedOutput, ClassFileBytesDisassembler.DETAILED);
 	}
-	protected void checkDisassembledClassFile(String fileName, String className, String expectedOutput, int mode) throws Exception {
+	protected static void checkDisassembledClassFile(String fileName, String className, String expectedOutput, int mode) throws Exception {
 		File classFile = new File(fileName);
 		if (!classFile.exists()) {
 			assertTrue(".class file doesn't exist", false);
@@ -1446,7 +1446,7 @@ protected static class JavacTestOptions {
 		}
 	}
 
-	protected void compileAndDeploy(String source, String directoryName, String className, boolean suppressConsole) {
+	protected static void compileAndDeploy(AbstractRegressionTest abstractRegressionTest, String source, String directoryName, String className, boolean suppressConsole) {
 		File directory = new File(SOURCE_DIRECTORY);
 		if (!directory.exists()) {
 			if (!directory.mkdirs()) {
@@ -1478,26 +1478,26 @@ protected static class JavacTestOptions {
 			.append(fileName)
 			.append("\" -d \"")
 			.append(EVAL_DIRECTORY);
-		String processAnnot = this.enableAPT ? "" : "-proc:none";
-		if (this.complianceLevel < ClassFileConstants.JDK1_5) {
+		String processAnnot = abstractRegressionTest.enableAPT ? "" : "-proc:none";
+		if (abstractRegressionTest.complianceLevel < ClassFileConstants.JDK1_5) {
 			buffer.append("\" -1.4 -source 1.3 -target 1.2");
-		} else if (this.complianceLevel == ClassFileConstants.JDK1_5) {
+		} else if (abstractRegressionTest.complianceLevel == ClassFileConstants.JDK1_5) {
 			buffer.append("\" -1.5");
-		} else if (this.complianceLevel == ClassFileConstants.JDK1_6) {
+		} else if (abstractRegressionTest.complianceLevel == ClassFileConstants.JDK1_6) {
 			buffer.append("\" -1.6 " + processAnnot);
-		} else if (this.complianceLevel == ClassFileConstants.JDK1_7) {
+		} else if (abstractRegressionTest.complianceLevel == ClassFileConstants.JDK1_7) {
 			buffer.append("\" -1.7 " + processAnnot);
-		} else if (this.complianceLevel == ClassFileConstants.JDK1_8) {
+		} else if (abstractRegressionTest.complianceLevel == ClassFileConstants.JDK1_8) {
 			buffer.append("\" -1.8 " + processAnnot);
-		} else if (this.complianceLevel == ClassFileConstants.JDK9) {
+		} else if (abstractRegressionTest.complianceLevel == ClassFileConstants.JDK9) {
 			buffer.append("\" -9 " + processAnnot);
-		} else if (this.complianceLevel == ClassFileConstants.JDK10) {
+		} else if (abstractRegressionTest.complianceLevel == ClassFileConstants.JDK10) {
 			buffer.append("\" -10 " + processAnnot);
 		} else {
-			int major = (int)(this.complianceLevel>>16);
+			int major = (int)(abstractRegressionTest.complianceLevel>>16);
 			buffer.append("\" -" + (major - ClassFileConstants.MAJOR_VERSION_0));
 		}
-		if (this.complianceLevel == ClassFileConstants.getLatestJDKLevel()  && this.enablePreview)
+		if (abstractRegressionTest.complianceLevel == ClassFileConstants.getLatestJDKLevel()  && abstractRegressionTest.enablePreview)
 			buffer.append(" --enable-preview ");
 		buffer
 			.append(" -preserveAllLocals -proceedOnError -nowarn -g -classpath \"")
@@ -1537,9 +1537,9 @@ protected static class JavacTestOptions {
 			if (problemLog.sameAs(alternatePlatformIndependantExpectedLogs[i]))
 				return; // OK
 		}
-		logTestTitle();
+		AbstractRegressionTest.logTestTitle(this);
 		System.out.println(Util.displayString(computedProblemLog, INDENT, SHIFT));
-		logTestFiles(false, testFiles);
+		AbstractRegressionTest.logTestFiles(this, false, testFiles);
 		if (exception == null) {
 			assertEquals("Invalid problem log ", alternatePlatformIndependantExpectedLogs[i-1], computedProblemLog);
 		}
@@ -1587,12 +1587,13 @@ protected static class JavacTestOptions {
 		}
 	}
 
-	protected void dualPrintln(String message) {
+	protected static void dualPrintln(String message) {
 		System.out.println(message);
 		javacFullLog.println(message);
 	}
-	protected void executeClass(
-			String sourceFile,
+
+	protected static void executeClass(
+			AbstractRegressionTest abstractRegressionTest, String sourceFile,
 			String expectedSuccessOutputString,
 			String[] classLib,
 			boolean shouldFlushOutputDirectory,
@@ -1605,35 +1606,35 @@ protected static class JavacTestOptions {
 		if (className.endsWith(PACKAGE_INFO_NAME)) return;
 
 		if (vmArguments != null) {
-			if (this.verifier != null) {
-				this.verifier.shutDown();
+			if (abstractRegressionTest.verifier != null) {
+				abstractRegressionTest.verifier.shutDown();
 			}
-			this.verifier = new TestVerifier(false);
-			this.createdVerifier = true;
+			abstractRegressionTest.verifier = new TestVerifier(false);
+			abstractRegressionTest.createdVerifier = true;
 		}
 		boolean passed =
-			this.verifier.verifyClassFiles(
+			abstractRegressionTest.verifier.verifyClassFiles(
 				sourceFile,
 				className,
 				expectedSuccessOutputString,
-				this.classpaths,
+				abstractRegressionTest.classpaths,
 				null,
 				vmArguments);
-		assertTrue(this.verifier.failureReason, // computed by verifyClassFiles(...) action
+		assertTrue(abstractRegressionTest.verifier.failureReason, // computed by verifyClassFiles(...) action
 				passed);
 		if (vmArguments != null) {
-			if (this.verifier != null) {
-				this.verifier.shutDown();
+			if (abstractRegressionTest.verifier != null) {
+				abstractRegressionTest.verifier.shutDown();
 			}
-			this.verifier = new TestVerifier(false);
-			this.createdVerifier = true;
+			abstractRegressionTest.verifier = new TestVerifier(false);
+			abstractRegressionTest.createdVerifier = true;
 		}
 	}
 
 	/*
 	 * Returns the references in the given .class file.
 	 */
-	protected String findReferences(String classFilePath) {
+	protected static String findReferences(String classFilePath) {
 		// check that "new Z().init()" is bound to "AbstractB.init()"
 		final StringBuilder references = new StringBuilder(10);
 		final SearchParticipant participant = new JavaSearchParticipant() {
@@ -1673,7 +1674,7 @@ protected static class JavacTestOptions {
 		return computedReferences;
 	}
 
-	protected ClassFileReader getClassFileReader(String fileName, String className) {
+	protected static ClassFileReader getClassFileReader(String fileName, String className) {
 		File classFile = new File(fileName);
 		if (!classFile.exists()) {
 			assertTrue(".class file doesn't exist", false);
@@ -1701,27 +1702,27 @@ protected static class JavacTestOptions {
 		return null;
 	}
 
-	protected INameEnvironment[] getClassLibs(boolean useDefaultClasspaths, Map<String, String> options) {
+	protected static INameEnvironment[] getClassLibs(AbstractRegressionTest abstractRegressionTest, boolean useDefaultClasspaths, Map<String, String> options) {
 		if (options == null)
-			options = getCompilerOptions();
-		String encoding = getCompilerOptions().get(CompilerOptions.OPTION_Encoding);
+			options = abstractRegressionTest.getCompilerOptions();
+		String encoding = abstractRegressionTest.getCompilerOptions().get(CompilerOptions.OPTION_Encoding);
 		if ("".equals(encoding))
 			encoding = null;
 		String release = null;
 		if (CompilerOptions.ENABLED.equals(options.get(CompilerOptions.OPTION_Release))) {
-			release = getCompilerOptions().get(CompilerOptions.OPTION_Compliance);
+			release = abstractRegressionTest.getCompilerOptions().get(CompilerOptions.OPTION_Compliance);
 		}
 		if (useDefaultClasspaths && encoding == null)
-			return DefaultJavaRuntimeEnvironment.create(this.classpaths, release);
+			return DefaultJavaRuntimeEnvironment.create(abstractRegressionTest.classpaths, release);
 		// fall back to FileSystem
 		INameEnvironment[] classLibs = new INameEnvironment[1];
-		classLibs[0] = new FileSystem(this.classpaths, new String[]{}, // ignore initial file names
+		classLibs[0] = new FileSystem(abstractRegressionTest.classpaths, new String[]{}, // ignore initial file names
 				encoding, release
 		);
 		return classLibs;
 	}
 	protected INameEnvironment[] getClassLibs(boolean useDefaultClasspaths) {
-		return getClassLibs(useDefaultClasspaths, null);
+		return AbstractRegressionTest.getClassLibs(this, useDefaultClasspaths, null);
 	}
 	@Override
 	protected Map<String, String> getCompilerOptions() {
@@ -1738,13 +1739,13 @@ protected static class JavacTestOptions {
 		defaultOptions.put(CompilerOptions.OPTION_ReportDeadCode, CompilerOptions.WARNING);
 		return defaultOptions;
 	}
-	protected boolean isMinimumCompliant(long compliance) {
-		Map options = getCompilerOptions();
+	protected static boolean isMinimumCompliant(AbstractRegressionTest abstractRegressionTest, long compliance) {
+		Map options = abstractRegressionTest.getCompilerOptions();
 		CompilerOptions compOptions = new CompilerOptions(options);
 		return compOptions.complianceLevel >= compliance;
 	}
 
-	protected void enableAllWarningsForIrritants(Map<String, String> options, IrritantSet irritants) {
+	protected static void enableAllWarningsForIrritants(Map<String, String> options, IrritantSet irritants) {
 		int[] bits = irritants.getBits();
 		for (int i = 0; i < bits.length; i++) {
 			int bit = bits[i];
@@ -1764,9 +1765,10 @@ protected static class JavacTestOptions {
 	protected String[] getDefaultClassPaths() {
 		return DefaultJavaRuntimeEnvironment.getDefaultClassPaths();
 	}
-	/** Get class library paths built from default class paths plus the JDT null annotations. */
-	protected String[] getLibsWithNullAnnotations(long sourceLevel) {
-		String[] defaultLibs = getDefaultClassPaths();
+	/** Get class library paths built from default class paths plus the JDT null annotations.
+	 * @param abstractRegressionTest TODO*/
+	protected static String[] getLibsWithNullAnnotations(AbstractRegressionTest abstractRegressionTest, long sourceLevel) {
+		String[] defaultLibs = abstractRegressionTest.getDefaultClassPaths();
 		int len = defaultLibs.length;
 		String[] libs = new String[len+1];
 		System.arraycopy(defaultLibs, 0, libs, 0, len);
@@ -1779,7 +1781,7 @@ protected static class JavacTestOptions {
 			libs[len] = bundleFile.getPath();
 		return libs;
 	}
-	protected IErrorHandlingPolicy getErrorHandlingPolicy() {
+	protected static IErrorHandlingPolicy getErrorHandlingPolicy() {
 		return new IErrorHandlingPolicy() {
 			public boolean stopOnFirstError() {
 				return false;
@@ -1803,12 +1805,12 @@ protected static class JavacTestOptions {
 	 */
 	protected INameEnvironment getNameEnvironment(final String[] testFiles, String[] classPaths, Map<String, String> options) {
 		this.classpaths = classPaths == null ? getDefaultClassPaths() : classPaths;
-		return new InMemoryNameEnvironment(testFiles, getClassLibs((classPaths == null), options));
+		return new InMemoryNameEnvironment(testFiles, AbstractRegressionTest.getClassLibs(this, (classPaths == null), options));
 	}
-	protected INameEnvironment getNameEnvironment(final String[] testFiles, String[] classPaths) {
-		return getNameEnvironment(testFiles, classPaths, null);
+	protected static INameEnvironment getNameEnvironment(AbstractRegressionTest abstractRegressionTest, final String[] testFiles, String[] classPaths) {
+		return abstractRegressionTest.getNameEnvironment(testFiles, classPaths, null);
 	}
-	protected IProblemFactory getProblemFactory() {
+	protected static IProblemFactory getProblemFactory() {
 		return new DefaultProblemFactory(Locale.getDefault());
 	}
 	// overridden in AbstractRegressionTests9
@@ -1826,9 +1828,9 @@ protected static class JavacTestOptions {
 		}
 	}
 
-	void logTestFiles(boolean logTitle, String[] testFiles) {
+	static void logTestFiles(AbstractRegressionTest abstractRegressionTest, boolean logTitle, String[] testFiles) {
 		if (logTitle) {
-			logTestTitle();
+			AbstractRegressionTest.logTestTitle(abstractRegressionTest);
 		}
 		for (int i = 0; i < testFiles.length; i += 2) {
 			System.out.print(testFiles[i]);
@@ -1843,15 +1845,15 @@ protected static class JavacTestOptions {
 			System.out.println("]"); //$NON-NLS-1$
 		}
 	}
-	void logTestTitle() {
-		System.out.println(getClass().getName() + '#' + getName());
+	static void logTestTitle(AbstractRegressionTest abstractRegressionTest) {
+		System.out.println(abstractRegressionTest.getClass().getName() + '#' + abstractRegressionTest.getName());
 	}
 
 	/*
 	 * Write given source test files in current output sub-directory.
 	 * Use test name for this sub-directory name (ie. test001, test002, etc...)
 	 */
-	protected void printFiles(String[] testFiles) {
+	protected static void printFiles(String[] testFiles) {
 		for (int i=0, length=testFiles.length; i<length; i++) {
 			System.out.println(testFiles[i++]);
 			String content = testFiles[i];
@@ -1872,23 +1874,23 @@ protected static class JavacTestOptions {
 				TESTS_COUNTERS.put(CURRENT_CLASS_NAME, Integer.valueOf(newCount));
 				if (newCount == 0) {
 					if (DIFF_COUNTERS[0]!=0 || DIFF_COUNTERS[1]!=0 || DIFF_COUNTERS[2]!=0) {
-						dualPrintln("===========================================================================");
-						dualPrintln("Results summary:");
+						AbstractRegressionTest.dualPrintln("===========================================================================");
+						AbstractRegressionTest.dualPrintln("Results summary:");
 					}
 					if (DIFF_COUNTERS[0]!=0)
-						dualPrintln("	- "+DIFF_COUNTERS[0]+" test(s) where Javac found errors/warnings but Eclipse did not");
+						AbstractRegressionTest.dualPrintln("	- "+DIFF_COUNTERS[0]+" test(s) where Javac found errors/warnings but Eclipse did not");
 					if (DIFF_COUNTERS[1]!=0)
-						dualPrintln("	- "+DIFF_COUNTERS[1]+" test(s) where Eclipse found errors/warnings but Javac did not");
+						AbstractRegressionTest.dualPrintln("	- "+DIFF_COUNTERS[1]+" test(s) where Eclipse found errors/warnings but Javac did not");
 					if (DIFF_COUNTERS[2]!=0)
-						dualPrintln("	- "+DIFF_COUNTERS[2]+" test(s) where Eclipse and Javac did not have same output");
+						AbstractRegressionTest.dualPrintln("	- "+DIFF_COUNTERS[2]+" test(s) where Eclipse and Javac did not have same output");
 					System.out.println("\n");
 				}
 			}
-			dualPrintln("\n\nFull results sent to " + javacFullLogFileName);
+			AbstractRegressionTest.dualPrintln("\n\nFull results sent to " + javacFullLogFileName);
 			javacFullLog.flush();
 		}
 	}
-	protected void removeTempClass(String className) {
+	protected static void removeTempClass(String className) {
 		File dir = new File(SOURCE_DIRECTORY);
 		String[] fileNames = dir.list();
 		if (fileNames != null) {
@@ -1914,8 +1916,8 @@ protected static class JavacTestOptions {
 // WORK replace null logs (no test) by empty string in most situations (more
 //      complete coverage) and see what happens
 	protected void runConformTest(String[] testFiles) {
-		runTest(
-	 		// test directory preparation
+		AbstractRegressionTest.runTest(
+	 		this, // test directory preparation
 			true /* flush output directory */,
 			testFiles /* test files */,
 			// compiler options
@@ -1938,9 +1940,9 @@ protected static class JavacTestOptions {
 
 	// WORK replace null logs (no test) by empty string in most situations (more
 	//  complete coverage) and see what happens
-	protected void runConformTest(String[] testFiles, ASTVisitor visitor) {
-		runTest(
-	 		// test directory preparation
+	protected static void runConformTest(AbstractRegressionTest abstractRegressionTest, String[] testFiles, ASTVisitor visitor) {
+		AbstractRegressionTest.runTest(
+	 		abstractRegressionTest, // test directory preparation
 			true /* flush output directory */,
 			testFiles /* test files */,
 			new String[] {},
@@ -1967,11 +1969,11 @@ protected static class JavacTestOptions {
 	}
 
 	protected void runConformTest(String[] testFiles, String expectedOutputString) {
-		runConformTest(false, JavacTestOptions.DEFAULT, testFiles, expectedOutputString);
+		AbstractRegressionTest.runConformTest(this, false, JavacTestOptions.DEFAULT, testFiles, expectedOutputString);
 	}
-	protected void runConformTest(boolean skipJavac, JavacTestOptions javacTestOptions, String[] testFiles, String expectedOutputString) {
-		runTest(
-			// test directory preparation
+	protected static void runConformTest(AbstractRegressionTest abstractRegressionTest, boolean skipJavac, JavacTestOptions javacTestOptions, String[] testFiles, String expectedOutputString) {
+		AbstractRegressionTest.runTest(
+			abstractRegressionTest, // test directory preparation
 			true /* flush output directory */,
 			testFiles /* test files */,
 			// compiler options
@@ -1992,9 +1994,9 @@ protected static class JavacTestOptions {
 			skipJavac ? JavacTestOptions.SKIP :
 				javacTestOptions != null ? javacTestOptions : JavacTestOptions.DEFAULT /* default javac test options */);
 	}
-	protected void runConformTest(String[] testFiles, Map<String, String> customOptions) {
-		runTest(
-			// test directory preparation
+	protected static void runConformTest(AbstractRegressionTest abstractRegressionTest, String[] testFiles, Map<String, String> customOptions) {
+		AbstractRegressionTest.runTest(
+			abstractRegressionTest, // test directory preparation
 			true /* flush output directory */,
 			testFiles /* test files */,
 			// compiler options
@@ -2017,9 +2019,9 @@ protected static class JavacTestOptions {
 	protected void runConformTest(String[] testFiles, String expectedOutput, Map<String, String> customOptions) {
 		runConformTest(testFiles, expectedOutput, customOptions, null);
 	}
-	protected void runConformTest(String[] testFiles, String expectedOutput, Map<String, String> customOptions, String[] vmArguments, Charset charset) {
-		runTest(
-				// test directory preparation
+	protected static void runConformTest(AbstractRegressionTest abstractRegressionTest, String[] testFiles, String expectedOutput, Map<String, String> customOptions, String[] vmArguments, Charset charset) {
+		AbstractRegressionTest.runTest(
+				abstractRegressionTest, // test directory preparation
 				true /* flush output directory */,
 				testFiles /* test files */,
 				// compiler options
@@ -2040,9 +2042,9 @@ protected static class JavacTestOptions {
 				JavacTestOptions.DEFAULT /* default javac test options */,
 				charset);
 	}
-	protected void runConformTest(String[] testFiles, String expectedOutput, Map<String, String> customOptions, String[] vmArguments, JavacTestOptions javacOptions) {
-		runTest(
-			// test directory preparation
+	protected static void runConformTest(AbstractRegressionTest abstractRegressionTest, String[] testFiles, String expectedOutput, Map<String, String> customOptions, String[] vmArguments, JavacTestOptions javacOptions) {
+		AbstractRegressionTest.runTest(
+			abstractRegressionTest, // test directory preparation
 			true /* flush output directory */,
 			testFiles /* test files */,
 			// compiler options
@@ -2063,8 +2065,8 @@ protected static class JavacTestOptions {
 			javacOptions);
 	}
 	protected void runConformTest(String[] testFiles, String expectedOutput, Map<String, String> customOptions, String[] vmArguments) {
-		runTest(
-			// test directory preparation
+		AbstractRegressionTest.runTest(
+			this, // test directory preparation
 			true /* flush output directory */,
 			testFiles /* test files */,
 			// compiler options
@@ -2084,11 +2086,11 @@ protected static class JavacTestOptions {
 			// javac options
 			JavacTestOptions.DEFAULT /* default javac test options */);
 	}
-	protected void runConformTest(
-			String[] testFiles,
+	protected static void runConformTest(
+			AbstractRegressionTest abstractRegressionTest, String[] testFiles,
 			String[] dependantFiles,
 			String expectedSuccessOutputString) {
-		runTest(
+		abstractRegressionTest.runTest(
 				true,
 				testFiles,
 				dependantFiles,
@@ -2116,8 +2118,8 @@ protected static class JavacTestOptions {
 		String[] classLibraries,
 		boolean shouldFlushOutputDirectory,
 		String[] vmArguments) {
-		runTest(
-	 		// test directory preparation
+		AbstractRegressionTest.runTest(
+	 		this, // test directory preparation
 			shouldFlushOutputDirectory /* should flush output directory */,
 			testFiles /* test files */,
 			// compiler options
@@ -2138,16 +2140,16 @@ protected static class JavacTestOptions {
 			JavacTestOptions.DEFAULT /* default javac test options */);
 	}
 
-	protected void runConformTest(
-		String[] testFiles,
+	protected static void runConformTest(
+		AbstractRegressionTest abstractRegressionTest, String[] testFiles,
 		String expectedOutputString,
 		String[] classLibraries,
 		boolean shouldFlushOutputDirectory,
 		String[] vmArguments,
 		Map<String, String> customOptions,
 		ICompilerRequestor customRequestor) {
-		runTest(
-	 		// test directory preparation
+		AbstractRegressionTest.runTest(
+	 		abstractRegressionTest, // test directory preparation
 			shouldFlushOutputDirectory /* should flush output directory */,
 			testFiles /* test files */,
 			// compiler options
@@ -2169,8 +2171,8 @@ protected static class JavacTestOptions {
 	}
 
 	// WORK good candidate for elimination (8 instances)
-	protected void runConformTest(
-		String[] testFiles,
+	protected static void runConformTest(
+		AbstractRegressionTest abstractRegressionTest, String[] testFiles,
 		String expectedSuccessOutputString,
 		String[] classLib,
 		boolean shouldFlushOutputDirectory,
@@ -2178,8 +2180,8 @@ protected static class JavacTestOptions {
 		Map customOptions,
 		ICompilerRequestor clientRequestor,
 		boolean skipJavac) {
-		runConformTest(
-				testFiles,
+		AbstractRegressionTest.runConformTest(
+				abstractRegressionTest, testFiles,
 				expectedSuccessOutputString,
 				classLib,
 				shouldFlushOutputDirectory,
@@ -2192,8 +2194,8 @@ protected static class JavacTestOptions {
 						JavacTestOptions.DEFAULT));
 	}
 
-	protected void runConformTest(
-			String[] testFiles,
+	protected static void runConformTest(
+			AbstractRegressionTest abstractRegressionTest, String[] testFiles,
 			String expectedSuccessOutputString,
 			String[] classLib,
 			boolean shouldFlushOutputDirectory,
@@ -2202,8 +2204,8 @@ protected static class JavacTestOptions {
 			ICompilerRequestor clientRequestor,
 			boolean skipJavac,
 			JavacTestOptions javacTestOptions) {
-			runTest(
-				shouldFlushOutputDirectory,
+			AbstractRegressionTest.runTest(
+				abstractRegressionTest, shouldFlushOutputDirectory,
 				testFiles,
 				classLib,
 				customOptions,
@@ -2340,7 +2342,7 @@ protected static class JavacTestOptions {
 					System.out.println(testName + " - Javac has found error(s) but Eclipse expects conform result:\n");
 					javacFullLog.println("JAVAC_MISMATCH: Javac has found error(s) but Eclipse expects conform result");
 					System.out.println(errorLogger.buffer.toString());
-					printFiles(testFiles);
+					AbstractRegressionTest.printFiles(testFiles);
 					DIFF_COUNTERS[0]++;
 				}
 				else {
@@ -2350,7 +2352,7 @@ protected static class JavacTestOptions {
 						System.out.println(testName + " - Javac has found warning(s) but Eclipse expects conform result:\n");
 						javacFullLog.println("JAVAC_MISMATCH: Javac has found warning(s) but Eclipse expects conform result");
 						System.out.println(errorLogger.buffer.toString());
-						printFiles(testFiles);
+						AbstractRegressionTest.printFiles(testFiles);
 						DIFF_COUNTERS[0]++;
 					}
 					if (expectedSuccessOutputString != null && !javacTestErrorFlag) {
@@ -2371,12 +2373,12 @@ protected static class JavacTestOptions {
 							System.out.println("----------------------------------------");
 							System.out.println(testName + " - Javac and Eclipse runtime output is not the same:");
 							javacFullLog.println("JAVAC_MISMATCH: Javac and Eclipse runtime output is not the same");
-							dualPrintln("eclipse:");
-							dualPrintln(expectedSuccessOutputString);
-							dualPrintln("javac:");
-							dualPrintln(javaOutput);
+							AbstractRegressionTest.dualPrintln("eclipse:");
+							AbstractRegressionTest.dualPrintln(expectedSuccessOutputString);
+							AbstractRegressionTest.dualPrintln("javac:");
+							AbstractRegressionTest.dualPrintln(javaOutput);
 							System.out.println("\n");
-							printFiles(testFiles); // PREMATURE consider printing files to the log as well
+							AbstractRegressionTest.printFiles(testFiles); // PREMATURE consider printing files to the log as well
 							DIFF_COUNTERS[2]++;
 						}
 					}
@@ -2388,19 +2390,19 @@ protected static class JavacTestOptions {
 					System.out.println("----------------------------------------");
 					System.out.println(testName + " - Eclipse has found error(s)/warning(s) but Javac did not find any:");
 					javacFullLog.println("JAVAC_MISMATCH: Eclipse has found error(s)/warning(s) but Javac did not find any");
-					dualPrintln("eclipse:");
-					dualPrintln(expectedProblemLog);
-					printFiles(testFiles);
+					AbstractRegressionTest.dualPrintln("eclipse:");
+					AbstractRegressionTest.dualPrintln(expectedProblemLog);
+					AbstractRegressionTest.printFiles(testFiles);
 					DIFF_COUNTERS[1]++;
 				} else if (expectedProblemLog.indexOf("ERROR") > 0 && exitValue == 0){
 					System.out.println("----------------------------------------");
 					System.out.println(testName + " - Eclipse has found error(s) but Javac only found warning(s):");
 					javacFullLog.println("JAVAC_MISMATCH: Eclipse has found error(s) but Javac only found warning(s)");
-					dualPrintln("eclipse:");
-					dualPrintln(expectedProblemLog);
+					AbstractRegressionTest.dualPrintln("eclipse:");
+					AbstractRegressionTest.dualPrintln(expectedProblemLog);
 					System.out.println("javac:");
 					System.out.println(errorLogger.buffer.toString());
-					printFiles(testFiles);
+					AbstractRegressionTest.printFiles(testFiles);
 					DIFF_COUNTERS[1]++;
 				} else {
 					// PREMATURE refine comparison
@@ -2433,7 +2435,7 @@ protected static class JavacTestOptions {
 		}
 	}
 	// WORK factorize all runJavac implementations, including overrides
-	protected boolean runJavac(String options, String[] testFileNames, String currentDirectoryPath) {
+	protected static boolean runJavac(String options, String[] testFileNames, String currentDirectoryPath) {
 		Process compileProcess = null;
 		try {
 			// Prepare command line
@@ -2497,8 +2499,8 @@ protected static class JavacTestOptions {
  * (or higher).
  */
 // WORK unify use of output, error, log, etc...
-protected void runJavac(
-		String[] testFiles,
+protected static void runJavac(
+		AbstractRegressionTest abstractRegressionTest, String[] testFiles,
 		boolean expectingCompilerErrors,
 		String expectedCompilerLog,
 		String expectedOutputString,
@@ -2527,7 +2529,7 @@ protected void runJavac(
 		newOptions = newOptions.concat(" -implicit:none");
 	}
 	if (classLibraries == null) {
-		classLibraries = this.classpaths;
+		classLibraries = abstractRegressionTest.classpaths;
 	}
 	if (classLibraries != null) {
 		List<String> filteredLibs = new ArrayList<>();
@@ -2541,11 +2543,11 @@ protected void runJavac(
 					.concat(String.join(File.pathSeparator, filteredLibs.toArray(new String[filteredLibs.size()])));
 		}
 	}
-	String testName = testName();
+	String testName = abstractRegressionTest.testName();
 	Iterator<JavacCompiler> compilers = javacCompilers.iterator();
 	while (compilers.hasNext()) {
 		JavacCompiler compiler = compilers.next();
-		if (!options.skip(compiler) && compiler.compliance == this.complianceLevel) {
+		if (!options.skip(compiler) && compiler.compliance == abstractRegressionTest.complianceLevel) {
 			// WORK this may exclude some compilers under some conditions (when
 			//      complianceLevel is not set); consider accepting the compiler
 			//      in such case and see what happens
@@ -2561,14 +2563,14 @@ protected void runJavac(
 				if (shouldFlushOutputDirectory) {
 					Util.delete(javacOutputDirectory);
 				} else {
-					deleteSourceFiles(javacOutputDirectory);
+					AbstractRegressionTest.deleteSourceFiles(javacOutputDirectory);
 				}
 				javacOutputDirectory.mkdirs();
 				// write test files
 				for (int i = 0, length = testFiles.length; i < length; ) {
 					String fileName = testFiles[i++];
 					String contents = testFiles[i++];
-					fileName = expandFileNameForJavac(fileName);
+					fileName = abstractRegressionTest.expandFileNameForJavac(fileName);
 					File file = new File(javacOutputDirectory, fileName);
 					if (fileName.lastIndexOf('/') >= 0) {
 						File dir = file.getParentFile();
@@ -2582,7 +2584,7 @@ protected void runJavac(
 				int testFilesLength = testFiles.length;
 				sourceFileNames = new String[testFilesLength / 2];
 				for (int i = 0, j = 0; i < testFilesLength; i += 2, j++) {
-					sourceFileNames[j] = expandFileNameForJavac(testFiles[i]);
+					sourceFileNames[j] = abstractRegressionTest.expandFileNameForJavac(testFiles[i]);
 				}
 
 				// compile
@@ -2662,8 +2664,8 @@ protected void runJavac(
 					//      it should have had contents, stderr is leveraged as
 					//      potentially holding indications regarding the failure
 					if (expectedErrorString != null /* null skips error test */ && mismatch == 0) {
-						err = adjustErrorOutput(stderr.toString().trim());
-						if (!errorStringMatch(expectedErrorString, err)) {
+						err = AbstractRegressionTest.adjustErrorOutput(stderr.toString().trim());
+						if (!AbstractRegressionTest.errorStringMatch(expectedErrorString, err)) {
 							mismatch = JavacTestOptions.MismatchType.ErrorOutputMismatch;
 						}
 					}
@@ -2677,12 +2679,12 @@ protected void runJavac(
 				e.printStackTrace();
 				mismatch = JavacTestOptions.MismatchType.JavaNotLaunched;
 			}
-			handleMismatch(compiler, testName, testFiles, expectedCompilerLog, expectedOutputString,
+			AbstractRegressionTest.handleMismatch(abstractRegressionTest, compiler, testName, testFiles, expectedCompilerLog, expectedOutputString,
 					expectedErrorString, compilerLog, output, err, excuse, mismatch);
 		}
 	}
 }
-private void deleteSourceFiles(File directory) {
+private static void deleteSourceFiles(File directory) {
 	try {
 		if (!directory.exists())
 			return;
@@ -2695,7 +2697,7 @@ private void deleteSourceFiles(File directory) {
 		e.printStackTrace();
 	}
 }
-private boolean errorStringMatch(String expectedErrorStringStart, String actualError) {
+private static boolean errorStringMatch(String expectedErrorStringStart, String actualError) {
 	/*
 	 * From TestVerifier.checkBuffers():
 	 * This is an opportunistic heuristic for error strings comparison:
@@ -2721,7 +2723,7 @@ private boolean errorStringMatch(String expectedErrorStringStart, String actualE
 protected String expandFileNameForJavac(String fileName) {
 	return fileName;
 }
-void handleMismatch(JavacCompiler compiler, String testName, String[] testFiles, String expectedCompilerLog,
+static void handleMismatch(AbstractRegressionTest abstractRegressionTest, JavacCompiler compiler, String testName, String[] testFiles, String expectedCompilerLog,
 		String expectedOutputString, String expectedErrorString, StringBuilder compilerLog, String output, String err,
 		JavacTestOptions.Excuse excuse, int mismatch) {
 	if (mismatch != 0) {
@@ -2729,7 +2731,7 @@ void handleMismatch(JavacCompiler compiler, String testName, String[] testFiles,
 			excuse = null;
 		} else {
 			System.err.println("----------------------------------------");
-			logTestFiles(true, testFiles);
+			AbstractRegressionTest.logTestFiles(abstractRegressionTest, true, testFiles);
 			switch (mismatch) {
 				case JavacTestOptions.MismatchType.EclipseErrorsJavacNone:
 					assertEquals(testName + " - Eclipse found error(s) but Javac did not find any",
@@ -2787,7 +2789,7 @@ void handleMismatch(JavacCompiler compiler, String testName, String[] testFiles,
 	}
 }
 
-private String adjustErrorOutput(String error) {
+private static String adjustErrorOutput(String error) {
 	// VerifyTests performs an explicit e.printStackTrace() which has slightly different format
 	// from a stack trace written directly by a dying JVM (during javac testing), adjust if needed:
 	final String excPrefix = "Exception in thread \"main\" ";
@@ -2803,7 +2805,7 @@ private String adjustErrorOutput(String error) {
 //	// compiler results
 //	"" /* expected compiler log */);
 protected void runNegativeTest(String[] testFiles, String expectedCompilerLog) {
-	runNegativeTest(false/*skipJavac*/, null, testFiles, expectedCompilerLog);
+	AbstractRegressionTest.runNegativeTest(this, false/*skipJavac*/, null, testFiles, expectedCompilerLog);
 }
 //runNegativeTest(
 // skipJavac
@@ -2813,9 +2815,9 @@ protected void runNegativeTest(String[] testFiles, String expectedCompilerLog) {
 //	},
 //// compiler results
 //"" /* expected compiler log */);
-protected void runNegativeTest(boolean skipJavac, JavacTestOptions javacTestOptions, String[] testFiles, String expectedCompilerLog) {
-	runTest(
- 		// test directory preparation
+protected static void runNegativeTest(AbstractRegressionTest abstractRegressionTest, boolean skipJavac, JavacTestOptions javacTestOptions, String[] testFiles, String expectedCompilerLog) {
+	AbstractRegressionTest.runTest(
+ 		abstractRegressionTest, // test directory preparation
 		true /* flush output directory */,
 		testFiles /* test files */,
 		// compiler options
@@ -2842,12 +2844,12 @@ protected void runNegativeTest(boolean skipJavac, JavacTestOptions javacTestOpti
 			javacTestOptions != null ? javacTestOptions :
 		JavacTestOptions.DEFAULT /* default javac test options */);
 }
-protected void runNegativeTest(String[] testFiles, String expectedCompilerLog, boolean performStatementRecovery) {
-	runNegativeTest(false/*skipJavac*/, null, testFiles, expectedCompilerLog, performStatementRecovery);
+protected static void runNegativeTest(AbstractRegressionTest abstractRegressionTest, String[] testFiles, String expectedCompilerLog, boolean performStatementRecovery) {
+	AbstractRegressionTest.runNegativeTest(abstractRegressionTest, false/*skipJavac*/, null, testFiles, expectedCompilerLog, performStatementRecovery);
 }
-protected void runNegativeTest(boolean skipJavac, JavacTestOptions javacTestOptions, String[] testFiles, String expectedCompilerLog, boolean performStatementRecovery) {
-	runTest(
- 		// test directory preparation
+protected static void runNegativeTest(AbstractRegressionTest abstractRegressionTest, boolean skipJavac, JavacTestOptions javacTestOptions, String[] testFiles, String expectedCompilerLog, boolean performStatementRecovery) {
+	AbstractRegressionTest.runTest(
+ 		abstractRegressionTest, // test directory preparation
 		true /* flush output directory */,
 		testFiles /* test files */,
 		// compiler options
@@ -2875,22 +2877,22 @@ protected void runNegativeTest(boolean skipJavac, JavacTestOptions javacTestOpti
 		JavacTestOptions.DEFAULT /* default javac test options */);
 }
 	// WORK potential elimination candidate (24 calls) - else clean up inline
-	protected void runNegativeTest(
-		String[] testFiles,
+	protected static void runNegativeTest(
+		AbstractRegressionTest abstractRegressionTest, String[] testFiles,
 		String expectedProblemLog,
 		String[] classLib,
 		boolean shouldFlushOutputDirectory) {
-		runNegativeTest(false, null, testFiles, expectedProblemLog, classLib, shouldFlushOutputDirectory);
+		AbstractRegressionTest.runNegativeTest(abstractRegressionTest, false, null, testFiles, expectedProblemLog, classLib, shouldFlushOutputDirectory);
 	}
-	protected void runNegativeTest(
-			boolean skipJavac,
+	protected static void runNegativeTest(
+			AbstractRegressionTest abstractRegressionTest, boolean skipJavac,
 			JavacTestOptions javacTestOptions,
 			String[] testFiles,
 			String expectedProblemLog,
 			String[] classLib,
 			boolean shouldFlushOutputDirectory) {
-			runTest(
-				shouldFlushOutputDirectory,
+			AbstractRegressionTest.runTest(
+				abstractRegressionTest, shouldFlushOutputDirectory,
 				testFiles,
 				classLib,
 				null,
@@ -2915,23 +2917,23 @@ protected void runNegativeTest(boolean skipJavac, JavacTestOptions javacTestOpti
 					javacTestOptions != null ? javacTestOptions :
 						JavacTestOptions.DEFAULT /* javac test options */);
 		}
-	protected void runNegativeTest(
-			String[] testFiles,
+	protected static void runNegativeTest(
+			AbstractRegressionTest abstractRegressionTest, String[] testFiles,
 			String expectedCompilerLog,
 			String[] classLibraries,
 			boolean shouldFlushOutputDirectory,
 			Map customOptions) {
-		runNegativeTest(testFiles, expectedCompilerLog, classLibraries, shouldFlushOutputDirectory, null, customOptions);
+		AbstractRegressionTest.runNegativeTest(abstractRegressionTest, testFiles, expectedCompilerLog, classLibraries, shouldFlushOutputDirectory, null, customOptions);
 	}
-	protected void runNegativeTest(
-		String[] testFiles,
+	protected static void runNegativeTest(
+		AbstractRegressionTest abstractRegressionTest, String[] testFiles,
 		String expectedCompilerLog,
 		String[] classLibraries,
 		boolean shouldFlushOutputDirectory,
 		String[] vmArguments,
 		Map customOptions) {
-		runTest(
-	 		// test directory preparation
+		AbstractRegressionTest.runTest(
+	 		abstractRegressionTest, // test directory preparation
 			shouldFlushOutputDirectory /* should flush output directory */,
 			testFiles /* test files */,
 			// compiler options
@@ -2956,16 +2958,16 @@ protected void runNegativeTest(boolean skipJavac, JavacTestOptions javacTestOpti
 			// javac options
 			JavacTestOptions.DEFAULT /* default javac test options */);
 	}
-	protected void runNegativeTest(
-			boolean skipJavac,
+	protected static void runNegativeTest(
+			AbstractRegressionTest abstractRegressionTest, boolean skipJavac,
 			JavacTestOptions javacTestOptions,
 			String[] testFiles,
 			String expectedCompilerLog,
 			String[] classLibraries,
 			boolean shouldFlushOutputDirectory,
 			Map customOptions) {
-			runTest(
-		 		// test directory preparation
+			AbstractRegressionTest.runTest(
+		 		abstractRegressionTest, // test directory preparation
 				shouldFlushOutputDirectory /* should flush output directory */,
 				testFiles /* test files */,
 				// compiler options
@@ -2992,27 +2994,27 @@ protected void runNegativeTest(boolean skipJavac, JavacTestOptions javacTestOpti
 				javacTestOptions != null ? javacTestOptions :
 				JavacTestOptions.DEFAULT /* default javac test options */);
 		}
-	protected void runNegativeTest(
-			String[] testFiles,
+	protected static void runNegativeTest(
+			AbstractRegressionTest abstractRegressionTest, String[] testFiles,
 			String expectedCompilerLog,
 			String[] classLibraries,
 			boolean shouldFlushOutputDirectory,
 			Map customOptions,
 			String expectedErrorString) {
-			runNegativeTest(testFiles, expectedCompilerLog, classLibraries,
+			AbstractRegressionTest.runNegativeTest(abstractRegressionTest, testFiles, expectedCompilerLog, classLibraries,
 					shouldFlushOutputDirectory, customOptions, expectedErrorString,
 					JavacTestOptions.DEFAULT);
 		}
-	protected void runNegativeTest(
-			String[] testFiles,
+	protected static void runNegativeTest(
+			AbstractRegressionTest abstractRegressionTest, String[] testFiles,
 			String expectedCompilerLog,
 			String[] classLibraries,
 			boolean shouldFlushOutputDirectory,
 			Map customOptions,
 			String expectedErrorString,
 			JavacTestOptions javacTestOptions) {
-			runTest(
-		 		// test directory preparation
+			AbstractRegressionTest.runTest(
+		 		abstractRegressionTest, // test directory preparation
 				shouldFlushOutputDirectory /* should flush output directory */,
 				testFiles /* test files */,
 				// compiler options
@@ -3037,8 +3039,8 @@ protected void runNegativeTest(boolean skipJavac, JavacTestOptions javacTestOpti
 				// javac options
 				javacTestOptions /* default javac test options */);
 		}
-	protected void runNegativeTest(
-		String[] testFiles,
+	protected static void runNegativeTest(
+		AbstractRegressionTest abstractRegressionTest, String[] testFiles,
 		String expectedProblemLog,
 		String[] classLibraries,
 		boolean shouldFlushOutputDirectory,
@@ -3046,8 +3048,8 @@ protected void runNegativeTest(boolean skipJavac, JavacTestOptions javacTestOpti
 		boolean generateOutput,
 		boolean showCategory,
 		boolean showWarningToken) {
-		runTest(
-			// test directory preparation
+		AbstractRegressionTest.runTest(
+			abstractRegressionTest, // test directory preparation
 			shouldFlushOutputDirectory /* should flush output directory */,
 			testFiles /* test files */,
 			// compiler options
@@ -3075,10 +3077,11 @@ protected void runNegativeTest(boolean skipJavac, JavacTestOptions javacTestOpti
 
 	/**
 	 * Log contains all problems (warnings+errors)
+	 * @param abstractRegressionTest TODO
 	 */
 	// WORK potential candidate for elimination (19 calls)
-	protected void runNegativeTest(
-		String[] testFiles,
+	protected static void runNegativeTest(
+		AbstractRegressionTest abstractRegressionTest, String[] testFiles,
 		String expectedCompilerLog,
 		String[] classLibraries,
 		boolean shouldFlushOutputDirectory,
@@ -3088,8 +3091,8 @@ protected void runNegativeTest(boolean skipJavac, JavacTestOptions javacTestOpti
 		boolean showWarningToken,
 		boolean skipJavac,
 		boolean performStatementsRecovery) {
-		runTest(
-	 		// test directory preparation
+		AbstractRegressionTest.runTest(
+	 		abstractRegressionTest, // test directory preparation
 			shouldFlushOutputDirectory /* should flush output directory */,
 			testFiles /* test files */,
 			// compiler options
@@ -3116,8 +3119,8 @@ protected void runNegativeTest(boolean skipJavac, JavacTestOptions javacTestOpti
 					JavacTestOptions.SKIP :
 					JavacTestOptions.DEFAULT /* javac test options */);
 	}
-	protected void runNegativeTest(
-			String[] testFiles,
+	protected static void runNegativeTest(
+			AbstractRegressionTest abstractRegressionTest, String[] testFiles,
 			String expectedCompilerLog,
 			String[] classLibraries,
 			boolean shouldFlushOutputDirectory,
@@ -3128,8 +3131,8 @@ protected void runNegativeTest(boolean skipJavac, JavacTestOptions javacTestOpti
 			boolean skipJavac,
 			JavacTestOptions javacOptions,
 			boolean performStatementsRecovery) {
-			runTest(
-		 		// test directory preparation
+			AbstractRegressionTest.runTest(
+		 		abstractRegressionTest, // test directory preparation
 				shouldFlushOutputDirectory /* should flush output directory */,
 				testFiles /* test files */,
 				// compiler options
@@ -3156,8 +3159,8 @@ protected void runNegativeTest(boolean skipJavac, JavacTestOptions javacTestOpti
 						JavacTestOptions.SKIP :
 						 javacOptions/* javac test options */);
 		}
-	protected void runTest(
-			String[] testFiles,
+	protected static void runTest(
+			AbstractRegressionTest abstractRegressionTest, String[] testFiles,
 			boolean expectingCompilerErrors,
 			String expectedCompilerLog,
 			String expectedOutputString,
@@ -3169,8 +3172,8 @@ protected void runNegativeTest(boolean skipJavac, JavacTestOptions javacTestOpti
 			Map customOptions,
 			ICompilerRequestor customRequestor,
 			boolean skipJavac) {
-		runTest(
-	 		// test directory preparation
+		AbstractRegressionTest.runTest(
+	 		abstractRegressionTest, // test directory preparation
 			shouldFlushOutputDirectory /* should flush output directory */,
 			testFiles /* test files */,
 			// compiler options
@@ -3195,8 +3198,8 @@ protected void runNegativeTest(boolean skipJavac, JavacTestOptions javacTestOpti
 	}
 
 	// WORK get this out
-	protected void runTest(
-			String[] testFiles,
+	protected static void runTest(
+			AbstractRegressionTest abstractRegressionTest, String[] testFiles,
 			boolean expectingCompilerErrors,
 			String expectedCompilerLog,
 			String expectedOutputString,
@@ -3208,8 +3211,8 @@ protected void runNegativeTest(boolean skipJavac, JavacTestOptions javacTestOpti
 			Map customOptions,
 			ICompilerRequestor clientRequestor,
 			JavacTestOptions javacTestOptions) {
-		runTest(
-	 		// test directory preparation
+		AbstractRegressionTest.runTest(
+	 		abstractRegressionTest, // test directory preparation
 			shouldFlushOutputDirectory /* should flush output directory */,
 			testFiles /* test files */,
 			// compiler options
@@ -3229,8 +3232,8 @@ protected void runNegativeTest(boolean skipJavac, JavacTestOptions javacTestOpti
 			// javac options
 			javacTestOptions /* javac test options */);
 	}
-	protected void runTest(
-			// test directory preparation
+	protected static void runTest(
+			AbstractRegressionTest abstractRegressionTest, // test directory preparation
 			boolean shouldFlushOutputDirectory,
 			String[] testFiles,
 			// compiler options
@@ -3249,7 +3252,7 @@ protected void runNegativeTest(boolean skipJavac, JavacTestOptions javacTestOpti
 			String expectedErrorString,
 			// javac options
 			JavacTestOptions javacTestOptions) {
-		runTest(
+		abstractRegressionTest.runTest(
 			shouldFlushOutputDirectory,
 			testFiles,
 			new String[] {},
@@ -3270,8 +3273,8 @@ protected void runNegativeTest(boolean skipJavac, JavacTestOptions javacTestOpti
 			javacTestOptions,
 			Charset.defaultCharset());
 	}
-	private void runTest(
-			// test directory preparation
+	private static void runTest(
+			AbstractRegressionTest abstractRegressionTest, // test directory preparation
 			boolean shouldFlushOutputDirectory,
 			String[] testFiles,
 			// compiler options
@@ -3291,7 +3294,7 @@ protected void runNegativeTest(boolean skipJavac, JavacTestOptions javacTestOpti
 			// javac options
 			JavacTestOptions javacTestOptions,
 			Charset charset) {
-		runTest(
+		abstractRegressionTest.runTest(
 			shouldFlushOutputDirectory,
 			testFiles,
 			new String[] {},
@@ -3312,9 +3315,10 @@ protected void runNegativeTest(boolean skipJavac, JavacTestOptions javacTestOpti
 			javacTestOptions,
 			charset);
 	}
-	/** Call this if the compiler randomly produces different error logs. */
-	protected void runNegativeTestMultiResult(String[] testFiles, Map options, String[] alternateCompilerErrorLogs) {
-		runTest(
+	/** Call this if the compiler randomly produces different error logs.
+	 * @param abstractRegressionTest TODO*/
+	protected static void runNegativeTestMultiResult(AbstractRegressionTest abstractRegressionTest, String[] testFiles, Map options, String[] alternateCompilerErrorLogs) {
+		abstractRegressionTest.runTest(
 			false,
 			testFiles,
 			new String[] {},
@@ -3339,8 +3343,8 @@ protected void runNegativeTest(boolean skipJavac, JavacTestOptions javacTestOpti
 			JavacTestOptions.DEFAULT,
 			Charset.defaultCharset());
 	}
-	private void runTest(
-			// test directory preparation
+	private static void runTest(
+			AbstractRegressionTest abstractRegressionTest, // test directory preparation
 			boolean shouldFlushOutputDirectory,
 			String[] testFiles,
 			String[] dependantFiles,
@@ -3364,7 +3368,7 @@ protected void runNegativeTest(boolean skipJavac, JavacTestOptions javacTestOpti
 			// javac options
 			String expectedJavacOutputString,
 			JavacTestOptions javacTestOptions) {
-		runTest( shouldFlushOutputDirectory,
+		abstractRegressionTest.runTest( shouldFlushOutputDirectory,
 				testFiles,
 				dependantFiles,
 				classLibraries,
@@ -3511,10 +3515,10 @@ protected void runNegativeTest(boolean skipJavac, JavacTestOptions javacTestOpti
 		Compiler batchCompiler =
 			new Compiler(
 				nameEnvironment,
-				getErrorHandlingPolicy(),
+				AbstractRegressionTest.getErrorHandlingPolicy(),
 				compilerOptions,
 				requestor,
-				getProblemFactory()) {
+				AbstractRegressionTest.getProblemFactory()) {
 				public void process(org.eclipse.jdt.internal.compiler.ast.CompilationUnitDeclaration unit, int i) {
 					super.process(unit, i);
 					if (visitor != null) {
@@ -3523,7 +3527,7 @@ protected void runNegativeTest(boolean skipJavac, JavacTestOptions javacTestOpti
 				}
 			};
 		if (this.enableAPT) {
-			batchCompiler.annotationProcessorManager = getAnnotationProcessorManager(batchCompiler);
+			batchCompiler.annotationProcessorManager = AbstractRegressionTest.getAnnotationProcessorManager(this, batchCompiler);
 		}
 		compilerOptions.produceReferenceInfo = true;
 		Throwable exception = null;
@@ -3551,12 +3555,12 @@ protected void runNegativeTest(boolean skipJavac, JavacTestOptions javacTestOpti
 			if (exception == null) {
 				if (expectingCompilerErrors) {
 					if (!requestor.hasErrors) {
-						logTestFiles(true, testFiles);
+						AbstractRegressionTest.logTestFiles(this, true, testFiles);
 						fail("Unexpected success");
 					}
 				} else if (requestor.hasErrors) {
 					if (!"".equals(requestor.problemLog)) {
-						logTestFiles(true, testFiles);
+						AbstractRegressionTest.logTestFiles(this, true, testFiles);
 						System.out.println("Copy-paste compiler log:");
 						System.out.println(Util.displayString(Util.convertToIndependantLineDelimiter(requestor.problemLog.toString()), INDENT, SHIFT));
 						assertEquals("Unexpected failure", "", requestor.problemLog);
@@ -3597,7 +3601,7 @@ protected void runNegativeTest(boolean skipJavac, JavacTestOptions javacTestOpti
 					if (execOutputString != null && execOutputString.length() > 0) {
 						System.out.println("[OUT]:"+execOutputString); //$NON-NLS-1$
 					}
-					logTestFiles(false, testFiles);
+					AbstractRegressionTest.logTestFiles(this, false, testFiles);
 					assertEquals(this.verifier.failureReason, expectedErrorString == null ? "" : expectedErrorString, execErrorString);
 					assertEquals(this.verifier.failureReason, expectedOutputString == null ? "" : expectedOutputString, execOutputString);
 				}
@@ -3614,7 +3618,7 @@ protected void runNegativeTest(boolean skipJavac, JavacTestOptions javacTestOpti
 		}
 		// javac part
 		if (RUN_JAVAC && javacTestOptions != JavacTestOptions.SKIP) {
-			runJavac(testFiles, expectingCompilerErrors, expectedCompilerLog,
+			AbstractRegressionTest.runJavac(this, testFiles, expectingCompilerErrors, expectedCompilerLog,
 					expectedJavacOutputString, expectedErrorString, shouldFlushOutputDirectory,
 					javacTestOptions, vmArguments, classLibraries, libsOnModulePath);
 		}
@@ -3672,9 +3676,9 @@ protected void runNegativeTest(boolean skipJavac, JavacTestOptions javacTestOpti
 		}
 	}
 
-	protected AbstractAnnotationProcessorManager getAnnotationProcessorManager(Compiler compiler) {
+	protected static AbstractAnnotationProcessorManager getAnnotationProcessorManager(AbstractRegressionTest abstractRegressionTest, Compiler compiler) {
 		try {
-			AbstractAnnotationProcessorManager annotationManager = new DummyAnnotationProcessingManager();
+			AbstractAnnotationProcessorManager annotationManager = abstractRegressionTest.new DummyAnnotationProcessingManager();
 			annotationManager.configure(compiler, new String[0]);
 			annotationManager.setErr(new PrintWriter(System.err));
 			annotationManager.setOut(new PrintWriter(System.out));
@@ -3692,13 +3696,13 @@ protected void runNegativeTest(boolean skipJavac, JavacTestOptions javacTestOpti
 //		JavacTestOptions.SKIP /* skip javac tests */);
 //		JavacTestOptions.DEFAULT /* default javac test options */);
 //		javacTestOptions /* javac test options */);
-public void runConformTest(
-	// test directory preparation
+public static void runConformTest(
+	AbstractRegressionTest abstractRegressionTest, // test directory preparation
 	String[] testFiles,
 	// javac options
 	JavacTestOptions javacTestOptions) {
-runTest(
-	// test directory preparation
+AbstractRegressionTest.runTest(
+	abstractRegressionTest, // test directory preparation
 	true /* flush output directory */,
 	testFiles /* test files */,
 	// compiler options
@@ -3747,8 +3751,8 @@ runTest(
 //		JavacTestOptions.SKIP /* skip javac tests */);
 //		JavacTestOptions.DEFAULT /* default javac test options */);
 //		javacTestOptions /* javac test options */);
-protected void runConformTest(
-		// test directory preparation
+protected static void runConformTest(
+		AbstractRegressionTest abstractRegressionTest, // test directory preparation
 		boolean shouldFlushOutputDirectory,
 		String[] testFiles,
 		// compiler results
@@ -3758,8 +3762,8 @@ protected void runConformTest(
 		String expectedErrorString,
 		// javac options
 		JavacTestOptions javacTestOptions) {
-	runTest(
-		// test directory preparation
+	AbstractRegressionTest.runTest(
+		abstractRegressionTest, // test directory preparation
 		shouldFlushOutputDirectory /* should flush output directory */,
 		testFiles /* test files */,
 		// compiler options
@@ -3814,8 +3818,8 @@ protected void runConformTest(
 //		JavacTestOptions.SKIP /* skip javac tests */);
 //		JavacTestOptions.DEFAULT /* default javac test options */);
 //		javacTestOptions /* javac test options */);
-protected void runConformTest(
-		// test directory preparation
+protected static void runConformTest(
+		AbstractRegressionTest abstractRegressionTest, // test directory preparation
 		boolean shouldFlushOutputDirectory,
 		String[] testFiles,
 		//compiler options
@@ -3828,8 +3832,8 @@ protected void runConformTest(
 		String expectedErrorString,
 		// javac options
 		JavacTestOptions javacTestOptions) {
-	runTest(
-		// test directory preparation
+	AbstractRegressionTest.runTest(
+		abstractRegressionTest, // test directory preparation
 		shouldFlushOutputDirectory /* should flush output directory */,
 		testFiles /* test files */,
 		// compiler options
@@ -3860,15 +3864,15 @@ protected void runConformTest(
 //		JavacTestOptions.SKIP /* skip javac tests */);
 //		JavacTestOptions.DEFAULT /* default javac test options */);
 //		javacTestOptions /* javac test options */);
-protected void runNegativeTest(
-		// test directory preparation
+protected static void runNegativeTest(
+		AbstractRegressionTest abstractRegressionTest, // test directory preparation
 		String[] testFiles,
 		// compiler results
 		String expectedCompilerLog,
 		// javac options
 		JavacTestOptions javacTestOptions) {
-	runTest(
- 		// test directory preparation
+	AbstractRegressionTest.runTest(
+ 		abstractRegressionTest, // test directory preparation
 		true /* flush output directory */,
 		testFiles /* test files */,
 		// compiler options
@@ -3899,15 +3903,15 @@ protected void runNegativeTest(
 //JavacTestOptions.SKIP /* skip javac tests */);
 //JavacTestOptions.DEFAULT /* default javac test options */);
 //javacTestOptions /* javac test options */);
-protected void runNegativeTest(
-// test directory preparation
+protected static void runNegativeTest(
+AbstractRegressionTest abstractRegressionTest, // test directory preparation
 String[] testFiles,
 String[] dependentFiles,
 // compiler results
 String expectedCompilerLog,
 // javac options
 JavacTestOptions javacTestOptions) {
-	runTest(
+	abstractRegressionTest.runTest(
 			// test directory preparation
 		true /* flush output directory */,
 		testFiles /* test files */,
@@ -3961,8 +3965,8 @@ JavacTestOptions javacTestOptions) {
 //		JavacTestOptions.SKIP /* skip javac tests */);
 //		JavacTestOptions.DEFAULT /* default javac test options */);
 //		javacTestOptions /* javac test options */);
-protected void runNegativeTest(
-		// test directory preparation
+protected static void runNegativeTest(
+		AbstractRegressionTest abstractRegressionTest, // test directory preparation
 		boolean shouldFlushOutputDirectory,
 		String[] testFiles,
 		// compiler options
@@ -3972,8 +3976,8 @@ protected void runNegativeTest(
 		String expectedCompilerLog,
 		// javac options
 		JavacTestOptions javacTestOptions) {
-	runTest(
-		// test directory preparation
+	AbstractRegressionTest.runTest(
+		abstractRegressionTest, // test directory preparation
 		shouldFlushOutputDirectory /* should flush output directory */,
 		testFiles /* test files */,
 		// compiler options
@@ -4030,8 +4034,8 @@ protected void runNegativeTest(
 //    JavacTestOptions.SKIP /* skip javac tests */);
 //    JavacTestOptions.DEFAULT /* default javac test options */);
 //    javacTestOptions /* javac test options */);
-protected void runNegativeTest(
-	// test directory preparation
+protected static void runNegativeTest(
+	AbstractRegressionTest abstractRegressionTest, // test directory preparation
 	boolean shouldFlushOutputDirectory,
 	String[] testFiles,
 	// compiler options
@@ -4044,8 +4048,8 @@ protected void runNegativeTest(
 	String expectedErrorString,
 	// javac options
 	JavacTestOptions javacTestOptions) {
-	runTest(
-		// test directory preparation
+	AbstractRegressionTest.runTest(
+		abstractRegressionTest, // test directory preparation
 		shouldFlushOutputDirectory /* should flush output directory */,
 		testFiles /* test files */,
 		// compiler options
@@ -4129,9 +4133,9 @@ protected void runNegativeTest(
 				}
 				// per class initialization
 				CURRENT_CLASS_NAME = getClass().getName();
-				dualPrintln("***************************************************************************");
+				AbstractRegressionTest.dualPrintln("***************************************************************************");
 				System.out.print("* Comparison with Sun Javac compiler for class ");
-				dualPrintln(CURRENT_CLASS_NAME.substring(CURRENT_CLASS_NAME.lastIndexOf('.')+1) +
+				AbstractRegressionTest.dualPrintln(CURRENT_CLASS_NAME.substring(CURRENT_CLASS_NAME.lastIndexOf('.')+1) +
 						" (" + TESTS_COUNTERS.get(CURRENT_CLASS_NAME) + " tests)");
 				System.out.println("***************************************************************************");
 				DIFF_COUNTERS[0] = 0;
@@ -4171,7 +4175,7 @@ protected void runNegativeTest(
 	/**
 	 * Returns the OS path to the directory that contains this plugin.
 	 */
-	protected String getCompilerTestsPluginDirectoryPath() {
+	protected static String getCompilerTestsPluginDirectoryPath() {
 		try {
 			URL platformURL = Platform.getBundle("org.eclipse.jdt.core.tests.compiler").getEntry("/");
 			return new File(FileLocator.toFileURL(platformURL).getFile()).getAbsolutePath();
@@ -4180,8 +4184,8 @@ protected void runNegativeTest(
 		}
 		return null;
 	}
-	protected Map<String, String> setPresetPreviewOptions() {
-		Map<String, String> options = getCompilerOptions();
+	protected static Map<String, String> setPresetPreviewOptions(AbstractRegressionTest abstractRegressionTest) {
+		Map<String, String> options = abstractRegressionTest.getCompilerOptions();
 		options.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.latestSupportedJavaVersion());
 		options.put(JavaCore.COMPILER_SOURCE, JavaCore.latestSupportedJavaVersion());
 		options.put(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, JavaCore.latestSupportedJavaVersion());

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractRegressionTest9.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractRegressionTest9.java
@@ -52,7 +52,7 @@ public class AbstractRegressionTest9 extends AbstractRegressionTest {
 	@Override
 	protected INameEnvironment getNameEnvironment(final String[] testFiles, String[] classPaths, Map<String, String> options) {
 		this.classpaths = classPaths == null ? getDefaultClassPaths() : classPaths;
-		INameEnvironment[] classLibs = getClassLibs(classPaths == null, options);
+		INameEnvironment[] classLibs = AbstractRegressionTest.getClassLibs(this, classPaths == null, options);
 		for (INameEnvironment nameEnvironment : classLibs) {
 			((FileSystem) nameEnvironment).scanForModules(createParser());
 		}
@@ -119,7 +119,7 @@ public class AbstractRegressionTest9 extends AbstractRegressionTest {
 		Map<String,String> opts = new HashMap<>();
 		opts.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_9);
 		return new Parser(
-				new ProblemReporter(getErrorHandlingPolicy(), new CompilerOptions(opts), getProblemFactory()),
+				new ProblemReporter(AbstractRegressionTest.getErrorHandlingPolicy(), new CompilerOptions(opts), AbstractRegressionTest.getProblemFactory()),
 				false);
 	}
 

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AmbiguousMethodTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AmbiguousMethodTest.java
@@ -1128,8 +1128,8 @@ X.java:4: warning: [unchecked] unchecked method invocation: method pickOne in cl
 			},
 			"truetruetruetruetruetruetruetruetruetruetruetruetruetruetruetrue"
 		);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"Y.java",
 				"public class Y extends X {\n" +
 				"	public static void ambiguousCases() {\n" +
@@ -2595,8 +2595,8 @@ public void test046() {
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=163590
 public void test047() {
-	this.runNegativeTest(
- 		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+ 		this, // test directory preparation
 		new String[] { /* test files */
 			"X.java",
 			"public class X<T extends I & J> {\n" +
@@ -2706,8 +2706,8 @@ public void test050() {
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=166355
 public void test051() {
-	this.runNegativeTest(
-		false /* skipJavac */,
+	AbstractRegressionTest.runNegativeTest(
+		this, false /* skipJavac */,
 		this.complianceLevel < ClassFileConstants.JDK1_8 ?
 				null : JavacTestOptions.EclipseHasABug.EclipseBug427719,
 		new String[] { /* test files */
@@ -2788,8 +2788,8 @@ public void test052() {
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=166355
 // variant
 public void test053() {
-	this.runNegativeTest(
-		false /* skipJavac */,
+	AbstractRegressionTest.runNegativeTest(
+		this, false /* skipJavac */,
 		this.complianceLevel < ClassFileConstants.JDK1_8 ?
 				null : JavacTestOptions.EclipseHasABug.EclipseBug427719,
 		new String[] { /* test files */
@@ -3506,8 +3506,8 @@ public void test073() {
 
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=206930
 public void test074() {
-	this.runNegativeTest(
-		false /* skipJavac */,
+	AbstractRegressionTest.runNegativeTest(
+		this, false /* skipJavac */,
 		this.complianceLevel < ClassFileConstants.JDK1_8 ?
 				null : JavacTestOptions.EclipseHasABug.EclipseBug427719,
 		new String[] {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AnnotationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AnnotationTest.java
@@ -497,8 +497,8 @@ public class AnnotationTest extends AbstractComparableTest {
 
 	// check for duplicate member value pairs
 	public void test018() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"@interface Name {\n" +
 				"	String first();\n" +
@@ -2823,8 +2823,8 @@ public class AnnotationTest extends AbstractComparableTest {
 				"@Target({}) @interface I {}",
 			},
 			"");
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"@I public class X {}"
 			},
@@ -3444,8 +3444,8 @@ public class AnnotationTest extends AbstractComparableTest {
     		"Class is a raw type. References to generic type Class<T> should be parameterized\n" +
     		"----------\n";
 
-		this.runNegativeTest(
-				true,
+		AbstractRegressionTest.runNegativeTest(
+				this, true,
 	    		new String[] {
 						"X.java",
 						"import java.lang.annotation.Annotation;\n" +
@@ -4036,8 +4036,8 @@ public class AnnotationTest extends AbstractComparableTest {
 		for (int i = 0, ceil = warnings.length; i < ceil; i++) {
 			customOptions.put(warnings[i], CompilerOptions.WARNING);
 		}
-        this.runConformTest(
-        	true,
+        AbstractRegressionTest.runConformTest(
+        	this, true,
             new String[] {
                 "X.java",
 				"public class X {\n" +
@@ -4088,8 +4088,8 @@ public class AnnotationTest extends AbstractComparableTest {
     }
     // check @SuppressWarning support
     public void test132() {
-        this.runNegativeTest(
-            new String[] {
+        AbstractRegressionTest.runNegativeTest(
+            this, new String[] {
                 "X.java",
     			"import java.io.Serializable;\n" +
     			"import java.util.List;\n" +
@@ -4317,8 +4317,8 @@ public class AnnotationTest extends AbstractComparableTest {
 			customOptions.put(warnings[i], CompilerOptions.WARNING);
 		}
 		customOptions.put(CompilerOptions.OPTION_SuppressWarnings, CompilerOptions.DISABLED);
-        this.runNegativeTest(
-            new String[] {
+        AbstractRegressionTest.runNegativeTest(
+            this, new String[] {
                 "X.java",
     			"import java.io.Serializable;\n" +
     			"import java.util.List;\n" +
@@ -4399,9 +4399,9 @@ public class AnnotationTest extends AbstractComparableTest {
     public void test138() {
     	Map customOptions = new Hashtable();
     	customOptions.put(CompilerOptions.OPTION_ReportUnhandledWarningToken, CompilerOptions.WARNING);
-        this.runNegativeTest(
+        AbstractRegressionTest.runNegativeTest(
 
-            new String[] {
+            this, new String[] {
                 "X.java",
     			"@SuppressWarnings(\"zork\")//$NON-NLS-1$\n" +
     			"public class X {\n" +
@@ -4425,9 +4425,9 @@ public class AnnotationTest extends AbstractComparableTest {
     public void test139() {
     	Map customOptions = new Hashtable();
     	customOptions.put(CompilerOptions.OPTION_ReportUnhandledWarningToken, CompilerOptions.WARNING);
-        this.runNegativeTest(
+        AbstractRegressionTest.runNegativeTest(
 
-            new String[] {
+            this, new String[] {
                 "X.java",
     			"@SuppressWarnings({\"zork\", \"warningToken\"})//$NON-NLS-1$//$NON-NLS-2$\n" +
     			"public class X {\n" +
@@ -4467,8 +4467,8 @@ public class AnnotationTest extends AbstractComparableTest {
 			"	            ^^^^^\n" +
 			"The method foo() of type Bar must override or implement a supertype method\n" +
 			"----------\n";
-        this.runNegativeTest(
-            new String[] {
+        AbstractRegressionTest.runNegativeTest(
+            this, new String[] {
                 "X.java",
 				"public class X {\n" +
 				"  static void foo(){}\n" +
@@ -4519,8 +4519,8 @@ public class AnnotationTest extends AbstractComparableTest {
     }
     // https://bugs.eclipse.org/bugs/show_bug.cgi?id=94308
     public void test142() {
-        this.runNegativeTest(
-            new String[] {
+        AbstractRegressionTest.runNegativeTest(
+            this, new String[] {
                 "X.java",
 				"@SuppressWarnings(\"deprecation\")\n" +
 				"public class X extends p.OldStuff {\n" +
@@ -4559,8 +4559,8 @@ public class AnnotationTest extends AbstractComparableTest {
 		// admittingly, when these are errors, SuppressWarnings is not enough to
 		// filter them out *but* the deprecation level being WARNING, we get them
 		// out anyway
-	    this.runNegativeTest(
-	        new String[] {
+	    AbstractRegressionTest.runNegativeTest(
+	        this, new String[] {
 	            "X.java",
 				"@SuppressWarnings(\"deprecation\")\n" +
 				"public class X extends p.OldStuff {\n" +
@@ -4600,8 +4600,8 @@ public void test142c() {
 			CompilerOptions.OPTION_ReportDeprecation, CompilerOptions.ERROR);
 	raiseDeprecationReduceInvalidJavadocSeverity.put(
 			CompilerOptions.OPTION_ReportInvalidJavadoc, CompilerOptions.WARNING);
-    this.runNegativeTest(
-    	true,
+    AbstractRegressionTest.runNegativeTest(
+    	this, true,
         new String[] {
             "X.java",
 			"@SuppressWarnings(\"deprecation\")\n" +
@@ -4797,8 +4797,8 @@ public void test143() {
     public void test147() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_ReportNonExternalizedStringLiteral, CompilerOptions.WARNING);
-        this.runNegativeTest(
-            new String[] {
+        AbstractRegressionTest.runNegativeTest(
+            this, new String[] {
                 "X.java",
 				"@SuppressWarnings({\"nls\"})\n" +
 				"public class X<T> {\n" +
@@ -4874,8 +4874,8 @@ public void test143() {
 
     //https://bugs.eclipse.org/bugs/show_bug.cgi?id=98091
     public void test150() {
-        this.runConformTest(
-        	true,
+        AbstractRegressionTest.runConformTest(
+        	this, true,
             new String[] {
                 "X.java",
 				"@SuppressWarnings(\"assertIdentifier\")\n" +
@@ -4894,8 +4894,8 @@ public void test143() {
     public void test151() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_ReportAutoboxing, CompilerOptions.WARNING);
-        this.runNegativeTest(
-            new String[] {
+        AbstractRegressionTest.runNegativeTest(
+            this, new String[] {
                 "X.java",
 				"@SuppressWarnings({\"boxing\"})\n" +
 				"public class X {\n" +
@@ -4915,8 +4915,8 @@ public void test143() {
     public void test152() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_ReportAutoboxing, CompilerOptions.WARNING);
-        this.runNegativeTest(
-            new String[] {
+        AbstractRegressionTest.runNegativeTest(
+            this, new String[] {
                 "X.java",
 				"@SuppressWarnings({\"boxing\"})\n" +
 				"public class X {\n" +
@@ -4936,8 +4936,8 @@ public void test143() {
     public void test153() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_ReportIncompleteEnumSwitch, CompilerOptions.WARNING);
-        this.runConformTest(
-            new String[] {
+        AbstractRegressionTest.runConformTest(
+            this, new String[] {
                 "X.java",
                 "enum E { A, B, C }\n" +
 				"public class X {\n" +
@@ -4960,8 +4960,8 @@ public void test143() {
     public void test154() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_ReportFieldHiding, CompilerOptions.WARNING);
-        this.runNegativeTest(
-            new String[] {
+        AbstractRegressionTest.runNegativeTest(
+            this, new String[] {
                 "X.java",
 				"public class X {\n" +
 				"	 static int i;\n" +
@@ -4983,8 +4983,8 @@ public void test143() {
     public void test155() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_ReportLocalVariableHiding, CompilerOptions.WARNING);
-        this.runNegativeTest(
-            new String[] {
+        AbstractRegressionTest.runNegativeTest(
+            this, new String[] {
                 "X.java",
 				"@SuppressWarnings({\"hiding\"})\n" +
 	   			"public class X {	\n"+
@@ -5008,8 +5008,8 @@ public void test143() {
     public void test156() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_ReportTypeParameterHiding, CompilerOptions.WARNING);
-        this.runNegativeTest(
-            new String[] {
+        AbstractRegressionTest.runNegativeTest(
+            this, new String[] {
                 "X.java",
 	   			"class T {}\n" +
 				"@SuppressWarnings({\"hiding\"})\n" +
@@ -5082,8 +5082,8 @@ public void test143() {
     public void test158() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_ReportFinallyBlockNotCompletingNormally, CompilerOptions.WARNING);
-        this.runNegativeTest(
-            new String[] {
+        AbstractRegressionTest.runNegativeTest(
+            this, new String[] {
                 "X.java",
     			"public class X {\n" +
 				"   @SuppressWarnings({\"finally\"})\n" +
@@ -5162,8 +5162,8 @@ public void test143() {
     public void test161() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_ReportUnqualifiedFieldAccess, CompilerOptions.WARNING);
-        this.runNegativeTest(
-            new String[] {
+        AbstractRegressionTest.runNegativeTest(
+            this, new String[] {
                 "X.java",
                 "@SuppressWarnings(\"unqualified-field-access\")\n" +
 	   			"public class X {\n" +
@@ -5183,8 +5183,8 @@ public void test143() {
     public void test162() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_ReportUncheckedTypeOperation, CompilerOptions.WARNING);
-        this.runNegativeTest(
-            new String[] {
+        AbstractRegressionTest.runNegativeTest(
+            this, new String[] {
                 "X.java",
                 "@SuppressWarnings({\"unchecked\", \"rawtypes\"})\n" +
 				"public class X<T> {\n" +
@@ -5223,8 +5223,8 @@ public void test143() {
 		options.put(CompilerOptions.OPTION_ReportUnusedParameter, CompilerOptions.WARNING);
 		options.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.WARNING);
 		options.put(CompilerOptions.OPTION_ReportUnusedDeclaredThrownException, CompilerOptions.WARNING);
-        this.runNegativeTest(
-            new String[] {
+        AbstractRegressionTest.runNegativeTest(
+            this, new String[] {
                 "X.java",
                 "import java.io.*;\n" +
                 "@SuppressWarnings(\"unused\")\n" +
@@ -5274,12 +5274,12 @@ public void test143() {
         };
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_ReportSyntheticAccessEmulation, CompilerOptions.WARNING);
-		if (isMinimumCompliant(ClassFileConstants.JDK11)) { // no synthetic due to nestmate
+		if (AbstractRegressionTest.isMinimumCompliant(this, ClassFileConstants.JDK11)) { // no synthetic due to nestmate
 			this.runConformTest(testFiles);
 			return;
 		}
-		this.runNegativeTest(
-            testFiles,
+		AbstractRegressionTest.runNegativeTest(
+            this, testFiles,
             "",
 			null,
 			true,
@@ -5298,8 +5298,8 @@ public void test143() {
 		options.put(CompilerOptions.OPTION_ReportInvalidJavadoc, CompilerOptions.WARNING);
 		options.put(CompilerOptions.OPTION_DocCommentSupport, CompilerOptions.ENABLED);
 		options.put(CompilerOptions.OPTION_ReportInvalidJavadocTagsVisibility, CompilerOptions.PRIVATE);
-	    this.runConformTest(
-	    	true,
+	    AbstractRegressionTest.runConformTest(
+	    	this, true,
             new String[] {
                 "X.java",
 				"/**\n" +
@@ -5650,8 +5650,8 @@ public void test143() {
     public void test169() {
     	Map customOptions = getCompilerOptions();
     	customOptions.put(CompilerOptions.OPTION_ReportNonExternalizedStringLiteral, CompilerOptions.WARNING);
-        this.runConformTest(
-        	true,
+        AbstractRegressionTest.runConformTest(
+        	this, true,
             new String[] {
                 "X.java",
     			"@SuppressWarnings(\"serial\")\n" +
@@ -5674,8 +5674,8 @@ public void test143() {
     public void test170() {
     	Map customOptions = getCompilerOptions();
     	customOptions.put(CompilerOptions.OPTION_ReportNonExternalizedStringLiteral, CompilerOptions.WARNING);
-        this.runConformTest(
-            new String[] {
+        AbstractRegressionTest.runConformTest(
+            this, new String[] {
                 "X.java",
     			"public class X extends Exception {\n" +
     			"   @SuppressWarnings(\"nls\")\n" +
@@ -5690,8 +5690,8 @@ public void test143() {
     public void test171() {
     	Map customOptions = getCompilerOptions();
     	customOptions.put(CompilerOptions.OPTION_ReportNonExternalizedStringLiteral, CompilerOptions.WARNING);
-        this.runConformTest(
-        	true,
+        AbstractRegressionTest.runConformTest(
+        	this, true,
             new String[] {
                 "X.java",
     			"public class X extends Exception {\n" +
@@ -5724,8 +5724,8 @@ public void test143() {
     public void test172() {
     	Map customOptions = getCompilerOptions();
     	customOptions.put(CompilerOptions.OPTION_ReportNonExternalizedStringLiteral, CompilerOptions.WARNING);
-        this.runConformTest(
-        	true,
+        AbstractRegressionTest.runConformTest(
+        	this, true,
         	new String[] {
                 "X.java",
     			"@SuppressWarnings(\"serial\")\n" +
@@ -5754,8 +5754,8 @@ public void test143() {
     public void test173() {
     	Map customOptions = getCompilerOptions();
     	customOptions.put(CompilerOptions.OPTION_ReportNonExternalizedStringLiteral, CompilerOptions.WARNING);
-        this.runConformTest(
-        	true,
+        AbstractRegressionTest.runConformTest(
+        	this, true,
             new String[] {
                 "X.java",
     			"@interface Annot {\n" +
@@ -5806,8 +5806,8 @@ public void test143() {
     			"   @SuppressWarnings(\"serial\")\n" +
     			"	String s2 = \"Hello2\"; \n" +
     			"}";
-		this.runConformTest(
-			true,
+		AbstractRegressionTest.runConformTest(
+			this, true,
             new String[] {
                 "X.java",
     			source
@@ -5842,8 +5842,8 @@ public void test143() {
     			"   @SuppressWarnings(\"serial\")\n" +
     			"	String s2 = \"Hello2\"; \n" +
     			"}";
-		this.runConformTest(
-			true,
+		AbstractRegressionTest.runConformTest(
+			this, true,
             new String[] {
                 "X.java",
     			source
@@ -5884,8 +5884,8 @@ public void test143() {
     			"	String s2 = \"Hello2\"; \n" +
     			"	@Annot(value=5) void foo() {}\n" +
     			"}";
-		this.runConformTest(
-			true,
+		AbstractRegressionTest.runConformTest(
+			this, true,
             new String[] {
                 "X.java",
     			source
@@ -5922,8 +5922,8 @@ public void test143() {
     }
     // https://bugs.eclipse.org/bugs/show_bug.cgi?id=111076
     public void test178() {
-        runConformTest(
-        	true,
+        AbstractRegressionTest.runConformTest(
+        	this, true,
             new String[] {
                 "X.java",
     			"import java.util.*;\n" +
@@ -5944,8 +5944,8 @@ public void test143() {
     }
     // https://bugs.eclipse.org/bugs/show_bug.cgi?id=112433
     public void test179() {
-    	this.runConformTest(
-    		true,
+    	AbstractRegressionTest.runConformTest(
+    		this, true,
     		new String[] {
     			"X.java",
     			"import static java.lang.annotation.ElementType.*;\n" +
@@ -6259,8 +6259,8 @@ public void test143() {
     }
     // partial recompile - keep a binary
 	public void test189() {
-		this.runConformTest(
-			true,
+		AbstractRegressionTest.runConformTest(
+			this, true,
 			new String[] {
 				"A1.java",
 				"@A2(@A1(m1 = \"u\"))\n" +
@@ -6279,8 +6279,8 @@ public void test143() {
 			null,
 			JavacTestOptions.DEFAULT);
 		// keep A2 binary, recompile A1 with a name change
-		this.runConformTest(
-			false, // do not flush A2.class
+		AbstractRegressionTest.runConformTest(
+			this, false, // do not flush A2.class
 			new String[] {
 				"A1.java",
 				"@A2(@A1(m1 = \"u\"))\n" +
@@ -6671,8 +6671,8 @@ public void test198() {
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=138443
 public void test199() {
-	this.runConformTest(
-		true,
+	AbstractRegressionTest.runConformTest(
+		this, true,
 		new String[] {
 			"X.java",
 			"@interface AttributeOverrides {\n" +
@@ -7169,8 +7169,8 @@ public void test214() {
 			"	     ^^^^^\n" +
 			"The method foo() of type I must override or implement a supertype method\n" +
 			"----------\n";
-    this.runNegativeTest(
-    	true,
+    AbstractRegressionTest.runNegativeTest(
+    	this, true,
         new String[] {
             "X.java",
 			"interface I {\n" +
@@ -7283,8 +7283,8 @@ public void test217() {
 		"	                               ^^^^^^^\n" +
 		"The method message() is undefined for the type Annotation\n" +
 		"----------\n";
-    this.runNegativeTest(
-    	true,
+    AbstractRegressionTest.runNegativeTest(
+    	this, true,
         new String[] {
             "X.java",
 			"import java.lang.annotation.Annotation;\n" +
@@ -7313,8 +7313,8 @@ public void test217() {
 }
 // extending java.lang.annotation.Annotation
 public void test218() {
-    this.runNegativeTest(
-        new String[] {
+    AbstractRegressionTest.runNegativeTest(
+        this, new String[] {
             "X.java",
 			"import java.lang.annotation.Annotation;\n" +
 			"import java.lang.reflect.Constructor;\n" +
@@ -7613,8 +7613,8 @@ public void test224() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=XXXXX
 public void test225() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n"+
 			"  public void myMethod() {\n"+
@@ -7752,9 +7752,9 @@ public void test229() {
 public void test230() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnusedWarningToken, CompilerOptions.ERROR);
-	enableAllWarningsForIrritants(options, IrritantSet.UNUSED);
-	this.runNegativeTest(
-		true,
+	AbstractRegressionTest.enableAllWarningsForIrritants(options, IrritantSet.UNUSED);
+	AbstractRegressionTest.runNegativeTest(
+		this, true,
 		new String[] {
 				"X.java",
 				"public class X {\n" +
@@ -7791,9 +7791,9 @@ public void test230() {
 public void test231() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnusedWarningToken, CompilerOptions.ERROR);
-	enableAllWarningsForIrritants(options, IrritantSet.UNUSED);
-	this.runNegativeTest(
-		true,
+	AbstractRegressionTest.enableAllWarningsForIrritants(options, IrritantSet.UNUSED);
+	AbstractRegressionTest.runNegativeTest(
+		this, true,
 		new String[] {
 				"X.java",
 				"public class X {\n" +
@@ -7827,8 +7827,8 @@ public void test231() {
 public void test232() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnusedWarningToken, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		true,
+	AbstractRegressionTest.runNegativeTest(
+		this, true,
 		new String[] {
 				"X.java",
 				"public class X {\n" +
@@ -7981,8 +7981,8 @@ public void test238() {
 	// check that if promoted to ERROR, unhandled warning token shouldn't be suppressed by @SuppressWarnings("all")
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnhandledWarningToken, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		true,
+	AbstractRegressionTest.runNegativeTest(
+		this, true,
 		new String[] {
 				"X.java",
 				"public class X {\n" +
@@ -8003,8 +8003,8 @@ public void test238() {
 public void test239() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportRedundantSuperinterface, CompilerOptions.WARNING);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 				"X.java",
 				"class X implements I {}\n" +
 				"@SuppressWarnings(\"unused\")\n" +
@@ -8049,8 +8049,8 @@ public void test240() {
 public void test241() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnusedWarningToken, CompilerOptions.ERROR);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"\n" +
@@ -8132,8 +8132,8 @@ public void test243() {
 	options.put(CompilerOptions.OPTION_ReportUnusedWarningToken, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportUncheckedTypeOperation, CompilerOptions.IGNORE);
 	options.put(CompilerOptions.OPTION_ReportRawTypeReference, CompilerOptions.IGNORE);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"	\n" +
@@ -8156,8 +8156,8 @@ public void test244() {
 	options.put(CompilerOptions.OPTION_ReportUnusedWarningToken, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportUncheckedTypeOperation, CompilerOptions.WARNING);
 	options.put(CompilerOptions.OPTION_ReportRawTypeReference, CompilerOptions.WARNING);
-	this.runNegativeTest(
-		true,
+	AbstractRegressionTest.runNegativeTest(
+		this, true,
 		new String[] {
 				"X.java",
 				"public class X {\n" +
@@ -8184,9 +8184,9 @@ public void test245() {
 	options.put(CompilerOptions.OPTION_ReportUncheckedTypeOperation, CompilerOptions.IGNORE);
 	options.put(CompilerOptions.OPTION_ReportRawTypeReference, CompilerOptions.IGNORE);
 	options.put(CompilerOptions.OPTION_ReportUnnecessaryTypeCheck, CompilerOptions.WARNING);
-	enableAllWarningsForIrritants(options, IrritantSet.UNUSED);
-	this.runNegativeTest(
-		true,
+	AbstractRegressionTest.enableAllWarningsForIrritants(options, IrritantSet.UNUSED);
+	AbstractRegressionTest.runNegativeTest(
+		this, true,
 		new String[] {
 				"X.java",
 				"public class X {\n" +
@@ -8219,9 +8219,9 @@ public void test245_ignored() {
 	options.put(CompilerOptions.OPTION_ReportRawTypeReference, CompilerOptions.IGNORE);
 	options.put(CompilerOptions.OPTION_ReportUnnecessaryTypeCheck, CompilerOptions.WARNING);
 	options.put(CompilerOptions.OPTION_ReportSuppressWarningNotFullyAnalysed, CompilerOptions.IGNORE);
-	enableAllWarningsForIrritants(options, IrritantSet.UNUSED);
-	this.runNegativeTest(
-		true,
+	AbstractRegressionTest.enableAllWarningsForIrritants(options, IrritantSet.UNUSED);
+	AbstractRegressionTest.runNegativeTest(
+		this, true,
 		new String[] {
 				"X.java",
 				"public class X {\n" +
@@ -8249,9 +8249,9 @@ public void test245_error() {
 	options.put(CompilerOptions.OPTION_ReportRawTypeReference, CompilerOptions.IGNORE);
 	options.put(CompilerOptions.OPTION_ReportUnnecessaryTypeCheck, CompilerOptions.WARNING);
 	options.put(CompilerOptions.OPTION_ReportSuppressWarningNotFullyAnalysed, CompilerOptions.ERROR);
-	enableAllWarningsForIrritants(options, IrritantSet.UNUSED);
-	this.runNegativeTest(
-		true,
+	AbstractRegressionTest.enableAllWarningsForIrritants(options, IrritantSet.UNUSED);
+	AbstractRegressionTest.runNegativeTest(
+		this, true,
 		new String[] {
 				"X.java",
 				"public class X {\n" +
@@ -8282,8 +8282,8 @@ public void test246() {
 	options.put(CompilerOptions.OPTION_ReportUnusedWarningToken, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportUncheckedTypeOperation, CompilerOptions.WARNING);
 	options.put(CompilerOptions.OPTION_ReportRawTypeReference, CompilerOptions.WARNING);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"	\n" +
@@ -8316,8 +8316,8 @@ public void test247() {
 				"}"
 			},
 			"");
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"	@TestAnnotation\n" +
@@ -8349,8 +8349,8 @@ public void test248() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=191090
 public void test249() throws Exception {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java", //-----------------------------------------------------------------------
 			"@Zork\n" +
 			"public class X {}",
@@ -8368,12 +8368,12 @@ public void test249() throws Exception {
 		false,
 		false);
 	String expectedOutput = "public class X {";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=191090
 public void test250() throws Exception {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java", //-----------------------------------------------------------------------
 			"@Deprecated\n" +
 			"@Zork\n" +
@@ -8403,12 +8403,12 @@ public void test250() throws Exception {
 		"@java.lang.Deprecated\n" +
 		"@Annot(value=(int) 1)\n" +
 		"public class X {";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=191090
 public void test251() throws Exception {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java", //-----------------------------------------------------------------------
 			"@Deprecated\n" +
 			"@Zork\n" +
@@ -8438,12 +8438,12 @@ public void test251() throws Exception {
 		"@Annot(value=(int) 1)\n" +
 		"@java.lang.Deprecated\n" +
 		"public class X {";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=191090
 public void test252() throws Exception {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java", //-----------------------------------------------------------------------
 			"public class X {\n" +
 			"	public void foo(@Deprecated @Zork @Annot(2) int i) {}\n" +
@@ -8480,12 +8480,12 @@ public void test252() throws Exception {
 		"        #18 @Annot(\n" +
 		"          #19 value=(int) 2 (constant type)\n" +
 		"        )\n";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+	AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=191090
 public void test253() throws Exception {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java", //-----------------------------------------------------------------------
 			"public class X {\n" +
 			"	public void foo(@Deprecated @Zork @Annot(2) int i) {}\n" +
@@ -8522,12 +8522,12 @@ public void test253() throws Exception {
 		"      Number of annotations for parameter 0: 1\n" +
 		"        #17 @Zork(\n" +
 		"        )\n";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+	AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=191090
 public void test254() throws Exception {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java", //-----------------------------------------------------------------------
 			"public class X {\n" +
 			"	public void foo(@Deprecated int j, @Zork @Annot(3) int i) {}\n" +
@@ -8566,12 +8566,12 @@ public void test254() throws Exception {
 		"      Number of annotations for parameter 1: 1\n" +
 		"        #17 @Zork(\n" +
 		"        )\n";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+	AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=191090
 public void test255() throws Exception {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java", //-----------------------------------------------------------------------
 			"public class X {\n" +
 			"	public void foo(@Deprecated int j, @Annot(\"\") @Deprecated int i) {}\n" +
@@ -8604,12 +8604,12 @@ public void test255() throws Exception {
 		"      Number of annotations for parameter 1: 1\n" +
 		"        #17 @java.lang.Deprecated(\n" +
 		"        )\n";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+	AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=191090
 public void test256() throws Exception {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java", //-----------------------------------------------------------------------
 			"public class X {\n" +
 			"	public void foo(@Deprecated int j, @Annot(\"\") @Deprecated int i) {}\n" +
@@ -8642,7 +8642,7 @@ public void test256() throws Exception {
 		"      Number of annotations for parameter 1: 1\n" +
 		"        #20 @java.lang.Deprecated(\n" +
 		"        )";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+	AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=216570
 public void test257() {
@@ -8781,8 +8781,8 @@ public void test260() {
 public void test261() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_Process_Annotations, CompilerOptions.ENABLED);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",//=====================
 			"public class X {\n" +
 			"	public static void main(String[] args) {\n" +
@@ -8807,8 +8807,8 @@ public void test261() {
 		null,
 		options,
 		null);
-	this.runConformTest(
-			new String[] {
+	AbstractRegressionTest.runConformTest(
+			this, new String[] {
 				"X.java",//=====================
 				"public class X {\n" +
 				"	public static void main(String[] args) {\n" +
@@ -8827,8 +8827,8 @@ public void test261() {
 public void test262() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_Process_Annotations, CompilerOptions.ENABLED);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",//=====================
 			"public class X {\n" +
 			"	public static void main(String[] args) {\n" +
@@ -8853,8 +8853,8 @@ public void test262() {
 		null,
 		options,
 		null);
-	this.runConformTest(
-			new String[] {
+	AbstractRegressionTest.runConformTest(
+			this, new String[] {
 				"X.java",//=====================
 				"public class X {\n" +
 				"	public static void main(String[] args) {\n" +
@@ -8873,8 +8873,8 @@ public void test262() {
 public void test263() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_Process_Annotations, CompilerOptions.ENABLED);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",//=====================
 			"public class X {\n" +
 			"	public static void main(String[] args) {\n" +
@@ -8899,8 +8899,8 @@ public void test263() {
 		null,
 		options,
 		null);
-	this.runConformTest(
-			new String[] {
+	AbstractRegressionTest.runConformTest(
+			this, new String[] {
 				"X.java",//=====================
 				"public class X {\n" +
 				"	public static void main(String[] args) {\n" +
@@ -9013,8 +9013,8 @@ public void test267() {
 	customOptions.put(CompilerOptions.OPTION_SuppressWarnings, CompilerOptions.ENABLED);
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedWarningToken, CompilerOptions.ERROR);
 
-	runNegativeTest(
-		true,
+	AbstractRegressionTest.runNegativeTest(
+		this, true,
 		new String[] {
 				"com/SomeTest.java",
 				"package com;\n" +
@@ -9072,8 +9072,8 @@ public void test269() {
 	for (int i = 0, ceil = warnings.length; i < ceil; i++) {
 		customOptions.put(warnings[i], CompilerOptions.WARNING);
 	}
-	this.runConformTest(
-			true,
+	AbstractRegressionTest.runConformTest(
+			this, true,
 			new String[] {
 					"X.java",
 					"@interface X {}",
@@ -9126,7 +9126,7 @@ public void test271() throws Exception {
 		"  // Stack: 0, Locals: 2\n" +
 		"  private void foo(@A java.lang.Object o);\n";
 
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator  +"X.class", "X", expectedOutput, ClassFileBytesDisassembler.DETAILED);
+	AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator  +"X.class", "X", expectedOutput, ClassFileBytesDisassembler.DETAILED);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=289516
 public void test272() throws Exception {
@@ -9137,8 +9137,8 @@ public void test272() throws Exception {
 	options.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_1_5);
 	options.put(CompilerOptions.OPTION_TargetPlatform, CompilerOptions.VERSION_1_4);
 	options.put(CompilerOptions.OPTION_Compliance, CompilerOptions.VERSION_1_5);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"@interface A {}\n" +
 			"public class X {\n" +
@@ -9159,7 +9159,7 @@ public void test272() throws Exception {
 		"  // Stack: 0, Locals: 2\n" +
 		"  private void foo(@A java.lang.Object o);\n";
 
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator  +"X.class", "X", expectedOutput, ClassFileBytesDisassembler.DETAILED);
+	AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator  +"X.class", "X", expectedOutput, ClassFileBytesDisassembler.DETAILED);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=289576
 public void test273() throws Exception {
@@ -9179,7 +9179,7 @@ public void test273() throws Exception {
 		"  // Stack: 1, Locals: 2\n" +
 		"  private X(@A java.lang.Object o);\n";
 
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator  +"X.class", "X", expectedOutput, ClassFileBytesDisassembler.DETAILED);
+	AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator  +"X.class", "X", expectedOutput, ClassFileBytesDisassembler.DETAILED);
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=163194
 // To check Missing override annotation error when a method implements
@@ -9211,15 +9211,15 @@ public void test274a() {
 				"	            ^^^\n" +
 				"The method m() of type B should be tagged with @Override since it actually overrides a superinterface method\n" +
 				"----------\n";
-		this.runNegativeTest(
-				true,
+		AbstractRegressionTest.runNegativeTest(
+				this, true,
 				testString,
 				null, customOptions,
 				expectedOutput,
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	} else {
-		this.runConformTest(
-				true, testString,
+		AbstractRegressionTest.runConformTest(
+				this, true, testString,
 				null,
 				customOptions,
 				null,
@@ -9256,15 +9256,15 @@ public void test274b() {
 			"	            ^^^\n" +
 			"The method m() of type Over should be tagged with @Override since it actually overrides a superinterface method\n" +
 			"----------\n";
-		this.runNegativeTest(
-				true,
+		AbstractRegressionTest.runNegativeTest(
+				this, true,
 				testString,
 				null, customOptions,
 				expectedOutput,
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	} else {
-		this.runConformTest(
-				true, testString,
+		AbstractRegressionTest.runConformTest(
+				this, true, testString,
 				null,
 				customOptions,
 				null,
@@ -9300,15 +9300,15 @@ public void test274c() {
 				"	     ^^^\n" +
 				"The method m() of type B should be tagged with @Override since it actually overrides a superinterface method\n" +
 				"----------\n";
-		this.runNegativeTest(
-				true,
+		AbstractRegressionTest.runNegativeTest(
+				this, true,
 				testString,
 				null, customOptions,
 				expectedOutput,
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	} else {
-		this.runConformTest(
-				true, testString,
+		AbstractRegressionTest.runConformTest(
+				this, true, testString,
 				null,
 				customOptions,
 				null,
@@ -9342,15 +9342,15 @@ public void test274d() {
 			"	       ^^^^^^^^^^\n" +
 			"The method toString() of type A should be tagged with @Override since it actually overrides a superinterface method\n" +
 			"----------\n";
-		this.runNegativeTest(
-				true,
+		AbstractRegressionTest.runNegativeTest(
+				this, true,
 				testString,
 				null, customOptions,
 				expectedOutput,
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	} else {
-		this.runConformTest(
-				true, testString,
+		AbstractRegressionTest.runConformTest(
+				this, true, testString,
 				null,
 				customOptions,
 				null,
@@ -9363,8 +9363,8 @@ public void test275() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportDeadCodeInTrivialIfStatement, CompilerOptions.ENABLED);
 
-	runConformTest(
-		true,
+	AbstractRegressionTest.runConformTest(
+		this, true,
 		new String[] {
 				"X.java",
 				"public class X {\n" +
@@ -9396,8 +9396,8 @@ public void test276() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportDeadCodeInTrivialIfStatement, CompilerOptions.ENABLED);
 
-	runConformTest(
-		true,
+	AbstractRegressionTest.runConformTest(
+		this, true,
 		new String[] {
 				"X.java",
 				"public class X {\n" +
@@ -9424,8 +9424,8 @@ public void test277() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportDeadCodeInTrivialIfStatement, CompilerOptions.DISABLED);
 
-	runConformTest(
-		true,
+	AbstractRegressionTest.runConformTest(
+		this, true,
 		new String[] {
 				"X.java",
 				"public class X {\n" +
@@ -9512,8 +9512,8 @@ public void test280() {
 			"	private int i;\n" + // problem configured as warning but still suppressed
 			"}\n"
 			};
-	runConformTest(
-			testFiles,
+	AbstractRegressionTest.runConformTest(
+			this, testFiles,
 			null,
 			null,
 			true,
@@ -9541,8 +9541,8 @@ public void test281() {
 			"	            ^\n" +
 			"The value of the field A.i is not used\n" +
 			"----------\n";
-	runNegativeTest(
-			true,
+	AbstractRegressionTest.runNegativeTest(
+			this, true,
 			testFiles,
 			null,
 			customOptions,
@@ -9562,8 +9562,8 @@ public void test282() {
 			"	private Map i;\n" +
 			"}\n"
 			};
-	runConformTest(
-			testFiles,
+	AbstractRegressionTest.runConformTest(
+			this, testFiles,
 			null,
 			null,
 			true,
@@ -9590,8 +9590,8 @@ public void test283() {
 			"	             ^\n" +
 			"void is an invalid type for the variable i\n" +
 			"----------\n";
-	runNegativeTest(
-			true,
+	AbstractRegressionTest.runNegativeTest(
+			this, true,
 			testFiles,
 			null,
 			customOptions,
@@ -9623,8 +9623,8 @@ public void test284() {
 		"	                  ^^^^^^\n" +
 		"Unnecessary @SuppressWarnings(\"cast\")\n" +
 		"----------\n";
-	runNegativeTest(
-			true,
+	AbstractRegressionTest.runNegativeTest(
+			this, true,
 			testFiles,
 			null,
 			customOptions,
@@ -9656,8 +9656,8 @@ public void test285() {
 		"	                  ^^^^^^\n" +
 		"Unnecessary @SuppressWarnings(\"cast\")\n" +
 		"----------\n";
-	runNegativeTest(
-			true,
+	AbstractRegressionTest.runNegativeTest(
+			this, true,
 			testFiles,
 			null,
 			customOptions,
@@ -9674,8 +9674,8 @@ public void test286() {
 			CompilerOptions.OPTION_SuppressOptionalErrors, CompilerOptions.ENABLED);
 	raiseDeprecationReduceInvalidJavadocSeverity.put(
 			CompilerOptions.OPTION_ReportInvalidJavadoc, CompilerOptions.WARNING);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 				"X.java",
 				"@SuppressWarnings(\"deprecation\")\n" +
 				"public class X extends p.OldStuff {\n" +
@@ -9707,8 +9707,8 @@ public void test287() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUncheckedTypeOperation, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_SuppressOptionalErrors, CompilerOptions.ENABLED);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 				"X.java",
 				"import java.util.ArrayList;\n" +
 				"\n" +
@@ -9737,8 +9737,8 @@ public void test288() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUncheckedTypeOperation, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_SuppressOptionalErrors, CompilerOptions.ENABLED);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 				"X.java",
 				"import java.util.ArrayList;\n" +
 				"\n" +
@@ -9762,8 +9762,8 @@ public void test289() {
 	options.put(CompilerOptions.OPTION_ReportUncheckedTypeOperation, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportRawTypeReference, CompilerOptions.IGNORE);
 	options.put(CompilerOptions.OPTION_SuppressOptionalErrors, CompilerOptions.ENABLED);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 				"X.java",
 				"import java.util.ArrayList;\n" +
 				"\n" +
@@ -9797,8 +9797,8 @@ public void test290() {
 	options.put(CompilerOptions.OPTION_ReportRawTypeReference, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_SuppressOptionalErrors, CompilerOptions.ENABLED);
 	options.put(CompilerOptions.OPTION_ReportUnusedWarningToken, CompilerOptions.ERROR);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 				"X.java",
 				"import java.util.ArrayList;\n" +
 				"class X {\n" +
@@ -9825,8 +9825,8 @@ public void test291() {
 	options.put(CompilerOptions.OPTION_ReportRawTypeReference, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_SuppressOptionalErrors, CompilerOptions.ENABLED);
 	options.put(CompilerOptions.OPTION_ReportUnusedWarningToken, CompilerOptions.ERROR);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 				"X.java",
 				"import java.util.ArrayList;\n" +
 				"class X {\n" +
@@ -9853,8 +9853,8 @@ public void test292() {
 	options.put(CompilerOptions.OPTION_ReportRawTypeReference, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_SuppressOptionalErrors, CompilerOptions.ENABLED);
 	options.put(CompilerOptions.OPTION_ReportUnusedWarningToken, CompilerOptions.ERROR);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 				"X.java",
 				"import java.util.ArrayList;\n" +
 				"class X {\n" +
@@ -9904,8 +9904,8 @@ public void test294() {
 			"	public int foo(int i) { return 0; }\n" +
 			"}\n"
 			};
-	runConformTest(
-			testFiles,
+	AbstractRegressionTest.runConformTest(
+			this, testFiles,
 			null,
 			null,
 			true,
@@ -9931,8 +9931,8 @@ public void test295() {
 			"	public int foo(int i) { return 0; }\n" +
 			"}\n"
 			};
-	runConformTest(
-			testFiles,
+	AbstractRegressionTest.runConformTest(
+			this, testFiles,
 			null,
 			null,
 			true,
@@ -9958,8 +9958,8 @@ public void test296() {
 			"	public int foo(int i) { return 0; }\n" +
 			"}\n"
 			};
-	runConformTest(
-			testFiles,
+	AbstractRegressionTest.runConformTest(
+			this, testFiles,
 			null,
 			null,
 			true,
@@ -10324,7 +10324,7 @@ public void testBug366003e() {
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=365437
 public void testBug365437a() {
 	Map customOptions = getCompilerOptions();
-	enableAllWarningsForIrritants(customOptions, IrritantSet.NULL);
+	AbstractRegressionTest.enableAllWarningsForIrritants(customOptions, IrritantSet.NULL);
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.ERROR);
 	String testFiles [] = new String[] {
 			"p/A.java",
@@ -10362,8 +10362,8 @@ public void testBug365437a() {
 			"	           	             ^^^^^^\n" +
 			"The method foo3() from the type A is never used locally\n" +
 			"----------\n";
-	runNegativeTest(
-			true,
+	AbstractRegressionTest.runNegativeTest(
+			this, true,
 			testFiles,
 			null,
 			customOptions,
@@ -10418,8 +10418,8 @@ public void testBug365437b() {
 			List<String> limitModules = Arrays.asList("java.se", "java.xml.ws.annotation");
 			this.javaClassLib = new CustomFileSystem(limitModules);
 		}
-		runNegativeTest(
-				true,
+		AbstractRegressionTest.runNegativeTest(
+				this, true,
 				testFiles,
 				null,
 				customOptions,
@@ -10434,7 +10434,7 @@ public void testBug365437b() {
 public void testBug365437c() {
 	if (this.complianceLevel < ClassFileConstants.JDK1_7) return;
 	Map customOptions = getCompilerOptions();
-	enableAllWarningsForIrritants(customOptions, IrritantSet.NULL);
+	AbstractRegressionTest.enableAllWarningsForIrritants(customOptions, IrritantSet.NULL);
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.ERROR);
 	String testFiles [] = new String[] {
 			"p/A.java",
@@ -10472,8 +10472,8 @@ public void testBug365437c() {
 			"	            	                   ^^^^^^^^^^^^^^^^^\n" +
 			"The method foo3(Object...) from the type A is never used locally\n" +
 			"----------\n";
-	runNegativeTest(
-			true,
+	AbstractRegressionTest.runNegativeTest(
+			this, true,
 			testFiles,
 			null,
 			customOptions,
@@ -10484,13 +10484,13 @@ public void testBug365437c() {
 // unused constructor
 public void testBug365437d() {
 	Map customOptions = getCompilerOptions();
-	enableAllWarningsForIrritants(customOptions, IrritantSet.NULL);
+	AbstractRegressionTest.enableAllWarningsForIrritants(customOptions, IrritantSet.NULL);
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.ERROR);
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.ERROR);
 	customOptions.put(CompilerOptions.OPTION_AnnotationBasedNullAnalysis, CompilerOptions.ENABLED);
 	customOptions.put(CompilerOptions.OPTION_NonNullByDefaultAnnotationName, "p.NonNullByDefault");
-	this.runNegativeTest(
-		true,
+	AbstractRegressionTest.runNegativeTest(
+		this, true,
 		new String[] {
 			"Example.java",
 			"class Example {\n" +
@@ -10564,13 +10564,13 @@ public void testBug365437d() {
 // unused field
 public void testBug365437e() {
 	Map customOptions = getCompilerOptions();
-	enableAllWarningsForIrritants(customOptions, IrritantSet.NULL);
+	AbstractRegressionTest.enableAllWarningsForIrritants(customOptions, IrritantSet.NULL);
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.ERROR);
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.ERROR);
 	customOptions.put(CompilerOptions.OPTION_AnnotationBasedNullAnalysis, CompilerOptions.ENABLED);
 	customOptions.put(CompilerOptions.OPTION_NonNullAnnotationName, "p.NonNull");
-	this.runNegativeTest(
-		true,
+	AbstractRegressionTest.runNegativeTest(
+		this, true,
 		new String[] {
 			"Example.java",
 			"class Example {\n" +
@@ -10637,13 +10637,13 @@ public void testBug365437e() {
 // unused type
 public void testBug365437f() {
 	Map customOptions = getCompilerOptions();
-	enableAllWarningsForIrritants(customOptions, IrritantSet.NULL);
+	AbstractRegressionTest.enableAllWarningsForIrritants(customOptions, IrritantSet.NULL);
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.ERROR);
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.ERROR);
 	customOptions.put(CompilerOptions.OPTION_AnnotationBasedNullAnalysis, CompilerOptions.ENABLED);
 	customOptions.put(CompilerOptions.OPTION_NonNullByDefaultAnnotationName, "p.NonNullByDefault");
-	this.runNegativeTest(
-		true,
+	AbstractRegressionTest.runNegativeTest(
+		this, true,
 		new String[] {
 			"Example.java",
 			"class Example {\n" +
@@ -10713,8 +10713,8 @@ public void testBug376590a() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.ERROR);
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		true,
+	AbstractRegressionTest.runNegativeTest(
+		this, true,
 		new String[] {
 			GOOGLE_INJECT_NAME,
 			GOOGLE_INJECT_CONTENT,
@@ -10742,8 +10742,8 @@ public void testBug376590b() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.ERROR);
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		true,
+	AbstractRegressionTest.runNegativeTest(
+		this, true,
 		new String[] {
 			JAVAX_INJECT_NAME,
 			JAVAX_INJECT_CONTENT,
@@ -10777,8 +10777,8 @@ public void testBug376590c() {
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.ERROR);
 	customOptions.put(CompilerOptions.OPTION_AnnotationBasedNullAnalysis, CompilerOptions.ENABLED);
 	customOptions.put(CompilerOptions.OPTION_NonNullAnnotationName, "p.NonNull");
-	this.runNegativeTest(
-		true,
+	AbstractRegressionTest.runNegativeTest(
+		this, true,
 		new String[] {
 			JAVAX_INJECT_NAME,
 			JAVAX_INJECT_CONTENT,
@@ -10902,8 +10902,8 @@ public void testBug371832() throws Exception {
 			"	       ^^^^^^^^^^^^^^\n" +
 			"The import java.util.List is never used\n" +
 			"----------\n";
-	runNegativeTest(
-			true,
+	AbstractRegressionTest.runNegativeTest(
+			this, true,
 			testFiles,
 			null,
 			customOptions,
@@ -10970,8 +10970,8 @@ public void testBug386356_2() {
 			List<String> limitModules = Arrays.asList("java.se", "java.xml.bind");
 			this.javaClassLib = new CustomFileSystem(limitModules);
 		}
-		runConformTest(
-			new String[] {
+		AbstractRegressionTest.runConformTest(
+			this, new String[] {
 				"com/ermahgerd/Ermahgerd.java",
 				"package com.ermahgerd;\n" +
 				"\n" +
@@ -11018,8 +11018,8 @@ public void test398657() throws Exception {
 	options.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_1_5);
 	options.put(CompilerOptions.OPTION_TargetPlatform, CompilerOptions.VERSION_1_4);
 	options.put(CompilerOptions.OPTION_Compliance, CompilerOptions.VERSION_1_5);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"p/Annot.java",
 			"package p;\n" +
 			"public @interface Annot {\n" +
@@ -11045,7 +11045,7 @@ public void test398657() throws Exception {
 		"    [inner class info: #22 p/Annot$E, outer class info: #24 p/Annot\n" +
 		"     inner name: #26 E, accessflags: 16409 public static final]\n";
 
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator  +"X.class", "X", expectedOutput, ClassFileBytesDisassembler.DETAILED);
+	AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator  +"X.class", "X", expectedOutput, ClassFileBytesDisassembler.DETAILED);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=398657
 public void test398657_2() throws Exception {
@@ -11056,8 +11056,8 @@ public void test398657_2() throws Exception {
 	options.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_1_5);
 	options.put(CompilerOptions.OPTION_TargetPlatform, CompilerOptions.VERSION_1_4);
 	options.put(CompilerOptions.OPTION_Compliance, CompilerOptions.VERSION_1_5);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"p/Y.java",
 			"package p;\n" +
 			"public class Y {\n" +
@@ -11083,7 +11083,7 @@ public void test398657_2() throws Exception {
 			"    [inner class info: #21 p/Y$Annot, outer class info: #23 p/Y\n" +
 			"     inner name: #25 Annot, accessflags: 9737 public abstract static]\n";
 
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator  +"X.class", "X", expectedOutput, ClassFileBytesDisassembler.DETAILED);
+	AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator  +"X.class", "X", expectedOutput, ClassFileBytesDisassembler.DETAILED);
 }
 // check invalid and annotations on package
 public void test384567() {
@@ -11207,8 +11207,8 @@ public void test427367() throws Exception {
 	options.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_1_5);
 	options.put(CompilerOptions.OPTION_TargetPlatform, CompilerOptions.VERSION_1_4);
 	options.put(CompilerOptions.OPTION_Compliance, CompilerOptions.VERSION_1_5);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"@interface Annot1 {\n" +
 			"   Thread.State value() default Thread.State.NEW;\n" +
@@ -11257,7 +11257,7 @@ public void test427367() throws Exception {
 					"\n" +
 					"}";
 	try {
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator  +"X.class", "X", expectedOutput, ClassFileBytesDisassembler.DETAILED);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator  +"X.class", "X", expectedOutput, ClassFileBytesDisassembler.DETAILED);
 	} catch(org.eclipse.jdt.core.util.ClassFormatException cfe) {
 		fail("Error reading classfile");
 	}
@@ -11267,8 +11267,8 @@ public void test376977() throws Exception {
 	if (this.complianceLevel < ClassFileConstants.JDK1_5) {
 		return;
 	}
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"import p.Outer;\n" +
 			"@Outer(nest= {@Nested()})\n" +
@@ -11369,8 +11369,8 @@ public void test434556() throws Exception {
 	if (this.complianceLevel < ClassFileConstants.JDK1_5) {
 		return;
 	}
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"A.java",
 			"import java.lang.annotation.Retention;\n" +
 			"import java.lang.annotation.RetentionPolicy;\n" +
@@ -11412,7 +11412,7 @@ public void test434556() throws Exception {
 			"        [pc: 0, pc: 10] local: this index: 0 type: A\n" +
 			"  \n";
 	try {
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator  +"A.class", "A", expectedOutput, ClassFileBytesDisassembler.DETAILED);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator  +"A.class", "A", expectedOutput, ClassFileBytesDisassembler.DETAILED);
 	} catch(org.eclipse.jdt.core.util.ClassFormatException cfe) {
 		fail("Error reading classfile");
 	}
@@ -11435,10 +11435,10 @@ public void test433747() throws Exception {
 	};
 	if (this.complianceLevel <= ClassFileConstants.JDK1_6) {
 		this.runConformTest(src, "");
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "p/package-info.class", "", "p123456");
+		AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "p/package-info.class", "", "p123456");
 	} else {
-	this.runNegativeTest(
-			src,
+	AbstractRegressionTest.runNegativeTest(
+			this, src,
 			"----------\n" +
 			"1. ERROR in p\\package-info.java (at line 1)\n" +
 			"	@PackageAnnot(\"p123456\")\n" +
@@ -11462,8 +11462,8 @@ public void test456960() throws Exception {
 	options.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_1_5);
 	options.put(CompilerOptions.OPTION_TargetPlatform, CompilerOptions.VERSION_1_5);
 	options.put(CompilerOptions.OPTION_Compliance, CompilerOptions.VERSION_1_5);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"@Bar(String)\n" +
 			"public class X {\n" +
@@ -11506,7 +11506,7 @@ public void test456960() throws Exception {
 			"        [pc: 0, pc: 10] local: this index: 0 type: X\n" +
 			"}";
 	try {
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator  +"X.class", "X", expectedOutput, ClassFileBytesDisassembler.DETAILED);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator  +"X.class", "X", expectedOutput, ClassFileBytesDisassembler.DETAILED);
 	} catch(org.eclipse.jdt.core.util.ClassFormatException cfe) {
 		fail("Error reading classfile");
 	}
@@ -11525,7 +11525,7 @@ public void test449330() throws Exception {
 	};
 	if (this.complianceLevel <= ClassFileConstants.JDK1_6) {
 		this.runConformTest(testFiles);
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "p/package-info.class", "", "HELLO");
+		AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "p/package-info.class", "", "HELLO");
 	} else {
 		this.runNegativeTest(testFiles,
 			"----------\n" +
@@ -11551,7 +11551,7 @@ public void test449330a() throws Exception {
 	};
 	if (this.complianceLevel <= ClassFileConstants.JDK1_6) {
 		this.runConformTest(testFiles, "");
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "p/package-info.class", "", "HELLO");
+		AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "p/package-info.class", "", "HELLO");
 	} else {
 		this.runNegativeTest(testFiles,
 			"----------\n" +
@@ -11574,15 +11574,15 @@ public void test449330b() throws Exception {
 		"package p;\n"
 	};
 	this.runConformTest(testFiles, "");
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "p/package-info.class", "", "HELLO");
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "p/package-info.class", "", "HELLO");
 }
 //https://bugs.eclipse.org/386692
 public void testBug386692() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.ERROR);
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		true,
+	AbstractRegressionTest.runNegativeTest(
+		this, true,
 		new String[] {
 			SPRINGFRAMEWORK_AUTOWIRED_NAME,
 			SPRINGFRAMEWORK_AUTOWIRED_CONTENT,
@@ -11643,7 +11643,7 @@ public void testBug464977() throws Exception {
 							"}";
 	try {
 		this.enableAPT = true;
-		checkClassFile("DeprecatedClass", source, expectedOutput, ClassFileBytesDisassembler.DETAILED | ClassFileBytesDisassembler.COMPACT);
+		AbstractRegressionTest.checkClassFile(this, "DeprecatedClass", source, expectedOutput, ClassFileBytesDisassembler.DETAILED | ClassFileBytesDisassembler.COMPACT);
 	} finally {
 		this.enableAPT = apt;
 	}
@@ -11780,7 +11780,7 @@ public void test472178() throws Exception {
 			"        local variable entries:\n" +
 			"          [pc: 31, pc: 37] index: 4\n" +
 			"      )\n";
-	checkClassFile("Test", source, expectedOutput, ClassFileBytesDisassembler.DETAILED | ClassFileBytesDisassembler.COMPACT);
+	AbstractRegressionTest.checkClassFile(this, "Test", source, expectedOutput, ClassFileBytesDisassembler.DETAILED | ClassFileBytesDisassembler.COMPACT);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=470665
 public void testBug470665() throws Exception {
@@ -11788,7 +11788,7 @@ public void testBug470665() throws Exception {
 		return; // Enough to run in the last two levels!
 	}
 	boolean apt = this.enableAPT;
-	String errMessage = isMinimumCompliant(ClassFileConstants.JDK11) ?
+	String errMessage = AbstractRegressionTest.isMinimumCompliant(this, ClassFileConstants.JDK11) ?
 			"----------\n" +
 			"1. ERROR in A.java (at line 10)\n" +
 			"	};\n" +
@@ -11882,8 +11882,8 @@ public void testBug506888b() throws Exception {
 	options.put(CompilerOptions.OPTION_ReportUnusedWarningToken, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportIncompleteEnumSwitch, CompilerOptions.WARNING);
 	options.put(CompilerOptions.OPTION_ReportMissingDefaultCase, CompilerOptions.IGNORE);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"	\n" +
@@ -11937,8 +11937,8 @@ public void testBug506888d() throws Exception {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnusedWarningToken, CompilerOptions.IGNORE);
 	options.put(CompilerOptions.OPTION_ReportIncompleteEnumSwitch, CompilerOptions.IGNORE);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"	\n" +
@@ -11957,8 +11957,8 @@ public void testBug506888e() throws Exception {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnusedWarningToken, CompilerOptions.IGNORE);
 	options.put(CompilerOptions.OPTION_ReportUnusedLabel, CompilerOptions.WARNING);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"	\n" +
@@ -11994,7 +11994,7 @@ public void testBug506888f() throws Exception {
 	options.put(CompilerOptions.OPTION_ReportUnusedDeclaredThrownException, CompilerOptions.IGNORE);
 	options.put(CompilerOptions.OPTION_ReportUnusedLocal, CompilerOptions.WARNING);
 	MyCompilerRequestor requestor = new MyCompilerRequestor();
-	runTest(new String[] {
+	AbstractRegressionTest.runTest(this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"	\n" +
@@ -12100,7 +12100,7 @@ public void testBug537593_001() {
 	for (Object option : opts)
 		options.put(option, CompilerOptions.WARNING);
 	MyCompilerRequestor requestor = new MyCompilerRequestor();
-	runTest(files,
+	AbstractRegressionTest.runTest(this, files,
 			false,
 			"",
 			"" /*expectedOutputString */,
@@ -12196,8 +12196,8 @@ public void testBug542520c() throws Exception {
 public void testBug542520d() throws Exception {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		true,
+	AbstractRegressionTest.runNegativeTest(
+		this, true,
 		new String[] {
 			JUNIT_METHODSOURCE_NAME,
 			JUNIT_METHODSOURCE_CONTENT,

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AnnotationTest_9.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AnnotationTest_9.java
@@ -48,8 +48,8 @@ public class AnnotationTest_9 extends AbstractComparableTest {
             },"", null, false, null);
 	}
     public void testBug521054a() throws Exception {
-    	this.runNegativeTest(
-    		new String[] {
+    	AbstractRegressionTest.runNegativeTest(
+    		this, new String[] {
     				"X.java",
     				"public @interface X {\n" +
     				"	String value(X this);\n" +
@@ -64,8 +64,8 @@ public class AnnotationTest_9 extends AbstractComparableTest {
     		null, true);
     }
     public void testBug521054b() throws Exception {
-    	this.runNegativeTest(
-    		new String[] {
+    	AbstractRegressionTest.runNegativeTest(
+    		this, new String[] {
     				"X.java",
     				"@java.lang.annotation.Repeatable(Container.class)\n" +
     				"public @interface X {\n" +
@@ -84,8 +84,8 @@ public class AnnotationTest_9 extends AbstractComparableTest {
     		null, true);
     }
     public void testBug521054c() throws Exception {
-    	this.runNegativeTest(
-    		new String[] {
+    	AbstractRegressionTest.runNegativeTest(
+    		this, new String[] {
     				"X.java",
     				"@java.lang.annotation.Repeatable(Container.class)\n" +
     				"public @interface X {\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ArrayTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ArrayTest.java
@@ -412,8 +412,8 @@ public void test014() throws Exception {
 		// check that #clone() return type is changed ONLY from -source 1.5 only (independant from compliance level)
 		optionsMap.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_1_4);
 	}
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"	void foo(long[] longs) throws Exception {\n" +
@@ -510,8 +510,8 @@ public void test017() throws Exception {
 		// check that #clone() return type is changed ONLY from -source 1.5 only (independant from compliance level)
 		optionsMap.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_1_4);
 	}
-	this.runConformTest(
-			new String[] {
+	AbstractRegressionTest.runConformTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"	void foo(long[] longs) throws Exception {\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AssignmentTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AssignmentTest.java
@@ -411,8 +411,8 @@ public void test033() {
 public void test034() {
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_UNUSED_PRIVATE_MEMBER, JavaCore.IGNORE);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public final class X \n" +
 			"{\n" +
@@ -838,8 +838,8 @@ public void test035() {
 		"----------\n");
 }
 public void test036() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"\n" +
@@ -1000,8 +1000,8 @@ public void test039() {
 public void test040() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportParameterAssignment, CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -1030,8 +1030,8 @@ public void test040() {
 public void test041() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportParameterAssignment, CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -1062,8 +1062,8 @@ public void test041() {
 public void test042() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportParameterAssignment, CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -1095,8 +1095,8 @@ public void test042() {
 public void test043() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportParameterAssignment, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo(final boolean b) {\n" +
@@ -1116,8 +1116,8 @@ public void test043() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=100369
 public void test044() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	int length1 = 0;\n" +
@@ -1173,8 +1173,8 @@ public void test044() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=133351
 public void test045() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	void foo() {\n" +
@@ -1199,8 +1199,8 @@ public void test045() {
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=200724
 public void test046() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	public static String s;\n" +
@@ -1252,8 +1252,8 @@ public void _test048() {
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=200724
 // adding a package to the picture
 public void test049() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"p/X.java",
 			"package p;\n" +
 			"public class X {\n" +
@@ -1313,8 +1313,8 @@ public void test050() {
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=200724
 // swap lhs and rhs
 public void test051() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	public static String s;\n" +
@@ -1414,8 +1414,8 @@ public void _test054_definite_unassignment_try_catch() {
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=235543
 // variant
 public void test055_definite_unassignment_try_catch() {
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		new String[] { /* test files */
 			"X.java",
 			"public class X {\n" +
@@ -1448,8 +1448,8 @@ public void test055_definite_unassignment_try_catch() {
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=235546
 public void test056_definite_unassignment_infinite_for_loop() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -1478,8 +1478,8 @@ public void test056_definite_unassignment_infinite_for_loop() {
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=235546
 // variant
 public void test057_definite_unassignment_infinite_while_loop() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -1532,8 +1532,8 @@ public void test058_definite_unassignment_try_finally() {
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=235555
 public void test059_definite_unassignment_assign_in_for_condition() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -1921,8 +1921,8 @@ public void test064() {
 public void test065() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportComparingIdentical, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	protected boolean foo = false;\n" +
@@ -1953,8 +1953,8 @@ public void test065() {
 public void test066() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportComparingIdentical, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	public boolean test() {\n" +
@@ -1984,8 +1984,8 @@ public void test066() {
 public void test067() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportComparingIdentical, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	public boolean test() {\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AutoBoxingTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AutoBoxingTest.java
@@ -2530,8 +2530,8 @@ public class AutoBoxingTest extends AbstractComparableTest {
 	public void test088() {
 		Map customOptions = getCompilerOptions();
 		customOptions.put(CompilerOptions.OPTION_ReportAutoboxing, CompilerOptions.WARNING);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"	int f;\n" +
@@ -3016,8 +3016,8 @@ public class AutoBoxingTest extends AbstractComparableTest {
 	}
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=84801
 	public void test102() {
-		runConformTest(
-			// test directory preparation
+		AbstractRegressionTest.runConformTest(
+			this, // test directory preparation
 			true /* flush output directory */,
 			new String[] { /* test files */
 				"X.java",
@@ -3158,8 +3158,8 @@ public class AutoBoxingTest extends AbstractComparableTest {
 	}
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=95868
 	public void test104() {
-		this.runConformTest(
-			false /* skipJavac */,
+		AbstractRegressionTest.runConformTest(
+			this, false /* skipJavac */,
 			JavacTestOptions.Excuse.JavacGeneratesIncorrectCode,
 			new String[] {
 				"X.java",
@@ -3181,8 +3181,8 @@ public class AutoBoxingTest extends AbstractComparableTest {
 	}
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=101779
 public void test105() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -3225,8 +3225,8 @@ public void test105() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=101779 - variation
 public void test106() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -3259,8 +3259,8 @@ public void test106() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=101779 - variation
 public void test107() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -3293,8 +3293,8 @@ public void test107() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=101779 - variation
 public void test108() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -3359,8 +3359,8 @@ public void test110() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=105524
 public void test111() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -3585,8 +3585,8 @@ public void test117() {
 
 // Integer array and method with T extends Integer bound
 public void test118() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -3612,8 +3612,8 @@ public void test118() {
 
 // Integer as member of a parametrized class
 public void test119() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -4082,8 +4082,8 @@ public void test134() {
 public void test135() {
 	Map settings = getCompilerOptions();
 	settings.put(CompilerOptions.OPTION_PreserveUnusedLocal, CompilerOptions.OPTIMIZE_OUT);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"class A<T> {\n" +
 			"        public T foo() { return null; }\n" +
@@ -4114,8 +4114,8 @@ public void test135() {
 public void test136() {
 	Map settings = getCompilerOptions();
 	settings.put(CompilerOptions.OPTION_PreserveUnusedLocal, CompilerOptions.OPTIMIZE_OUT);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"class A<T> {\n" +
 			"        public T foo(Object o) {\n" +
@@ -4147,8 +4147,8 @@ public void test136() {
 public void test137() {
 	Map settings = getCompilerOptions();
 	settings.put(CompilerOptions.OPTION_PreserveUnusedLocal, CompilerOptions.OPTIMIZE_OUT);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"class A<T> {\n" +
 			"        public T foo;\n" +
@@ -4180,8 +4180,8 @@ public void test137() {
 public void test138() {
 	Map settings = getCompilerOptions();
 	settings.put(CompilerOptions.OPTION_PreserveUnusedLocal, CompilerOptions.OPTIMIZE_OUT);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"class A<T> {\n" +
 			"        public T foo;\n" +
@@ -4215,8 +4215,8 @@ public void test138() {
 public void test139() {
 	Map settings = getCompilerOptions();
 	settings.put(CompilerOptions.OPTION_PreserveUnusedLocal, CompilerOptions.OPTIMIZE_OUT);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"class A<T> {\n" +
 			"        public T foo;\n" +
@@ -4250,8 +4250,8 @@ public void test139() {
 public void test140() {
 	Map settings = getCompilerOptions();
 	settings.put(CompilerOptions.OPTION_PreserveUnusedLocal, CompilerOptions.OPTIMIZE_OUT);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"class A {\n" +
 			"        long foo() {\n" +
@@ -4278,8 +4278,8 @@ public void test140() {
 public void test141() {
 	Map settings = getCompilerOptions();
 	settings.put(CompilerOptions.OPTION_PreserveUnusedLocal, CompilerOptions.OPTIMIZE_OUT);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"class A {\n" +
 			"        long foo = 0L;\n" +
@@ -4304,8 +4304,8 @@ public void test141() {
 public void test142() {
 	Map settings = getCompilerOptions();
 	settings.put(CompilerOptions.OPTION_PreserveUnusedLocal, CompilerOptions.OPTIMIZE_OUT);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"class A {\n" +
 			"        long foo = 0L;\n" +
@@ -4332,8 +4332,8 @@ public void test142() {
 public void test143() {
 	Map settings = getCompilerOptions();
 	settings.put(CompilerOptions.OPTION_PreserveUnusedLocal, CompilerOptions.OPTIMIZE_OUT);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"class A {\n" +
 			"        long foo = 0L;\n" +
@@ -4360,8 +4360,8 @@ public void test143() {
 public void test144() {
 	Map settings = getCompilerOptions();
 	settings.put(CompilerOptions.OPTION_PreserveUnusedLocal, CompilerOptions.OPTIMIZE_OUT);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"class A<T> {\n" +
 			"        public T[] foo;\n" +
@@ -4395,8 +4395,8 @@ public void test144() {
 public void test145() {
 	Map settings = getCompilerOptions();
 	settings.put(CompilerOptions.OPTION_PreserveUnusedLocal, CompilerOptions.OPTIMIZE_OUT);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"class A {\n" +
 			"        long[] foo = { 0L };\n" +
@@ -4423,8 +4423,8 @@ public void test145() {
 public void test146() {
 	Map settings = getCompilerOptions();
 	settings.put(CompilerOptions.OPTION_PreserveUnusedLocal, CompilerOptions.OPTIMIZE_OUT);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"class A<T> {\n" +
 			"        public T foo;\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/BatchCompilerTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/BatchCompilerTest.java
@@ -4740,7 +4740,7 @@ public void test107() throws Exception {
      "",
      true);
 	String expectedOutput = "// Compiled from X.java (version 1.1 : 45.3, super bit)";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=141830
 //compliance 1.4 source 1.3
@@ -4758,7 +4758,7 @@ public void test108() throws Exception {
 		"",
 		true);
 	String expectedOutput = "// Compiled from X.java (version 1.2 : 46.0, super bit)";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=141830
 //compliance 1.4 source 1.4
@@ -4776,7 +4776,7 @@ public void test109() throws Exception {
 		"",
 		true);
 	String expectedOutput = "// Compiled from X.java (version 1.4 : 48.0, super bit)";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=141830
 //compliance 1.5 source 1.3
@@ -4794,7 +4794,7 @@ public void test110() throws Exception {
 		"",
 		true);
 	String expectedOutput = "// Compiled from X.java (version 1.4 : 48.0, super bit)";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=141830
 //compliance 1.5 source 1.4
@@ -4812,7 +4812,7 @@ public void test111() throws Exception {
 		"",
 		true);
 	String expectedOutput = "// Compiled from X.java (version 1.4 : 48.0, super bit)";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=141830
 //compliance 1.5 source 1.5
@@ -4830,7 +4830,7 @@ public void test112() throws Exception {
 		"",
 		true);
 	String expectedOutput = "// Compiled from X.java (version 1.5 : 49.0, super bit)";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=141830
 //compliance 1.6 source 1.3
@@ -4848,7 +4848,7 @@ public void test113() throws Exception {
 		"",
 		true);
 	String expectedOutput = "// Compiled from X.java (version 1.4 : 48.0, super bit)";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=141830
 //compliance 1.6 source 1.4
@@ -4866,7 +4866,7 @@ public void test114() throws Exception {
 		"",
 		true);
 	String expectedOutput = "// Compiled from X.java (version 1.4 : 48.0, super bit)";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=141830
 //compliance 1.6 source 1.5
@@ -4884,7 +4884,7 @@ public void test115() throws Exception {
 		"",
 		true);
 	String expectedOutput = "// Compiled from X.java (version 1.6 : 50.0, super bit)";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=141830
 //compliance 1.6 source 1.6
@@ -4902,7 +4902,7 @@ public void test116() throws Exception {
 		"",
 		true);
 	String expectedOutput = "// Compiled from X.java (version 1.6 : 50.0, super bit)";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=141830
 //compliance 1.7 source 1.3
@@ -4920,7 +4920,7 @@ public void test117() throws Exception {
 		"",
 		true);
 	String expectedOutput = "// Compiled from X.java (version 1.4 : 48.0, super bit)";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=141830
 //compliance 1.7 source 1.4
@@ -4938,7 +4938,7 @@ public void test118() throws Exception {
 		"",
 		true);
 	String expectedOutput = "// Compiled from X.java (version 1.4 : 48.0, super bit)";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=141830
 //compliance 1.7 source 1.5
@@ -4956,7 +4956,7 @@ public void test119() throws Exception {
 		"",
 		true);
 	String expectedOutput = "// Compiled from X.java (version 1.6 : 50.0, super bit)";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=141830
 //compliance 1.7 source 1.6
@@ -4974,7 +4974,7 @@ public void test120() throws Exception {
 		"",
 		true);
 	String expectedOutput = "// Compiled from X.java (version 1.6 : 50.0, super bit)";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=141830
 //compliance 1.7 source 1.7
@@ -4993,7 +4993,7 @@ public void test121() throws Exception {
 		"",
 		true);
 	String expectedOutput = "// Compiled from X.java (version 1.7 : 51.0, super bit)";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 }
 // command line - unusual classpath (ends with ';;;', still OK)
 public void test122_classpath(){
@@ -5279,7 +5279,7 @@ public void test144() throws Exception {
 			"Annotation processing got disabled, since it requires a 1.6 compliant JVM\n",
 			true);
 		String expectedOutput = "// Compiled from X.java (version 1.6 : 50.0, super bit)";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+		AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 	}
 }
 // reporting unnecessary declaration of thrown checked exceptions
@@ -8545,7 +8545,7 @@ public void test231_sourcepath_vs_classpath() throws IOException, InterruptedExc
 					null /* log */) == 0);
 			// compile fails as well
 		}
-		assertFalse(runJavac(commonOptions, new String[] {sourceFilePath}, OUTPUT_DIR));
+		assertFalse(AbstractRegressionTest.runJavac(commonOptions, new String[] {sourceFilePath}, OUTPUT_DIR));
 	}
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=216684

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/BatchCompilerTest2.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/BatchCompilerTest2.java
@@ -149,7 +149,7 @@ public void test004() throws Exception {
 					"",
 					true);
 	String expectedOutput = ".65535, super bit)";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 }
 public void test005() throws Exception {
 	this.runConformTest(
@@ -174,7 +174,7 @@ public void test005() throws Exception {
 					"",
 					true);
 	String expectedOutput = "65535, super bit)";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 }
 public void test006() throws Exception {
 	this.runConformTest(
@@ -199,7 +199,7 @@ public void test006() throws Exception {
 					"",
 					true);
 	String expectedOutput = "// Compiled from X.java (version 11 : 55.0, super bit)";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 }
 public void testBug540123a() throws Exception {
 	this.runConformTest(
@@ -232,7 +232,7 @@ public void testBug540123a() throws Exception {
 					"",
 					true);
 	String expectedOutput = "invokevirtual SecurePrefsRoot.node(java.lang.String) : SecurePrefs [14]";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "SecurePrefsRoot.class", "SecurePrefsRoot", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "SecurePrefsRoot.class", "SecurePrefsRoot", expectedOutput);
 }
 public void testBug540123b() throws Exception {
 	this.runConformTest(
@@ -265,7 +265,7 @@ public void testBug540123b() throws Exception {
 					"",
 					true);
 	String expectedOutput = "invokevirtual SecurePrefsRoot.node(java.lang.String) : SecurePrefs [14]";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "SecurePrefsRoot.class", "SecurePrefsRoot", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "SecurePrefsRoot.class", "SecurePrefsRoot", expectedOutput);
 }
 public void testBug540123c() throws Exception {
 	this.runConformTest(
@@ -298,7 +298,7 @@ public void testBug540123c() throws Exception {
 					"",
 					true);
 	String expectedOutput = "invokevirtual SecurePrefsRoot.node(java.lang.String) : SecurePrefs [14]";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "SecurePrefsRoot.class", "SecurePrefsRoot", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "SecurePrefsRoot.class", "SecurePrefsRoot", expectedOutput);
 }
 public void testBug540123d() throws Exception {
 	this.runConformTest(
@@ -331,7 +331,7 @@ public void testBug540123d() throws Exception {
 					"",
 					true);
 	String expectedOutput = "invokevirtual SecurePrefsRoot.node(java.lang.String) : SecurePrefs [14]";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "SecurePrefsRoot.class", "SecurePrefsRoot", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "SecurePrefsRoot.class", "SecurePrefsRoot", expectedOutput);
 }
 public void testBug540123e() throws Exception {
 	this.runConformTest(
@@ -364,7 +364,7 @@ public void testBug540123e() throws Exception {
 					"",
 					true);
 	String expectedOutput = "invokevirtual SecurePrefs.node(java.lang.String) : SecurePrefs [14]";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "SecurePrefsRoot.class", "SecurePrefsRoot", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "SecurePrefsRoot.class", "SecurePrefsRoot", expectedOutput);
 }
 public void testBug562473() {
 	this.runConformTest(
@@ -466,6 +466,6 @@ public void testIssue147() throws Exception {
 				"",
 				true);
 	String expectedOutput = "java.lang.invoke.MethodHandle.invoke(java.lang.Object)";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 }
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/BatchCompilerTest_14.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/BatchCompilerTest_14.java
@@ -81,6 +81,6 @@ public void testBatchBug565787_001() throws Exception {
 			"		#46 (Ljava/lang/Object;Ljava/lang/Object;)I\n" +
 			"		#51 X$MR.mrCompare:(Ljava/lang/String;Ljava/lang/String;)I\n" +
 			"		#52 (Ljava/lang/String;Ljava/lang/String;)I\n";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 }
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/BinaryLiteralTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/BinaryLiteralTest.java
@@ -83,8 +83,8 @@ public class BinaryLiteralTest extends AbstractRegressionTest {
 		customedOptions.put(CompilerOptions.OPTION_Compliance, CompilerOptions.VERSION_1_6);
 		customedOptions.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_1_6);
 		customedOptions.put(CompilerOptions.OPTION_TargetPlatform, CompilerOptions.VERSION_1_6);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {	\n" +
 				"	public static void main(String[] args) {\n" +
@@ -107,8 +107,8 @@ public class BinaryLiteralTest extends AbstractRegressionTest {
 		customedOptions.put(CompilerOptions.OPTION_Compliance, CompilerOptions.VERSION_1_6);
 		customedOptions.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_1_6);
 		customedOptions.put(CompilerOptions.OPTION_TargetPlatform, CompilerOptions.VERSION_1_6);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {	\n" +
 				"	public static void main(String[] args) {\n" +
@@ -131,8 +131,8 @@ public class BinaryLiteralTest extends AbstractRegressionTest {
 		customedOptions.put(CompilerOptions.OPTION_Compliance, CompilerOptions.VERSION_1_6);
 		customedOptions.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_1_6);
 		customedOptions.put(CompilerOptions.OPTION_TargetPlatform, CompilerOptions.VERSION_1_6);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {	\n" +
 				"	public static void main(String[] args) {\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/BootstrapMethodAttributeTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/BootstrapMethodAttributeTest.java
@@ -45,7 +45,7 @@ public class BootstrapMethodAttributeTest extends AbstractRegressionTest {
 	public void test001() throws Exception {
 
 			ClassFileBytesDisassembler disassembler = ToolFactory.createDefaultClassFileBytesDisassembler();
-			String path = this.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "TestBootstrapMethodAtt.class";
+			String path = AbstractRegressionTest.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "TestBootstrapMethodAtt.class";
 			byte[] classFileBytes = org.eclipse.jdt.internal.compiler.util.Util.getFileByteContent(new File(path));
 			String actualOutput =
 				disassembler.disassemble(

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/CastTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/CastTest.java
@@ -106,8 +106,8 @@ public void test001() throws Exception {
 public void test002() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnnecessaryTypeCheck, CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -147,8 +147,8 @@ public void test002() {
 public void test003() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnnecessaryTypeCheck, CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -184,8 +184,8 @@ public void test003() {
 public void test004() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnnecessaryTypeCheck, CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -222,8 +222,8 @@ public void test004() {
 public void test005() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnnecessaryTypeCheck, CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -273,8 +273,8 @@ public void test005() {
 public void _test006() { // TODO (philippe) add support to conditional expression for unnecessary cast
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnnecessaryTypeCheck, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	public static void main(String[] args) {\n" +
@@ -307,8 +307,8 @@ public void _test006() { // TODO (philippe) add support to conditional expressio
 public void test007() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnnecessaryTypeCheck, CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -363,8 +363,8 @@ public void test007() {
 public void test008() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnnecessaryTypeCheck, CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -393,8 +393,8 @@ public void test008() {
 public void test009() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnnecessaryTypeCheck, CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -428,8 +428,8 @@ public void test009() {
 public void test010() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnnecessaryTypeCheck, CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -463,8 +463,8 @@ public void test010() {
 public void test011() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnnecessaryTypeCheck, CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -493,8 +493,8 @@ public void test011() {
 public void test012() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnnecessaryTypeCheck, CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -534,8 +534,8 @@ public void test012() {
 public void test013() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnnecessaryTypeCheck, CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -573,8 +573,8 @@ public void test013() {
 public void test014() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnnecessaryTypeCheck, CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -599,8 +599,8 @@ public void test014() {
 public void test015() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnnecessaryTypeCheck, CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -630,8 +630,8 @@ public void test015() {
 public void test016() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnnecessaryTypeCheck, CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -662,8 +662,8 @@ public void test016() {
 public void test017() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnnecessaryTypeCheck, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	void bar() {\n" +
@@ -693,8 +693,8 @@ public void test017() {
 public void test018() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnnecessaryTypeCheck, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"class Y {\n" +
 			"	static Y[] foo(int[] tab) {\n" +
@@ -721,8 +721,8 @@ public void test018() {
 public void tes019() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnnecessaryTypeCheck, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	void bar() {\n" +
@@ -750,8 +750,8 @@ public void tes019() {
 public void test020() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnnecessaryTypeCheck, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	void bar() {\n" +
@@ -774,8 +774,8 @@ public void test020() {
 public void test021() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnnecessaryTypeCheck, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"p1/A.java",
 			"package p1;\n" +
 			"public class A {\n" +
@@ -851,8 +851,8 @@ public void test022() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnnecessaryTypeCheck, CompilerOptions.ERROR);
 	customOptions.put(CompilerOptions.OPTION_ReportUncheckedTypeOperation, CompilerOptions.IGNORE);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -882,8 +882,8 @@ public void test022() {
 public void test023() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnnecessaryTypeCheck, CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -917,8 +917,8 @@ public void test023() {
 public void test024() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnnecessaryTypeCheck, CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -947,8 +947,8 @@ public void test024() {
 public void test025() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnnecessaryTypeCheck, CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -1268,8 +1268,8 @@ public void test032() {
 public void test033() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnnecessaryTypeCheck, CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -1444,7 +1444,7 @@ public void test035() {
 			"}\n"
 		};
 	if (this.complianceLevel < ClassFileConstants.JDK9) {
-		runNegativeTest(sources,
+		AbstractRegressionTest.runNegativeTest(this, sources,
 			"----------\n" +
 			"1. ERROR in Test231.java (at line 9)\n" +
 			"	return	(Test231i)this;\n" +
@@ -1458,8 +1458,8 @@ public void test035() {
 	}
 }
 public void test036() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -1735,8 +1735,8 @@ public void test045() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=282869
 public void test046() {
-	this.runConformTest(
-		true,
+	AbstractRegressionTest.runConformTest(
+		this, true,
 		new String[] {
 			"X.java",
 			"public class X {\n" +
@@ -1801,8 +1801,8 @@ public void testBug418795() {
 	if (this.complianceLevel < ClassFileConstants.JDK1_5) return; // uses autoboxing
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnnecessaryTypeCheck, CompilerOptions.ERROR);
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	void foo() {\n" +
@@ -1834,8 +1834,8 @@ public void testBug329437() {
 	if (this.complianceLevel < ClassFileConstants.JDK1_5) return; // uses autoboxing
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnnecessaryTypeCheck, CompilerOptions.ERROR);
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	public static void main(String... args) {\n" +
@@ -3185,8 +3185,8 @@ public void test441731() {
 		return;
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnnecessaryTypeCheck, CompilerOptions.ERROR);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"interface MUIElement {}\n" +
 			"interface MUIElementContainer<T extends MUIElement> extends MUIElement{}\n" +
@@ -3276,8 +3276,8 @@ public void test461706() {
 		return;
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnnecessaryTypeCheck, CompilerOptions.ERROR);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"Bug.java",
 			"import java.util.ArrayList;\n" +
 			"import java.util.List;\n" +
@@ -3426,8 +3426,8 @@ public void test548647() {
 		return;
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnnecessaryTypeCheck, CompilerOptions.ERROR);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"interface MUIElement {}\n" +
 			"interface MUIElementContainer<T extends MUIElement> extends MUIElement{}\n" +
@@ -3537,8 +3537,8 @@ public void testBug561167() {
 		return;
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnnecessaryTypeCheck, CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -3576,8 +3576,8 @@ public void testBug572534() {
 		Map customOptions = getCompilerOptions();
 		customOptions.put(CompilerOptions.OPTION_ReportUnnecessaryTypeCheck, CompilerOptions.ERROR);
 		customOptions.put(CompilerOptions.OPTION_ReportSyntheticAccessEmulation, CompilerOptions.IGNORE);
-		runNegativeTest(
-			// test directory preparation
+		AbstractRegressionTest.runNegativeTest(
+			this, // test directory preparation
 			true /* flush output directory */,
 			new String[] { /* test files */
 				"X.java",

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ClassFileComparatorTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ClassFileComparatorTest.java
@@ -121,7 +121,7 @@ public class ClassFileComparatorTest extends AbstractRegressionTest {
 			compileAndDeploy(sourceA001_2, "A001_2");
 			assertTrue(!areStructurallyDifferent("A001", "A001_2", false, false));
 		} finally {
-			removeTempClass("A001");
+			AbstractRegressionTest.removeTempClass("A001");
 		}
 	}
 
@@ -146,7 +146,7 @@ public class ClassFileComparatorTest extends AbstractRegressionTest {
 			compileAndDeploy(sourceA002_2, "A002_2");
 			assertTrue(areStructurallyDifferent("A002", "A002_2", false, false));
 		} finally {
-			removeTempClass("A002");
+			AbstractRegressionTest.removeTempClass("A002");
 		}
 	}
 
@@ -164,7 +164,7 @@ public class ClassFileComparatorTest extends AbstractRegressionTest {
 			compileAndDeploy(sourceA003_2, "A003_2");
 			assertTrue(areStructurallyDifferent("A003", "A003_2", false, false));
 		} finally {
-			removeTempClass("A003");
+			AbstractRegressionTest.removeTempClass("A003");
 		}
 	}
 	public void test004() {
@@ -191,7 +191,7 @@ public class ClassFileComparatorTest extends AbstractRegressionTest {
 			compileAndDeploy(sourceA004_2, "A004_2");
 			assertTrue(!areStructurallyDifferent("A004", "A004_2", true, true));
 		} finally {
-			removeTempClass("A004");
+			AbstractRegressionTest.removeTempClass("A004");
 		}
 	}
 	public void test005() {
@@ -215,7 +215,7 @@ public class ClassFileComparatorTest extends AbstractRegressionTest {
 			compileAndDeploy(sourceA005_2, "A005_2");
 			assertTrue(areStructurallyDifferent("A005", "A005_2", true, true));
 		} finally {
-			removeTempClass("A005");
+			AbstractRegressionTest.removeTempClass("A005");
 		}
 	}
 	public void test006() {
@@ -232,7 +232,7 @@ public class ClassFileComparatorTest extends AbstractRegressionTest {
 			compileAndDeploy(sourceA006_2, "A006_2");
 			assertTrue(areStructurallyDifferent("A006", "A006_2", true, true));
 		} finally {
-			removeTempClass("A006");
+			AbstractRegressionTest.removeTempClass("A006");
 		}
 	}
 
@@ -256,7 +256,7 @@ public class ClassFileComparatorTest extends AbstractRegressionTest {
 			compileAndDeploy(sourceA007_2, "A007_2");
 			assertTrue(!areStructurallyDifferent("A007", "A007_2", true, true));
 		} finally {
-			removeTempClass("A007");
+			AbstractRegressionTest.removeTempClass("A007");
 		}
 	}
 	public void test008() {
@@ -279,7 +279,7 @@ public class ClassFileComparatorTest extends AbstractRegressionTest {
 			compileAndDeploy(sourceA008_2, "A008_2");
 			assertTrue(!areStructurallyDifferent("A008", "A008_2", true, false));
 		} finally {
-			removeTempClass("A008");
+			AbstractRegressionTest.removeTempClass("A008");
 		}
 	}
 
@@ -308,7 +308,7 @@ public class ClassFileComparatorTest extends AbstractRegressionTest {
 			compileAndDeploy(sourceA009_2, "A009_2");
 			assertTrue(areStructurallyDifferent("A009", "A009_2", true, false));
 		} finally {
-			removeTempClass("A009");
+			AbstractRegressionTest.removeTempClass("A009");
 		}
 	}
 	public void test010() {
@@ -336,7 +336,7 @@ public class ClassFileComparatorTest extends AbstractRegressionTest {
 			compileAndDeploy(sourceA010_2, "A010_2");
 			assertTrue(!areStructurallyDifferent("A010", "A010_2", true, true));
 		} finally {
-			removeTempClass("A010");
+			AbstractRegressionTest.removeTempClass("A010");
 		}
 	}
 
@@ -365,7 +365,7 @@ public class ClassFileComparatorTest extends AbstractRegressionTest {
 			compileAndDeploy(sourceA011_2, "A011_2");
 			assertTrue(!areStructurallyDifferent("A011", "A011_2", false, true));
 		} finally {
-			removeTempClass("A011");
+			AbstractRegressionTest.removeTempClass("A011");
 		}
 	}
 	public void test012() {
@@ -386,7 +386,7 @@ public class ClassFileComparatorTest extends AbstractRegressionTest {
 			compileAndDeploy(sourceA012_2, "A012_2");
 			assertTrue(areStructurallyDifferent("A012", "A012_2", false, false));
 		} finally {
-			removeTempClass("A012");
+			AbstractRegressionTest.removeTempClass("A012");
 		}
 	}
 	public void test013() {
@@ -407,7 +407,7 @@ public class ClassFileComparatorTest extends AbstractRegressionTest {
 			compileAndDeploy(sourceA013_2, "A013_2");
 			assertTrue(!areStructurallyDifferent("A013", "A013_2", false, true));
 		} finally {
-			removeTempClass("A013");
+			AbstractRegressionTest.removeTempClass("A013");
 		}
 	}
 	public void test014() {
@@ -428,7 +428,7 @@ public class ClassFileComparatorTest extends AbstractRegressionTest {
 			compileAndDeploy(sourceA014_2, "A014_2");
 			assertTrue(!areStructurallyDifferent("A014", "A014_2", true, true));
 		} finally {
-			removeTempClass("A014");
+			AbstractRegressionTest.removeTempClass("A014");
 		}
 	}
 
@@ -448,7 +448,7 @@ public class ClassFileComparatorTest extends AbstractRegressionTest {
 			compileAndDeploy(sourceA015, "A015");
 			assertTrue(!areStructurallyDifferent("A015$B", "A015$B", false, false));
 		} finally {
-			removeTempClass("A015");
+			AbstractRegressionTest.removeTempClass("A015");
 		}
 	}
 
@@ -468,7 +468,7 @@ public class ClassFileComparatorTest extends AbstractRegressionTest {
 			compileAndDeploy(sourceA016_2, "A016_2");
 			assertTrue(areStructurallyDifferent("A016", "A016_2", false, false));
 		} finally {
-			removeTempClass("A016");
+			AbstractRegressionTest.removeTempClass("A016");
 		}
 	}
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ClassFileReaderTest_17.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ClassFileReaderTest_17.java
@@ -52,7 +52,7 @@ public class ClassFileReaderTest_17 extends AbstractRegressionTest {
 				"final class Y extends X{}\n" +
 				"final class Z extends X{}\n";
 
-		org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader classFileReader = getInternalClassFile("", "X", "X", source);
+		org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader classFileReader = AbstractRegressionTest.getInternalClassFile(this, "", "X", "X", source);
 		char[][] permittedSubtypesNames = classFileReader.getPermittedSubtypeNames();
 
 		assertEquals(2, permittedSubtypesNames.length);
@@ -71,7 +71,7 @@ public class ClassFileReaderTest_17 extends AbstractRegressionTest {
 				"   }\n"+
 				"}";
 
-		org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader classFileReader = getInternalClassFile("", "X", "X", source);
+		org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader classFileReader = AbstractRegressionTest.getInternalClassFile(this, "", "X", "X", source);
 		char[][] permittedSubtypesNames = classFileReader.getPermittedSubtypeNames();
 
 		assertEquals(1, permittedSubtypesNames.length);
@@ -94,7 +94,7 @@ public class ClassFileReaderTest_17 extends AbstractRegressionTest {
 				"   }\n"+
 				"}";
 
-		org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader classFileReader = getInternalClassFile("", "X.E", "X$E", source);
+		org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader classFileReader = AbstractRegressionTest.getInternalClassFile(this, "", "X.E", "X$E", source);
 		char[][] permittedSubtypesNames = classFileReader.getPermittedSubtypeNames();
 
 		assertEquals(1, permittedSubtypesNames.length);
@@ -110,7 +110,7 @@ public class ClassFileReaderTest_17 extends AbstractRegressionTest {
 				"strictfp class X {\n"+
 				"}";
 
-		org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader classFileReader = getInternalClassFile("", "X", "X", source);
+		org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader classFileReader = AbstractRegressionTest.getInternalClassFile(this, "", "X", "X", source);
 
 		int modifiers = classFileReader.getModifiers();
 		assertTrue("strictfp modifier not expected", (modifiers & ClassFileConstants.AccStrictfp) == 0);
@@ -121,7 +121,7 @@ public class ClassFileReaderTest_17 extends AbstractRegressionTest {
 				"  strictfp void foo() {}\n"+
 				"}";
 
-		org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader classFileReader = getInternalClassFile("", "X", "X", source);
+		org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader classFileReader = AbstractRegressionTest.getInternalClassFile(this, "", "X", "X", source);
 		IBinaryMethod[] methods = classFileReader.getMethods();
 		IBinaryMethod method = methods[1];
 		int modifiers = method.getModifiers();
@@ -133,7 +133,7 @@ public class ClassFileReaderTest_17 extends AbstractRegressionTest {
 				"  void foo() {}\n"+
 				"}";
 
-		org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader classFileReader = getInternalClassFile("", "X", "X", source);
+		org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader classFileReader = AbstractRegressionTest.getInternalClassFile(this, "", "X", "X", source);
 		IBinaryMethod[] methods = classFileReader.getMethods();
 		IBinaryMethod method = methods[1];
 		int modifiers = method.getModifiers();
@@ -164,7 +164,7 @@ public class ClassFileReaderTest_17 extends AbstractRegressionTest {
 				+ "    void addValueChangeListener(HasValue.ValueChangeListener<? super E> listener);\n"
 				+ "}\n";
 
-		org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader classFileReader = getInternalClassFile("", "X", "X", source);
+		org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader classFileReader = AbstractRegressionTest.getInternalClassFile(this, "", "X", "X", source);
 		IBinaryMethod[] methods = classFileReader.getMethods();
 		IBinaryMethod method = methods[3];
 		String name = new String(method.getSelector());

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ClassFileReaderTest_1_4.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ClassFileReaderTest_1_4.java
@@ -69,7 +69,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"        [pc: 0, line: 9]\n" +
 			"      Local variable table:\n" +
 			"        [pc: 0, pc: 12] local: this index: 0 type: A001\n";
-		checkClassFile("A001", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "A001", source, expectedOutput);
 	}
 
 	/**
@@ -98,7 +98,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"        [pc: 12, line: 5]\n" +
 			"      Local variable table:\n" +
 			"        [pc: 0, pc: 13] local: args index: 0 type: java.lang.String[]\n";
-		checkClassFile("A002", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "A002", source, expectedOutput);
 	}
 
 	/**
@@ -140,7 +140,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"        [pc: 10, line: 9]\n" +
 			"      Local variable table:\n" +
 			"        [pc: 0, pc: 11] local: this index: 0 type: A003\n";
-		checkClassFile("A003", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "A003", source, expectedOutput);
 	}
 
 	/**
@@ -186,7 +186,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"        [pc: 0, pc: 23] local: args index: 0 type: java.lang.String[]\n" +
 			"        [pc: 2, pc: 23] local: b index: 1 type: boolean\n" +
 			"        [pc: 5, pc: 23] local: i index: 2 type: int\n";
-		checkClassFile("A", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "A", source, expectedOutput);
 	}
 
 	/**
@@ -224,7 +224,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"      Local variable table:\n" +
 			"        [pc: 0, pc: 17] local: args index: 0 type: java.lang.String[]\n" +
 			"        [pc: 3, pc: 17] local: i index: 1 type: int\n";
-		checkClassFile("A", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "A", source, expectedOutput);
 	}
 
 	/**
@@ -254,7 +254,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"      Local variable table:\n" +
 			"        [pc: 0, pc: 4] local: args index: 0 type: java.lang.String[]\n" +
 			"        [pc: 3, pc: 4] local: i index: 1 type: int\n";
-		checkClassFile("A", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "A", source, expectedOutput);
 	}
 
 	/**
@@ -290,7 +290,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"      Local variable table:\n" +
 			"        [pc: 0, pc: 13] local: args index: 0 type: java.lang.String[]\n" +
 			"        [pc: 2, pc: 13] local: b index: 1 type: boolean\n";
-		checkClassFile("A", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "A", source, expectedOutput);
 	}
 
 	/**
@@ -320,7 +320,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"      Local variable table:\n" +
 			"        [pc: 0, pc: 3] local: args index: 0 type: java.lang.String[]\n" +
 			"        [pc: 2, pc: 3] local: b index: 1 type: boolean\n";
-		checkClassFile("A", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "A", source, expectedOutput);
 	}
 
 	/**
@@ -366,7 +366,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"        [pc: 0, pc: 23] local: args index: 0 type: java.lang.String[]\n" +
 			"        [pc: 2, pc: 23] local: b index: 1 type: boolean\n" +
 			"        [pc: 5, pc: 23] local: i index: 2 type: int\n";
-		checkClassFile("A", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "A", source, expectedOutput);
 	}
 
 	/**
@@ -400,7 +400,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"      Local variable table:\n" +
 			"        [pc: 0, pc: 11] local: args index: 0 type: java.lang.String[]\n" +
 			"        [pc: 3, pc: 11] local: i index: 1 type: int\n";
-		checkClassFile("A", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "A", source, expectedOutput);
 	}
 
 	/**
@@ -438,7 +438,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"      Local variable table:\n" +
 			"        [pc: 0, pc: 17] local: args index: 0 type: java.lang.String[]\n" +
 			"        [pc: 3, pc: 17] local: i index: 1 type: int\n";
-		checkClassFile("A", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "A", source, expectedOutput);
 	}
 
 	/**
@@ -471,7 +471,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"      Local variable table:\n" +
 			"        [pc: 0, pc: 9] local: args index: 0 type: java.lang.String[]\n" +
 			"        [pc: 2, pc: 9] local: b index: 1 type: boolean\n";
-		checkClassFile("A", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "A", source, expectedOutput);
 	}
 
 	/**
@@ -507,7 +507,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"      Local variable table:\n" +
 			"        [pc: 0, pc: 13] local: args index: 0 type: java.lang.String[]\n" +
 			"        [pc: 2, pc: 13] local: b index: 1 type: boolean\n";
-		checkClassFile("A", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "A", source, expectedOutput);
 	}
 
 	/**
@@ -560,7 +560,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"        [pc: 0, pc: 36] local: args index: 0 type: java.lang.String[]\n" +
 			"        [pc: 2, pc: 36] local: b index: 1 type: boolean\n" +
 			"        [pc: 5, pc: 36] local: i index: 2 type: int\n";
-		checkClassFile("A", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "A", source, expectedOutput);
 	}
 
 	/**
@@ -598,7 +598,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"      Local variable table:\n" +
 			"        [pc: 0, pc: 17] local: args index: 0 type: java.lang.String[]\n" +
 			"        [pc: 3, pc: 17] local: i index: 1 type: int\n";
-		checkClassFile("A", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "A", source, expectedOutput);
 	}
 
 	/**
@@ -636,7 +636,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"      Local variable table:\n" +
 			"        [pc: 0, pc: 17] local: args index: 0 type: java.lang.String[]\n" +
 			"        [pc: 3, pc: 17] local: i index: 1 type: int\n";
-		checkClassFile("A", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "A", source, expectedOutput);
 	}
 
 	/**
@@ -672,7 +672,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"      Local variable table:\n" +
 			"        [pc: 0, pc: 13] local: args index: 0 type: java.lang.String[]\n" +
 			"        [pc: 2, pc: 13] local: b index: 1 type: boolean\n";
-		checkClassFile("A", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "A", source, expectedOutput);
 	}
 
 	/**
@@ -708,7 +708,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"      Local variable table:\n" +
 			"        [pc: 0, pc: 13] local: args index: 0 type: java.lang.String[]\n" +
 			"        [pc: 2, pc: 13] local: b index: 1 type: boolean\n";
-		checkClassFile("A", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "A", source, expectedOutput);
 	}
 
 	/**
@@ -758,7 +758,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"        [pc: 0, pc: 29] local: args index: 0 type: java.lang.String[]\n" +
 			"        [pc: 2, pc: 29] local: b index: 1 type: boolean\n" +
 			"        [pc: 5, pc: 29] local: i index: 2 type: int\n";
-		checkClassFile("A", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "A", source, expectedOutput);
 	}
 
 	/**
@@ -797,7 +797,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"      Local variable table:\n" +
 			"        [pc: 0, pc: 16] local: args index: 0 type: java.lang.String[]\n" +
 			"        [pc: 3, pc: 16] local: i index: 1 type: int\n";
-		checkClassFile("A", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "A", source, expectedOutput);
 	}
 
 	/**
@@ -834,7 +834,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"      Local variable table:\n" +
 			"        [pc: 0, pc: 15] local: args index: 0 type: java.lang.String[]\n" +
 			"        [pc: 3, pc: 15] local: i index: 1 type: int\n";
-		checkClassFile("A", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "A", source, expectedOutput);
 	}
 
 	/**
@@ -871,7 +871,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"      Local variable table:\n" +
 			"        [pc: 0, pc: 15] local: args index: 0 type: java.lang.String[]\n" +
 			"        [pc: 3, pc: 15] local: i index: 1 type: int\n";
-		checkClassFile("A", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "A", source, expectedOutput);
 	}
 
 	/**
@@ -908,7 +908,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"      Local variable table:\n" +
 			"        [pc: 0, pc: 15] local: args index: 0 type: java.lang.String[]\n" +
 			"        [pc: 3, pc: 15] local: i index: 1 type: int\n";
-		checkClassFile("A", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "A", source, expectedOutput);
 	}
 
 	/**
@@ -945,7 +945,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"      Local variable table:\n" +
 			"        [pc: 0, pc: 15] local: args index: 0 type: java.lang.String[]\n" +
 			"        [pc: 3, pc: 15] local: i index: 1 type: int\n";
-		checkClassFile("A", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "A", source, expectedOutput);
 	}
 
 	/**
@@ -984,7 +984,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"      Local variable table:\n" +
 			"        [pc: 0, pc: 16] local: args index: 0 type: java.lang.String[]\n" +
 			"        [pc: 3, pc: 16] local: i index: 1 type: int\n";
-		checkClassFile("A", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "A", source, expectedOutput);
 	}
 
 
@@ -1022,7 +1022,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"      Local variable table:\n" +
 			"        [pc: 0, pc: 15] local: args index: 0 type: java.lang.String[]\n" +
 			"        [pc: 3, pc: 15] local: i index: 1 type: int\n";
-		checkClassFile("A", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "A", source, expectedOutput);
 	}
 
 
@@ -1060,7 +1060,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"      Local variable table:\n" +
 			"        [pc: 0, pc: 15] local: args index: 0 type: java.lang.String[]\n" +
 			"        [pc: 3, pc: 15] local: i index: 1 type: int\n";
-		checkClassFile("A", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "A", source, expectedOutput);
 	}
 
 	/**
@@ -1099,7 +1099,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"      Local variable table:\n" +
 			"        [pc: 0, pc: 16] local: args index: 0 type: java.lang.String[]\n" +
 			"        [pc: 3, pc: 16] local: i index: 1 type: int\n";
-		checkClassFile("A", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "A", source, expectedOutput);
 	}
 
 	/**
@@ -1136,7 +1136,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"      Local variable table:\n" +
 			"        [pc: 0, pc: 15] local: args index: 0 type: java.lang.String[]\n" +
 			"        [pc: 3, pc: 15] local: i index: 1 type: int\n";
-		checkClassFile("A", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "A", source, expectedOutput);
 	}
 
 
@@ -1174,7 +1174,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"      Local variable table:\n" +
 			"        [pc: 0, pc: 15] local: args index: 0 type: java.lang.String[]\n" +
 			"        [pc: 3, pc: 15] local: i index: 1 type: int\n";
-		checkClassFile("A", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "A", source, expectedOutput);
 	}
 
 	/**
@@ -1213,7 +1213,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"      Local variable table:\n" +
 			"        [pc: 0, pc: 16] local: args index: 0 type: java.lang.String[]\n" +
 			"        [pc: 3, pc: 16] local: i index: 1 type: int\n";
-		checkClassFile("A", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "A", source, expectedOutput);
 	}
 
 	/**
@@ -1252,7 +1252,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"      Local variable table:\n" +
 			"        [pc: 0, pc: 16] local: args index: 0 type: java.lang.String[]\n" +
 			"        [pc: 3, pc: 16] local: i index: 1 type: int\n";
-		checkClassFile("A", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "A", source, expectedOutput);
 	}
 
 	/**
@@ -1306,7 +1306,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"        [pc: 0, pc: 37] local: args index: 0 type: java.lang.String[]\n" +
 			"        [pc: 2, pc: 37] local: b index: 1 type: boolean\n" +
 			"        [pc: 5, pc: 37] local: i index: 2 type: int\n";
-		checkClassFile("A", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "A", source, expectedOutput);
 	}
 
 	/**
@@ -1344,7 +1344,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"      Local variable table:\n" +
 			"        [pc: 0, pc: 17] local: args index: 0 type: java.lang.String[]\n" +
 			"        [pc: 3, pc: 17] local: i index: 1 type: int\n";
-		checkClassFile("A", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "A", source, expectedOutput);
 	}
 
 	/**
@@ -1374,7 +1374,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"      Local variable table:\n" +
 			"        [pc: 0, pc: 4] local: args index: 0 type: java.lang.String[]\n" +
 			"        [pc: 3, pc: 4] local: i index: 1 type: int\n";
-		checkClassFile("A", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "A", source, expectedOutput);
 	}
 
 	/**
@@ -1410,7 +1410,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"      Local variable table:\n" +
 			"        [pc: 0, pc: 13] local: args index: 0 type: java.lang.String[]\n" +
 			"        [pc: 2, pc: 13] local: b index: 1 type: boolean\n";
-		checkClassFile("A", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "A", source, expectedOutput);
 	}
 
 	/**
@@ -1440,7 +1440,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"      Local variable table:\n" +
 			"        [pc: 0, pc: 3] local: args index: 0 type: java.lang.String[]\n" +
 			"        [pc: 2, pc: 3] local: b index: 1 type: boolean\n";
-		checkClassFile("A", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "A", source, expectedOutput);
 	}
 
 	/**
@@ -1494,7 +1494,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"        [pc: 0, pc: 37] local: args index: 0 type: java.lang.String[]\n" +
 			"        [pc: 2, pc: 37] local: b index: 1 type: boolean\n" +
 			"        [pc: 5, pc: 37] local: i index: 2 type: int\n";
-		checkClassFile("A", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "A", source, expectedOutput);
 	}
 
 	/**
@@ -1528,7 +1528,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"      Local variable table:\n" +
 			"        [pc: 0, pc: 11] local: args index: 0 type: java.lang.String[]\n" +
 			"        [pc: 3, pc: 11] local: i index: 1 type: int\n";
-		checkClassFile("A", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "A", source, expectedOutput);
 	}
 
 	/**
@@ -1566,7 +1566,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"      Local variable table:\n" +
 			"        [pc: 0, pc: 17] local: args index: 0 type: java.lang.String[]\n" +
 			"        [pc: 3, pc: 17] local: i index: 1 type: int\n";
-		checkClassFile("A", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "A", source, expectedOutput);
 	}
 
 	/**
@@ -1599,7 +1599,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"      Local variable table:\n" +
 			"        [pc: 0, pc: 9] local: args index: 0 type: java.lang.String[]\n" +
 			"        [pc: 2, pc: 9] local: b index: 1 type: boolean\n";
-		checkClassFile("A", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "A", source, expectedOutput);
 	}
 
 	/**
@@ -1635,7 +1635,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"      Local variable table:\n" +
 			"        [pc: 0, pc: 13] local: args index: 0 type: java.lang.String[]\n" +
 			"        [pc: 2, pc: 13] local: b index: 1 type: boolean\n";
-		checkClassFile("A", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "A", source, expectedOutput);
 	}
 
 	/**
@@ -1689,7 +1689,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"        [pc: 0, pc: 37] local: args index: 0 type: java.lang.String[]\n" +
 			"        [pc: 2, pc: 37] local: b index: 1 type: boolean\n" +
 			"        [pc: 5, pc: 37] local: i index: 2 type: int\n";
-		checkClassFile("A", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "A", source, expectedOutput);
 	}
 
 	/**
@@ -1727,7 +1727,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"      Local variable table:\n" +
 			"        [pc: 0, pc: 17] local: args index: 0 type: java.lang.String[]\n" +
 			"        [pc: 3, pc: 17] local: i index: 1 type: int\n";
-		checkClassFile("A", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "A", source, expectedOutput);
 	}
 
 	/**
@@ -1765,7 +1765,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"      Local variable table:\n" +
 			"        [pc: 0, pc: 17] local: args index: 0 type: java.lang.String[]\n" +
 			"        [pc: 3, pc: 17] local: i index: 1 type: int\n";
-		checkClassFile("A", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "A", source, expectedOutput);
 	}
 
 	/**
@@ -1801,7 +1801,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"      Local variable table:\n" +
 			"        [pc: 0, pc: 13] local: args index: 0 type: java.lang.String[]\n" +
 			"        [pc: 2, pc: 13] local: b index: 1 type: boolean\n";
-		checkClassFile("A", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "A", source, expectedOutput);
 	}
 
 	/**
@@ -1837,7 +1837,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"      Local variable table:\n" +
 			"        [pc: 0, pc: 13] local: args index: 0 type: java.lang.String[]\n" +
 			"        [pc: 2, pc: 13] local: b index: 1 type: boolean\n";
-		checkClassFile("A", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "A", source, expectedOutput);
 	}
 
 	public void test048() throws Exception {
@@ -1899,7 +1899,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"        [pc: 0, pc: 30] local: bool index: 0 type: boolean\n" +
 			"        [pc: 11, pc: 14] local: j index: 1 type: int\n" +
 			"        [pc: 23, pc: 30] local: j index: 1 type: int\n";
-		checkClassFile("A", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "A", source, expectedOutput);
 	}
 
 	public void test049() throws Exception {
@@ -1927,7 +1927,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"        [pc: 2, line: 10]\n" +
 			"      Local variable table:\n" +
 			"        [pc: 2, pc: 3] local: i index: 0 type: int\n";
-		checkClassFile("X", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "X", source, expectedOutput);
 	}
 
 	public void test050() throws Exception {
@@ -1960,7 +1960,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"        [pc: 9, line: 11]\n" +
 			"      Local variable table:\n" +
 			"        [pc: 2, pc: 10] local: i index: 0 type: int\n";
-		checkClassFile("X", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "X", source, expectedOutput);
 	}
 
 	public void test051() throws Exception {
@@ -1989,7 +1989,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"        [pc: 3, line: 11]\n" +
 			"      Local variable table:\n" +
 			"        [pc: 3, pc: 4] local: i index: 0 type: int\n";
-		checkClassFile("X", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "X", source, expectedOutput);
 	}
 
 	public void test052() throws Exception {
@@ -2021,7 +2021,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"        [pc: 10, line: 10]\n" +
 			"      Local variable table:\n" +
 			"        [pc: 3, pc: 11] local: i index: 0 type: int\n";
-		checkClassFile("X", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "X", source, expectedOutput);
 	}
 
 	public void test053() throws Exception {
@@ -2058,7 +2058,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"        [pc: 12, line: 13]\n" +
 			"      Local variable table:\n" +
 			"        [pc: 2, pc: 13] local: i index: 0 type: int\n";
-		checkClassFile("X", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "X", source, expectedOutput);
 	}
 
 	public void test054() throws Exception {
@@ -2100,7 +2100,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"        [pc: 19, line: 14]\n" +
 			"      Local variable table:\n" +
 			"        [pc: 2, pc: 20] local: i index: 0 type: int\n";
-		checkClassFile("X", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "X", source, expectedOutput);
 	}
 
 	public void test055() throws Exception {
@@ -2138,7 +2138,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"        [pc: 13, line: 14]\n" +
 			"      Local variable table:\n" +
 			"        [pc: 3, pc: 14] local: i index: 0 type: int\n";
-		checkClassFile("X", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "X", source, expectedOutput);
 	}
 
 	public void test056() throws Exception {
@@ -2179,7 +2179,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"        [pc: 20, line: 13]\n" +
 			"      Local variable table:\n" +
 			"        [pc: 3, pc: 21] local: i index: 0 type: int\n";
-		checkClassFile("X", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "X", source, expectedOutput);
 	}
 
 	public void test057() throws Exception {
@@ -2207,7 +2207,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"        [pc: 2, line: 10]\n" +
 			"      Local variable table:\n" +
 			"        [pc: 2, pc: 3] local: i index: 0 type: int\n";
-		checkClassFile("X", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "X", source, expectedOutput);
 	}
 
 	public void test058() throws Exception {
@@ -2240,7 +2240,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"        [pc: 9, line: 11]\n" +
 			"      Local variable table:\n" +
 			"        [pc: 2, pc: 10] local: i index: 0 type: int\n";
-		checkClassFile("X", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "X", source, expectedOutput);
 	}
 
 	public void test059() throws Exception {
@@ -2269,7 +2269,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"        [pc: 3, line: 11]\n" +
 			"      Local variable table:\n" +
 			"        [pc: 3, pc: 4] local: i index: 0 type: int\n";
-		checkClassFile("X", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "X", source, expectedOutput);
 	}
 
 	public void test060() throws Exception {
@@ -2301,7 +2301,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"        [pc: 10, line: 10]\n" +
 			"      Local variable table:\n" +
 			"        [pc: 3, pc: 11] local: i index: 0 type: int\n";
-		checkClassFile("X", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "X", source, expectedOutput);
 	}
 
 	public void test061() throws Exception {
@@ -2332,7 +2332,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"        [pc: 2, line: 13]\n" +
 			"      Local variable table:\n" +
 			"        [pc: 2, pc: 3] local: i index: 0 type: int\n";
-		checkClassFile("X", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "X", source, expectedOutput);
 	}
 
 	public void test062() throws Exception {
@@ -2368,7 +2368,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"        [pc: 9, line: 14]\n" +
 			"      Local variable table:\n" +
 			"        [pc: 2, pc: 10] local: i index: 0 type: int\n";
-		checkClassFile("X", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "X", source, expectedOutput);
 	}
 
 	public void test063() throws Exception {
@@ -2400,7 +2400,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"        [pc: 3, line: 14]\n" +
 			"      Local variable table:\n" +
 			"        [pc: 3, pc: 4] local: i index: 0 type: int\n";
-		checkClassFile("X", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "X", source, expectedOutput);
 	}
 
 	public void test064() throws Exception {
@@ -2435,7 +2435,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"        [pc: 10, line: 13]\n" +
 			"      Local variable table:\n" +
 			"        [pc: 3, pc: 11] local: i index: 0 type: int\n";
-		checkClassFile("X", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "X", source, expectedOutput);
 	}
 
 	public void test065() throws Exception {
@@ -2472,7 +2472,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"        [pc: 12, line: 13]\n" +
 			"      Local variable table:\n" +
 			"        [pc: 2, pc: 13] local: i index: 0 type: int\n";
-		checkClassFile("X", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "X", source, expectedOutput);
 	}
 
 	public void test066() throws Exception {
@@ -2514,7 +2514,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"        [pc: 19, line: 14]\n" +
 			"      Local variable table:\n" +
 			"        [pc: 2, pc: 20] local: i index: 0 type: int\n";
-		checkClassFile("X", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "X", source, expectedOutput);
 	}
 
 	public void test067() throws Exception {
@@ -2552,7 +2552,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"        [pc: 13, line: 14]\n" +
 			"      Local variable table:\n" +
 			"        [pc: 3, pc: 14] local: i index: 0 type: int\n";
-		checkClassFile("X", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "X", source, expectedOutput);
 	}
 
 	public void test068() throws Exception {
@@ -2593,7 +2593,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"        [pc: 20, line: 13]\n" +
 			"      Local variable table:\n" +
 			"        [pc: 3, pc: 21] local: i index: 0 type: int\n";
-		checkClassFile("X", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "X", source, expectedOutput);
 	}
 
 	/**
@@ -2614,7 +2614,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"    constant #5 utf8: \"SourceFile\"\n" +
 			"    constant #6 utf8: \"I.java\"\n" +
 			"}";
-		checkClassFile("I", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "I", source, expectedOutput);
 	}
 
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=111219
@@ -2689,7 +2689,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"  \n" +
 			"  abstract java.lang.String foo12();\n" +
 			"}";
-		checkClassFile("p", "X", source, expectedOutput, ClassFileBytesDisassembler.WORKING_COPY);
+		AbstractRegressionTest.checkClassFile(this, "p", "X", source, expectedOutput, ClassFileBytesDisassembler.WORKING_COPY);
 	}
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=111219
 	public void test073() throws Exception {
@@ -2706,7 +2706,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"  X(X x) {\n" +
 			"  }\n" +
 			"}";
-		checkClassFile("", "X", source, expectedOutput, ClassFileBytesDisassembler.WORKING_COPY);
+		AbstractRegressionTest.checkClassFile(this, "", "X", source, expectedOutput, ClassFileBytesDisassembler.WORKING_COPY);
 	}
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=111219
 	public void test074() throws Exception {
@@ -2725,7 +2725,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"  X(X x) {\n" +
 			"  }\n" +
 			"}";
-		checkClassFile("p", "X", source, expectedOutput, ClassFileBytesDisassembler.WORKING_COPY | ClassFileBytesDisassembler.COMPACT);
+		AbstractRegressionTest.checkClassFile(this, "p", "X", source, expectedOutput, ClassFileBytesDisassembler.WORKING_COPY | ClassFileBytesDisassembler.COMPACT);
 	}
 
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=111219
@@ -2745,7 +2745,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"  X(X x) {\n" +
 			"  }\n" +
 			"}";
-		checkClassFile("p", "X", source, expectedOutput, ClassFileBytesDisassembler.WORKING_COPY | ClassFileBytesDisassembler.COMPACT);
+		AbstractRegressionTest.checkClassFile(this, "p", "X", source, expectedOutput, ClassFileBytesDisassembler.WORKING_COPY | ClassFileBytesDisassembler.COMPACT);
 	}
 
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=111219
@@ -2763,7 +2763,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 		String expectedOutput =
 			"      Exception Table:\n" +
 			"        [pc: 0, pc: 8] -> 11 when : Exception\n";
-		checkClassFile("", "X", source, expectedOutput, ClassFileBytesDisassembler.DETAILED | ClassFileBytesDisassembler.COMPACT);
+		AbstractRegressionTest.checkClassFile(this, "", "X", source, expectedOutput, ClassFileBytesDisassembler.DETAILED | ClassFileBytesDisassembler.COMPACT);
 	}
 
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=34373
@@ -2775,7 +2775,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"}";
 		String expectedOutput =
 			"private static class p.X$A {\n";
-		checkClassFile("p", "X", "X$A", source, expectedOutput, ClassFileBytesDisassembler.DETAILED | ClassFileBytesDisassembler.COMPACT, false);
+		AbstractRegressionTest.checkClassFile(this, "p", "X", "X$A", source, expectedOutput, ClassFileBytesDisassembler.DETAILED | ClassFileBytesDisassembler.COMPACT, false);
 	}
 
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=102473
@@ -2785,7 +2785,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"	X(int i, int j) {}\n" +
 			"	void foo(String s, double d) {}\n" +
 			"}";
-		org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader classFileReader = getInternalClassFile("", "X", "X", source);
+		org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader classFileReader = AbstractRegressionTest.getInternalClassFile(this, "", "X", "X", source);
 		IBinaryMethod[] methodInfos = classFileReader.getMethods();
 		assertNotNull("No method infos", methodInfos);
 		int length = methodInfos.length;
@@ -2820,7 +2820,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"		}\n" +
 			"	}\n" +
 			"}";
-		org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader classFileReader = getInternalClassFile("", "X", "X", source);
+		org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader classFileReader = AbstractRegressionTest.getInternalClassFile(this, "", "X", "X", source);
 		IBinaryMethod[] methodInfos = classFileReader.getMethods();
 		assertNotNull("No method infos", methodInfos);
 		int length = methodInfos.length;
@@ -2856,7 +2856,7 @@ public class ClassFileReaderTest_1_4 extends AbstractRegressionTest {
 			"		}\n" +
 			"	}\n" +
 			"}";
-		org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader classFileReader = getInternalClassFile("", "X", "X", source);
+		org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader classFileReader = AbstractRegressionTest.getInternalClassFile(this, "", "X", "X", source);
 		IBinaryMethod[] methodInfos = classFileReader.getMethods();
 		assertNotNull("No method infos", methodInfos);
 		int length = methodInfos.length;

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ClassFileReaderTest_1_5.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ClassFileReaderTest_1_5.java
@@ -49,7 +49,7 @@ public class ClassFileReaderTest_1_5 extends AbstractRegressionTest {
 	 * @deprecated
 	 */
 	private void checkClassFileUsingInputStream(String directoryName, String className, String source, String expectedOutput, int mode) throws IOException {
-		compileAndDeploy(source, directoryName, className, false);
+		AbstractRegressionTest.compileAndDeploy(this, source, directoryName, className, false);
 		BufferedInputStream inputStream = null;
 		try {
 			File directory = new File(EVAL_DIRECTORY, directoryName);
@@ -76,7 +76,7 @@ public class ClassFileReaderTest_1_5 extends AbstractRegressionTest {
 					// ignore
 				}
 			}
-			removeTempClass(className);
+			AbstractRegressionTest.removeTempClass(className);
 		}
 	}
 
@@ -104,7 +104,7 @@ public class ClassFileReaderTest_1_5 extends AbstractRegressionTest {
 			"        [pc: 0, pc: 1] local: l index: 2 type: long\n" +
 			"        [pc: 0, pc: 1] local: args index: 4 type: java.lang.String[][][]\n" +
 			"}";
-		checkClassFile("X", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "X", source, expectedOutput);
 	}
 
 	/**
@@ -135,7 +135,7 @@ public class ClassFileReaderTest_1_5 extends AbstractRegressionTest {
 			"    18  invokevirtual long[].clone() : java.lang.Object [22]\n" +
 			"    21  invokevirtual java.io.PrintStream.println(java.lang.Object) : void [28]\n" +
 			"    24  return\n";
-		checkClassFile("X", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "X", source, expectedOutput);
 	}
 
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=111420
@@ -163,7 +163,7 @@ public class ClassFileReaderTest_1_5 extends AbstractRegressionTest {
 			"    return null;\n" +
 			"  }\n" +
 			"}";
-		checkClassFile("", "Y", source, expectedOutput, ClassFileBytesDisassembler.WORKING_COPY | ClassFileBytesDisassembler.COMPACT);
+		AbstractRegressionTest.checkClassFile(this, "", "Y", source, expectedOutput, ClassFileBytesDisassembler.WORKING_COPY | ClassFileBytesDisassembler.COMPACT);
 	}
 
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=111420
@@ -191,7 +191,7 @@ public class ClassFileReaderTest_1_5 extends AbstractRegressionTest {
 			"    return null;\n" +
 			"  }\n" +
 			"}";
-		checkClassFile("", "Y", source, expectedOutput, ClassFileBytesDisassembler.WORKING_COPY);
+		AbstractRegressionTest.checkClassFile(this, "", "Y", source, expectedOutput, ClassFileBytesDisassembler.WORKING_COPY);
 	}
 
 	/**
@@ -217,7 +217,7 @@ public class ClassFileReaderTest_1_5 extends AbstractRegressionTest {
 			"        [pc: 0, pc: 1] local: l index: 1 type: long\n" +
 			"        [pc: 0, pc: 1] local: args index: 3 type: java.lang.String[][][]\n" +
 			"}";
-		checkClassFile("X", source, expectedOutput);
+		AbstractRegressionTest.checkClassFile(this, "X", source, expectedOutput);
 	}
 	/**
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=111494
@@ -243,7 +243,7 @@ public class ClassFileReaderTest_1_5 extends AbstractRegressionTest {
 			"  private X(int i) {\n" +
 			"  }\n" +
 			"}";
-		checkClassFile("", "X", source, expectedOutput, ClassFileBytesDisassembler.WORKING_COPY);
+		AbstractRegressionTest.checkClassFile(this, "", "X", source, expectedOutput, ClassFileBytesDisassembler.WORKING_COPY);
 	}
 
 	/**
@@ -287,7 +287,7 @@ public class ClassFileReaderTest_1_5 extends AbstractRegressionTest {
 			"  \n" +
 			"  public abstract java.lang.String colorName();\n" +
 			"}";
-		checkClassFile("", "X", source, expectedOutput, ClassFileBytesDisassembler.WORKING_COPY);
+		AbstractRegressionTest.checkClassFile(this, "", "X", source, expectedOutput, ClassFileBytesDisassembler.WORKING_COPY);
 	}
 
 	/**
@@ -331,7 +331,7 @@ public class ClassFileReaderTest_1_5 extends AbstractRegressionTest {
 			"  private X(int i) {\n" +
 			"  }\n" +
 			"}";
-		checkClassFile("", "X", source, expectedOutput, ClassFileBytesDisassembler.WORKING_COPY);
+		AbstractRegressionTest.checkClassFile(this, "", "X", source, expectedOutput, ClassFileBytesDisassembler.WORKING_COPY);
 	}
 
 	/**
@@ -350,7 +350,7 @@ public class ClassFileReaderTest_1_5 extends AbstractRegressionTest {
 			"  \n" +
 			"  public abstract java.lang.String lastName() default \"Smith\";\n" +
 			"}";
-		checkClassFile("", "X", source, expectedOutput, ClassFileBytesDisassembler.WORKING_COPY);
+		AbstractRegressionTest.checkClassFile(this, "", "X", source, expectedOutput, ClassFileBytesDisassembler.WORKING_COPY);
 	}
 
 	/**
@@ -412,7 +412,7 @@ public class ClassFileReaderTest_1_5 extends AbstractRegressionTest {
 			"      #11 value=java.lang.annotation.RetentionPolicy.RUNTIME(enum type #13.#14)\n" +
 			"    )\n" +
 			"}";
-		checkClassFile("", "X", source, expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkClassFile(this, "", "X", source, expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 	/**
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=203609
@@ -428,7 +428,7 @@ public class ClassFileReaderTest_1_5 extends AbstractRegressionTest {
 			expectedOutput = "abstract synthetic interface p.package-info {\n" +
 			"}";
 		}
-		checkClassFile("p", "package-info", source, expectedOutput, ClassFileBytesDisassembler.DEFAULT);
+		AbstractRegressionTest.checkClassFile(this, "p", "package-info", source, expectedOutput, ClassFileBytesDisassembler.DEFAULT);
 	}
 	/**
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=217907
@@ -469,7 +469,7 @@ public class ClassFileReaderTest_1_5 extends AbstractRegressionTest {
 			"      #11 value=RetentionPolicy.RUNTIME(enum type #13.#14)\n" +
 			"    )\n" +
 			"}";
-		checkClassFile("", "X", source, expectedOutput, ClassFileBytesDisassembler.SYSTEM | ClassFileBytesDisassembler.COMPACT);
+		AbstractRegressionTest.checkClassFile(this, "", "X", source, expectedOutput, ClassFileBytesDisassembler.SYSTEM | ClassFileBytesDisassembler.COMPACT);
 	}
 	/**
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=217907
@@ -489,7 +489,7 @@ public class ClassFileReaderTest_1_5 extends AbstractRegressionTest {
 			"public abstract @interface X extends Annotation {\n" +
 			"\n" +
 			"}";
-		checkClassFile("", "X", source, expectedOutput, ClassFileBytesDisassembler.DETAILED | ClassFileBytesDisassembler.COMPACT);
+		AbstractRegressionTest.checkClassFile(this, "", "X", source, expectedOutput, ClassFileBytesDisassembler.DETAILED | ClassFileBytesDisassembler.COMPACT);
 	}
 	/**
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=217910
@@ -507,7 +507,7 @@ public class ClassFileReaderTest_1_5 extends AbstractRegressionTest {
 			"}";
 		String expectedOutput =
 			"  public void foo(@Deprecated @Annot(value=(int) 2) int i);";
-		checkClassFile("", "X", source, expectedOutput, ClassFileBytesDisassembler.DETAILED | ClassFileBytesDisassembler.COMPACT);
+		AbstractRegressionTest.checkClassFile(this, "", "X", source, expectedOutput, ClassFileBytesDisassembler.DETAILED | ClassFileBytesDisassembler.COMPACT);
 	}
 	/**
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=286405
@@ -521,7 +521,7 @@ public class ClassFileReaderTest_1_5 extends AbstractRegressionTest {
 			"";
 		String expectedOutput =
 			"  public abstract char test2() default \'\\u0000\';";
-		checkClassFile("", "MonAnnotation", source, expectedOutput, ClassFileBytesDisassembler.DETAILED | ClassFileBytesDisassembler.COMPACT);
+		AbstractRegressionTest.checkClassFile(this, "", "MonAnnotation", source, expectedOutput, ClassFileBytesDisassembler.DETAILED | ClassFileBytesDisassembler.COMPACT);
 	}
 
 	public void testBug504031() throws Exception {
@@ -616,7 +616,7 @@ public class ClassFileReaderTest_1_5 extends AbstractRegressionTest {
 				"    )\n" +
 				"}";
 		int mode = ClassFileBytesDisassembler.DETAILED | ClassFileBytesDisassembler.COMPACT | ClassFileBytesDisassembler.SYSTEM;
-		checkClassFile("test", "AllTests", "AllTests", source, expectedOutput, mode, true/*suppress expected errors*/);
+		AbstractRegressionTest.checkClassFile(this, "test", "AllTests", "AllTests", source, expectedOutput, mode, true/*suppress expected errors*/);
 	}
 
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ClassFileReaderTest_1_8.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ClassFileReaderTest_1_8.java
@@ -65,7 +65,7 @@ public class ClassFileReaderTest_1_8 extends AbstractRegressionTest {
 			"        int iii() default -1;\n" +
 			"}";
 
-		org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader classFileReader = getInternalClassFile("", "X", "X", source);
+		org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader classFileReader = AbstractRegressionTest.getInternalClassFile(this, "", "X", "X", source);
 
 		IBinaryTypeAnnotation[] typeAnnotations = classFileReader.getTypeAnnotations();
 		assertEquals(2,typeAnnotations.length);
@@ -88,7 +88,7 @@ public class ClassFileReaderTest_1_8 extends AbstractRegressionTest {
 			"        int iii() default -1;\n" +
 			"}";
 
-		org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader classFileReader = getInternalClassFile("", "X", "X", source);
+		org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader classFileReader = AbstractRegressionTest.getInternalClassFile(this, "", "X", "X", source);
 
 		IBinaryTypeAnnotation[] typeAnnotations = classFileReader.getTypeAnnotations();
 		assertEquals(2,typeAnnotations.length);
@@ -113,7 +113,7 @@ public class ClassFileReaderTest_1_8 extends AbstractRegressionTest {
 			"        int value() default -1;\n" +
 			"}";
 
-		org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader cfr = getInternalClassFile("", "X", "X", source);
+		org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader cfr = AbstractRegressionTest.getInternalClassFile(this, "", "X", "X", source);
 
 		IBinaryMethod method = getMethod(cfr,"foo");
 		assertNotNull(method);
@@ -140,7 +140,7 @@ public class ClassFileReaderTest_1_8 extends AbstractRegressionTest {
 			"        int iii() default -1;\n" +
 			"}";
 
-		org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader classFileReader = getInternalClassFile("", "X", "X", source);
+		org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader classFileReader = AbstractRegressionTest.getInternalClassFile(this, "", "X", "X", source);
 
 		IBinaryTypeAnnotation[] typeAnnotations = classFileReader.getTypeAnnotations();
 		assertEquals(3,typeAnnotations.length);
@@ -166,7 +166,7 @@ public class ClassFileReaderTest_1_8 extends AbstractRegressionTest {
 			"        int iii() default -1;\n" +
 			"}";
 
-		org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader classFileReader = getInternalClassFile("", "X", "X", source);
+		org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader classFileReader = AbstractRegressionTest.getInternalClassFile(this, "", "X", "X", source);
 
 		IBinaryTypeAnnotation[] typeAnnotations = classFileReader.getTypeAnnotations();
 		assertEquals(3,typeAnnotations.length);
@@ -190,7 +190,7 @@ public class ClassFileReaderTest_1_8 extends AbstractRegressionTest {
 			"        int value() default -1;\n" +
 			"}";
 
-		org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader classFileReader = getInternalClassFile("", "X", "X", source);
+		org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader classFileReader = AbstractRegressionTest.getInternalClassFile(this, "", "X", "X", source);
 
 		IBinaryTypeAnnotation[] typeAnnotations = classFileReader.getTypeAnnotations();
 		assertEquals(4,typeAnnotations.length);
@@ -218,7 +218,7 @@ public class ClassFileReaderTest_1_8 extends AbstractRegressionTest {
 			"        int value() default -1;\n" +
 			"}";
 
-		org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader cfr = getInternalClassFile("", "X", "X", source);
+		org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader cfr = AbstractRegressionTest.getInternalClassFile(this, "", "X", "X", source);
 
 		IBinaryMethod method = getMethod(cfr,"foo");
 		assertNotNull(method);
@@ -250,7 +250,7 @@ public class ClassFileReaderTest_1_8 extends AbstractRegressionTest {
 			"        int value() default -1;\n" +
 			"}";
 
-		org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader cfr = getInternalClassFile("", "X", "X", source);
+		org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader cfr = AbstractRegressionTest.getInternalClassFile(this, "", "X", "X", source);
 
 		IBinaryField field = getField(cfr,"field3");
 		assertNotNull(field);
@@ -287,7 +287,7 @@ public class ClassFileReaderTest_1_8 extends AbstractRegressionTest {
 			"        int value() default -1;\n" +
 			"}";
 
-		org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader cfr = getInternalClassFile("", "X", "X", source);
+		org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader cfr = AbstractRegressionTest.getInternalClassFile(this, "", "X", "X", source);
 
 		IBinaryMethod method = getMethod(cfr,"foo");
 		assertNotNull(method);
@@ -323,7 +323,7 @@ public class ClassFileReaderTest_1_8 extends AbstractRegressionTest {
 			"        int value() default -1;\n" +
 			"}";
 
-		org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader cfr = getInternalClassFile("", "X", "X", source);
+		org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader cfr = AbstractRegressionTest.getInternalClassFile(this, "", "X", "X", source);
 
 		IBinaryMethod method = getMethod(cfr,"foo");
 		assertNotNull(method);
@@ -350,7 +350,7 @@ public class ClassFileReaderTest_1_8 extends AbstractRegressionTest {
 			"        int value() default -1;\n" +
 			"}";
 
-		org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader cfr = getInternalClassFile("", "X", "X", source);
+		org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader cfr = AbstractRegressionTest.getInternalClassFile(this, "", "X", "X", source);
 
 		IBinaryMethod method = getMethod(cfr,"foo");
 		assertNotNull(method);
@@ -378,7 +378,7 @@ public class ClassFileReaderTest_1_8 extends AbstractRegressionTest {
 			"        int value() default -1;\n" +
 			"}";
 
-		org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader cfr = getInternalClassFile("", "X", "X", source);
+		org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader cfr = AbstractRegressionTest.getInternalClassFile(this, "", "X", "X", source);
 
 		IBinaryMethod method = getMethod(cfr,"foo");
 		assertNotNull(method);
@@ -407,7 +407,7 @@ public class ClassFileReaderTest_1_8 extends AbstractRegressionTest {
 			"        int value() default -1;\n" +
 			"}";
 
-		org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader cfr = getInternalClassFile("", "X", "X", source);
+		org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader cfr = AbstractRegressionTest.getInternalClassFile(this, "", "X", "X", source);
 
 		IBinaryMethod method = getMethod(cfr,"foo");
 		assertNotNull(method);
@@ -450,7 +450,7 @@ public class ClassFileReaderTest_1_8 extends AbstractRegressionTest {
 		String[] libs = getDefaultClassPaths();
 		int len = libs.length;
 		System.arraycopy(libs, 0, libs = new String[len+1], 0, len);
-		libs[libs.length-1] = this.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "Test548596.jar";
+		libs[libs.length-1] = AbstractRegressionTest.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "Test548596.jar";
 
 		runConformTest(
 			new String[] {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/CompilerInvocationTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/CompilerInvocationTests.java
@@ -204,7 +204,7 @@ public class CompilerInvocationTests extends AbstractRegressionTest {
 		if (customOptions != null) {
 			options.putAll(customOptions);
 		}
-		this.runConformTest(testFiles, "", null /* no extra class libraries */, true /* flush output directory */,
+		AbstractRegressionTest.runConformTest(this, testFiles, "", null /* no extra class libraries */, true /* flush output directory */,
 				null, /* no VM args */
 				options, reader, true /* skip javac */);
 		String tags = taskTagsAsStrings(reader.result.tasks);

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/Compliance_1_3.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/Compliance_1_3.java
@@ -574,7 +574,7 @@ public void test021() {
 		},
 		"AbstractB.init()"); // no special vm args
 
-		String computedReferences = findReferences(OUTPUT_DIR + "/p1/Z.class");
+		String computedReferences = AbstractRegressionTest.findReferences(OUTPUT_DIR + "/p1/Z.class");
 		boolean check =
 			computedReferences.indexOf("ref/p1") >= 0
 			&& computedReferences.indexOf("ref/AbstractB") >= 0
@@ -1199,8 +1199,8 @@ public void test036() {
 public void test037() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_TaskTags, "TODO:");
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"p/X.java",
 			"package p;	\n"+
 			"public class X {\n"+
@@ -1225,8 +1225,8 @@ public void test037() {
 public void test038() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_TaskTags, "TODO:");
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"// TODO: something"
 		},
@@ -3191,8 +3191,8 @@ public void test098() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=77349
 public void test099() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"I.java",
 			"public interface I extends Cloneable {\n" +
 			"	class Inner {\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/Compliance_1_4.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/Compliance_1_4.java
@@ -558,7 +558,7 @@ public void test021() {
 		"AbstractB.init()"); // no special vm args
 
 		// check that "new Z().init()" is bound to "Z.init()"
-		String computedReferences = findReferences(OUTPUT_DIR + "/p1/Z.class");
+		String computedReferences = AbstractRegressionTest.findReferences(OUTPUT_DIR + "/p1/Z.class");
 		boolean check =
 			computedReferences.indexOf("constructorRef/Z/0") >= 0
 			&& computedReferences.indexOf("methodRef/init/0") >= 0;
@@ -1186,8 +1186,8 @@ public void test036() {
 public void test037() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_TaskTags, "TODO:");
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"p/X.java",
 			"package p;	\n"+
 			"public class X {\n"+
@@ -1214,8 +1214,8 @@ public void test037() {
 public void test038() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_TaskTags, "TODO:");
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"// TODO: something"
 		},

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/Compliance_1_5.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/Compliance_1_5.java
@@ -291,8 +291,8 @@ public void test013() {
 		+"*8* this.bar(): Top.bar()"
 		+"*9* this.foo(): Top.foo()");
 
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		false /* do not flush output directory */,
 		new String[] { /* test files */
 			"p1/Updated.java",
@@ -569,7 +569,7 @@ public void test021() {
 		"AbstractB.init()"); // no special vm args
 
 		// check that "new Z().init()" is bound to "Z.init()"
-		String computedReferences = findReferences(OUTPUT_DIR + "/p1/Z.class");
+		String computedReferences = AbstractRegressionTest.findReferences(OUTPUT_DIR + "/p1/Z.class");
 		boolean check =
 			computedReferences.indexOf("constructorRef/Z/0") >= 0
 			&& computedReferences.indexOf("methodRef/init/0") >= 0;
@@ -1207,8 +1207,8 @@ public void test036() {
 public void test037() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_TaskTags, "TODO:");
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"p/X.java",
@@ -1243,8 +1243,8 @@ public void test037() {
 public void test038() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_TaskTags, "TODO:");
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -1837,8 +1837,8 @@ public void test054() {
 	);
 }
 public void test055() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"p/X.java",
@@ -1966,8 +1966,8 @@ public void test058() {
 }
 
 public void test059() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"p/FieldQualification.java",
@@ -2037,8 +2037,8 @@ public void test060() {
  * http://bugs.eclipse.org/bugs/show_bug.cgi?id=32342
  */
 public void test061() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"p/X.java", //======================
@@ -2616,8 +2616,8 @@ public void test075() {
  */
 public void test076() {
 	this.docSupport = true;
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"IX.java",
 			"interface IX {\n" +
 				"	public static class Problem extends Exception {}\n" +
@@ -2912,8 +2912,8 @@ public void test084() {
  * Test unused import with static
  */
 public void test085() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"A.java",
@@ -3540,8 +3540,8 @@ public void test104() {
 
 // enclosing instance - note that the behavior is different in 1.3 and 1.4
 public void test105() {
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"    static class Y { }\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/Compliance_1_6.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/Compliance_1_6.java
@@ -44,8 +44,8 @@ public void test1() {
 	options.put(CompilerOptions.OPTION_Compliance, CompilerOptions.VERSION_1_6);
 	options.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_1_5);
 	options.put(CompilerOptions.OPTION_TargetPlatform, CompilerOptions.VERSION_1_5);
-	this.runConformTest(
-			new String[] {
+	AbstractRegressionTest.runConformTest(
+			this, new String[] {
 					"Test.java",
 					"public class Test {\n" +
 					"	public interface MyInterface {\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/Compliance_1_7.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/Compliance_1_7.java
@@ -55,7 +55,7 @@ public void test1() {
 		},
 		""); // no special vm args
 
-		String computedReferences = findReferences(OUTPUT_DIR + "/p1/Z.class");
+		String computedReferences = AbstractRegressionTest.findReferences(OUTPUT_DIR + "/p1/Z.class");
 		boolean check = computedReferences.indexOf("annotationRef/SafeVarargs") >= 0;
 		if (!check){
 			System.out.println(computedReferences);
@@ -74,7 +74,7 @@ public void test2() {
 		},
 		""); // no special vm args
 
-		String computedReferences = findReferences(OUTPUT_DIR + "/p2/Z.class");
+		String computedReferences = AbstractRegressionTest.findReferences(OUTPUT_DIR + "/p2/Z.class");
 		boolean check = computedReferences.indexOf("annotationRef/Inherited") >= 0;
 		if (!check){
 			System.out.println(computedReferences);
@@ -88,8 +88,8 @@ public void testBug390889_a() {
 	options.put(CompilerOptions.OPTION_Compliance, CompilerOptions.VERSION_1_7);
 	options.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_1_7);
 	options.put(CompilerOptions.OPTION_TargetPlatform, CompilerOptions.VERSION_1_7);
-	this.runConformTest(
-			new String[] {
+	AbstractRegressionTest.runConformTest(
+			this, new String[] {
 					"MyComp.java",
 					"import java.util.Comparator;\n" +
 					"public class MyComp implements Comparator {\n" +
@@ -133,8 +133,8 @@ public void testBug390889_b() {
 	options.put(CompilerOptions.OPTION_Compliance, CompilerOptions.VERSION_1_7);
 	options.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_1_7);
 	options.put(CompilerOptions.OPTION_TargetPlatform, CompilerOptions.VERSION_1_7);
-	this.runConformTest(
-			new String[] {
+	AbstractRegressionTest.runConformTest(
+			this, new String[] {
 					"C1.java",
 					"public class C1 implements I1 {\n" +
 					"}\n"
@@ -163,8 +163,8 @@ public void testBug390889_c() {
 	options.put(CompilerOptions.OPTION_Compliance, CompilerOptions.VERSION_1_7);
 	options.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_1_7);
 	options.put(CompilerOptions.OPTION_TargetPlatform, CompilerOptions.VERSION_1_7);
-	this.runConformTest(
-			new String[] {
+	AbstractRegressionTest.runConformTest(
+			this, new String[] {
 				"CI.java",
 				"public class CI implements I {\n" +
 				"	 void test(I i) {\n" +
@@ -189,8 +189,8 @@ public void testBug490988() {
 	options.put(CompilerOptions.OPTION_Compliance, CompilerOptions.VERSION_1_7);
 	options.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_1_7);
 	options.put(CompilerOptions.OPTION_TargetPlatform, CompilerOptions.VERSION_1_7);
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"Thing.java",
 				"import java.util.Comparator;\n" +
 				"import java.util.Iterator;\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/Compliance_CLDC.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/Compliance_CLDC.java
@@ -215,7 +215,7 @@ public void test002() throws Exception {
 		"        [pc: 173, full, stack: {java.io.PrintStream, java.lang.Class}, locals: {java.lang.String[]}]\n" +
 		"        [pc: 180, full, stack: {java.io.PrintStream}, locals: {java.lang.String[]}]\n" +
 		"        [pc: 181, full, stack: {java.io.PrintStream, int}, locals: {java.lang.String[]}]\n";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 }
 public void test003() throws Exception {
 	this.runConformTest(
@@ -265,7 +265,7 @@ public void test003() throws Exception {
 		"        [pc: 13, full, stack: {java.io.PrintStream}, locals: {java.lang.String[]}]\n" +
 		"        [pc: 14, full, stack: {java.io.PrintStream, int}, locals: {java.lang.String[]}]\n" +
 		"}";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 }
 public void test004() {
 	this.runConformTest(

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ConditionalExpressionTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ConditionalExpressionTest.java
@@ -516,8 +516,8 @@ public class ConditionalExpressionTest extends AbstractRegressionTest {
 			return;
 		Map<String,String> options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_ReportDeprecation, CompilerOptions.IGNORE);
-		this.runNegativeTest(
-				new String[] {
+		AbstractRegressionTest.runNegativeTest(
+				this, new String[] {
 						"X.java",
 						"import java.util.Collection;\n" +
 						"import java.util.List;\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/Deprecated15Test.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/Deprecated15Test.java
@@ -34,8 +34,8 @@ public static Test suite() {
 public void test001() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportRawTypeReference, CompilerOptions.WARNING);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"p/X.java",
 			"package p;\n" +
 			"/**\n" +
@@ -118,8 +118,8 @@ public void test002() {
 	Map customOptions = new HashMap();
 	customOptions.put(CompilerOptions.OPTION_ReportDeprecation, CompilerOptions.ERROR);
 	customOptions.put(CompilerOptions.OPTION_ReportNullReference, CompilerOptions.IGNORE);
-	this.runNegativeTest(
-		true,
+	AbstractRegressionTest.runNegativeTest(
+		this, true,
 		new String[] {
 			"p/M1.java",
 			"package p;\n" +
@@ -167,8 +167,8 @@ public void test002() {
 public void test003() {
 	Map customOptions = new HashMap();
 	customOptions.put(CompilerOptions.OPTION_ReportDeprecation, CompilerOptions.ERROR);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"class X {\n" +
 			"  void foo() {\n" +
@@ -196,8 +196,8 @@ public void test003() {
 public void test004() {
 	Map customOptions = new HashMap();
 	customOptions.put(CompilerOptions.OPTION_ReportDeprecation, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		true,
+	AbstractRegressionTest.runNegativeTest(
+		this, true,
 		new String[] {
 			"test1/E01.java",
 			"package test1;\n" +
@@ -232,8 +232,8 @@ public void test004() {
 public void test005() {
 	Map customOptions = new HashMap();
 	customOptions.put(CompilerOptions.OPTION_ReportDeprecation, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		true,
+	AbstractRegressionTest.runNegativeTest(
+		this, true,
 		new String[] {
 			"p1/X.java",
 			"package p1;\n" +
@@ -276,8 +276,8 @@ public void test005() {
 public void test006() {
 	Map customOptions = new HashMap();
 	customOptions.put(CompilerOptions.OPTION_ReportDeprecation, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		true,
+	AbstractRegressionTest.runNegativeTest(
+		this, true,
 		new String[] {
 			"test1/E02.java",
 			"package test1;\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/Deprecated18Test.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/Deprecated18Test.java
@@ -30,8 +30,8 @@ public static Test suite() {
 public void test412555() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportDeprecation, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		false /* skipJavac */,
+	AbstractRegressionTest.runNegativeTest(
+		this, false /* skipJavac */,
 		JavacTestOptions.Excuse.EclipseWarningConfiguredAsError,
 		new String[] {
 			"X.java",
@@ -63,8 +63,8 @@ public void test412555() {
 public void testGH1370() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportDeprecation, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		false /* skipJavac */,
+	AbstractRegressionTest.runNegativeTest(
+		this, false /* skipJavac */,
 		JavacTestOptions.Excuse.EclipseWarningConfiguredAsError,
 		new String[] {
 			"X.java",

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/Deprecated9Test.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/Deprecated9Test.java
@@ -59,8 +59,8 @@ public class Deprecated9Test extends AbstractRegressionTest9 {
 		customOptions.put(JavaCore.COMPILER_PB_DEPRECATION, CompilerOptions.WARNING);
 		customOptions.put(JavaCore.COMPILER_PB_TERMINAL_DEPRECATION, CompilerOptions.ERROR);
 		customOptions.put(CompilerOptions.OPTION_ReportNullReference, CompilerOptions.IGNORE);
-		this.runNegativeTest(
-			true,
+		AbstractRegressionTest.runNegativeTest(
+			this, true,
 			new String[] {
 				"p/M1.java",
 				"package p;\n" +
@@ -161,8 +161,8 @@ public class Deprecated9Test extends AbstractRegressionTest9 {
 		Map<String, String> customOptions = new HashMap<>();
 		customOptions.put(JavaCore.COMPILER_PB_DEPRECATION, CompilerOptions.WARNING);
 		customOptions.put(JavaCore.COMPILER_PB_TERMINAL_DEPRECATION, CompilerOptions.ERROR);
-		this.runNegativeTest(
-			true,
+		AbstractRegressionTest.runNegativeTest(
+			this, true,
 			new String[] {
 				"test1/E01.java",
 				"package test1;\n" +
@@ -198,8 +198,8 @@ public class Deprecated9Test extends AbstractRegressionTest9 {
 		Map<String, String> customOptions = new HashMap<>();
 		customOptions.put(CompilerOptions.OPTION_ReportDeprecation, CompilerOptions.WARNING);
 		customOptions.put(CompilerOptions.OPTION_ReportTerminalDeprecation, CompilerOptions.ERROR);
-		this.runNegativeTest(
-			true,
+		AbstractRegressionTest.runNegativeTest(
+			this, true,
 			new String[] {
 				"p1/X.java",
 				"package p1;\n" +
@@ -242,8 +242,8 @@ public class Deprecated9Test extends AbstractRegressionTest9 {
 		Map<String, String> customOptions = new HashMap<>();
 		customOptions.put(CompilerOptions.OPTION_ReportDeprecation, CompilerOptions.WARNING);
 		customOptions.put(CompilerOptions.OPTION_ReportTerminalDeprecation, CompilerOptions.IGNORE);
-		this.runConformTest(
-			new String[] {
+		AbstractRegressionTest.runConformTest(
+			this, new String[] {
 				"p1/X.java",
 				"package p1;\n" +
 				"public class X {\n" +
@@ -336,8 +336,8 @@ public class Deprecated9Test extends AbstractRegressionTest9 {
 		customOptions.put(CompilerOptions.OPTION_ReportDeprecation, CompilerOptions.WARNING);
 		customOptions.put(CompilerOptions.OPTION_ReportTerminalDeprecation, CompilerOptions.ERROR);
 		customOptions.put(CompilerOptions.OPTION_ReportDeprecationWhenOverridingDeprecatedMethod, CompilerOptions.ENABLED);
-		this.runNegativeTest(
-			true,
+		AbstractRegressionTest.runNegativeTest(
+			this, true,
 			new String[] {
 				"p1/X.java",
 				"package p1;\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/DeprecatedTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/DeprecatedTest.java
@@ -55,7 +55,7 @@ protected void tearDown() throws Exception {
 protected INameEnvironment getNameEnvironment(final String[] testFiles, String[] classPaths, Map<String, String> options) {
 	// constructs a name environment that is able to hide a type of name 'this.invisibleType':
 	this.classpaths = classPaths == null ? getDefaultClassPaths() : classPaths;
-	return new InMemoryNameEnvironment(testFiles, getClassLibs(classPaths == null, options)) {
+	return new InMemoryNameEnvironment(testFiles, AbstractRegressionTest.getClassLibs(this, classPaths == null, options)) {
 		@Override
 		public NameEnvironmentAnswer findType(char[][] compoundTypeName) {
 			if (DeprecatedTest.this.invisibleType != null && CharOperation.equals(DeprecatedTest.this.invisibleType, compoundTypeName))
@@ -221,8 +221,8 @@ public void test004() {
 		"----------\n");
 }
 public void test005() {
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 		  "public class X {\n"
 			+ "/**\n"
@@ -241,8 +241,8 @@ public void test005() {
 		null, // special vm args
 		null,  // custom options
 		null); // custom requestor
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"A.java",
 			"public class A extends X.Y {}"
 		},
@@ -258,8 +258,8 @@ public void test005() {
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=40839
 public void test006() {
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	/**\n" +
@@ -278,8 +278,8 @@ public void test006() {
 		null, // special vm args
 		null,  // custom options
 		null); // custom requestor
-		runConformTest(
-			// test directory preparation
+		AbstractRegressionTest.runConformTest(
+			this, // test directory preparation
 	 		false /* do not flush output directory */,
 			new String[] { /* test files */
 				"A.java",
@@ -344,8 +344,8 @@ public void test008() {
 			"}\n",
 		},
 		"");
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"Y.java",
 			"/**\n" +
 			" * @deprecated\n" +
@@ -441,8 +441,8 @@ public void test009() {
 public void test010() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_DocCommentSupport, CompilerOptions.ENABLED);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
             "X.java",
             "/**\n" +
             " * @deprecated\n" +
@@ -514,8 +514,8 @@ public void test012() {
 		CompilerOptions.ERROR);
 	customOptions.put(CompilerOptions.OPTION_ReportDeprecationInDeprecatedCode,
 		CompilerOptions.IGNORE);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
             "X.java",
@@ -558,8 +558,8 @@ public void test013() {
 			CompilerOptions.ERROR);
 		customOptions.put(CompilerOptions.OPTION_ReportDeprecationInDeprecatedCode,
 			CompilerOptions.IGNORE);
-		runNegativeTest(
-			// test directory preparation
+		AbstractRegressionTest.runNegativeTest(
+			this, // test directory preparation
 			true /* flush output directory */,
 			new String[] { /* test files */
 	            "X.java",
@@ -656,8 +656,8 @@ public void test015() {
 	Map customOptions = new HashMap();
 	customOptions.put(CompilerOptions.OPTION_ReportDeprecation, CompilerOptions.ERROR);
 	customOptions.put(CompilerOptions.OPTION_ReportNullReference, CompilerOptions.IGNORE);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"p/M1.java",
@@ -708,8 +708,8 @@ public void test016() {
 	Map customOptions = new HashMap();
 	customOptions.put(CompilerOptions.OPTION_ReportDeprecation, CompilerOptions.ERROR);
 	customOptions.put(CompilerOptions.OPTION_ReportNullReference, CompilerOptions.IGNORE);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"a/N1.java",
@@ -761,8 +761,8 @@ public void test017() {
 	Map customOptions = new HashMap();
 	customOptions.put(CompilerOptions.OPTION_ReportDeprecation, CompilerOptions.ERROR);
 	customOptions.put(CompilerOptions.OPTION_ReportDeprecationInDeprecatedCode, CompilerOptions.ERROR);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"a/N1.java",
 			"package a;\n" +
 			"public class N1 {\n" +
@@ -794,8 +794,8 @@ public void test018() {
 	customOptions.put(CompilerOptions.OPTION_ReportDeprecation, CompilerOptions.ERROR);
 	customOptions.put(CompilerOptions.OPTION_ReportDeprecationInDeprecatedCode, CompilerOptions.ERROR);
 	customOptions.put(CompilerOptions.OPTION_ReportNullReference, CompilerOptions.IGNORE);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"a/N1.java",
 			"package a;\n" +
 			"public class N1 {\n" +
@@ -814,8 +814,8 @@ public void test018() {
 		customOptions,
 		null,
 		false);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		false /* do not flush output directory */,
 		new String[] { /* test files */
 			"p/M1.java",
@@ -854,8 +854,8 @@ public void test018() {
 public void test019() {
 	Map customOptions = new HashMap();
 	customOptions.put(CompilerOptions.OPTION_ReportDeprecation, CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"test1/E01.java",
@@ -895,8 +895,8 @@ public void test019() {
 public void test020() {
 	Map customOptions = new HashMap();
 	customOptions.put(CompilerOptions.OPTION_ReportDeprecation, CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"a.b.c.d/Deprecated.java",

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/EnclosingMethodAttributeTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/EnclosingMethodAttributeTest.java
@@ -168,7 +168,7 @@ public class EnclosingMethodAttributeTest extends AbstractComparableTest {
 			"enclosing class = class X\n" +
 			"enclosing method = public void X.test() throws java.lang.NoSuchMethodException,java.lang.IllegalAccessException,java.lang.reflect.InvocationTargetException");
 
-		INameEnvironment nameEnvironment = getNameEnvironment(new String[]{}, null);
+		INameEnvironment nameEnvironment = AbstractRegressionTest.getNameEnvironment(this, new String[]{}, null);
 		nameEnvironment.findType(new char[][] {new char[0], "X$1LocalClass".toCharArray()});
 		ClassFileBytesDisassembler disassembler = ToolFactory.createDefaultClassFileBytesDisassembler();
 		byte[] classFileBytes = org.eclipse.jdt.internal.compiler.util.Util.getFileByteContent(new File(OUTPUT_DIR + File.separator  + "X$1LocalClass.class"));
@@ -246,14 +246,14 @@ public class EnclosingMethodAttributeTest extends AbstractComparableTest {
 		CompilerOptions compilerOptions = new CompilerOptions(options);
 		compilerOptions.performMethodsFullRecovery = true;
 		compilerOptions.performStatementsRecovery = true;
-		INameEnvironment nameEnvironment = getNameEnvironment(new String[]{}, null);
+		INameEnvironment nameEnvironment = AbstractRegressionTest.getNameEnvironment(this, new String[]{}, null);
 		Compiler batchCompiler =
 			new Compiler(
 				nameEnvironment,
-				getErrorHandlingPolicy(),
+				AbstractRegressionTest.getErrorHandlingPolicy(),
 				compilerOptions,
 				requestor,
-				getProblemFactory());
+				AbstractRegressionTest.getProblemFactory());
 		ReferenceBinding binaryType = batchCompiler.lookupEnvironment.askForType(new char[][] {new char[0], "X$1".toCharArray()}, batchCompiler.lookupEnvironment.UnNamedModule);
 		assertNotNull("Should not be null", binaryType);
 	}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/EnumTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/EnumTest.java
@@ -1057,8 +1057,8 @@ public void test033() {
 	);
 }
 public void test034() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"E.java",
 			"	/**\n" +
 				"	 * Invalid javadoc\n" +
@@ -1110,8 +1110,8 @@ public void test035() {
 	);
 }
 public void test036() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"E.java",
 			"	/**\n" +
 				"	 * @see \"invalid\" no text allowed after the string\n" +
@@ -1159,8 +1159,8 @@ public void test037() {
 }
 public void test038() {
 	this.reportMissingJavadocComments = CompilerOptions.ERROR;
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"E.java",
 			"public enum E { TEST, VALID;\n" +
 			"	public void foo() {}\n" +
@@ -1191,8 +1191,8 @@ public void test038() {
 	);
 }
 public void test039() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"E.java",
 			"public enum E {\n" +
 				"	/**\n" +
@@ -1255,8 +1255,8 @@ public void test040() {
 	);
 }
 public void test041() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"E.java",
 			"public enum E {\n" +
 				"	/**\n" +
@@ -1848,8 +1848,8 @@ public void test061() {
 public void test062() {
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_SWITCH_MISSING_DEFAULT_CASE, JavaCore.WARNING);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public enum X {\n" +
 			"	A, B, C;\n" +
@@ -3266,8 +3266,8 @@ to refer to itself or an enum constant of the same type that is declared to
 the right of e1."
 	*/
 public void test100() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public enum X {\n" +
 			"\n" +
@@ -3471,8 +3471,8 @@ public void test105() {
 		null
 	);
 
-	executeClass(
-		"pack/X.java",
+	AbstractRegressionTest.executeClass(
+		this, "pack/X.java",
 		"Black",
 		null,
 		false,
@@ -3485,8 +3485,8 @@ public void test105() {
 public void test106() {
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_INCOMPLETE_ENUM_SWITCH, JavaCore.IGNORE);
-	this.runConformTest(
-			new String[] {
+	AbstractRegressionTest.runConformTest(
+			this, new String[] {
 				"pack/X.java",
 				"package pack;\n" +
 				"import static pack.Color.*;\n" +
@@ -3522,8 +3522,8 @@ public void test106() {
 		null
 	);
 
-	executeClass(
-		"pack/X.java",
+	AbstractRegressionTest.executeClass(
+		this, "pack/X.java",
 		"SUCCESS",
 		null,
 		false,
@@ -3535,8 +3535,8 @@ public void test106() {
 public void test107() {
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_INCOMPLETE_ENUM_SWITCH, JavaCore.IGNORE);
-	this.runConformTest(
-			new String[] {
+	AbstractRegressionTest.runConformTest(
+			this, new String[] {
 				"pack/X.java",
 				"package pack;\n" +
 				"import static pack.Color.*;\n" +
@@ -3585,8 +3585,8 @@ public void test107() {
 		null
 	);
 
-	executeClass(
-		"pack/X.java",
+	AbstractRegressionTest.executeClass(
+		this, "pack/X.java",
 		"BlackBlack",
 		null,
 		false,
@@ -3599,8 +3599,8 @@ public void test107() {
 public void test108() {
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_INCOMPLETE_ENUM_SWITCH, JavaCore.IGNORE);
-	this.runConformTest(
-			new String[] {
+	AbstractRegressionTest.runConformTest(
+			this, new String[] {
 				"pack/X.java",
 				"package pack;\n" +
 				"import static pack.Color.*;\n" +
@@ -3644,8 +3644,8 @@ public void test108() {
 		null
 	);
 
-	executeClass(
-		"pack/X.java",
+	AbstractRegressionTest.executeClass(
+		this, "pack/X.java",
 		"Black",
 		null,
 		false,
@@ -3658,8 +3658,8 @@ public void test108() {
 public void test109() {
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_INCOMPLETE_ENUM_SWITCH, JavaCore.IGNORE);
-	this.runConformTest(
-			new String[] {
+	AbstractRegressionTest.runConformTest(
+			this, new String[] {
 				"pack/X.java",
 				"package pack;\n" +
 				"import static pack.Color.*;\n" +
@@ -3706,8 +3706,8 @@ public void test109() {
 		null
 	);
 
-	executeClass(
-		"pack/X.java",
+	AbstractRegressionTest.executeClass(
+		this, "pack/X.java",
 		"SUCCESS",
 		null,
 		false,
@@ -3720,8 +3720,8 @@ public void test109() {
 public void test110() {
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_INCOMPLETE_ENUM_SWITCH, JavaCore.IGNORE);
-	this.runConformTest(
-			new String[] {
+	AbstractRegressionTest.runConformTest(
+			this, new String[] {
 				"pack/X.java",
 				"package pack;\n" +
 				"import static pack.Color.*;\n" +
@@ -3764,8 +3764,8 @@ public void test110() {
 		null
 	);
 
-	executeClass(
-		"pack/X.java",
+	AbstractRegressionTest.executeClass(
+		this, "pack/X.java",
 		"Black",
 		null,
 		false,
@@ -3828,8 +3828,8 @@ public void test111() {
 		null
 	);
 
-	executeClass(
-		"pack/X.java",
+	AbstractRegressionTest.executeClass(
+		this, "pack/X.java",
 		"BlackBlack",
 		null,
 		false,
@@ -3842,8 +3842,8 @@ public void test111() {
 public void test112() {
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_INCOMPLETE_ENUM_SWITCH, JavaCore.IGNORE);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"com/annot/Foo.java",
 			"package com.annot;\n" +
 			"\n" +
@@ -4211,8 +4211,8 @@ public void test119() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=102213
 public void test120() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public enum X {\n" +
 			"\n" +
@@ -4462,8 +4462,8 @@ public void test128() {
 	options.put(CompilerOptions.OPTION_ReportRawTypeReference, CompilerOptions.IGNORE);
 	options.put(CompilerOptions.OPTION_ReportMissingSerialVersion, CompilerOptions.IGNORE);
 
-	this.runNegativeTest(
-         new String[] {
+	AbstractRegressionTest.runNegativeTest(
+         this, new String[] {
         		 "X.java",
         		 "public class X {\n" +
         		 "	public static void main( String[] args) {\n" +
@@ -4656,8 +4656,8 @@ public void test130() {
 		null
 	);
 
-	executeClass(
-		"X.java",
+	AbstractRegressionTest.executeClass(
+		this, "X.java",
 		"12default",
 		null,
 		false,
@@ -4778,8 +4778,8 @@ public void test133() throws Exception {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=149042
 public void test134() {
-    this.runNegativeTest(
-        new String[] {
+    AbstractRegressionTest.runNegativeTest(
+        this, new String[] {
             "X.java",
 			"public enum X {\n" +
 			"    INITIAL ,\n" +
@@ -5178,8 +5178,8 @@ public void test144() {
 public void test145() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportNonStaticAccessToStatic, CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"EnumA.java",
@@ -5248,8 +5248,8 @@ public void test146() {
 public void test146b() {
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_SWITCH_MISSING_DEFAULT_CASE, JavaCore.WARNING);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"	enum MyEnum {\n" +
@@ -5286,8 +5286,8 @@ public void test146b() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=227502
 public void test147() {
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 					"p/X.java",
 					"package p;\n" +
 					"public class X {\n" +
@@ -5308,8 +5308,8 @@ public void test147() {
 			true, // generate output
 			false,
 			false);
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		false /* do not flush output directory */,
 		new String[] { /* test files */
 			"Y.java",
@@ -5330,8 +5330,8 @@ public void test147() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=227502 - variation
 public void test148() {
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 					"p/X.java",
 					"package p;\n" +
 					"public class X {\n" +
@@ -5357,8 +5357,8 @@ public void test148() {
 			true, // generate output
 			false,
 			false);
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		false /* do not flush output directory */,
 		new String[] { /* test files */
 			"Y.java",
@@ -5519,8 +5519,8 @@ public void test152() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=228109
 public void test153() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 				"TestEnum.java",
 				"public enum TestEnum {\n" +
 				"	RED, GREEN, BLUE; \n" +
@@ -5541,8 +5541,8 @@ public void test153() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=228109 - variation
 public void test154() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 				"TestEnum2.java",
 				"public enum TestEnum2 {\n" +
 				"	; \n" +
@@ -5605,8 +5605,8 @@ public void test156() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=228109 - variation
 public void test157() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 				"Foo.java",
 				"enum Foo {\n" +
 				"	ONE, TWO, THREE;\n" +
@@ -6017,8 +6017,8 @@ public void test165() throws Exception {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=251814
 public void test166() throws Exception {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java", // =================
 			"public enum X {\n" +
 			"        ;\n" +
@@ -6076,12 +6076,12 @@ public void test166() throws Exception {
 		"        [pc: 0, pc: 10] local: this index: 0 type: X\n" +
 		"}";
 
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=251814 - variation
 public void test167() throws Exception {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java", // =================
 			"public enum X {\n" +
 			"    ;\n" +
@@ -6121,8 +6121,8 @@ public void test167() throws Exception {
 		false,
 		false);
 	// check consistency of problem when incremental compiling against X problemType
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 				"Other.java",// =================
 				"public class Other {\n" +
 				"    void foo() {\n" +
@@ -6327,8 +6327,8 @@ public void test170() {
 public void test171() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.WARNING);
-	this.runConformTest(
-		true,
+	AbstractRegressionTest.runConformTest(
+		this, true,
 		new String[] {
 			"X.java",
 			"public class X { \n" +
@@ -6357,8 +6357,8 @@ public void test171() {
 public void test172() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.WARNING);
-	this.runConformTest(
-		true,
+	AbstractRegressionTest.runConformTest(
+		this, true,
 		new String[] {
 			"X.java",
 			"public class X { \n" +
@@ -6500,8 +6500,8 @@ public void test176() {
 	);
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_Process_Annotations, CompilerOptions.ENABLED);
-	this.runConformTest(
-		false,
+	AbstractRegressionTest.runConformTest(
+		this, false,
 		new String[] {
 			"Y.java",
 			"public class Y {\n" +
@@ -6547,8 +6547,8 @@ public void test177() {
 	);
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_Process_Annotations, CompilerOptions.ENABLED);
-	this.runConformTest(
-		false,
+	AbstractRegressionTest.runConformTest(
+		this, false,
 		new String[] {
 			"Y.java",
 			"public class Y {\n" +
@@ -6595,8 +6595,8 @@ public void test178() {
 	);
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_Process_Annotations, CompilerOptions.ENABLED);
-	this.runConformTest(
-		false,
+	AbstractRegressionTest.runConformTest(
+		this, false,
 		new String[] {
 			"Z.java",
 			"public class Z {\n" +
@@ -6643,8 +6643,8 @@ public void test179() {
 	);
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_Process_Annotations, CompilerOptions.ENABLED);
-	this.runConformTest(
-		false,
+	AbstractRegressionTest.runConformTest(
+		this, false,
 		new String[] {
 			"Z.java",
 			"public class Z {\n" +
@@ -6697,8 +6697,8 @@ public void test180() {
 	if(this.complianceLevel >= ClassFileConstants.JDK16) {
 		excuse = null;
 	}
-	this.runConformTest(
-		false,
+	AbstractRegressionTest.runConformTest(
+		this, false,
 		new String[] {
 			"X.java",
 			"import test180.Test;\n" +
@@ -6721,8 +6721,8 @@ public void test180() {
 public void test180a() {
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_ANNOTATION_NULL_ANALYSIS, JavaCore.ENABLED);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"p/package-info.java",
 			"@p.Annot(state=p.MyEnum.BROKEN)\n" +
 			"package p;",
@@ -6761,8 +6761,8 @@ public void test180a() {
 	if(this.complianceLevel >= ClassFileConstants.JDK16) {
 		excuse = null;
 	}
-	this.runConformTest(
-		false,
+	AbstractRegressionTest.runConformTest(
+		this, false,
 		new String[] {
 			"X.java",
 			"import test180.Test;\n" +
@@ -6809,8 +6809,8 @@ public void test182() throws Exception {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedLocal, CompilerOptions.ERROR);
 	customOptions.put(CompilerOptions.OPTION_PreserveUnusedLocal, CompilerOptions.OPTIMIZE_OUT);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	public static void main(String argv[])   {\n" +
@@ -6850,8 +6850,8 @@ public void test183() throws Exception {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedLocal, CompilerOptions.ERROR);
 	customOptions.put(CompilerOptions.OPTION_PreserveUnusedLocal, CompilerOptions.OPTIMIZE_OUT);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	public static void main(String argv[]) {\n" +
@@ -6890,8 +6890,8 @@ public void test184() throws Exception {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedLocal, CompilerOptions.ERROR);
 	customOptions.put(CompilerOptions.OPTION_PreserveUnusedLocal, CompilerOptions.OPTIMIZE_OUT);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	public static void main(String argv[]) {\n" +
@@ -6953,8 +6953,8 @@ public void test185() {
 public void test186() {
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_MISSING_ENUM_CASE_DESPITE_DEFAULT, JavaCore.ENABLED);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"Y.java",
 			"enum X {\n" +
 			"  A, B;\n" +
@@ -6990,8 +6990,8 @@ public void test187() {
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_MISSING_ENUM_CASE_DESPITE_DEFAULT, JavaCore.ENABLED);
 	options.put(JavaCore.COMPILER_PB_INCOMPLETE_ENUM_SWITCH, JavaCore.ERROR);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"Y.java",
 			"enum X {\n" +
 			"  A, B;\n" +
@@ -7018,8 +7018,8 @@ public void test187() {
 public void test187a() {
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_MISSING_ENUM_CASE_DESPITE_DEFAULT, JavaCore.ENABLED);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"Y.java",
 			"enum X {\n" +
 			"  A, B;\n" +
@@ -7055,8 +7055,8 @@ public void test187b() {
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_SWITCH_MISSING_DEFAULT_CASE, JavaCore.ERROR);
 	options.put(JavaCore.COMPILER_PB_SUPPRESS_OPTIONAL_ERRORS, JavaCore.ENABLED);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"Y.java",
 			"enum X {\n" +
 			"  A, B;\n" +
@@ -7081,8 +7081,8 @@ public void test187b() {
 public void test188() {
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_SWITCH_MISSING_DEFAULT_CASE, JavaCore.WARNING);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"Y.java",
 			"enum X {\n" +
 			"  A, B;\n" +
@@ -7117,8 +7117,8 @@ public void test188() {
 public void test189() {
 	Map options = getCompilerOptions();
 	//options.put(JavaCore.COMPILER_PB_MISSING_DEFAULT_CASE, JavaCore.WARNING);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"Y.java",
 			"enum X {\n" +
 			"  A, B;\n" +
@@ -7147,8 +7147,8 @@ public void test189() {
 public void test433060() {
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_REDUNDANT_TYPE_ARGUMENTS, JavaCore.ERROR);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public enum X<T> {\n" +
 			"	OBJ;\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ExpressionContextTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ExpressionContextTests.java
@@ -265,8 +265,8 @@ public void test008() {
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=399773, [1.8][compiler] Cast expression should allow for additional bounds to form intersection types
 public void test009() {
-	this.runNegativeTest(
-			false /* skipJavac */,
+	AbstractRegressionTest.runNegativeTest(
+			this, false /* skipJavac */,
 			JavacTestOptions.Excuse.EclipseHasSomeMoreWarnings,
 			new String[] {
 				"X.java",
@@ -507,8 +507,8 @@ public void test017() {
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=399778, [1.8][compiler] Conditional operator expressions should propagate target types
 public void test018() {
-	this.runNegativeTest(
-			false /* skipJavac */,
+	AbstractRegressionTest.runNegativeTest(
+			this, false /* skipJavac */,
 			JavacTestOptions.Excuse.EclipseHasSomeMoreWarnings,
 			new String[] {
 				"X.java",
@@ -531,8 +531,8 @@ public void test018() {
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=399778, [1.8][compiler] Conditional operator expressions should propagate target types
 public void test019() {
-	this.runNegativeTest(
-			false /* skipJavac */,
+	AbstractRegressionTest.runNegativeTest(
+			this, false /* skipJavac */,
 			JavacTestOptions.Excuse.EclipseHasSomeMoreWarnings,
 			new String[] {
 				"X.java",

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ExternalizeStringLiteralsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ExternalizeStringLiteralsTest.java
@@ -38,8 +38,8 @@ public static Test suite() {
 public void test001() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportNonExternalizedStringLiteral, CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"A.java",
@@ -71,8 +71,8 @@ public void test001() {
 public void test002() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportNonExternalizedStringLiteral, CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -136,8 +136,8 @@ public void test002() {
 public void test003() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportNonExternalizedStringLiteral, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"p/Foo.java",
 			"package p;\n" +
 			"public class Foo { \n" +
@@ -164,8 +164,8 @@ public void test003() {
 public void test004() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportNonExternalizedStringLiteral, CompilerOptions.ERROR);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"p/Foo.java",
 			"package p;\n" +
 			"public class Foo { \n" +
@@ -184,8 +184,8 @@ public void test004() {
 public void test005() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportNonExternalizedStringLiteral, CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -211,8 +211,8 @@ public void test005() {
 public void test006() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportNonExternalizedStringLiteral, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\r\n" +
 			"	public static void main(String[] args) {\r\n" +
@@ -238,8 +238,8 @@ public void test006() {
 public void test007() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportNonExternalizedStringLiteral, CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -270,8 +270,8 @@ public void test007() {
 public void test008() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportNonExternalizedStringLiteral, CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -307,8 +307,8 @@ public void test008() {
 public void test009() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportNonExternalizedStringLiteral, CompilerOptions.ERROR);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"p/Foo.java",
 			"package p;\n" +
 			"public class Foo { \n" +
@@ -327,8 +327,8 @@ public void test009() {
 public void test010() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportNonExternalizedStringLiteral, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	public static void main(String[] args) {\n" +
@@ -366,8 +366,8 @@ public void test010() {
 public void test011() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportNonExternalizedStringLiteral, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	public static void main(String[] args) {\n" +
@@ -405,8 +405,8 @@ public void test011() {
 public void test012() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportNonExternalizedStringLiteral, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	public static void main(String[] args) {\n" +
@@ -439,8 +439,8 @@ public void test012() {
 public void test013() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportNonExternalizedStringLiteral, CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -468,8 +468,8 @@ public void test013() {
 public void test014() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportNonExternalizedStringLiteral, CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -502,8 +502,8 @@ public void test014() {
 public void test015() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportNonExternalizedStringLiteral, CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -537,8 +537,8 @@ public void test016() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportNonExternalizedStringLiteral, CompilerOptions.ERROR);
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.IGNORE);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -572,8 +572,8 @@ public void test016() {
 public void test017() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportNonExternalizedStringLiteral, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	public void foo(String locationInAST) {\n" +
@@ -603,8 +603,8 @@ public void test017() {
 public void test018() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportNonExternalizedStringLiteral, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	#\n" +
@@ -633,8 +633,8 @@ public void test018() {
 public void test019() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportNonExternalizedStringLiteral, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	String s1= \"1\"; //$NON-NLS-1$\n" +
@@ -663,8 +663,8 @@ public void test019() {
 public void test020() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportNonExternalizedStringLiteral, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	String s1= \"1\"; //$NON-NLS-1$\n" +
@@ -693,8 +693,8 @@ public void test020() {
 public void test021() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportNonExternalizedStringLiteral, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	String s1= \"1\"; //$NON-NLS-1$\n" +
@@ -723,8 +723,8 @@ public void test021() {
 public void test022() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportNonExternalizedStringLiteral, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	#\n" +
@@ -759,8 +759,8 @@ public void test022() {
 public void test023() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportNonExternalizedStringLiteral, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"        public String toString() {\n" +
@@ -792,8 +792,8 @@ public void test443456() {
 		return;
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportNonExternalizedStringLiteral, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"import java.util.concurrent.Callable;\n" +
 			"public class X {\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ExternalizeStringLiteralsTest_15.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ExternalizeStringLiteralsTest_15.java
@@ -43,8 +43,8 @@ public void test001() {
 	customOptions.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_15);
 	customOptions.put(CompilerOptions.OPTION_TargetPlatform, CompilerOptions.VERSION_15);
 
-	this.runNegativeTest(
-		true,
+	AbstractRegressionTest.runNegativeTest(
+		this, true,
 		new String[] {
 			"X.java",
 			"public class X\n" +
@@ -75,8 +75,8 @@ public void test002() {
 	customOptions.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_15);
 	customOptions.put(CompilerOptions.OPTION_TargetPlatform, CompilerOptions.VERSION_15);
 
-	this.runNegativeTest(
-		true,
+	AbstractRegressionTest.runNegativeTest(
+		this, true,
 		new String[] {
 			"X.java",
 			"public class X\n" +
@@ -104,8 +104,8 @@ public void test003() {
 	customOptions.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_15);
 	customOptions.put(CompilerOptions.OPTION_TargetPlatform, CompilerOptions.VERSION_15);
 
-	this.runNegativeTest(
-		true,
+	AbstractRegressionTest.runNegativeTest(
+		this, true,
 		new String[] {
 			"X.java",
 			"public class X\n" +
@@ -142,8 +142,8 @@ public void test004() {
 	customOptions.put(CompilerOptions.OPTION_Compliance, CompilerOptions.VERSION_15);
 	customOptions.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_15);
 	customOptions.put(CompilerOptions.OPTION_TargetPlatform, CompilerOptions.VERSION_15);
-	this.runNegativeTest(
-		true,
+	AbstractRegressionTest.runNegativeTest(
+		this, true,
 		new String[] {
 			"X.java",
 			"class X {\n" +
@@ -173,8 +173,8 @@ public void test005() {
 	customOptions.put(CompilerOptions.OPTION_Compliance, CompilerOptions.VERSION_15);
 	customOptions.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_15);
 	customOptions.put(CompilerOptions.OPTION_TargetPlatform, CompilerOptions.VERSION_15);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"\n" +
@@ -200,8 +200,8 @@ public void test006() {
 	customOptions.put(CompilerOptions.OPTION_Compliance, CompilerOptions.VERSION_15);
 	customOptions.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_15);
 	customOptions.put(CompilerOptions.OPTION_TargetPlatform, CompilerOptions.VERSION_15);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	@Annot({\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ExternalizeStringLiteralsTest_1_5.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ExternalizeStringLiteralsTest_1_5.java
@@ -38,8 +38,8 @@ public static Test suite() {
 public void test001() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportNonExternalizedStringLiteral, CompilerOptions.ERROR);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"import static java.lang.annotation.ElementType.*;\n" +
 			"import static java.lang.annotation.RetentionPolicy.*;\n" +
@@ -65,8 +65,8 @@ public void test001() {
 public void test002() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportNonExternalizedStringLiteral, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		true,
+	AbstractRegressionTest.runNegativeTest(
+		this, true,
 		new String[] {
 			"X.java",
 			"class X {\n" +
@@ -109,8 +109,8 @@ public void test002() {
 public void test003() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportNonExternalizedStringLiteral, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		true,
+	AbstractRegressionTest.runNegativeTest(
+		this, true,
 		new String[] {
 			"X.java",
 			"class X {\n" +
@@ -153,8 +153,8 @@ public void test003() {
 public void test004() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportNonExternalizedStringLiteral, CompilerOptions.WARNING);
-	this.runConformTest(
-		true,
+	AbstractRegressionTest.runConformTest(
+		this, true,
 		new String[] {
 			"X.java",
 			"class X {\n" +
@@ -183,8 +183,8 @@ public void test004() {
 public void test005() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportNonExternalizedStringLiteral, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		true,
+	AbstractRegressionTest.runNegativeTest(
+		this, true,
 		new String[] {
 			"X.java",
 			"class X {\n" +
@@ -208,8 +208,8 @@ public void test005() {
 public void test006() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportNonExternalizedStringLiteral, CompilerOptions.WARNING);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	@SuppressWarnings(\"nls\")\n" +
@@ -230,8 +230,8 @@ public void test006() {
 public void test007() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportNonExternalizedStringLiteral, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	@Annot({\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/FieldAccessTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/FieldAccessTest.java
@@ -63,8 +63,8 @@ public void test001() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=149004
 public void test002() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"foo/BaseFoo.java",
 			"package foo;\n" +
 			"public class BaseFoo {\n" +
@@ -92,8 +92,8 @@ public void test002() {
 public void test003() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportNonStaticAccessToStatic, CompilerOptions.IGNORE);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"foo/BaseFoo.java",
 			"package foo;\n" +
 			"class BaseFoo {\n" +
@@ -122,8 +122,8 @@ public void test003() {
 public void test004() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportNonStaticAccessToStatic, CompilerOptions.IGNORE);
-	this.runNegativeTest(
-		true,
+	AbstractRegressionTest.runNegativeTest(
+		this, true,
 		new String[] {
 			"foo/BaseFoo.java",
 			"package foo;\n" +
@@ -156,8 +156,8 @@ public void test004() {
 public void test005() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnqualifiedFieldAccess, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		true,
+	AbstractRegressionTest.runNegativeTest(
+		this, true,
 		new String[] {
 			"X.java",
 			"public class X {\n" +
@@ -181,8 +181,8 @@ public void test005() {
 public void test006() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnqualifiedFieldAccess, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		true,
+	AbstractRegressionTest.runNegativeTest(
+		this, true,
 		new String[] {
 			"X.java",
 			"public class X {\n" +
@@ -206,8 +206,8 @@ public void test006() {
 public void test007() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.IGNORE);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	private void foo() {\n" +
@@ -236,8 +236,8 @@ public void test007() {
 public void test008() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.IGNORE);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	private void foo() {\n" +
@@ -266,8 +266,8 @@ public void test008() {
 public void test009() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.IGNORE);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	private void foo() {\n" +
@@ -296,8 +296,8 @@ public void test009() {
 public void test010() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.IGNORE);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	private void foo() {\n" +
@@ -326,8 +326,8 @@ public void test010() {
 public void test011() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.IGNORE);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	private void foo() {\n" +
@@ -356,8 +356,8 @@ public void test011() {
 public void test012() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.IGNORE);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	private void foo() {\n" +
@@ -386,8 +386,8 @@ public void test012() {
 public void test013() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.IGNORE);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X extends A {\n" +
 			"	private void foo() {\n" +
@@ -413,8 +413,8 @@ public void test013() {
 public void test014() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.IGNORE);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X extends A {\n" +
 			"	private void foo() {\n" +
@@ -440,8 +440,8 @@ public void test014() {
 public void test015() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.IGNORE);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X extends A {\n" +
 			"	private void foo() {\n" +
@@ -468,8 +468,8 @@ public void test015() {
 public void test016() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.IGNORE);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X extends A {\n" +
 			"	private void foo() {\n" +
@@ -498,8 +498,8 @@ public void test017() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportFieldHiding, CompilerOptions.WARNING);
 
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"		Zork z;\n" +
@@ -527,8 +527,8 @@ public void test018() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportFieldHiding, CompilerOptions.WARNING);
 
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"		Zork z;\n" +
@@ -567,8 +567,8 @@ public void test019() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportLocalVariableHiding, CompilerOptions.WARNING);
 
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"		Zork z;\n" +
@@ -595,8 +595,8 @@ public void test020() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportLocalVariableHiding, CompilerOptions.WARNING);
 
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"		Zork z;\n" +
@@ -633,8 +633,8 @@ public void test020() {
 public void test021() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportRawTypeReference, CompilerOptions.IGNORE);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"import java.util.ArrayList;\n" +
 			"\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/FlowAnalysisTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/FlowAnalysisTest.java
@@ -89,8 +89,8 @@ public void test001() {
 public void test002() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportParameterAssignment, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"    public void test() {\n" +
@@ -115,8 +115,8 @@ public void test002() {
 public void test003() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportParameterAssignment, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"    public void test() {\n" +
@@ -141,8 +141,8 @@ public void test003() {
 public void test004() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportParameterAssignment, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"    public void test() {\n" +
@@ -167,8 +167,8 @@ public void test004() {
 public void test005() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportParameterAssignment, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"    public void test() {\n" +
@@ -194,8 +194,8 @@ public void test005() {
 public void test006() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportFallthroughCase, CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -238,8 +238,8 @@ public void test007() {
 	if (this.complianceLevel == ClassFileConstants.JDK1_5) {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_ReportFallthroughCase, CompilerOptions.WARNING);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"    @SuppressWarnings(\"fallthrough\")\n" +
@@ -272,8 +272,8 @@ public void test007() {
 public void test008() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportFallthroughCase, CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -310,8 +310,8 @@ public void test008() {
 public void test009() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportFallthroughCase, CompilerOptions.ERROR);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"    public void test(int p, boolean b) {\n" +
@@ -340,8 +340,8 @@ public void test009() {
 public void test010() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportFallthroughCase, CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -376,8 +376,8 @@ public void test011() {
 	if (this.complianceLevel == ClassFileConstants.JDK1_5) {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_ReportFallthroughCase, CompilerOptions.WARNING);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"    @SuppressWarnings(\"all\")\n" +
@@ -408,8 +408,8 @@ public void test011() {
 public void _test012() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportFallthroughCase, CompilerOptions.ERROR);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"    public void test(int p) {\n" +
@@ -433,8 +433,8 @@ public void _test012() {
 public void _test013() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportFallthroughCase, CompilerOptions.ERROR);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"    public void test(int p) {\n" +
@@ -458,8 +458,8 @@ public void _test013() {
 public void test014() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportFallthroughCase, CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -495,8 +495,8 @@ public void test014() {
 public void test015() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportFallthroughCase, CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -532,8 +532,8 @@ public void test015() {
 public void test016() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportFallthroughCase, CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -569,8 +569,8 @@ public void test016() {
 public void _test017() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportFallthroughCase, CompilerOptions.ERROR);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"    public void test(int p) {\n" +
@@ -594,8 +594,8 @@ public void _test017() {
 public void _test018() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportFallthroughCase, CompilerOptions.ERROR);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"    public void test(int p) {\n" +
@@ -619,8 +619,8 @@ public void _test018() {
 public void test019() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportFallthroughCase, CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -691,8 +691,8 @@ public void test022() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportEmptyStatement, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportDeadCode, CompilerOptions.IGNORE);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -723,8 +723,8 @@ public void test022() {
 		JavacTestOptions.Excuse.EclipseWarningConfiguredAsError /* javac test options */);
 }
 public void test023() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	public static void main(String[] args) {\n" +
@@ -1422,8 +1422,8 @@ public void test045() {
 }
 // for and definite assignment
 public void test046() {
-	this.runConformTest(
-		true,
+	AbstractRegressionTest.runConformTest(
+		this, true,
 		new String[] {
 			"X.java",
 			"public abstract class X {\n" +
@@ -1467,8 +1467,8 @@ public void test047() {
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=200158
 // contrast this with test049
 public void test048() {
-	runTest(
-		new String[] {
+	AbstractRegressionTest.runTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  private static final boolean b = false;\n" +
@@ -1506,8 +1506,8 @@ public void test048() {
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=200158
 // variant: this one passes
 public void test049() {
-	runTest(
-		new String[] {
+	AbstractRegressionTest.runTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  private static final boolean b = false;\n" +
@@ -2042,8 +2042,8 @@ public void test062() {
 public void test063() {
 	Map compilerOptions = getCompilerOptions();
 	compilerOptions.put(CompilerOptions.OPTION_ReportUnusedObjectAllocation, CompilerOptions.ERROR);
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"   boolean bar() { return false; } \n" +
@@ -2068,8 +2068,8 @@ public void test063() {
 public void test064() {
 	Map compilerOptions = getCompilerOptions();
 	compilerOptions.put(CompilerOptions.OPTION_ReportUnusedObjectAllocation, CompilerOptions.ERROR);
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"   boolean bar() { return false; } \n" +
@@ -2095,8 +2095,8 @@ public void test065() {
 	if (this.complianceLevel < ClassFileConstants.JDK1_5) return;
 	Map compilerOptions = getCompilerOptions();
 	compilerOptions.put(CompilerOptions.OPTION_ReportUnusedObjectAllocation, CompilerOptions.WARNING);
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"   boolean bar() { return false; }\n" +
@@ -2137,8 +2137,8 @@ public void test066() {
 public void test067() {
 	Map compilerOptions = getCompilerOptions();
 	compilerOptions.put(CompilerOptions.OPTION_ReportUnusedObjectAllocation, CompilerOptions.ERROR);
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"   boolean bar() { return false; }\n" +
@@ -2161,8 +2161,8 @@ public void test067() {
 public void test068() {
 	Map compilerOptions = getCompilerOptions();
 	compilerOptions.put(CompilerOptions.OPTION_ReportUnusedObjectAllocation, CompilerOptions.ERROR);
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"   boolean bar() { return false; }\n" +
@@ -2184,8 +2184,8 @@ public void test068() {
 public void test069() {
 	Map compilerOptions = getCompilerOptions();
 	compilerOptions.put(CompilerOptions.OPTION_ReportUnusedObjectAllocation, CompilerOptions.ERROR);
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"   boolean bar() { return false; } \n" +
@@ -2209,8 +2209,8 @@ public void test069() {
 public void test070() {
 	Map compilerOptions = getCompilerOptions();
 	compilerOptions.put(CompilerOptions.OPTION_ReportUnusedObjectAllocation, CompilerOptions.ERROR);
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public final class X {\n" +
 			"    private X (){\n" +
@@ -2383,8 +2383,8 @@ public void testBug338234d() {
 public void testCloseable1() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.WARNING);
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"import java.io.File;\n" +
 				"import java.io.FileReader;\n" +
@@ -2411,8 +2411,8 @@ public void testCloseable1() {
 public void testCloseable2() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.WARNING);
-	this.runConformTest(
-			new String[] {
+	AbstractRegressionTest.runConformTest(
+			this, new String[] {
 				"X.java",
 				"import java.io.File;\n" +
 				"import java.io.FileReader;\n" +
@@ -2795,8 +2795,8 @@ public void testBug506315() {
 			"----------\n");
 }
 public void _testBug533435() {
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"public interface X {}\n"
 		}, new ASTVisitor() {
@@ -2910,7 +2910,7 @@ public void testBug537804_comment5() {
 public void testBug548318_001() {
 	if (!checkSwitchAllowedLevel())
 		return;
-	setPresetPreviewOptions();
+	AbstractRegressionTest.setPresetPreviewOptions(this);
 	String expectedProblemLog =
 			"----------\n" +
 			"1. ERROR in X.java (at line 11)\n" +
@@ -2949,8 +2949,8 @@ public void testBug548318_001() {
 			"	}\n" +
 			"}\n",
 		};
-	this.runNegativeTest(
-			testFiles,
+	AbstractRegressionTest.runNegativeTest(
+			this, testFiles,
 			expectedProblemLog,
 			null,
 			true);
@@ -2959,7 +2959,7 @@ public void testBug548318_001() {
 public void testBug548318_002() {
 	if (!checkSwitchAllowedLevel())
 		return;
-	setPresetPreviewOptions();
+	AbstractRegressionTest.setPresetPreviewOptions(this);
 	String expectedProblemLog =
 			"----------\n" +
 			"1. ERROR in X.java (at line 5)\n" +
@@ -2998,8 +2998,8 @@ public void testBug548318_002() {
 			"	}\n" +
 			"}\n",
 		};
-	this.runNegativeTest(
-			testFiles,
+	AbstractRegressionTest.runNegativeTest(
+			this, testFiles,
 			expectedProblemLog,
 			null,
 			true);
@@ -3010,7 +3010,7 @@ public void testBug548318_002() {
 public void testBug548318_003() {
 	if (!checkSwitchAllowedLevel())
 		return;
-	setPresetPreviewOptions();
+	AbstractRegressionTest.setPresetPreviewOptions(this);
 	String expectedProblemLog =
 			"----------\n" +
 			"1. ERROR in X.java (at line 23)\n" +
@@ -3050,8 +3050,8 @@ public void testBug548318_003() {
 			"	}\n" +
 			"}\n",
 	};
-	this.runNegativeTest(
-			testFiles,
+	AbstractRegressionTest.runNegativeTest(
+			this, testFiles,
 			expectedProblemLog,
 			null,
 			true);
@@ -3059,7 +3059,7 @@ public void testBug548318_003() {
 public void testBug548318_004() {
 	if (!checkSwitchAllowedLevel())
 		return;
-	setPresetPreviewOptions();
+	AbstractRegressionTest.setPresetPreviewOptions(this);
 	String expectedProblemLog =
 			"----------\n" +
 			"1. ERROR in X.java (at line 7)\n" +
@@ -3114,8 +3114,8 @@ public void testBug548318_004() {
 			"	}\n" +
 			"}\n",
 	};
-	this.runNegativeTest(
-			testFiles,
+	AbstractRegressionTest.runNegativeTest(
+			this, testFiles,
 			expectedProblemLog,
 			null,
 			true);
@@ -3123,7 +3123,7 @@ public void testBug548318_004() {
 public void testBug548318_005() {
 	if (!checkSwitchAllowedLevel())
 		return;
-	setPresetPreviewOptions();
+	AbstractRegressionTest.setPresetPreviewOptions(this);
 	String expectedProblemLog =
 			"----------\n" +
 			"1. ERROR in X.java (at line 11)\n" +
@@ -3172,8 +3172,8 @@ public void testBug548318_005() {
 			"	}\n" +
 			"}\n",
 	};
-	this.runNegativeTest(
-			testFiles,
+	AbstractRegressionTest.runNegativeTest(
+			this, testFiles,
 			expectedProblemLog,
 			null,
 			true);
@@ -3189,7 +3189,7 @@ public void testBug548318_005() {
 public void testBug548318_006() {
 	if (!checkSwitchAllowedLevel())
 		return;
-	setPresetPreviewOptions();
+	AbstractRegressionTest.setPresetPreviewOptions(this);
 	String expectedProblemLog =
 			"----------\n" +
 			"1. ERROR in X.java (at line 22)\n" +
@@ -3228,8 +3228,8 @@ public void testBug548318_006() {
 			"	}\n" +
 			"}\n",
 	};
-	this.runNegativeTest(
-			testFiles,
+	AbstractRegressionTest.runNegativeTest(
+			this, testFiles,
 			expectedProblemLog,
 			null,
 			true);
@@ -3247,7 +3247,7 @@ public void testBug548318_006() {
 public void testBug548318_007() {
 	if (!checkSwitchAllowedLevel())
 		return;
-	setPresetPreviewOptions();
+	AbstractRegressionTest.setPresetPreviewOptions(this);
 	String expectedProblemLog =
 			"----------\n" +
 			"1. ERROR in X.java (at line 18)\n" +
@@ -3291,8 +3291,8 @@ public void testBug548318_007() {
 			"	}\n" +
 			"}\n",
 	};
-	this.runNegativeTest(
-			testFiles,
+	AbstractRegressionTest.runNegativeTest(
+			this, testFiles,
 			expectedProblemLog,
 			null,
 			true);
@@ -3343,8 +3343,8 @@ public void testBug548318_008() {
 			"	}\n" +
 			"}\n",
 	};
-	this.runNegativeTest(
-			testFiles,
+	AbstractRegressionTest.runNegativeTest(
+			this, testFiles,
 			expectedProblemLog,
 			null,
 			true);
@@ -3357,7 +3357,7 @@ public void testBug548318_008() {
 public void testBug548318_009() {
 	if (!checkSwitchAllowedLevel())
 		return;
-	setPresetPreviewOptions();
+	AbstractRegressionTest.setPresetPreviewOptions(this);
 	String expectedProblemLog =
 			"----------\n" +
 			"1. ERROR in X.java (at line 4)\n" +
@@ -3401,8 +3401,8 @@ public void testBug548318_009() {
 			"	}\n" +
 			"}\n",
 	};
-	this.runNegativeTest(
-			testFiles,
+	AbstractRegressionTest.runNegativeTest(
+			this, testFiles,
 			expectedProblemLog,
 			null,
 			true);
@@ -3416,7 +3416,7 @@ public void testBug548318_009() {
 public void testBug548318_010() {
 	if (!checkSwitchAllowedLevel())
 		return;
-	setPresetPreviewOptions();
+	AbstractRegressionTest.setPresetPreviewOptions(this);
 	String expectedProblemLog =
 			"----------\n" +
 			"1. ERROR in X.java (at line 22)\n" +
@@ -3455,8 +3455,8 @@ public void testBug548318_010() {
 			"	}\n" +
 			"}\n",
 	};
-	this.runNegativeTest(
-			testFiles,
+	AbstractRegressionTest.runNegativeTest(
+			this, testFiles,
 			expectedProblemLog,
 			null,
 			true);
@@ -3470,7 +3470,7 @@ public void testBug548318_010() {
 public void testBug548318_011() {
 	if (!checkSwitchAllowedLevel())
 		return;
-	setPresetPreviewOptions();
+	AbstractRegressionTest.setPresetPreviewOptions(this);
 	String expectedProblemLog =
 			"----------\n" +
 			"1. ERROR in X.java (at line 6)\n" +
@@ -3514,8 +3514,8 @@ public void testBug548318_011() {
 			"	}\n" +
 			"}\n",
 	};
-	this.runNegativeTest(
-			testFiles,
+	AbstractRegressionTest.runNegativeTest(
+			this, testFiles,
 			expectedProblemLog,
 			null,
 			true);
@@ -3530,7 +3530,7 @@ public void testBug548318_011() {
 public void testBug548318_012() {
 	if (!checkSwitchAllowedLevel())
 		return;
-	setPresetPreviewOptions();
+	AbstractRegressionTest.setPresetPreviewOptions(this);
 	String expectedProblemLog =
 			"----------\n" +
 			"1. ERROR in X.java (at line 22)\n" +
@@ -3569,8 +3569,8 @@ public void testBug548318_012() {
 			"	}\n" +
 			"}\n",
 	};
-	this.runNegativeTest(
-			testFiles,
+	AbstractRegressionTest.runNegativeTest(
+			this, testFiles,
 			expectedProblemLog,
 			null,
 			true);
@@ -3585,7 +3585,7 @@ public void testBug548318_012() {
 public void testBug548318_012b() {
 	if (!checkSwitchAllowedLevel())
 		return;
-	setPresetPreviewOptions();
+	AbstractRegressionTest.setPresetPreviewOptions(this);
 	String expectedProblemLog =
 			"----------\n" +
 			"1. ERROR in X.java (at line 15)\n" +
@@ -3626,8 +3626,8 @@ public void testBug548318_012b() {
 			"	}\n" +
 			"}\n",
 	};
-	this.runNegativeTest(
-			testFiles,
+	AbstractRegressionTest.runNegativeTest(
+			this, testFiles,
 			expectedProblemLog,
 			null,
 			true);
@@ -3642,7 +3642,7 @@ public void testBug548318_012b() {
 public void testBug548318_013() {
 	if (!checkSwitchAllowedLevel())
 		return;
-	setPresetPreviewOptions();
+	AbstractRegressionTest.setPresetPreviewOptions(this);
 	String expectedProblemLog =
 			"----------\n" +
 			"1. ERROR in X.java (at line 9)\n" +
@@ -3686,8 +3686,8 @@ public void testBug548318_013() {
 			"	}\n" +
 			"}\n",
 	};
-	this.runNegativeTest(
-			testFiles,
+	AbstractRegressionTest.runNegativeTest(
+			this, testFiles,
 			expectedProblemLog,
 			null,
 			true);
@@ -3711,7 +3711,7 @@ public void testBug548318_013() {
 public void testBug548318_014() {
 	if (!checkSwitchAllowedLevel())
 		return;
-	setPresetPreviewOptions();
+	AbstractRegressionTest.setPresetPreviewOptions(this);
 	String expectedProblemLog =
 			"----------\n" +
 			"1. ERROR in X.java (at line 23)\n" +
@@ -3755,8 +3755,8 @@ public void testBug548318_014() {
 			"	}\n" +
 			"}\n",
 	};
-	this.runNegativeTest(
-			testFiles,
+	AbstractRegressionTest.runNegativeTest(
+			this, testFiles,
 			expectedProblemLog,
 			null,
 			true);
@@ -3782,7 +3782,7 @@ public void testBug548318_014() {
 public void testBug548318_015() {
 	if (!checkSwitchAllowedLevel())
 		return;
-	setPresetPreviewOptions();
+	AbstractRegressionTest.setPresetPreviewOptions(this);
 	String expectedProblemLog =
 			"----------\n" +
 			"1. ERROR in X.java (at line 17)\n" +
@@ -3829,8 +3829,8 @@ public void testBug548318_015() {
 			"	}\n" +
 			"}\n",
 	};
-	this.runNegativeTest(
-			testFiles,
+	AbstractRegressionTest.runNegativeTest(
+			this, testFiles,
 			expectedProblemLog,
 			null,
 			true);
@@ -3844,7 +3844,7 @@ public void testBug548318_015() {
 public void testBug548318_016() {
 	if (!checkSwitchAllowedLevel())
 		return;
-	setPresetPreviewOptions();
+	AbstractRegressionTest.setPresetPreviewOptions(this);
 	String expectedProblemLog =
 			"----------\n" +
 			"1. ERROR in X.java (at line 14)\n" +
@@ -3879,8 +3879,8 @@ public void testBug548318_016() {
 			"	}\n" +
 			"}\n",
 	};
-	this.runNegativeTest(
-			testFiles,
+	AbstractRegressionTest.runNegativeTest(
+			this, testFiles,
 			expectedProblemLog,
 			null,
 			true);
@@ -3895,7 +3895,7 @@ public void testBug548318_016() {
 public void testBug548318_017() {
 	if (!checkSwitchAllowedLevel())
 		return;
-	setPresetPreviewOptions();
+	AbstractRegressionTest.setPresetPreviewOptions(this);
 	String expectedProblemLog =
 			"----------\n" +
 			"1. ERROR in X.java (at line 6)\n" +
@@ -3940,8 +3940,8 @@ public void testBug548318_017() {
 			"	}\n" +
 			"}\n",
 	};
-	this.runNegativeTest(
-			testFiles,
+	AbstractRegressionTest.runNegativeTest(
+			this, testFiles,
 			expectedProblemLog,
 			null,
 			true);
@@ -3955,7 +3955,7 @@ public void testBug548318_017() {
 public void testBug548318_018() {
 	if (!checkSwitchAllowedLevel())
 		return;
-	setPresetPreviewOptions();
+	AbstractRegressionTest.setPresetPreviewOptions(this);
 	String expectedProblemLog =
 			"----------\n" +
 			"1. ERROR in X.java (at line 20)\n" +
@@ -3992,8 +3992,8 @@ public void testBug548318_018() {
 			"	}\n" +
 			"}\n",
 	};
-	this.runNegativeTest(
-			testFiles,
+	AbstractRegressionTest.runNegativeTest(
+			this, testFiles,
 			expectedProblemLog,
 			null,
 			true);
@@ -4007,7 +4007,7 @@ public void testBug548318_018() {
 public void testBug548318_019() {
 	if (!checkSwitchAllowedLevel())
 		return;
-	setPresetPreviewOptions();
+	AbstractRegressionTest.setPresetPreviewOptions(this);
 	String expectedProblemLog =
 			"----------\n" +
 			"1. ERROR in X.java (at line 15)\n" +
@@ -4048,8 +4048,8 @@ public void testBug548318_019() {
 			"	}\n" +
 			"}\n",
 	};
-	this.runNegativeTest(
-			testFiles,
+	AbstractRegressionTest.runNegativeTest(
+			this, testFiles,
 			expectedProblemLog,
 			null,
 			true);
@@ -4062,7 +4062,7 @@ public void testBug548318_019() {
 public void testBug548318_020() {
 	if (!checkSwitchAllowedLevel())
 		return;
-	setPresetPreviewOptions();
+	AbstractRegressionTest.setPresetPreviewOptions(this);
 	String expectedProblemLog =
 			"----------\n" +
 			"1. ERROR in X.java (at line 19)\n" +
@@ -4098,8 +4098,8 @@ public void testBug548318_020() {
 			"	}\n" +
 			"}\n",
 	};
-	this.runNegativeTest(
-			testFiles,
+	AbstractRegressionTest.runNegativeTest(
+			this, testFiles,
 			expectedProblemLog,
 			null,
 			true);
@@ -4112,7 +4112,7 @@ public void testBug548318_020() {
 public void testBug548318_021() {
 	if (!checkSwitchAllowedLevel())
 		return;
-	setPresetPreviewOptions();
+	AbstractRegressionTest.setPresetPreviewOptions(this);
 	String expectedProblemLog =
 			"----------\n" +
 			"1. ERROR in X.java (at line 4)\n" +
@@ -4153,8 +4153,8 @@ public void testBug548318_021() {
 			"	}\n" +
 			"}\n",
 	};
-	this.runNegativeTest(
-			testFiles,
+	AbstractRegressionTest.runNegativeTest(
+			this, testFiles,
 			expectedProblemLog,
 			null,
 			true);
@@ -4171,7 +4171,7 @@ public void testBug548318_021() {
 public void testBug548318_022() {
 	if (!checkSwitchAllowedLevel())
 		return;
-	setPresetPreviewOptions();
+	AbstractRegressionTest.setPresetPreviewOptions(this);
 	String expectedProblemLog =
 			"----------\n" +
 			"1. ERROR in X.java (at line 19)\n" +
@@ -4207,8 +4207,8 @@ public void testBug548318_022() {
 			"	}\n" +
 			"}\n",
 	};
-	this.runNegativeTest(
-			testFiles,
+	AbstractRegressionTest.runNegativeTest(
+			this, testFiles,
 			expectedProblemLog,
 			null,
 			true);
@@ -4225,7 +4225,7 @@ public void testBug548318_022() {
 public void testBug548318_023() {
 	if (!checkSwitchAllowedLevel())
 		return;
-	setPresetPreviewOptions();
+	AbstractRegressionTest.setPresetPreviewOptions(this);
 	String expectedProblemLog =
 			"----------\n" +
 			"1. ERROR in X.java (at line 6)\n" +
@@ -4266,8 +4266,8 @@ public void testBug548318_023() {
 			"	}\n" +
 			"}\n",
 	};
-	this.runNegativeTest(
-			testFiles,
+	AbstractRegressionTest.runNegativeTest(
+			this, testFiles,
 			expectedProblemLog,
 			null,
 			true);
@@ -4284,7 +4284,7 @@ public void testBug548318_023() {
 public void testBug548318_024() {
 	if (!checkSwitchAllowedLevel())
 		return;
-	setPresetPreviewOptions();
+	AbstractRegressionTest.setPresetPreviewOptions(this);
 	String expectedProblemLog =
 			"----------\n" +
 			"1. ERROR in X.java (at line 9)\n" +
@@ -4325,8 +4325,8 @@ public void testBug548318_024() {
 			"	}\n" +
 			"}\n",
 	};
-	this.runNegativeTest(
-			testFiles,
+	AbstractRegressionTest.runNegativeTest(
+			this, testFiles,
 			expectedProblemLog,
 			null,
 			true);
@@ -4340,7 +4340,7 @@ public void testBug548318_024() {
 public void testBug548318_025() {
 	if (!checkSwitchAllowedLevel())
 		return;
-	setPresetPreviewOptions();
+	AbstractRegressionTest.setPresetPreviewOptions(this);
 	String expectedProblemLog =
 			"----------\n" +
 			"1. ERROR in X.java (at line 20)\n" +
@@ -4382,8 +4382,8 @@ public void testBug548318_025() {
 			"	}\n" +
 			"}\n",
 	};
-	this.runNegativeTest(
-			testFiles,
+	AbstractRegressionTest.runNegativeTest(
+			this, testFiles,
 			expectedProblemLog,
 			null,
 			true);
@@ -4397,7 +4397,7 @@ public void testBug548318_025() {
 public void testBug548318_026() {
 	if (!checkSwitchAllowedLevel())
 		return;
-	setPresetPreviewOptions();
+	AbstractRegressionTest.setPresetPreviewOptions(this);
 	String expectedProblemLog =
 			"----------\n" +
 			"1. ERROR in X.java (at line 16)\n" +
@@ -4444,8 +4444,8 @@ public void testBug548318_026() {
 			"	}\n" +
 			"}\n",
 	};
-	this.runNegativeTest(
-			testFiles,
+	AbstractRegressionTest.runNegativeTest(
+			this, testFiles,
 			expectedProblemLog,
 			null,
 			true);
@@ -4459,7 +4459,7 @@ public void testBug548318_026() {
 public void testBug548318_027() {
 	if (!checkSwitchAllowedLevel())
 		return;
-	setPresetPreviewOptions();
+	AbstractRegressionTest.setPresetPreviewOptions(this);
 	String expectedProblemLog =
 			"----------\n" +
 			"1. ERROR in X.java (at line 20)\n" +
@@ -4501,8 +4501,8 @@ public void testBug548318_027() {
 			"	}\n" +
 			"}\n",
 	};
-	this.runNegativeTest(
-			testFiles,
+	AbstractRegressionTest.runNegativeTest(
+			this, testFiles,
 			expectedProblemLog,
 			null,
 			true);
@@ -4516,7 +4516,7 @@ public void testBug548318_027() {
 public void testBug548318_028() {
 	if (!checkSwitchAllowedLevel())
 		return;
-	setPresetPreviewOptions();
+	AbstractRegressionTest.setPresetPreviewOptions(this);
 	String expectedProblemLog =
 			"----------\n" +
 			"1. ERROR in X.java (at line 7)\n" +
@@ -4563,8 +4563,8 @@ public void testBug548318_028() {
 			"	}\n" +
 			"}\n",
 	};
-	this.runNegativeTest(
-			testFiles,
+	AbstractRegressionTest.runNegativeTest(
+			this, testFiles,
 			expectedProblemLog,
 			null,
 			true);
@@ -4583,7 +4583,7 @@ public void testBug548318_028() {
 public void testBug548318_029() {
 	if (!checkSwitchAllowedLevel())
 		return;
-	setPresetPreviewOptions();
+	AbstractRegressionTest.setPresetPreviewOptions(this);
 	String expectedProblemLog =
 			"----------\n" +
 			"1. ERROR in X.java (at line 24)\n" +
@@ -4629,8 +4629,8 @@ public void testBug548318_029() {
 			"	}\n" +
 			"}\n",
 	};
-	this.runNegativeTest(
-			testFiles,
+	AbstractRegressionTest.runNegativeTest(
+			this, testFiles,
 			expectedProblemLog,
 			null,
 			true);
@@ -4649,7 +4649,7 @@ public void testBug548318_029() {
 public void testBug548318_030() {
 	if (!checkSwitchAllowedLevel())
 		return;
-	setPresetPreviewOptions();
+	AbstractRegressionTest.setPresetPreviewOptions(this);
 	String expectedProblemLog =
 			"----------\n" +
 			"1. ERROR in X.java (at line 20)\n" +
@@ -4700,8 +4700,8 @@ public void testBug548318_030() {
 			"	}\n" +
 			"}\n",
 	};
-	this.runNegativeTest(
-			testFiles,
+	AbstractRegressionTest.runNegativeTest(
+			this, testFiles,
 			expectedProblemLog,
 			null,
 			true);

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/FlowAnalysisTest8.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/FlowAnalysisTest8.java
@@ -211,8 +211,8 @@ public void testLambda_05() {
 // Lambda has no descriptor (overriding method from Object), don't bail out with NPE during analysis
 public void testLambda_05a() {
 	Map customOptions = getCompilerOptions();
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"ISAM.java",
 			"import org.eclipse.jdt.annotation.*;\n" +
 			"public interface ISAM {\n" +
@@ -244,8 +244,8 @@ public void testLambda_05a() {
 public void testReferenceExpression1() {
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_UNUSED_LOCAL, JavaCore.ERROR);
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			 "I.java",
 			 "public interface I {\n" +
 			 "	public void bar();\n" +
@@ -292,8 +292,8 @@ public void testReferenceExpression1() {
 public void testReferenceExpression_null_1() {
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_NULL_REFERENCE, JavaCore.ERROR);
-	runNegativeTest(
-		false /*skipJavac */,
+	AbstractRegressionTest.runNegativeTest(
+		this, false /*skipJavac */,
 		JavacTestOptions.Excuse.EclipseWarningConfiguredAsError,
 		new String[] {
 			 "I.java",
@@ -375,8 +375,8 @@ public void testReferenceExpression_nullAnnotation_2() {
 		"----------\n");
 }
 public void testReferenceExpression_nullAnnotation_3() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			 "I.java",
 			 "import org.eclipse.jdt.annotation.*;\n" +
 			 "public interface I {\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ForeachStatementTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ForeachStatementTest.java
@@ -200,8 +200,8 @@ public void test007() throws Exception {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_PreserveUnusedLocal, CompilerOptions.PRESERVE);
 
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"    \n" +
@@ -2086,8 +2086,8 @@ public void test040() throws Exception {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_PreserveUnusedLocal, CompilerOptions.PRESERVE);
 
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"import java.util.HashSet;\n" +
 			"import java.util.Set;\n" +
@@ -2225,8 +2225,8 @@ public void test042() throws Exception {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_PreserveUnusedLocal, CompilerOptions.PRESERVE);
 
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"        public static void main(String[] args) {\n" +
@@ -2334,8 +2334,8 @@ public void test044() throws Exception {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_PreserveUnusedLocal, CompilerOptions.PRESERVE);
 
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"        public static void main(String[] args) {\n" +
@@ -2400,8 +2400,8 @@ public void test045() throws Exception {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_PreserveUnusedLocal, CompilerOptions.PRESERVE);
 
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"        public static void main(String[] args) {\n" +
@@ -2471,8 +2471,8 @@ public void test046() throws Exception {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_PreserveUnusedLocal, CompilerOptions.OPTIMIZE_OUT);
 
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"        public static void main(String[] args) {\n" +
@@ -2921,8 +2921,8 @@ public void test057() throws Exception {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_PreserveUnusedLocal, CompilerOptions.OPTIMIZE_OUT);
 
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"import java.util.ArrayList;\n" +
 			"\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericTypeTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericTypeTest.java
@@ -1212,8 +1212,8 @@ public class GenericTypeTest extends AbstractComparableTest {
 	}
 	// Access to enclosing 't' of type 'T' (not substituted from X<X> as private thus non inherited)
 	public void test0048() {
-		this.runNegativeTest(
-			// test directory preparation
+		AbstractRegressionTest.runNegativeTest(
+			this, // test directory preparation
 			new String[] { /* test files */
 				"X.java",
 				"public class X <T> {\n" +
@@ -1800,8 +1800,8 @@ public class GenericTypeTest extends AbstractComparableTest {
 	// raw type: assignments
 	public void test0065() {
 		Map customOptions = getCompilerOptions();
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"import java.io.IOException;\n" +
 				"\n" +
@@ -2586,8 +2586,8 @@ public class GenericTypeTest extends AbstractComparableTest {
 
 	public void test0086() {
 		Map customOptions = getCompilerOptions();
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X<T> {\n" +
 				"    \n" +
@@ -2634,8 +2634,8 @@ public class GenericTypeTest extends AbstractComparableTest {
 		// check no unsafe type operation problem is issued
 		customOptions.put(CompilerOptions.OPTION_ReportUncheckedTypeOperation, CompilerOptions.ERROR);
 		customOptions.put(CompilerOptions.OPTION_ReportRawTypeReference, CompilerOptions.IGNORE);
-		this.runConformTest(
-			new String[] {
+		AbstractRegressionTest.runConformTest(
+			this, new String[] {
 				"X.java",
 				"public class X<T> {\n" +
 				"    \n" +
@@ -2664,8 +2664,8 @@ public class GenericTypeTest extends AbstractComparableTest {
 		// check no unsafe type operation problem is issued
 		customOptions.put(CompilerOptions.OPTION_ReportUncheckedTypeOperation, CompilerOptions.ERROR);
 		customOptions.put(CompilerOptions.OPTION_ReportRawTypeReference, CompilerOptions.IGNORE);
-		this.runConformTest(
-			new String[] {
+		AbstractRegressionTest.runConformTest(
+			this, new String[] {
 				"X.java",
 				"public class X<T> {\n" +
 				"     AX ax = new AX();\n" +
@@ -2706,8 +2706,8 @@ public class GenericTypeTest extends AbstractComparableTest {
 		Map customOptions = getCompilerOptions();
 		// check no unsafe type operation problem is issued
 		customOptions.put(CompilerOptions.OPTION_ReportUncheckedTypeOperation, CompilerOptions.ERROR);
-		this.runConformTest(
-			new String[] {
+		AbstractRegressionTest.runConformTest(
+			this, new String[] {
 				"X.java",
 				"public class X<T> {\n" +
 				"    T q;\n" +
@@ -2882,8 +2882,8 @@ public class GenericTypeTest extends AbstractComparableTest {
 	public void test0098() {
 		Map customOptions = getCompilerOptions();
 		customOptions.put(CompilerOptions.OPTION_ReportUncheckedTypeOperation, CompilerOptions.ERROR);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X<T> {\n" +
 				"    \n" +
@@ -3297,8 +3297,8 @@ public class GenericTypeTest extends AbstractComparableTest {
 	// unsafe assignment thru binaries
 	public void test0107() {
 		Map customOptions = getCompilerOptions();
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"import java.util.ArrayList;\n" +
 				"\n" +
@@ -3333,8 +3333,8 @@ public class GenericTypeTest extends AbstractComparableTest {
 		Map customOptions = getCompilerOptions();
 		customOptions.put(CompilerOptions.OPTION_ReportUncheckedTypeOperation, CompilerOptions.ERROR);
 		customOptions.put(CompilerOptions.OPTION_ReportRawTypeReference, CompilerOptions.IGNORE);
-		this.runConformTest(
-			new String[] {
+		AbstractRegressionTest.runConformTest(
+			this, new String[] {
 				"X.java",
 			"public class X {\n" +
 			"    Class k;\n" +
@@ -3664,8 +3664,8 @@ public class GenericTypeTest extends AbstractComparableTest {
 	}
 	// test generic method
 	public void test0118a() {
-		this.runConformTest(
-			// test directory preparation
+		AbstractRegressionTest.runConformTest(
+			this, // test directory preparation
 			true /* flush output directory */,
 			new String[] { /* test files */
 				"X.java",
@@ -3748,8 +3748,8 @@ public class GenericTypeTest extends AbstractComparableTest {
 	}
 	// test generic method
 	public void test0120a() {
-		this.runConformTest(
-			// test directory preparation
+		AbstractRegressionTest.runConformTest(
+			this, // test directory preparation
 			new String[] { /* test files */
 				"X.java",
 				"public class X<E> {\n" +
@@ -5289,8 +5289,8 @@ public class GenericTypeTest extends AbstractComparableTest {
 	// unsafe raw return value
 	public void test0176() {
 		Map customOptions = getCompilerOptions();
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"import java.util.*;\n" +
 				"\n" +
@@ -5328,8 +5328,8 @@ public class GenericTypeTest extends AbstractComparableTest {
 	// cast to type variable allowed, can be diagnosed as unnecessary
 	public void test0177() {
 		Map options = getCompilerOptions();
-		runConformTest(
-	 		// test directory preparation
+		AbstractRegressionTest.runConformTest(
+	 		this, // test directory preparation
 			true /* flush output directory */,
 			new String[] { /* test files */
 				"X.java",
@@ -5361,8 +5361,8 @@ public class GenericTypeTest extends AbstractComparableTest {
 		if (this.complianceLevel >= ClassFileConstants.JDK16)
 			return;
 		Map customOptions = getCompilerOptions();
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X <T> {\n" +
 				"	\n" +
@@ -5407,8 +5407,8 @@ public class GenericTypeTest extends AbstractComparableTest {
 			return;
 		Map customOptions = getCompilerOptions();
 		customOptions.put(CompilerOptions.OPTION_ReportPreviewFeatures, CompilerOptions.WARNING);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X <T> {\n" +
 				"	\n" +
@@ -6556,8 +6556,8 @@ public class GenericTypeTest extends AbstractComparableTest {
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=69135 - unnecessary cast operation
 	public void test0217() {
 		Map customOptions = getCompilerOptions();
-		runConformTest(
-			// test directory preparation
+		AbstractRegressionTest.runConformTest(
+			this, // test directory preparation
 			true /* flush output directory */,
 			new String[] { /* test files */
 				"X.java",
@@ -6703,8 +6703,8 @@ public class GenericTypeTest extends AbstractComparableTest {
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=69251- instantiating wildcards
 	public void test0223() {
 		Map customOptions = getCompilerOptions();
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"import java.util.HashMap;\n" +
 				"import java.util.Map;\n" +
@@ -6986,8 +6986,8 @@ public class GenericTypeTest extends AbstractComparableTest {
 	}
 	// can resolve member through type variable
 	public void test0229() {
-		runConformTest(
-			true,
+		AbstractRegressionTest.runConformTest(
+			this, true,
 			new String[] {
 				"X.java",
 				" public class X <T extends XC> {\n" +
@@ -7341,8 +7341,8 @@ public class GenericTypeTest extends AbstractComparableTest {
 	public void test0242() {
 		Map<String,String> options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_ReportDeprecation, CompilerOptions.IGNORE);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"import java.util.HashMap;\n" +
 				"import java.util.Map;\n" +
@@ -7493,8 +7493,8 @@ public class GenericTypeTest extends AbstractComparableTest {
 	// generic method of raw type
 	public void test0245() {
 		if (this.complianceLevel < ClassFileConstants.JDK1_7) {
-			this.runNegativeTest(
-					new String[] {
+			AbstractRegressionTest.runNegativeTest(
+					this, new String[] {
 						"X.java",
 						"public class X <T> { \n" +
 						"        <G> T foo(G g) {\n" +
@@ -7540,8 +7540,8 @@ public class GenericTypeTest extends AbstractComparableTest {
 					JavacTestOptions.EclipseHasABug.EclipseBug236242);
 			return;
 		}
-		this.runNegativeTest(
-				new String[] {
+		AbstractRegressionTest.runNegativeTest(
+				this, new String[] {
 					"X.java",
 					"public class X <T> { \n" +
 					"        <G> T foo(G g) {\n" +
@@ -8772,8 +8772,8 @@ public class GenericTypeTest extends AbstractComparableTest {
 			},
 			"SUCCESS");
 
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"C.java", //---------------------------
 				"public class C<Z,Y> {\n" +
 				"    public B<Z> test(Z zValue,B<D<Y>> yValue){ return new B<Z>(zValue,yValue); }\n" +
@@ -9799,8 +9799,8 @@ public class GenericTypeTest extends AbstractComparableTest {
 	}
 	// wildcard captures bound and variable superinterfaces
 	public void test0327() {
-		this.runConformTest(
-	 		// test directory preparation
+		AbstractRegressionTest.runConformTest(
+	 		this, // test directory preparation
 			new String[] { /* test files */
 				"X.java",
 				"public class X<T extends IFoo> {\n" +
@@ -9885,8 +9885,8 @@ public class GenericTypeTest extends AbstractComparableTest {
 	}
 	// wildcard captures bound and variable superinterfaces
 	public void test0329() {
-		this.runConformTest(
-			// test directory preparation
+		AbstractRegressionTest.runConformTest(
+			this, // test directory preparation
 			true /* flush output directory */,
 			new String[] { /* test files */
 				"X.java",
@@ -9964,8 +9964,8 @@ public class GenericTypeTest extends AbstractComparableTest {
 	}
 	// wildcard captures bound superclass and variable superclass
 	public void test0331() {
-		this.runConformTest(
-			// test directory preparation
+		AbstractRegressionTest.runConformTest(
+			this, // test directory preparation
 			true /* flush output directory */,
 			new String[] { /* test files */
 				"X.java",
@@ -10572,8 +10572,8 @@ public class GenericTypeTest extends AbstractComparableTest {
 	// checking scenario where generic type and method share the same type parameter name
 	public void test0348() {
 		if (this.complianceLevel < ClassFileConstants.JDK1_7) {
-			this.runNegativeTest(
-				new String[] {
+			AbstractRegressionTest.runNegativeTest(
+				this, new String[] {
 					"X.java",
 					"import java.io.IOException;\n" +
 					"public abstract class X<T extends Runnable> {\n" +
@@ -10614,8 +10614,8 @@ public class GenericTypeTest extends AbstractComparableTest {
 				JavacTestOptions.EclipseHasABug.EclipseBug236242);
 			return;
 		}
-		this.runNegativeTest(
-				new String[] {
+		AbstractRegressionTest.runNegativeTest(
+				this, new String[] {
 					"X.java",
 					"import java.io.IOException;\n" +
 					"public abstract class X<T extends Runnable> {\n" +
@@ -10923,8 +10923,8 @@ public class GenericTypeTest extends AbstractComparableTest {
 	public void test0362() {
 		Map customOptions= getCompilerOptions();
 		customOptions.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.ERROR);
-		this.runConformTest(
-			new String[] {
+		AbstractRegressionTest.runConformTest(
+			this, new String[] {
 				"Test.java",
 				"import java.util.ArrayList;\n" +
 					"import java.util.List;\n" +
@@ -13050,8 +13050,8 @@ public class GenericTypeTest extends AbstractComparableTest {
 	}
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=78293
 	public void test0429c() {
-		runNegativeTest(
-			// test directory preparation
+		AbstractRegressionTest.runNegativeTest(
+			this, // test directory preparation
 			new String[] { /* test files */
 				"X4.java",
 				"class X4 <T extends Comparable<Z> & Comparable<Z>> {}\n" +
@@ -13716,8 +13716,8 @@ public class GenericTypeTest extends AbstractComparableTest {
 
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=82159
 	public void test0446() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X<A> {\n" +
 				"  class Inner<B> { }\n" +
@@ -13846,8 +13846,8 @@ public class GenericTypeTest extends AbstractComparableTest {
 
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=82159 - variation
 	public void test0448a() {
-		runConformTest(
-		// test directory preparation
+		AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		new String[] { /* test files */
 			"X.java",
 			"public class X<T> {\n" +
@@ -13916,8 +13916,8 @@ public class GenericTypeTest extends AbstractComparableTest {
 
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=82159 - variation
 	public void test0451() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X<A> {\n" +
 				"  class Inner<B> { \n" +
@@ -15334,8 +15334,8 @@ public class GenericTypeTest extends AbstractComparableTest {
 public void test0498(){
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_1_4);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -17384,8 +17384,8 @@ public void test0500(){
 			"----------\n");
 	}
 	public void test0547() {
-		runConformTest(
-		// test directory preparation
+		AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		new String[] { /* test files */
 			"X.java",
 			"import java.util.*;\n" +
@@ -18160,8 +18160,8 @@ X.java:4: method foo in class X cannot be applied to given types
 			"----------\n");
 	}
 	public void test0571() {
-		runConformTest(
-			// test directory preparation
+		AbstractRegressionTest.runConformTest(
+			this, // test directory preparation
 			true /* flush output directory */,
 			new String[] { /* test files */
 				"X.java",
@@ -18802,8 +18802,8 @@ X.java:6: name clash: <T#1>foo(Object) and <T#2>foo(Object) have the same erasur
 				"	    List<? extends Class<?>> classes2 = Arrays.asList(String.class, Boolean.class);\n" +
 				"}\n";
 	    if (this.complianceLevel < ClassFileConstants.JDK1_8) {
-	    	this.runNegativeTest(
-    			new String[] {
+	    	AbstractRegressionTest.runNegativeTest(
+    			this, new String[] {
     				"X.java",
     				xSource,
     			},
@@ -18817,7 +18817,7 @@ X.java:6: name clash: <T#1>foo(Object) and <T#2>foo(Object) have the same erasur
 				true,
 				options);
 	    } else {
-	    	runConformTest(new String[] { "X.java", xSource }, options);
+	    	AbstractRegressionTest.runConformTest(this, new String[] { "X.java", xSource }, options);
 	    }
 	}
 	public void test0594() {
@@ -19785,7 +19785,7 @@ public void test0617() {
 	}
 	//https://bugs.eclipse.org/bugs/show_bug.cgi?id=92037
 	public void test0626() {
-		String errMessage = isMinimumCompliant(ClassFileConstants.JDK11) ?
+		String errMessage = AbstractRegressionTest.isMinimumCompliant(this, ClassFileConstants.JDK11) ?
 				"----------\n" +
 	    		"1. WARNING in X.java (at line 7)\n" +
 	    		"	private static class B<A> {\n" +
@@ -20053,8 +20053,8 @@ public void test0617() {
 	}
 	//https://bugs.eclipse.org/bugs/show_bug.cgi?id=92982 - variation
 	public void test0633() {
-	    runConformTest(
-    		// test directory preparation
+	    AbstractRegressionTest.runConformTest(
+    		this, // test directory preparation
     		true /* flush output directory */,
     		new String[] { /* test files */
                 "X.java",
@@ -20737,8 +20737,8 @@ public void test0617() {
 			null);
 	}
 	public void test0651() {
-	    runConformTest(
-            new String[] {
+	    AbstractRegressionTest.runConformTest(
+            this, new String[] {
                 "X.java",
 				"public class X<U> {\n" +
 				"\n" +
@@ -21708,8 +21708,8 @@ public void _test0667() {
 		"----------\n");
 }
 public void test0668() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		new String[] { /* test files */
 			"X.java",
 			"import java.util.List;\n" +
@@ -21757,8 +21757,8 @@ public void test0669() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=95021 (ensure not even a warning)
 public void test0670() {
-	runConformTest(
-		true,
+	AbstractRegressionTest.runConformTest(
+		this, true,
 		new String[] {
 			"X.java",
 			"import java.util.Map;\n" +
@@ -21954,8 +21954,8 @@ public void test0674() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=95638 - variation
 public void test0675() {
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		new String[] { /* test files */
 			"X.java",
 			"class Key<E extends Key<E>> {}\n" +
@@ -22580,8 +22580,8 @@ public void test0700() {
 public void test0701() {
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_UNCHECKED_TYPE_OPERATION, JavaCore.IGNORE);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"import java.util.Arrays;\n" +
 			"import java.util.List;\n" +
@@ -23834,8 +23834,8 @@ public void test0736() {
 		"----------\n");
 }
 public void test0737() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		new String[] { /* test files */
 			"X.java",
 			"class Sup {\n" +
@@ -24119,8 +24119,8 @@ public void test0745() {
 public void test0746() {
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_UNCHECKED_TYPE_OPERATION, JavaCore.IGNORE);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	void test() {\n" +
@@ -24382,8 +24382,8 @@ public void test0755() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=99999 - variation
 public void test0756() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		new String[] { /* test files */
 			"X.java",
 			"public class X<T> {\n" +
@@ -24634,8 +24634,8 @@ public void test0764() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=98379
 public void test0765() {
-	this.runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		new String[] { /* test files */
 			"X.java",
 			"public class X {\n" +
@@ -25007,8 +25007,8 @@ public void test0775() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=103023
 public void test0776() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -25575,8 +25575,8 @@ public void test0790() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=104655
 public void test0791() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -25603,8 +25603,8 @@ public void test0791() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=104649
 public void test0792() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		new String[] { /* test files */
 			"X.java",
 			"public class X<E> {\n" +
@@ -25913,8 +25913,8 @@ public void test0799() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=106744
 public void test0800() {
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		new String[] { /* test files */
 			"X.java",
 			"import java.lang.reflect.Constructor;\n" +
@@ -26018,8 +26018,8 @@ public void test0802() {
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=101831
 public void test0803() {
-	this.runNegativeTest(
-		false /* skipJavac */,
+	AbstractRegressionTest.runNegativeTest(
+		this, false /* skipJavac */,
 		this.complianceLevel < ClassFileConstants.JDK1_8 ? null : JavacTestOptions.Excuse.EclipseHasSomeMoreWarnings,
 		new String[] {
 			"X.java",
@@ -26329,8 +26329,8 @@ public void test0809() {
 		"----------\n");
 }
 public void test0810() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -26416,8 +26416,8 @@ public void test0812() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=108372 - variation
 public void test0813() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -26811,8 +26811,8 @@ public void test0822() throws Exception {
 	}
 }
 public void test0823() throws Exception {
-	runConformTest(
-		true,
+	AbstractRegressionTest.runConformTest(
+		this, true,
 		new String[] {
 			"X.java",
 			"import java.io.Serializable;\n" +
@@ -26881,8 +26881,8 @@ public void test0823() throws Exception {
 	}
 }
 public void test0824() throws Exception {
-	runConformTest(
-		true,
+	AbstractRegressionTest.runConformTest(
+		this, true,
 		new String[] {
 			"X.java",
 			"import java.io.Serializable;\n" +
@@ -28068,8 +28068,8 @@ public void test0853() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=113236
 public void test0854() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -28109,8 +28109,8 @@ public void test0854() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=113218
 public void test0855() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -28172,8 +28172,8 @@ public void test0855() {
 		JavacTestOptions.JavacHasABug.JavacBugFixed_6_10 /* javac test options */);
 }
 public void test0856() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -28492,8 +28492,8 @@ public void test0867() {
 public void test0868() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportRawTypeReference, CompilerOptions.IGNORE);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"import java.util.Collection;\n" +
 			"import java.util.Iterator;\n" +
@@ -29205,8 +29205,8 @@ public void test0885() {
 public void test0886() {
 	Map customOptions= getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_1_4);
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java", // =================
@@ -29267,8 +29267,8 @@ public void test0888() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=122775 - variation
 public void test0889() {
-	this.runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"Test.java", // =================
@@ -29309,8 +29309,8 @@ public void test0889() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=122775 - variation
 public void test0890() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		new String[] { /* test files */
 			"Simple.java", // =================
 			"class A<T extends A<T>> {}\n" +
@@ -29490,8 +29490,8 @@ public void test0893() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=126177 - variation
 public void test0894() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java", // =================
@@ -29572,8 +29572,8 @@ public void test0895() {
 			"----------\n");
 }
 public void test0896() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java", // =================
@@ -29612,8 +29612,8 @@ public void test0896() {
 		JavacTestOptions.JavacHasABug.JavacBugFixed_6_10 /* javac test options */);
 }
 public void test0897() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		new String[] { /* test files */
 			"Test.java", // =================
 			"interface I { }\n" +
@@ -29631,8 +29631,8 @@ public void test0897() {
 		JavacTestOptions.JavacHasABug.JavacBugFixed_6_10 /* javac test options */);
 }
 public void test0898() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		new String[] { /* test files */
 			"X.java", // =================
 			"interface I1 {\n" +
@@ -29748,8 +29748,8 @@ public void test0900() {
 }
 // Object array vs Object into generic method
 public void test0901() {
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		new String[] { /* test files */
 			"X.java",
 			"public class X {\n" +
@@ -29772,8 +29772,8 @@ public void test0901() {
 
 // circular references amongst generic interfaces with co-implementing classes
 public void test0902() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		new String[] { /* test files */
 			"I.java",
 			"public interface I<U extends J<? extends I<U>>> {\n" +
@@ -29818,8 +29818,8 @@ public void test0903() {
 
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=126914
 public void test0904() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		new String[] { /* test files */
 			"X.java",
 			"interface I<T extends J<T,U>, U extends I<T,U>> {\n" +
@@ -29841,8 +29841,8 @@ public void test0904() {
 
 // array in super bound
 public void test0905() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		new String[] { /* test files */
 			"X.java",
 			"import java.util.List;\n" +
@@ -29940,8 +29940,8 @@ public void test0907() {
 
 // check capture for conditional operator - variant
 public void test0908() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		new String[] { /* test files */
 			"X.java",
 			"public abstract class X {\n" +
@@ -30417,8 +30417,8 @@ public void test0915() {
 
 // synchronized inheritance for multiple generic types
 public void test0916() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		new String[] { /* test files */
 			"X.java",
 			"public class X<T extends X2<?>> {\n" +
@@ -30518,8 +30518,8 @@ public void test0917c() {
 
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=128560
 public void test0918() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		new String[] { /* test files */
 			"BasicNode.java",
 			"class BasicEdge<N extends BasicNode<E, N> & Node<E>, E extends BasicEdge<N, E> & Edge<N>>\n" +
@@ -30622,8 +30622,8 @@ public void test0920() {
 }
 // FIXME: javac8 rejects
 public void test0921() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		new String[] { /* test files */
 			"Graph.java",
 			"class Node<N extends Node<N,E>, E extends Edge<N,E>> {\n" +
@@ -30705,8 +30705,8 @@ public void test0923() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=129190
 public void test0924() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"ExtendedOuter.java",
@@ -30739,8 +30739,8 @@ public void test0924() {
 		JavacTestOptions.JavacHasABug.JavacBugFixed_6_10 /* javac test options */);
 }
 public void test0925() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -30835,8 +30835,8 @@ public void test0926() {
 			"	}\n" +
 			"}\n";
 	if (this.complianceLevel < ClassFileConstants.JDK1_8) {
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				xSource
 			},
@@ -31539,8 +31539,8 @@ public void test0945() {
 		"----------\n");
 }
 public void test0946() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java", //================================
@@ -31604,8 +31604,8 @@ public void test0947() {
 		"	}\n" +
 		"}\n";
 	if (this.complianceLevel < ClassFileConstants.JDK1_8) {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 			"X.java",
 			xSource,
 			},
@@ -32279,8 +32279,8 @@ public void test0961() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=134645
 public void test0962() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java", //================================
 			"public class X<T> {\n" +
 			"    public void bug() throws Exception {\n" +
@@ -32541,8 +32541,8 @@ public void test0971() {
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=137203
 // simulate incremental compile
 public void test0972() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"Outer.java", //================================
@@ -33030,8 +33030,8 @@ public void test0984() {
 		},
 		// runtime results
 		"" /* expected output string */);
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		false /* do not flush output directory */,
 		new String[] { /* test files */
 			"Y.java",
@@ -33053,8 +33053,8 @@ public void test0984() {
 public void test0985() {
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_UNCHECKED_TYPE_OPERATION, JavaCore.IGNORE);
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 					"X.java", // =================
 					"import java.util.*;\n" +
 					"public class X {\n" +
@@ -33375,8 +33375,8 @@ public void test0992() {
 
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=142897
 public void test0993() {
-	runConformTest(
-		true,
+	AbstractRegressionTest.runConformTest(
+		this, true,
 		new String[] {
 			"X.java",//===================
 			"public class X {\n" +
@@ -33515,8 +33515,8 @@ public void test0996() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=142897 - variation
 public void test0997() {
-	runConformTest(
-		true,
+	AbstractRegressionTest.runConformTest(
+		this, true,
 		new String[] {
 			"X.java",//===================
 			"public class X implements Outer {\n" +
@@ -33861,8 +33861,8 @@ public void test1003() {
 		"");
 }
 public void test1004() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		new String[] { /* test files */
 			"X.java",
 			"public class X {\n" +
@@ -33879,8 +33879,8 @@ public void test1004() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=145420
 public void test1005() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -34480,8 +34480,8 @@ public void test1018() {
 		"");
 }
 public void test1018a() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -34706,8 +34706,8 @@ public void test1023() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=151275
 public void test1024() {
-	runConformTest(
-		true,
+	AbstractRegressionTest.runConformTest(
+		this, true,
 		new String[] {
 			"X.java",
 			"public class X {\n" +
@@ -34753,8 +34753,8 @@ public void test1025() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=155753
 public void test1026() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		new String[] { /* test files */
 			"X.java",
 			"import java.util.LinkedHashSet;\n" +
@@ -34781,8 +34781,8 @@ public void test1026() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=155753 - variation
 public void test1027() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		new String[] { /* test files */
 			"X.java",
 			this.complianceLevel < ClassFileConstants.JDK1_7 ?
@@ -34835,8 +34835,8 @@ public void test1027() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=155753 - variation
 public void test1028() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		new String[] { /* test files */
 			"X.java",
 			"import java.util.LinkedHashSet;\n" +
@@ -34879,8 +34879,8 @@ public void test1029() {
 			"        }\n" +
 			"}";
 	if (this.complianceLevel < ClassFileConstants.JDK1_8) {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				xSource,
 			},
@@ -34971,8 +34971,8 @@ public void test1031() {
 		"----------\n");
 }
 public void test1032() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -35084,8 +35084,8 @@ public void test1033() {
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=158519
 // FAIL ERRMSG
 public void test1034() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"ChainedClosure.java",
 			"interface Closure<I> {\n" +
 			"    public void execute(I input);\n" +
@@ -35399,8 +35399,8 @@ public void test1037() {
 public void test1038() throws Exception {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_PreserveUnusedLocal, CompilerOptions.OPTIMIZE_OUT);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"interface I<T> {\n" +
 			"    int CONST = A.foo();\n" +
@@ -35468,8 +35468,8 @@ public void test1038() throws Exception {
 public void test1039() throws Exception {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_PreserveUnusedLocal, CompilerOptions.OPTIMIZE_OUT);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"interface I<T> {\n" +
 			"	Value<String> CONST = A.foo(\"[I.CONST]\");\n" +
@@ -35560,8 +35560,8 @@ public void test1039() throws Exception {
 public void test1040() throws Exception {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_PreserveUnusedLocal, CompilerOptions.OPTIMIZE_OUT);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"interface I<T> {\n" +
 			"	Value<String> CONST = A.foo(\"[I.CONST]\");\n" +
@@ -35712,8 +35712,8 @@ public void test1042() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=159214
 public void test1043() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"A.java",
 			"class A<T extends Number, S extends T> {\n" +
 			"  T t;\n" +
@@ -36018,8 +36018,8 @@ public void test1052() {
 	options.put(CompilerOptions.OPTION_ReportUncheckedTypeOperation, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportRawTypeReference, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportUnnecessaryTypeCheck, CompilerOptions.ERROR);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"public class X extends java.util.ArrayList<Integer> {\n" +
 			"	private static final long serialVersionUID = 713223190582506215L;\n" +
@@ -36067,8 +36067,8 @@ public void test1054() {
 		"	         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
 		"Type mismatch: cannot convert from Annotation to Bar\n" +
 		"----------\n";
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"import java.lang.annotation.Retention;\n" +
 			"import java.lang.annotation.RetentionPolicy;\n" +
@@ -36174,8 +36174,8 @@ public void test1057() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=141289
 public void test1058() throws Exception {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java", // =================
@@ -36274,8 +36274,8 @@ public void test1059() {
 }
 // See corresponding FIXME in TypeBinding.isTypeArgumentContainedBy(..)
 public void test1060() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		new String[] { /* test files */
 			"X.java", // =================
 			"import java.util.Collection;\n" +
@@ -36292,8 +36292,8 @@ public void test1060() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=159752
 public void test1061() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		new String[] { /* test files */
 			"predicate/Predicate.java", // =================
 			"package predicate;\n" +
@@ -36425,8 +36425,8 @@ public void test1064() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=141289 - variation
 public void test1065() throws Exception {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java", // =================
@@ -37126,8 +37126,8 @@ public void test1071() {
 public void test1072() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportRawTypeReference, CompilerOptions.IGNORE);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java", // =================
 			"import java.util.*;\n" +
 			"public class X {\n" +
@@ -37178,8 +37178,8 @@ public void test1072() {
 public void test1073() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportRawTypeReference, CompilerOptions.IGNORE);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java", // =================
 			"import java.util.*;\n" +
 			"public class X {\n" +
@@ -37238,8 +37238,8 @@ public void test1073() {
 public void test1074() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportRawTypeReference, CompilerOptions.IGNORE);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java", // =================
 			"import java.util.*;\n" +
 			"public class X {\n" +
@@ -37339,8 +37339,8 @@ public void test1075() {
 		},
 		// runtime results
 		"" /* expected output string */);
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		false /* do not flush output directory */,
 		new String[] {
 			"Y.java",
@@ -37787,8 +37787,8 @@ public void test1086() {
 
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=165645 - variation
 public void test1087() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		new String[] { /* test files */
 			"X.java",
 			"public class X<M> {\n" +
@@ -37952,8 +37952,8 @@ public void test1091() {
 public void test1092() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportRawTypeReference, CompilerOptions.IGNORE);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"Class_01.java",
 			"public interface Class_01<H extends Class_02<? extends Class_01>> extends\n" +
 			"		Class_09<H> {\n" +
@@ -38034,8 +38034,8 @@ public void test1092() {
 		null);
 
 	// incremental build
-	this.runConformTest(
-			new String[] {
+	AbstractRegressionTest.runConformTest(
+			this, new String[] {
 					"Class_01.java",
 					"public interface Class_01<H extends Class_02<? extends Class_01>> extends\n" +
 					"		Class_09<H> {\n" +
@@ -38053,7 +38053,7 @@ public void test1092() {
 public void test1093() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportRawTypeReference, CompilerOptions.IGNORE);
-	this.runNegativeTest(new String[] {
+	AbstractRegressionTest.runNegativeTest(this, new String[] {
 			"X.java",
 			"public class X<T> {\n" +
 			"  X<T> foo() {\n" +
@@ -38088,8 +38088,8 @@ public void test1093() {
 public void test1094() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportRawTypeReference, CompilerOptions.IGNORE);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"Crazy.java",
 			"public interface Crazy<O extends Other, T extends O> {}",
 			"ExampleFactory.java",
@@ -38111,8 +38111,8 @@ public void test1094() {
 		null /* vm arguments*/,
 		customOptions,
 		null /* compiler requestor*/);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"ExampleFactoryImpl.java",
 			"public class ExampleFactoryImpl implements ExampleFactory {\n" +
 			"	public <O extends Other, T extends O> Crazy<O, T> createCrazy() {\n" +
@@ -38133,8 +38133,8 @@ public void test1095() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportRawTypeReference, CompilerOptions.IGNORE);
 	customOptions.put(CompilerOptions.OPTION_ReportUncheckedTypeOperation, CompilerOptions.IGNORE);
-	runNegativeTest(
-	// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+	this, // test directory preparation
 	true /* flush output directory */,
 	new String[] { /* test files */
 		"X.java",
@@ -38172,8 +38172,8 @@ public void test1096() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportRawTypeReference, CompilerOptions.IGNORE);
 	customOptions.put(CompilerOptions.OPTION_ReportUncheckedTypeOperation, CompilerOptions.IGNORE);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"import java.lang.reflect.Constructor;\n" +
 			"\n" +
@@ -38199,8 +38199,8 @@ public void test1096() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=168232
 public void _test1097() {
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		new String[] { /* test files */
 			"X.java",
 			"public class X {\n" +
@@ -38224,7 +38224,7 @@ public void _test1097() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=152961
 public void test1098() {
-	String errMessage = isMinimumCompliant(ClassFileConstants.JDK11) ?
+	String errMessage = AbstractRegressionTest.isMinimumCompliant(this, ClassFileConstants.JDK11) ?
 			"----------\n" +
 			"1. ERROR in X.java (at line 9)\n" +
 			"	class Y extends Zork {}\n" +
@@ -38258,8 +38258,8 @@ public void test1098() {
 		errMessage);
 }
 public void test1099() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -38440,7 +38440,7 @@ public void test1104() {
 public void test1105() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportRawTypeReference, CompilerOptions.IGNORE);
-	this.runNegativeTest(new String[] {
+	AbstractRegressionTest.runNegativeTest(this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	public static void main(String[] args) {\n" +
@@ -38460,8 +38460,8 @@ public void test1105() {
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=174766
 public void test1106() {
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		new String[] { /* test files */
 			"X.java",
 			"public class X<T> {\n" +
@@ -38527,7 +38527,7 @@ public void test1107() throws Exception {
 		"    28  checkcast java.util.Collection [38]\n" +
 		"    31  aload 4 [call]\n" +
 		"    33  " +
-		(isMinimumCompliant(ClassFileConstants.JDK11) ? "invokevirtual" : "invokespecial") +
+		(AbstractRegressionTest.isMinimumCompliant(this, ClassFileConstants.JDK11) ? "invokevirtual" : "invokespecial") +
 		" X.externLocks(java.util.Collection, java.lang.Object) : java.util.List [40]\n" +
 		"    36  astore 5\n" +
 		"    38  aload_3 [iter]\n" +
@@ -38638,8 +38638,8 @@ public void test1110() {
 public void test1111() {
 	Map settings = getCompilerOptions();
 	settings.put(CompilerOptions.OPTION_PreserveUnusedLocal, CompilerOptions.OPTIMIZE_OUT);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"class A<T> {\n" +
 			"        public T foo(Object o) {\n" +
@@ -38671,8 +38671,8 @@ public void test1111() {
 public void test1112() {
 	Map settings = getCompilerOptions();
 	settings.put(CompilerOptions.OPTION_PreserveUnusedLocal, CompilerOptions.OPTIMIZE_OUT);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"class A<T> {\n" +
 			"        public T foo;\n" +
@@ -38704,8 +38704,8 @@ public void test1112() {
 public void test1113() {
 	Map settings = getCompilerOptions();
 	settings.put(CompilerOptions.OPTION_PreserveUnusedLocal, CompilerOptions.OPTIMIZE_OUT);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"class A<T> {\n" +
 			"        public T foo;\n" +
@@ -38739,8 +38739,8 @@ public void test1113() {
 public void test1114() {
 	Map settings = getCompilerOptions();
 	settings.put(CompilerOptions.OPTION_PreserveUnusedLocal, CompilerOptions.OPTIMIZE_OUT);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"class A<T> {\n" +
 			"        public T foo;\n" +
@@ -38774,8 +38774,8 @@ public void test1114() {
 public void test1115() {
 	Map settings = getCompilerOptions();
 	settings.put(CompilerOptions.OPTION_PreserveUnusedLocal, CompilerOptions.OPTIMIZE_OUT);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"class A<T> {\n" +
 			"        public T foo;\n" +
@@ -38844,8 +38844,8 @@ public void test1116() {
 public void test1117() throws Exception {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_PreserveUnusedLocal, CompilerOptions.OPTIMIZE_OUT);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"interface I<T> {\n" +
 			"	Value<String> CONST = null;\n" +
@@ -38940,8 +38940,8 @@ public void test1118() {
 			"	}\n" +
 			"}\n";
 	if (this.complianceLevel < ClassFileConstants.JDK1_8) {
-		runConformTest(
-				new String[] { "X.java", source },
+		AbstractRegressionTest.runConformTest(
+				this, new String[] { "X.java", source },
 				JavacTestOptions.EclipseHasABug.EclipseBug177715 /* javac test options */);
 	} else {
 		runNegativeTest(
@@ -39159,7 +39159,7 @@ public void test1123() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=182192
 public void test1124() {
-	String errMessage = isMinimumCompliant(ClassFileConstants.JDK11) ?
+	String errMessage = AbstractRegressionTest.isMinimumCompliant(this, ClassFileConstants.JDK11) ?
 			"----------\n" +
 			"1. WARNING in X.java (at line 13)\n" +
 			"	public static class InnerClassThatShowsBug extends X {\n" +
@@ -39784,8 +39784,8 @@ public void test1136() {
 			"class B<T> extends A<T> implements I {}\n" +
 			"class C<T> extends A<T> implements I {}\n";
 	if (this.complianceLevel < ClassFileConstants.JDK1_8) {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				xSource,
 			},
@@ -39804,7 +39804,7 @@ public void test1136() {
 			true,
 			options);
 	} else {
-		runConformTest(new String[] { "X.java", xSource }, options);
+		AbstractRegressionTest.runConformTest(this, new String[] { "X.java", xSource }, options);
 	}
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=154267
@@ -39962,8 +39962,8 @@ public void test1141() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=190945
 public void test1142() {
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		new String[] { /* test files */
 			"X.java",
 			"import java.util.Comparator;\n" +
@@ -40334,8 +40334,8 @@ public void test1149() {
 		"	    new<ClassNotFoundException> A();\n" +
 		"    }\n" +
 		"}\n";
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		new String[] { /* test files */
 			"A.java",
 			"public class A {\n" +
@@ -40349,8 +40349,8 @@ public void test1149() {
 		},
 		// javac options
 		JavacTestOptions.EclipseJustification.EclipseBug234815 /* javac test options */);
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		false /* do not flush output directory */,
 		new String[] { /* test files */
 			"B.java",
@@ -40834,7 +40834,7 @@ public void test1162() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=203061 - variation
 public void test1163() {
-	String errMessage = isMinimumCompliant(ClassFileConstants.JDK11) ?
+	String errMessage = AbstractRegressionTest.isMinimumCompliant(this, ClassFileConstants.JDK11) ?
 			"----------\n" +
 			"1. ERROR in X.java (at line 5)\n" +
 			"	Object o1 = mObj;\n" +
@@ -40896,7 +40896,7 @@ public void test1163() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=203061 - variation
 public void test1164() {
-	String errMessage = isMinimumCompliant(ClassFileConstants.JDK11) ?
+	String errMessage = AbstractRegressionTest.isMinimumCompliant(this, ClassFileConstants.JDK11) ?
 			"----------\n" +
 			"1. ERROR in X.java (at line 5)\n" +
 			"	Object o1 = mObj;\n" +
@@ -41297,8 +41297,8 @@ public void test1175() {
 		"----------\n");
 }
 public void test1176() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		new String[] { /* test files */
 			"X.java",
 			"public class X<T extends Foo & Bar> {\n" +
@@ -41321,8 +41321,8 @@ public void test1176() {
 		JavacTestOptions.JavacHasABug.JavacBugFixed_6_10 /* javac test options */);
 }
 public void test1177() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		new String[] { /* test files */
 			"X.java",
 			"public class X<T extends Foo & Bar> {\n" +
@@ -41344,8 +41344,8 @@ public void test1177() {
 		JavacTestOptions.JavacHasABug.JavacBugFixed_6_10 /* javac test options */);
 }
 public void test1178() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		new String[] { /* test files */
 			"X.java",
 			"public class X<T extends Foo & Bar> {\n" +
@@ -41993,8 +41993,8 @@ public void test1195() {
 		"");
 }
 public void test1196() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		new String[] { /* test files */
 			"X.java",
 			"public class X<T> {\n" +
@@ -42299,8 +42299,8 @@ public void test1203a() {
 			"The method bar(String, String) of type X is not generic; it cannot be parameterized with arguments <String>\n" +
 			"----------\n");
 	} else {
-		runConformTest(
-			true,
+		AbstractRegressionTest.runConformTest(
+			this, true,
 			sources,
 			"----------\n" +
 			"1. WARNING in X.java (at line 3)\n" +
@@ -42429,8 +42429,8 @@ public void test1203c() {
 			"Unused type arguments for the non generic method d(String, Object) of type X; it should not be parameterized with arguments <String>\n" +
 			"----------\n");
 	} else {
-		runConformTest(
-			true,
+		AbstractRegressionTest.runConformTest(
+			this, true,
 			sources,
 			"----------\n" +
 			"1. WARNING in X.java (at line 4)\n" +
@@ -42510,8 +42510,8 @@ public void test1203d() {
 			"The method d(String, Object) of type X is not generic; it cannot be parameterized with arguments <String>\n" +
 			"----------\n");
 	} else {
-		runConformTest(
-			true,
+		AbstractRegressionTest.runConformTest(
+			this, true,
 			sources,
 			"----------\n" +
 			"1. WARNING in X.java (at line 4)\n" +
@@ -42809,8 +42809,8 @@ public void test1211() {
 public void test1212() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportRedundantSuperinterface,  CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -42839,8 +42839,8 @@ public void test1212() {
 public void test1213() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportRedundantSuperinterface, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X<T> implements I<T> {}\n" +
 			"class Y<T extends Z, U extends T> extends X<T> implements I<U>, J {}\n" +
@@ -42860,8 +42860,8 @@ public void test1213() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=208873
 public void test1214() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -42886,8 +42886,8 @@ public void test1214() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=208873 - variation
 public void test1215() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		new String[] { /* test files */
 			"X.java",
 			"public class X {\n" +
@@ -42957,7 +42957,7 @@ public void test1216() {
 		"	           ^^^^^^^^^\n" +
 		"The type A.P is not visible\n" +
 		"----------\n" +
-		(isMinimumCompliant(ClassFileConstants.JDK11) ? "" :
+		(AbstractRegressionTest.isMinimumCompliant(this, ClassFileConstants.JDK11) ? "" :
 		"----------\n" +
 		"1. WARNING in p\\A.java (at line 18)\n" +
 		"	this.box.set(new P());\n" +
@@ -43085,8 +43085,8 @@ public void test1218() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=209779
 public void test1219() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -43284,8 +43284,8 @@ public void test1224() {
 		"");
 }
 public void test1225() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		new String[] { /* test files */
 			"X.java",
 			"import java.util.Collection;\n" +
@@ -43470,8 +43470,8 @@ public void test1230() {
 			"}\n",
 		},
 		"");
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"Z.java",
 				"public class Z {\n" +
 				"	public static void main(String[] args) {\n" +
@@ -43581,8 +43581,8 @@ public void test1233() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=215843 - variation
 public void test1234() {
-	this.runNegativeTest(
-		false /* skipJavac */,
+	AbstractRegressionTest.runNegativeTest(
+		this, false /* skipJavac */,
 		JavacTestOptions.EclipseHasABug.EclipseBug427719,
 		new String[] {
 			"X.java",
@@ -43861,8 +43861,8 @@ public void test1241() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=164665
 public void test1242() {
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		new String[] { /* test files */
 			"X.java",
 			"import java.util.LinkedList;\n" +
@@ -44051,8 +44051,8 @@ public void test1247() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=216558 - variation
 public void test1248() {
-	runConformTest(
- 		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+ 		this, // test directory preparation
 		new String[] { /* test files */
 			"X.java",
 			"public class X {\n" +
@@ -45461,8 +45461,8 @@ public void test1290() {
 public void test1291() {
 	if (this.complianceLevel >= ClassFileConstants.JDK1_8)
 		return;
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 					"X.java",
 					"import java.util.ArrayList;\n" +
 					"import java.util.List;\n" +
@@ -45580,8 +45580,8 @@ public void test1294() {
 public void test1295() {
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_UNCHECKED_TYPE_OPERATION, JavaCore.IGNORE);
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 					"X.java",
 					"class Deejay {\n" +
 					"	class Counter<T> {}\n" +
@@ -45730,8 +45730,8 @@ public void test1301() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=220361 - variation
 public void test1302() {
-	runConformTest(
-		true,
+	AbstractRegressionTest.runConformTest(
+		this, true,
 		new String[] {
 			"EMap.java",
 			"import java.util.ArrayList;\n" +
@@ -45883,8 +45883,8 @@ public void test1305() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=106744 - variation
 public void test1306() {
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		new String[] { /* test files */
 				"X.java",
 				"import java.lang.reflect.Constructor;\n" +
@@ -47209,8 +47209,8 @@ public void test1340() {
 public void test1341() {
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_UNCHECKED_TYPE_OPERATION, JavaCore.IGNORE);
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java", // =================
 				"import java.util.*;\n" +
 				"public class X {\n" +
@@ -50092,8 +50092,8 @@ public void test1420() {
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=257849
 // FIXME javac8 doesn't find the error
 public void test1421() {
-	this.runNegativeTest(
-			false /* skipJavac */,
+	AbstractRegressionTest.runNegativeTest(
+			this, false /* skipJavac */,
 			this.complianceLevel < ClassFileConstants.JDK1_8 ?
 			null : JavacTestOptions.Excuse.JavacCompilesIncorrectSource,
 			new String[] {
@@ -51549,8 +51549,8 @@ public void test1459() {
 // SHOULD FAIL AT 1.8 (18.2.3): The method get(Class<W>, T) in the type Test is not applicable for the arguments (Class<Test.W_Description>, Object)
 // FIXME: javac rejects (correctly? how?), see http://mail.openjdk.java.net/pipermail/lambda-spec-experts/2013-December/000443.html
 public void test277643() {
-	this.runNegativeTest(
-		false /* skipJavac */,
+	AbstractRegressionTest.runNegativeTest(
+		this, false /* skipJavac */,
 		this.complianceLevel < ClassFileConstants.JDK1_8 ? null :
 		JavacTestOptions.EclipseHasABug.EclipseBug428061,
 		new String[] {
@@ -51648,8 +51648,8 @@ public void test280054() {
 // SHOULD FAIL AT 1.8 (18.2.3): The method get(Class<V>, Class<S>) in the type X.L is not applicable for the arguments (Class<V>, Class<X.B>)
 // FIXME: javac rejects (correctly? how?), see http://mail.openjdk.java.net/pipermail/lambda-spec-experts/2013-December/000443.html
 public void test283306() {
-	this.runNegativeTest(
-		false /* skipJavac */,
+	AbstractRegressionTest.runNegativeTest(
+		this, false /* skipJavac */,
 		this.complianceLevel < ClassFileConstants.JDK1_8 ? null :
 		JavacTestOptions.EclipseHasABug.EclipseBug428061,
 		new String[] {
@@ -52201,8 +52201,8 @@ public void test1464() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=320275
 public void _test1465() {
-	this.runConformTest(
-			new String[] {
+	AbstractRegressionTest.runConformTest(
+			this, new String[] {
 				"AbstractSubClass.java",
 				"public abstract class AbstractSubClass extends AbstractClass {}",
 			},
@@ -52439,8 +52439,8 @@ public void testBug460491() {
 	if (this.complianceLevel >= ClassFileConstants.JDK1_7) {
 		Map customOptions = getCompilerOptions();
 		customOptions.put(CompilerOptions.OPTION_ReportRedundantSpecificationOfTypeArguments, CompilerOptions.WARNING);
-		this.runConformTest(
-			new String[] {
+		AbstractRegressionTest.runConformTest(
+			this, new String[] {
 				"A.java",
 				"class A {\n" +
 				"	private static final B.C c = new B.D<Void>();\n" +
@@ -52548,8 +52548,8 @@ public void testBug541772() {
 		getCompilerOptions()
 	);
 
-	runConformTest(
-	new String[] {
+	AbstractRegressionTest.runConformTest(
+	this, new String[] {
 		"token/Token.java",
 		"package token;\n" +
 		"\n" +
@@ -52588,8 +52588,8 @@ public void testBug541772() {
 
 	Util.flushDirectoryContent(new File(OUTPUT_DIR + File.separator + "bug541772Runtime"));
 
-	runConformTest(
-	new String[] {
+	AbstractRegressionTest.runConformTest(
+	this, new String[] {
 		"pkg/Example.java",
 		"package pkg;\n" +
 		"\n" +
@@ -52628,8 +52628,8 @@ public void testBug541772_typeannotations() {
 		getCompilerOptions()
 	);
 
-	runConformTest(
-	new String[] {
+	AbstractRegressionTest.runConformTest(
+	this, new String[] {
 		"token/Ann.java",
 		"package token;\n" +
 		"import java.lang.annotation.*;\n" +
@@ -52676,8 +52676,8 @@ public void testBug541772_typeannotations() {
 
 	Map compilerOptions = getCompilerOptions();
 	compilerOptions.put(JavaCore.COMPILER_ANNOTATION_NULL_ANALYSIS, JavaCore.ENABLED);
-	runConformTest(
-	new String[] {
+	AbstractRegressionTest.runConformTest(
+	this, new String[] {
 		"pkg/Example.java",
 		"package pkg;\n" +
 		"\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest.java
@@ -422,8 +422,8 @@ public void test330869() {
 public void test322817() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnavoidableGenericTypeProblems, CompilerOptions.DISABLED);
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 					"X.java",
 					"interface Adaptable {\n" +
 					"    public Object getAdapter(Class clazz);    \n" +
@@ -448,8 +448,8 @@ public void test322817() {
 public void test322817b() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnavoidableGenericTypeProblems, CompilerOptions.ENABLED);
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 					"X.java",
 					"interface Adaptable {\n" +
 					"    public Object getAdapter(Class clazz);    \n" +
@@ -479,8 +479,8 @@ public void test322817b() {
 public void test322817c() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnavoidableGenericTypeProblems, CompilerOptions.DISABLED);
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 					"X.java",
 					"interface Adaptable {\n" +
 					"    public Object getAdapter(Class<String> clazz);    \n" +
@@ -505,8 +505,8 @@ public void test322817c() {
 public void test322817d() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnavoidableGenericTypeProblems, CompilerOptions.DISABLED);
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 					"X.java",
 					"interface Adaptable {\n" +
 					"    public Object getAdapter(Class<String> clazz);    \n" +
@@ -538,8 +538,8 @@ public void test322817d() {
 public void test322817e() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnavoidableGenericTypeProblems, CompilerOptions.DISABLED);
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 					"X.java",
 					"import java.util.List;\n" +
 					"class Top {\n" +
@@ -577,8 +577,8 @@ public void test322817e() {
 public void test322817f() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnavoidableGenericTypeProblems, CompilerOptions.DISABLED);
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 					"X.java",
 					"import java.util.List;\n" +
 					"class Top {\n" +
@@ -621,8 +621,8 @@ public void test322817f() {
 public void test322817g() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnavoidableGenericTypeProblems, CompilerOptions.DISABLED);
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 					"Top.java",
 					"import java.util.List;\n" +
 					"public class Top {\n" +
@@ -702,8 +702,8 @@ public void test322817g() {
 public void test322817h() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnavoidableGenericTypeProblems, CompilerOptions.ENABLED);
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 					"Top.java",
 					"import java.util.List;\n" +
 					"public class Top {\n" +
@@ -814,8 +814,8 @@ public void test322817h() {
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=322817 (Default options)
 public void test322817i() {
 	Map customOptions = getCompilerOptions();
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 					"Top.java",
 					"import java.util.List;\n" +
 					"public class Top {\n" +
@@ -927,8 +927,8 @@ public void test322817i() {
 public void test322817j() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnavoidableGenericTypeProblems, CompilerOptions.DISABLED);
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 					"X.java",
 					"import java.util.List;\n" +
 					"class Top {\n" +
@@ -1007,8 +1007,8 @@ public void test322817j() {
 public void test322817k() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnavoidableGenericTypeProblems, CompilerOptions.DISABLED);
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 					"X.java",
 					"import java.util.Arrays;\n" +
 					"import java.util.Set;\n" +
@@ -1086,8 +1086,8 @@ public void test338350() {
 	};
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnavoidableGenericTypeProblems, CompilerOptions.ENABLED);
-	this.runNegativeTest(
-			testFiles,
+	AbstractRegressionTest.runNegativeTest(
+			this, testFiles,
 			"----------\n" +
 			"1. WARNING in Try.java (at line 6)\n" +
 			"	takeObj((E) Bar.getObject());\n" +
@@ -1154,8 +1154,8 @@ public void test338350() {
 			true,
 			customOptions);
 	customOptions.put(CompilerOptions.OPTION_ReportUnavoidableGenericTypeProblems, CompilerOptions.DISABLED);
-	this.runNegativeTest(
-			testFiles,
+	AbstractRegressionTest.runNegativeTest(
+			this, testFiles,
 			"----------\n" +
 			"1. WARNING in Try.java (at line 6)\n" +
 			"	takeObj((E) Bar.getObject());\n" +
@@ -1411,8 +1411,8 @@ public void test337751() {
 	compilerOptions14.put(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, JavaCore.VERSION_1_2);
 	compilerOptions14.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_4);
 	compilerOptions14.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_3);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"Project.java",
 			"import java.util.Map;\n" +
 			"public class Project {\n" +
@@ -1433,8 +1433,8 @@ public void test337751() {
 	compilerOptions15.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_5);
 	compilerOptions15.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_5);
 	compilerOptions15.put(CompilerOptions.OPTION_ReportUnavoidableGenericTypeProblems, CompilerOptions.ENABLED);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"Y.java",
 			"import java.util.Map;\n" +
 			"public class Y {\n" +
@@ -1473,8 +1473,8 @@ public void test337751a() {
 	compilerOptions14.put(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, JavaCore.VERSION_1_2);
 	compilerOptions14.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_4);
 	compilerOptions14.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_3);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"Project.java",
 			"import java.util.Map;\n" +
 			"public class Project {\n" +
@@ -1495,8 +1495,8 @@ public void test337751a() {
 	compilerOptions15.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_5);
 	compilerOptions15.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_5);
 	compilerOptions15.put(CompilerOptions.OPTION_ReportUnavoidableGenericTypeProblems, CompilerOptions.DISABLED);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"Y.java",
 			"import java.util.Map;\n" +
 			"public class Y {\n" +
@@ -1522,8 +1522,8 @@ public void test337962() {
 	compilerOptions15.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_5);
 	compilerOptions15.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_5);
 	compilerOptions15.put(CompilerOptions.OPTION_ReportUnavoidableGenericTypeProblems, CompilerOptions.ENABLED);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"import java.util.List;\n" +
 			"import java.util.ArrayList;\n" +
@@ -1629,8 +1629,8 @@ public void test337962b() {
 	compilerOptions15.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_5);
 	compilerOptions15.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_5);
 	compilerOptions15.put(CompilerOptions.OPTION_ReportUnavoidableGenericTypeProblems, CompilerOptions.DISABLED);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"import java.util.List;\n" +
 			"import java.util.ArrayList;\n" +
@@ -1706,8 +1706,8 @@ public void test338011() {
 	compilerOptions15.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_5);
 	compilerOptions15.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_5);
 	compilerOptions15.put(CompilerOptions.OPTION_ReportUnavoidableGenericTypeProblems, CompilerOptions.DISABLED);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"import java.util.*;\n" +
 			"public class X extends A {\n" +
@@ -1754,8 +1754,8 @@ public void test338011b() {
 	compilerOptions15.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_5);
 	compilerOptions15.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_5);
 	compilerOptions15.put(CompilerOptions.OPTION_ReportUnavoidableGenericTypeProblems, CompilerOptions.ENABLED);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"import java.util.*;\n" +
 			"public class X extends A {\n" +
@@ -2684,8 +2684,8 @@ public void test385780() {
 	customOptions.put(
 			CompilerOptions.OPTION_ReportUnusedTypeParameter,
 			CompilerOptions.ERROR);
-	this.runNegativeTest(
-		false /* skipJavac */,
+	AbstractRegressionTest.runNegativeTest(
+		this, false /* skipJavac */,
 		JavacTestOptions.Excuse.EclipseWarningConfiguredAsError,
 		new String[] {
 			"X.java",
@@ -2837,8 +2837,8 @@ public void test397888a() {
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedParameterIncludeDocCommentReference,
 	          CompilerOptions.ENABLED);
 
-	this.runNegativeTest(
-		false /*skipJavac */,
+	AbstractRegressionTest.runNegativeTest(
+		this, false /*skipJavac */,
 		JavacTestOptions.Excuse.EclipseWarningConfiguredAsError,
 		 new String[] {
  		"X.java",
@@ -2870,8 +2870,8 @@ public void test397888b() {
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedParameterIncludeDocCommentReference,
         CompilerOptions.DISABLED);
 
-	this.runNegativeTest(
-		false /* skipJavac */,
+	AbstractRegressionTest.runNegativeTest(
+		this, false /* skipJavac */,
 		JavacTestOptions.Excuse.EclipseWarningConfiguredAsError,
         new String[] {
      		   "X.java",
@@ -3191,8 +3191,8 @@ public void testBug415734() {
 			"    }\n" +
 			"}\n";
 	if (this.complianceLevel < ClassFileConstants.JDK1_8) {
-		runNegativeTest(
-			false /* skipJavac */,
+		AbstractRegressionTest.runNegativeTest(
+			this, false /* skipJavac */,
 			JavacTestOptions.EclipseHasABug.EclipseBug428061,
 			new String[] {
 				"Compile.java",
@@ -3685,8 +3685,8 @@ public void test425719b() {
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=427282,  Internal compiler error: java.lang.ArrayIndexOutOfBoundsException: -1 at org.eclipse.jdt.internal.compiler.ClassFile.traverse
 public void test427282() {
-	runNegativeTest(
-		false /* skipJavac */,
+	AbstractRegressionTest.runNegativeTest(
+		this, false /* skipJavac */,
 		JavacTestOptions.Excuse.EclipseHasSomeMoreWarnings,
 		new String[] {
 			"X.java",
@@ -3892,8 +3892,8 @@ public void test427728a() {
 public void test427736() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_DocCommentSupport, CompilerOptions.ENABLED);
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"Test1.java",
 			"class Test1<K, V> {\n" +
 			" static class Node<K2, V2> {}\n" +
@@ -3935,8 +3935,8 @@ public void test426836() {
 public void test428071() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_Store_Annotations, CompilerOptions.ENABLED);
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"K1.java",
 			"import java.util.List;\n" +
 			"import java.util.Map;\n" +
@@ -4461,8 +4461,8 @@ public void testBug431581() {
 		"----------\n");
 }
 public void testBug432603() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"Test.java",
 			"import java.util.Map;\n" +
 			"import java.util.Map.Entry;\n" +
@@ -4526,8 +4526,8 @@ public void testBug432603a() {
 		});
 }
 public void testBug399527() {
-	runNegativeTest(
-		false /*skipJavac */,
+	AbstractRegressionTest.runNegativeTest(
+		this, false /*skipJavac */,
 		JavacTestOptions.Excuse.JavacCompilesIncorrectSource,
 		new String[] {
 			"TypeInferenceProblem.java",
@@ -4786,8 +4786,8 @@ public void testBug434570_comment3() {
 public void testBug434570_comment3b() {
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_ANNOTATION_NULL_ANALYSIS, JavaCore.ENABLED);
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"TestWontCompile.java",
 			"import org.bug.AnnotationWithClassParameter;\n" +
 			"import org.bug.CustomHandler;\n" +
@@ -4991,8 +4991,8 @@ public void testBug434044_comment36() {
 public void testBug434793() {
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_ANNOTATION_NULL_ANALYSIS, JavaCore.ENABLED);
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"Outer.java",
 			"import java.util.*;\n" +
 			"\n" +
@@ -5097,14 +5097,14 @@ public void testBug438337comment3() {
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=422832, Class file triggers StackOverflowError when creating type hierarchy
 public void testBug422832() {
-	String path = getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator +
+	String path = AbstractRegressionTest.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator +
 			"Bug422832ClassFile" + File.separator + "aspose.pdf.jar";
 	String[] libs = getDefaultClassPaths();
 	int len = libs.length;
 	System.arraycopy(libs, 0, libs = new String[len+1], 0, len);
 	libs[len] = path;
-	runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 					"ExampleClass.java",
 					"public class ExampleClass extends aspose.b.a.a {}\n",
 			},
@@ -5248,8 +5248,8 @@ public void test440019_c9() {
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=446223, [1.8][compiler] Java8 generics eclipse doesn't compile
 public void test446223() {
-		this.runNegativeTest(
-		   false /* skipJavac */,
+		AbstractRegressionTest.runNegativeTest(
+		   this, false /* skipJavac */,
 		   JavacTestOptions.Excuse.EclipseHasSomeMoreWarnings,
 		   new String[] {
 			   "X.java",
@@ -5509,8 +5509,8 @@ public void testBug452194() {
 public void testBug454644() {
 	Map<String,String> options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportDeprecation, CompilerOptions.IGNORE);
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"example/CollectionFactory.java",
 			"/*\n" +
 			" * Copyright 2002-2014 the original author or authors.\n" +
@@ -5870,8 +5870,8 @@ public void testBug498057() {
 			"",
 		}
 	);
-	runConformTest(
-		false,
+	AbstractRegressionTest.runConformTest(
+		this, false,
 		new String[] {
 			"scanner/ModifyMe.java",
 			"package scanner;\n" +
@@ -5923,8 +5923,8 @@ public void testBug498486() {
 				"",
 			}
 		);
-	runConformTest(
-			false,
+	AbstractRegressionTest.runConformTest(
+			this, false,
 			new String[] {
 				"i/Test.java",
 				"package i;\n" +
@@ -5979,8 +5979,8 @@ public void testBug499126() {
 			"",
 		}
 	);
-	runConformTest(
-			false,
+	AbstractRegressionTest.runConformTest(
+			this, false,
 			new String[] {
 				"Usage.java",
 				"public class Usage {\n" +
@@ -6057,8 +6057,8 @@ public void testBug469297() {
 public void testBug508799() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(JavaCore.COMPILER_PB_RAW_TYPE_REFERENCE, JavaCore.IGNORE);
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"test/A.java",
 			"package test;\n" +
 			"\n" +
@@ -6083,7 +6083,7 @@ public void testBug508799() {
 		},
 		customOptions
 	);
-	runConformTest(false,
+	AbstractRegressionTest.runConformTest(this, false,
 		new String[] {
 			"test/C.java",
 			"package test;\n" +
@@ -6208,8 +6208,8 @@ public void testBug526423() {
 public void testBug526132() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnavoidableGenericTypeProblems, CompilerOptions.DISABLED);
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"Test.java",
 			"import java.util.HashMap;\n" +
 			"import java.util.Map;\n" +
@@ -6266,8 +6266,8 @@ public void testBug526132() {
 public void testBug520482() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(JavaCore.COMPILER_PB_UNAVOIDABLE_GENERIC_TYPE_PROBLEMS, JavaCore.DISABLED);
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"test/A.java",
 			"package test;\n" +
 			"\n" +
@@ -6279,7 +6279,7 @@ public void testBug520482() {
 		},
 		customOptions
 	);
-	runNegativeTest(false,
+	AbstractRegressionTest.runNegativeTest(this, false,
 		new String[] {
 			"test/B.java",
 			"package test;\n" +
@@ -6350,8 +6350,8 @@ public void testBug532137() {
 			"",
 		}
 	);
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"subtypes/TestImpl.java",
 			"package subtypes;\n" +
 			"\n" +
@@ -6619,7 +6619,7 @@ public void testBug561544() {
 		return;
 	Map customOptions = getCompilerOptions();
 	customOptions.put(JavaCore.COMPILER_PB_UNAVOIDABLE_GENERIC_TYPE_PROBLEMS, JavaCore.DISABLED);
-	runNegativeTest(false,
+	AbstractRegressionTest.runNegativeTest(this, false,
 		new String[] {
 			"com/bsbportal/music/C2193c.java",
 			"package com.bsbportal.music;\n"

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_1_7.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_1_7.java
@@ -2011,8 +2011,8 @@ public void test0052() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportRedundantSpecificationOfTypeArguments, CompilerOptions.ERROR);
 	customOptions.put(CompilerOptions.OPTION_ReportRawTypeReference, CompilerOptions.IGNORE);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X<E> {\n" +
 			"    X(E e) {}\n" +
@@ -2128,8 +2128,8 @@ public void test0052b() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportRedundantSpecificationOfTypeArguments, CompilerOptions.ERROR);
 	customOptions.put(CompilerOptions.OPTION_ReportRawTypeReference, CompilerOptions.IGNORE);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X<E> {\n" +
 			"	 E eField;\n" +
@@ -2218,8 +2218,8 @@ public void test0052c() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportRedundantSpecificationOfTypeArguments, CompilerOptions.ERROR);
 	customOptions.put(CompilerOptions.OPTION_ReportRawTypeReference, CompilerOptions.IGNORE);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X<E> {\n" +
 			"	X(String abc, String def) {}\n" +
@@ -2258,8 +2258,8 @@ public void test0052d() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportRedundantSpecificationOfTypeArguments, CompilerOptions.ERROR);
 	customOptions.put(CompilerOptions.OPTION_ReportRawTypeReference, CompilerOptions.IGNORE);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X<E> {\n" +
 			"    X(E e) {}\n" +
@@ -2287,8 +2287,8 @@ public void test0053() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportRedundantSpecificationOfTypeArguments, CompilerOptions.ERROR);
 	customOptions.put(CompilerOptions.OPTION_ReportRawTypeReference, CompilerOptions.IGNORE);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"Z.java",
 			"public class Z <T extends ZB> { \n" +
 			"    public static void main(String[] args) {\n" +
@@ -2315,8 +2315,8 @@ public void test0054() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportRedundantSpecificationOfTypeArguments, CompilerOptions.ERROR);
 	customOptions.put(CompilerOptions.OPTION_ReportRawTypeReference, CompilerOptions.IGNORE);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"Y.java",
 			"public class Y<V> {\n" +
 			"  public static <W extends ABC> Y<W> make(Class<W> clazz) {\n" +
@@ -2340,8 +2340,8 @@ public void test0055() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportRedundantSpecificationOfTypeArguments, CompilerOptions.ERROR);
 	customOptions.put(CompilerOptions.OPTION_ReportRawTypeReference, CompilerOptions.IGNORE);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X<A> {\n" +
 			"  class Inner<B> { }\n" +
@@ -2399,8 +2399,8 @@ public void test0056() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportRedundantSpecificationOfTypeArguments, CompilerOptions.ERROR);
 	customOptions.put(CompilerOptions.OPTION_ReportRawTypeReference, CompilerOptions.IGNORE);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X <T> {\n" +
 			"	void foo1() {\n" +
@@ -2443,8 +2443,8 @@ public void test0056b() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportRedundantSpecificationOfTypeArguments, CompilerOptions.ERROR);
 	customOptions.put(CompilerOptions.OPTION_ReportRawTypeReference, CompilerOptions.IGNORE);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X <T> {\n" +
 			"	static class X1<Z> {\n" +
@@ -2484,8 +2484,8 @@ public void test0056c() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportRedundantSpecificationOfTypeArguments, CompilerOptions.ERROR);
 	customOptions.put(CompilerOptions.OPTION_ReportRawTypeReference, CompilerOptions.IGNORE);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X <T> {\n" +
 			"	X(T t){}\n" +
@@ -2524,8 +2524,8 @@ public void test0057() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportRedundantSpecificationOfTypeArguments, CompilerOptions.ERROR);
 	customOptions.put(CompilerOptions.OPTION_ReportRawTypeReference, CompilerOptions.IGNORE);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	void test() {\n" +
@@ -2552,8 +2552,8 @@ public void test0058() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportRedundantSpecificationOfTypeArguments, CompilerOptions.ERROR);
 	customOptions.put(CompilerOptions.OPTION_ReportRawTypeReference, CompilerOptions.IGNORE);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"import java.util.ArrayList;\n" +
 			"\n" +
@@ -2581,8 +2581,8 @@ public void test0059() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportRedundantSpecificationOfTypeArguments, CompilerOptions.ERROR);
 	customOptions.put(CompilerOptions.OPTION_ReportRawTypeReference, CompilerOptions.IGNORE);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"import java.util.ArrayList;\n" +
 			"import java.util.List;\n" +
@@ -2601,8 +2601,8 @@ public void test0059() {
 public void test0060() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_1_4);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"import java.util.ArrayList;\n" +
 			"import java.util.List;\n" +
@@ -2632,8 +2632,8 @@ public void test0060() {
 public void test0060a() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_1_4);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"\n" +
 			"public class X {\n" +
@@ -2697,8 +2697,8 @@ public void test0061() {
 public void test428220() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_DocCommentSupport, CompilerOptions.ENABLED);
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class HashMap<K, V> {\n" +
 			"	static class Node<K, V> {\n" +
@@ -2723,8 +2723,8 @@ public void test428220() {
 public void test428220a() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_Store_Annotations, CompilerOptions.ENABLED);
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class HashMap<K, V> {\n" +
 			"	static class Node<K, V> {\n" +
@@ -2788,8 +2788,8 @@ public void test442929() {
 public void test448028() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportRedundantSpecificationOfTypeArguments, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		   new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		   this, new String[] {
 			   "X.java",
 			   "public class X {\n" +
 			   "\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_1_8.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_1_8.java
@@ -460,8 +460,8 @@ public void testBug424403() {
 		});
 }
 public void testBug401850a() {
-	runNegativeTest(
-		false /* skipJavac */,
+	AbstractRegressionTest.runNegativeTest(
+		this, false /* skipJavac */,
 		this.complianceLevel < ClassFileConstants.JDK1_8 ?
 		null : JavacTestOptions.Excuse.EclipseHasSomeMoreWarnings,
 		new String[] {
@@ -803,8 +803,8 @@ public void testBug425142_full() {
 		"----------\n");
 }
 public void testBug424195a() {
-	runNegativeTestMultiResult(
-		new String[] {
+	AbstractRegressionTest.runNegativeTestMultiResult(
+		this, new String[] {
 			"NPEOnCollector.java",
 			"import java.io.IOException;\n" +
 			"import java.nio.file.Path;\n" +
@@ -1724,8 +1724,8 @@ public void testBug426998b() {
 		});
 }
 public void testBug427164() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"NNLambda.java",
 			"import java.util.*;\n" +
 			"\n" +
@@ -2725,8 +2725,8 @@ public void testBug429430b2() {
 public void testBug429430c() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_Store_Annotations, CompilerOptions.ENABLED);
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"Main.java",
 			"import java.io.*;\n" +
 			"import java.lang.annotation.*;\n" +
@@ -2890,8 +2890,8 @@ public void testBug426537c() {
 public void testBug429203() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportRedundantSpecificationOfTypeArguments, CompilerOptions.ERROR);
-	runNegativeTest(
-		false /*skipJavac */,
+	AbstractRegressionTest.runNegativeTest(
+		this, false /*skipJavac */,
 		JavacTestOptions.Excuse.EclipseWarningConfiguredAsError,
 		new String[] {
 			"DTest.java",
@@ -3381,8 +3381,8 @@ public void testBug433845() {
 		"----------\n");
 }
 public void testBug435187() {
-	runNegativeTest(
-		false /*skipJavac */,
+	AbstractRegressionTest.runNegativeTest(
+		this, false /*skipJavac */,
 		JavacTestOptions.Excuse.EclipseHasSomeMoreWarnings,
 		new String[] {
 			"ExtractLocalLambda.java",
@@ -5166,8 +5166,8 @@ public void testBug455945() {
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=445231, [compiler] IllegalAccessError running Eclipse-compiled class
 // This is a bug in Oracle JREs. Workaround in ECJ: https://bugs.eclipse.org/bugs/show_bug.cgi?id=466675
 public void testBug445231() {
-	runConformTest(
-		true,
+	AbstractRegressionTest.runConformTest(
+		this, true,
 		new String[] {
 		"com/n/Bug.java",
 		"package com.n;\n" +
@@ -5809,8 +5809,8 @@ public void testBug483019() {
 		"1");
 }
 public void testBug483019a() {
-	runConformTest(
-		false /*skipJavac */,
+	AbstractRegressionTest.runConformTest(
+		this, false /*skipJavac */,
 		JavacTestOptions.Excuse.JavacHasErrorsEclipseHasNone,
 		new String[] {
 			"Test.java",
@@ -5844,8 +5844,8 @@ public void testBug484448() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_DocCommentSupport, CompilerOptions.ENABLED);
 
-	runConformTest(
-			new String[] {
+	AbstractRegressionTest.runConformTest(
+			this, new String[] {
 				"test/Test.java",
 				"package test;\n" +
 				"\n" +
@@ -7335,8 +7335,8 @@ public void testBug488663() {
 		testFiles,
 		"", options);
 	} else {
-		this.runNegativeTest(
-			testFiles,
+		AbstractRegressionTest.runNegativeTest(
+			this, testFiles,
 			"----------\n" +
 			"1. ERROR in C.java (at line 3)\n" +
 			"	Comparator<String> comparator = new Comparator<String>() { //\n" +
@@ -10548,8 +10548,8 @@ public void testBug508834_comment0() {
 	public void testGH1794() {
 		Map customOptions = getCompilerOptions();
 		customOptions.put(CompilerOptions.OPTION_ReportRedundantSpecificationOfTypeArguments, CompilerOptions.ERROR);
-		runNegativeTest(
-			false /*skipJavac */,
+		AbstractRegressionTest.runNegativeTest(
+			this, false /*skipJavac */,
 			JavacTestOptions.Excuse.EclipseWarningConfiguredAsError,
 			new String[] {
 				"TypeArgumentsTest.java",
@@ -10577,8 +10577,8 @@ public void testBug508834_comment0() {
 	public void testBug576002() {
 		Map customOptions = getCompilerOptions();
 		customOptions.put(CompilerOptions.OPTION_ReportRedundantSpecificationOfTypeArguments, CompilerOptions.ERROR);
-		runNegativeTest(
-			false /*skipJavac */,
+		AbstractRegressionTest.runNegativeTest(
+			this, false /*skipJavac */,
 			JavacTestOptions.Excuse.EclipseWarningConfiguredAsError,
 			new String[] {
 				"Test.java",
@@ -10603,8 +10603,8 @@ public void testBug508834_comment0() {
 	public void testBug550864() {
 		Map customOptions = getCompilerOptions();
 		customOptions.put(CompilerOptions.OPTION_ReportRedundantSpecificationOfTypeArguments, CompilerOptions.ERROR);
-		runNegativeTest(
-			false /*skipJavac */,
+		AbstractRegressionTest.runNegativeTest(
+			this, false /*skipJavac */,
 			JavacTestOptions.Excuse.EclipseWarningConfiguredAsError,
 			new String[] {
 				"TypeArgBug.java",

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
@@ -379,8 +379,8 @@ public void testBug488663_012() {
 public void testBug488663_013() {
 	Map<String, String> options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportRedundantSpecificationOfTypeArguments, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	String name;\n" +
@@ -701,8 +701,8 @@ public void testBug551913_001() {
 public void testBug551913_002() {
 	Map<String, String> options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportRedundantSpecificationOfTypeArguments, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	void foo() {\n" +
@@ -728,8 +728,8 @@ public void testBug551913_002() {
 public void testBug551913_003() {
 	Map<String, String> options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportRedundantSpecificationOfTypeArguments, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	void foo() {\n" +
@@ -755,8 +755,8 @@ public void testBug551913_003() {
 public void testBug551913_004() {
 	Map<String, String> options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportRedundantSpecificationOfTypeArguments, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	void foo() {\n" +
@@ -777,8 +777,8 @@ public void testBug551913_004() {
 public void testGH1506() {
 	Map<String, String> options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportRedundantSpecificationOfTypeArguments, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"import java.io.File;\n" +
 			"import java.util.Arrays;\n" +
@@ -810,8 +810,8 @@ public void testGH1506() {
 public void testGH1506_2() {
 	Map<String, String> options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportRedundantSpecificationOfTypeArguments, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"import java.io.File;\n" +
 			"import java.util.Arrays;\n" +
@@ -848,8 +848,8 @@ public void testGH1506_2() {
 public void testGH1506_3() {
 	Map<String, String> options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportRedundantSpecificationOfTypeArguments, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X<E> {\n" +
 			"    static class AX<T>{}\n" +
@@ -878,8 +878,8 @@ public void testGH1506_3() {
 public void testGH1506_4() {
 	Map<String, String> options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportRedundantSpecificationOfTypeArguments, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X<E> {\n" +
 			"    static class AX<T>{}\n" +
@@ -908,8 +908,8 @@ public void testGH1506_4() {
 public void testGH1560() {
 	Map<String, String> options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportRedundantSpecificationOfTypeArguments, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"""
 			import java.util.Collection;
@@ -960,8 +960,8 @@ public void testGH1560() {
 public void testGH1560_2() {
 	Map<String, String> options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportRedundantSpecificationOfTypeArguments, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"""
 			import java.util.Collection;

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/InitializationTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/InitializationTests.java
@@ -76,8 +76,8 @@ public void test318020b() {
 public void test318020c() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportDeadCode, CompilerOptions.IGNORE);
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"   public int a;" +
@@ -110,8 +110,8 @@ public void test318020c() {
 public void test318020d() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportDeadCode, CompilerOptions.IGNORE);
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"   private int a;" +
@@ -143,8 +143,8 @@ public void test318020d() {
 public void test318020e() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportDeadCode, CompilerOptions.IGNORE);
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"   private int a;" +
@@ -173,8 +173,8 @@ public void test318020e() {
 public void test318020f() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportDeadCode, CompilerOptions.IGNORE);
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"   private int a;" +
@@ -205,8 +205,8 @@ public void test318020f() {
 public void test318020g() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportDeadCode, CompilerOptions.IGNORE);
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"   private int a;" +
@@ -290,8 +290,8 @@ public void test318020i() {
 public void test318020j() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportDeadCode, CompilerOptions.IGNORE);
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"   private int a;" +
@@ -320,8 +320,8 @@ public void test318020j() {
 public void test318020k() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportDeadCode, CompilerOptions.IGNORE);
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"   private int a;\n" +
@@ -350,8 +350,8 @@ public void test318020k() {
 public void test325567() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportDeadCode, CompilerOptions.IGNORE);
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"import java.io.IOException;\n" +
 				"\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/InnerEmulationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/InnerEmulationTest.java
@@ -144,7 +144,7 @@ public void test002() {
  * 1FZ2G7R: use of non static inner class in constuctor
  */
 public void test003() {
-	String errMessage = isMinimumCompliant(ClassFileConstants.JDK11) ?
+	String errMessage = AbstractRegressionTest.isMinimumCompliant(this, ClassFileConstants.JDK11) ?
 			"----------\n" +
 			"1. ERROR in A.java (at line 8)\n" +
 			"	super(getRunnable(), new B().toString()); \n" +
@@ -1454,7 +1454,7 @@ public void test032() {
  * Missing implementation in the compiler compiling invalid code
  */
 public void test033() {
-	String errMessage = isMinimumCompliant(ClassFileConstants.JDK11) ?
+	String errMessage = AbstractRegressionTest.isMinimumCompliant(this, ClassFileConstants.JDK11) ?
 			"----------\n" +
 			"1. ERROR in p1\\A2.java (at line 20)\n" +
 			"	(new D.E(null, null, null, new F(get()) {}) {}).execute();	\n" +
@@ -1546,7 +1546,7 @@ public void test034() {
  * Missing implementation in the compiler compiling invalid code
  */
 public void test035() {
-	String errMessage = isMinimumCompliant(ClassFileConstants.JDK11) ?
+	String errMessage = AbstractRegressionTest.isMinimumCompliant(this, ClassFileConstants.JDK11) ?
 			"----------\n" +
 			"1. ERROR in p1\\A2.java (at line 20)\n" +
 			"	(new D.E(null, null, null, new F(get()) {})).execute();	\n" +
@@ -2766,8 +2766,8 @@ public void test070() {
 
 // test too many synthetic arguments
 public void test071() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {	\n"+
 			"	void foo(int i) {	\n"+
@@ -2966,8 +2966,8 @@ public void test075() {
 		},
 		"SUCCESS");
 
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"Y.java",
 			"public class Y {	\n" +
 			"	void foo(){	\n" +
@@ -3466,8 +3466,8 @@ public void test087() {
 			"[X$1$N]");
 		return;
 	}
-	this.runConformTest(
-		true,
+	AbstractRegressionTest.runConformTest(
+		this, true,
 		new String[] {
 			"X.java",
 			"public class X {\n"+
@@ -3711,8 +3711,8 @@ public void test097() {
  * http://bugs.eclipse.org/bugs/show_bug.cgi?id=33751
  */
 public void test098() {
-	this.runConformTest(
-		true,
+	AbstractRegressionTest.runConformTest(
+		this, true,
 		new String[] {
 			"X.java",
 			"public class X {	\n"+
@@ -3760,8 +3760,8 @@ public void test099() {
 
 	CompilerOptions options = new CompilerOptions(getCompilerOptions());
 	if (options.complianceLevel <= ClassFileConstants.JDK1_4) {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X { \n" +
 				"    public static void main(String argv[]) { \n" +
@@ -3779,8 +3779,8 @@ public void test099() {
 			false);
 		return;
 	}
-	this.runNegativeTest(
-		false,
+	AbstractRegressionTest.runNegativeTest(
+		this, false,
 		new String[] {
 			"X.java",
 			"public class X { \n" +
@@ -4858,7 +4858,7 @@ public void test125() throws Exception {
 				"  \n" +
 				"  // Method descriptor #10 (LX;Ljava/lang/String;)V\n" +
 				"  // Stack: 2, Locals: 3\n" +
-				(isMinimumCompliant(ClassFileConstants.JDK11) ? "  private " :"  ") +
+				(AbstractRegressionTest.isMinimumCompliant(this, ClassFileConstants.JDK11) ? "  private " :"  ") +
 				"X$1Local(X arg0, java.lang.String arg1);\n" +
 				"     0  aload_0 [this]\n" +
 				"     1  aload_1 [arg0]\n" +
@@ -4891,7 +4891,7 @@ public void test125() throws Exception {
 				"  Inner classes:\n" +
 				"    [inner class info: #1 X$1Local, outer class info: #0\n" +
 				"     inner name: #44 Local, accessflags: 0 default]\n" +
-				(isMinimumCompliant(ClassFileConstants.JDK11) ?
+				(AbstractRegressionTest.isMinimumCompliant(this, ClassFileConstants.JDK11) ?
 				"  Enclosing Method: #39  #41 X.foo(Ljava/lang/String;)V\n" +
 				"\n" +
 				"Nest Host: #39 X\n" : "");
@@ -5063,8 +5063,8 @@ public void test129() {
 public void test130() {
 	CompilerOptions options = new CompilerOptions(getCompilerOptions());
 	if (options.sourceLevel <= ClassFileConstants.JDK1_3) {
-    	runConformTest(
-   			true /* flush output directory */,
+    	AbstractRegressionTest.runConformTest(
+   			this, true /* flush output directory */,
     		new String[] { /* test files */
     			"X.java", //========================
     			"public class X {\n" +
@@ -5231,8 +5231,8 @@ public void test131() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=165662
 public void test132() {
-	this.runConformTest(
-		true,
+	AbstractRegressionTest.runConformTest(
+		this, true,
 		new String[] {
 			"X.java",
 			"public class X {\n" +
@@ -5519,7 +5519,7 @@ public void test138() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=152961 - variation
 public void test139() {
-	String errMessage = isMinimumCompliant(ClassFileConstants.JDK11) ?
+	String errMessage = AbstractRegressionTest.isMinimumCompliant(this, ClassFileConstants.JDK11) ?
 			"----------\n" +
 			"1. ERROR in X.java (at line 9)\n" +
 			"	class Y extends Zork {}\n" +
@@ -5574,7 +5574,7 @@ public void test140() throws Exception {
 		"  Inner classes:\n" +
 		"    [inner class info: #5 p/A$I, outer class info: #20 p/A\n" +
 		"     inner name: #22 I, accessflags: 1545 public abstract static]\n";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "p1" + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "p1" + File.separator + "X.class", "X", expectedOutput);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=171184
 public void test141() throws Exception {
@@ -5596,7 +5596,7 @@ public void test141() throws Exception {
 		"  Inner classes:\n" +
 		"    [inner class info: #3 p/A$B, outer class info: #17 p/A\n" +
 		"     inner name: #19 B, accessflags: 9 public static]\n";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "p1" + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "p1" + File.separator + "X.class", "X", expectedOutput);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=171184
 public void test142() throws Exception {
@@ -5627,7 +5627,7 @@ public void test142() throws Exception {
 			"    [inner class info: #16 p/A$B, outer class info: #18 p/A\n" +
 			"     inner name: #27 B, accessflags: 1 public]\n";
 	}
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "p1" + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "p1" + File.separator + "X.class", "X", expectedOutput);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=171184
 public void test143() throws Exception {
@@ -5649,7 +5649,7 @@ public void test143() throws Exception {
 			"  Inner classes:\n" +
 			"    [inner class info: #16 A$B, outer class info: #21 A\n" +
 			"     inner name: #23 B, accessflags: 1 public]\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+		AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 	}
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=171184
@@ -5671,7 +5671,7 @@ public void test144() throws Exception {
 		"  Inner classes:\n" +
 		"    [inner class info: #17 A$B, outer class info: #25 A\n" +
 		"     inner name: #27 B, accessflags: 9 public static]\n";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=171184
 public void test145() throws Exception {
@@ -5689,7 +5689,7 @@ public void test145() throws Exception {
 		"  Inner classes:\n" +
 		"    [inner class info: #19 A$B, outer class info: #21 A\n" +
 		"     inner name: #23 B, accessflags: 9 public static]\n";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=171184
 public void test146() throws Exception {
@@ -5709,7 +5709,7 @@ public void test146() throws Exception {
 		"  Inner classes:\n" +
 		"    [inner class info: #21 A$B, outer class info: #23 A\n" +
 		"     inner name: #25 B, accessflags: 9 public static]\n";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=171184
 public void test147() throws Exception {
@@ -5729,7 +5729,7 @@ public void test147() throws Exception {
 		"  Inner classes:\n" +
 		"    [inner class info: #19 A$B, outer class info: #21 A\n" +
 		"     inner name: #23 B, accessflags: 9 public static]\n";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=171184
 public void test148() throws Exception {
@@ -5748,7 +5748,7 @@ public void test148() throws Exception {
 		"  Inner classes:\n" +
 		"    [inner class info: #16 A$B, outer class info: #21 A\n" +
 		"     inner name: #23 B, accessflags: 9 public static]\n";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=171749
 public void test149() throws Exception {
@@ -5798,7 +5798,7 @@ public void test149() throws Exception {
 		"     inner name: #0, accessflags: 0 default],\n" +
 		"    [inner class info: #54 X$Foo6, outer class info: #1 X\n" +
 		"     inner name: #56 Foo6, accessflags: 9 public static]\n";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=210422
 public void test150() {
@@ -6354,7 +6354,7 @@ public void test156() throws Exception {
 		"  static synthetic void access$0(package2.C arg0);\n" +
 		"    0  aload_0 [arg0]\n" +
 		"    1  invokevirtual package2.C.outerMethod() : void";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "package2" + File.separator + "C.class", "C", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "package2" + File.separator + "C.class", "C", expectedOutput);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=249107
 public void test157() throws Exception {
@@ -6392,7 +6392,7 @@ public void test157() throws Exception {
 		"  static synthetic int access$0(package2.C arg0);\n" +
 		"    0  aload_0 [arg0]\n" +
 		"    1  getfield package2.C.outerField : int";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "package2" + File.separator + "C.class", "C", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "package2" + File.separator + "C.class", "C", expectedOutput);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=249107 - variation
 public void test158() throws Exception {
@@ -6432,7 +6432,7 @@ public void test158() throws Exception {
 		"    1  iload_1 [arg1]\n" +
 		"    2  putfield package2.C.outerField : int";
 
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "package2" + File.separator + "C.class", "C", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "package2" + File.separator + "C.class", "C", expectedOutput);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=249107 - variation
 public void test159() throws Exception {
@@ -6470,7 +6470,7 @@ public void test159() throws Exception {
 		"  static synthetic int access$0(package2.C arg0);\n" +
 		"    0  aload_0 [arg0]\n" +
 		"    1  getfield package2.C.outerField : int";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "package2" + File.separator + "C.class", "C", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "package2" + File.separator + "C.class", "C", expectedOutput);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=249107 - variation
 public void test160() throws Exception {
@@ -6509,7 +6509,7 @@ public void test160() throws Exception {
 		"    0  aload_0 [arg0]\n" +
 		"    1  iload_1 [arg1]\n" +
 		"    2  putfield package2.C.outerField : int";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "package2" + File.separator + "C.class", "C", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "package2" + File.separator + "C.class", "C", expectedOutput);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=249107 - variation
 public void test161() throws Exception {
@@ -6546,7 +6546,7 @@ public void test161() throws Exception {
 		"  // Stack: 1, Locals: 0\n" +
 		"  static synthetic int access$0();\n" +
 		"    0  getstatic package2.C.outerField : int";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "package2" + File.separator + "C.class", "C", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "package2" + File.separator + "C.class", "C", expectedOutput);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=249107 - variation
 public void test162() throws Exception {
@@ -6585,7 +6585,7 @@ public void test162() throws Exception {
 		"    0  iload_0 [arg0]\n" +
 		"    1  putstatic package2.C.outerField : int";
 
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "package2" + File.separator + "C.class", "C", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "package2" + File.separator + "C.class", "C", expectedOutput);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=249107 - variation
 public void test163() throws Exception {
@@ -6622,7 +6622,7 @@ public void test163() throws Exception {
 		"  // Stack: 1, Locals: 0\n" +
 		"  static synthetic int access$0();\n" +
 		"    0  getstatic package2.C.outerField : int";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "package2" + File.separator + "C.class", "C", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "package2" + File.separator + "C.class", "C", expectedOutput);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=249107 - variation
 public void test164() throws Exception {
@@ -6660,7 +6660,7 @@ public void test164() throws Exception {
 		"  static synthetic void access$0(int arg0);\n" +
 		"    0  iload_0 [arg0]\n" +
 		"    1  putstatic package2.C.outerField : int";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "package2" + File.separator + "C.class", "C", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "package2" + File.separator + "C.class", "C", expectedOutput);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=128563 - variation
 public void test165() throws Exception {
@@ -6697,7 +6697,7 @@ public void test165() throws Exception {
 		"  // Stack: 0, Locals: 0\n" +
 		"  static synthetic void access$0();\n" +
 		"    0  invokestatic package2.C.outerMethod() : void";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "package2" + File.separator + "C.class", "C", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "package2" + File.separator + "C.class", "C", expectedOutput);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=249107 - variation
 public void test166() throws Exception {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/InnerEmulationTest_1_5.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/InnerEmulationTest_1_5.java
@@ -45,7 +45,7 @@ public void test1() throws Exception {
 		"  Inner classes:\n" +
 		"    [inner class info: #25 java/util/Map$Entry, outer class info: #27 java/util/Map\n" +
 		"     inner name: #29 Entry, accessflags: 1545 public abstract static]\n";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=275381
 public void test2() throws Exception {
@@ -62,7 +62,7 @@ public void test2() throws Exception {
 		"  Inner classes:\n" +
 		"    [inner class info: #21 java/util/Map$Entry, outer class info: #23 java/util/Map\n" +
 		"     inner name: #25 Entry, accessflags: 1545 public abstract static]\n";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "p" + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "p" + File.separator + "X.class", "X", expectedOutput);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=275381
 public void test3() throws Exception {
@@ -79,7 +79,7 @@ public void test3() throws Exception {
 		"  Inner classes:\n" +
 		"    [inner class info: #27 java/util/Map$Entry, outer class info: #29 java/util/Map\n" +
 		"     inner name: #31 Entry, accessflags: 1545 public abstract static]\n";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=275381
 public void test4() throws Exception {
@@ -93,7 +93,7 @@ public void test4() throws Exception {
 		"  Inner classes:\n" +
 		"    [inner class info: #21 java/util/Map$Entry, outer class info: #23 java/util/Map\n" +
 		"     inner name: #25 Entry, accessflags: 1545 public abstract static]\n";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=275381
 public void test5() throws Exception {
@@ -110,7 +110,7 @@ public void test5() throws Exception {
 		"  Inner classes:\n" +
 		"    [inner class info: #25 java/util/Map$Entry, outer class info: #27 java/util/Map\n" +
 		"     inner name: #29 Entry, accessflags: 1545 public abstract static]\n";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "p" + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "p" + File.separator + "X.class", "X", expectedOutput);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=275381
 public void test6() throws Exception {
@@ -127,7 +127,7 @@ public void test6() throws Exception {
 		"  Inner classes:\n" +
 		"    [inner class info: #21 java/util/Map$Entry, outer class info: #23 java/util/Map\n" +
 		"     inner name: #25 Entry, accessflags: 1545 public abstract static]\n";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "p" + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "p" + File.separator + "X.class", "X", expectedOutput);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=275381
 public void test7() throws Exception {
@@ -143,7 +143,7 @@ public void test7() throws Exception {
 		"  Inner classes:\n" +
 		"    [inner class info: #21 java/util/Map$Entry, outer class info: #23 java/util/Map\n" +
 		"     inner name: #25 Entry, accessflags: 1545 public abstract static]\n";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "p" + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "p" + File.separator + "X.class", "X", expectedOutput);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=275381
 public void test8() throws Exception {
@@ -164,7 +164,7 @@ public void test8() throws Exception {
 		"     inner name: #25 Entry, accessflags: 1545 public abstract static],\n" +
 		"    [inner class info: #26 p/A$B, outer class info: #28 p/A\n" +
 		"     inner name: #30 B, accessflags: 8 static]\n";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "p" + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "p" + File.separator + "X.class", "X", expectedOutput);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=275381
 public void test9() throws Exception {
@@ -186,7 +186,7 @@ public void test9() throws Exception {
 		"     inner name: #29 Entry, accessflags: 1545 public abstract static],\n" +
 		"    [inner class info: #30 p/A$B, outer class info: #32 p/A\n" +
 		"     inner name: #34 B, accessflags: 8 static]\n";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "p" + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "p" + File.separator + "X.class", "X", expectedOutput);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=275381
 public void test10() throws Exception {
@@ -213,7 +213,7 @@ public void test10() throws Exception {
 		"     inner name: #34 B, accessflags: 1544 abstract static],\n" +
 		"    [inner class info: #35 p/C$D, outer class info: #37 p/C\n" +
 		"     inner name: #39 D, accessflags: 8 static]\n";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "p" + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "p" + File.separator + "X.class", "X", expectedOutput);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=275381
 public void test11() throws Exception {
@@ -248,7 +248,7 @@ public void test11() throws Exception {
 		"     inner name: #40 SubType, accessflags: 8 static],\n" +
 		"    [inner class info: #41 X$SuperType, outer class info: #1 X\n" +
 		"     inner name: #43 SuperType, accessflags: 8 static]\n";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=275381
 public void test12() throws Exception {
@@ -265,7 +265,7 @@ public void test12() throws Exception {
 		"  Inner classes:\n" +
 		"    [inner class info: #21 java/util/Map$Entry, outer class info: #23 java/util/Map\n" +
 		"     inner name: #25 Entry, accessflags: 1545 public abstract static]\n";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "p" + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "p" + File.separator + "X.class", "X", expectedOutput);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=275381
 public void test13() throws Exception {
@@ -289,7 +289,7 @@ public void test13() throws Exception {
 		"     inner name: #21 B, accessflags: 1544 abstract static],\n" +
 		"    [inner class info: #3 p/C$D, outer class info: #22 p/C\n" +
 		"     inner name: #24 D, accessflags: 8 static]\n";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "p" + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "p" + File.separator + "X.class", "X", expectedOutput);
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=343713
 // [compiler] bogus line number in constructor of inner class in 1.5 compliance
@@ -324,7 +324,7 @@ public void test14() throws Exception {
 		"        [pc: 0, line: 3]\n" +
 		"        [pc: 9, line: 4]\n" +
 		"        [pc: 17, line: 5]\n";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "LineNumberBug$Inner.class", "LineNumberBug$Inner", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "LineNumberBug$Inner.class", "LineNumberBug$Inner", expectedOutput);
 }
 public void testBug546362() throws Exception {
 	runConformTest(new String[] {
@@ -343,7 +343,7 @@ public void testBug546362() throws Exception {
 			"    [inner class info: #41 java/util/Map$Entry, outer class info: #43 java/util/Map\n" +
 			"     inner name: #45 Entry, accessflags: 1545 public abstract static]\n" +
 			"";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "Schema.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "Schema.class", "X", expectedOutput);
 }
 public static Class testClass() {
 	return InnerEmulationTest_1_5.class;

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/InstanceofPrimaryPatternTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/InstanceofPrimaryPatternTest.java
@@ -55,7 +55,7 @@ public class InstanceofPrimaryPatternTest extends AbstractRegressionTest {
 	protected void runConformTest(String[] testFiles, String expectedOutput, Map<String, String> customOptions) {
 		if(!isJRE17Plus)
 			return;
-		runConformTest(testFiles, expectedOutput, customOptions, new String[] {"--enable-preview"}, JAVAC_OPTIONS);
+		AbstractRegressionTest.runConformTest(this, testFiles, expectedOutput, customOptions, new String[] {"--enable-preview"}, JAVAC_OPTIONS);
 	}
 	protected void runNegativeTest(
 			String[] testFiles,

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/InterfaceMethodsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/InterfaceMethodsTest.java
@@ -415,8 +415,8 @@ public class InterfaceMethodsTest extends AbstractComparableTest {
 	public void testModifiers7() {
 		Map options = getCompilerOptions();
 		options.put(JavaCore.COMPILER_PB_UNDOCUMENTED_EMPTY_BLOCK, JavaCore.ERROR);
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"I.java",
 				"public interface I {\n" +
 				"    default void foo();\n" +
@@ -1240,7 +1240,7 @@ public class InterfaceMethodsTest extends AbstractComparableTest {
 				"    0  aload_0 [this]\n" +
 				"    1  invokespecial java.util.List.spliterator() : java.util.Spliterator [17]\n" +
 				"    4  areturn\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "OrderedSet.class", "OrderedSet", expectedOutput);
+		AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "OrderedSet.class", "OrderedSet", expectedOutput);
 	}
 
 	// some illegal cases
@@ -1609,7 +1609,7 @@ public class InterfaceMethodsTest extends AbstractComparableTest {
 				"      Local variable table:\n" +
 				"        [pc: 0, pc: 19] local: args index: 0 type: java.lang.String[]\n" +
 				"        [pc: 8, pc: 19] local: c index: 1 type: C\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "C.class", "C", expectedOutput);
+		AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "C.class", "C", expectedOutput);
 	}
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=399780
 	// Test invocation of static methods with different contexts - negative tests
@@ -1917,8 +1917,8 @@ public class InterfaceMethodsTest extends AbstractComparableTest {
 		Map compilerOptions = getCompilerOptions();
 		compilerOptions.put(CompilerOptions.OPTION_ReportMethodCanBeStatic, CompilerOptions.ERROR);
 		compilerOptions.put(CompilerOptions.OPTION_ReportMethodCanBePotentiallyStatic, CompilerOptions.ERROR);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"interface X {\n" +
 				"	default int foo() {\n" +
@@ -2898,8 +2898,8 @@ public class InterfaceMethodsTest extends AbstractComparableTest {
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=437522, [1.8][compiler] Missing compile error in Java 8 mode for Interface.super.field access
 	// Example JLS: 15.11.2-1.
 	public void testBug437522a() throws Exception {
-		runConformTest(
-			true,
+		AbstractRegressionTest.runConformTest(
+			this, true,
 			new String[] {
 				"X.java",
 				"interface I  { int x = 0; }\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JEP286Test.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JEP286Test.java
@@ -472,8 +472,8 @@ public void test0016_dont_capture_deep_poly_expressions() throws IOException {
 
 public void test0017_simple_variable_types() throws Exception {
 	InferredTypeVerifier typeVerifier = new InferredTypeVerifier();
-	this.runConformTest(
-			new String[] {
+	AbstractRegressionTest.runConformTest(
+			this, new String[] {
 				"X.java",
 				"import java.util.List;\n" +
 				"\n" +
@@ -502,8 +502,8 @@ public void test0017_simple_variable_types() throws Exception {
 }
 public void test0018_primitive_variable_types() throws Exception {
 	InferredTypeVerifier typeVerifier = new InferredTypeVerifier();
-	this.runConformTest(
-			new String[] {
+	AbstractRegressionTest.runConformTest(
+			this, new String[] {
 				"Y.java",
 				"class Y {\n" +
 				"    boolean[] booleanArray = { true };\n" +
@@ -554,8 +554,8 @@ public void test0018_primitive_variable_types() throws Exception {
 }
 public void test0018_project_variable_types() throws Exception {
 	InferredTypeVerifier typeVerifier = new InferredTypeVerifier();
-	this.runConformTest(
-			new String[] {
+	AbstractRegressionTest.runConformTest(
+			this, new String[] {
 				"Z.java",
 				"import java.util.Collection;\n" +
 				"import java.util.List;\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JSR308SpecSnippetTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JSR308SpecSnippetTests.java
@@ -91,7 +91,7 @@ public class JSR308SpecSnippetTests extends AbstractRegressionTest {
 				"        target type = 0x13 FIELD\n" +
 				"        location = [TYPE_ARGUMENT(1), TYPE_ARGUMENT(0)]\n" +
 				"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 	// note, javac 8b100 emits offset incorrectly.
 	public void test002() throws Exception {
@@ -122,7 +122,7 @@ public class JSR308SpecSnippetTests extends AbstractRegressionTest {
 				"        offset = 3\n" +
 				"        type argument index = 0\n" +
 				"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test003() throws Exception {
@@ -169,7 +169,7 @@ public class JSR308SpecSnippetTests extends AbstractRegressionTest {
 				"      target type = 0x11 CLASS_TYPE_PARAMETER_BOUND\n" +
 				"      type parameter index = 0 type parameter bound index = 0\n" +
 				"    )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 	public void test004() throws Exception {
 		this.runConformTest(
@@ -200,7 +200,7 @@ public class JSR308SpecSnippetTests extends AbstractRegressionTest {
 				"      type index = 0\n" +
 				"      location = [TYPE_ARGUMENT(0)]\n" +
 				"    )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 	public void test005() throws Exception {
 		this.runConformTest(
@@ -227,7 +227,7 @@ public class JSR308SpecSnippetTests extends AbstractRegressionTest {
 				"        target type = 0x17 THROWS\n" +
 				"        throws index = 0\n" +
 				"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 	public void test006() throws Exception {
 		this.runConformTest(
@@ -275,7 +275,7 @@ public class JSR308SpecSnippetTests extends AbstractRegressionTest {
 				"        offset = 12\n" +
 				"        location = [INNER_TYPE]\n" +
 				"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 	public void test007() throws Exception {
 		this.runConformTest(
@@ -306,7 +306,7 @@ public class JSR308SpecSnippetTests extends AbstractRegressionTest {
 				"      #8 @NonNull(\n" +
 				"        target type = 0x13 FIELD\n" +
 				"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 	public void test008() throws Exception {
 		this.runConformTest(
@@ -354,7 +354,7 @@ public class JSR308SpecSnippetTests extends AbstractRegressionTest {
 				"        type argument index = 0\n" +
 				"      )\n" +
 				"}";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 	public void test009() throws Exception {
 		this.runConformTest(
@@ -389,7 +389,7 @@ public class JSR308SpecSnippetTests extends AbstractRegressionTest {
 				"        target type = 0x43 INSTANCEOF\n" +
 				"        offset = 1\n" +
 				"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 	public void test010() throws Exception {
 		this.runConformTest(
@@ -446,7 +446,7 @@ public class JSR308SpecSnippetTests extends AbstractRegressionTest {
 				"        offset = 12\n" +
 				"        type argument index = 0\n" +
 				"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test011() throws Exception {
@@ -582,7 +582,7 @@ public class JSR308SpecSnippetTests extends AbstractRegressionTest {
 				"      Local variable table:\n" +
 				"        [pc: 0, pc: 5] local: this index: 0 type: X\n" +
 				"}";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 	public void test012() throws Exception {
 		this.runConformTest(
@@ -667,7 +667,7 @@ public class JSR308SpecSnippetTests extends AbstractRegressionTest {
 				"        offset = 30\n" +
 				"        location = [ARRAY]\n" +
 				"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 	public void test013() throws Exception {
 		this.runConformTest(
@@ -725,7 +725,7 @@ public class JSR308SpecSnippetTests extends AbstractRegressionTest {
 				"        target type = 0x14 METHOD_RETURN\n" +
 				"      )\n" +
 				"}";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 	public void test014() throws Exception {
 		this.runNegativeTest(
@@ -822,7 +822,7 @@ public class JSR308SpecSnippetTests extends AbstractRegressionTest {
 				"        target type = 0x15 METHOD_RECEIVER\n" +
 				"        location = [INNER_TYPE]\n" +
 				"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X$Y.class", "Y", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X$Y.class", "Y", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 	public void test016() throws Exception {
 		this.runConformTest(
@@ -859,7 +859,7 @@ public class JSR308SpecSnippetTests extends AbstractRegressionTest {
 				"        target type = 0x15 METHOD_RECEIVER\n" +
 				"        location = [INNER_TYPE, INNER_TYPE]\n" +
 				"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "Outer$Middle$Inner.class", "Inner", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "Outer$Middle$Inner.class", "Inner", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 	public void test017() throws Exception {
 		this.runConformTest(
@@ -887,7 +887,7 @@ public class JSR308SpecSnippetTests extends AbstractRegressionTest {
 				"      #22 @Receiver(\n" +
 				"        target type = 0x15 METHOD_RECEIVER\n" +
 				"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X$Y.class", "Y", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X$Y.class", "Y", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 	public void test018() throws Exception {
 		this.runNegativeTest(
@@ -937,7 +937,7 @@ public class JSR308SpecSnippetTests extends AbstractRegressionTest {
 				"      target type = 0x0 CLASS_TYPE_PARAMETER\n" +
 				"      type parameter index = 0\n" +
 				"    )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 	public void test020() throws Exception {
 		this.runNegativeTest(
@@ -1116,7 +1116,7 @@ public class JSR308SpecSnippetTests extends AbstractRegressionTest {
 				"      #17 @Readonly(\n" +
 				"        target type = 0x14 METHOD_RETURN\n" +
 				"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 	public void test023() throws Exception {
 		this.runConformTest(
@@ -1142,7 +1142,7 @@ public class JSR308SpecSnippetTests extends AbstractRegressionTest {
 				"      #13 @Readonly(\n" +
 				"        target type = 0x14 METHOD_RETURN\n" +
 				"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 	public void test024() throws Exception {
 		this.runConformTest(
@@ -1174,7 +1174,7 @@ public class JSR308SpecSnippetTests extends AbstractRegressionTest {
 				"        target type = 0x42 EXCEPTION_PARAMETER\n" +
 				"        exception table index = 1\n" +
 				"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 	public void test025() throws Exception {
 		this.runConformTest(
@@ -1204,7 +1204,7 @@ public class JSR308SpecSnippetTests extends AbstractRegressionTest {
 				"        method parameter index = 0\n" +
 				"        location = [ARRAY, ARRAY]\n" +
 				"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 	public void test026() throws Exception {
 		this.runConformTest(
@@ -1234,7 +1234,7 @@ public class JSR308SpecSnippetTests extends AbstractRegressionTest {
 				"        method parameter index = 0\n" +
 				"        location = [ARRAY, ARRAY]\n" +
 				"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 	public void test027() throws Exception {
 		this.runConformTest(
@@ -1262,7 +1262,7 @@ public class JSR308SpecSnippetTests extends AbstractRegressionTest {
 				"        target type = 0x13 FIELD\n" +
 				"        location = [ARRAY]\n" +
 				"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 	public void test028() throws Exception {
 		this.runConformTest(
@@ -1366,7 +1366,7 @@ public class JSR308SpecSnippetTests extends AbstractRegressionTest {
 				"      type parameter index = 0\n" +
 				"    )\n" +
 				"}";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 	public void test029() throws Exception {
 		this.runNegativeTest(
@@ -1486,7 +1486,7 @@ public class JSR308SpecSnippetTests extends AbstractRegressionTest {
 				"    #18 @TypeAnnotation(\n" +
 				"    )\n" +
 				"}";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test030a() throws Exception {
@@ -1543,7 +1543,7 @@ public class JSR308SpecSnippetTests extends AbstractRegressionTest {
 				"    #18 @TypeAnnotation(\n" +
 				"    )\n" +
 				"}";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test030b() throws Exception {
@@ -1621,7 +1621,7 @@ public class JSR308SpecSnippetTests extends AbstractRegressionTest {
 				"    #18 @TypeAnnotation(\n" +
 				"    )\n" +
 				"}";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 	// Test that annotations in initializer code are not attached to the field.
 	public void test031() throws Exception {
@@ -1658,7 +1658,7 @@ public class JSR308SpecSnippetTests extends AbstractRegressionTest {
 				"        offset = 5\n" +
 				"      )\n" +
 				"}";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 	// Test co-existence of parameter annotations and type annotations.
 	public void test032() throws Exception {
@@ -1695,7 +1695,7 @@ public class JSR308SpecSnippetTests extends AbstractRegressionTest {
 				"      #20 @NonNull(\n" +
 				"        target type = 0x15 METHOD_RECEIVER\n" +
 				"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 	// Test type annotations in initializer code.
 	public void test033() throws Exception {
@@ -1821,7 +1821,7 @@ public class JSR308SpecSnippetTests extends AbstractRegressionTest {
 				"        offset = 4\n" +
 				"      )\n" +
 				"}";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 	public void test034() throws Exception {
 		this.runConformTest(
@@ -1884,7 +1884,7 @@ public class JSR308SpecSnippetTests extends AbstractRegressionTest {
 				"      type parameter index = 0 type parameter bound index = 1\n" +
 				"    )\n" +
 				"}";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	// Bug 415543 - Incorrect bound index in RuntimeInvisibleTypeAnnotations attribute
@@ -2070,7 +2070,7 @@ public class JSR308SpecSnippetTests extends AbstractRegressionTest {
 				"      type parameter index = 0 type parameter bound index = 2\n" +
 				"    )\n" +
 				"}";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 	public void test035() throws Exception {
 		this.runConformTest(
@@ -2111,7 +2111,7 @@ public class JSR308SpecSnippetTests extends AbstractRegressionTest {
 				"          [pc: 6, pc: 14] index: 1\n" +
 				"        location = [ARRAY]\n" +
 				"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 	// test that parameter index does not include explicit this parameter.
 	public void test036() throws Exception {
@@ -2143,7 +2143,7 @@ public class JSR308SpecSnippetTests extends AbstractRegressionTest {
 				"      #18 @NonNull(\n" +
 				"        target type = 0x15 METHOD_RECEIVER\n" +
 				"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 	public void test037() throws Exception {
 		this.runConformTest(
@@ -2186,7 +2186,7 @@ public class JSR308SpecSnippetTests extends AbstractRegressionTest {
 				"        offset = 7\n" +
 				"      )\n" +
 				"}";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 	// test anonymous class, the class itself should have class_extends target ?
 	public void test038() throws Exception {
@@ -2227,7 +2227,7 @@ public class JSR308SpecSnippetTests extends AbstractRegressionTest {
 				"        target type = 0x44 NEW\n" +
 				"        offset = 5\n" +
 				"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 	public void test039() throws Exception {
 		this.runConformTest(
@@ -2263,7 +2263,7 @@ public class JSR308SpecSnippetTests extends AbstractRegressionTest {
 				"        location = [TYPE_ARGUMENT(0)]\n" +
 				"      )\n" +
 				"}";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 	public void test040() throws Exception {
 		this.runConformTest(
@@ -2296,7 +2296,7 @@ public class JSR308SpecSnippetTests extends AbstractRegressionTest {
 				"        local variable entries:\n" +
 				"          [pc: 8, pc: 21] index: 1\n" +
 				"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 	public void test041() throws Exception {
 		this.runConformTest(
@@ -2334,7 +2334,7 @@ public class JSR308SpecSnippetTests extends AbstractRegressionTest {
 				"      type parameter index = 1 type parameter bound index = 1\n" +
 				"    )\n" +
 				"}";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 	// type path tests.
 	public void test042() throws Exception {
@@ -2392,7 +2392,7 @@ public class JSR308SpecSnippetTests extends AbstractRegressionTest {
 				"        location = [TYPE_ARGUMENT(1), TYPE_ARGUMENT(0)]\n" +
 				"      )\n" +
 				"  \n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	// Bug 414384 - [1.8] type annotation on abbreviated inner class is not marked as inner type
@@ -2472,7 +2472,7 @@ public class JSR308SpecSnippetTests extends AbstractRegressionTest {
 				"    [inner class info: #24 pkg/Clazz$Inner, outer class info: #1 pkg/Clazz\n" +
 				"     inner name: #26 Inner, accessflags: 1 public]\n" +
 				"}";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "pkg" + File.separator + "Clazz.class", "pkg.Clazz", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "pkg" + File.separator + "Clazz.class", "pkg.Clazz", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 	// More type path tests
 	public void test044() throws Exception {
@@ -2522,7 +2522,7 @@ public class JSR308SpecSnippetTests extends AbstractRegressionTest {
 				"        location = [ARRAY, ARRAY]\n" +
 				"      )\n" +
 				"  \n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "Z", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "Z", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 	// More type path tests
 	public void test045() throws Exception {
@@ -2579,7 +2579,7 @@ public class JSR308SpecSnippetTests extends AbstractRegressionTest {
 				"        location = [INNER_TYPE, INNER_TYPE, INNER_TYPE]\n" +
 				"      )\n" +
 				"  \n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "Z", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "Z", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 	// More type path tests
 	public void test046() throws Exception {
@@ -2663,7 +2663,7 @@ public class JSR308SpecSnippetTests extends AbstractRegressionTest {
 				"        location = [TYPE_ARGUMENT(1), TYPE_ARGUMENT(0)]\n" +
 				"      )\n" +
 				"  \n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "Z", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "Z", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 	// More type path tests
 	public void test047() throws Exception {
@@ -2758,7 +2758,7 @@ public class JSR308SpecSnippetTests extends AbstractRegressionTest {
 			"        location = [INNER_TYPE, INNER_TYPE, INNER_TYPE, TYPE_ARGUMENT(1)]\n" +
 			"      )\n" +
 			"  \n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "Z", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "Z", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 	public void test048() throws Exception {
 		this.runConformTest(
@@ -2831,7 +2831,7 @@ public class JSR308SpecSnippetTests extends AbstractRegressionTest {
 				"      location = [TYPE_ARGUMENT(1), TYPE_ARGUMENT(0)]\n" +
 				"    )\n" +
 				"}";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "Z", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "Z", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 	public void test049() throws Exception {
 		this.runConformTest(
@@ -2917,6 +2917,6 @@ public class JSR308SpecSnippetTests extends AbstractRegressionTest {
 				"        location = [INNER_TYPE]\n" +
 				"      )\n" +
 				"\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "Z", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "Z", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JSR335ClassFileTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JSR335ClassFileTest.java
@@ -3746,8 +3746,8 @@ public void test430035() throws IOException, ClassFormatException {
 public void test430571() throws IOException, ClassFormatException {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_MethodParametersAttribute, CompilerOptions.GENERATE);
-	this.runConformTest(
-			new String[] {
+	AbstractRegressionTest.runConformTest(
+			this, new String[] {
 				"X.java",
 				"import java.lang.annotation.ElementType;\n" +
 				"import java.lang.annotation.Target;\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocBugsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocBugsTest.java
@@ -357,8 +357,8 @@ public void testBug45669() {
  */
 public void testBug45669a() {
 	this.reportMissingJavadocTags = CompilerOptions.ERROR;
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	/**\n" +
@@ -416,8 +416,8 @@ public void testBug45958() {
 	);
 }
 public void testBug45958a() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 		   "X.java",
 	   		"public class X {\n" +
 	   		"	int x;\n" +
@@ -441,8 +441,8 @@ public void testBug45958a() {
 	);
 }
 public void testBug45958b() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 		   "X.java",
 	   		"public class X {\n" +
 	   		"	int x;\n" +
@@ -523,8 +523,8 @@ public void testBug46901() {
  * @see <a href="http://bugs.eclipse.org/bugs/show_bug.cgi?id=47215">47215</a>
  */
 public void testBug47215() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"	/**\n" +
 			"	 * @see X\n" +
@@ -676,8 +676,8 @@ public void testBug47339a() {
 }
 public void testBug47339b() {
 	this.reportMissingJavadocTags = CompilerOptions.ERROR;
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"/** */\n" +
 			"public class X implements Comparable {\n" +
@@ -712,8 +712,8 @@ public void testBug47339b() {
 }
 public void testBug47339c() {
 	this.reportMissingJavadocTags = CompilerOptions.ERROR;
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"/** */\n" +
 			"public class X extends RuntimeException {\n" +
@@ -740,8 +740,8 @@ public void testBug47339c() {
  */
 public void testBug48064() {
 	this.reportMissingJavadocTags = CompilerOptions.ERROR;
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	public X(String str) {}\n" +
@@ -770,8 +770,8 @@ public void testBug48064() {
 }
 public void testBug48064a() {
 	this.reportMissingJavadocTags = CompilerOptions.ERROR;
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	public void foo(String str) {}\n" +
@@ -883,8 +883,8 @@ public void testBug45782() {
 }
 public void testBug45782a() {
 	this.reportMissingJavadocTags = CompilerOptions.ERROR;
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 				"	/**\n" +
@@ -948,8 +948,8 @@ public void testBug49260() {
  * @see <a href="http://bugs.eclipse.org/bugs/show_bug.cgi?id=48385">48385</a>
  */
 public void testBug48385() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"import java.util.Vector;\n" +
 				"public class X {\n" +
@@ -995,8 +995,8 @@ public void testBug48385() {
 }
 
 public void testBug48385And49620() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"import java.util.Vector;\n" +
 				"public class X {\n" +
@@ -1058,8 +1058,8 @@ public void testBug48385And49620() {
 	);
 }
 public void testBug48385a() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 				"	/**\n" +
@@ -1125,8 +1125,8 @@ public void testBug49491() {
 				"}\n" });
 }
 public void testBug49491a() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public final class X {\n" +
 				"	/**\n" +
@@ -1184,8 +1184,8 @@ public void testBug48376() {
 	 });
 }
 public void testBug48376a() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"/**\n" +
 				"	* @see <a href=\"http:/www.ibm.com\">IBM Home Page\n" +
@@ -1289,8 +1289,8 @@ public void testBug50695() {
 		 });
 }
 public void testBug50695b() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 				"	/**\n" +
@@ -1365,8 +1365,8 @@ public void testBug52216a() {
 	 });
 }
 public void testBug52216b() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"/**\n" +
 				"* @see <a href=\"http://www.ietf.org/rfc/rfc2045.txt\">RFC 2045 - Section 6.8</a>		   \n" +
@@ -1429,8 +1429,8 @@ public void testBug51529a() {
 }
 public void testBug51529b() {
 	this.docCommentSupport = CompilerOptions.DISABLED;
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"import java.util.Vector;\n" +
 			"public class X {\n" +
@@ -1521,8 +1521,8 @@ public void testBug51911c() {
  * @see <a href="http://bugs.eclipse.org/bugs/show_bug.cgi?id=53279">53279</a>
  */
 public void testBug53279() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 				"	/**\n" +
@@ -1542,8 +1542,8 @@ public void testBug53279() {
 	);
 }
 public void testBug53279a() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 				"	/**\n" +
@@ -1564,8 +1564,8 @@ public void testBug53279a() {
 	);
 }
 public void testBug53279b() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 				"	/**\n" +
@@ -1590,8 +1590,8 @@ public void testBug53279b() {
 	);
 }
 public void testBug53279c() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 				"	/**\n" +
@@ -1622,8 +1622,8 @@ public void testBug53279c() {
  * @see <a href="http://bugs.eclipse.org/bugs/show_bug.cgi?id=53290">53290</a>
  */
 public void testBug53290() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 				"	/**\n" +
@@ -1656,8 +1656,8 @@ public void testBug53290() {
  * @see <a href="http://bugs.eclipse.org/bugs/show_bug.cgi?id=62812">62812</a>
  */
 public void testBug62812() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"Test.java",
 			"/**\n" +
 				" * @see Object#clone())\n" +
@@ -1693,8 +1693,8 @@ public void testBug62812() {
 	);
 }
 public void testBug62812a() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"Test.java",
 			"/**\n" +
 				" * {@link Object#clone())}\n" +
@@ -2116,8 +2116,8 @@ public void testBug65180f() {
  */
 public void testBug65253() {
 	this.reportMissingJavadocTags = CompilerOptions.ERROR;
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"Test.java",
 			"/**\n" +
 				" * Comment \n" +
@@ -2218,8 +2218,8 @@ public void testBug66551c() {
  * @see <a href="http://bugs.eclipse.org/bugs/show_bug.cgi?id=66573">66573</a>
  */
 public void testBug66573() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"Test.java",
 			"public class Test {\n" +
 				"    /**\n" +
@@ -2262,8 +2262,8 @@ public void testBug68017conform() {
 	);
 }
 public void testBug68017negative() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 				"	/**@return*/\n" +
@@ -2304,8 +2304,8 @@ public void testBug68017negative() {
 }
 // Javadoc issue a warning on following tests
 public void testBug68017javadocWarning1() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 				"	/**\n" +
@@ -2347,8 +2347,8 @@ public void testBug68017javadocWarning2() {
 	);
 }
 public void testBug68017javadocWarning3() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 				"	/**\n" +
@@ -2404,8 +2404,8 @@ public void testBug68025conform() {
 	);
 }
 public void testBug68025negative() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 				"	public int field;\n" +
@@ -2500,8 +2500,8 @@ public void testBug68726conform2() {
 	);
 }
 public void testBug68726negative1() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 				"	/**\n" +
@@ -2588,8 +2588,8 @@ public void testBug68726negative1() {
 	);
 }
 public void testBug68726negative2() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"/**\n" +
 				"	* @see <a href=\"http:/www.ibm.com\" target=\"_top\">IBM Home Page\n" +
@@ -2671,8 +2671,8 @@ public void testBug69272classValid() {
 	);
 }
 public void testBug69272classInvalid() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 				"	/**@see Object* */\n" +
@@ -2725,8 +2725,8 @@ public void testBug69272fieldValid() {
 	);
 }
 public void testBug69272fieldInvalid() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 				"	int field;\n" +
@@ -2779,8 +2779,8 @@ public void testBug69272methodValid() {
 	);
 }
 public void testBug69272methodInvalid() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 				"	/**@see Object#wait()* */\n" +
@@ -2837,8 +2837,8 @@ public void testBug69275conform() {
 	);
 }
 public void testBug69275negative() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 				"	/**@see <a href=\"http://www.eclipse.org\">text</a>* */\n" +
@@ -2887,8 +2887,8 @@ public void testBug69302conform1() {
 	);
 }
 public void testBug69302negative1() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 				"	/**\n" +
@@ -2916,8 +2916,8 @@ public void testBug69302negative1() {
 	);
 }
 public void testBug69302negative2() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 				"	/**@see Unknown blabla <a href=\"http://www.eclipse.org\">text</a>*/\n" +
@@ -2997,7 +2997,7 @@ public void testBug70892b() {
 	if (this.complianceLevel <= ClassFileConstants.JDK1_4) {
 		runConformTest(testFiles);
 	} else {
-		runNegativeTest(testFiles,
+		AbstractRegressionTest.runNegativeTest(this, testFiles,
 			"----------\n" +
 			"1. ERROR in X.java (at line 3)\r\n" +
 			"	* {@value \"invalid\"}\r\n" +
@@ -3054,8 +3054,8 @@ public void testBug73348conform() {
 	);
 }
 public void testBug73348negative() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 				"	/**\n" +
@@ -3117,8 +3117,8 @@ public void testBug73352a() {
 	};
 	this.reportInvalidJavadoc = CompilerOptions.WARNING;
 	this.reportMissingJavadocDescription = CompilerOptions.ALL_STANDARD_TAGS;
-	runConformTest(
-			true,
+	AbstractRegressionTest.runConformTest(
+			this, true,
 			units,
 			"----------\n" +
 			"1. WARNING in X.java (at line 2)\n" +
@@ -3249,8 +3249,8 @@ public void testBug73352c() {
 	};
 	this.reportInvalidJavadoc = CompilerOptions.WARNING;
 	this.reportMissingJavadocDescription = CompilerOptions.RETURN_TAG;
-	runConformTest(
-		true,
+	AbstractRegressionTest.runConformTest(
+		this, true,
 		units,
 		"----------\n" +
 		"1. WARNING in X.java (at line 9)\n" +
@@ -3305,8 +3305,8 @@ public void testBug73352d() {
  * @see <a href="http://bugs.eclipse.org/bugs/show_bug.cgi?id=73479">73479</a>
  */
 public void testBug73479() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 				"	/**\n" +
@@ -3374,8 +3374,8 @@ public void testBug74369() {
 	);
 }
 public void testBug74369deprecated() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"p/Y.java",
 			"package p;\n" +
 				"\n" +
@@ -3452,8 +3452,8 @@ public void testBug76324() {
 }
 // URL Link references
 public void testBug76324url() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 				"	/**\n" +
@@ -3554,8 +3554,8 @@ public void testBug76324url() {
 }
 // String references
 public void testBug76324string() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 		"X.java",
 		"public class X {\n" +
 		"	/**\n" +
@@ -3600,8 +3600,8 @@ public void testBug76324string() {
  * @see <a href="http://bugs.eclipse.org/bugs/show_bug.cgi?id=77510">77510</a>
  */
 public void testBug77510enabled() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"A.java",
 			"public class A {\n" +
 				"	/** \\u0009 @deprecated */\n" +
@@ -3659,8 +3659,8 @@ public void testBug77510enabled() {
 }
 public void testBug77510disabled() {
 	this.docCommentSupport = CompilerOptions.IGNORE;
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"A.java",
 			"public class A {\n" +
 				"	/** \\u0009 @deprecated */\n" +
@@ -3758,8 +3758,8 @@ public void testBug77260() {
 public void testBug77260nested() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportDeprecationInDeprecatedCode, CompilerOptions.ENABLED);
-	runNegativeTest(
-		true,
+	AbstractRegressionTest.runNegativeTest(
+		this, true,
 		new String[] {
 			"X.java",
 			"/** @deprecated */\n" +
@@ -3847,8 +3847,8 @@ public void testBug77260nested_disabled() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportDeprecationInDeprecatedCode, CompilerOptions.ENABLED);
 	options.put(CompilerOptions.OPTION_ReportInvalidJavadocTagsDeprecatedRef, CompilerOptions.DISABLED);
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"/** @deprecated */\n" +
 				"public class X {\n" +
@@ -3893,8 +3893,8 @@ public void testBug77260nested_disabled() {
  * Bug 77602: [javadoc] "Only consider members as visible as" is does not work for syntax error
  */
 public void testBug77602() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 				"  /**\n" +
@@ -3942,8 +3942,8 @@ public void testBug77602_Public() {
  */
 public void testBug78091() {
 	this.reportMissingJavadocTags = CompilerOptions.ERROR;
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 				"	/**\n" +
@@ -3984,8 +3984,8 @@ public void testBug78091() {
  * @see "http://bugs.eclipse.org/bugs/show_bug.cgi?id=80910"
  */
 public void testBug80910() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"Test.java",
 			"public class Test {\n" +
 			"	int field;\n" +
@@ -4013,8 +4013,8 @@ public void testBug80910() {
  * @see "http://bugs.eclipse.org/bugs/show_bug.cgi?id=82088"
  */
 public void testBug82088() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"Test.java",
 			"public class Test {\n" +
 			"	int field;\n" +
@@ -4085,8 +4085,8 @@ public void testBug83285b() {
 	);
 }
 public void testBug83285c() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"p/A.java",
 			"package p;\n" +
 			"class A {\n" +
@@ -4145,8 +4145,8 @@ public void testBug83285c() {
 public void testBug86769_Classes1() {
 	this.reportMissingJavadocComments = CompilerOptions.ERROR;
 	this.reportMissingJavadocCommentsVisibility = CompilerOptions.PROTECTED;
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"A.java",
 			"/**\n" +
 			" * Test bug 86769 \n" +
@@ -4215,8 +4215,8 @@ public void testBug86769_Classes1() {
 public void testBug86769_Classes2() {
 	this.reportMissingJavadocComments = CompilerOptions.ERROR;
 	this.reportMissingJavadocCommentsVisibility = CompilerOptions.DEFAULT;
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"B.java",
 			"/**\n" +
 			" * Test bug 86769\n" +
@@ -4318,8 +4318,8 @@ public void testBug86769_Classes2() {
 public void testBug86769_Field1() {
 	this.reportMissingJavadocComments = CompilerOptions.ERROR;
 	this.reportMissingJavadocCommentsVisibility = CompilerOptions.PUBLIC;
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"A.java",
 			"/**\n" +
 			" * Test bug 86769\n" +
@@ -4368,8 +4368,8 @@ public void testBug86769_Field1() {
 public void testBug86769_Fields2() {
 	this.reportMissingJavadocComments = CompilerOptions.ERROR;
 	this.reportMissingJavadocCommentsVisibility = CompilerOptions.PRIVATE;
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"B.java",
 			"/**\n" +
 			" * Test bug 86769\n" +
@@ -4515,8 +4515,8 @@ public void testBug86769_Fields2() {
 public void testBug86769_Metthods1() {
 	this.reportMissingJavadocComments = CompilerOptions.ERROR;
 	this.reportMissingJavadocCommentsVisibility = CompilerOptions.PUBLIC;
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"A.java",
 			"/**\n" +
 			" * Test bug 86769\n" +
@@ -4637,8 +4637,8 @@ public void testBug87404() {
  */
 public void testBug90302() {
 	this.reportMissingJavadocTags = CompilerOptions.ERROR;
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"/**\n" +
 			" * @see #foo(String)\n" +
@@ -4694,8 +4694,8 @@ public void testBug90302() {
 }
 public void testBug90302b() {
 	this.reportMissingJavadocTags = CompilerOptions.ERROR;
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"/** */\n" +
 			"public class X {\n" +
@@ -4784,7 +4784,7 @@ public void testBug103304a_public() {
 			"}\n"
 		};
 	if (this.complianceLevel <= ClassFileConstants.JDK1_4) {
-		runNegativeTest(units,
+		AbstractRegressionTest.runNegativeTest(this, units,
 			//boden\TestValid.java:8: warning - Tag @see: reference not found: ValidationException
 			"----------\n" +
 			"1. ERROR in boden\\TestValid.java (at line 4)\n" +
@@ -4845,7 +4845,7 @@ public void testBug103304a_private() {
 			"}\n"
 		};
 	if (this.complianceLevel <= ClassFileConstants.JDK1_4) {
-		runNegativeTest(units,
+		AbstractRegressionTest.runNegativeTest(this, units,
 			//boden\TestValid.java:8: warning - Tag @see: reference not found: ValidationException
 			//boden\TestValid.java:12: warning - Tag @see: reference not found: ValidationException#IAFAState.ValidationException(String, IAFAState)
 			"----------\n" +
@@ -4987,7 +4987,7 @@ public void testBug103304b() {
 	if (this.complianceLevel <= ClassFileConstants.JDK1_4) {
 		runNegativeTest(units, errors_14);
 	} else {
-		runNegativeTest(units, errors_50, JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
+		AbstractRegressionTest.runNegativeTest(this, units, errors_50, JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 
 }
@@ -5023,8 +5023,8 @@ public void testBug103304c() {
 	);
 }
 public void testBug103304d() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"test/Test.java",
 			"package test;\n" +
 			"public interface Test {\n" +
@@ -5098,8 +5098,8 @@ public void testBug103304e() {
 	);
 }
 public void testBug103304f() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"implicit/Invalid.java",
 			"package implicit;\n" +
 			"public interface Invalid {\n" +
@@ -5202,7 +5202,7 @@ public void testBug125518a() {
 		"}\n"
 	};
 	this.reportInvalidJavadoc = CompilerOptions.WARNING;
-	runConformTest(true, units,
+	AbstractRegressionTest.runConformTest(this, true, units,
 			"----------\n" +
 			"1. WARNING in pkg\\X.java (at line 5)\n" +
 			"	* @see <a href=\"ccwww.xyzzy.com/rfc123.html\">invalid></\n" +
@@ -5228,7 +5228,7 @@ public void testBug125518b() {
 		"}\n"
 	};
 	this.reportInvalidJavadoc = CompilerOptions.WARNING;
-	runConformTest(true, units,
+	AbstractRegressionTest.runConformTest(this, true, units,
 			"----------\n" +
 			"1. WARNING in pkg\\X.java (at line 5)\n" +
 			"	* @see <a href=\"ccwww.xyzzy.com/rfc123.html\">invalid></a\n" +
@@ -5254,7 +5254,7 @@ public void testBug125518c() {
 		"}\n"
 	};
 	this.reportInvalidJavadoc = CompilerOptions.WARNING;
-	runConformTest(true, units,
+	AbstractRegressionTest.runConformTest(this, true, units,
 			"----------\n" +
 			"1. WARNING in pkg\\X.java (at line 5)\n" +
 			"	* @see <a href=\"ccwww.xyzzy.com/rfc123.html\">invalid></>\n" +
@@ -5280,7 +5280,7 @@ public void testBug125518d() {
 		"}\n"
 	};
 	this.reportInvalidJavadoc = CompilerOptions.WARNING;
-	runConformTest(true, units,
+	AbstractRegressionTest.runConformTest(this, true, units,
 			"----------\n" +
 			"1. WARNING in pkg\\X.java (at line 5)\n" +
 			"	* @see <a href=\"ccwww.xyzzy.com/rfc123.html\">invalid></aa>\n" +
@@ -5315,8 +5315,8 @@ public void testBug125518e() {
  */
 public void testBug125903() {
 	this.reportMissingJavadocTags = CompilerOptions.ERROR;
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"/**\n" +
 			" * {@ link java.lang.String}\n" +
@@ -5347,8 +5347,8 @@ public void testBug125903() {
 public void testBug128954() {
 	this.reportInvalidJavadoc = CompilerOptions.WARNING;
 	this.reportDeprecation = CompilerOptions.WARNING;
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java", //========================
 			"public class X {\n" +
 			"	/**\n" +
@@ -5392,8 +5392,8 @@ public void testBug128954() {
 public void testBug128954a() {
 	this.reportInvalidJavadoc = CompilerOptions.WARNING;
 	this.reportDeprecation = CompilerOptions.WARNING;
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	\n" +
@@ -5429,8 +5429,8 @@ public void testBug128954a() {
  * @see "http://bugs.eclipse.org/bugs/show_bug.cgi?id=129241"
  */
 public void testBug129241a() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	/**\n" +
@@ -5456,8 +5456,8 @@ public void testBug129241a() {
 }
 public void testBug129241b() {
 	this.reportDeprecation = CompilerOptions.IGNORE;
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	/**\n" +
@@ -5586,8 +5586,8 @@ public void testBug149013_Private01() {
 public void testBug149013_Public01() {
 	this.reportMissingJavadocTags = CompilerOptions.DISABLED;
 	this.reportInvalidJavadocVisibility = CompilerOptions.PUBLIC;
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"test1/X.java",
 			"package test1;\n" +
 			"public class X {\n" +
@@ -5631,8 +5631,8 @@ public void testBug149013_Public01() {
 }
 public void testBug149013_Private02() {
 	this.reportMissingJavadocTags = CompilerOptions.IGNORE;
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"test1/X.java",
 			"package test1;\n" +
 			"public class X {\n" +
@@ -5677,8 +5677,8 @@ public void testBug149013_Private02() {
 public void testBug149013_Public02() {
 	this.reportMissingJavadocTags = CompilerOptions.DISABLED;
 	this.reportInvalidJavadocVisibility = CompilerOptions.PUBLIC;
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"test1/X.java",
 			"package test1;\n" +
 			"public class X {\n" +
@@ -5722,8 +5722,8 @@ public void testBug149013_Public02() {
 }
 public void testBug149013_Private03() {
 	this.reportMissingJavadocTags = CompilerOptions.IGNORE;
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"test1/X.java",
 			"package test1;\n" +
 			"public class X {\n" +
@@ -5765,8 +5765,8 @@ public void testBug149013_Private03() {
 public void testBug149013_Public03() {
 	this.reportMissingJavadocTags = CompilerOptions.DISABLED;
 	this.reportInvalidJavadocVisibility = CompilerOptions.PUBLIC;
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"test1/X.java",
 			"package test1;\n" +
 			"public class X {\n" +
@@ -5925,7 +5925,7 @@ public void testBug153399d() {
 			"----------\n"
 		);
 	} else {
-		runNegativeTest(testFiles,
+		AbstractRegressionTest.runNegativeTest(this, testFiles,
 			"----------\n" +
 			"1. ERROR in X.java (at line 5)\n" +
 			"	* {@value Invalid}\n" +
@@ -5957,7 +5957,7 @@ public void testBug153399e() {
 			"----------\n"
 		);
 	} else {
-		runNegativeTest(testFiles,
+		AbstractRegressionTest.runNegativeTest(this, testFiles,
 			"----------\n" +
 			"1. ERROR in X.java (at line 3)\n" +
 			"	* {@value Invalid}\n" +
@@ -5974,7 +5974,7 @@ public void testBug153399e() {
  * @see "http://bugs.eclipse.org/bugs/show_bug.cgi?id=160015"
  */
 public void testBug160015() {
-	runNegativeTest(new String[] {
+	AbstractRegressionTest.runNegativeTest(this, new String[] {
 			"Test.java",
 			"/**\n" +
 			" * @see #method(Long) Warning!\n" +
@@ -6008,8 +6008,8 @@ public void testBug160015() {
  * @see "http://bugs.eclipse.org/bugs/show_bug.cgi?id=163659"
  */
 public void testBug163659() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"Test.java",
 			"/**\n" +
 			" * @see #foo(MyInterface)\n" +
@@ -6108,7 +6108,7 @@ public void testBug166365() {
 		"}\n"
 	};
 	this.reportInvalidJavadocVisibility = CompilerOptions.PUBLIC;
-	runNegativeTest(testFiles,
+	AbstractRegressionTest.runNegativeTest(this, testFiles,
 		"----------\n" +
 		"1. ERROR in X.java (at line 21)\n" +
 		"	* @return\n" +
@@ -6171,7 +6171,7 @@ public void testBug166436() {
 			"----------\n"
 		);
 	} else {
-		runNegativeTest(testFiles,
+		AbstractRegressionTest.runNegativeTest(this, testFiles,
 			"----------\n" +
 			"1. ERROR in X.java (at line 10)\n" +
 			"	* 	<li>{@value #PROTECTED_CONST}</li>\n" +
@@ -6212,7 +6212,7 @@ public void testBug168849a() {
 		"}\n"
 	};
 	this.reportInvalidJavadoc = CompilerOptions.WARNING;
-	runConformTest(true, units,
+	AbstractRegressionTest.runConformTest(this, true, units,
 			"----------\n" +
 			"1. WARNING in pkg\\X.java (at line 5)\n" +
 			"	* @see http://www.eclipse.org/\n" +
@@ -6238,7 +6238,7 @@ public void testBug168849b() {
 		"}\n"
 	};
 	this.reportInvalidJavadoc = CompilerOptions.WARNING;
-	runConformTest(true, units,
+	AbstractRegressionTest.runConformTest(this, true, units,
 			"----------\n" +
 			"1. WARNING in pkg\\X.java (at line 5)\n" +
 			"	* @see http://ftp.eclipse.org/\n" +
@@ -6264,8 +6264,8 @@ public void testBug168849c() {
 		"}\n"
 	};
 	this.reportInvalidJavadoc = CompilerOptions.WARNING;
-	runConformTest(
-			true, units,
+	AbstractRegressionTest.runConformTest(
+			this, true, units,
 			"----------\n" +
 			"1. WARNING in pkg\\X.java (at line 5)\n" +
 			"	* @see ://\n" +
@@ -6291,7 +6291,7 @@ public void testBug168849d() {
 		"}\n"
 	};
 	this.reportInvalidJavadoc = CompilerOptions.WARNING;
-	runConformTest(true, units,
+	AbstractRegressionTest.runConformTest(this, true, units,
 			"----------\n" +
 			"1. WARNING in pkg\\X.java (at line 5)\n" +
 			"	* @see http://www.eclipse.org\n" +
@@ -6353,7 +6353,7 @@ public void testBug168849g() {
 		"}\n"
 	};
 	this.reportInvalidJavadoc = CompilerOptions.WARNING;
-	runConformTest(true, units,
+	AbstractRegressionTest.runConformTest(this, true, units,
 			"----------\n" +
 			"1. WARNING in pkg\\X.java (at line 5)\n" +
 			"	* @see http:/ invalid reference\n" +
@@ -6379,7 +6379,7 @@ public void testBug168849h() {
 		"}\n"
 	};
 	this.reportInvalidJavadoc = CompilerOptions.WARNING;
-	runConformTest(true, units,
+	AbstractRegressionTest.runConformTest(this, true, units,
 			"----------\n" +
 			"1. WARNING in pkg\\X.java (at line 5)\n" +
 			"	* @see Object:/ invalid reference\n" +
@@ -6405,7 +6405,7 @@ public void testBug168849i() {
 		"}\n"
 	};
 	this.reportInvalidJavadoc = CompilerOptions.WARNING;
-	runConformTest(true, units,
+	AbstractRegressionTest.runConformTest(this, true, units,
 			"----------\n" +
 			"1. WARNING in pkg\\X.java (at line 5)\n" +
 			"	* @see http:/ invalid reference\n" +
@@ -6431,7 +6431,7 @@ public void testBug168849j() {
 		"}\n"
 	};
 	this.reportInvalidJavadoc = CompilerOptions.WARNING;
-	runConformTest(true, units,
+	AbstractRegressionTest.runConformTest(this, true, units,
 			"----------\n" +
 			"1. WARNING in pkg\\X.java (at line 5)\n" +
 			"	* @see Object:/ invalid reference\n" +
@@ -7034,7 +7034,7 @@ public void testBug176027h_public() {
 		runNegativeTest(units,error14);
 	}
 	else {
-		runNegativeTest(units,error50, JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
+		AbstractRegressionTest.runNegativeTest(this, units,error50, JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 }
 
@@ -7148,7 +7148,7 @@ public void testBug176027h_private() {
 		runNegativeTest(units,error14);
 	}
 	else {
-		runNegativeTest(units,error50, JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
+		AbstractRegressionTest.runNegativeTest(this, units,error50, JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 }
 
@@ -7179,8 +7179,8 @@ public void testBug177009a() {
 		"}\n"
 	};
 	this.reportMissingJavadocTags = CompilerOptions.WARNING;
-	runConformTest(
-			true,
+	AbstractRegressionTest.runConformTest(
+			this, true,
 			units,
 			"----------\n" +
 			"1. WARNING in pkg\\Y.java (at line 8)\n" +
@@ -7216,7 +7216,7 @@ public void testBug177009b() {
 		"}\n"
 	};
 	this.reportMissingJavadocTags = CompilerOptions.WARNING;
-	runConformTest(true, units,
+	AbstractRegressionTest.runConformTest(this, true, units,
 			"----------\n" +
 			"1. WARNING in pkg\\Y.java (at line 9)\n" +
 			"	public Y(String str, int anInt, int anotherInt) {\n" +
@@ -7234,8 +7234,8 @@ public void testBug177009b() {
 public void testBug190970a() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.WARNING);
-	this.runConformTest(
-		true,
+	AbstractRegressionTest.runConformTest(
+		this, true,
 		new String[] {
 			"X.java",
 			"public class X {\n" +
@@ -7268,8 +7268,8 @@ public void testBug190970a() {
 public void testBug190970b() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.WARNING);
-	this.runConformTest(
-		true,
+	AbstractRegressionTest.runConformTest(
+		this, true,
 		new String[] {
 			"pkg/X.java",
 			"package pkg;\n" +
@@ -7303,8 +7303,8 @@ public void testBug190970b() {
 public void testBug190970c() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.WARNING);
-	runConformTest(
-		true,
+	AbstractRegressionTest.runConformTest(
+		this, true,
 	new String[] {
 		"pkg/X.java",
 		"package pkg;\n" +
@@ -7718,7 +7718,7 @@ public void testBug222902() {
 	};
 	this.reportInvalidJavadoc = CompilerOptions.WARNING;
 	this.reportMissingJavadocDescription = CompilerOptions.ALL_STANDARD_TAGS;
-	runConformTest(true, units,
+	AbstractRegressionTest.runConformTest(this, true, units,
 		"----------\n" +
 		"1. WARNING in X.java (at line 2)\n" +
 		"	* {@code}\n" +
@@ -7986,8 +7986,8 @@ public void testBug233887() {
 		"	   ^^^^^\n" +
 		"Javadoc: Unexpected tag\n" +
 		"----------\n";
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"NPETest.java",
 			"public class NPETest {\n" +
 			"	public NPETest() {\n" +
@@ -8288,8 +8288,8 @@ public void testBug258798_3() {
 // is used with classes and interfaces.
 public void testBug247037() {
 	this.reportMissingJavadocTags = CompilerOptions.ERROR;
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"/**\n" +
 			" * {@inheritDoc}\n" +              // error, cannot be applied to a class
@@ -8323,8 +8323,8 @@ public void testBug247037() {
 // field or constructor, we complain.
 public void testBug247037b() {
 	this.reportMissingJavadocTags = CompilerOptions.ERROR;
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"}\n" +
@@ -8358,8 +8358,8 @@ public void testBug247037b() {
 // block tags.
 public void testBug247037c() {
 	this.reportMissingJavadocTags = CompilerOptions.ERROR;
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"    /**\n" +
@@ -8417,8 +8417,8 @@ public void testBug247037c() {
 // a message from the compiler
 public void testBug247037d() {
 	this.reportMissingJavadocTags = CompilerOptions.ERROR;
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"}\n" +
@@ -8768,8 +8768,8 @@ public void testBug281609b() {
 public void testBug292510() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportDeprecationInDeprecatedCode, CompilerOptions.ENABLED);
-	runNegativeTest(
-		true,
+	AbstractRegressionTest.runNegativeTest(
+		this, true,
 		new String[] {
 			"X.java",
 			"/**  @deprecated */\n" +
@@ -8847,7 +8847,7 @@ public void testBug222188a() {
 		"     public void m() { }\n" +
 		"}\n"
 	};
-	runNegativeTest(units,
+	AbstractRegressionTest.runNegativeTest(this, units,
 		// warning - Tag @link: reference not found: Test.Inner
 		"----------\n" +
 		"1. ERROR in pack2\\X.java (at line 5)\n" +
@@ -8876,7 +8876,7 @@ public void testBug222188b() {
 		"     public void m() { }\n" +
 		"}\n"
 	};
-	runNegativeTest(units,
+	AbstractRegressionTest.runNegativeTest(this, units,
 		// warning - Tag @link: reference not found: Test.Inner
 		"----------\n" +
 		"1. ERROR in pack2\\X.java (at line 4)\n" +
@@ -8910,7 +8910,7 @@ public void testBug221539a() {
 		"	static class Inner {}\n" +
 		"}\n"
 	};
-	runNegativeTest(units,
+	AbstractRegressionTest.runNegativeTest(this, units,
 		// warning - Tag @link: reference not found: Test.Inner
 		"----------\n" +
 		"1. ERROR in p\\Test.java (at line 3)\n" +
@@ -8941,7 +8941,7 @@ public void testBug221539b() {
 		"	public static class Inner {}\n" +
 		"}\n"
 	};
-	runNegativeTest(units,
+	AbstractRegressionTest.runNegativeTest(this, units,
 		// warning - Tag @link: reference not found: Test.Inner
 		// warning - Tag @link: reference not found: Foo.Inner
 		"----------\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocTest.java
@@ -383,7 +383,7 @@ public abstract class JavadocTest extends AbstractRegressionTest {
 			System.arraycopy(testFiles, 0, completedFiles, referencedClasses.length, testFiles.length);
 			expected = expectedDiagnosticsFromReferencedClasses + expected;
 		}
-		runNegativeTest(completedFiles, expected, javacTestOptions);
+		AbstractRegressionTest.runNegativeTest(this, completedFiles, expected, javacTestOptions);
 	}
 
 	/* (non-Javadoc)
@@ -564,7 +564,7 @@ public abstract class JavadocTest extends AbstractRegressionTest {
 					System.out.println(testName + " - Javadoc has found error(s) but Eclipse expects conform result:\n");
 					javacFullLog.println("JAVAC_MISMATCH: Javadoc has found error(s) but Eclipse expects conform result");
 					System.out.println(errorLogger.buffer.toString());
-					printFiles(testFiles);
+					AbstractRegressionTest.printFiles(testFiles);
 					DIFF_COUNTERS[0]++;
 				}
 				else {
@@ -574,7 +574,7 @@ public abstract class JavadocTest extends AbstractRegressionTest {
 						System.out.println(testName + " - Javadoc has found warning(s) but Eclipse expects conform result:\n");
 						javacFullLog.println("JAVAC_MISMATCH: Javadoc has found warning(s) but Eclipse expects conform result");
 						System.out.println(errorLogger.buffer.toString());
-						printFiles(testFiles);
+						AbstractRegressionTest.printFiles(testFiles);
 						DIFF_COUNTERS[0]++;
 					}
 				}
@@ -585,19 +585,19 @@ public abstract class JavadocTest extends AbstractRegressionTest {
 					System.out.println("----------------------------------------");
 					System.out.println(testName + " - Eclipse has found error(s)/warning(s) but Javadoc did not find any:");
 					javacFullLog.println("JAVAC_MISMATCH: Eclipse has found error(s)/warning(s) but Javadoc did not find any");
-					dualPrintln("eclipse:");
-					dualPrintln(expectedProblemLog);
-					printFiles(testFiles);
+					AbstractRegressionTest.dualPrintln("eclipse:");
+					AbstractRegressionTest.dualPrintln(expectedProblemLog);
+					AbstractRegressionTest.printFiles(testFiles);
 					DIFF_COUNTERS[1]++;
 				} else if (expectedProblemLog.indexOf("ERROR") > 0 && exitValue == 0){
 					System.out.println("----------------------------------------");
 					System.out.println(testName + " - Eclipse has found error(s) but Javadoc only found warning(s):");
 					javacFullLog.println("JAVAC_MISMATCH: Eclipse has found error(s) but Javadoc only found warning(s)");
-					dualPrintln("eclipse:");
-					dualPrintln(expectedProblemLog);
+					AbstractRegressionTest.dualPrintln("eclipse:");
+					AbstractRegressionTest.dualPrintln(expectedProblemLog);
 					System.out.println("javadoc:");
 					System.out.println(errorLogger.buffer.toString());
-					printFiles(testFiles);
+					AbstractRegressionTest.printFiles(testFiles);
 					DIFF_COUNTERS[1]++;
 				} else {
 					// PREMATURE refine comparison
@@ -637,13 +637,13 @@ public abstract class JavadocTest extends AbstractRegressionTest {
 				TESTS_COUNTERS.put(CURRENT_CLASS_NAME, Integer.valueOf(newCount));
 				if (newCount == 0) {
 					if (DIFF_COUNTERS[0]!=0 || DIFF_COUNTERS[1]!=0 || DIFF_COUNTERS[2]!=0) {
-						dualPrintln("===========================================================================");
-						dualPrintln("Results summary:");
+						AbstractRegressionTest.dualPrintln("===========================================================================");
+						AbstractRegressionTest.dualPrintln("Results summary:");
 					}
 					if (DIFF_COUNTERS[0]!=0)
-						dualPrintln("	- "+DIFF_COUNTERS[0]+" test(s) where Javadoc found errors/warnings but Eclipse did not");
+						AbstractRegressionTest.dualPrintln("	- "+DIFF_COUNTERS[0]+" test(s) where Javadoc found errors/warnings but Eclipse did not");
 					if (DIFF_COUNTERS[1]!=0)
-						dualPrintln("	- "+DIFF_COUNTERS[1]+" test(s) where Eclipse found errors/warnings but Javadoc did not");
+						AbstractRegressionTest.dualPrintln("	- "+DIFF_COUNTERS[1]+" test(s) where Eclipse found errors/warnings but Javadoc did not");
 					System.out.println("\n");
 				}
 			}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocTestForClass.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocTestForClass.java
@@ -62,8 +62,8 @@ public class JavadocTestForClass extends JavadocTest {
 	}
 
 	public void test002() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"	/**\n"
 					+ "	 * Invalid class javadoc\n"
@@ -83,8 +83,8 @@ public class JavadocTestForClass extends JavadocTest {
 	}
 
 	public void test003() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"	/**\n"
 					+ "	 * Invalid class javadoc\n"
@@ -104,8 +104,8 @@ public class JavadocTestForClass extends JavadocTest {
 	}
 
 	public void test004() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"	/**\n"
 					+ "	 * Invalid class javadoc\n"
@@ -125,8 +125,8 @@ public class JavadocTestForClass extends JavadocTest {
 	}
 
 	public void test005() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"	/**\n"
 					+ "	 * Invalid class javadoc\n"
@@ -146,8 +146,8 @@ public class JavadocTestForClass extends JavadocTest {
 	}
 
 	public void test006() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"	/**\n"
 					+ "	 * Invalid class javadoc\n"
@@ -231,8 +231,8 @@ public class JavadocTestForClass extends JavadocTest {
 	 */
 	// String references
 	public void test010() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"	/**\n"
 					+ "	 * Invalid string references \n"
@@ -288,8 +288,8 @@ public class JavadocTestForClass extends JavadocTest {
 
 	// URL Link references
 	public void test012() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"	/**\n"
 					+ "	 * Invalid URL link references \n"
@@ -633,8 +633,8 @@ public class JavadocTestForClass extends JavadocTest {
 	}
 
 	public void test041() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"import java.util.Vector;\n"
 					+ "	/**\n"
@@ -685,8 +685,8 @@ public class JavadocTestForClass extends JavadocTest {
 	}
 
 	public void test043() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"	/**\n"
 					+ "	 * Invalid local methods references\n"
@@ -705,8 +705,8 @@ public class JavadocTestForClass extends JavadocTest {
 	}
 
 	public void test044() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"	/**\n"
 					+ "	 * Invalid local methods references\n"

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocTestForConstructor.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocTestForConstructor.java
@@ -49,8 +49,8 @@ public class JavadocTestForConstructor extends JavadocTest {
 	 * Test @deprecated tag
 	 */
 	public void test001() {
-		this.runConformTest(
-			true,
+		AbstractRegressionTest.runConformTest(
+			this, true,
 			new String[] {
 				"X.java",
 				"public class X {\n"
@@ -111,8 +111,8 @@ public class JavadocTestForConstructor extends JavadocTest {
 	}
 
 	public void test003() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"
 					+ "	\n"
@@ -182,8 +182,8 @@ public class JavadocTestForConstructor extends JavadocTest {
 	 */
 	// String references
 	public void test010() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"
 					+ "	/**\n"
@@ -227,8 +227,8 @@ public class JavadocTestForConstructor extends JavadocTest {
 
 	// URL Link references
 	public void test012() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"
 					+ "	/**\n"
@@ -574,8 +574,8 @@ public class JavadocTestForConstructor extends JavadocTest {
 	}
 
 	public void test041() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"import java.util.Vector;\n"
 					+ "public class X {\n"
@@ -628,8 +628,8 @@ public class JavadocTestForConstructor extends JavadocTest {
 	}
 
 	public void test043() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"
 					+ "	/**\n"
@@ -650,8 +650,8 @@ public class JavadocTestForConstructor extends JavadocTest {
 	}
 
 	public void test044() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"
 					+ "	/**\n"

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocTestForField.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocTestForField.java
@@ -62,8 +62,8 @@ public class JavadocTestForField extends JavadocTest {
 	}
 
 	public void test002() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"
 					+ "	/**\n"
@@ -82,8 +82,8 @@ public class JavadocTestForField extends JavadocTest {
 	}
 
 	public void test003() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"
 					+ "	/**\n"
@@ -102,8 +102,8 @@ public class JavadocTestForField extends JavadocTest {
 	}
 
 	public void test004() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"
 					+ "	/**\n"
@@ -122,8 +122,8 @@ public class JavadocTestForField extends JavadocTest {
 	}
 
 	public void test005() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"
 					+ "	/**\n"
@@ -142,8 +142,8 @@ public class JavadocTestForField extends JavadocTest {
 	}
 
 	public void test006() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"
 					+ "	/**\n"
@@ -183,8 +183,8 @@ public class JavadocTestForField extends JavadocTest {
 	 * Test @deprecated tag
 	 */
 	public void test007() {
-		this.runConformTest(
-			true,
+		AbstractRegressionTest.runConformTest(
+			this, true,
 			new String[] {
 				"X.java",
 				"public class X {\n"
@@ -211,8 +211,8 @@ public class JavadocTestForField extends JavadocTest {
 	}
 
 	public void test008() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"
 					+ "	int x;\n"
@@ -271,8 +271,8 @@ public class JavadocTestForField extends JavadocTest {
 	 */
 	// String references
 	public void test010() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"
 					+ "	/**\n"
@@ -314,8 +314,8 @@ public class JavadocTestForField extends JavadocTest {
 
 	// URL Link references
 	public void test012() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"
 					+ "	/**\n"
@@ -651,8 +651,8 @@ public class JavadocTestForField extends JavadocTest {
 	}
 
 	public void test041() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"import java.util.Vector;\n"
 					+ "public class X {\n"
@@ -705,8 +705,8 @@ public class JavadocTestForField extends JavadocTest {
 	}
 
 	public void test043() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"
 					+ "	/**\n"
@@ -730,8 +730,8 @@ public class JavadocTestForField extends JavadocTest {
 	}
 
 	public void test044() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"
 					+ "	/**\n"

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocTestForInterface.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocTestForInterface.java
@@ -64,8 +64,8 @@ public class JavadocTestForInterface extends JavadocTest {
 	}
 
 	public void test002() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"IX.java",
 				"	/**\n"
 					+ "	 * Invalid class javadoc\n"
@@ -84,8 +84,8 @@ public class JavadocTestForInterface extends JavadocTest {
 	}
 
 	public void test003() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"IX.java",
 				"	/**\n"
 					+ "	 * Invalid class javadoc\n"
@@ -104,8 +104,8 @@ public class JavadocTestForInterface extends JavadocTest {
 	}
 
 	public void test004() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"IX.java",
 				"	/**\n"
 					+ "	 * Invalid class javadoc\n"
@@ -124,8 +124,8 @@ public class JavadocTestForInterface extends JavadocTest {
 	}
 
 	public void test005() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"IX.java",
 				"	/**\n"
 					+ "	 * Invalid class javadoc\n"
@@ -144,8 +144,8 @@ public class JavadocTestForInterface extends JavadocTest {
 	}
 
 	public void test006() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"IX.java",
 				"	/**\n"
 					+ "	 * Invalid class javadoc\n"
@@ -226,8 +226,8 @@ public class JavadocTestForInterface extends JavadocTest {
 
 	// @see tag
 	public void test010() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"IX.java",
 				"	/**\n"
 					+ "	 * Invalid string references \n"
@@ -268,8 +268,8 @@ public class JavadocTestForInterface extends JavadocTest {
 	}
 
 	public void test012() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"IX.java",
 				"	/**\n"
 					+ "	 * Invalid URL link references \n"
@@ -602,8 +602,8 @@ public class JavadocTestForInterface extends JavadocTest {
 	}
 
 	public void test041() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"IX.java",
 				"import java.util.Vector;\n"
 					+ "	/**\n"
@@ -648,8 +648,8 @@ public class JavadocTestForInterface extends JavadocTest {
 	}
 
 	public void test043() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"IX.java",
 				"	/**\n"
 					+ "	 * Invalid local methods references\n"
@@ -672,8 +672,8 @@ public class JavadocTestForInterface extends JavadocTest {
 	}
 
 	public void test044() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"IX.java",
 				"	/**\n"
 					+ "	 * Invalid local methods references\n"
@@ -973,8 +973,8 @@ public class JavadocTestForInterface extends JavadocTest {
 	 */
 	// @deprecated tag
 	public void test060() {
-		this.runConformTest(
-			true,
+		AbstractRegressionTest.runConformTest(
+			this, true,
 			new String[] {
 				"X.java",
 				"public class X {\n"
@@ -1000,8 +1000,8 @@ public class JavadocTestForInterface extends JavadocTest {
 	}
 
 	public void test061() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"IX.java",
 				"public interface IX {\n"
 					+ "	/** @deprecated */\n"
@@ -1091,8 +1091,8 @@ public class JavadocTestForInterface extends JavadocTest {
 	}
 
 	public void test063() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"
 					+ "	\n"
@@ -1179,8 +1179,8 @@ public class JavadocTestForInterface extends JavadocTest {
 	}
 
 	public void test066() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"IX.java",
 				"public interface IX {\n"
 					+ "	/**\n"
@@ -1222,8 +1222,8 @@ public class JavadocTestForInterface extends JavadocTest {
 	}
 
 	public void test068() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"IX.java",
 				"public interface IX {\n"
 					+ "	/**\n"
@@ -1251,8 +1251,8 @@ public class JavadocTestForInterface extends JavadocTest {
 	}
 
 	public void test069() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"IX.java",
 				"public interface IX {\n"
 					+ "	/**\n"
@@ -1280,8 +1280,8 @@ public class JavadocTestForInterface extends JavadocTest {
 	}
 
 	public void test070() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"IX.java",
 				"public interface IX {\n"
 					+ "	/**\n"
@@ -1336,8 +1336,8 @@ public class JavadocTestForInterface extends JavadocTest {
 	}
 
 	public void test072() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"IX.java",
 				"public interface IX {\n"
 					+ "	/**\n"
@@ -1361,8 +1361,8 @@ public class JavadocTestForInterface extends JavadocTest {
 	}
 
 	public void test073() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"IX.java",
 				"import java.io.FileNotFoundException;\n"
 					+ "public interface IX {\n"
@@ -1466,8 +1466,8 @@ public class JavadocTestForInterface extends JavadocTest {
 	}
 
 	public void test082() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"IX.java",
 				"public interface IX {\n"
 					+ "	/**\n"
@@ -1485,8 +1485,8 @@ public class JavadocTestForInterface extends JavadocTest {
 	}
 
 	public void test083() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"IX.java",
 				"public interface IX {\n"
 					+ "	/**\n"
@@ -1507,8 +1507,8 @@ public class JavadocTestForInterface extends JavadocTest {
 	}
 
 	public void test084() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"IX.java",
 				"public interface IX {\n"
 					+ "	/**\n"
@@ -1529,8 +1529,8 @@ public class JavadocTestForInterface extends JavadocTest {
 
 	// @see tag: string
 	public void test090() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"IX.java",
 				"public interface IX {\n"
 					+ "	/**\n"
@@ -1572,8 +1572,8 @@ public class JavadocTestForInterface extends JavadocTest {
 
 	// @see tag: URL
 	public void test092() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"IX.java",
 				"public interface IX {\n"
 					+ "	/**\n"
@@ -1892,8 +1892,8 @@ public class JavadocTestForInterface extends JavadocTest {
 	}
 
 	public void test111() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"IX.java",
 				"import java.util.Vector;\n"
 					+ "public interface IX {\n"
@@ -1941,8 +1941,8 @@ public class JavadocTestForInterface extends JavadocTest {
 	}
 
 	public void test113() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"IX.java",
 				"public interface IX {\n"
 					+ "	/**\n"
@@ -1965,8 +1965,8 @@ public class JavadocTestForInterface extends JavadocTest {
 	}
 
 	public void test114() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"IX.java",
 				"public interface IX {\n"
 					+ "	/**\n"

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocTestForMethod.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocTestForMethod.java
@@ -59,8 +59,8 @@ public class JavadocTestForMethod extends JavadocTest {
 	 * Test @deprecated tag
 	 */
 	public void test001() {
-		this.runConformTest(
-			true,
+		AbstractRegressionTest.runConformTest(
+			this, true,
 			new String[] {
 				"X.java",
 				"public class X {\n"
@@ -88,8 +88,8 @@ public class JavadocTestForMethod extends JavadocTest {
 	}
 
 	public void test002() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"	/** @deprecated */\n" +
@@ -185,8 +185,8 @@ public class JavadocTestForMethod extends JavadocTest {
 	}
 
 	public void test004() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"
 					+ "	\n"
@@ -290,8 +290,8 @@ public class JavadocTestForMethod extends JavadocTest {
 	}
 
 	public void test006() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"
 					+ "	\n"
@@ -396,8 +396,8 @@ public class JavadocTestForMethod extends JavadocTest {
 	}
 
 	public void test008() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"
 					+ "	\n"
@@ -487,8 +487,8 @@ public class JavadocTestForMethod extends JavadocTest {
 	}
 
 	public void test013() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"
 					+ "	/**\n"
@@ -532,8 +532,8 @@ public class JavadocTestForMethod extends JavadocTest {
 	}
 
 	public void test015() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"
 					+ "	/**\n"
@@ -578,8 +578,8 @@ public class JavadocTestForMethod extends JavadocTest {
 	}
 
 	public void test017() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"
 					+ "	/**\n"
@@ -608,8 +608,8 @@ public class JavadocTestForMethod extends JavadocTest {
 	}
 
 	public void test020() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"
 					+ "	/**\n"
@@ -638,8 +638,8 @@ public class JavadocTestForMethod extends JavadocTest {
 	}
 
 	public void test021() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"
 					+ "	/**\n"
@@ -664,8 +664,8 @@ public class JavadocTestForMethod extends JavadocTest {
 	}
 
 	public void test022() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"
 					+ "	/**\n"
@@ -690,8 +690,8 @@ public class JavadocTestForMethod extends JavadocTest {
 	}
 
 	public void test023() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"
 					+ "	/**\n"
@@ -716,8 +716,8 @@ public class JavadocTestForMethod extends JavadocTest {
 	}
 
 	public void test024() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"
 					+ "	/**\n"
@@ -738,8 +738,8 @@ public class JavadocTestForMethod extends JavadocTest {
 	}
 
 	public void test025() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"
 					+ "	/**\n"
@@ -760,8 +760,8 @@ public class JavadocTestForMethod extends JavadocTest {
 	}
 
 	public void test026() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"
 					+ "	/**\n"
@@ -782,8 +782,8 @@ public class JavadocTestForMethod extends JavadocTest {
 	}
 
 	public void test030() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"
 					+ "	/**\n"
@@ -816,8 +816,8 @@ public class JavadocTestForMethod extends JavadocTest {
 	}
 
 	public void test031() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"
 					+ "	/**\n"
@@ -842,8 +842,8 @@ public class JavadocTestForMethod extends JavadocTest {
 	}
 
 	public void test032() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"
 					+ "	/**\n"
@@ -864,8 +864,8 @@ public class JavadocTestForMethod extends JavadocTest {
 	}
 
 	public void test033() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"
 					+ "	/**\n"
@@ -903,8 +903,8 @@ public class JavadocTestForMethod extends JavadocTest {
 	}
 
 	public void test034() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"
 					+ "	/**\n"
@@ -1001,8 +1001,8 @@ public class JavadocTestForMethod extends JavadocTest {
 	}
 
 	public void test037() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"
 					+ "	/**\n"
@@ -1029,8 +1029,8 @@ public class JavadocTestForMethod extends JavadocTest {
 	}
 
 	public void test038() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"import java.util.Hashtable;\n"
 					+ "public class X {\n"
@@ -1081,8 +1081,8 @@ public class JavadocTestForMethod extends JavadocTest {
 	}
 
 	public void test051() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"
 					+ "	/**\n"
@@ -1107,8 +1107,8 @@ public class JavadocTestForMethod extends JavadocTest {
 	}
 
 	public void test052() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"
 					+ "	/**\n"
@@ -1133,8 +1133,8 @@ public class JavadocTestForMethod extends JavadocTest {
 	}
 
 	public void test053() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"import java.io.FileNotFoundException;\n"
 					+ "public class X {\n"
@@ -1274,8 +1274,8 @@ public class JavadocTestForMethod extends JavadocTest {
 	}
 
 	public void test060() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"
 					+ "	/**\n"
@@ -1298,8 +1298,8 @@ public class JavadocTestForMethod extends JavadocTest {
 	}
 
 	public void test061() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"
 					+ "	/**\n"
@@ -1329,8 +1329,8 @@ public class JavadocTestForMethod extends JavadocTest {
 	}
 
 	public void test062() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"
 					+ "	/**\n"
@@ -1360,8 +1360,8 @@ public class JavadocTestForMethod extends JavadocTest {
 	}
 
 	public void test063() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"import java.io.FileNotFoundException;\n"
 					+ "public class X {\n"
@@ -1692,8 +1692,8 @@ public class JavadocTestForMethod extends JavadocTest {
 	}
 
 	public void test073() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"
 					+ "	/**\n"
@@ -1713,8 +1713,8 @@ public class JavadocTestForMethod extends JavadocTest {
 	}
 
 	public void test074() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"
 					+ "	/**\n"
@@ -1737,8 +1737,8 @@ public class JavadocTestForMethod extends JavadocTest {
 	}
 
 	public void test075() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"
 					+ "	/**\n"
@@ -1759,8 +1759,8 @@ public class JavadocTestForMethod extends JavadocTest {
 	}
 
 	public void test076() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"
 					+ "	/**\n"
@@ -1797,8 +1797,8 @@ public class JavadocTestForMethod extends JavadocTest {
 	 */
 	// String references
 	public void test080() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"
 					+ "	/**\n"
@@ -1854,8 +1854,8 @@ public class JavadocTestForMethod extends JavadocTest {
 
 	// URL Link references
 	public void test085() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"
 					+ "	/**\n"
@@ -1971,8 +1971,8 @@ public class JavadocTestForMethod extends JavadocTest {
 	}
 
 	public void test087() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"
 				+ "	/**\n"
@@ -2726,8 +2726,8 @@ public class JavadocTestForMethod extends JavadocTest {
 	}
 
 	public void test116() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"import java.util.Vector;\n"
 					+ "public class X {\n"
@@ -2867,8 +2867,8 @@ public class JavadocTestForMethod extends JavadocTest {
 	}
 
 	public void test117() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"import java.util.Vector;\n"
 					+ "public class X {\n"
@@ -2948,8 +2948,8 @@ public class JavadocTestForMethod extends JavadocTest {
 	}
 
 	public void test118() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"import java.util.Vector;\n"
 					+ "public class X {\n"
@@ -3070,8 +3070,8 @@ public class JavadocTestForMethod extends JavadocTest {
 	}
 
 	public void test121() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"
 					+ "	/**\n"
@@ -3108,8 +3108,8 @@ public class JavadocTestForMethod extends JavadocTest {
 	}
 
 	public void test122() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"
 					+ "	/**\n"
@@ -3170,8 +3170,8 @@ public class JavadocTestForMethod extends JavadocTest {
 	}
 
 	public void test123() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"
 					+ "	/**\n"
@@ -3214,8 +3214,8 @@ public class JavadocTestForMethod extends JavadocTest {
 	}
 
 	public void test124() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"
 					+ "	/**\n"
@@ -3264,8 +3264,8 @@ public class JavadocTestForMethod extends JavadocTest {
 	}
 
 	public void test125() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"
 					+ "	/**\n"
@@ -3332,8 +3332,8 @@ public class JavadocTestForMethod extends JavadocTest {
 	}
 
 	public void test126() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"
 					+ "	/**\n"
@@ -3376,8 +3376,8 @@ public class JavadocTestForMethod extends JavadocTest {
 	}
 
 	public void test127() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"import java.util.Vector;\n"
 					+ "public class X {\n"
@@ -3487,8 +3487,8 @@ public class JavadocTestForMethod extends JavadocTest {
 	}
 
 	public void test131() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"
 					+ "	/**\n"
@@ -3525,8 +3525,8 @@ public class JavadocTestForMethod extends JavadocTest {
 	}
 
 	public void test132() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"import java.util.Vector;\n"
 					+ "public class X {\n"
@@ -3582,8 +3582,8 @@ public class JavadocTestForMethod extends JavadocTest {
 	}
 
 	public void test133() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"import java.util.Vector;\n"
 					+ "public class X {\n"
@@ -3674,8 +3674,8 @@ public class JavadocTestForMethod extends JavadocTest {
 	}
 
 	public void test136() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"test/deep/qualified/name/p/X.java",
 				"package test.deep.qualified.name.p;\n"
 					+ "public class X {\n"
@@ -3713,8 +3713,8 @@ public class JavadocTestForMethod extends JavadocTest {
 	}
 
 	public void test137() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"test/deep/qualified/name/p/X.java",
 				"package test.deep.qualified.name.p;\n"
 					+ "import java.util.Vector;\n"
@@ -3771,8 +3771,8 @@ public class JavadocTestForMethod extends JavadocTest {
 	}
 
 	public void test138() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"test/deep/qualified/name/p/X.java",
 				"package test.deep.qualified.name.p;\n"
 					+ "import java.util.Vector;\n"

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocTestForModule.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocTestForModule.java
@@ -260,7 +260,7 @@ public class JavadocTestForModule extends AbstractBatchCompilerTest {
 					e.printStackTrace();
 					throw new AssertionFailedError(e.getMessage());
 				}
-				handleMismatch(javacCompiler, testName(), testFiles, javacErrorMatch,
+				AbstractRegressionTest.handleMismatch(this, javacCompiler, testName(), testFiles, javacErrorMatch,
 						"", "", log, "", "",
 						excuse, mismatch);
 				final Set<String> expectedFiles = new HashSet<>(outFiles);

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocTestForRecord.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocTestForRecord.java
@@ -109,7 +109,7 @@ public class JavadocTestForRecord extends JavadocTest {
 
 	@Override
 	protected void runNegativeTest(String[] testFiles, String expectedCompilerLog) {
-		runNegativeTest(testFiles, expectedCompilerLog, JavacTestOptions.forReleaseWithPreview("16"));
+		AbstractRegressionTest.runNegativeTest(this, testFiles, expectedCompilerLog, JavacTestOptions.forReleaseWithPreview("16"));
 	}
 
 	@Override
@@ -146,7 +146,7 @@ public class JavadocTestForRecord extends JavadocTest {
 		if(this.complianceLevel < ClassFileConstants.JDK14) {
 			return;
 		}
-		this.runNegativeTest(new String[] { "X.java", "public record X() {\n" + "}\n" },
+		AbstractRegressionTest.runNegativeTest(this, new String[] { "X.java", "public record X() {\n" + "}\n" },
 				"----------\n" + "1. ERROR in X.java (at line 1)\n" + "	public record X() {\n" + "	              ^\n"
 						+ "Javadoc: Missing comment for public declaration\n" + "----------\n",
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
@@ -156,8 +156,8 @@ public class JavadocTestForRecord extends JavadocTest {
 		if(this.complianceLevel < ClassFileConstants.JDK14) {
 			return;
 		}
-		this.runNegativeTest(
-				new String[] { "X.java",
+		AbstractRegressionTest.runNegativeTest(
+				this, new String[] { "X.java",
 						"	/**\n" + "	 * @param radius radius of X\n" + "	 */\n" + "public record X(int radius) {\n"
 								+ "	public void foo() {\n" + "	}\n" + "}\n" },
 				"----------\n" + "1. ERROR in X.java (at line 5)\n" + "	public void foo() {\n" + "	            ^^^^^\n"
@@ -198,7 +198,7 @@ public class JavadocTestForRecord extends JavadocTest {
 		if(this.complianceLevel < ClassFileConstants.JDK14) {
 			return;
 		}
-		runNegativeTest(new String[] { "X.java",
+		AbstractRegressionTest.runNegativeTest(this, new String[] { "X.java",
 				"		/**  \n" +
 				"		 */  \n" +
 				"		public record X(int a) {\n" +
@@ -222,7 +222,7 @@ public class JavadocTestForRecord extends JavadocTest {
 		if(this.complianceLevel < ClassFileConstants.JDK14) {
 			return;
 		}
-		runNegativeTest(new String[] { "X.java",
+		AbstractRegressionTest.runNegativeTest(this, new String[] { "X.java",
 				"		/**  \n" +
 				"		 * @param a\n" +
 				"		 * @param a\n" +
@@ -248,7 +248,7 @@ public class JavadocTestForRecord extends JavadocTest {
 		if(this.complianceLevel < ClassFileConstants.JDK14) {
 			return;
 		}
-		runNegativeTest(new String[] { "X.java",
+		AbstractRegressionTest.runNegativeTest(this, new String[] { "X.java",
 				"		/**  \n" +
 				"		 * @param a\n" +
 				"		 * @param b\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocTestMixed.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocTestMixed.java
@@ -183,8 +183,8 @@ public class JavadocTestMixed extends JavadocTest {
 	}
 
 	public void test010() {
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"test/X.java",
 				"package test;\n"
 					+ "public class X {\n"
@@ -208,8 +208,8 @@ public class JavadocTestMixed extends JavadocTest {
 	}
 
 	public void test011() {
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"test/X.java",
 				"package test;\n"
 					+ "/** Class javadoc comment */\n"
@@ -233,8 +233,8 @@ public class JavadocTestMixed extends JavadocTest {
 	}
 
 	public void test012() {
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"test/X.java",
 				"package test;\n"
 					+ "/** Class javadoc comment */\n"
@@ -258,8 +258,8 @@ public class JavadocTestMixed extends JavadocTest {
 	}
 
 	public void test013() {
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"test/X.java",
 				"package test;\n"
 					+ "/** Class javadoc comment */\n"
@@ -328,8 +328,8 @@ public class JavadocTestMixed extends JavadocTest {
 	}
 
 	public void test022() {
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"test/X.java",
 				"package test;\n"
 					+ "/**\n"
@@ -378,8 +378,8 @@ public class JavadocTestMixed extends JavadocTest {
 	}
 
 	public void test023() {
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"test/X.java",
 				"package test;\n"
 					+ "/**\n"
@@ -428,8 +428,8 @@ public class JavadocTestMixed extends JavadocTest {
 	}
 
 	public void test024() {
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"test/X.java",
 				"package test;\n"
 					+ "/**\n"
@@ -482,8 +482,8 @@ public class JavadocTestMixed extends JavadocTest {
 	}
 
 	public void test025() {
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"test/X.java",
 				"package test;\n"
 					+ "/**\n"
@@ -536,8 +536,8 @@ public class JavadocTestMixed extends JavadocTest {
 	}
 
 	public void test026() {
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"test/X.java",
 				"package test;\n"
 					+ "/**\n"
@@ -853,8 +853,8 @@ public class JavadocTestMixed extends JavadocTest {
 
 	public void test041() {
 		this.reportMissingJavadocComments = CompilerOptions.IGNORE;
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n" +
 					"	/**\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocTestOptions.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocTestOptions.java
@@ -1021,7 +1021,7 @@ public class JavadocTestOptions extends JavadocTest {
 		for (int i=0; i<length; i++) {
 			expectedProblemLog.append(errors[i]);
 		}
-		runNegativeTest(testFiles, expectedProblemLog.toString(),
+		AbstractRegressionTest.runNegativeTest(this, testFiles, expectedProblemLog.toString(),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
     }
 
@@ -1498,28 +1498,28 @@ public class JavadocTestOptions extends JavadocTest {
 		this.reportInvalidJavadoc = CompilerOptions.ERROR;
 		this.reportInvalidJavadocTags = CompilerOptions.ENABLED;
 		this.reportInvalidJavadocTagsVisibility = CompilerOptions.PUBLIC;
-		runNegativeTest(CLASSES_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.PUBLIC_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, CLASSES_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.PUBLIC_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 	public void testInvalidTagsFieldErrorTagsPublic() {
 		this.reportInvalidJavadoc = CompilerOptions.ERROR;
 		this.reportInvalidJavadocTags = CompilerOptions.ENABLED;
 		this.reportInvalidJavadocTagsVisibility = CompilerOptions.PUBLIC;
-		runNegativeTest(FIELDS_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.PUBLIC_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, FIELDS_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.PUBLIC_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 	public void testInvalidTagsMethodErrorTagsPublic() {
 		this.reportInvalidJavadoc = CompilerOptions.ERROR;
 		this.reportInvalidJavadocTags = CompilerOptions.ENABLED;
 		this.reportInvalidJavadocTagsVisibility = CompilerOptions.PUBLIC;
-		runNegativeTest(METHODS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.PUBLIC_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, METHODS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.PUBLIC_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 	public void testInvalidTagsConstructorErrorTagsPublic() {
 		this.reportInvalidJavadoc = CompilerOptions.ERROR;
 		this.reportInvalidJavadocTags = CompilerOptions.ENABLED;
 		this.reportInvalidJavadocTagsVisibility = CompilerOptions.PUBLIC;
-		runNegativeTest(CONSTRUCTORS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.PUBLIC_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, CONSTRUCTORS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.PUBLIC_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 
@@ -1528,28 +1528,28 @@ public class JavadocTestOptions extends JavadocTest {
 		this.reportInvalidJavadoc = CompilerOptions.ERROR;
 		this.reportInvalidJavadocTags = CompilerOptions.ENABLED;
 		this.reportInvalidJavadocTagsVisibility = CompilerOptions.PROTECTED;
-		runNegativeTest(CLASSES_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.PROTECTED_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, CLASSES_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.PROTECTED_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 	public void testInvalidTagsFieldErrorTagsProtected() {
 		this.reportInvalidJavadoc = CompilerOptions.ERROR;
 		this.reportInvalidJavadocTags = CompilerOptions.ENABLED;
 		this.reportInvalidJavadocTagsVisibility = CompilerOptions.PROTECTED;
-		runNegativeTest(FIELDS_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.PROTECTED_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, FIELDS_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.PROTECTED_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 	public void testInvalidTagsMethodErrorTagsProtected() {
 		this.reportInvalidJavadoc = CompilerOptions.ERROR;
 		this.reportInvalidJavadocTags = CompilerOptions.ENABLED;
 		this.reportInvalidJavadocTagsVisibility = CompilerOptions.PROTECTED;
-		runNegativeTest(METHODS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.PROTECTED_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, METHODS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.PROTECTED_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 	public void testInvalidTagsConstructorErrorTagsProtected() {
 		this.reportInvalidJavadoc = CompilerOptions.ERROR;
 		this.reportInvalidJavadocTags = CompilerOptions.ENABLED;
 		this.reportInvalidJavadocTagsVisibility = CompilerOptions.PROTECTED;
-		runNegativeTest(CONSTRUCTORS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.PROTECTED_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, CONSTRUCTORS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.PROTECTED_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 
@@ -1558,28 +1558,28 @@ public class JavadocTestOptions extends JavadocTest {
 		this.reportInvalidJavadoc = CompilerOptions.ERROR;
 		this.reportInvalidJavadocTags = CompilerOptions.ENABLED;
 		this.reportInvalidJavadocTagsVisibility = CompilerOptions.DEFAULT;
-		runNegativeTest(CLASSES_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.DEFAULT_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, CLASSES_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.DEFAULT_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 	public void testInvalidTagsFieldErrorTagsPackage() {
 		this.reportInvalidJavadoc = CompilerOptions.ERROR;
 		this.reportInvalidJavadocTags = CompilerOptions.ENABLED;
 		this.reportInvalidJavadocTagsVisibility = CompilerOptions.DEFAULT;
-		runNegativeTest(FIELDS_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.DEFAULT_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, FIELDS_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.DEFAULT_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 	public void testInvalidTagsMethodErrorTagsPackage() {
 		this.reportInvalidJavadoc = CompilerOptions.ERROR;
 		this.reportInvalidJavadocTags = CompilerOptions.ENABLED;
 		this.reportInvalidJavadocTagsVisibility = CompilerOptions.DEFAULT;
-		runNegativeTest(METHODS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.DEFAULT_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, METHODS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.DEFAULT_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 	public void testInvalidTagsConstructorErrorTagsPackage() {
 		this.reportInvalidJavadoc = CompilerOptions.ERROR;
 		this.reportInvalidJavadocTags = CompilerOptions.ENABLED;
 		this.reportInvalidJavadocTagsVisibility = CompilerOptions.DEFAULT;
-		runNegativeTest(CONSTRUCTORS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.DEFAULT_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, CONSTRUCTORS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.DEFAULT_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 
@@ -1607,7 +1607,7 @@ public class JavadocTestOptions extends JavadocTest {
 		this.reportInvalidJavadocTags = CompilerOptions.ENABLED;
 		this.reportInvalidJavadocTagsDeprecatedRef = CompilerOptions.DISABLED;
 		this.reportInvalidJavadocTagsVisibility = CompilerOptions.PUBLIC;
-		runNegativeTest(CLASSES_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.PUBLIC_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, CLASSES_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.PUBLIC_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 	public void testInvalidTagsDeprecatedRefFieldErrorTagsPublic() {
@@ -1615,7 +1615,7 @@ public class JavadocTestOptions extends JavadocTest {
 		this.reportInvalidJavadocTags = CompilerOptions.ENABLED;
 		this.reportInvalidJavadocTagsDeprecatedRef = CompilerOptions.DISABLED;
 		this.reportInvalidJavadocTagsVisibility = CompilerOptions.PUBLIC;
-		runNegativeTest(FIELDS_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.PUBLIC_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, FIELDS_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.PUBLIC_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 	public void testInvalidTagsDeprecatedRefMethodErrorTagsPublic() {
@@ -1623,7 +1623,7 @@ public class JavadocTestOptions extends JavadocTest {
 		this.reportInvalidJavadocTags = CompilerOptions.ENABLED;
 		this.reportInvalidJavadocTagsDeprecatedRef = CompilerOptions.DISABLED;
 		this.reportInvalidJavadocTagsVisibility = CompilerOptions.PUBLIC;
-		runNegativeTest(METHODS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.PUBLIC_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, METHODS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.PUBLIC_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 	public void testInvalidTagsDeprecatedRefConstructorErrorTagsPublic() {
@@ -1631,7 +1631,7 @@ public class JavadocTestOptions extends JavadocTest {
 		this.reportInvalidJavadocTags = CompilerOptions.ENABLED;
 		this.reportInvalidJavadocTagsDeprecatedRef = CompilerOptions.DISABLED;
 		this.reportInvalidJavadocTagsVisibility = CompilerOptions.PUBLIC;
-		runNegativeTest(CONSTRUCTORS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.PUBLIC_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, CONSTRUCTORS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.PUBLIC_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 
@@ -1641,7 +1641,7 @@ public class JavadocTestOptions extends JavadocTest {
 		this.reportInvalidJavadocTags = CompilerOptions.ENABLED;
 		this.reportInvalidJavadocTagsDeprecatedRef = CompilerOptions.DISABLED;
 		this.reportInvalidJavadocTagsVisibility = CompilerOptions.PROTECTED;
-		runNegativeTest(CLASSES_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.PROTECTED_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, CLASSES_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.PROTECTED_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 	public void testInvalidTagsDeprecatedRefFieldErrorTagsProtected() {
@@ -1649,7 +1649,7 @@ public class JavadocTestOptions extends JavadocTest {
 		this.reportInvalidJavadocTags = CompilerOptions.ENABLED;
 		this.reportInvalidJavadocTagsDeprecatedRef = CompilerOptions.DISABLED;
 		this.reportInvalidJavadocTagsVisibility = CompilerOptions.PROTECTED;
-		runNegativeTest(FIELDS_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.PROTECTED_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, FIELDS_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.PROTECTED_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 	public void testInvalidTagsDeprecatedRefMethodErrorTagsProtected() {
@@ -1657,7 +1657,7 @@ public class JavadocTestOptions extends JavadocTest {
 		this.reportInvalidJavadocTags = CompilerOptions.ENABLED;
 		this.reportInvalidJavadocTagsDeprecatedRef = CompilerOptions.DISABLED;
 		this.reportInvalidJavadocTagsVisibility = CompilerOptions.PROTECTED;
-		runNegativeTest(METHODS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.PROTECTED_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, METHODS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.PROTECTED_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 	public void testInvalidTagsDeprecatedRefConstructorErrorTagsProtected() {
@@ -1665,7 +1665,7 @@ public class JavadocTestOptions extends JavadocTest {
 		this.reportInvalidJavadocTags = CompilerOptions.ENABLED;
 		this.reportInvalidJavadocTagsDeprecatedRef = CompilerOptions.DISABLED;
 		this.reportInvalidJavadocTagsVisibility = CompilerOptions.PROTECTED;
-		runNegativeTest(CONSTRUCTORS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.PROTECTED_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, CONSTRUCTORS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.PROTECTED_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 
@@ -1675,7 +1675,7 @@ public class JavadocTestOptions extends JavadocTest {
 		this.reportInvalidJavadocTags = CompilerOptions.ENABLED;
 		this.reportInvalidJavadocTagsDeprecatedRef = CompilerOptions.DISABLED;
 		this.reportInvalidJavadocTagsVisibility = CompilerOptions.DEFAULT;
-		runNegativeTest(CLASSES_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.DEFAULT_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, CLASSES_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.DEFAULT_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 	public void testInvalidTagsDeprecatedRefFieldErrorTagsPackage() {
@@ -1683,7 +1683,7 @@ public class JavadocTestOptions extends JavadocTest {
 		this.reportInvalidJavadocTags = CompilerOptions.ENABLED;
 		this.reportInvalidJavadocTagsDeprecatedRef = CompilerOptions.DISABLED;
 		this.reportInvalidJavadocTagsVisibility = CompilerOptions.DEFAULT;
-		runNegativeTest(FIELDS_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.DEFAULT_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, FIELDS_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.DEFAULT_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 	public void testInvalidTagsDeprecatedRefMethodErrorTagsPackage() {
@@ -1691,7 +1691,7 @@ public class JavadocTestOptions extends JavadocTest {
 		this.reportInvalidJavadocTags = CompilerOptions.ENABLED;
 		this.reportInvalidJavadocTagsDeprecatedRef = CompilerOptions.DISABLED;
 		this.reportInvalidJavadocTagsVisibility = CompilerOptions.DEFAULT;
-		runNegativeTest(METHODS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.DEFAULT_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, METHODS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.DEFAULT_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 	public void testInvalidTagsDeprecatedRefConstructorErrorTagsPackage() {
@@ -1699,7 +1699,7 @@ public class JavadocTestOptions extends JavadocTest {
 		this.reportInvalidJavadocTags = CompilerOptions.ENABLED;
 		this.reportInvalidJavadocTagsDeprecatedRef = CompilerOptions.DISABLED;
 		this.reportInvalidJavadocTagsVisibility = CompilerOptions.DEFAULT;
-		runNegativeTest(CONSTRUCTORS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.DEFAULT_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, CONSTRUCTORS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.DEFAULT_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 
@@ -1707,25 +1707,25 @@ public class JavadocTestOptions extends JavadocTest {
 	public void testInvalidTagsDeprecatedRefClassErrorTagsPrivate() {
 		this.reportInvalidJavadoc = CompilerOptions.ERROR;
 		this.reportInvalidJavadocTagsDeprecatedRef = CompilerOptions.DISABLED;
-		runNegativeTest(CLASSES_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.PRIVATE_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, CLASSES_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.PRIVATE_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 	public void testInvalidTagsDeprecatedRefFieldErrorTagsPrivate() {
 		this.reportInvalidJavadoc = CompilerOptions.ERROR;
 		this.reportInvalidJavadocTagsDeprecatedRef = CompilerOptions.DISABLED;
-		runNegativeTest(FIELDS_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.PRIVATE_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, FIELDS_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.PRIVATE_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 	public void testInvalidTagsDeprecatedRefMethodErrorTagsPrivate() {
 		this.reportInvalidJavadoc = CompilerOptions.ERROR;
 		this.reportInvalidJavadocTagsDeprecatedRef = CompilerOptions.DISABLED;
-		runNegativeTest(METHODS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.PRIVATE_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, METHODS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.PRIVATE_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 	public void testInvalidTagsDeprecatedRefConstructorErrorTagsPrivate() {
 		this.reportInvalidJavadoc = CompilerOptions.ERROR;
 		this.reportInvalidJavadocTagsDeprecatedRef = CompilerOptions.DISABLED;
-		runNegativeTest(CONSTRUCTORS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.PRIVATE_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, CONSTRUCTORS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.PRIVATE_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 
@@ -1735,7 +1735,7 @@ public class JavadocTestOptions extends JavadocTest {
 		this.reportInvalidJavadocTags = CompilerOptions.ENABLED;
 		this.reportInvalidJavadocTagsNotVisibleRef = CompilerOptions.DISABLED;
 		this.reportInvalidJavadocTagsVisibility = CompilerOptions.PUBLIC;
-		runNegativeTest(CLASSES_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.PUBLIC_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, CLASSES_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.PUBLIC_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 	public void testInvalidTagsNotVisibleRefFieldErrorTagsPublic() {
@@ -1743,7 +1743,7 @@ public class JavadocTestOptions extends JavadocTest {
 		this.reportInvalidJavadocTags = CompilerOptions.ENABLED;
 		this.reportInvalidJavadocTagsNotVisibleRef = CompilerOptions.DISABLED;
 		this.reportInvalidJavadocTagsVisibility = CompilerOptions.PUBLIC;
-		runNegativeTest(FIELDS_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.PUBLIC_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, FIELDS_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.PUBLIC_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 	public void testInvalidTagsNotVisibleRefMethodErrorTagsPublic() {
@@ -1751,7 +1751,7 @@ public class JavadocTestOptions extends JavadocTest {
 		this.reportInvalidJavadocTags = CompilerOptions.ENABLED;
 		this.reportInvalidJavadocTagsNotVisibleRef = CompilerOptions.DISABLED;
 		this.reportInvalidJavadocTagsVisibility = CompilerOptions.PUBLIC;
-		runNegativeTest(METHODS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.PUBLIC_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, METHODS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.PUBLIC_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 	public void testInvalidTagsNotVisibleRefConstructorErrorTagsPublic() {
@@ -1759,7 +1759,7 @@ public class JavadocTestOptions extends JavadocTest {
 		this.reportInvalidJavadocTags = CompilerOptions.ENABLED;
 		this.reportInvalidJavadocTagsNotVisibleRef = CompilerOptions.DISABLED;
 		this.reportInvalidJavadocTagsVisibility = CompilerOptions.PUBLIC;
-		runNegativeTest(CONSTRUCTORS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.PUBLIC_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, CONSTRUCTORS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.PUBLIC_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 
@@ -1769,7 +1769,7 @@ public class JavadocTestOptions extends JavadocTest {
 		this.reportInvalidJavadocTags = CompilerOptions.ENABLED;
 		this.reportInvalidJavadocTagsNotVisibleRef = CompilerOptions.DISABLED;
 		this.reportInvalidJavadocTagsVisibility = CompilerOptions.PROTECTED;
-		runNegativeTest(CLASSES_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.PROTECTED_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, CLASSES_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.PROTECTED_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 	public void testInvalidTagsNotVisibleRefFieldErrorTagsProtected() {
@@ -1777,7 +1777,7 @@ public class JavadocTestOptions extends JavadocTest {
 		this.reportInvalidJavadocTags = CompilerOptions.ENABLED;
 		this.reportInvalidJavadocTagsNotVisibleRef = CompilerOptions.DISABLED;
 		this.reportInvalidJavadocTagsVisibility = CompilerOptions.PROTECTED;
-		runNegativeTest(FIELDS_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.PROTECTED_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, FIELDS_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.PROTECTED_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 	public void testInvalidTagsNotVisibleRefMethodErrorTagsProtected() {
@@ -1785,7 +1785,7 @@ public class JavadocTestOptions extends JavadocTest {
 		this.reportInvalidJavadocTags = CompilerOptions.ENABLED;
 		this.reportInvalidJavadocTagsNotVisibleRef = CompilerOptions.DISABLED;
 		this.reportInvalidJavadocTagsVisibility = CompilerOptions.PROTECTED;
-		runNegativeTest(METHODS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.PROTECTED_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, METHODS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.PROTECTED_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 	public void testInvalidTagsNotVisibleRefConstructorErrorTagsProtected() {
@@ -1793,7 +1793,7 @@ public class JavadocTestOptions extends JavadocTest {
 		this.reportInvalidJavadocTags = CompilerOptions.ENABLED;
 		this.reportInvalidJavadocTagsNotVisibleRef = CompilerOptions.DISABLED;
 		this.reportInvalidJavadocTagsVisibility = CompilerOptions.PROTECTED;
-		runNegativeTest(CONSTRUCTORS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.PROTECTED_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, CONSTRUCTORS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.PROTECTED_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 
@@ -1803,7 +1803,7 @@ public class JavadocTestOptions extends JavadocTest {
 		this.reportInvalidJavadocTags = CompilerOptions.ENABLED;
 		this.reportInvalidJavadocTagsNotVisibleRef = CompilerOptions.DISABLED;
 		this.reportInvalidJavadocTagsVisibility = CompilerOptions.DEFAULT;
-		runNegativeTest(CLASSES_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.DEFAULT_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, CLASSES_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.DEFAULT_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 	public void testInvalidTagsNotVisibleRefFieldErrorTagsPackage() {
@@ -1811,7 +1811,7 @@ public class JavadocTestOptions extends JavadocTest {
 		this.reportInvalidJavadocTags = CompilerOptions.ENABLED;
 		this.reportInvalidJavadocTagsNotVisibleRef = CompilerOptions.DISABLED;
 		this.reportInvalidJavadocTagsVisibility = CompilerOptions.DEFAULT;
-		runNegativeTest(FIELDS_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.DEFAULT_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, FIELDS_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.DEFAULT_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 	public void testInvalidTagsNotVisibleRefMethodErrorTagsPackage() {
@@ -1819,7 +1819,7 @@ public class JavadocTestOptions extends JavadocTest {
 		this.reportInvalidJavadocTags = CompilerOptions.ENABLED;
 		this.reportInvalidJavadocTagsNotVisibleRef = CompilerOptions.DISABLED;
 		this.reportInvalidJavadocTagsVisibility = CompilerOptions.DEFAULT;
-		runNegativeTest(METHODS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.DEFAULT_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, METHODS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.DEFAULT_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 	public void testInvalidTagsNotVisibleRefConstructorErrorTagsPackage() {
@@ -1827,7 +1827,7 @@ public class JavadocTestOptions extends JavadocTest {
 		this.reportInvalidJavadocTags = CompilerOptions.ENABLED;
 		this.reportInvalidJavadocTagsNotVisibleRef = CompilerOptions.DISABLED;
 		this.reportInvalidJavadocTagsVisibility = CompilerOptions.DEFAULT;
-		runNegativeTest(CONSTRUCTORS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.DEFAULT_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, CONSTRUCTORS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.DEFAULT_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 
@@ -1835,25 +1835,25 @@ public class JavadocTestOptions extends JavadocTest {
 	public void testInvalidTagsNotVisibleRefClassErrorTagsPrivate() {
 		this.reportInvalidJavadoc = CompilerOptions.ERROR;
 		this.reportInvalidJavadocTagsNotVisibleRef = CompilerOptions.DISABLED;
-		runNegativeTest(CLASSES_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.PRIVATE_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, CLASSES_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.PRIVATE_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 	public void testInvalidTagsNotVisibleRefFieldErrorTagsPrivate() {
 		this.reportInvalidJavadoc = CompilerOptions.ERROR;
 		this.reportInvalidJavadocTagsNotVisibleRef = CompilerOptions.DISABLED;
-		runNegativeTest(FIELDS_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.PRIVATE_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, FIELDS_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.PRIVATE_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 	public void testInvalidTagsNotVisibleRefMethodErrorTagsPrivate() {
 		this.reportInvalidJavadoc = CompilerOptions.ERROR;
 		this.reportInvalidJavadocTagsNotVisibleRef = CompilerOptions.DISABLED;
-		runNegativeTest(METHODS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.PRIVATE_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, METHODS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.PRIVATE_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 	public void testInvalidTagsNotVisibleRefConstructorErrorTagsPrivate() {
 		this.reportInvalidJavadoc = CompilerOptions.ERROR;
 		this.reportInvalidJavadocTagsNotVisibleRef = CompilerOptions.DISABLED;
-		runNegativeTest(CONSTRUCTORS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.PRIVATE_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, CONSTRUCTORS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.PRIVATE_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 
@@ -1864,7 +1864,7 @@ public class JavadocTestOptions extends JavadocTest {
 		this.reportInvalidJavadocTagsDeprecatedRef = CompilerOptions.DISABLED;
 		this.reportInvalidJavadocTagsNotVisibleRef = CompilerOptions.DISABLED;
 		this.reportInvalidJavadocTagsVisibility = CompilerOptions.PUBLIC;
-		runNegativeTest(CLASSES_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.PUBLIC_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, CLASSES_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.PUBLIC_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 	public void testInvalidTagsDeprecatedAndNotVisibleRefFieldErrorTagsPublic() {
@@ -1873,7 +1873,7 @@ public class JavadocTestOptions extends JavadocTest {
 		this.reportInvalidJavadocTagsDeprecatedRef = CompilerOptions.DISABLED;
 		this.reportInvalidJavadocTagsNotVisibleRef = CompilerOptions.DISABLED;
 		this.reportInvalidJavadocTagsVisibility = CompilerOptions.PUBLIC;
-		runNegativeTest(FIELDS_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.PUBLIC_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, FIELDS_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.PUBLIC_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 	public void testInvalidTagsDeprecatedAndNotVisibleRefMethodErrorTagsPublic() {
@@ -1882,7 +1882,7 @@ public class JavadocTestOptions extends JavadocTest {
 		this.reportInvalidJavadocTagsDeprecatedRef = CompilerOptions.DISABLED;
 		this.reportInvalidJavadocTagsNotVisibleRef = CompilerOptions.DISABLED;
 		this.reportInvalidJavadocTagsVisibility = CompilerOptions.PUBLIC;
-		runNegativeTest(METHODS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.PUBLIC_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, METHODS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.PUBLIC_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 	public void testInvalidTagsDeprecatedAndNotVisibleRefConstructorErrorTagsPublic() {
@@ -1891,7 +1891,7 @@ public class JavadocTestOptions extends JavadocTest {
 		this.reportInvalidJavadocTagsDeprecatedRef = CompilerOptions.DISABLED;
 		this.reportInvalidJavadocTagsNotVisibleRef = CompilerOptions.DISABLED;
 		this.reportInvalidJavadocTagsVisibility = CompilerOptions.PUBLIC;
-		runNegativeTest(CONSTRUCTORS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.PUBLIC_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, CONSTRUCTORS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.PUBLIC_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 
@@ -1902,7 +1902,7 @@ public class JavadocTestOptions extends JavadocTest {
 		this.reportInvalidJavadocTagsDeprecatedRef = CompilerOptions.DISABLED;
 		this.reportInvalidJavadocTagsNotVisibleRef = CompilerOptions.DISABLED;
 		this.reportInvalidJavadocTagsVisibility = CompilerOptions.PROTECTED;
-		runNegativeTest(CLASSES_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.PROTECTED_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, CLASSES_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.PROTECTED_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 	public void testInvalidTagsDeprecatedAndNotVisibleRefFieldErrorTagsProtected() {
@@ -1911,7 +1911,7 @@ public class JavadocTestOptions extends JavadocTest {
 		this.reportInvalidJavadocTagsDeprecatedRef = CompilerOptions.DISABLED;
 		this.reportInvalidJavadocTagsNotVisibleRef = CompilerOptions.DISABLED;
 		this.reportInvalidJavadocTagsVisibility = CompilerOptions.PROTECTED;
-		runNegativeTest(FIELDS_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.PROTECTED_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, FIELDS_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.PROTECTED_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 	public void testInvalidTagsDeprecatedAndNotVisibleRefMethodErrorTagsProtected() {
@@ -1920,7 +1920,7 @@ public class JavadocTestOptions extends JavadocTest {
 		this.reportInvalidJavadocTagsDeprecatedRef = CompilerOptions.DISABLED;
 		this.reportInvalidJavadocTagsNotVisibleRef = CompilerOptions.DISABLED;
 		this.reportInvalidJavadocTagsVisibility = CompilerOptions.PROTECTED;
-		runNegativeTest(METHODS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.PROTECTED_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, METHODS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.PROTECTED_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 	public void testInvalidTagsDeprecatedAndNotVisibleRefConstructorErrorTagsProtected() {
@@ -1929,7 +1929,7 @@ public class JavadocTestOptions extends JavadocTest {
 		this.reportInvalidJavadocTagsDeprecatedRef = CompilerOptions.DISABLED;
 		this.reportInvalidJavadocTagsNotVisibleRef = CompilerOptions.DISABLED;
 		this.reportInvalidJavadocTagsVisibility = CompilerOptions.PROTECTED;
-		runNegativeTest(CONSTRUCTORS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.PROTECTED_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, CONSTRUCTORS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.PROTECTED_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 
@@ -1940,7 +1940,7 @@ public class JavadocTestOptions extends JavadocTest {
 		this.reportInvalidJavadocTagsDeprecatedRef = CompilerOptions.DISABLED;
 		this.reportInvalidJavadocTagsNotVisibleRef = CompilerOptions.DISABLED;
 		this.reportInvalidJavadocTagsVisibility = CompilerOptions.DEFAULT;
-		runNegativeTest(CLASSES_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.DEFAULT_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, CLASSES_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.DEFAULT_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 	public void testInvalidTagsDeprecatedAndNotVisibleRefFieldErrorTagsPackage() {
@@ -1949,7 +1949,7 @@ public class JavadocTestOptions extends JavadocTest {
 		this.reportInvalidJavadocTagsDeprecatedRef = CompilerOptions.DISABLED;
 		this.reportInvalidJavadocTagsNotVisibleRef = CompilerOptions.DISABLED;
 		this.reportInvalidJavadocTagsVisibility = CompilerOptions.DEFAULT;
-		runNegativeTest(FIELDS_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.DEFAULT_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, FIELDS_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.DEFAULT_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 	public void testInvalidTagsDeprecatedAndNotVisibleRefMethodErrorTagsPackage() {
@@ -1958,7 +1958,7 @@ public class JavadocTestOptions extends JavadocTest {
 		this.reportInvalidJavadocTagsDeprecatedRef = CompilerOptions.DISABLED;
 		this.reportInvalidJavadocTagsNotVisibleRef = CompilerOptions.DISABLED;
 		this.reportInvalidJavadocTagsVisibility = CompilerOptions.DEFAULT;
-		runNegativeTest(METHODS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.DEFAULT_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, METHODS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.DEFAULT_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 	public void testInvalidTagsDeprecatedAndNotVisibleRefConstructorErrorTagsPackage() {
@@ -1967,7 +1967,7 @@ public class JavadocTestOptions extends JavadocTest {
 		this.reportInvalidJavadocTagsDeprecatedRef = CompilerOptions.DISABLED;
 		this.reportInvalidJavadocTagsNotVisibleRef = CompilerOptions.DISABLED;
 		this.reportInvalidJavadocTagsVisibility = CompilerOptions.DEFAULT;
-		runNegativeTest(CONSTRUCTORS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.DEFAULT_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, CONSTRUCTORS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.DEFAULT_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 
@@ -1976,28 +1976,28 @@ public class JavadocTestOptions extends JavadocTest {
 		this.reportInvalidJavadoc = CompilerOptions.ERROR;
 		this.reportInvalidJavadocTagsDeprecatedRef = CompilerOptions.DISABLED;
 		this.reportInvalidJavadocTagsNotVisibleRef = CompilerOptions.DISABLED;
-		runNegativeTest(CLASSES_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.PRIVATE_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, CLASSES_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.PRIVATE_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 	public void testInvalidTagsDeprecatedAndNotVisibleRefFieldErrorTagsPrivate() {
 		this.reportInvalidJavadoc = CompilerOptions.ERROR;
 		this.reportInvalidJavadocTagsDeprecatedRef = CompilerOptions.DISABLED;
 		this.reportInvalidJavadocTagsNotVisibleRef = CompilerOptions.DISABLED;
-		runNegativeTest(FIELDS_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.PRIVATE_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, FIELDS_INVALID_COMMENT, resultForInvalidTagsClassOrField(JavadocTestOptions.PRIVATE_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 	public void testInvalidTagsDeprecatedAndNotVisibleRefMethodErrorTagsPrivate() {
 		this.reportInvalidJavadoc = CompilerOptions.ERROR;
 		this.reportInvalidJavadocTagsDeprecatedRef = CompilerOptions.DISABLED;
 		this.reportInvalidJavadocTagsNotVisibleRef = CompilerOptions.DISABLED;
-		runNegativeTest(METHODS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.PRIVATE_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, METHODS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.PRIVATE_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 	public void testInvalidTagsDeprecatedAndNotVisibleRefConstructorErrorTagsPrivate() {
 		this.reportInvalidJavadoc = CompilerOptions.ERROR;
 		this.reportInvalidJavadocTagsDeprecatedRef = CompilerOptions.DISABLED;
 		this.reportInvalidJavadocTagsNotVisibleRef = CompilerOptions.DISABLED;
-		runNegativeTest(CONSTRUCTORS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.PRIVATE_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, CONSTRUCTORS_INVALID_COMMENT, resultForInvalidTagsMethodOrConstructor(JavadocTestOptions.PRIVATE_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 
@@ -2014,7 +2014,7 @@ public class JavadocTestOptions extends JavadocTest {
 		this.reportMissingJavadocTags = CompilerOptions.ERROR;
 		this.reportMissingJavadocTagsVisibility = CompilerOptions.PUBLIC;
 		this.reportMissingJavadocTagsOverriding = CompilerOptions.ENABLED;
-		runNegativeTest(MISSING_TAGS, resultForMissingTags(JavadocTestOptions.PUBLIC_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, MISSING_TAGS, resultForMissingTags(JavadocTestOptions.PUBLIC_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 
@@ -2023,7 +2023,7 @@ public class JavadocTestOptions extends JavadocTest {
 		this.reportMissingJavadocTags = CompilerOptions.ERROR;
 		this.reportMissingJavadocTagsVisibility = CompilerOptions.PUBLIC;
 		this.reportMissingJavadocTagsOverriding = CompilerOptions.DISABLED;
-		runNegativeTest(MISSING_TAGS, resultForMissingTags(JavadocTestOptions.PUBLIC_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, MISSING_TAGS, resultForMissingTags(JavadocTestOptions.PUBLIC_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 
@@ -2032,7 +2032,7 @@ public class JavadocTestOptions extends JavadocTest {
 		this.reportMissingJavadocTags = CompilerOptions.ERROR;
 		this.reportMissingJavadocTagsVisibility = CompilerOptions.PROTECTED;
 		this.reportMissingJavadocTagsOverriding = CompilerOptions.ENABLED;
-		runNegativeTest(MISSING_TAGS, resultForMissingTags(JavadocTestOptions.PROTECTED_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, MISSING_TAGS, resultForMissingTags(JavadocTestOptions.PROTECTED_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 
@@ -2041,7 +2041,7 @@ public class JavadocTestOptions extends JavadocTest {
 		this.reportMissingJavadocTags = CompilerOptions.ERROR;
 		this.reportMissingJavadocTagsVisibility = CompilerOptions.PROTECTED;
 		this.reportMissingJavadocTagsOverriding = CompilerOptions.DISABLED;
-		runNegativeTest(MISSING_TAGS, resultForMissingTags(JavadocTestOptions.PROTECTED_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, MISSING_TAGS, resultForMissingTags(JavadocTestOptions.PROTECTED_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 
@@ -2050,7 +2050,7 @@ public class JavadocTestOptions extends JavadocTest {
 		this.reportMissingJavadocTags = CompilerOptions.ERROR;
 		this.reportMissingJavadocTagsVisibility = CompilerOptions.DEFAULT;
 		this.reportMissingJavadocTagsOverriding = CompilerOptions.ENABLED;
-		runNegativeTest(MISSING_TAGS, resultForMissingTags(JavadocTestOptions.DEFAULT_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, MISSING_TAGS, resultForMissingTags(JavadocTestOptions.DEFAULT_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 
@@ -2059,7 +2059,7 @@ public class JavadocTestOptions extends JavadocTest {
 		this.reportMissingJavadocTags = CompilerOptions.ERROR;
 		this.reportMissingJavadocTagsVisibility = CompilerOptions.DEFAULT;
 		this.reportMissingJavadocTagsOverriding = CompilerOptions.DISABLED;
-		runNegativeTest(MISSING_TAGS, resultForMissingTags(JavadocTestOptions.DEFAULT_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, MISSING_TAGS, resultForMissingTags(JavadocTestOptions.DEFAULT_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 
@@ -2068,7 +2068,7 @@ public class JavadocTestOptions extends JavadocTest {
 		this.reportMissingJavadocTags = CompilerOptions.ERROR;
 		this.reportMissingJavadocTagsVisibility = CompilerOptions.PRIVATE;
 		this.reportMissingJavadocTagsOverriding = CompilerOptions.ENABLED;
-		runNegativeTest(MISSING_TAGS, resultForMissingTags(JavadocTestOptions.PRIVATE_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, MISSING_TAGS, resultForMissingTags(JavadocTestOptions.PRIVATE_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 
@@ -2077,7 +2077,7 @@ public class JavadocTestOptions extends JavadocTest {
 		this.reportMissingJavadocTags = CompilerOptions.ERROR;
 		this.reportMissingJavadocTagsVisibility = CompilerOptions.PRIVATE;
 		this.reportMissingJavadocTagsOverriding = CompilerOptions.DISABLED;
-		runNegativeTest(MISSING_TAGS, resultForMissingTags(JavadocTestOptions.PRIVATE_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, MISSING_TAGS, resultForMissingTags(JavadocTestOptions.PRIVATE_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 
@@ -2094,7 +2094,7 @@ public class JavadocTestOptions extends JavadocTest {
 		this.reportMissingJavadocComments = CompilerOptions.ERROR;
 		this.reportMissingJavadocCommentsVisibility = CompilerOptions.PUBLIC;
 		this.reportMissingJavadocCommentsOverriding = CompilerOptions.ENABLED;
-		runNegativeTest(MISSING_COMMENTS, resultForMissingComments(JavadocTestOptions.PUBLIC_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, MISSING_COMMENTS, resultForMissingComments(JavadocTestOptions.PUBLIC_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 
@@ -2103,7 +2103,7 @@ public class JavadocTestOptions extends JavadocTest {
 		this.reportMissingJavadocComments = CompilerOptions.ERROR;
 		this.reportMissingJavadocCommentsVisibility = CompilerOptions.PUBLIC;
 		this.reportMissingJavadocCommentsOverriding = CompilerOptions.DISABLED;
-		runNegativeTest(MISSING_COMMENTS, resultForMissingComments(JavadocTestOptions.PUBLIC_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, MISSING_COMMENTS, resultForMissingComments(JavadocTestOptions.PUBLIC_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 
@@ -2112,7 +2112,7 @@ public class JavadocTestOptions extends JavadocTest {
 		this.reportMissingJavadocComments = CompilerOptions.ERROR;
 		this.reportMissingJavadocCommentsVisibility = CompilerOptions.PROTECTED;
 		this.reportMissingJavadocCommentsOverriding = CompilerOptions.ENABLED;
-		runNegativeTest(MISSING_COMMENTS, resultForMissingComments(JavadocTestOptions.PROTECTED_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, MISSING_COMMENTS, resultForMissingComments(JavadocTestOptions.PROTECTED_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 
@@ -2121,7 +2121,7 @@ public class JavadocTestOptions extends JavadocTest {
 		this.reportMissingJavadocComments = CompilerOptions.ERROR;
 		this.reportMissingJavadocCommentsVisibility = CompilerOptions.PROTECTED;
 		this.reportMissingJavadocCommentsOverriding = CompilerOptions.DISABLED;
-		runNegativeTest(MISSING_COMMENTS, resultForMissingComments(JavadocTestOptions.PROTECTED_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, MISSING_COMMENTS, resultForMissingComments(JavadocTestOptions.PROTECTED_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 
@@ -2130,7 +2130,7 @@ public class JavadocTestOptions extends JavadocTest {
 		this.reportMissingJavadocComments = CompilerOptions.ERROR;
 		this.reportMissingJavadocCommentsVisibility = CompilerOptions.DEFAULT;
 		this.reportMissingJavadocCommentsOverriding = CompilerOptions.ENABLED;
-		runNegativeTest(MISSING_COMMENTS, resultForMissingComments(JavadocTestOptions.DEFAULT_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, MISSING_COMMENTS, resultForMissingComments(JavadocTestOptions.DEFAULT_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 
@@ -2139,7 +2139,7 @@ public class JavadocTestOptions extends JavadocTest {
 		this.reportMissingJavadocComments = CompilerOptions.ERROR;
 		this.reportMissingJavadocCommentsVisibility = CompilerOptions.DEFAULT;
 		this.reportMissingJavadocCommentsOverriding = CompilerOptions.DISABLED;
-		runNegativeTest(MISSING_COMMENTS, resultForMissingComments(JavadocTestOptions.DEFAULT_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, MISSING_COMMENTS, resultForMissingComments(JavadocTestOptions.DEFAULT_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 
@@ -2148,7 +2148,7 @@ public class JavadocTestOptions extends JavadocTest {
 		this.reportMissingJavadocComments = CompilerOptions.ERROR;
 		this.reportMissingJavadocCommentsVisibility = CompilerOptions.PRIVATE;
 		this.reportMissingJavadocCommentsOverriding = CompilerOptions.ENABLED;
-		runNegativeTest(MISSING_COMMENTS, resultForMissingComments(JavadocTestOptions.PRIVATE_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, MISSING_COMMENTS, resultForMissingComments(JavadocTestOptions.PRIVATE_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 
@@ -2157,7 +2157,7 @@ public class JavadocTestOptions extends JavadocTest {
 		this.reportMissingJavadocComments = CompilerOptions.ERROR;
 		this.reportMissingJavadocCommentsVisibility = CompilerOptions.PRIVATE;
 		this.reportMissingJavadocCommentsOverriding = CompilerOptions.DISABLED;
-		runNegativeTest(MISSING_COMMENTS, resultForMissingComments(JavadocTestOptions.PRIVATE_VISIBILITY),
+		AbstractRegressionTest.runNegativeTest(this, MISSING_COMMENTS, resultForMissingComments(JavadocTestOptions.PRIVATE_VISIBILITY),
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocTest_15.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocTest_15.java
@@ -113,7 +113,7 @@ protected Map getCompilerOptions() {
 @Override
 protected INameEnvironment getNameEnvironment(final String[] testFiles, String[] classPaths, Map<String, String> options) {
 	this.classpaths = classPaths == null ? getDefaultClassPaths() : classPaths;
-	INameEnvironment[] classLibs = getClassLibs(classPaths == null, options);
+	INameEnvironment[] classLibs = AbstractRegressionTest.getClassLibs(this, classPaths == null, options);
 	for (INameEnvironment nameEnvironment : classLibs) {
 		((FileSystem) nameEnvironment).scanForModules(createParser());
 	}
@@ -123,7 +123,7 @@ Parser createParser() {
 	Map<String,String> opts = new HashMap<>();
 	opts.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_9);
 	return new Parser(
-			new ProblemReporter(getErrorHandlingPolicy(), new CompilerOptions(opts), getProblemFactory()),
+			new ProblemReporter(AbstractRegressionTest.getErrorHandlingPolicy(), new CompilerOptions(opts), AbstractRegressionTest.getProblemFactory()),
 			false);
 }
 IModule extractModuleDesc(String fileName, String fileContent) {
@@ -241,7 +241,7 @@ public void test001() {
 	String[] testFiles = new String[] {"p/I1.java", I1 ,"p/P1.java", P1};
 	String[] modFiles =  new String[] {"module-info.java", moduleInfo  };
 	populateModuleMap(modFiles);
-	this.runConformTest( testFiles, modFiles, "" );
+	AbstractRegressionTest.runConformTest( this, testFiles, modFiles, "" );
 }
 
 public void test002() {
@@ -283,7 +283,7 @@ public void test002() {
 	String[] testFiles = new String[] {"p/I1.java", I1 ,"p/P1.java", P1};
 	String[] modFiles =  new String[] {"module-info.java", moduleInfo  };
 	populateModuleMap(modFiles);
-	this.runConformTest(testFiles , modFiles, "" );
+	AbstractRegressionTest.runConformTest(this, testFiles , modFiles, "" );
 }
 
 public void test003() {
@@ -327,7 +327,7 @@ public void test003() {
 	String[] testFiles = new String[] {"p/I1.java", I1 ,"p/P1.java", P1};
 	String[] modFiles =  new String[] {"module-info.java", moduleInfo  };
 	populateModuleMap(modFiles);
-	this.runConformTest(testFiles , modFiles, "" );
+	AbstractRegressionTest.runConformTest(this, testFiles , modFiles, "" );
 }
 
 public void test004() {
@@ -370,7 +370,7 @@ public void test004() {
 	String[] testFiles = new String[] {"p/I1.java", I1 ,"p/P1.java", P1};
 	String[] modFiles =  new String[] {"module-info.java", moduleInfo  };
 	populateModuleMap(modFiles);
-	this.runConformTest(testFiles , modFiles, "" );
+	AbstractRegressionTest.runConformTest(this, testFiles , modFiles, "" );
 }
 
 public void test005() {
@@ -414,7 +414,7 @@ public void test005() {
 	String[] testFiles = new String[] {"p/I1.java", I1 ,"p/P1.java", P1};
 	String[] modFiles =  new String[] {"module-info.java", moduleInfo  };
 	populateModuleMap(modFiles);
-	this.runConformTest(testFiles , modFiles, "" );
+	AbstractRegressionTest.runConformTest(this, testFiles , modFiles, "" );
 }
 
 public void test006() {
@@ -465,7 +465,7 @@ public void test006() {
 	String[] testFiles = new String[] {"p/I1.java", I1 ,"p/P1.java", P1};
 	String[] modFiles =  new String[] {"module-info.java", moduleInfo  };
 	populateModuleMap(modFiles);
-	this.runNegativeTest(testFiles , modFiles, errorMsg,
+	AbstractRegressionTest.runNegativeTest(this, testFiles , modFiles, errorMsg,
 			            JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 }
 
@@ -509,7 +509,7 @@ public void test007() {
 	String[] testFiles = new String[] {"p/I1.java", I1 ,"p/P1.java", P1};
 	String[] modFiles =  new String[] {"module-info.java", moduleInfo  };
 	populateModuleMap(modFiles);
-	this.runConformTest(testFiles , modFiles, "" );
+	AbstractRegressionTest.runConformTest(this, testFiles , modFiles, "" );
 }
 
 public void test008() {
@@ -552,7 +552,7 @@ public void test008() {
 	String[] testFiles = new String[] {"p/I1.java", I1 ,"p/P1.java", P1};
 	String[] modFiles =  new String[] {"module-info.java", moduleInfo  };
 	populateModuleMap(modFiles);
-	this.runConformTest(testFiles , modFiles, "" );
+	AbstractRegressionTest.runConformTest(this, testFiles , modFiles, "" );
 }
 
 public void test009() {
@@ -595,7 +595,7 @@ public void test009() {
 	String[] testFiles = new String[] {"p/I1.java", I1 ,"p/P1.java", P1};
 	String[] modFiles =  new String[] {"module-info.java", moduleInfo  };
 	populateModuleMap(modFiles);
-	this.runConformTest(testFiles , modFiles, "" );
+	AbstractRegressionTest.runConformTest(this, testFiles , modFiles, "" );
 }
 
 public void test010() {
@@ -646,7 +646,7 @@ public void test010() {
 	String[] testFiles = new String[] {"p/I1.java", I1 ,"p/P1.java", P1};
 	String[] modFiles =  new String[] {"module-info.java", moduleInfo  };
 	populateModuleMap(modFiles);
-	this.runNegativeTest(testFiles , modFiles, errorMsg,
+	AbstractRegressionTest.runNegativeTest(this, testFiles , modFiles, errorMsg,
 			            JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 }
 
@@ -698,7 +698,7 @@ public void test011() {
 	String[] testFiles = new String[] {"p/I1.java", I1 ,"p/P1.java", P1};
 	String[] modFiles =  new String[] {"module-info.java", moduleInfo  };
 	populateModuleMap(modFiles);
-	this.runNegativeTest(testFiles , modFiles, errorMsg,
+	AbstractRegressionTest.runNegativeTest(this, testFiles , modFiles, errorMsg,
 			            JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 }
 
@@ -750,7 +750,7 @@ public void test012() {
 	String[] testFiles = new String[] {"p/I1.java", I1 ,"p/P1.java", P1};
 	String[] modFiles =  new String[] {"module-info.java", moduleInfo  };
 	populateModuleMap(modFiles);
-	this.runNegativeTest(testFiles , modFiles, errorMsg,
+	AbstractRegressionTest.runNegativeTest(this, testFiles , modFiles, errorMsg,
 			            JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 }
 

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocTest_16.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocTest_16.java
@@ -149,8 +149,8 @@ public void testInlineReturn_broken1() {
 	if(this.complianceLevel < ClassFileConstants.JDK16) {
 		return;
 	}
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"""
 			public class X {
@@ -178,8 +178,8 @@ public void testInlineReturn_broken2() {
 	if(this.complianceLevel < ClassFileConstants.JDK16) {
 		return;
 	}
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 					"X.java",
 			"""
 			public class X

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocTest_18.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocTest_18.java
@@ -115,8 +115,8 @@ public void test001() {
 	if(this.complianceLevel < ClassFileConstants.JDK18) {
 		return;
 	}
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 				" /**\n"
 				+ " * {@snippet : public static void main(String... args) {\n"
@@ -146,8 +146,8 @@ public void test002() {
 	if(this.complianceLevel < ClassFileConstants.JDK18) {
 		return;
 	}
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 				" /**\n"
 				+ " * {@snippet : "
@@ -172,8 +172,8 @@ public void test003() {
 	if(this.complianceLevel < ClassFileConstants.JDK18) {
 		return;
 	}
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 				" /**\n"
 				+ " * {@snippet:\n"
@@ -218,8 +218,8 @@ public void test005() {
 	if(this.complianceLevel < ClassFileConstants.JDK18) {
 		return;
 	}
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 				" /**\n"
 				+ " * {@snippet :\n"
@@ -244,8 +244,8 @@ public void test006() {
 	if(this.complianceLevel < ClassFileConstants.JDK18) {
 		return;
 	}
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 				" /**\n"
 				+ " * {@snippet \n"
@@ -269,8 +269,8 @@ public void test007() {
 	if(this.complianceLevel < ClassFileConstants.JDK18) {
 		return;
 	}
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 				" /**\n"
 				+ " * {@snippet \n"
@@ -295,8 +295,8 @@ public void test008() {
 	if(this.complianceLevel < ClassFileConstants.JDK18) {
 		return;
 	}
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 				" /**\n"
 				+ " * {@snippet : \n"
@@ -320,8 +320,8 @@ public void test009() {
 	if(this.complianceLevel < ClassFileConstants.JDK18) {
 		return;
 	}
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 				" /**\n"
 				+ " * {@snippet : \n"
@@ -346,8 +346,8 @@ public void test010() {
 	if(this.complianceLevel < ClassFileConstants.JDK18) {
 		return;
 	}
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 				" /**\n"
 				+ " * {@snippet : \n"

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocTest_1_5.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocTest_1_5.java
@@ -142,8 +142,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 		);
 	}
 	public void test006() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 					" /**\n" +
 					"  * Invalid type parameter reference\n" +
@@ -161,8 +161,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 		);
 	}
 	public void test007() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 					" /**\n" +
 					"  * Invalid type parameter reference\n" +
@@ -180,8 +180,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 		);
 	}
 	public void test008() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 					" /**\n" +
 					"  * Invalid type parameter reference\n" +
@@ -206,8 +206,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 		);
 	}
 	public void test009() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 					" /**\n" +
 					"  * Invalid type parameter reference\n" +
@@ -248,8 +248,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 		);
 	}
 	public void test011() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 					" /**\n" +
 					"  * Invalid type parameter reference\n" +
@@ -276,8 +276,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 		);
 	}
 	public void test012() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 					" /**\n" +
 					"  * Invalid type parameter reference\n" +
@@ -304,8 +304,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 		);
 	}
 	public void test013() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 					" /**\n" +
 					"  * Invalid type parameter reference\n" +
@@ -328,8 +328,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 		);
 	}
 	public void test014() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 					" /**\n" +
 					"  * Invalid type parameter reference\n" +
@@ -352,8 +352,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 		);
 	}
 	public void test015() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 					" /**\n" +
 					"  * Invalid type parameter reference\n" +
@@ -372,8 +372,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 		);
 	}
 	public void test016() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 					" /**\n" +
 					"  * Invalid type parameter reference\n" +
@@ -392,8 +392,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 		);
 	}
 	public void test017() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 					" /**\n" +
 					"  * Invalid type parameter reference\n" +
@@ -412,8 +412,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 		);
 	}
 	public void test018() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 					" /**\n" +
 					"  * Invalid type parameter reference\n" +
@@ -436,8 +436,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 		);
 	}
 	public void test019() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 					" /**\n" +
 					"  * Invalid type parameter reference\n" +
@@ -474,8 +474,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 		);
 	}
 	public void test020() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 					" /**\n" +
 					"  * Invalid type parameter reference\n" +
@@ -607,8 +607,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 		);
 	}
 	public void test026() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				" public class X {\n" +
 					"	/**\n" +
@@ -630,8 +630,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 		);
 	}
 	public void test027() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				" public class X {\n" +
 					"	/**\n" +
@@ -661,8 +661,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 		);
 	}
 	public void test028() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				" public class X {\n" +
 					"	/**\n" +
@@ -711,8 +711,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 		);
 	}
 	public void test029() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				" public class X {\n" +
 					"	/**\n" +
@@ -761,8 +761,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 		);
 	}
 	public void test031() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				" public class X {\n" +
 					"	/**\n" +
@@ -801,8 +801,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 		);
 	}
 	public void test032() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				" public class X {\n" +
 					"	/**\n" +
@@ -833,8 +833,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 		);
 	}
 	public void test033() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				" public class X {\n" +
 					"	/**\n" +
@@ -861,8 +861,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 		);
 	}
 	public void test034() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				" public class X {\n" +
 					"	/**\n" +
@@ -919,8 +919,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 		);
 	}
 	public void test035() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				" public class X {\n" +
 					"	/**\n" +
@@ -1022,8 +1022,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 		);
 	}
 	public void test038() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				" /**\n" +
 					"  * Invalid type parameter reference\n" +
@@ -1070,8 +1070,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 		);
 	}
 	public void test039() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				" /**\n" +
 					"  * Invalid type parameter reference\n" +
@@ -1136,8 +1136,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 	 * @see "http://bugs.eclipse.org/bugs/show_bug.cgi?id=80257"
 	 */
 	public void testBug80257() {
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"/**\n" +
 				" * @see G#G(Object)\n" +
@@ -1166,8 +1166,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 	 */
 	// FAIL ERRMSG
 	public void _testBug82514() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class ComparableUtils {\n" +
 				"   public static <T extends Comparable< ? super T>> int compareTo(final Object first, final Object firstPrime,  final Class<T> type) throws ClassCastException\n" +
@@ -1207,8 +1207,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 	 */
 	public void testBug83127a() {
 		this.reportMissingJavadocTags = CompilerOptions.IGNORE;
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"Test.java",
 				"/** \n" +
 				" * @see Test#add(T) \n" +
@@ -1262,8 +1262,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 	}
 	public void testBug83127b() {
 		this.reportMissingJavadocTags = CompilerOptions.IGNORE;
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"Test.java",
 				"/** \n" +
 				" * @see Sub#add(T)\n" +
@@ -1307,8 +1307,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 	}
 	public void testBug83127c() {
 		this.reportMissingJavadocTags = CompilerOptions.IGNORE;
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"Test.java",
 				"/** \n" +
 				" * @see Sub#add(E) \n" +
@@ -1349,8 +1349,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 	}
 	public void testBug83127d() {
 		this.reportMissingJavadocTags = CompilerOptions.IGNORE;
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"Unrelated1.java",
 				"public class Unrelated1<E extends Number> {\n" +
 				"	public Unrelated1(E e) {}\n" +
@@ -1396,8 +1396,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 	}
 	public void testBug83127e() {
 		this.reportMissingJavadocTags = CompilerOptions.IGNORE;
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"Unrelated1.java",
 				"public class Unrelated1<E extends Number> {\n" +
 				"	public Unrelated1(E e) {}\n" +
@@ -1477,8 +1477,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 	}
 	public void testBug83127g() {
 		this.reportMissingJavadocTags = CompilerOptions.IGNORE;
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"Unrelated1.java",
 				"public class Unrelated1<E extends Number> {\n" +
 				"	public Unrelated1(E e) {}\n" +
@@ -1525,8 +1525,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 	}
 	public void testBug83127h() {
 		this.reportMissingJavadocTags = CompilerOptions.IGNORE;
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"Unrelated2.java",
 				"public interface Unrelated2<E> {\n" +
 				"	boolean add(E e);\n" +
@@ -1596,8 +1596,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 		);
 	}
 	public void testBug83393b() {
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"Test.java",
 				"public class Test {\n" +
 				"	public void foo(int a, int b) {} \n" +
@@ -1668,8 +1668,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 	 * @see "http://bugs.eclipse.org/bugs/show_bug.cgi?id=83804"
 	 */
 	public void testBug83804() {
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"pack/package-info.java",
 				"/**\n" +
 				" * Valid javadoc.\n" +
@@ -1737,8 +1737,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 	 */
 	public void _testBug86769() {
 		this.reportMissingJavadocComments = CompilerOptions.ERROR;
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"E.java",
 				"public enum E {\n" +
 				"	A,\n" +
@@ -1979,8 +1979,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 	}
 	public void testBug96237_Public03() {
 		this.reportInvalidJavadocVisibility = CompilerOptions.PUBLIC;
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"comment6a/def/Test.java",
 				"package comment6a.def;\n" +
 				"public class Test {\n" +
@@ -2033,8 +2033,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 	}
 	public void testBug96237_Public04() {
 		this.reportInvalidJavadocVisibility = CompilerOptions.PUBLIC;
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"comment6b/Invalid.java",
 				"package comment6b;\n" +
 				"\n" +
@@ -2072,8 +2072,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 	}
 	public void testBug96237_Public05() {
 		this.reportInvalidJavadocVisibility = CompilerOptions.PUBLIC;
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"test/a/Test.java",
 				"package test.a;\n" +
 				"/**\n" +
@@ -2102,8 +2102,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 	}
 	public void testBug96237_Public06() {
 		this.reportInvalidJavadocVisibility = CompilerOptions.PUBLIC;
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"test/b/Test.java",
 				"package test.b;\n" +
 				"/** \n" +
@@ -2150,8 +2150,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 	}
 	public void testBug96237_Public07() {
 		this.reportInvalidJavadocVisibility = CompilerOptions.PUBLIC;
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"test/c/Test.java",
 				"package test.c;\n" +
 				"/**\n" +
@@ -2215,8 +2215,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 	}
 	public void testBug96237_Public08() {
 		this.reportInvalidJavadocVisibility = CompilerOptions.PUBLIC;
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"test/d/Reference.java",
 				"package test.d;\n" +
 				"class Reference {\n" +
@@ -2266,8 +2266,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 	}
 	public void testBug96237_Private02() {
 		this.reportInvalidJavadocVisibility = CompilerOptions.PRIVATE;
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"comment6/Invalid.java",
 				"package comment6;\n" +
 				"public class Invalid {\n" +
@@ -2293,8 +2293,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 	}
 	public void testBug96237_Private03() {
 		this.reportInvalidJavadocVisibility = CompilerOptions.PRIVATE;
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"comment6a/def/Test.java",
 				"package comment6a.def;\n" +
 				"public class Test {\n" +
@@ -2347,8 +2347,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 	}
 	public void testBug96237_Private04() {
 		this.reportInvalidJavadocVisibility = CompilerOptions.PRIVATE;
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"comment6b/Invalid.java",
 				"package comment6b;\n" +
 				"\n" +
@@ -2475,8 +2475,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 	 * @see "http://bugs.eclipse.org/bugs/show_bug.cgi?id=101283"
 	 */
 	public void testBug101283a() {
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X<T, F> {\n" +
 				"\n" +
@@ -2514,8 +2514,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 		);
 	}
 	public void testBug101283b() {
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X<T, F> {\n" +
 				"\n" +
@@ -2553,8 +2553,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 		);
 	}
 	public void testBug101283c() {
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X<T, F> {\n" +
 				"\n" +
@@ -2592,8 +2592,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 		);
 	}
 	public void testBug101283d() {
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X<T, F> {\n" +
 				"\n" +
@@ -2633,8 +2633,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 	// Verify duplicate test case: bug https://bugs.eclipse.org/bugs/show_bug.cgi?id=102735
 	public void testBug101283e() {
 		this.reportMissingJavadocTags = CompilerOptions.DISABLED;
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"Test.java",
 				"public interface Test<V, R extends Component<?>, C extends\n" +
 				"Test<V, R, C>> extends Control<SelectModel<V>, C>\n" +
@@ -2898,8 +2898,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 	public void testBug119857_Public01() {
 		this.reportMissingJavadocTags = CompilerOptions.DISABLED;
 		this.reportInvalidJavadocVisibility = CompilerOptions.PUBLIC;
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"pack/Test.java",
 				"package pack;\n" +
 				"public class Test {\n" +
@@ -2975,8 +2975,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 	public void testBug119857_Public03() {
 		this.reportMissingJavadocTags = CompilerOptions.IGNORE;
 		this.reportInvalidJavadocVisibility = CompilerOptions.PUBLIC;
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"pack/Test.java",
 				"package pack;\n" +
 				"public class Test {\n" +
@@ -3115,8 +3115,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 	public void testBug87500a() {
 		this.reportMissingJavadocComments = CompilerOptions.ERROR;
 		this.reportMissingJavadocCommentsVisibility = CompilerOptions.DEFAULT;
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"A.java",
 				"enum A {\n" +
 				"	clubs,\n" +
@@ -3177,8 +3177,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 		this.reportMissingJavadocTags = CompilerOptions.IGNORE;
 		this.reportMissingJavadocComments = CompilerOptions.IGNORE;
 		this.reportMissingJavadocCommentsVisibility = CompilerOptions.WARNING;
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X<T> {\n" +
 			    "    /** @see T.R */\n" +
@@ -3216,8 +3216,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 	 */
 	public void testBug209936a() {
 		this.reportMissingJavadocCommentsVisibility = CompilerOptions.WARNING;
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"p/X.java",
 				"package p;\n" +
 				"public abstract class X extends Y {\n" +
@@ -3254,8 +3254,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 
 	public void testBug209936b() {
 		this.reportMissingJavadocCommentsVisibility = CompilerOptions.WARNING;
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"p/X.java",
 				"package p;\n" +
 				"public abstract class X extends Y {\n" +
@@ -3292,8 +3292,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 	public void testBug209936_GenericMemberImplicitReference() {
 		this.reportMissingJavadocTags = CompilerOptions.IGNORE;
 		this.reportMissingJavadocCommentsVisibility = CompilerOptions.WARNING;
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"p1/A.java",
 				"package p1;\n" +
 				"public class A<R> {\n" +
@@ -3340,8 +3340,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 	public void testBug209936_GenericMemberSingleReference() {
 		this.reportMissingJavadocTags = CompilerOptions.IGNORE;
 		this.reportMissingJavadocCommentsVisibility = CompilerOptions.WARNING;
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"p1/A.java",
 				"package p1;\n" +
 				"public class A<R> {\n" +
@@ -3392,8 +3392,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 
 	public void testBug209936_GenericMemberQualifiedSingleReference() {
 		this.reportMissingJavadocCommentsVisibility = CompilerOptions.WARNING;
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"p1/A.java",
 				"package p1;\n" +
 				"public class A<R> {\n" +
@@ -3439,8 +3439,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 
 	public void testBug209936_GenericMemberFullyQualifiedSingleReference() {
 		this.reportMissingJavadocCommentsVisibility = CompilerOptions.WARNING;
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"p1/A.java",
 				"package p1;\n" +
 				"public class A<R> {\n" +
@@ -3487,8 +3487,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 	public void testBug209936_MemberImplicitReference() {
 		this.reportMissingJavadocTags = CompilerOptions.IGNORE;
 		this.reportMissingJavadocCommentsVisibility = CompilerOptions.WARNING;
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"p1/A.java",
 				"package p1;\n" +
 				"public class A<R> {\n" +
@@ -3535,8 +3535,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 	public void testBug209936_MemberSingleReference1(){
 		this.reportMissingJavadocTags = CompilerOptions.IGNORE;
 		this.reportMissingJavadocCommentsVisibility = CompilerOptions.WARNING;
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"p1/A.java",
 				"package p1;\n" +
 				"public class A<R> {\n" +
@@ -3588,8 +3588,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 	public void testBug209936_MemberSingleReference2(){
 		this.reportMissingJavadocTags = CompilerOptions.IGNORE;
 		this.reportMissingJavadocCommentsVisibility = CompilerOptions.WARNING;
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"p1/A.java",
 				"package p1;\n" +
 				"public class A<R> {\n" +
@@ -3641,8 +3641,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 	public void testBug209936_MemberSingleReference3(){
 		this.reportMissingJavadocTags = CompilerOptions.IGNORE;
 		this.reportMissingJavadocCommentsVisibility = CompilerOptions.WARNING;
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"p1/A.java",
 				"package p1;\n" +
 				"public class A {\n" +
@@ -3694,8 +3694,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 	public void testBug209936_MemberSingleReference4(){
 		this.reportMissingJavadocTags = CompilerOptions.IGNORE;
 		this.reportMissingJavadocCommentsVisibility = CompilerOptions.WARNING;
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"p1/A.java",
 				"package p1;\n" +
 				"public class A {\n" +
@@ -3836,8 +3836,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 
 	public void testBug209936_MemberFullyQualifiedSingleReference() {
 		this.reportMissingJavadocCommentsVisibility = CompilerOptions.WARNING;
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"p1/A.java",
 				"package p1;\n" +
 				"\n" +
@@ -4166,8 +4166,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 	public void testBug322581a() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_ReportMissingJavadocTagsMethodTypeParameters, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			true,
+		AbstractRegressionTest.runNegativeTest(
+			this, true,
 			new String[] {
 				"X.java",
 				" public class X {\n" +
@@ -4198,8 +4198,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 	public void testBug322581b() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_ReportMissingJavadocTagsMethodTypeParameters, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			true,
+		AbstractRegressionTest.runNegativeTest(
+			this, true,
 			new String[] {
 				"ListCallable.java",
 				" import java.util.Collections;\n" +
@@ -4240,8 +4240,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 	public void testBug331872() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_ReportMissingJavadocTagsMethodTypeParameters, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			true,
+		AbstractRegressionTest.runNegativeTest(
+			this, true,
 			new String[] {
 				"X.java",
 				"/**\n" +
@@ -4271,8 +4271,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 	public void testBug331872b() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_ReportMissingJavadocTagsMethodTypeParameters, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			true,
+		AbstractRegressionTest.runNegativeTest(
+			this, true,
 			new String[] {
 				"X.java",
 				"/**\n" +
@@ -4302,8 +4302,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 	public void testBug331872c() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_ReportMissingJavadocTagsMethodTypeParameters, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			true,
+		AbstractRegressionTest.runNegativeTest(
+			this, true,
 			new String[] {
 				"X.java",
 				"/**\n" +
@@ -4333,8 +4333,8 @@ public class JavadocTest_1_5 extends JavadocTest {
 	public void testBug331872d() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_ReportMissingJavadocTagsMethodTypeParameters, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			true,
+		AbstractRegressionTest.runNegativeTest(
+			this, true,
 			new String[] {
 				"X.java",
 				"/**\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/Jsr14Test.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/Jsr14Test.java
@@ -78,7 +78,7 @@ public void test1() throws Exception {
 		"    34  athrow\n" +
 		"    35  invokevirtual java.io.PrintStream.println(java.lang.Object) : void [45]\n" +
 		"    38  return\n";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 }
 public static Class testClass() {
 	return Jsr14Test.class;

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LambdaExpressionsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LambdaExpressionsTest.java
@@ -1173,8 +1173,8 @@ public void test043() {
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=406773, [1.8][compiler][codegen] "java.lang.IncompatibleClassChangeError" caused by attempted invocation of private constructor
 public void test044() {
-	this.runConformTest(
-			false,
+	AbstractRegressionTest.runConformTest(
+			this, false,
 			JavacHasABug.JavacBugFixed_901,
 			new String[] {
 					"X.java",
@@ -1470,8 +1470,8 @@ public void test050() {
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=406773, [1.8][compiler][codegen] "java.lang.IncompatibleClassChangeError" caused by attempted invocation of private constructor
 public void test051() {
-	this.runConformTest(
-			false /* skipJavac*/,
+	AbstractRegressionTest.runConformTest(
+			this, false /* skipJavac*/,
 			JavacHasABug.JavacBugFixed_901,
 			new String[] {
 					"p2/B.java",
@@ -1918,8 +1918,8 @@ public void testReferenceExpressionInference2() {
 }
 
 public void testReferenceExpressionInference3a() {
-	runConformTest(
-		false /* skipJavac*/,
+	AbstractRegressionTest.runConformTest(
+		this, false /* skipJavac*/,
 		JavacTestOptions.Excuse.JavacDoesNotCompileCorrectSource,
 		new String[] {
 			"X.java",
@@ -3364,8 +3364,8 @@ public void test428261() {
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=428261, [1.8][compiler] Incorrect error: No enclosing instance of the type X is accessible in scope
 public void test428261a() {
-	this.runConformTest(
-			false,
+	AbstractRegressionTest.runConformTest(
+			this, false,
 			JavacHasABug.JavacBugFixed_901,
 			new String[] {
 				"X.java",
@@ -3932,8 +3932,8 @@ public void test430035c() {
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=430035, [1.8][compiler][codegen] Bridge methods are not generated for lambdas/method references
 public void test430035d() { // 8b131 complains of ambiguity.
-	this.runConformTest(
-			false,
+	AbstractRegressionTest.runConformTest(
+			this, false,
 			EclipseHasABug.EclipseBug510528,
 			new String[] {
 				"X.java",
@@ -3962,8 +3962,8 @@ public void test430035d() { // 8b131 complains of ambiguity.
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=430035, [1.8][compiler][codegen] Bridge methods are not generated for lambdas/method references
 public void test430035e() { // 8b131 complains of ambiguity in call.
-	this.runConformTest(
-			false,
+	AbstractRegressionTest.runConformTest(
+			this, false,
 			EclipseHasABug.EclipseBug510528,
 			new String[] {
 				"X.java",
@@ -5196,8 +5196,8 @@ public void test448802() throws Exception {
 public void test449063() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_LambdaGenericSignature, CompilerOptions.GENERATE);
-	this.runConformTest(
-		false,
+	AbstractRegressionTest.runConformTest(
+		this, false,
 		new String[] {
 			"Test.java",
 			"import java.io.Serializable;\n" +
@@ -5241,8 +5241,8 @@ public void test449063() {
 public void test449063a() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_LambdaGenericSignature, CompilerOptions.GENERATE);
-	this.runConformTest(
-		false,
+	AbstractRegressionTest.runConformTest(
+		this, false,
 		new String[] {
 			"Test.java",
 			"import java.io.Serializable;\n" +
@@ -5739,8 +5739,8 @@ public void test467825a() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=461004 Multiple spurious errors compiling FunctionalJava project
 public void test461004() {
-	this.runConformTest(
-		false /* skipJavac */,
+	AbstractRegressionTest.runConformTest(
+		this, false /* skipJavac */,
 		JavacHasABug.JavacBugFixed_901,
 		new String[] {
 			"Ice.java",
@@ -5868,8 +5868,8 @@ public void test477263() {
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=477263 [1.8][compiler] No enclosing instance of the type Outer is accessible in scope for method reference
 public void test477263a() {
-	this.runConformTest(
-		false,
+	AbstractRegressionTest.runConformTest(
+		this, false,
 		JavacHasABug.JavacBug8144673,
 		new String[] {
 			"X.java",

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LambdaRegressionTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LambdaRegressionTest.java
@@ -128,8 +128,8 @@ public void test003() {
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=446317, java.lang.VerifyError: Bad type on operand stack with Lambdas and/or inner classes
 public void test004() {
-	this.runConformTest(
-		false,
+	AbstractRegressionTest.runConformTest(
+		this, false,
 		JavacHasABug.JavacThrowsAnException,
 		new String[] {
 			"Y.java",
@@ -963,8 +963,8 @@ public void testBug477888() {
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=472648
 // [compiler][1.8] Lambda expression referencing method with generic type has incorrect compile errors
 public void testBug472648() {
-	runNegativeTest(
-		false,
+	AbstractRegressionTest.runNegativeTest(
+		this, false,
 		JavacHasABug.JavacBugFixed_901,
 		new String [] {
 		"Test.java",

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LocalEnumTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LocalEnumTest.java
@@ -1278,8 +1278,8 @@ public void test033() {
 	);
 }
 public void test034() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"  public static void main(String[] args) {\n" +
@@ -1339,8 +1339,8 @@ public void test035() {
 	);
 }
 public void test036() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"  public static void main(String[] args) {\n" +
@@ -1396,8 +1396,8 @@ public void test037() {
 }
 public void test038() {
 	this.reportMissingJavadocComments = CompilerOptions.ERROR;
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  public static void main(String[] args) {\n" +
@@ -1422,8 +1422,8 @@ public void test038() {
 	);
 }
 public void test039() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"  public static void main(String[] args) {\n" +
@@ -1494,8 +1494,8 @@ public void test040() {
 	);
 }
 public void test041() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"  public static void main(String[] args) {\n" +
@@ -2139,8 +2139,8 @@ public void test061() {
 public void test062() {
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_SWITCH_MISSING_DEFAULT_CASE, JavaCore.WARNING);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"\n" +
 			"class A {\n" +
@@ -3654,8 +3654,8 @@ to refer to itself or an enum constant of the same type that is declared to
 the right of e1."
 	*/
 public void testNPE100() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X { \n" +
 			"	public static void main(String[] args) {\n" +
@@ -3871,8 +3871,8 @@ public void _NA_test105() {
 		null
 	);
 
-	executeClass(
-		"pack/X.java",
+	AbstractRegressionTest.executeClass(
+		this, "pack/X.java",
 		"Black",
 		null,
 		false,
@@ -3885,8 +3885,8 @@ public void _NA_test105() {
 public void  _NA_test106() {
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_INCOMPLETE_ENUM_SWITCH, JavaCore.IGNORE);
-	this.runConformTest(
-			new String[] {
+	AbstractRegressionTest.runConformTest(
+			this, new String[] {
 				"pack/X.java",
 				"package pack;\n" +
 				"import static pack.Color.*;\n" +
@@ -3922,8 +3922,8 @@ public void  _NA_test106() {
 		null
 	);
 
-	executeClass(
-		"pack/X.java",
+	AbstractRegressionTest.executeClass(
+		this, "pack/X.java",
 		"SUCCESS",
 		null,
 		false,
@@ -3935,8 +3935,8 @@ public void  _NA_test106() {
 public void  _NA_test107() {
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_INCOMPLETE_ENUM_SWITCH, JavaCore.IGNORE);
-	this.runConformTest(
-			new String[] {
+	AbstractRegressionTest.runConformTest(
+			this, new String[] {
 				"pack/X.java",
 				"package pack;\n" +
 				"import static pack.Color.*;\n" +
@@ -3985,8 +3985,8 @@ public void  _NA_test107() {
 		null
 	);
 
-	executeClass(
-		"pack/X.java",
+	AbstractRegressionTest.executeClass(
+		this, "pack/X.java",
 		"BlackBlack",
 		null,
 		false,
@@ -3999,8 +3999,8 @@ public void  _NA_test107() {
 public void  _NA_test108() {
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_INCOMPLETE_ENUM_SWITCH, JavaCore.IGNORE);
-	this.runConformTest(
-			new String[] {
+	AbstractRegressionTest.runConformTest(
+			this, new String[] {
 				"pack/X.java",
 				"package pack;\n" +
 				"import static pack.Color.*;\n" +
@@ -4044,8 +4044,8 @@ public void  _NA_test108() {
 		null
 	);
 
-	executeClass(
-		"pack/X.java",
+	AbstractRegressionTest.executeClass(
+		this, "pack/X.java",
 		"Black",
 		null,
 		false,
@@ -4058,8 +4058,8 @@ public void  _NA_test108() {
 public void  _NA_test109() {
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_INCOMPLETE_ENUM_SWITCH, JavaCore.IGNORE);
-	this.runConformTest(
-			new String[] {
+	AbstractRegressionTest.runConformTest(
+			this, new String[] {
 				"pack/X.java",
 				"package pack;\n" +
 				"import static pack.Color.*;\n" +
@@ -4106,8 +4106,8 @@ public void  _NA_test109() {
 		null
 	);
 
-	executeClass(
-		"pack/X.java",
+	AbstractRegressionTest.executeClass(
+		this, "pack/X.java",
 		"SUCCESS",
 		null,
 		false,
@@ -4120,8 +4120,8 @@ public void  _NA_test109() {
 public void  _NAtest110() {
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_INCOMPLETE_ENUM_SWITCH, JavaCore.IGNORE);
-	this.runConformTest(
-			new String[] {
+	AbstractRegressionTest.runConformTest(
+			this, new String[] {
 				"pack/X.java",
 				"package pack;\n" +
 				"import static pack.Color.*;\n" +
@@ -4164,8 +4164,8 @@ public void  _NAtest110() {
 		null
 	);
 
-	executeClass(
-		"pack/X.java",
+	AbstractRegressionTest.executeClass(
+		this, "pack/X.java",
 		"Black",
 		null,
 		false,
@@ -4228,8 +4228,8 @@ public void  _NA_test111() {
 		null
 	);
 
-	executeClass(
-		"pack/X.java",
+	AbstractRegressionTest.executeClass(
+		this, "pack/X.java",
 		"BlackBlack",
 		null,
 		false,
@@ -4244,8 +4244,8 @@ public void _NA_test112() {
 	options.put(JavaCore.COMPILER_PB_INCOMPLETE_ENUM_SWITCH, JavaCore.IGNORE);
 	options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.ENABLED);
 	options.put(CompilerOptions.OPTION_ReportPreviewFeatures, CompilerOptions.IGNORE);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"com/annot/X.java",
 			"package com.annot;\n" +
 					"import java.lang.annotation.Target;\n"+
@@ -4628,8 +4628,8 @@ public void test119() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=102213
 public void test120() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	public static void main(String argv[]) {\n" +
@@ -4942,8 +4942,8 @@ public void test128() {
 	options.put(CompilerOptions.OPTION_ReportRawTypeReference, CompilerOptions.IGNORE);
 	options.put(CompilerOptions.OPTION_ReportMissingSerialVersion, CompilerOptions.IGNORE);
 
-	this.runNegativeTest(
-         new String[] {
+	AbstractRegressionTest.runNegativeTest(
+         this, new String[] {
         		 "X.java",
         		 "public class X {\n" +
         		 "	public static void main( String[] args) {\n" +
@@ -5200,8 +5200,8 @@ public void test133() throws Exception {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=149042
 public void test134() {
-    this.runNegativeTest(
-        new String[] {
+    AbstractRegressionTest.runNegativeTest(
+        this, new String[] {
             "X.java",
 			"public class X {\n" +
 		  	"	public static void main(String[] args) {\n" +
@@ -5618,8 +5618,8 @@ public void test144() {
 public void test145() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportNonStaticAccessToStatic, CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"ClassC.java",
@@ -5688,8 +5688,8 @@ public void test146() {
 public void test146b() {
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_SWITCH_MISSING_DEFAULT_CASE, JavaCore.WARNING);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"	final String test;\n" +
@@ -5727,8 +5727,8 @@ public void test146b() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=227502
 public void test147() {
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 					"p/X.java",
 					"package p;\n" +
 					"public class X {\n" +
@@ -5754,8 +5754,8 @@ public void test147() {
 	}
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=227502 - variation
 public void test148() {
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 					"p/X.java",
 					"package p;\n" +
 					"public class X {\n" +
@@ -5990,8 +5990,8 @@ public void test152() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=228109
 public void test153() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 				"Y.java",
 				"public class Y {\n" +
 				"	public static void main(String[] args) {\n" +
@@ -6016,8 +6016,8 @@ public void test153() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=228109 - variation
 public void test154() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 				"Y.java",
 				"public class Y {\n" +
 				"	public static void main(String[] args) {\n" +
@@ -6092,8 +6092,8 @@ public void test156() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=228109 - variation
 public void test157() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 				"Y.java",
 				"public class Y {\n" +
 				"	public static void main(String[] args) {\n" +
@@ -6536,8 +6536,8 @@ public void test165() throws Exception {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=251814
 public void test166() throws Exception {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java", // =================
 			"public class X { \n" +
 			"	public static void main(String[] args) {\n" +
@@ -6580,8 +6580,8 @@ public void test166() throws Exception {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=251814 - variation
 public void test167() throws Exception {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java", // =================
 			"public class X { \n" +
 			"	public static void main(String[] args) {\n" +
@@ -6818,8 +6818,8 @@ public void test170() {
 public void test171() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.WARNING);
-	this.runConformTest(
-		true,
+	AbstractRegressionTest.runConformTest(
+		this, true,
 		new String[] {
 			"X.java",
 			"public class X { \n" +
@@ -6847,8 +6847,8 @@ public void test171() {
 public void test172() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.WARNING);
-	this.runConformTest(
-		true,
+	AbstractRegressionTest.runConformTest(
+		this, true,
 		new String[] {
 			"X.java",
 			"public class X { \n" +
@@ -6993,8 +6993,8 @@ public void test176() {
 	);
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_Process_Annotations, CompilerOptions.ENABLED);
-	this.runConformTest(
-		false,
+	AbstractRegressionTest.runConformTest(
+		this, false,
 		new String[] {
 				"X.java",
 				"public class X {\n" +
@@ -7057,8 +7057,8 @@ public void test177() {
 	);
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_Process_Annotations, CompilerOptions.ENABLED);
-	this.runConformTest(
-		false,
+	AbstractRegressionTest.runConformTest(
+		this, false,
 		new String[] {
 			"X.java",
 			"public class X {\n" +
@@ -7123,8 +7123,8 @@ public void _NA_test178() {
 	);
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_Process_Annotations, CompilerOptions.ENABLED);
-	this.runConformTest(
-		false,
+	AbstractRegressionTest.runConformTest(
+		this, false,
 		new String[] {
 			"Z.java",
 			"public class Z {\n" +
@@ -7147,8 +7147,8 @@ public void test179() {
 	}
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_Process_Annotations, CompilerOptions.ENABLED);
-	this.runConformTest(
-		false,
+	AbstractRegressionTest.runConformTest(
+		this, false,
 		new String[] {
 			"Z.java",
 			"public class Z {\n" +
@@ -7206,8 +7206,8 @@ public void test180() {
 	);
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_Process_Annotations, CompilerOptions.ENABLED);
-	this.runConformTest(
-		false,
+	AbstractRegressionTest.runConformTest(
+		this, false,
 		new String[] {
 			"X.java",
 			"import p.MyEnum;\n" +
@@ -7235,8 +7235,8 @@ public void test180() {
 public void test180a() {
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_ANNOTATION_NULL_ANALYSIS, JavaCore.ENABLED);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"p/package-info.java",
 			"@p.Annot(state=p.MyEnum.BROKEN)\n" +
 			"package p;",
@@ -7262,8 +7262,8 @@ public void test180a() {
 	);
 	options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_Process_Annotations, CompilerOptions.ENABLED);
-	this.runConformTest(
-		false,
+	AbstractRegressionTest.runConformTest(
+		this, false,
 		new String[] {
 			"X.java",
 			"import p.MyEnum;\n" +
@@ -7323,8 +7323,8 @@ public void test182() throws Exception {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedLocal, CompilerOptions.ERROR);
 	customOptions.put(CompilerOptions.OPTION_PreserveUnusedLocal, CompilerOptions.OPTIMIZE_OUT);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	public static void main(String argv[])   {\n" +
@@ -7366,8 +7366,8 @@ public void test183() throws Exception {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedLocal, CompilerOptions.ERROR);
 	customOptions.put(CompilerOptions.OPTION_PreserveUnusedLocal, CompilerOptions.OPTIMIZE_OUT);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	public static void main(String argv[]) {\n" +
@@ -7409,8 +7409,8 @@ public void test184() throws Exception {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedLocal, CompilerOptions.ERROR);
 	customOptions.put(CompilerOptions.OPTION_PreserveUnusedLocal, CompilerOptions.OPTIMIZE_OUT);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	public static void main(String argv[]) {\n" +
@@ -7481,8 +7481,8 @@ public void test186() {
 	}
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_MISSING_ENUM_CASE_DESPITE_DEFAULT, JavaCore.ENABLED);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"Y.java",
 			"public class Y {\n" +
 			"    void _test(boolean val) {\n" +
@@ -7522,8 +7522,8 @@ public void test187() {
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_MISSING_ENUM_CASE_DESPITE_DEFAULT, JavaCore.ENABLED);
 	options.put(JavaCore.COMPILER_PB_INCOMPLETE_ENUM_SWITCH, JavaCore.ERROR);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"Y.java",
 			"public class Y {\n" +
 			"    void _test(boolean val) {\n" +
@@ -7554,8 +7554,8 @@ public void test187a() {
 	}
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_MISSING_ENUM_CASE_DESPITE_DEFAULT, JavaCore.ENABLED);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"Y.java",
 			"public class Y {\n" +
 			"    void _test(boolean val) {\n" +
@@ -7595,8 +7595,8 @@ public void test187b() {
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_SWITCH_MISSING_DEFAULT_CASE, JavaCore.ERROR);
 	options.put(JavaCore.COMPILER_PB_SUPPRESS_OPTIONAL_ERRORS, JavaCore.ENABLED);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"Y.java",
 			"public class Y {\n" +
 			"    @SuppressWarnings(\"incomplete-switch\")\n" +
@@ -7625,8 +7625,8 @@ public void test188() {
 	}
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_SWITCH_MISSING_DEFAULT_CASE, JavaCore.WARNING);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"Y.java",
 			"public class Y {\n" +
 			"    void _test(boolean val) {\n" +
@@ -7665,8 +7665,8 @@ public void test189() {
 	}
 	Map options = getCompilerOptions();
 	//options.put(JavaCore.COMPILER_PB_MISSING_DEFAULT_CASE, JavaCore.WARNING);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"Y.java",
 			"public class Y {\n" +
 			"    public int test(boolean val) {\n" +
@@ -7699,8 +7699,8 @@ public void test433060() {
 	}
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_REDUNDANT_TYPE_ARGUMENTS, JavaCore.ERROR);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"Y.java",
 			"public class Y{\n" +
 			"	public static void main(String argv[]) {\n" +
@@ -7820,8 +7820,8 @@ public void test566758() {
 	if(this.complianceLevel < ClassFileConstants.JDK1_6) {
 		return;
 	}
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"class X {\n" +
 			"	<T> void m(T t) {\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LocalStaticsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LocalStaticsTest.java
@@ -69,7 +69,7 @@ public class LocalStaticsTest extends AbstractRegressionTest {
 	}
 	@Override
 	protected void runNegativeTest(String[] testFiles, String expectedCompilerLog) {
-		runNegativeTest(testFiles, expectedCompilerLog, null);
+		AbstractRegressionTest.runNegativeTest(this, testFiles, expectedCompilerLog, null);
 	}
 	protected void runWarningTest(String[] testFiles, String expectedCompilerLog) {
 		runWarningTest(testFiles, expectedCompilerLog, null);
@@ -945,8 +945,8 @@ public class LocalStaticsTest extends AbstractRegressionTest {
 	public void testBug568514LocalEnums_002() {
 		Map<String, String> options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X {\n"+
 				"    public void foo() {\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LocalVariableTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LocalVariableTest.java
@@ -217,7 +217,7 @@ public void test010() {
 	options.put(
 		CompilerOptions.OPTION_DocCommentSupport,
 		CompilerOptions.ENABLED);
-	this.runConformTest(new String[] {
+	AbstractRegressionTest.runConformTest(this, new String[] {
 		"p/X.java",
 		"package p;\n" +
 		"/**\n" +
@@ -344,8 +344,8 @@ public void test015() {
 	Map options = getCompilerOptions();
 	if (this.complianceLevel == ClassFileConstants.JDK1_3) return;
 	options.put(CompilerOptions.OPTION_PreserveUnusedLocal, CompilerOptions.OPTIMIZE_OUT);
-	this.runConformTest(
-			new String[] {
+	AbstractRegressionTest.runConformTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"        public static boolean test() {\n" +
@@ -374,8 +374,8 @@ public void test016() {
 	options.put(CompilerOptions.OPTION_ReportUnusedParameterIncludeDocCommentReference, CompilerOptions.ENABLED);
 	options.put(CompilerOptions.OPTION_ReportUnusedParameterWhenOverridingConcrete, CompilerOptions.DISABLED);
 	options.put(CompilerOptions.OPTION_ReportUnusedParameterWhenImplementingAbstract, CompilerOptions.DISABLED);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -432,8 +432,8 @@ public void test017() {
 	options.put(CompilerOptions.OPTION_ReportUnusedParameterIncludeDocCommentReference, CompilerOptions.ENABLED);
 	options.put(CompilerOptions.OPTION_ReportUnusedParameterWhenOverridingConcrete, CompilerOptions.DISABLED);
 	options.put(CompilerOptions.OPTION_ReportUnusedParameterWhenImplementingAbstract, CompilerOptions.DISABLED);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -500,8 +500,8 @@ public void test018() {
 	options.put(CompilerOptions.OPTION_ReportUnusedParameterIncludeDocCommentReference, CompilerOptions.DISABLED);
 	options.put(CompilerOptions.OPTION_ReportUnusedParameterWhenOverridingConcrete, CompilerOptions.DISABLED);
 	options.put(CompilerOptions.OPTION_ReportUnusedParameterWhenImplementingAbstract, CompilerOptions.DISABLED);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -568,8 +568,8 @@ public void test019() {
 	options.put(CompilerOptions.OPTION_ReportUnusedParameterIncludeDocCommentReference, CompilerOptions.DISABLED);
 	options.put(CompilerOptions.OPTION_ReportUnusedParameterWhenOverridingConcrete, CompilerOptions.ENABLED);
 	options.put(CompilerOptions.OPTION_ReportUnusedParameterWhenImplementingAbstract, CompilerOptions.ENABLED);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -651,8 +651,8 @@ public void test020() {
 	options.put(CompilerOptions.OPTION_ReportUnusedParameterIncludeDocCommentReference, CompilerOptions.DISABLED);
 	options.put(CompilerOptions.OPTION_ReportUnusedParameterWhenOverridingConcrete, CompilerOptions.ENABLED);
 	options.put(CompilerOptions.OPTION_ReportUnusedParameterWhenImplementingAbstract, CompilerOptions.ENABLED);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -841,8 +841,8 @@ public void test412119d() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnusedParameter, CompilerOptions.WARNING);
 	options.put(CompilerOptions.OPTION_ReportUnusedExceptionParameter, CompilerOptions.WARNING);
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"p/X.java",
 				"package p;\n" +
 				"class X {\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LookupTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LookupTest.java
@@ -657,7 +657,7 @@ public void test019() {
  * member class
  */
 public void test020() {
-	String errMessage = isMinimumCompliant(ClassFileConstants.JDK11) ?
+	String errMessage = AbstractRegressionTest.isMinimumCompliant(this, ClassFileConstants.JDK11) ?
 			"----------\n" +
 			"1. ERROR in p1\\A.java (at line 13)\n" +
 			"	System.out.println(foo.rating + bar.other);	\n" +
@@ -990,8 +990,8 @@ public void test030() {
 	Hashtable target1_2 = new Hashtable();
 	target1_2.put(CompilerOptions.OPTION_TargetPlatform, CompilerOptions.VERSION_1_2);
 
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"p1/A.java",
 			"package p1; \n"+
 			"public abstract class A implements I {	\n" +
@@ -1010,8 +1010,8 @@ public void test030() {
 		target1_2,  // custom options
 		null/*no custom requestor*/);
 
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"p1/C.java",
 			"package p1; \n"+
 			"public class C {	\n" +
@@ -1612,8 +1612,8 @@ public void test047() {
 }
 // 73740 - missing serialVersionUID diagnosis shouldn't trigger load of Serializable
 public void test048() {
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java", //---------------------------
 			"public class X {\n" +
 			"   public static void main(String[] args) {\n"+
@@ -1971,8 +1971,8 @@ public void test061() {
 		// ensure target is 1.1 for having default abstract methods involved
 		options.put(CompilerOptions.OPTION_TargetPlatform, CompilerOptions.VERSION_1_1);
 	}
-    this.runConformTest(
-        new String[] {
+    AbstractRegressionTest.runConformTest(
+        this, new String[] {
         		"X.java", // =================
     			"interface MyInterface {\n" +
     			"        public void writeToStream();\n" +
@@ -2003,8 +2003,8 @@ public void test062() {
 		// ensure target is 1.1 for having default abstract methods involved
 		options.put(CompilerOptions.OPTION_TargetPlatform, CompilerOptions.VERSION_1_1);
 	}
-    this.runConformTest(
-        new String[] {
+    AbstractRegressionTest.runConformTest(
+        this, new String[] {
         		"X.java", // =================
     			"interface MyInterface {\n" +
     			"        public void writeToStream();\n" +
@@ -2086,8 +2086,8 @@ public void test064() {
 		// ensure target is 1.1 for having default abstract methods involved
 		options.put(CompilerOptions.OPTION_TargetPlatform, CompilerOptions.VERSION_1_1);
 	}
-	this.runConformTest(
-			new String[] {
+	AbstractRegressionTest.runConformTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"	public static void main(String[] args) {\n" +
@@ -2288,8 +2288,8 @@ public void test068() {
 	CompilerOptions compOptions = new CompilerOptions(options);
 	if (compOptions.complianceLevel < ClassFileConstants.JDK1_5) return;
 	options.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_1_4);
-	this.runConformTest(
-			new String[] {
+	AbstractRegressionTest.runConformTest(
+			this, new String[] {
 				"X.java",//===================
 				"public class X {\n" +
 				"    public X() {\n" +
@@ -2342,8 +2342,8 @@ public void test068a() {
 		null);
 
 	options.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_1_4);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"Test14.java",//===================
 			"public class Test14 {\n" +
 			"    public static void main(String[] args) {\n" +
@@ -2415,8 +2415,8 @@ public void test071() {
 			"}",
 		},
 		"");
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"Y.java",
 			"import p.*;\n" +
 			"public class Y {\n" +
@@ -3116,7 +3116,7 @@ public void test096() {
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id= 317212
 public void test097() {
-	String errMessage = isMinimumCompliant(ClassFileConstants.JDK11) ?
+	String errMessage = AbstractRegressionTest.isMinimumCompliant(this, ClassFileConstants.JDK11) ?
 			"----------\n" +
 			"1. WARNING in B.java (at line 6)\n" +
 			"	public class M {\n" +
@@ -3316,7 +3316,7 @@ public void test103() {
 	Map options = getCompilerOptions();
 	CompilerOptions compOptions = new CompilerOptions(options);
 	if (compOptions.complianceLevel < ClassFileConstants.JDK1_4) return;
-	String errMessage = isMinimumCompliant(ClassFileConstants.JDK11) ?
+	String errMessage = AbstractRegressionTest.isMinimumCompliant(this, ClassFileConstants.JDK11) ?
 			"----------\n" +
 			"1. WARNING in A.java (at line 2)\n" +
 			"	private int x;\n" +
@@ -3449,7 +3449,7 @@ public void test105() {
 	Map options = getCompilerOptions();
 	CompilerOptions compOptions = new CompilerOptions(options);
 	if (compOptions.complianceLevel < ClassFileConstants.JDK1_4) return;
-	String errMessage =	isMinimumCompliant(ClassFileConstants.JDK11) ?
+	String errMessage =	AbstractRegressionTest.isMinimumCompliant(this, ClassFileConstants.JDK11) ?
 			"----------\n" +
 			"1. WARNING in A.java (at line 2)\n" +
 			"	private int x;\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/MethodHandleTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/MethodHandleTest.java
@@ -276,8 +276,8 @@ public class MethodHandleTest extends AbstractRegressionTest {
 	public void test009() {
 		Map customOptions = getCompilerOptions();
 		customOptions.put(CompilerOptions.OPTION_ReportUnnecessaryTypeCheck, CompilerOptions.ERROR);
-		runNegativeTest(
-				// test directory preparation
+		AbstractRegressionTest.runNegativeTest(
+				this, // test directory preparation
 				true /* flush output directory */,
 				new String[] { /* test files */
 						"X.java",
@@ -312,8 +312,8 @@ public class MethodHandleTest extends AbstractRegressionTest {
 	public void test010() {
 		Map customOptions = getCompilerOptions();
 		customOptions.put(CompilerOptions.OPTION_ReportUnnecessaryTypeCheck, CompilerOptions.ERROR);
-		runNegativeTest(
-				// test directory preparation
+		AbstractRegressionTest.runNegativeTest(
+				this, // test directory preparation
 				true /* flush output directory */,
 				new String[] { /* test files */
 						"X.java",

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/MethodParametersAttributeTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/MethodParametersAttributeTest.java
@@ -97,7 +97,7 @@ public class MethodParametersAttributeTest extends AbstractRegressionTest {
 	public void test001() throws Exception {
 
 			ClassFileBytesDisassembler disassembler = ToolFactory.createDefaultClassFileBytesDisassembler();
-			String path = this.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "ParameterNames.class";
+			String path = AbstractRegressionTest.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "ParameterNames.class";
 			byte[] classFileBytes = org.eclipse.jdt.internal.compiler.util.Util.getFileByteContent(new File(path));
 			String actualOutput =
 				disassembler.disassemble(
@@ -178,7 +178,7 @@ public class MethodParametersAttributeTest extends AbstractRegressionTest {
 	public void test002() throws Exception {
 
 		ClassFileBytesDisassembler disassembler = ToolFactory.createDefaultClassFileBytesDisassembler();
-		String path = this.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "ParameterNames$1.class";
+		String path = AbstractRegressionTest.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "ParameterNames$1.class";
 		byte[] classFileBytes = org.eclipse.jdt.internal.compiler.util.Util.getFileByteContent(new File(path));
 		String actualOutput =
 			disassembler.disassemble(
@@ -245,7 +245,7 @@ public class MethodParametersAttributeTest extends AbstractRegressionTest {
 	public void test003() throws Exception {
 
 		ClassFileBytesDisassembler disassembler = ToolFactory.createDefaultClassFileBytesDisassembler();
-		String path = this.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "ParameterNames$1Local.class";
+		String path = AbstractRegressionTest.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "ParameterNames$1Local.class";
 		byte[] classFileBytes = org.eclipse.jdt.internal.compiler.util.Util.getFileByteContent(new File(path));
 		String actualOutput =
 			disassembler.disassemble(
@@ -319,7 +319,7 @@ public class MethodParametersAttributeTest extends AbstractRegressionTest {
 	public void test004() throws Exception {
 
 		// Test the results of the ClassFileReader
-		String path = this.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "ParameterNames.class";
+		String path = AbstractRegressionTest.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "ParameterNames.class";
 
 		org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader classFileReader = ClassFileReader.read(path);
 		IBinaryMethod[] methodInfos = classFileReader.getMethods();
@@ -332,7 +332,7 @@ public class MethodParametersAttributeTest extends AbstractRegressionTest {
 
 	public void test005() throws Exception {
 		// Test the results of the ClassFileReader where some of the paramers are synthetic and/or mandated
-		String path = this.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "ParameterNames$1Local.class";
+		String path = AbstractRegressionTest.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "ParameterNames$1Local.class";
 
 		org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader classFileReader = ClassFileReader.read(path);
 		IBinaryMethod[] methodInfos = classFileReader.getMethods();
@@ -964,8 +964,8 @@ public class MethodParametersAttributeTest extends AbstractRegressionTest {
 		Map<String, String> compilerOptions = getCompilerOptions();
 		compilerOptions.put(CompilerOptions.OPTION_LocalVariableAttribute, CompilerOptions.DO_NOT_GENERATE);
 		compilerOptions.put(CompilerOptions.OPTION_MethodParametersAttribute, CompilerOptions.GENERATE);
-		this.runConformTest(
-			new String[] {
+		AbstractRegressionTest.runConformTest(
+			this, new String[] {
 				fileName,
 				body
 			},

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/MethodVerifyTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/MethodVerifyTest.java
@@ -307,8 +307,8 @@ public class MethodVerifyTest extends AbstractComparableTest {
 			},
 			""
 		);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"Y.java",
 				"public class Y<T> extends X<A> { public void foo(T t) {} }\n"
 			},
@@ -338,8 +338,8 @@ public class MethodVerifyTest extends AbstractComparableTest {
 			},
 			""
 		);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"J.java",
 				"public class J<T> implements I<A> { public void foo(T t) {} }\n"
 			},
@@ -374,8 +374,8 @@ public class MethodVerifyTest extends AbstractComparableTest {
 			},
 			""
 		);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"YY.java",
 				"public class YY<T> extends X { public void foo(T t) {} }\n"
 			},
@@ -410,8 +410,8 @@ public class MethodVerifyTest extends AbstractComparableTest {
 			},
 			""
 		);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"JJ.java",
 				"public class JJ<T> implements I { public void foo(T t) {} }\n"
 			},
@@ -643,8 +643,8 @@ public class MethodVerifyTest extends AbstractComparableTest {
 			},
 			""
 		);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"J.java",
 				"class J<T> implements I<B> { public T foo() {return null;} }\n",
 				"K.java",
@@ -1473,8 +1473,8 @@ public class MethodVerifyTest extends AbstractComparableTest {
 			},
 			""
 		);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"B.java",
 				"class B extends A {\n" +
 				"	@Override void foo(java.util.Map<String, Class<?>> m) { } \n" +
@@ -1711,8 +1711,8 @@ public class MethodVerifyTest extends AbstractComparableTest {
 		);
 	}
 	public void test025e() { // 81618
-		this.runConformTest(
-			true,
+		AbstractRegressionTest.runConformTest(
+			this, true,
 			new String[] {
 				"X.java",
 				"interface X<T extends X> { T x(); }\n" +
@@ -1745,8 +1745,8 @@ public class MethodVerifyTest extends AbstractComparableTest {
 		);
 	}
 	public void test025f() { // 81618
-		this.runConformTest(
-			true,
+		AbstractRegressionTest.runConformTest(
+			this, true,
 			new String[] {
 				"X.java",
 				"interface X<T extends X> { T[] x(); }\n" +
@@ -1983,8 +1983,8 @@ public class MethodVerifyTest extends AbstractComparableTest {
 		java.util.Map options = super.getCompilerOptions();
 		options.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_1_4);
 
-		this.runConformTest(
-			new String[] {
+		AbstractRegressionTest.runConformTest(
+			this, new String[] {
 				"X.java",
 				"import java.io.OutputStreamWriter;\n" +
 				"import java.io.PrintWriter;\n" +
@@ -2859,8 +2859,8 @@ public class MethodVerifyTest extends AbstractComparableTest {
 
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=83902
 	public void test041() { // inherited cases for bridge methods, varargs clashes, return type conversion checks
-		runConformTest(
-			true,
+		AbstractRegressionTest.runConformTest(
+			this, true,
 			new String[] {
 				"X.java",
 				"public class X { public void foo(String... n) {} }\n" +
@@ -2881,8 +2881,8 @@ public class MethodVerifyTest extends AbstractComparableTest {
 	}
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=83902
 	public void test041a() { // inherited cases for bridge methods, varargs clashes, return type conversion checks
-		this.runConformTest(
-			true,
+		AbstractRegressionTest.runConformTest(
+			this, true,
 			new String[] {
 				"X.java",
 				"public class X { public void foo(String[] n) {} }\n" +
@@ -2947,8 +2947,8 @@ public class MethodVerifyTest extends AbstractComparableTest {
 	}
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=83902
 	public void test041d() { // inherited cases for bridge methods, varargs clashes, return type conversion checks
-		this.runConformTest(
-			true,
+		AbstractRegressionTest.runConformTest(
+			this, true,
 			new String[] {
 				"X.java",
 				"public class X { public Object foo() { return null; } }\n" +
@@ -2992,8 +2992,8 @@ public class MethodVerifyTest extends AbstractComparableTest {
 
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=72704
 	public void test043() { // ambiguous message sends because of substitution from 2 different type variables
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X { void test(E<Integer,Integer> e) { e.id(Integer.valueOf(1)); } }\n" +
 				"abstract class C<A> { public abstract void id(A x); }\n" +
@@ -5852,8 +5852,8 @@ X.java:7: name clash: <T#1>foo2(T#1) in X and <T#2>foo2(A) in Y have the same er
 	public void test070() {
 		Map<String,String> options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_ReportDeprecation, CompilerOptions.IGNORE);
-		this.runConformTest(
-			true,
+		AbstractRegressionTest.runConformTest(
+			this, true,
 			new String[] {
 				"BooleanFactory.java",
 				"interface Factory<T> {\n" +
@@ -6292,8 +6292,8 @@ X.java:7: name clash: <T#1>foo2(T#1) in X and <T#2>foo2(A) in Y have the same er
 		customOptions.put(CompilerOptions.OPTION_Compliance, CompilerOptions.VERSION_1_5);
 		customOptions.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_1_4);
 		customOptions.put(CompilerOptions.OPTION_TargetPlatform, CompilerOptions.VERSION_1_4);
-		this.runNegativeTest(
-			true,
+		AbstractRegressionTest.runNegativeTest(
+			this, true,
 			new String[] {
 				"X.java",
 				"public abstract class X implements IAppendable {\n" +
@@ -7229,8 +7229,8 @@ X.java:7: name clash: <T#1>foo2(T#1) in X and <T#2>foo2(A) in Y have the same er
 
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=146383
 public void test094() {
-	this.runNegativeTest(
-		false /* skipJavac */,
+	AbstractRegressionTest.runNegativeTest(
+		this, false /* skipJavac */,
 		JavacTestOptions.Excuse.JavacCompilesIncorrectSource,
 		new String[] {
 			"X.java",//===================
@@ -7343,8 +7343,8 @@ public void test098() {
 public void test099() {
 	Map customOptions= getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_1_4);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"TestCharset.java",
 			"import java.nio.charset.*;\n" +
 			"public class TestCharset extends Charset {\n" +
@@ -7464,8 +7464,8 @@ public void test101() {
 public void test102() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportSyntheticAccessEmulation, CompilerOptions.IGNORE);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	private interface ReturnBase {\n" +
@@ -7517,8 +7517,8 @@ public void test102() {
 public void test103() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportSyntheticAccessEmulation, CompilerOptions.IGNORE);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	private interface ReturnBase {\n" +
@@ -7583,8 +7583,8 @@ public void test103() {
 public void test104() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportSyntheticAccessEmulation, CompilerOptions.IGNORE);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	private interface ReturnBase {\n" +
@@ -7649,8 +7649,8 @@ public void test104() {
 public void test105() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportSyntheticAccessEmulation, CompilerOptions.IGNORE);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	private interface ReturnBase {\n" +
@@ -7734,8 +7734,8 @@ public void test105() {
 public void test106() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportSyntheticAccessEmulation, CompilerOptions.IGNORE);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	private interface ReturnBase {\n" +
@@ -7819,8 +7819,8 @@ public void test106() {
 public void test107() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportSyntheticAccessEmulation, CompilerOptions.IGNORE);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	private interface ReturnBase {\n" +
@@ -7885,8 +7885,8 @@ public void test107() {
 public void test108() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportSyntheticAccessEmulation, CompilerOptions.IGNORE);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	private interface ReturnBase {\n" +
@@ -7938,8 +7938,8 @@ public void test108() {
 public void test109() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportSyntheticAccessEmulation, CompilerOptions.IGNORE);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	private interface ReturnBase {\n" +
@@ -8004,8 +8004,8 @@ public void test109() {
 public void test110() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportSyntheticAccessEmulation, CompilerOptions.IGNORE);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	private interface ReturnBase {\n" +
@@ -8070,8 +8070,8 @@ public void test110() {
 public void test111() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportSyntheticAccessEmulation, CompilerOptions.IGNORE);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	private interface ReturnBase {\n" +
@@ -8155,8 +8155,8 @@ public void test111() {
 public void test112() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportSyntheticAccessEmulation, CompilerOptions.IGNORE);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	private interface ReturnBase {\n" +
@@ -8240,8 +8240,8 @@ public void test112() {
 public void test113() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportOverridingMethodWithoutSuperInvocation, CompilerOptions.ERROR);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"abstract class Y {\n" +
 			"  abstract void foo();\n" +
@@ -8265,8 +8265,8 @@ public void test113() {
 public void test114() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportOverridingMethodWithoutSuperInvocation, CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -8296,8 +8296,8 @@ public void test114() {
 public void test115() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportOverridingMethodWithoutSuperInvocation, CompilerOptions.ERROR);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"class Y {\n" +
 			"  void foo() {}\n" +
@@ -8321,8 +8321,8 @@ public void test115() {
 public void test116() {
    	Map options = getCompilerOptions();
    	options.put(CompilerOptions.OPTION_ReportOverridingMethodWithoutSuperInvocation, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"class Y {\n" +
 			"  Zork foo() {}\n" +
@@ -8377,8 +8377,8 @@ public void test116() {
 public void test117() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportOverridingMethodWithoutSuperInvocation, CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -8421,8 +8421,8 @@ public void test117() {
 public void test118() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportOverridingMethodWithoutSuperInvocation, CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -8456,8 +8456,8 @@ public void test118() {
 public void test119() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportOverridingMethodWithoutSuperInvocation, CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -8739,8 +8739,8 @@ public void test125() {
 //}
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=174445
 public void test127() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  enum Enum1 {\n" +
@@ -8820,8 +8820,8 @@ public void test129() {
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=180789
 // variant - Z<Object> is not a subtype of Z<U>, and |Z<U>| = Z, not Z<Object>
 public void test130() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"interface I<U, V> {\n" +
 			"  Z<U> foo(Object o, V v);\n" +
@@ -10105,8 +10105,8 @@ public void test168() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=243820
 public void test169() {
-	this.runNegativeTest(
-		false,
+	AbstractRegressionTest.runNegativeTest(
+		this, false,
 		new String[] {
 			"X.java",
 			"class X<T> {\n" +
@@ -10137,8 +10137,8 @@ public void test169() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=243820
 public void test169a() {
-	this.runNegativeTest(
-		false,
+	AbstractRegressionTest.runNegativeTest(
+		this, false,
 		new String[] {
 			"X.java",
 			"class X<T> {\n" +
@@ -10172,8 +10172,8 @@ public void test169a() {
 public void test170() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportMissingSynchronizedOnInheritedMethod, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		false,
+	AbstractRegressionTest.runNegativeTest(
+		this, false,
 		new String[] {
 			"X.java",
 			"class X { synchronized void foo() {} }\n" +
@@ -10194,8 +10194,8 @@ public void test170() {
 public void test171() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportMissingSynchronizedOnInheritedMethod, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		false,
+	AbstractRegressionTest.runNegativeTest(
+		this, false,
 		new String[] {
 			"X.java",
 			"public enum X {\n" +
@@ -10218,8 +10218,8 @@ public void test171() {
 public void test172() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportMissingSynchronizedOnInheritedMethod, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		false,
+	AbstractRegressionTest.runNegativeTest(
+		this, false,
 		new String[] {
 			"X.java",
 			"public class X {\n" +
@@ -10242,8 +10242,8 @@ public void test172() {
 public void test173() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportMissingSynchronizedOnInheritedMethod, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		false,
+	AbstractRegressionTest.runNegativeTest(
+		this, false,
 		new String[] {
 			"X.java",
 			"public class X { synchronized void foo() {} }\n" +
@@ -10286,8 +10286,8 @@ public void test174() {
 public void test175() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportMissingHashCodeMethod, CompilerOptions.WARNING);
-	this.runNegativeTest(
-		false,
+	AbstractRegressionTest.runNegativeTest(
+		this, false,
 		new String[] {
 			"A.java",
 			"class A {\n" +
@@ -10309,8 +10309,8 @@ public void test175() {
 public void test176() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportMissingHashCodeMethod, CompilerOptions.WARNING);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"A.java",
 			"class A {\n" +
 			"	@Override public boolean equals(Object o) { return true; }\n" +
@@ -10545,8 +10545,8 @@ public void test180() {
 
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=249134
 public void test181() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"I.java",
 			"interface I {\n" +
 			"	String m();\n" +
@@ -10636,8 +10636,8 @@ public void test181() {
 		false,
 		false
 	);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"B.java",
 			"class B extends A implements I {}",
 			"B2.java",
@@ -10715,8 +10715,8 @@ public void test182() {
 		"The type B2 must implement the inherited abstract method I.m() to override A2.m()\n" +
 		"----------\n"
 	);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"B.java",
 			"class B extends A implements I {}",
 			"B2.java",
@@ -10879,8 +10879,8 @@ public void test185() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=271303
 public void test186() {
-	this.runNegativeTest(
-		false,
+	AbstractRegressionTest.runNegativeTest(
+		this, false,
 		new String[] {
 			"p1/A.java",
 			"package p1;\n" +
@@ -10969,8 +10969,8 @@ public void test187() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=279836
 public void test188() {
-	this.runNegativeTest(
-		false,
+	AbstractRegressionTest.runNegativeTest(
+		this, false,
 		new String[] {
 			"Y.java",
 			"abstract class Y<T extends Number> implements I<T> {\n" +
@@ -11372,8 +11372,8 @@ public void test199() {
 		},
 		""
 	);
-	this.runConformTest(
-		false,
+	AbstractRegressionTest.runConformTest(
+		this, false,
 		new String[] {
 			"Foo.java",
 			"public class Foo {\n" +
@@ -11815,8 +11815,8 @@ public void test213() {
 	compilerOptions15.put(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, JavaCore.VERSION_1_5);
 	compilerOptions15.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_5);
 	compilerOptions15.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_5);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"Y.java",
 			"public abstract class Y implements I<Y> {\n" +
 			"		public final Y foo(Object o, J<Y> j) {\n" +
@@ -11844,8 +11844,8 @@ public void test213() {
 	compilerOptions14.put(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, JavaCore.VERSION_1_2);
 	compilerOptions14.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_4);
 	compilerOptions14.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_3);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	public Object foo() {\n" +
@@ -11866,8 +11866,8 @@ public void test213a() {
 	compilerOptions15.put(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, JavaCore.VERSION_1_5);
 	compilerOptions15.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_5);
 	compilerOptions15.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_5);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"Y.java",
 			"public abstract class Y implements I<Y> {\n" +
 			"		public final Y foo(Object o, J<Y, I<Y>> j) {\n" +
@@ -11895,8 +11895,8 @@ public void test213a() {
 	compilerOptions14.put(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, JavaCore.VERSION_1_2);
 	compilerOptions14.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_4);
 	compilerOptions14.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_3);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	public Object foo() {\n" +
@@ -11917,8 +11917,8 @@ public void test213b() {
 	compilerOptions15.put(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, CompilerOptions.VERSION_1_5);
 	compilerOptions15.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_5);
 	compilerOptions15.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_5);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"ConsoleSession.java",
 			"public abstract class ConsoleSession implements ServiceFactory<Object> {\n" +
 			"	public final void ungetService(Bundle bundle, ServiceRegistration<Object> registration, Object service) {\n" +
@@ -11952,8 +11952,8 @@ public void test213b() {
 	compilerOptions14.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_4);
 	compilerOptions14.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_3);
 	compilerOptions14.put(JavaCore.COMPILER_PB_UNNECESSARY_TYPE_CHECK, JavaCore.IGNORE);
-	this.runConformTest(
-			new String[] {
+	AbstractRegressionTest.runConformTest(
+			this, new String[] {
 					"OSGiConsole.java",
 					"public class OSGiConsole {\n" +
 					"	OSGiConsole() {\n" +
@@ -11975,8 +11975,8 @@ public void test213c() {
 	compilerOptions15.put(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, CompilerOptions.VERSION_1_5);
 	compilerOptions15.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_5);
 	compilerOptions15.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_5);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"ConsoleSession.java",
 			"public abstract class ConsoleSession implements ServiceFactory<ConsoleSession> {\n" +
 			"	public final void ungetService(Bundle bundle, ServiceRegistration<ConsoleSession> registration, ConsoleSession service) {\n" +
@@ -12010,8 +12010,8 @@ public void test213c() {
 	compilerOptions14.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_4);
 	compilerOptions14.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_3);
 	compilerOptions14.put(JavaCore.COMPILER_PB_UNNECESSARY_TYPE_CHECK, JavaCore.IGNORE);
-	this.runConformTest(
-			new String[] {
+	AbstractRegressionTest.runConformTest(
+			this, new String[] {
 					"OSGiConsole.java",
 					"public class OSGiConsole {\n" +
 					"	OSGiConsole() {\n" +
@@ -12054,8 +12054,8 @@ public void test328827() {
 	compilerOptions15.put(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, JavaCore.VERSION_1_5);
 	compilerOptions15.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_5);
 	compilerOptions15.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_5);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"Map.java",
 			"public interface Map<K,V> {}\n",
 
@@ -12078,8 +12078,8 @@ public void test328827() {
 	compilerOptions14.put(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, JavaCore.VERSION_1_2);
 	compilerOptions14.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_4);
 	compilerOptions14.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_3);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 				"Map.java",
 				"public interface Map {}\n",
 
@@ -12103,8 +12103,8 @@ public void test329584() {
 	compilerOptions15.put(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, CompilerOptions.VERSION_1_5);
 	compilerOptions15.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_5);
 	compilerOptions15.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_5);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"I.java",
 			"public interface I {\n" +
 			"	void foo(Object o[], Dictionary<Object, Object> dict);\n" +
@@ -12123,8 +12123,8 @@ public void test329584() {
 	compilerOptions14.put(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, JavaCore.VERSION_1_2);
 	compilerOptions14.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_4);
 	compilerOptions14.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_3);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"public class X implements I {\n" +
 			"	public void foo(Object o[], Dictionary dict) {}\n" +
@@ -12145,8 +12145,8 @@ public void test329588() {
 	compilerOptions15.put(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, CompilerOptions.VERSION_1_5);
 	compilerOptions15.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_5);
 	compilerOptions15.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_5);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"A.java",
 			"public class A {\n" +
 			"	public O<?> foo() {\n" +
@@ -12168,8 +12168,8 @@ public void test329588() {
 	compilerOptions14.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_4);
 	compilerOptions14.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_3);
 	compilerOptions14.put(JavaCore.COMPILER_PB_UNNECESSARY_TYPE_CHECK, JavaCore.IGNORE);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	public void foo(A a) {\n" +
@@ -12193,8 +12193,8 @@ public void test330445() {
 	compilerOptions15.put(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, CompilerOptions.VERSION_1_5);
 	compilerOptions15.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_5);
 	compilerOptions15.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_5);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"Y.java",
 			"import java.util.Map;\n" +
 			"public class Y {\n" +
@@ -12214,8 +12214,8 @@ public void test330445() {
 	compilerOptions14.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_4);
 	compilerOptions14.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_3);
 	compilerOptions14.put(JavaCore.COMPILER_PB_UNNECESSARY_TYPE_CHECK, JavaCore.IGNORE);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"import java.util.Properties;\n" +
 			"public class X {\n" +
@@ -12237,8 +12237,8 @@ public void test330435() {
 	compilerOptions15.put(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, CompilerOptions.VERSION_1_5);
 	compilerOptions15.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_5);
 	compilerOptions15.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_5);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"A.java",
 			"public class A {\n" +
 			"	public static <T> B<T> asList(T... tab) {\n" +
@@ -12262,8 +12262,8 @@ public void test330435() {
 	compilerOptions14.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_4);
 	compilerOptions14.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_3);
 	compilerOptions14.put(JavaCore.COMPILER_PB_UNNECESSARY_TYPE_CHECK, JavaCore.IGNORE);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	String[] foo(Object[] args) {\n" +
@@ -12288,8 +12288,8 @@ public void test330264() {
 	compilerOptions15.put(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, CompilerOptions.VERSION_1_5);
 	compilerOptions15.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_5);
 	compilerOptions15.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_5);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"BundleContext.java",
 			"public interface BundleContext {\n" +
 			"    <S> S getService(ServiceReference<S> reference);\n" +
@@ -12309,8 +12309,8 @@ public void test330264() {
 	compilerOptions14.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_4);
 	compilerOptions14.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_3);
 	compilerOptions14.put(JavaCore.COMPILER_PB_UNNECESSARY_TYPE_CHECK, JavaCore.IGNORE);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"Activator.java",
 			"public class Activator  {\n" +
 			"    public void start(BundleContext context, ServiceReference ref) {\n" +
@@ -12334,8 +12334,8 @@ public void test331446() {
 	compilerOptions15.put(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, CompilerOptions.VERSION_1_5);
 	compilerOptions15.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_5);
 	compilerOptions15.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_5);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"Test.java",
 			"import java.util.Comparator;\n" +
 			"import java.util.List;\n" +
@@ -12372,8 +12372,8 @@ public void test331446() {
 	compilerOptions14.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_4);
 	compilerOptions14.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_3);
 	compilerOptions14.put(JavaCore.COMPILER_PB_UNNECESSARY_TYPE_CHECK, JavaCore.IGNORE);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"import java.util.ArrayList;\n" +
 			"import java.util.Comparator;\n" +
@@ -12404,8 +12404,8 @@ public void test331446a() {
 	compilerOptions15.put(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, CompilerOptions.VERSION_1_4);
 	compilerOptions15.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_4);
 	compilerOptions15.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_4);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"Test.java",
 			"import java.util.Comparator;\n" +
 			"import java.util.List;\n" +
@@ -12442,8 +12442,8 @@ public void test331446a() {
 	compilerOptions14.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_4);
 	compilerOptions14.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_3);
 	compilerOptions14.put(JavaCore.COMPILER_PB_UNNECESSARY_TYPE_CHECK, JavaCore.IGNORE);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"import java.util.ArrayList;\n" +
 			"import java.util.Comparator;\n" +
@@ -12474,8 +12474,8 @@ public void test331446b() {
 	compilerOptions14.put(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, CompilerOptions.VERSION_1_4);
 	compilerOptions14.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_4);
 	compilerOptions14.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_4);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"Project.java",
 			"class List{}\n" +
 			"public class Project {\n" +
@@ -12490,8 +12490,8 @@ public void test331446b() {
 		compilerOptions14,
 		null);
 
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"Client.java",
 			"public class Client {\n" +
 			"    Client(List l) {\n" +
@@ -12512,8 +12512,8 @@ public void test331446c() {
 	compilerOptions15.put(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, CompilerOptions.VERSION_1_5);
 	compilerOptions15.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_5);
 	compilerOptions15.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_5);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"Project.java",
 			"class List<T> {}\n" +
 			"public class Project {\n" +
@@ -12533,8 +12533,8 @@ public void test331446c() {
 	compilerOptions14.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_4);
 	compilerOptions14.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_3);
 	compilerOptions14.put(JavaCore.COMPILER_PB_UNNECESSARY_TYPE_CHECK, JavaCore.IGNORE);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"Client.java",
 			"public class Client {\n" +
 			"    Client(List l) {\n" +
@@ -12555,8 +12555,8 @@ public void test331446d() {
 	compilerOptions15.put(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, CompilerOptions.VERSION_1_5);
 	compilerOptions15.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_5);
 	compilerOptions15.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_5);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"Project.java",
 			"class List<T> {}\n" +
 			"public class Project {\n" +
@@ -12570,8 +12570,8 @@ public void test331446d() {
 		null,
 		compilerOptions15,
 		null);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"Client.java",
 			"public class Client {\n" +
 			"    Client(List l) {\n" +
@@ -12592,8 +12592,8 @@ public void test1415Mix() {
 	compilerOptions15.put(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, CompilerOptions.VERSION_1_5);
 	compilerOptions15.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_5);
 	compilerOptions15.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_5);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"Abstract.java",
 			"abstract class Generic<T> {\n" +
 			"	abstract void foo(T t);\n" +
@@ -12613,8 +12613,8 @@ public void test1415Mix() {
 	compilerOptions14.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_4);
 	compilerOptions14.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_3);
 	compilerOptions14.put(JavaCore.COMPILER_PB_UNNECESSARY_TYPE_CHECK, JavaCore.IGNORE);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"Concrete.java",
 			"public class Concrete extends Abstract {\n" +
 			"}",
@@ -12635,8 +12635,8 @@ public void test1415Mix2() {
 	compilerOptions15.put(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, CompilerOptions.VERSION_1_5);
 	compilerOptions15.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_5);
 	compilerOptions15.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_5);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"Abstract.java",
 			"abstract class Generic<T> {\n" +
 			"	abstract void foo(T t);\n" +
@@ -12656,8 +12656,8 @@ public void test1415Mix2() {
 	compilerOptions14.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_4);
 	compilerOptions14.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_3);
 	compilerOptions14.put(JavaCore.COMPILER_PB_UNNECESSARY_TYPE_CHECK, JavaCore.IGNORE);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 				"Concrete.java",
 				"public class Concrete extends Abstract {\n" +
 				"    void foo(String s) {}\n" +
@@ -12676,8 +12676,8 @@ public void test332744() {
 	compilerOptions15.put(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, CompilerOptions.VERSION_1_5);
 	compilerOptions15.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_5);
 	compilerOptions15.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_5);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"EList.java",
 			"import java.util.List;\n" +
 			"public interface EList<E> extends List<E> {\n" +
@@ -12698,8 +12698,8 @@ public void test332744() {
 		compilerOptions15,
 		null);
 
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"Client.java",
 			"public class Client {\n" +
 			"    Client(FeatureMap fm) {\n" +
@@ -12720,8 +12720,8 @@ public void _test332744b() {
 	compilerOptions15.put(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, CompilerOptions.VERSION_1_5);
 	compilerOptions15.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_5);
 	compilerOptions15.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_5);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"EList.java",
 			"import java.util.List;\n" +
 			"public interface EList<E> extends List<E> {\n" +
@@ -12747,8 +12747,8 @@ public void _test332744b() {
 	compilerOptions14.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_1_4);
 	compilerOptions14.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_3);
 	compilerOptions14.put(JavaCore.COMPILER_PB_UNNECESSARY_TYPE_CHECK, JavaCore.IGNORE);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"Client.java",
 			"public class Client {\n" +
 			"    Client(FeatureMap fm) {\n" +
@@ -12922,8 +12922,8 @@ public void test346029b() throws Exception {
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=346029
 public void test346029c() throws Exception {
-	this.runNegativeTest(
-		false,
+	AbstractRegressionTest.runNegativeTest(
+		this, false,
 		new String[] {
 			"X.java",
 			"class A<T> {\n" +
@@ -12949,8 +12949,8 @@ public void test346029c() throws Exception {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=346029
 public void test346029d() throws Exception {
-	this.runNegativeTest(
-		false,
+	AbstractRegressionTest.runNegativeTest(
+		this, false,
 		new String[] {
 			"X.java",
 			"class A<T> {\n" +
@@ -12976,8 +12976,8 @@ public void test346029d() throws Exception {
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=346029
 public void test346029e() throws Exception {
-	this.runNegativeTest(
-		false,
+	AbstractRegressionTest.runNegativeTest(
+		this, false,
 		new String[] {
 			"X.java",
 			"class A<T> {\n" +
@@ -14167,8 +14167,8 @@ public void testBug469454() throws Exception {
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=469454, The compiler generates wrong code during inheritance
 public void testBug469454a() throws Exception {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"TestClass.java",
 			"public class TestClass {\n" +
 			"    public static class A {\n" +
@@ -14281,8 +14281,8 @@ public void testBug467776_regression() {
 	if (this.complianceLevel < ClassFileConstants.JDK1_6) return;
 	Map compilerOptions = getCompilerOptions();
 	compilerOptions.put(JavaCore.COMPILER_PB_UNCHECKED_TYPE_OPERATION, JavaCore.ERROR);
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"ITeam.java",
 			"public interface ITeam {\n" +
 			"        <T> T getRole(Object o, Class<T> clazz);\n" +
@@ -14336,8 +14336,8 @@ public void testBug500673() {
 		"----------\n");
 }
 public void testBug506653() {
-	runConformTest(
-		false, // flushOutputDirectory
+	AbstractRegressionTest.runConformTest(
+		this, false, // flushOutputDirectory
 		new String[] {
 			"A.java",
 			"   public class A {\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ModuleCompilationTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ModuleCompilationTests.java
@@ -270,7 +270,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 					e.printStackTrace();
 					throw new AssertionFailedError(e.getMessage());
 				}
-				handleMismatch(javacCompiler, testName(), testFiles, javacErrorMatch,
+				AbstractRegressionTest.handleMismatch(this, javacCompiler, testName(), testFiles, javacErrorMatch,
 						"", "", log, "", "",
 						excuse, mismatch);
 				final Set<String> expectedFiles = new HashSet<>(outFiles);
@@ -955,7 +955,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 	  "",
 	  true);
 		String expectedOutput = "// Compiled from X.java (version 9 : 53.0, super bit)";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+		AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 	}
 	//-source 8 -target 9
 	public void testBug495500b() throws Exception {
@@ -972,7 +972,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 			"",
 			true);
 		String expectedOutput = "// Compiled from X.java (version 9 : 53.0, super bit)";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+		AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 	}
 	// compliance 9 -source 9 -target 9
 	public void testBug495500c() throws Exception {
@@ -989,7 +989,7 @@ public class ModuleCompilationTests extends AbstractBatchCompilerTest {
 			"",
 			true);
 		String expectedOutput = "// Compiled from X.java (version 9 : 53.0, super bit)";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+		AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 	}
 	/*
 	 * Test add-exports grants visibility to another module
@@ -3953,7 +3953,7 @@ public void testBug521362_emptyFile() {
 		     "",
 		     true);
 		String expectedOutput = "// Compiled from X.java (version 1.8 : 52.0, super bit)";
-			checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+			AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 	}
 	public void testReleaseOption2() throws Exception {
 		if (!isJRE17Plus) return;
@@ -3970,7 +3970,7 @@ public void testBug521362_emptyFile() {
 		     "",
 		     true);
 		String expectedOutput = "// Compiled from X.java (version 10 : 54.0, super bit)";
-			checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+			AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 	}
 	public void testReleaseOption3() throws Exception {
 		if (!isJRE17Plus) return;
@@ -3987,7 +3987,7 @@ public void testBug521362_emptyFile() {
 		     "",
 		     true);
 		String expectedOutput = "// Compiled from X.java (version 10 : 54.0, super bit)";
-			checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+			AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 	}
 	public void testReleaseOption4() throws Exception {
 		this.runNegativeTest(
@@ -4675,7 +4675,7 @@ public void testBug521362_emptyFile() {
 				"  requires java.base;\n" +
 				"\n" +
 				"}";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "module-info.class", "module-info", expectedOutput);
+		AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "module-info.class", "module-info", expectedOutput);
 	}
 	public void testBug508889_002() throws Exception {
 		File outputDirectory = new File(OUTPUT_DIR);
@@ -4713,7 +4713,7 @@ public void testBug521362_emptyFile() {
 				"  exports pack1;\n" +
 				"\n" +
 				"}";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + out + File.separator + "module-info.class", "module-info", expectedOutput);
+		AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + out + File.separator + "module-info.class", "module-info", expectedOutput);
 	}
 	public void testBug508889_003() throws Exception {
 		File outputDirectory = new File(OUTPUT_DIR);
@@ -4786,7 +4786,7 @@ public void testBug521362_emptyFile() {
 				"  provides pack1.I11 with pack1.X11;\n" +
 				"\n" +
 				"}";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + out + File.separator + "module-info.class", "module-info", expectedOutput);
+		AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + out + File.separator + "module-info.class", "module-info", expectedOutput);
 	}
 	public void testBug520858() {
 		Util.flushDirectoryContent(new File(OUTPUT_DIR));
@@ -5533,7 +5533,7 @@ public void testBug521362_emptyFile() {
 				+ "}",
 			},
 	     "\"" + OUTPUT_DIR +  File.separator + "A.java\""
-	     + " -classpath " + "\"" + this.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "Test571363.jar\""
+	     + " -classpath " + "\"" + AbstractRegressionTest.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "Test571363.jar\""
 	     + " --release 11 -d \"" + OUTPUT_DIR + "\"",
 	     "",
 	     "",

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/MultiReleaseJarTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/MultiReleaseJarTests.java
@@ -35,7 +35,7 @@ public class MultiReleaseJarTests extends AbstractBatchCompilerTest {
 		return MultiReleaseJarTests.class;
 	}
 	public void test001() {
-		String path = this.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "multi.jar";
+		String path = AbstractRegressionTest.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "multi.jar";
 		String[] libs = new String[1];
 		libs[0] = path;
 		runNegativeTest(
@@ -64,7 +64,7 @@ public class MultiReleaseJarTests extends AbstractBatchCompilerTest {
 		   );
 	}
 	public void test002() {
-		String path = this.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "multi.jar";
+		String path = AbstractRegressionTest.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "multi.jar";
 		String[] libs = new String[1];
 		libs[0] = path;
 		runNegativeTest(
@@ -88,7 +88,7 @@ public class MultiReleaseJarTests extends AbstractBatchCompilerTest {
 		   );
 	}
 	public void test003() {
-		String path = this.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "multi.jar";
+		String path = AbstractRegressionTest.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "multi.jar";
 		String[] libs = new String[1];
 		libs[0] = path;
 		runConformTest(
@@ -107,7 +107,7 @@ public class MultiReleaseJarTests extends AbstractBatchCompilerTest {
 		   );
 	}
 	public void test004() {
-		String path = this.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "multi.jar";
+		String path = AbstractRegressionTest.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "multi.jar";
 		String[] libs = new String[1];
 		libs[0] = path;
 		runNegativeTest(
@@ -133,7 +133,7 @@ public class MultiReleaseJarTests extends AbstractBatchCompilerTest {
 	}
 	public void test005() {
 		Util.flushDirectoryContent(new File(OUTPUT_DIR));
-		String path = this.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "multi.jar";
+		String path = AbstractRegressionTest.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "multi.jar";
 		String[] libs = new String[1];
 		libs[0] = path;
 		File directory = new File(OUTPUT_DIR +  File.separator + "src" + File.separator + "MyModule" );
@@ -179,7 +179,7 @@ public class MultiReleaseJarTests extends AbstractBatchCompilerTest {
 	}
 	public void test006() {
 		if (!this.isJRE10) return;
-		String path = this.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "multi.jar";
+		String path = AbstractRegressionTest.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "multi.jar";
 		String[] libs = new String[1];
 		libs[0] = path;
 		File directory = new File(OUTPUT_DIR +  File.separator + "src" + File.separator + "MyModule" );

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NegativeLambdaExpressionsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NegativeLambdaExpressionsTest.java
@@ -233,8 +233,8 @@ public void test006() {
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=383096, NullPointerException with a wrong lambda code snippet
 public void _test007() {
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 					"X.java",
 					"interface I {}\n" +
 					"public class X {\n" +
@@ -1542,8 +1542,8 @@ public void test043() {
 	options.put(CompilerOptions.OPTION_ReportRawTypeReference, CompilerOptions.IGNORE);
 	options.put(CompilerOptions.OPTION_ReportTypeParameterHiding, CompilerOptions.IGNORE);
 
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 			"X.java",
             "import java.util.List;\n" +
 			"interface A { void foo(); }\n" +  // yes
@@ -1668,8 +1668,8 @@ public void test044() {
 	options.put(CompilerOptions.OPTION_ReportRawTypeReference, CompilerOptions.IGNORE);
 	options.put(CompilerOptions.OPTION_ReportTypeParameterHiding, CompilerOptions.IGNORE);
 
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 			"X.java",
 			"import java.util.List;\n" +
 			"interface A { <T> T foo(List<T> p); }\n" +
@@ -2361,8 +2361,8 @@ public void test068() {
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=382727, [1.8][compiler] Lambda expression parameters and locals cannot shadow variables from context
 public void test069() {
 	// Lambda argument hides a field.
-	this.runNegativeTest(
-			false /* skipJavac */,
+	AbstractRegressionTest.runNegativeTest(
+			this, false /* skipJavac */,
 			JavacTestOptions.Excuse.EclipseHasSomeMoreWarnings,
 			new String[] {
 					"X.java",
@@ -2460,8 +2460,8 @@ public void test072() {
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=382727, [1.8][compiler] Lambda expression parameters and locals cannot shadow variables from context
 public void test073() {
 	// Lambda local hides a field
-	this.runNegativeTest(
-			false /* skipJavac */,
+	AbstractRegressionTest.runNegativeTest(
+			this, false /* skipJavac */,
 			JavacTestOptions.Excuse.EclipseHasSomeMoreWarnings,
 			new String[] {
 					"X.java",
@@ -2590,8 +2590,8 @@ public void test077() {
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=382727, [1.8][compiler] Lambda expression parameters and locals cannot shadow variables from context
 public void test078() {
 	// Nested Lambda argument redeclares a field.
-	this.runNegativeTest(
-			false /* skipJavac */,
+	AbstractRegressionTest.runNegativeTest(
+			this, false /* skipJavac */,
 			JavacTestOptions.Excuse.EclipseHasSomeMoreWarnings,
 			new String[] {
 					"X.java",
@@ -2918,8 +2918,8 @@ public void test087() {
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=382727, [1.8][compiler] Lambda expression parameters and locals cannot shadow variables from context
 public void test088() {
 	// class inside lambda (!) redeclares a field.
-	this.runNegativeTest(
-			false /* skipJavac */,
+	AbstractRegressionTest.runNegativeTest(
+			this, false /* skipJavac */,
 			JavacTestOptions.Excuse.EclipseHasSomeMoreWarnings,
 			new String[] {
 					"X.java",
@@ -2946,8 +2946,8 @@ public void test088() {
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=382727, [1.8][compiler] Lambda expression parameters and locals cannot shadow variables from context
 public void test089() {
 	// class inside lambda redeclares outer method's argument.
-	this.runNegativeTest(
-			false /* skipJavac */,
+	AbstractRegressionTest.runNegativeTest(
+			this, false /* skipJavac */,
 			JavacTestOptions.Excuse.EclipseHasSomeMoreWarnings,
 			new String[] {
 					"X.java",
@@ -2979,8 +2979,8 @@ public void test089() {
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=382727, [1.8][compiler] Lambda expression parameters and locals cannot shadow variables from context
 public void test090() {
 	// class inside lambda redeclares outer method's local.
-	this.runNegativeTest(
-			false /* skipJavac */,
+	AbstractRegressionTest.runNegativeTest(
+			this, false /* skipJavac */,
 			JavacTestOptions.Excuse.EclipseHasSomeMoreWarnings,
 			new String[] {
 					"X.java",
@@ -3012,8 +3012,8 @@ public void test090() {
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=382727, [1.8][compiler] Lambda expression parameters and locals cannot shadow variables from context
 public void test091() {
 	// class inside lambda redeclares outer lambda's argument.
-	this.runNegativeTest(
-			false /* skipJavac */,
+	AbstractRegressionTest.runNegativeTest(
+			this, false /* skipJavac */,
 			JavacTestOptions.Excuse.EclipseHasSomeMoreWarnings,
 			new String[] {
 					"X.java",
@@ -3045,8 +3045,8 @@ public void test091() {
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=382727, [1.8][compiler] Lambda expression parameters and locals cannot shadow variables from context
 public void test092() {
 	// class inside lambda redeclares outer lambda's local.
-	this.runNegativeTest(
-			false /* skipJavac */,
+	AbstractRegressionTest.runNegativeTest(
+			this, false /* skipJavac */,
 			JavacTestOptions.Excuse.EclipseHasSomeMoreWarnings,
 			new String[] {
 					"X.java",
@@ -3079,8 +3079,8 @@ public void test092() {
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=382727, [1.8][compiler] Lambda expression parameters and locals cannot shadow variables from context
 public void test093() {
 	// local of class inside lambda redeclares a field.
-	this.runNegativeTest(
-			false /* skipJavac */,
+	AbstractRegressionTest.runNegativeTest(
+			this, false /* skipJavac */,
 			JavacTestOptions.Excuse.EclipseHasSomeMoreWarnings,
 			new String[] {
 					"X.java",
@@ -3118,8 +3118,8 @@ public void test093() {
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=382727, [1.8][compiler] Lambda expression parameters and locals cannot shadow variables from context
 public void test094() {
 	// local of class under lambda redeclares outer methods local.
-	this.runNegativeTest(
-			false /* skipJavac */,
+	AbstractRegressionTest.runNegativeTest(
+			this, false /* skipJavac */,
 			JavacTestOptions.Excuse.EclipseHasSomeMoreWarnings,
 			new String[] {
 					"X.java",
@@ -3157,8 +3157,8 @@ public void test094() {
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=382727, [1.8][compiler] Lambda expression parameters and locals cannot shadow variables from context
 public void test095() {
 	// local of class under lambda redeclares outer lambda's argument & local
-	this.runNegativeTest(
-			false /* skipJavac */,
+	AbstractRegressionTest.runNegativeTest(
+			this, false /* skipJavac */,
 			JavacTestOptions.Excuse.EclipseHasSomeMoreWarnings,
 			new String[] {
 					"X.java",
@@ -3363,8 +3363,8 @@ public void test400745() {
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=400745, [1.8][compiler] Compiler incorrectly allows shadowing of local class names.
 public void test400745a() {
 	// local type hiding scenario
-	this.runNegativeTest(
-			false /* skipJavac */,
+	AbstractRegressionTest.runNegativeTest(
+			this, false /* skipJavac */,
 			JavacTestOptions.Excuse.EclipseHasSomeMoreWarnings,
 			new String[] {
 					"X.java",
@@ -4213,8 +4213,8 @@ public void test384750i() {
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=384750, [1.8] Compiler should reject invalid method reference expressions
 public void test384750j() {
-	this.runNegativeTest(
-			false /* skipJavac */,
+	AbstractRegressionTest.runNegativeTest(
+			this, false /* skipJavac */,
 			JavacTestOptions.Excuse.EclipseHasSomeMoreWarnings,
 			new String[] {
 					"X.java",
@@ -4261,8 +4261,8 @@ public void test384750k() {
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=384750, [1.8] Compiler should reject invalid method reference expressions
 public void test384750l() {
-	this.runNegativeTest(
-			false /* skipJavac */,
+	AbstractRegressionTest.runNegativeTest(
+			this, false /* skipJavac */,
 			JavacTestOptions.Excuse.EclipseHasSomeMoreWarnings,
 			new String[] {
 					"X.java",
@@ -4760,8 +4760,8 @@ public void test384750y() {
 public void test384750z() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportIndirectStaticAccess, CompilerOptions.WARNING);
-	this.runNegativeTest(
-			false /* skipJavac */,
+	AbstractRegressionTest.runNegativeTest(
+			this, false /* skipJavac */,
 			JavacTestOptions.Excuse.EclipseHasSomeMoreWarnings,
 			new String[] {
 					"X.java",
@@ -4787,8 +4787,8 @@ public void test384750z() {
 public void test384750z1() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportDeprecation, CompilerOptions.WARNING);
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 					"X.java",
 					"interface I {\n" +
 					"	void doit();\n" +
@@ -4818,8 +4818,8 @@ public void test384750z1() {
 public void test384750z2() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedTypeArgumentsForMethodInvocation, CompilerOptions.WARNING);
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 					"X.java",
 					"interface I {\n" +
 					"	void doit();\n" +
@@ -4910,8 +4910,8 @@ public void test384750z5() {
 }
 //  https://bugs.eclipse.org/bugs/show_bug.cgi?id=384750, [1.8] Compiler should reject invalid method reference expressions
 public void test384750z6() {
-	this.runNegativeTest(
-			false /* skipJavac */,
+	AbstractRegressionTest.runNegativeTest(
+			this, false /* skipJavac */,
 			JavacTestOptions.DEFAULT,
 			new String[] {
 					"X.java",
@@ -4929,8 +4929,8 @@ public void test384750z6() {
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=384750, [1.8] Compiler should reject invalid method reference expressions
 public void test384750z7() {
-this.runNegativeTest(
-		false /* skipJavac */,
+AbstractRegressionTest.runNegativeTest(
+		this, false /* skipJavac */,
 		new JavacTestOptions("-Xlint:rawtypes"),
 		new String[] {
 				"X.java",
@@ -5214,8 +5214,8 @@ this.runNegativeTest(
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=401610, [1.8][compiler] Allow lambda/reference expressions in non-overloaded method invocation contexts
 // demonstrate that the bound problem is the only real issue in test401610e()
 public void test401610ee() {
-this.runNegativeTest(
-		false /* skipJavac */,
+AbstractRegressionTest.runNegativeTest(
+		this, false /* skipJavac */,
 		JavacTestOptions.Excuse.EclipseHasSomeMoreWarnings,
 		new String[] {
 				"X.java",
@@ -5685,8 +5685,8 @@ public void test401845e() {
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=401847, [1.8][compiler] Polyconditionals not accepted in method invocation contexts.
 public void test401847() {
-	this.runNegativeTest(
-			false /* skipJavac */,
+	AbstractRegressionTest.runNegativeTest(
+			this, false /* skipJavac */,
 			JavacTestOptions.Excuse.EclipseHasSomeMoreWarnings,
 			new String[] {
 				"X.java",
@@ -5760,8 +5760,8 @@ public void test401847a() {
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=401939, [1.8][compiler] Incorrect shape analysis leads to method resolution failure .
 public void test401939() {
-	this.runNegativeTest(
-			false /* skipJavac */,
+	AbstractRegressionTest.runNegativeTest(
+			this, false /* skipJavac */,
 			JavacTestOptions.Excuse.EclipseHasSomeMoreWarnings,
 			new String[] {
 				"X.java",
@@ -6011,8 +6011,8 @@ public void test402219() {
 public void test402219a() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUndocumentedEmptyBlock, CompilerOptions.ERROR);
-	this.runNegativeTest(
-			false /* skipJavac */,
+	AbstractRegressionTest.runNegativeTest(
+			this, false /* skipJavac */,
 			new JavacTestOptions("Xlint:empty"),
 			new String[] {
 				"X.java",
@@ -6560,8 +6560,8 @@ public void test406614() {
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=406588, [1.8][compiler][codegen] java.lang.invoke.LambdaConversionException: Incorrect number of parameters for static method newinvokespecial
 public void test406588() {
-	this.runNegativeTest(
-			false /* skipJavac */,
+	AbstractRegressionTest.runNegativeTest(
+			this, false /* skipJavac */,
 			null,
 			new String[] {
 				"X.java",
@@ -6619,8 +6619,8 @@ public void test401989() {
 		Map compilerOptions = getCompilerOptions();
 		compilerOptions.put(CompilerOptions.OPTION_ReportMethodCanBeStatic, CompilerOptions.ERROR);
 		compilerOptions.put(CompilerOptions.OPTION_ReportMethodCanBePotentiallyStatic, CompilerOptions.ERROR);
-		this.runNegativeTest(
-			false /* skipJavac */,
+		AbstractRegressionTest.runNegativeTest(
+			this, false /* skipJavac */,
 			JavacTestOptions.Excuse.EclipseWarningConfiguredAsError,
 			new String[] {
 				"X.java",
@@ -6654,7 +6654,7 @@ public void test406773() {
 		Map compilerOptions = getCompilerOptions();
 		compilerOptions.put(CompilerOptions.OPTION_ReportMethodCanBeStatic, CompilerOptions.ERROR);
 		compilerOptions.put(CompilerOptions.OPTION_ReportMethodCanBePotentiallyStatic, CompilerOptions.ERROR);
-		String errMessage = isMinimumCompliant(ClassFileConstants.JDK11) ?
+		String errMessage = AbstractRegressionTest.isMinimumCompliant(this, ClassFileConstants.JDK11) ?
 				"----------\n" +
 				"1. ERROR in X.java (at line 5)\n" +
 				"	void foo() {\n" +
@@ -6673,8 +6673,8 @@ public void test406773() {
 				"	      ^^^^^^\n" +
 				"Access to enclosing constructor X(int) is emulated by a synthetic accessor method\n" +
 				"----------\n";
-		this.runNegativeTest(
-			false,
+		AbstractRegressionTest.runNegativeTest(
+			this, false,
 			JavacTestOptions.SKIP, /* skip, because we are using custom error settings here */
 			new String[] {
 					"X.java",
@@ -6726,8 +6726,8 @@ public void test406859a() {
 		Map compilerOptions = getCompilerOptions();
 		compilerOptions.put(CompilerOptions.OPTION_ReportMethodCanBeStatic, CompilerOptions.ERROR);
 		compilerOptions.put(CompilerOptions.OPTION_ReportMethodCanBePotentiallyStatic, CompilerOptions.ERROR);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 					"X.java",
 					"interface I {\n" +
 					"	int foo(int i);\n" +
@@ -6754,8 +6754,8 @@ public void test406859b() {
 		Map compilerOptions = getCompilerOptions();
 		compilerOptions.put(CompilerOptions.OPTION_ReportMethodCanBeStatic, CompilerOptions.ERROR);
 		compilerOptions.put(CompilerOptions.OPTION_ReportMethodCanBePotentiallyStatic, CompilerOptions.ERROR);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 					"X.java",
 					"interface I {\n" +
 					"	void doit (Y y);\n" +
@@ -6786,8 +6786,8 @@ public void test406859c() {
 		Map compilerOptions = getCompilerOptions();
 		compilerOptions.put(CompilerOptions.OPTION_ReportMethodCanBeStatic, CompilerOptions.ERROR);
 		compilerOptions.put(CompilerOptions.OPTION_ReportMethodCanBePotentiallyStatic, CompilerOptions.ERROR);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 					"X.java",
 					"interface I {\n" +
 					"	void doit ();\n" +
@@ -6818,8 +6818,8 @@ public void test406859d() {
 	Map compilerOptions = getCompilerOptions();
 	compilerOptions.put(CompilerOptions.OPTION_ReportMethodCanBeStatic, CompilerOptions.ERROR);
 	compilerOptions.put(CompilerOptions.OPTION_ReportMethodCanBePotentiallyStatic, CompilerOptions.WARNING);
-	this.runNegativeTest(
-		false /* skipJavac */,
+	AbstractRegressionTest.runNegativeTest(
+		this, false /* skipJavac */,
 		JavacTestOptions.Excuse.EclipseHasSomeMoreWarnings,
 		new String[] {
 				"Y.java",
@@ -6871,8 +6871,8 @@ public void test410114() throws IOException {
 					"        }\n" +
 					"    }\n" +
 					"}\n";
-	this.runNegativeTest(
-			false /* skipJavac */,
+	AbstractRegressionTest.runNegativeTest(
+			this, false /* skipJavac */,
 			JavacTestOptions.Excuse.EclipseHasSomeMoreWarnings,
 			new String[]{"Y.java",
 						source},
@@ -6891,8 +6891,8 @@ public void test410114() throws IOException {
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=412453,
 //[1.8][compiler] Stackoverflow when compiling LazySeq
 public void test412453() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 				"X.java",
 				"import java.util.AbstractList;\n" +
 				"import java.util.Comparator;\n" +
@@ -6930,8 +6930,8 @@ public void test412453() {
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=412284,
 //[1.8][compiler] [1.8][compiler] Inspect all casts to/instanceof AbstractMethodDeclaration to eliminate potential CCEs
 public void test412284a() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 				"X.java",
 				"import java.io.IOException;\n" +
 				"interface I { void foo() throws IOException; }\n" +
@@ -6963,8 +6963,8 @@ public void test412284a() {
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=412284,
 //[1.8][compiler] [1.8][compiler] Inspect all casts to/instanceof AbstractMethodDeclaration to eliminate potential CCEs
 public void test412284b() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 				"X.java",
 				"interface I { void foo();}\n" +
 				"class X { \n" +
@@ -7005,8 +7005,8 @@ public void test412284b() {
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=412284,
 //[1.8][compiler] [1.8][compiler] Inspect all casts to/instanceof AbstractMethodDeclaration to eliminate potential CCEs
 public void test412284c() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 				"X.java",
 				"interface I { void foo();}\n" +
 				"class X { \n" +
@@ -7056,8 +7056,8 @@ public void test412284c() {
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=412650
 // [1.8][compiler]Incongruent Lambda Exception thrown
 public void test412650() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 				"X.java",
 				"interface I {\n" +
 				"	String sam();\n" +
@@ -7095,8 +7095,8 @@ public void test412650() {
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=409544
 // Bug 409544 - [1.8][compiler] Any local variable used but not declared in a lambda body must be definitely assigned before the lambda body.
 public void test409544() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 				"Sample.java",
 				"public class Sample{\n" +
 				"	interface Int { void setInt(int[] i); }\n" +
@@ -7122,8 +7122,8 @@ public void test409544() {
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=409544
 // Bug 409544 - [1.8][compiler] Any local variable used but not declared in a lambda body must be definitely assigned before the lambda body.
 public void test409544b() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"    interface Int {\n" +
@@ -7160,8 +7160,8 @@ public void test409544b() {
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=415844
 // Bug 415844 - [1.8][compiler] Blank final initialized in a lambda expression should not pass
 public void test415844a() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 				"Sample.java",
 				"public class Sample{\n" +
 				"	interface Int { void setInt(int i); }\n" +
@@ -7187,8 +7187,8 @@ public void test415844a() {
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=415844
 // Bug 415844 - [1.8][compiler] Blank final initialized in a lambda expression should not pass
 public void test415844b() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"    interface Int {\n" +
@@ -7405,8 +7405,8 @@ public void testUnderScoreParameter() {
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=383096, [1.8][compiler]NullPointerException with a wrong lambda code snippet.
 public void test383096() {
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 					"X.java",
 					"interface I {}\n" +
 					"class XI {\n" +
@@ -7437,8 +7437,8 @@ public void test383096() {
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=422516,  [1.8][compiler] NPE in ArrayReference.analyseAssignment.
 public void test422516() {
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 					"X.java",
 					"public class X {\n" +
 					"    public static void main(String[] args) throws InterruptedException {\n" +
@@ -7554,8 +7554,8 @@ public void test422489a() { // interfaces and methods order changed, triggers NP
 
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=422489, [1.8][compiler] NPE in CompoundAssignment.analyseCode when creating AST for java.util.stream.Collectors
 public void test422489b() { // interfaces and methods order changed, triggers NPE.
-	this.runNegativeTest(
-			false /* skipJavac */,
+	AbstractRegressionTest.runNegativeTest(
+			this, false /* skipJavac */,
 			JavacTestOptions.Excuse.JavacHasWarningsEclipseNotConfigured,
 			new String[] {
 					"X.java",
@@ -7698,8 +7698,8 @@ public void test422801a() {
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=405134, [1.8][code assist + compiler] compiler and code assist problem in multilevel lambda with curly bracketed body
 public void test405134a() {
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 					"X.java",
 					"interface Foo { \n" +
 					"	int run1(int s1, int s2);\n" +
@@ -7734,8 +7734,8 @@ public void test405134a() {
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=421927, [1.8][compiler] Bad diagnostic: Unnecessary cast from I to I for lambdas.
 public void test421927() {
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 					"X.java",
 					"interface I { \n" +
 					"	int foo();\n" +
@@ -7749,8 +7749,8 @@ public void test421927() {
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=421927, [1.8][compiler] Bad diagnostic: Unnecessary cast from I to I for lambdas.
 public void test421927a() {
-	this.runNegativeTest(
-			false,
+	AbstractRegressionTest.runNegativeTest(
+			this, false,
 			Excuse.EclipseHasSomeMoreWarnings,
 			new String[] {
 					"X.java",
@@ -7809,8 +7809,8 @@ public void test423429() {
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=423129,  [1.8][compiler] Hook up lambda expressions into statement recovery
 public void test423129() {
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 					"X.java",
 					"interface I {\n" +
 					"	String foo(Integer x);\n" +
@@ -7843,8 +7843,8 @@ public void test423129() {
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=423129,  [1.8][compiler] Hook up lambda expressions into statement recovery
 public void test423129b() {
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 					"X.java",
 					"import java.util.ArrayList;\n" +
 					"import java.util.Arrays;\n" +
@@ -8411,8 +8411,8 @@ public void test427207() {
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=425278, [1.8][compiler] Suspect error: The target type of this expression is not a well formed parameterized type due to bound(s) mismatch
 // NOTE: javac 8b127 incorrectly accepts this program due to https://bugs.openjdk.java.net/browse/JDK-8033810
 public void test425278() {
-	runNegativeTest(
-		false /*skipJavac */,
+	AbstractRegressionTest.runNegativeTest(
+		this, false /*skipJavac */,
 		JavacTestOptions.JavacHasABug.JavacBug8033810,
 		new String[] {
 			"X.java",
@@ -8637,8 +8637,8 @@ public void test428795() {
 public void test428857() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportRawTypeReference, CompilerOptions.ERROR);
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"import java.util.Arrays;\n" +
 			"import java.util.List;\n" +
@@ -8662,8 +8662,8 @@ public void test428857() {
 public void test428857a() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportRawTypeReference, CompilerOptions.ERROR);
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"import java.util.Arrays;\n" +
 			"import java.util.List;\n" +
@@ -8692,8 +8692,8 @@ public void test428857a() {
 public void test428857b() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportRawTypeReference, CompilerOptions.ERROR);
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"import java.util.Arrays;\n" +
 			"import java.util.List;\n" +
@@ -8722,8 +8722,8 @@ public void test428857b() {
 public void test428857c() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportRawTypeReference, CompilerOptions.ERROR);
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"import java.util.Arrays;\n" +
 			"import java.util.List;\n" +
@@ -8757,8 +8757,8 @@ public void test428857c() {
 public void test428857d() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportRawTypeReference, CompilerOptions.ERROR);
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"import java.util.Arrays;\n" +
 			"import java.util.List;\n" +
@@ -8792,8 +8792,8 @@ public void test428857d() {
 public void test428857e() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportRawTypeReference, CompilerOptions.ERROR);
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"import java.util.Arrays;\n" +
 			"import java.util.List;\n" +
@@ -8832,8 +8832,8 @@ public void test428857e() {
 public void test428857f() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportRawTypeReference, CompilerOptions.ERROR);
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"import java.util.Arrays;\n" +
 			"import java.util.List;\n" +
@@ -8867,8 +8867,8 @@ public void test428857f() {
 public void test428857g() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportRawTypeReference, CompilerOptions.ERROR);
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"import java.util.Arrays;\n" +
 			"import java.util.List;\n" +
@@ -9212,8 +9212,8 @@ public void test442983() {
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=438945, [1.8] NullPointerException InferenceContext18.checkExpression in java 8 with generics, primitives, and overloading
 public void test438945() {
-	this.runNegativeTest(
-		false /* skipJavac */,
+	AbstractRegressionTest.runNegativeTest(
+		this, false /* skipJavac */,
 		JavacTestOptions.Excuse.JavacHasWarningsEclipseNotConfigured,
 		new String[] {
 			"X.java",
@@ -9238,8 +9238,8 @@ public void test440643() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.ERROR);
 
-	this.runNegativeTest(
-		false /* skipJavac */,
+	AbstractRegressionTest.runNegativeTest(
+		this, false /* skipJavac */,
 		JavacTestOptions.Excuse.EclipseWarningConfiguredAsError,
 		new String[] {
 			"X.java",
@@ -9446,7 +9446,7 @@ public void test433458a() {
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=433588, [1.8][compiler] ECJ compiles an ambiguous call in the presence of an unrelated unused method.
 public void test433588() {
-	String errMessage = isMinimumCompliant(ClassFileConstants.JDK11) ?
+	String errMessage = AbstractRegressionTest.isMinimumCompliant(this, ClassFileConstants.JDK11) ?
 			"----------\n" +
 			"1. WARNING in X.java (at line 15)\n" +
 			"	public final @SafeVarargs void forEachOrdered(Consumer<? super T> action, Consumer<? super T>... actions) throws E {}\n" +
@@ -9533,7 +9533,7 @@ public void test433588() {
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=433588, [1.8][compiler] ECJ compiles an ambiguous call in the presence of an unrelated unused method.
 public void test433588a() {
-	String errMessage = isMinimumCompliant(ClassFileConstants.JDK11) ?
+	String errMessage = AbstractRegressionTest.isMinimumCompliant(this, ClassFileConstants.JDK11) ?
 			"----------\n" +
 			"1. ERROR in X.java (at line 29)\n" +
 			"	lines1.forEachOrdered(s -> Files.isHidden(Paths.get(s)));\n" +
@@ -9783,8 +9783,8 @@ public void test442446() {
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=432759,  [1.8][compiler] Some differences between Javac and ECJ regarding wildcards and static methods
 public void test432759() {
-	this.runNegativeTest(
-		false /* skipJavac */,
+	AbstractRegressionTest.runNegativeTest(
+		this, false /* skipJavac */,
 		JavacTestOptions.Excuse.JavacDoesNotCompileCorrectSource,
 		new String[] {
 			"X.java",
@@ -9985,8 +9985,8 @@ public void testBug487390b() {
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=458332, [1.8][compiler] only 409 method references/lambda expressions per class possible
 public void testBug458332() {
-	runConformTest(
-		false,
+	AbstractRegressionTest.runConformTest(
+		this, false,
 		null,
 		new String[] {
 			"Test.java",

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NegativeTypeAnnotationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NegativeTypeAnnotationTest.java
@@ -2920,8 +2920,8 @@ public class NegativeTypeAnnotationTest extends AbstractRegressionTest {
 	}
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=392119
 	public void test392119() throws Exception {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java", //-----------------------------------------------------------------------
 				"@Marker78 @Marker8 @Marker7\n" +
 				"public class X {\n" +
@@ -2959,12 +2959,12 @@ public class NegativeTypeAnnotationTest extends AbstractRegressionTest {
 				"    )\n" +
 				"  Attribute: MissingTypes Length: 4\n" +
 				"}";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=392119, variant with explicit class file retention.
 	public void test392119b() throws Exception {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java", //-----------------------------------------------------------------------
 				"@Marker78 @Marker8 @Marker7\n" +
 				"public class X {\n" +
@@ -3005,12 +3005,12 @@ public class NegativeTypeAnnotationTest extends AbstractRegressionTest {
 				"    )\n" +
 				"  Attribute: MissingTypes Length: 4\n" +
 				"}";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=392119, variant with explicit runtime retention.
 	public void test392119c() throws Exception {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java", //-----------------------------------------------------------------------
 				"@Marker78 @Marker8 @Marker7\n" +
 				"public class X {\n" +
@@ -3049,7 +3049,7 @@ public class NegativeTypeAnnotationTest extends AbstractRegressionTest {
 				"    )\n" +
 				"    #26 @Marker7(\n" +
 				"    )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=394355
 	public void testBug394355() {
@@ -4273,8 +4273,8 @@ public class NegativeTypeAnnotationTest extends AbstractRegressionTest {
 	}
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=414038, [1.8][compiler] CCE in resolveAnnotations
 	public void test414038() {
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 					"X.java",
 					"import java.lang.annotation.*;\n" +
 					"@Target(ElementType.TYPE_USE)\n" +
@@ -4293,8 +4293,8 @@ public class NegativeTypeAnnotationTest extends AbstractRegressionTest {
 	}
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=421791,  [1.8][compiler] TYPE_USE annotations should be allowed on annotation type declarations
 	public void test421791() {
-		runNegativeTest(
-				new String[] {
+		AbstractRegressionTest.runNegativeTest(
+				this, new String[] {
 						"X.java",
 						"import java.lang.annotation.ElementType;\n" +
 						"import java.lang.annotation.Target;\n" +
@@ -4311,8 +4311,8 @@ public class NegativeTypeAnnotationTest extends AbstractRegressionTest {
 	public void testBug426977() {
 		Map customOptions = getCompilerOptions();
 		customOptions.put(CompilerOptions.OPTION_Store_Annotations, CompilerOptions.ENABLED);
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"test/X.java",
 				"package test;\n" +
 				"import java.lang.annotation.ElementType;\n" +
@@ -4341,8 +4341,8 @@ public class NegativeTypeAnnotationTest extends AbstractRegressionTest {
 	public void testBug426977a() {
 		Map customOptions = getCompilerOptions();
 		customOptions.put(CompilerOptions.OPTION_Store_Annotations, CompilerOptions.ENABLED);
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"test/X.java",
 				"package test;\n" +
 				"import java.lang.annotation.ElementType;\n" +
@@ -4371,8 +4371,8 @@ public class NegativeTypeAnnotationTest extends AbstractRegressionTest {
 	public void test425599() {
 		Map customOptions = getCompilerOptions();
 		customOptions.put(CompilerOptions.OPTION_Store_Annotations, CompilerOptions.ENABLED);
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"import java.lang.annotation.ElementType;\n" +
 				"import java.lang.annotation.Target;\n" +
@@ -4393,8 +4393,8 @@ public class NegativeTypeAnnotationTest extends AbstractRegressionTest {
 	public void test427955() {
 		Map customOptions = getCompilerOptions();
 		customOptions.put(CompilerOptions.OPTION_Store_Annotations, CompilerOptions.ENABLED);
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"/**\n" +
 				" * @param <K> unused\n" +
@@ -4422,8 +4422,8 @@ public class NegativeTypeAnnotationTest extends AbstractRegressionTest {
 	}
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=419827,  [1.8] Annotation with TYPE_USE as target is not allowed to use container with target TYPE
 	public void test419827a() {
-		runNegativeTest(
-				new String[] {
+		AbstractRegressionTest.runNegativeTest(
+				this, new String[] {
 					"X.java",
 					"import java.lang.annotation.ElementType;\n" +
 					"import java.lang.annotation.Repeatable;\n" +
@@ -4445,8 +4445,8 @@ public class NegativeTypeAnnotationTest extends AbstractRegressionTest {
 	// Although the target of FooContainer is different from that of Foo, Foo container cannot be used in any place where
 	// Foo can't be used.
 	public void test419827b() {
-		runNegativeTest(
-				new String[] {
+		AbstractRegressionTest.runNegativeTest(
+				this, new String[] {
 					"X.java",
 					"import java.lang.annotation.ElementType;\n" +
 					"import java.lang.annotation.Repeatable;\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NonFatalErrorTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NonFatalErrorTest.java
@@ -46,8 +46,8 @@ public class NonFatalErrorTest extends AbstractRegressionTest {
 		Map customOptions = getCompilerOptions();
 		customOptions.put(CompilerOptions.OPTION_FatalOptionalError, CompilerOptions.DISABLED);
 		customOptions.put(CompilerOptions.OPTION_ReportUnusedImport, CompilerOptions.ERROR);
-		runNegativeTest(
-			// test directory preparation
+		AbstractRegressionTest.runNegativeTest(
+			this, // test directory preparation
 			true /* flush output directory */,
 			new String[] { /* test files */
 				"X.java",
@@ -80,8 +80,8 @@ public class NonFatalErrorTest extends AbstractRegressionTest {
 		Map customOptions = getCompilerOptions();
 		customOptions.put(CompilerOptions.OPTION_FatalOptionalError, CompilerOptions.ENABLED);
 		customOptions.put(CompilerOptions.OPTION_ReportUnusedImport, CompilerOptions.ERROR);
-		runNegativeTest(
-			// test directory preparation
+		AbstractRegressionTest.runNegativeTest(
+			this, // test directory preparation
 			true /* flush output directory */,
 			new String[] { /* test files */
 				"X.java",
@@ -115,8 +115,8 @@ public class NonFatalErrorTest extends AbstractRegressionTest {
 		Map customOptions = getCompilerOptions();
 		customOptions.put(CompilerOptions.OPTION_FatalOptionalError, CompilerOptions.DISABLED);
 		customOptions.put(CompilerOptions.OPTION_ReportNonExternalizedStringLiteral, CompilerOptions.ERROR);
-		runNegativeTest(
-			// test directory preparation
+		AbstractRegressionTest.runNegativeTest(
+			this, // test directory preparation
 			true /* flush output directory */,
 			new String[] { /* test files */
 				"X.java",
@@ -147,8 +147,8 @@ public class NonFatalErrorTest extends AbstractRegressionTest {
 		Map customOptions = getCompilerOptions();
 		customOptions.put(CompilerOptions.OPTION_FatalOptionalError, CompilerOptions.DISABLED);
 		customOptions.put(CompilerOptions.OPTION_ReportUndocumentedEmptyBlock, CompilerOptions.ERROR);
-		runNegativeTest(
-			// test directory preparation
+		AbstractRegressionTest.runNegativeTest(
+			this, // test directory preparation
 			true /* flush output directory */,
 			new String[] { /* test files */
 				"X.java",
@@ -181,8 +181,8 @@ public class NonFatalErrorTest extends AbstractRegressionTest {
 		Map customOptions = getCompilerOptions();
 		customOptions.put(CompilerOptions.OPTION_FatalOptionalError, CompilerOptions.ENABLED);
 		customOptions.put(CompilerOptions.OPTION_ReportUndocumentedEmptyBlock, CompilerOptions.ERROR);
-		runNegativeTest(
-			// test directory preparation
+		AbstractRegressionTest.runNegativeTest(
+			this, // test directory preparation
 			true /* flush output directory */,
 			new String[] { /* test files */
 				"X.java",
@@ -217,8 +217,8 @@ public class NonFatalErrorTest extends AbstractRegressionTest {
 		Map customOptions = getCompilerOptions();
 		customOptions.put(CompilerOptions.OPTION_FatalOptionalError, CompilerOptions.DISABLED);
 		customOptions.put(CompilerOptions.OPTION_ReportUndocumentedEmptyBlock, CompilerOptions.ERROR);
-		runNegativeTest(
-			// test directory preparation
+		AbstractRegressionTest.runNegativeTest(
+			this, // test directory preparation
 			true /* flush output directory */,
 			new String[] { /* test files */
 				"X.java",
@@ -279,8 +279,8 @@ public class NonFatalErrorTest extends AbstractRegressionTest {
 				CompilerOptions.ENABLED);
 		customOptions.put(CompilerOptions.OPTION_ReportUnusedWarningToken,
 				CompilerOptions.ERROR);
-		runConformTest(
-				new String[] { /* test files */
+		AbstractRegressionTest.runConformTest(
+				this, new String[] { /* test files */
 						"X.java",
 						"public class X {\n" +
 								"        @SuppressWarnings(\"unused\")\n" +
@@ -304,8 +304,8 @@ public class NonFatalErrorTest extends AbstractRegressionTest {
 	public void testImportUnresolved() {
 		Map<String,String> options = getCompilerOptions();
 		options.put(JavaCore.COMPILER_PB_UNUSED_IMPORT, JavaCore.ERROR);
-		runNegativeTest(
-			true, // flush dir
+		AbstractRegressionTest.runNegativeTest(
+			this, true, // flush dir
 			new String[] {
 				"X.java",
 				"import com.bogus.Missing;\n" +
@@ -336,8 +336,8 @@ public class NonFatalErrorTest extends AbstractRegressionTest {
 			options.put(JavaCore.COMPILER_PB_UNUSED_IMPORT, JavaCore.ERROR);
 			options.put(JavaCore.COMPILER_PB_FATAL_OPTIONAL_ERROR, JavaCore.ENABLED);
 			options.put(CompilerOptions.OPTION_ReportDeprecation, CompilerOptions.IGNORE);
-			runNegativeTest(
-					true, // flush dir
+			AbstractRegressionTest.runNegativeTest(
+					this, true, // flush dir
 					new String[] {
 							"p/Z.java",
 							"package p;\n" +
@@ -382,8 +382,8 @@ public class NonFatalErrorTest extends AbstractRegressionTest {
 		try {
 			options.put(CompilerOptions.OPTION_ReportDeprecation, CompilerOptions.IGNORE);
 
-			runNegativeTest(
-					true, // flush dir
+			AbstractRegressionTest.runNegativeTest(
+					this, true, // flush dir
 					new String[] {
 							"p/z.java",
 							"package p;\n" +
@@ -424,8 +424,8 @@ public class NonFatalErrorTest extends AbstractRegressionTest {
 		try {
 			options.put(CompilerOptions.OPTION_ReportDeprecation, CompilerOptions.IGNORE);
 
-			runNegativeTest(
-					true, // flush dir
+			AbstractRegressionTest.runNegativeTest(
+					this, true, // flush dir
 					new String[] {
 							"p/Z.java",
 							"package p;\n" +
@@ -485,8 +485,8 @@ public class NonFatalErrorTest extends AbstractRegressionTest {
 		if (this.complianceLevel < ClassFileConstants.JDK1_5) return; // uses static imports
 		Map<String,String> options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_ReportDeprecation, CompilerOptions.IGNORE);
-		runNegativeTest(
-			true, // flush dir
+		AbstractRegressionTest.runNegativeTest(
+			this, true, // flush dir
 			new String[] {
 				"p/Z.java",
 				"package p;\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullAnnotationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullAnnotationTest.java
@@ -134,7 +134,7 @@ protected void setUp() throws Exception {
 	if (this.complianceLevel >= ClassFileConstants.JDK1_8)
 		this.TEST_JAR_SUFFIX = "_1.8.jar";
 	if (this.LIBS == null) {
-		this.LIBS = getLibsWithNullAnnotations(this.complianceLevel);
+		this.LIBS = AbstractRegressionTest.getLibsWithNullAnnotations(this, this.complianceLevel);
 	}
 }
 
@@ -1980,8 +1980,8 @@ public void test_annotation_import_005() {
 	customOptions.put(JavaCore.COMPILER_PB_NULL_UNCHECKED_CONVERSION, JavaCore.ERROR);
 	customOptions.put(JavaCore.COMPILER_NULLABLE_ANNOTATION_NAME, "org.foo.MayBeNull");
 	customOptions.put(JavaCore.COMPILER_NONNULL_ANNOTATION_NAME, "org.foo.MustNotBeNull");
-	runNegativeTest(
-		true/*shouldFlushOutputDirectory*/,
+	AbstractRegressionTest.runNegativeTest(
+		this, true/*shouldFlushOutputDirectory*/,
 		new String[] {
 			"org/foo/MayBeNull.java",
 			"package org.foo;\n" +
@@ -2026,8 +2026,8 @@ public void test_annotation_import_006() {
 	customOptions.put(JavaCore.COMPILER_PB_NULL_UNCHECKED_CONVERSION, JavaCore.ERROR);
 	customOptions.put(JavaCore.COMPILER_NULLABLE_ANNOTATION_NAME, "org.foo.MayBeNull");
 	customOptions.put(JavaCore.COMPILER_NONNULL_ANNOTATION_NAME, "org.foo.MustNotBeNull");
-	runNegativeTest(
-		true/*shouldFlushOutputDirectory*/,
+	AbstractRegressionTest.runNegativeTest(
+		this, true/*shouldFlushOutputDirectory*/,
 		new String[] {
 			"Lib.java",
 			"public class Lib {\n" +
@@ -2100,8 +2100,8 @@ public void _test_illegal_annotation_002() {
 
 // a null annotation is illegally used on a void method:
 public void test_illegal_annotation_003() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"import org.eclipse.jdt.annotation.*;\n" +
 			"public class X {\n" +
@@ -2182,8 +2182,8 @@ public void test_illegal_annotation_005() {
 public void test_illegal_annotation_006() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(JavaCore.COMPILER_NULLABLE_ANNOTATION_NAME, "nullAnn.Nullable");
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"p/Test.java",
 			"package p;\n" +
 			"import nullAnn.*;  // 1 \n" +
@@ -2215,8 +2215,8 @@ public void test_illegal_annotation_006() {
 // see https://bugs.eclipse.org/bugs/show_bug.cgi?id=186342#c186
 public void test_illegal_annotation_007() {
 	Map customOptions = getCompilerOptions();
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"p/Test.java",
 			"package p;\n" +
 			"import org.eclipse.jdt.annotation.*;\n" +
@@ -5571,7 +5571,7 @@ public void test_enum_field_02() {
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=372011
 // Test whether @NonNullByDefault on a binary package or an enclosing type is respected from enclosed elements.
 public void testBug372011() {
-	String path = this.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "Test372011.jar";
+	String path = AbstractRegressionTest.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "Test372011.jar";
 	String[] libs = new String[this.LIBS.length + 1];
 	System.arraycopy(this.LIBS, 0, libs, 0, this.LIBS.length);
 	libs[this.LIBS.length] = path;
@@ -5624,7 +5624,7 @@ public void testBug372011() {
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=374129  - more tests for bug 372011
 // Test whether @NonNullByDefault on a binary package or an enclosing type is respected from enclosed elements.
 public void testBug374129() {
-	String path = this.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "Test374129"+this.TEST_JAR_SUFFIX;
+	String path = AbstractRegressionTest.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "Test374129"+this.TEST_JAR_SUFFIX;
 	/* content of Test372129.jar:
 	 	p1bin/package-info.java:
 	 		@org.eclipse.jdt.annotation.NonNullByDefault
@@ -5910,7 +5910,7 @@ public class C2 implements i2.I2 {
 // Test whether null annotations from a super interface are respected
 // Class and its super interface both read from binary
 public void testBug388281_01() {
-	String path = this.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "Test388281"+this.TEST_JAR_SUFFIX;
+	String path = AbstractRegressionTest.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "Test388281"+this.TEST_JAR_SUFFIX;
 	String[] libs = new String[this.LIBS.length + 1];
 	System.arraycopy(this.LIBS, 0, libs, 0, this.LIBS.length);
 	libs[this.LIBS.length] = path;
@@ -5947,7 +5947,7 @@ public void testBug388281_01() {
 // Test whether null annotations from a super interface are respected
 // Class from source, its supers (class + super interface) from binary
 public void testBug388281_02() {
-	String path = this.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "Test388281"+this.TEST_JAR_SUFFIX;
+	String path = AbstractRegressionTest.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "Test388281"+this.TEST_JAR_SUFFIX;
 	String[] libs = new String[this.LIBS.length + 1];
 	System.arraycopy(this.LIBS, 0, libs, 0, this.LIBS.length);
 	libs[this.LIBS.length] = path;
@@ -6009,7 +6009,7 @@ public void testBug388281_02() {
 // Test whether null annotations from a super interface trigger an error against the overriding implementation
 // Class from source, its super interface from binary
 public void testBug388281_03() {
-	String path = this.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "Test388281"+this.TEST_JAR_SUFFIX;
+	String path = AbstractRegressionTest.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "Test388281"+this.TEST_JAR_SUFFIX;
 	String[] libs = new String[this.LIBS.length + 1];
 	System.arraycopy(this.LIBS, 0, libs, 0, this.LIBS.length);
 	libs[this.LIBS.length] = path;
@@ -6109,7 +6109,7 @@ public void testBug388281_04() {
 // Class from source, its super interface from binary
 // Super interface subject to package level @NonNullByDefault
 public void testBug388281_05() {
-	String path = this.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "Test388281"+this.TEST_JAR_SUFFIX;
+	String path = AbstractRegressionTest.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "Test388281"+this.TEST_JAR_SUFFIX;
 	String[] libs = new String[this.LIBS.length + 1];
 	System.arraycopy(this.LIBS, 0, libs, 0, this.LIBS.length);
 	libs[this.LIBS.length] = path;
@@ -6162,7 +6162,7 @@ public void testBug388281_05() {
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=388281
 // Conflicting annotations from several indirect super interfaces must be detected
 public void testBug388281_06() {
-	String path = this.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "Test388281"+this.TEST_JAR_SUFFIX;
+	String path = AbstractRegressionTest.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "Test388281"+this.TEST_JAR_SUFFIX;
 	String[] libs = new String[this.LIBS.length + 1];
 	System.arraycopy(this.LIBS, 0, libs, 0, this.LIBS.length);
 	libs[this.LIBS.length] = path;
@@ -6268,7 +6268,7 @@ public void testBug388281_07() {
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=388281
 // report conflict between inheritance and default - binary types
 public void testBug388281_08() {
-	String path = this.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "Test388281"+this.TEST_JAR_SUFFIX;
+	String path = AbstractRegressionTest.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "Test388281"+this.TEST_JAR_SUFFIX;
 	String[] libs = new String[this.LIBS.length + 1];
 	System.arraycopy(this.LIBS, 0, libs, 0, this.LIBS.length);
 	libs[this.LIBS.length] = path;
@@ -6690,8 +6690,8 @@ public void testBug413460() {
 
 // missing type in constructor declaration must not cause NPE in QAE#resolveType(..)
 public void testBug415850_a() {
-	runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java", //-----------------------------------------------------------------------
 				"public class X {\n" +
 				"	void foo(X1 x1) {\n" +
@@ -6973,8 +6973,8 @@ public void testBug_415269() {
 		"");
 }
 public void testBug416267() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	void test() {\n" +
@@ -6999,8 +6999,8 @@ public void testBug416267() {
 }
 //duplicate of bug 416267
 public void testBug418843() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"TestEnum.java",
 			"public enum TestEnum {\n" +
 			"	TestEntry(1){};\n" +
@@ -7095,8 +7095,8 @@ public void testTypeAnnotationProblemNotIn17() {
 			getCompilerOptions(),
 			"");
 	else
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				source
 			},
@@ -7334,8 +7334,8 @@ public void testBug424624b() {
 		"");
 }
 public void testBug430084() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"import org.eclipse.jdt.annotation.NonNullByDefault;\n" +
 			"@NonNullByDefault\n" +
@@ -7814,8 +7814,8 @@ public void testBug435805() {
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_NONNULL_ANNOTATION_NAME, "org.foo.NonNull");
 	options.put(JavaCore.COMPILER_NULLABLE_ANNOTATION_NAME, "org.foo.Nullable");
-	runNegativeTest(
-		true/*flush*/,
+	AbstractRegressionTest.runNegativeTest(
+		this, true/*flush*/,
 		new String[] {
 			"org/foo/Nullable.java",
 			"package org.foo;\n" +
@@ -8765,8 +8765,8 @@ public void testBug418236() {
 public void testBug461878() {
 	Map compilerOptions = getCompilerOptions();
 	compilerOptions.put(JavaCore.COMPILER_NONNULL_ANNOTATION_NAME, "jakarta.annotation.Nonnull");
-	runNegativeTest(
-		true, /*flush*/
+	AbstractRegressionTest.runNegativeTest(
+		this, true, /*flush*/
 		new String[] {
 			"jakarta/annotation/Nonnull.java",
 			"package jakarta.annotation;\n" +
@@ -8873,8 +8873,8 @@ public void testMultipleAnnotations() {
 	Map options1 = new HashMap<>(getCompilerOptions());
 	options1.put(JavaCore.COMPILER_NONNULL_ANNOTATION_NAME, "org.foo1.NonNull");
 	options1.put(JavaCore.COMPILER_NULLABLE_ANNOTATION_NAME, "org.foo1.Nullable");
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"org/foo1/Nullable.java",
 			"package org.foo1;\n" +
 			"import java.lang.annotation.*;\n" +
@@ -8904,8 +8904,8 @@ public void testMultipleAnnotations() {
 	options2.put(JavaCore.COMPILER_NULLABLE_ANNOTATION_NAME, "org.foo2.Nullable2");
 	options2.put(JavaCore.COMPILER_NONNULL_BY_DEFAULT_ANNOTATION_NAME, "org.foo2.NoNulls2");
 	options2.put(JavaCore.COMPILER_PB_NULL_SPECIFICATION_VIOLATION, JavaCore.WARNING);
-	runConformTest(
-		false, // flush
+	AbstractRegressionTest.runConformTest(
+		this, false, // flush
 		new String[] {
 			"org/foo2/Nullable2.java",
 			"package org.foo2;\n" +
@@ -9050,8 +9050,8 @@ public void testBug489486conform() {
 }
 
 public void testBug489486negative() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"test/DurationAdapter.java",
 			"package test;\n" +
 			"\n" +
@@ -10569,7 +10569,7 @@ public void testBug542707_003() {
 		"	}\n" +
 		"}\n"
 	};
-	runner.expectedCompilerLog = checkPreviewAllowed() ?
+	runner.expectedCompilerLog = AbstractRegressionTest.checkPreviewAllowed(this) ?
 			"----------\n" +
 			"1. ERROR in X.java (at line 7)\n" +
 			"	default -> i == 3 ? maybe() : \"\";\n" +
@@ -10640,7 +10640,7 @@ public void testBug542707_005() {
 		"	}\n" +
 		"}\n"
 	};
-	runner.expectedCompilerLog = checkPreviewAllowed() ?
+	runner.expectedCompilerLog = AbstractRegressionTest.checkPreviewAllowed(this) ?
 			"----------\n" +
 			"1. ERROR in X.java (at line 5)\n" +
 			"	return switch(day) {\n" +
@@ -10677,7 +10677,7 @@ public void testBug542707_006() {
 		"	}\n" +
 		"}\n"
 	};
-	runner.expectedCompilerLog = checkPreviewAllowed() ?
+	runner.expectedCompilerLog = AbstractRegressionTest.checkPreviewAllowed(this) ?
 			"----------\n" +
 			"2. ERROR in X.java (at line 5)\n" +
 			"	return switch(day) {\n" +
@@ -10693,7 +10693,7 @@ public void testBug542707_006() {
 	runner.runNegativeTest();
 }
 public void testBug545715() {
-	if (!checkPreviewAllowed()) return; // switch expression
+	if (!AbstractRegressionTest.checkPreviewAllowed(this)) return; // switch expression
 	Map<String, String>  customOptions = getCompilerOptions();
 	customOptions.put(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, JavaCore.ENABLED);
 	customOptions.put(CompilerOptions.OPTION_ReportPreviewFeatures, CompilerOptions.IGNORE);

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullAnnotationTests9.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullAnnotationTests9.java
@@ -146,7 +146,7 @@ public class NullAnnotationTests9 extends AbstractNullAnnotationTest {
 	@Override
 	protected INameEnvironment getNameEnvironment(final String[] testFiles, String[] classPaths, Map<String, String> options) {
 		this.classpaths = classPaths == null ? getDefaultClassPaths() : classPaths;
-		INameEnvironment[] classLibs = getClassLibs(classPaths == null, options);
+		INameEnvironment[] classLibs = AbstractRegressionTest.getClassLibs(this, classPaths == null, options);
 		for (INameEnvironment nameEnvironment : classLibs) {
 			((FileSystem) nameEnvironment).scanForModules(createParser());
 		}
@@ -202,7 +202,7 @@ public class NullAnnotationTests9 extends AbstractNullAnnotationTest {
 		Map<String,String> opts = new HashMap<>();
 		opts.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_9);
 		return new Parser(
-				new ProblemReporter(getErrorHandlingPolicy(), new CompilerOptions(opts), getProblemFactory()),
+				new ProblemReporter(AbstractRegressionTest.getErrorHandlingPolicy(), new CompilerOptions(opts), AbstractRegressionTest.getProblemFactory()),
 				false);
 	}
 

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullChecksTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullChecksTests.java
@@ -425,8 +425,8 @@ public class NullChecksTests extends AbstractNullAnnotationTest {
 	public void testBug465085_comment12() {
 		Map<String, String> options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_ReportUnusedLocal, CompilerOptions.ERROR);
-		runConformTest(
-			new String[] {
+		AbstractRegressionTest.runConformTest(
+			this, new String[] {
 				"Snippet.java",
 				"import java.util.Collection;\n" +
 				"\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullReferenceTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullReferenceTest.java
@@ -105,13 +105,13 @@ protected Map getCompilerOptions() {
 }
 
 protected void runNegativeNullTest(String[] testFiles, String expectedCompilerLog) {
-	runNegativeTest(testFiles, expectedCompilerLog, JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
+	AbstractRegressionTest.runNegativeTest(this, testFiles, expectedCompilerLog, JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 }
 
 // null analysis -- simple case for local
 public void test0001_simple_local() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			  "public class X {\n" +
 			  "  void foo() {\n" +
@@ -153,8 +153,8 @@ public void test0002_simple_field() {
 
 // null analysis -- simple case for parameter
 public void test0003_simple_parameter() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo(Object o) {\n" +
@@ -173,8 +173,8 @@ public void test0003_simple_parameter() {
 
 // null analysis -- final local
 public void test0004_final_local() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo() {\n" +
@@ -213,8 +213,8 @@ public void test0005_final_local() {
 
 // null analysis -- final local
 public void test0006_final_local() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo() {\n" +
@@ -238,8 +238,8 @@ public void test0006_final_local() {
 
 // null analysis -- local with member
 public void test0007_local_with_member() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  Object m;\n" +
@@ -259,8 +259,8 @@ public void test0007_local_with_member() {
 
 // null analysis -- local with member
 public void test0008_local_with_member() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  Object m;\n" +
@@ -610,8 +610,8 @@ public void test0026_suppress_warnings() {
 	if (this.complianceLevel >= ClassFileConstants.JDK1_5) {
 		Map compilerOptions = getCompilerOptions();
 		compilerOptions.put(CompilerOptions.OPTION_ReportNullReference, CompilerOptions.WARNING);
-		this.runConformTest(
-			new String[] {
+		AbstractRegressionTest.runConformTest(
+			this, new String[] {
 				"X.java",
 				"@SuppressWarnings(\"null\")\n" +
 				"public class X {\n" +
@@ -626,8 +626,8 @@ public void test0026_suppress_warnings() {
 
 // null analysis -- embedded comparison
 public void test0027_embedded_comparison() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo(Object o) {\n" +
@@ -662,8 +662,8 @@ public void test0028_field_as_initializer() {
 
 // null analysis -- field
 public void test0029_field_assignment() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  Object m;\n" +
@@ -683,8 +683,8 @@ public void test0029_field_assignment() {
 
 // null analysis -- conditional expression
 public void test0030_conditional_expression() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo() {\n" +
@@ -708,8 +708,8 @@ public void test0030_conditional_expression() {
 
 // null analysis -- conditional expression
 public void test0031_conditional_expression() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo() {\n" +
@@ -747,8 +747,8 @@ public void test0032_conditional_expression() {
 
 // null analysis -- conditional expression
 public void test0033_conditional_expression() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo() {\n" +
@@ -891,8 +891,8 @@ public void test0035_conditional_expression() {
 
 // null analysis -- conditional expression
 public void test0036_conditional_expression() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  boolean b;\n" +
@@ -913,8 +913,8 @@ public void test0036_conditional_expression() {
 // https://bugs.eclipse.org/400761: [compiler][null] null may be return as boolean without a diagnostic
 public void test0037_conditional_expression_1() {
 	if (this.complianceLevel < ClassFileConstants.JDK1_5) return; // needs autoboxing
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	boolean badFunction(int i) {\n" +
@@ -934,8 +934,8 @@ public void test0037_conditional_expression_2() {
 	if (this.complianceLevel < ClassFileConstants.JDK1_5) return; // needs autoboxing
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_SUPPRESS_OPTIONAL_ERRORS, JavaCore.ENABLED);
-	runNegativeTest(
-		true,
+	AbstractRegressionTest.runNegativeTest(
+		this, true,
 		new String[] {
 			"X.java",
 			"public class X {\n" +
@@ -962,8 +962,8 @@ public void test0037_conditional_expression_3() {
 	if (this.complianceLevel < ClassFileConstants.JDK1_5) return; // needs autoboxing
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_POTENTIAL_NULL_REFERENCE, JavaCore.ERROR);
-	runNegativeTest(
-		true,
+	AbstractRegressionTest.runNegativeTest(
+		this, true,
 		new String[] {
 			"X.java",
 			"public class X {\n" +
@@ -989,8 +989,8 @@ public void test0037_conditional_expression_4() {
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_POTENTIAL_NULL_REFERENCE, JavaCore.ERROR);
 	options.put(JavaCore.COMPILER_PB_UNNECESSARY_ELSE, JavaCore.IGNORE);
-	runNegativeTest(
-		true,
+	AbstractRegressionTest.runNegativeTest(
+		this, true,
 		new String[] {
 			"X.java",
 			"public class X {\n" +
@@ -1017,8 +1017,8 @@ public void test0037_conditional_expression_4() {
 public void test0037_conditional_expression_5() {
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_POTENTIAL_NULL_REFERENCE, JavaCore.ERROR);
-	runNegativeTest(
-		true,
+	AbstractRegressionTest.runNegativeTest(
+		this, true,
 		new String[] {
 			"X.java",
 			"public class X {\n" +
@@ -1051,8 +1051,8 @@ public void test0037_autounboxing_1() {
 	if (this.complianceLevel < ClassFileConstants.JDK1_5) return;
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_POTENTIAL_NULL_REFERENCE, JavaCore.ERROR);
-	runNegativeTest(
-		true,
+	AbstractRegressionTest.runNegativeTest(
+		this, true,
 		new String[] {
 			"X.java",
 			"public class X {\n" +
@@ -1100,8 +1100,8 @@ public void test0037_autounboxing_2() {
 	if (this.complianceLevel < ClassFileConstants.JDK1_5) return;
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_POTENTIAL_NULL_REFERENCE, JavaCore.ERROR);
-	runNegativeTest(
-		true,
+	AbstractRegressionTest.runNegativeTest(
+		this, true,
 		new String[] {
 			"X.java",
 			"public class X {\n" +
@@ -1149,8 +1149,8 @@ public void test0037_autounboxing_3() {
 	if (this.complianceLevel < ClassFileConstants.JDK1_5) return;
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_POTENTIAL_NULL_REFERENCE, JavaCore.ERROR);
-	runNegativeTest(
-		true,
+	AbstractRegressionTest.runNegativeTest(
+		this, true,
 		new String[] {
 			"X.java",
 			"public class X {\n" +
@@ -1205,8 +1205,8 @@ public void test0037_autounboxing_4() {
 	if (this.complianceLevel < ClassFileConstants.JDK1_5) return;
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_POTENTIAL_NULL_REFERENCE, JavaCore.ERROR);
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	void foo3(Integer i, boolean b) {\n" +
@@ -1250,8 +1250,8 @@ public void test0037_autounboxing_5() {
 	if (this.complianceLevel < ClassFileConstants.JDK1_5) return;
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_POTENTIAL_NULL_REFERENCE, JavaCore.ERROR);
-	runNegativeTest(
-		true,
+	AbstractRegressionTest.runNegativeTest(
+		this, true,
 		new String[] {
 			"X.java",
 			"public class X {\n" +
@@ -1307,8 +1307,8 @@ public void test0037_autounboxing_6() {
 // null analysis -- autoboxing
 public void test0040_autoboxing_compound_assignment() {
 	if (this.complianceLevel >= ClassFileConstants.JDK1_5) {
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"  void foo() {\n" +
@@ -1329,8 +1329,8 @@ public void test0040_autoboxing_compound_assignment() {
 // null analysis -- autoboxing
 public void test0041_autoboxing_increment_operator() {
 	if (this.complianceLevel >= ClassFileConstants.JDK1_5) {
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"  void foo() {\n" +
@@ -1352,8 +1352,8 @@ public void test0041_autoboxing_increment_operator() {
 // null analysis -- autoboxing
 public void test0042_autoboxing_literal() {
 	if (this.complianceLevel >= ClassFileConstants.JDK1_5) {
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"  void foo() {\n" +
@@ -1379,8 +1379,8 @@ public void test0042_autoboxing_literal() {
 // null analysis -- autoboxing
 public void test0043_autoboxing_literal() {
 	if (this.complianceLevel >= ClassFileConstants.JDK1_5) {
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"  void foo() {\n" +
@@ -1418,8 +1418,8 @@ public void test0044_autoboxing() {
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=165346
 public void test0045_autoboxing_operator() {
 	if (this.complianceLevel >= ClassFileConstants.JDK1_5) {
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"  void foo() {\n" +
@@ -1461,8 +1461,8 @@ public void test0050_array() {
 
 // null analysis -- array
 public void test0051_array() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  public static void main(String args[]) {\n" +
@@ -1509,8 +1509,8 @@ public void test0053_array() {
 
 // null analysis -- method call
 public void test0061_method_call_guard() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo(Object o) {\n" +
@@ -1534,8 +1534,8 @@ public void test0061_method_call_guard() {
 
 // null analysis - method call
 public void test0062_method_call_isolation() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo(Object o) {\n" +
@@ -1576,8 +1576,8 @@ public void test0063_method_call_isolation() {
 
 // null analysis - method call
 public void test0064_method_call_isolation() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo(Object o) {\n" +
@@ -1619,8 +1619,8 @@ public void test0065_method_call_invocation_target() {
 
 // null analysis - method call
 public void test0066_method_call_invocation_target() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo() {\n" +
@@ -1639,8 +1639,8 @@ public void test0066_method_call_invocation_target() {
 
 // null analysis - method call
 public void test0067_method_call_invocation_target() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo(Object o) {\n" +
@@ -1681,8 +1681,8 @@ public void test0068_method_call_assignment() {
 
 // null analysis -- type reference
 public void test0070_type_reference() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  public static void main(String args[]) {\n" +
@@ -1705,8 +1705,8 @@ public void test0070_type_reference() {
 }
 
 public void test0080_shortcut_boolean_expressions() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo(Object o1, Object o2) {\n" +
@@ -1723,8 +1723,8 @@ public void test0080_shortcut_boolean_expressions() {
 }
 
 public void test0081_shortcut_boolean_expressions() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo(Object o1, Object o2) {\n" +
@@ -1742,8 +1742,8 @@ public void test0081_shortcut_boolean_expressions() {
 
 // null analysis - shortcut boolean expression
 public void test0082_shortcut_boolean_expression() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo(Object o) {\n" +
@@ -1774,8 +1774,8 @@ public void test0082_shortcut_boolean_expression() {
 
 // null analysis - shortcut boolean expression
 public void test0083_shortcut_boolean_expression() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo(Object o) {\n" +
@@ -1807,8 +1807,8 @@ public void test0083_shortcut_boolean_expression() {
 // null analysis - shortcut boolean expression
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=130311
 public void test0084_shortcut_boolean_expression() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  boolean foo(Integer i1, Integer i2) {\n" +
@@ -1828,8 +1828,8 @@ public void test0084_shortcut_boolean_expression() {
 // null analysis - shortcut boolean expression
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=130311
 public void test0085_shortcut_boolean_expression() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  boolean foo(Integer i1, Integer i2) {\n" +
@@ -1936,8 +1936,8 @@ public void test0091_instanceof() {
 // null analysis -- instanceof
 // can only be null always yields false
 public void test0092_instanceof() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"class X {\n" +
 			"  boolean dummy;\n" +
@@ -1957,8 +1957,8 @@ public void test0092_instanceof() {
 
 // null analysis -- instanceof
 public void test0093_instanceof() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"class X {\n" +
 			"  void foo(Object x) {\n" +
@@ -2001,8 +2001,8 @@ public void test0094_instanceof() {
 // null analysis -- instanceof combined with conditional or
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=145202
 public void test0095_instanceof_conditional_or() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"class X {\n" +
 			"  void foo(Object x) {\n" +
@@ -2056,8 +2056,8 @@ public void test0121_strings_concatenation() {
 
 // null analysis -- strings concatenation
 public void test0122_strings_concatenation() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  String foo(String s1) {\n" +
@@ -2168,8 +2168,8 @@ public void test0127_strings_concatenation() {
 // being the accommodation for the if (constant_flag_evaluating_to_false)
 // {code...} volontary code exclusion pattern)
 public void test0300_if_else() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  public void foo() {\n" +
@@ -2211,8 +2211,8 @@ public void test0300_if_else() {
 
 // null analysis - if/else
 public void test0301_if_else() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo() {\n" +
@@ -2232,8 +2232,8 @@ public void test0301_if_else() {
 
 // null analysis - if/else
 public void test0302_if_else() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo(Object o) throws Exception {\n" +
@@ -2255,8 +2255,8 @@ public void test0302_if_else() {
 
 // null analysis - if/else
 public void test0303_if_else() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo(Object o) {\n" +
@@ -2278,8 +2278,8 @@ public void test0303_if_else() {
 
 // null analysis - if/else
 public void test0304_if_else() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo(Object o) {\n" +
@@ -2299,8 +2299,8 @@ public void test0304_if_else() {
 
 // null analysis - if/else
 public void test0305_if_else() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo(Object o) {\n" +
@@ -2321,8 +2321,8 @@ public void test0305_if_else() {
 
 // null analysis - if/else
 public void test0306_if_else() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo(Object o) {\n" +
@@ -2373,8 +2373,8 @@ public void test0307_if_else() {
 
 // null analysis - if/else
 public void test0308_if_else() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  boolean b;\n" +
@@ -2396,8 +2396,8 @@ public void test0308_if_else() {
 
 // null analysis - if/else
 public void test0309_if_else() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  boolean b1, b2;\n" +
@@ -2422,8 +2422,8 @@ public void test0309_if_else() {
 
 // null analysis - if/else
 public void test0310_if_else() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  boolean b1, b2;\n" +
@@ -2469,8 +2469,8 @@ public void test0311_if_else() {
 
 // null analysis - if/else
 public void test0312_if_else() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"\n" +
@@ -2502,8 +2502,8 @@ public void test0312_if_else() {
 
 // null analysis - if/else
 public void test0313_if_else() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo(Object o) {\n" +
@@ -2530,8 +2530,8 @@ public void test0313_if_else() {
 
 // null analysis - if/else
 public void test0314_if_else() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo(Object o) {\n" +
@@ -2552,8 +2552,8 @@ public void test0314_if_else() {
 
 // null analysis - if/else
 public void test0315_if_else() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo(Object o) {\n" +
@@ -2574,8 +2574,8 @@ public void test0315_if_else() {
 
 // null analysis - if/else
 public void test0316_if_else() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo(Object o, boolean b) {\n" +
@@ -2648,8 +2648,8 @@ public void test0319_if_else_dead_branch() {
 
 // null analysis - if/else
 public void test0320_if_else() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo(Object o) {\n" +
@@ -2690,8 +2690,8 @@ public void test0321_if_else() {
 
 // null analysis - if/else
 public void test0322_if_else() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo(Object o, boolean b) {\n" +
@@ -2760,8 +2760,8 @@ public void test0324_if_else_nested() {
 
 // null analysis - if/else
 public void test0325_if_else_nested() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"class X {\n" +
 			"  void foo (boolean b) {\n" +
@@ -2798,8 +2798,8 @@ public void test0325_if_else_nested() {
 // limit: we cannot sync on external factors, even if this is a pattern
 // that is quite used
 public void test0326_if_else() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"class X {\n" +
 			"  void foo (boolean b) {\n" +
@@ -2823,8 +2823,8 @@ public void test0326_if_else() {
 // limit: we cannot sync on external factors, even if this is a pattern
 // that is quite used
 public void test0327_if_else() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"class X {\n" +
 			"  void foo (String s1) {\n" +
@@ -2848,8 +2848,8 @@ public void test0327_if_else() {
 
 // null analysis - if/else
 public void test0328_if_else() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo(Object o, boolean b) {\n" +
@@ -2873,8 +2873,8 @@ public void test0328_if_else() {
 
 // null analysis - if/else
 public void test0329_if_else_nested() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo(Object o, boolean b) {\n" +
@@ -2931,8 +2931,8 @@ public void test0331_if_else_nested() {
 
 // null analysis - if/else
 public void test0332_if_else() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo(Object o, boolean b) {\n" +
@@ -2956,8 +2956,8 @@ public void test0332_if_else() {
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=128014
 // invalid analysis when redundant check is done
 public void test0333_if_else() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo(Object o) {\n" +
@@ -2981,8 +2981,8 @@ public void test0333_if_else() {
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=128014
 // invalid analysis when redundant check is done - variant
 public void test0334_if_else() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo(Object o) {\n" +
@@ -3042,8 +3042,8 @@ public void test0335_if_else() {
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=128014
 // invalid analysis when redundant check is done - variant
 public void test0336_if_else() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo(Object o) {\n" +
@@ -3147,8 +3147,8 @@ public void test0338_if_else_nested() {
 
 // null analysis - if/else nested with unknown protection: unknown cannot protect
 public void test0339_if_else_nested() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo(Object o, boolean b) {\n" +
@@ -3173,8 +3173,8 @@ public void test0339_if_else_nested() {
 
 // null analysis - if/else nested
 public void test0340_if_else_nested() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo(Object o) {\n" +
@@ -3199,8 +3199,8 @@ public void test0340_if_else_nested() {
 
 // null analysis - if/else nested
 public void test0341_if_else_nested() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo(Object o1, Object o2, boolean b) {\n" +
@@ -3222,8 +3222,8 @@ public void test0341_if_else_nested() {
 
 // null analysis - if/else nested
 public void test0342_if_else_nested() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo(Object o1, Object o2, boolean b) {\n" +
@@ -3245,8 +3245,8 @@ public void test0342_if_else_nested() {
 
 // null analysis -- while
 public void test0401_while() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo() {\n" +
@@ -3266,8 +3266,8 @@ public void test0401_while() {
 
 // null analysis -- while
 public void test0402_while() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo() {\n" +
@@ -3325,8 +3325,8 @@ public void test0404_while() {
 
 // null analysis -- while
 public void test0405_while() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  boolean bar() {\n" +
@@ -3350,8 +3350,8 @@ public void test0405_while() {
 
 // null analysis -- while
 public void test0406_while() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  boolean dummy;\n" +
@@ -3371,8 +3371,8 @@ public void test0406_while() {
 
 // null analysis -- while
 public void test0407_while() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  boolean dummy;\n" +
@@ -3428,8 +3428,8 @@ public void test0408_while() {
 
 // null analysis -- while
 public void test0409_while() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  boolean dummy;\n" +
@@ -3499,8 +3499,8 @@ public void test0411_while_nested() {
 
 // null analysis -- while
 public void test0412_while_if_nested() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  boolean dummy, other;\n" +
@@ -3542,8 +3542,8 @@ public void test0413_while_unknown_field() {
 
 // null analysis -- while
 public void test0414_while_unknown_parameter() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  boolean dummy;\n" +
@@ -3586,8 +3586,8 @@ public void test0415_while_unknown_if_else() {
 
 // null analysis -- while
 public void test0416_while() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  boolean dummy;\n" +
@@ -3610,8 +3610,8 @@ public void test0416_while() {
 
 // null analysis -- while
 public void test0417_while() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  boolean dummy;\n" +
@@ -3654,8 +3654,8 @@ public void test0418_while_try() {
 
 // null analysis -- while
 public void test0419_while() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  boolean bool;\n" +
@@ -3677,8 +3677,8 @@ public void test0419_while() {
 
 // null analysis -- while
 public void test0420_while() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  boolean bool;\n" +
@@ -3721,8 +3721,8 @@ public void test0421_while() {
 
 // null analysis -- while
 public void test0422_while() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  boolean bool;\n" +
@@ -3751,8 +3751,8 @@ public void test0422_while() {
 
 // null analysis -- while
 public void test0423_while() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  boolean bool;\n" +
@@ -3804,8 +3804,8 @@ public void test0424_while_try() {
 
 // null analysis -- while
 public void test0425_while() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  boolean dummy;\n" +
@@ -3828,8 +3828,8 @@ public void test0425_while() {
 
 // null analysis -- while
 public void test0426_while() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  boolean dummy;\n" +
@@ -3855,8 +3855,8 @@ public void test0426_while() {
 
 // null analysis -- while
 public void test0427_while_return() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  boolean dummy;\n" +
@@ -3991,8 +3991,8 @@ public void test0432_while() {
 
 // null analysis - while
 public void test0433_while() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"class X {\n" +
 			"  boolean dummy;\n" +
@@ -4103,8 +4103,8 @@ public void test0437_while_exit() {
 
 // null analysis - while
 public void test0438_while() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"class X {\n" +
 			"  void foo(Object o) {\n" +
@@ -4140,8 +4140,8 @@ public void test0439_while() {
 
 // null analysis - while
 public void test0440_while() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"class X {\n" +
 			"  void foo(Object o) {\n" +
@@ -4162,8 +4162,8 @@ public void test0440_while() {
 
 // null analysis - while
 public void test0441_while() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"class X {\n" +
 			"  X bar() {\n" +
@@ -4187,8 +4187,8 @@ public void test0441_while() {
 
 // null analysis - while
 public void test0442_while() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"class X {\n" +
 			"  boolean bar() {\n" +
@@ -4260,8 +4260,8 @@ public void test0444_while_deeply_nested() {
 
 // null analysis - while
 public void test0445_while_deeply_nested() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"class X {\n" +
 			"  void foo(boolean b) {\n" +
@@ -4292,8 +4292,8 @@ public void test0445_while_deeply_nested() {
 
 // null analysis - while
 public void test0446_while() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"class X {\n" +
 			"  void foo(Object o, boolean b) {\n" +
@@ -4330,8 +4330,8 @@ public void test0447_while() {
 
 // null analysis - while
 public void test0448_while() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"class X {\n" +
 			"  void foo(boolean b[]) {\n" +
@@ -4396,8 +4396,8 @@ public void test0449_while_nested() {
 
 // null analysis - while
 public void test0450_while() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"class X {\n" +
 			"  void foo(boolean b) {\n" +
@@ -4420,8 +4420,8 @@ public void test0450_while() {
 // null analysis - while
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=133131
 public void test0451_while_nested() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"class X {\n" +
 			"  void foo(boolean b) {\n" +
@@ -4522,8 +4522,8 @@ public void test0454_while() {
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=133131
 // variant
 public void test0455_while_nested() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"class X {\n" +
 			"  void foo(boolean b) {\n" +
@@ -4620,8 +4620,8 @@ public void test0458_while_nested_explicit_label() {
 
 // null analysis -- while nested hits CAN_ONLY_NON_NULL
 public void test0459_while_nested() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo(boolean b) {\n" +
@@ -4969,8 +4969,8 @@ public void test0500_try_finally() {
 
 // null analysis -- try/finally
 public void test0501_try_finally() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo() {\n" +
@@ -5014,8 +5014,8 @@ public void test0502_try_finally() {
 
 // null analysis -- try/finally
 public void test0503_try_finally() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo(X x) {\n" +
@@ -5036,8 +5036,8 @@ public void test0503_try_finally() {
 
 // null analysis -- try/finally
 public void test0504_try_finally() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo(X x) {\n" +
@@ -5087,8 +5087,8 @@ public void test0505_try_finally() {
 
 // null analysis -- try finally
 public void test0506_try_finally() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo(Object o) {\n" +
@@ -5115,8 +5115,8 @@ public void test0506_try_finally() {
 
 // null analysis -- try finally
 public void test0507_try_finally() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo(Object o, boolean b) {\n" +
@@ -5147,8 +5147,8 @@ public void test0507_try_finally() {
 
 // null analysis -- try finally
 public void test0508_try_finally() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo(Object o) {\n" +
@@ -5172,8 +5172,8 @@ public void test0508_try_finally() {
 
 // null analysis -- try finally
 public void test0509_try_finally_embedded() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo(Object o1) {\n" +
@@ -5247,8 +5247,8 @@ public void test0511_try_finally() {
 
 // null analysis -- try/finally
 public void test0512_try_finally() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			" void foo(X x) {\n" +
@@ -5431,8 +5431,8 @@ public void test0517_try_finally() {
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=132120
 // [compiler][null] NPE batch compiling JDT/Core from HEAD
 public void test0518_try_finally() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			" void foo() {\n" +
@@ -5566,8 +5566,8 @@ public void test0521_try_finally() {
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=149665
 // variant
 public void test0522_try_finally() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X\n" +
 			"{\n" +
@@ -5600,8 +5600,8 @@ public void test0522_try_finally() {
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=149665
 // variant
 public void test0523_try_finally() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X\n" +
 			"{\n" +
@@ -5634,8 +5634,8 @@ public void test0523_try_finally() {
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=149665
 // variant
 public void test0524_try_finally() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X\n" +
 			"{\n" +
@@ -5667,8 +5667,8 @@ public void test0524_try_finally() {
 // null analysis -- try/finally
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=150082
 public void _test0525_try_finally_unchecked_exception() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X\n" +
 			"{\n" +
@@ -5704,8 +5704,8 @@ public void _test0525_try_finally_unchecked_exception() {
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=150082
 // variant
 public void test0526_try_finally_unchecked_exception() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X\n" +
 			"{\n" +
@@ -5740,8 +5740,8 @@ public void test0526_try_finally_unchecked_exception() {
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=150082
 //variant
 public void test0527_try_finally_unchecked_exception() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X\n" +
 			"{\n" +
@@ -5772,8 +5772,8 @@ public void test0527_try_finally_unchecked_exception() {
 // null analysis -- try/finally
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=158000
 public void test0528_try_finally() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo(X x) {\n" +
@@ -5803,8 +5803,8 @@ public void test0528_try_finally() {
 // null analysis -- try finally
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=158000
 public void test0529_try_finally() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo(Object o) {\n" +
@@ -5834,8 +5834,8 @@ public void test0529_try_finally() {
 // null analysis -- try/finally
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=158000
 public void test0530_try_finally() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			" void foo(X x) {\n" +
@@ -5866,8 +5866,8 @@ public void test0530_try_finally() {
 // null analysis -- try/finally
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=158000
 public void test0531_try_finally() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			" void foo() {\n" +
@@ -5942,8 +5942,8 @@ public void test0533_try_finally_field() {
 // null analysis - try finally
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=198970
 public void _test0534_try_finally() {
-	runTest(
-		new String[] {
+	AbstractRegressionTest.runTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  public static void main(String[] args) {\n" +
@@ -6003,8 +6003,8 @@ public void test0535_try_finally() {
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=320170 -  [compiler] [null] Whitebox issues in null analysis
 // trigger nullbits 0111 (pot n|nn|un), don't let "definitely unknown" override previous information
 public void test0536_try_finally() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			" X bar () { return null; }\n" +
@@ -6033,8 +6033,8 @@ public void test0536_try_finally() {
 // trigger nullbits 0111 (pot n|nn|un), don't let "definitely unknown" override previous information
 // multiple variables
 public void test0537_try_finally() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			" X bar () { return null; }\n" +
@@ -6094,8 +6094,8 @@ public void test0550_try_catch() {
 
 // null analysis - try/catch
 public void test0551_try_catch() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  boolean dummy;\n" +
@@ -6150,8 +6150,8 @@ public void test0552_try_catch() {
 
 // null analysis - try/catch
 public void test0553_try_catch() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  boolean dummy, other;\n" +
@@ -6226,8 +6226,8 @@ public void test0554_try_catch() {
 
 // null analysis - try/catch
 public void test0555_try_catch() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo() {\n" +
@@ -6255,8 +6255,8 @@ public void test0555_try_catch() {
 
 // null analysis - try/catch
 public void test0556_try_catch() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo() {\n" +
@@ -6284,8 +6284,8 @@ public void test0556_try_catch() {
 
 // null analysis - try/catch
 public void test0557_try_catch() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  boolean dummy;\n" +
@@ -6313,8 +6313,8 @@ public void test0557_try_catch() {
 
 // null analysis - try/catch
 public void test0558_try_catch() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  boolean dummy;\n" +
@@ -6346,8 +6346,8 @@ public void test0558_try_catch() {
 
 // null analysis - try/catch
 public void test0559_try_catch() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  boolean dummy;\n" +
@@ -6381,8 +6381,8 @@ public void test0559_try_catch() {
 
 // null analysis - try/catch
 public void test0560_try_catch() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  Class bar(boolean b) throws ClassNotFoundException {\n" +
@@ -6419,8 +6419,8 @@ public void test0560_try_catch() {
 // null analysis - try/catch
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=130359
 public void test0561_try_catch_unchecked_exception() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo() {\n" +
@@ -6451,8 +6451,8 @@ public void test0562_try_catch_unchecked_exception() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.WARNING);
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.WARNING);
-	this.runNegativeTest(
-		true,
+	AbstractRegressionTest.runNegativeTest(
+		this, true,
 		new String[] {
 			"X.java",
 			"import java.io.*;\n" +
@@ -6486,8 +6486,8 @@ public void test0562_try_catch_unchecked_exception() {
 // null analysis - try/catch
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=155117
 public void test0563_try_catch() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  public void foo(boolean b) {\n" +
@@ -6532,8 +6532,8 @@ public void test0563_try_catch() {
 public void test0564_try_catch_unchecked_exception() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.WARNING);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  public static Object foo() {\n" +
@@ -6561,8 +6561,8 @@ public void test0564_try_catch_unchecked_exception() {
 public void test0565_try_catch_unchecked_exception() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.WARNING);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  public static Object foo() {\n" +
@@ -6591,8 +6591,8 @@ public void test0565_try_catch_unchecked_exception() {
 public void test0566_try_catch_unchecked_exception() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.WARNING);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  public static Object foo(Y y) {\n" +
@@ -6830,8 +6830,8 @@ public void test0572_if_statement() {
 
 // take care for Java7 changes
 public void test0573_try_catch_unchecked_and_checked_exception() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"import java.io.IOException;\n" +
 			"public class X {\n" +
@@ -6867,8 +6867,8 @@ public void test0573_try_catch_unchecked_and_checked_exception() {
 // similar to test0573 using multi catch parameters
 public void test0574_try_multi_catch_unchecked_and_checked_exception() {
 	if (this.complianceLevel >=  ClassFileConstants.JDK1_7) {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"import java.io.IOException;\n" +
 				"public class X {\n" +
@@ -6897,8 +6897,8 @@ public void test0574_try_multi_catch_unchecked_and_checked_exception() {
 //multi catch variant of test0561_try_catch_unchecked_exception
 public void test0575_try_multi_catch_finally_unchecked_and_checked_exception() {
 	if (this.complianceLevel >=  ClassFileConstants.JDK1_7) {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"import java.io.IOException;\n" +
 				"public class X {\n" +
@@ -6927,8 +6927,8 @@ public void test0575_try_multi_catch_finally_unchecked_and_checked_exception() {
 // null test for resources inside try with resources statement
 public void test0576_try_with_resources() {
 	if (this.complianceLevel >=  ClassFileConstants.JDK1_7) {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"import java.io.FileInputStream;\n" +
 				"import java.io.IOException;\n" +
@@ -6991,8 +6991,8 @@ public void test0576_try_with_resources() {
 // null analysis - throw
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=201182
 public void test0595_throw() {
-	runTest(
-		new String[] {
+	AbstractRegressionTest.runTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  public static void main(String[] args) throws Throwable {\n" +
@@ -7023,8 +7023,8 @@ public void test0595_throw() {
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=201182
 // variant - potential NPE
 public void test0596_throw() {
-	runTest(
-		new String[] {
+	AbstractRegressionTest.runTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  public static void main(String[] args) throws Throwable {\n" +
@@ -7059,8 +7059,8 @@ public void test0596_throw() {
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=201182
 // variant - unknown
 public void test0597_throw() {
-	runTest(
-		new String[] {
+	AbstractRegressionTest.runTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo() throws Throwable {\n" +
@@ -7086,8 +7086,8 @@ public void test0597_throw() {
 
 // null analysis -- do while
 public void test0601_do_while() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo() {\n" +
@@ -7108,8 +7108,8 @@ public void test0601_do_while() {
 
 // null analysis -- do while
 public void test0602_do_while() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo() {\n" +
@@ -7130,8 +7130,8 @@ public void test0602_do_while() {
 
 // null analysis -- do while
 public void test0603_do_while() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo() {\n" +
@@ -7173,8 +7173,8 @@ public void test0604_do_while() {
 
 // null analysis -- do while
 public void test0605_do_while() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  boolean dummy;\n" +
@@ -7222,8 +7222,8 @@ public void test0606_do_while() {
 
 // null analysis -- do while
 public void test0607_do_while() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  boolean dummy;\n" +
@@ -7267,8 +7267,8 @@ public void test0608_do_while() {
 
 // null analysis -- do while
 public void test0609_do_while() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  boolean dummy;\n" +
@@ -7309,8 +7309,8 @@ public void test0610_do_while() {
 
 // null analysis - do while
 public void test0611_do_while() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"class X {\n" +
 			"  X bar() {\n" +
@@ -7386,8 +7386,8 @@ public void test0613_do_while() {
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=123399
 // variant
 public void _test0614_do_while() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo(Object doubt) {\n" +
@@ -7412,8 +7412,8 @@ public void _test0614_do_while() {
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=123399
 // variant
 public void _test0615_do_while() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo(Object doubt) {\n" +
@@ -7535,8 +7535,8 @@ public void test0619_do_while_infinite() {
 
 // null analysis -- for
 public void test0701_for() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo() {\n" +
@@ -7556,8 +7556,8 @@ public void test0701_for() {
 
 // null analysis -- for
 public void test0702_for() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo() {\n" +
@@ -7615,8 +7615,8 @@ public void test0704_for() {
 
 // null analysis -- for
 public void test0705_for() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  boolean bar() {\n" +
@@ -7655,8 +7655,8 @@ public void test0707_for() {
 
 // null analysis -- for
 public void test0708_for() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo(Object o) {\n" +
@@ -7675,8 +7675,8 @@ public void test0708_for() {
 
 // null analysis -- for
 public void test0709_for() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo(Object o) {\n" +
@@ -7694,8 +7694,8 @@ public void test0709_for() {
 
 // null analysis -- for
 public void test0710_for() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  boolean bar() {\n" +
@@ -7719,8 +7719,8 @@ public void test0710_for() {
 // null analysis -- for
 public void test0711_for() {
 	if (this.complianceLevel >= ClassFileConstants.JDK1_5) {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"  void foo() {\n" +
@@ -7742,8 +7742,8 @@ public void test0711_for() {
 // null analysis -- for
 public void test0712_for() {
 	if (this.complianceLevel >= ClassFileConstants.JDK1_5) {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"  void foo() {\n" +
@@ -7797,8 +7797,8 @@ public void test0714_for() {
 // null analysis -- for
 public void test0715_for() {
 	if (this.complianceLevel >= ClassFileConstants.JDK1_5) {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"  void foo() {\n" +
@@ -7824,8 +7824,8 @@ public void test0715_for() {
 // null analysis -- for
 public void test0716_for() {
 	if (this.complianceLevel >= ClassFileConstants.JDK1_5) {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"  void foo() {\n" +
@@ -7848,8 +7848,8 @@ public void test0716_for() {
 // null analysis -- for
 public void test0717_for() {
 	if (this.complianceLevel >= ClassFileConstants.JDK1_5) {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"  void foo(boolean dummy) {\n" +
@@ -7872,8 +7872,8 @@ public void test0717_for() {
 
 // null analysis -- for
 public void test0718_for() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo(boolean dummy) {\n" +
@@ -7920,8 +7920,8 @@ public void test0719_for() {
 
 // null analysis -- for
 public void test0720_for_continue_break() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			  "public class X {\n" +
 			  "  void foo() {\n" +
@@ -7965,8 +7965,8 @@ public void test0721_for() {
 
 // null analysis -- for
 public void test0722_for_return() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo (boolean b) {\n" +
@@ -8141,8 +8141,8 @@ public void test0729_for_try_catch_finally() {
 
 // null analysis - for
 public void test0730_for() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"class X {\n" +
 			"  void foo(Object o) {\n" +
@@ -8163,8 +8163,8 @@ public void test0730_for() {
 
 // null analysis - for
 public void test0731_for() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"class X {\n" +
 			"  X bar() {\n" +
@@ -8309,8 +8309,8 @@ public void test0736_for_embedded_lazy_init() {
 // null analysis - for with unknown protection: unknown cannot protect anything
 // suggested by https://bugs.eclipse.org/bugs/show_bug.cgi?id=127570
 public void test0737_for_unknown_protection() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"class X {\n" +
 			"  public boolean foo(Boolean p) {\n" +
@@ -8553,8 +8553,8 @@ public void test0746_for_try_catch() {
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=195638
 // variant: do not reset to null
 public void test0747_for_try_catch() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo() {\n" +
@@ -8603,8 +8603,8 @@ public void test0800_switch() {
 
 // null analysis -- switch
 public void test0801_switch() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			" int k;\n" +
@@ -8636,8 +8636,8 @@ public void test0801_switch() {
 
 // null analysis -- switch
 public void test0802_switch() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			" int k;\n" +
@@ -8661,8 +8661,8 @@ public void test0802_switch() {
 
 // null analysis -- switch
 public void test0803_switch() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			" int k;\n" +
@@ -8688,8 +8688,8 @@ public void test0803_switch() {
 
 // null analysis -- switch
 public void test0804_switch() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo (Object o, int info) {\n" +
@@ -8815,8 +8815,8 @@ public void _test0902_non_null_protection_tag() {
 
 // null analysis -- non null protection tag
 public void test0903_non_null_protection_tag() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo(Object o, boolean b) {\n" +
@@ -8883,8 +8883,8 @@ public void test0903_non_null_protection_tag() {
 
 // null analysis -- non null protection tag
 public void test0905_non_null_protection_tag() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo(Object o) {\n" +
@@ -8903,8 +8903,8 @@ public void test0905_non_null_protection_tag() {
 
 // null analysis -- non null protection tag
 public void test0906_non_null_protection_tag() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo(Object o) {\n" +
@@ -8943,8 +8943,8 @@ public void test0950_assert() {
 // [compiler] Null reference analysis doesn't understand assertions
 public void test0951_assert() {
 	if (this.complianceLevel >= ClassFileConstants.JDK1_4) {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"  void foo(Object o) {\n" +
@@ -8966,8 +8966,8 @@ public void test0951_assert() {
 // [compiler] Null reference analysis doesn't understand assertions
 public void test0952_assert() {
 	if (this.complianceLevel >= ClassFileConstants.JDK1_4) {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"  void foo(Object o, boolean b) {\n" +
@@ -8989,8 +8989,8 @@ public void test0952_assert() {
 // [compiler] Null reference analysis doesn't understand assertions
 public void test0953_assert_combined() {
 	if (this.complianceLevel >= ClassFileConstants.JDK1_4) {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"  void foo(Object o1, Object o2) {\n" +
@@ -9023,8 +9023,8 @@ public void test0953_assert_combined() {
 // [compiler] Null reference analysis doesn't understand assertions
 public void test0954_assert_fake_reachable() {
 	if (this.complianceLevel >= ClassFileConstants.JDK1_4) {
-		runConformTest(
-			true/*flush*/,
+		AbstractRegressionTest.runConformTest(
+			this, true/*flush*/,
 			new String[] {
 				"X.java",
 				"public class X {\n" +
@@ -9050,8 +9050,8 @@ public void test0954_assert_fake_reachable() {
 // [compiler] Null reference analysis doesn't understand assertions
 public void test0955_assert_combined() {
 	if (this.complianceLevel >= ClassFileConstants.JDK1_4) {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"  void foo(Object o) {\n" +
@@ -9078,8 +9078,8 @@ public void test0955_assert_combined() {
 // [compiler] Null reference analysis doesn't understand assertions
 public void test0956_assert_combined() {
 	if (this.complianceLevel >= ClassFileConstants.JDK1_4) {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"  void foo() {\n" +
@@ -9113,8 +9113,8 @@ public void test0956_assert_combined() {
 // but this doesn't affect the downstream info.
 public void test0957_assert() {
 	if (this.complianceLevel >= ClassFileConstants.JDK1_4) {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"  void m() {\n" +
@@ -9182,8 +9182,8 @@ public void test0957_assert() {
 // but this doesn't affect the downstream info.
 public void test0958_assert() {
 	if (this.complianceLevel >= ClassFileConstants.JDK1_5) {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"import java.util.HashMap;\n" +
 				"public class X {\n" +
@@ -9220,8 +9220,8 @@ public void test0958_assert() {
 // but this doesn't affect the downstream info.
 public void test0959a_assert_loop() {
 	if (this.complianceLevel >= ClassFileConstants.JDK1_4) {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"  void m() {\n" +
@@ -9291,8 +9291,8 @@ public void test0959a_assert_loop() {
 // but this doesn't affect the downstream info.
 public void test0959b_assert_loop() {
 	if (this.complianceLevel >= ClassFileConstants.JDK1_4) {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"  void m() {\n" +
@@ -9362,8 +9362,8 @@ public void test0959b_assert_loop() {
 // but this doesn't affect the downstream info.
 public void test0960_assert_finally() {
 	if (this.complianceLevel >= ClassFileConstants.JDK1_4) {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"  void m() {\n" +
@@ -9564,8 +9564,8 @@ public void _test0952_nullable_tag() {
 
 // moved from AssignmentTest
 public void test1004() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  X foo(X x) {\n" +
@@ -9672,8 +9672,8 @@ public void test1008() {
 }
 
 public void test1009() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"import java.io.File;\n" +
 			"\n" +
@@ -9735,8 +9735,8 @@ public void test1010() {
 }
 
 public void test1011() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"\n" +
@@ -9774,8 +9774,8 @@ public void test1011() {
 }
 
 public void test1012() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  \n" +
@@ -9804,8 +9804,8 @@ public void test1012() {
 // x cannot equal this then null with no assignment in between
 // each diagnostic is locally sound though
 public void test1013() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo(X x) {\n" +
@@ -9870,8 +9870,8 @@ public void test1015() {
 }
 
 public void test1016() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo(X x) {\n" +
@@ -9900,8 +9900,8 @@ public void test1016() {
 }
 
 public void test1017() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo(X x) {\n" +
@@ -9930,8 +9930,8 @@ public void test1017() {
 }
 
 public void test1018() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  \n" +
@@ -10052,8 +10052,8 @@ public void test1022() {
 }
 
 public void test1023() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"\n" +
@@ -10085,8 +10085,8 @@ public void test1023() {
 }
 
 public void test1024() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  \n" +
@@ -10119,8 +10119,8 @@ public void test1024() {
 }
 
 public void test1025() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  \n" +
@@ -10243,8 +10243,8 @@ public void test1029() {
 }
 
 public void test1030() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  \n" +
@@ -10275,8 +10275,8 @@ public void test1030() {
 }
 
 public void test1031() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  \n" +
@@ -10322,8 +10322,8 @@ public void test1031() {
 }
 
 public void test1032() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  void foo() {\n" +
@@ -10350,8 +10350,8 @@ public void test1032() {
 
 // (simplified to focus on nulls)
 public void test1033() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  \n" +
@@ -10427,8 +10427,8 @@ public void test1034() {
 }
 
 public void test1036() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"\n" +
@@ -10463,8 +10463,8 @@ public void test1036() {
 public void test1050_options_all_default() {
 	try {
 		setNullRelatedOptions = false;
-		runConformTest(
-			true, // flush
+		AbstractRegressionTest.runConformTest(
+			this, true, // flush
 			new String[] {
 				"X.java",
 				  "public class X {\n" +
@@ -10508,8 +10508,8 @@ public void test1051_options_all_ignore() {
 	customOptions.put(CompilerOptions.OPTION_ReportNullReference, CompilerOptions.IGNORE);
 	customOptions.put(CompilerOptions.OPTION_ReportPotentialNullReference, CompilerOptions.IGNORE);
     customOptions.put(CompilerOptions.OPTION_ReportRedundantNullCheck, CompilerOptions.IGNORE);
-	this.runConformTest(
-			new String[] {
+	AbstractRegressionTest.runConformTest(
+			this, new String[] {
 				"X.java",
 				  "public class X {\n" +
 				  "  void foo(Object p) {\n" +
@@ -10534,8 +10534,8 @@ public void test1051_options_all_ignore() {
 // adding distinct options to control null checks in more detail
 // all options set to error
 public void test1052_options_all_error() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			  "public class X {\n" +
 			  "  void foo(Object p) {\n" +
@@ -10581,8 +10581,8 @@ public void test1053_options_mix() {
 	customOptions.put(CompilerOptions.OPTION_ReportNullReference, CompilerOptions.ERROR);
 	customOptions.put(CompilerOptions.OPTION_ReportPotentialNullReference, CompilerOptions.IGNORE);
 	customOptions.put(CompilerOptions.OPTION_ReportRedundantNullCheck, CompilerOptions.IGNORE);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -10626,8 +10626,8 @@ public void test1054_options_mix() {
 	customOptions.put(CompilerOptions.OPTION_ReportNullReference, CompilerOptions.WARNING);
 	customOptions.put(CompilerOptions.OPTION_ReportPotentialNullReference, CompilerOptions.IGNORE);
 	customOptions.put(CompilerOptions.OPTION_ReportRedundantNullCheck, CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -10676,8 +10676,8 @@ public void test1055_options_mix() {
 	customOptions.put(CompilerOptions.OPTION_ReportNullReference, CompilerOptions.IGNORE);
 	customOptions.put(CompilerOptions.OPTION_ReportPotentialNullReference, CompilerOptions.ERROR);
 	customOptions.put(CompilerOptions.OPTION_ReportRedundantNullCheck, CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -10727,8 +10727,8 @@ public void test1056_options_mix_with_SuppressWarnings() {
 		customOptions.put(CompilerOptions.OPTION_ReportNullReference, CompilerOptions.ERROR);
 		customOptions.put(CompilerOptions.OPTION_ReportPotentialNullReference, CompilerOptions.WARNING);
 		customOptions.put(CompilerOptions.OPTION_ReportRedundantNullCheck, CompilerOptions.WARNING);
-		runNegativeTest(
-			// test directory preparation
+		AbstractRegressionTest.runNegativeTest(
+			this, // test directory preparation
 			true /* flush output directory */,
 			new String[] { /* test files */
 				"X.java",
@@ -10769,8 +10769,8 @@ public void test1056_options_mix_with_SuppressWarnings() {
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=170704
 // adding distinct options to control null checks in more detail
 public void test1057_options_instanceof_is_check() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			  "public class X {\n" +
 			  "  void foo(Object p) {\n" +
@@ -10793,8 +10793,8 @@ public void test1057_options_instanceof_is_check() {
 public void test1058_options_instanceof_is_check() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportRedundantNullCheck, CompilerOptions.IGNORE);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			  "public class X {\n" +
 			  "  void foo(Object p) {\n" +
@@ -10817,8 +10817,8 @@ public void test1058_options_instanceof_is_check() {
 public void test1059_options_cannot_be_null_check() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportRedundantNullCheck, CompilerOptions.IGNORE);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			  "public class X {\n" +
 			  "  void foo(Object p) {\n" +
@@ -10939,8 +10939,8 @@ public void test1503() {
 
 // flow info low-level validation
 public void test2000_flow_info() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"\n" +
@@ -11205,8 +11205,8 @@ public void test2008_flow_info() {
 
 // null analysis -- flow info
 public void test2009_flow_info() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  Object m0, m1, m2, m3, m4,\n" +
@@ -11246,8 +11246,8 @@ public void test2009_flow_info() {
 
 // null analysis -- flow info
 public void test2010_flow_info() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  Object m00, m01, m02, m03, m04,\n" +
@@ -11288,8 +11288,8 @@ public void test2010_flow_info() {
 
 // null analysis -- flow info
 public void test2011_flow_info() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  Object m000, m001, m002, m003, m004, m005, m006, m007, m008, m009,\n" +
@@ -11333,8 +11333,8 @@ public void test2011_flow_info() {
 
 // null analysis -- flow info
 public void test2012_flow_info() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  Object m000, m001, m002, m003, m004, m005, m006, m007, m008, m009,\n" +
@@ -11378,8 +11378,8 @@ public void test2012_flow_info() {
 
 // null analysis -- flow info
 public void test2013_flow_info() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  boolean dummy;\n" +
@@ -11844,8 +11844,8 @@ public void testBug291418b() {
 // Test that a redundant null check doesn't affect the null status of
 // a variable downstream.
 public void testBug293917a() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	public void foo(){\n" +
@@ -11874,8 +11874,8 @@ public void testBug293917a() {
 // Test that a redundant null check doesn't affect the null status of
 // a variable downstream in a loop.
 public void testBug293917b() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	public void foo(){\n" +
@@ -11901,8 +11901,8 @@ public void testBug293917b() {
 // Test that a redundant null check doesn't affect the null status of
 // a variable downstream in a finally block.
 public void testBug293917c() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	public void foo(){\n" +
@@ -11934,8 +11934,8 @@ public void testBug293917c() {
 // Test that a redundant null check doesn't affect the null status of
 // a variable downstream.
 public void testBug190623() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"    public static void main(String[] args) {\n" +
@@ -12254,8 +12254,8 @@ public void testBug303448a() throws Exception {
 	options.put(CompilerOptions.OPTION_ReportRedundantNullCheck, CompilerOptions.IGNORE);
 	options.put(CompilerOptions.OPTION_ReportRawTypeReference, CompilerOptions.IGNORE);
 	if (this.complianceLevel >= ClassFileConstants.JDK1_4) {
-		this.runConformTest(
-			new String[] {
+		AbstractRegressionTest.runConformTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"	public void foo() {\n" +
@@ -12478,8 +12478,8 @@ public void testBug303448b() throws Exception {
 	options.put(CompilerOptions.OPTION_ReportRedundantNullCheck, CompilerOptions.IGNORE);
 	options.put(CompilerOptions.OPTION_ReportRawTypeReference, CompilerOptions.IGNORE);
 	if (this.complianceLevel >= ClassFileConstants.JDK1_4) {
-		this.runConformTest(
-			new String[] {
+		AbstractRegressionTest.runConformTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"	public static void main(String[] args) {\n" +
@@ -12508,8 +12508,8 @@ public void testBug304416() throws Exception {
 	options.put(CompilerOptions.OPTION_ReportPotentialNullReference, CompilerOptions.WARNING);
 	options.put(CompilerOptions.OPTION_ReportRedundantNullCheck, CompilerOptions.WARNING);
 	options.put(CompilerOptions.OPTION_PreserveUnusedLocal, CompilerOptions.OPTIMIZE_OUT);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	public static void main(String[] args) {\n" +
@@ -12545,15 +12545,15 @@ public void testBug304416() throws Exception {
 		"    22  aload_2 [s2]\n" +
 		"    23  invokevirtual java.io.PrintStream.println(java.lang.String) : void [22]\n" +
 		"    26  return\n";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 }
 
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=305590
 // To verify that a "instanceof always yields false" warning is not elicited in the
 // case when the expression has been assigned a non null value in the instanceof check.
 public void testBug305590() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  public void foo() {\n" +
@@ -12579,8 +12579,8 @@ public void testBug305590() {
 public void testBug319201() {
 	if (this.complianceLevel < ClassFileConstants.JDK1_5)
 		return;
-	runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"  public void foo() {\n" +
@@ -12602,8 +12602,8 @@ public void testBug319201() {
 public void testBug319201a() {
 	if (this.complianceLevel < ClassFileConstants.JDK1_5)
 		return;
-	runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"  public void foo(Integer i) {\n" +
@@ -12626,8 +12626,8 @@ public void testBug319201a() {
 public void testBug319201b() {
 	if (this.complianceLevel < ClassFileConstants.JDK1_5)
 		return;
-	runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"  public void foo() {\n" +
@@ -12664,8 +12664,8 @@ public void testBug319201b() {
 public void testBug319201c() {
 	if (this.complianceLevel < ClassFileConstants.JDK1_5)
 		return;
-	runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
               "X.java",
               "class Y { public Y(boolean b1, boolean b2) {} }\n" +
               "public class X extends Y {\n" +
@@ -12795,8 +12795,8 @@ public void testBug319201d() {
 		return;
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnnecessaryElse, CompilerOptions.IGNORE);
-	runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
               "X.java",
               "public class X {\n" +
               "  public void foo(boolean cond, boolean cond2) {\n" +
@@ -12871,8 +12871,8 @@ public void testBug320414() throws Exception {
 	options.put(CompilerOptions.OPTION_ReportPotentialNullReference, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportRedundantNullCheck, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_PreserveUnusedLocal, CompilerOptions.OPTIMIZE_OUT);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	static class B {\n" +
@@ -12915,7 +12915,7 @@ public void testBug320414() throws Exception {
 		"    20  iload_2 [i]\n" +
 		"    21  invokevirtual java.io.PrintStream.println(int) : void [38]\n" +
 		"    24  return\n";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=321926
 // To verify that a "redundant null check" warning is NOT elicited for a variable assigned non-null
@@ -13359,8 +13359,8 @@ public void testBug321926l() {
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_REDUNDANT_NULL_CHECK, JavaCore.WARNING);
 
-	this.runTest(
-		new String[] {
+	AbstractRegressionTest.runTest(
+		this, new String[] {
 			"X.java",
 			"import java.io.IOException;\n" +
 			"public class X {\n" +
@@ -13556,8 +13556,8 @@ public void testBug321926p() {
 public void testBug321926q() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportRedundantNullCheck, CompilerOptions.WARNING);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"import java.io.IOException;\n" +
 			"public class X {\n" +
@@ -13589,8 +13589,8 @@ public void testBug321926q() {
 public void testBug321926r() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportRedundantNullCheck, CompilerOptions.IGNORE);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"import java.io.IOException;\n" +
 			"public class X {\n" +
@@ -13622,8 +13622,8 @@ public void testBug321926r() {
 public void testBug321926s() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportRedundantNullCheck, CompilerOptions.IGNORE);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"import java.io.IOException;\n" +
 			"public class X {\n" +
@@ -14003,8 +14003,8 @@ public void testBug317829f() {
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=292478 -  Report potentially null across variable assignment
 // LocalDeclaration
 public void testBug292478() {
-    this.runNegativeTest(
-            new String[] {
+    AbstractRegressionTest.runNegativeTest(
+            this, new String[] {
                 "X.java",
                 "public class X {\n" +
                 "  void foo(Object o) {\n" +
@@ -14025,8 +14025,8 @@ public void testBug292478() {
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=292478 -  Report potentially null across variable assignment
 // Assignment
 public void testBug292478a() {
-  this.runNegativeTest(
-          new String[] {
+  AbstractRegressionTest.runNegativeTest(
+          this, new String[] {
               "X.java",
               "public class X {\n" +
               "  void foo(Object o) {\n" +
@@ -14048,8 +14048,8 @@ public void testBug292478a() {
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=292478 -  Report potentially null across variable assignment
 // Assignment after definite null
 public void testBug292478b() {
-this.runNegativeTest(
-        new String[] {
+AbstractRegressionTest.runNegativeTest(
+        this, new String[] {
             "X.java",
             "public class X {\n" +
             "  void foo(Object o) {\n" +
@@ -14071,8 +14071,8 @@ this.runNegativeTest(
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=292478 -  Report potentially null across variable assignment
 // Assignment after definite null - many locals
 public void testBug292478c() {
-this.runNegativeTest(
-      new String[] {
+AbstractRegressionTest.runNegativeTest(
+      this, new String[] {
           "X.java",
           "public class X {\n" +
           "  void foo(Object o) {\n" +
@@ -14266,8 +14266,8 @@ public void testBug325229a() {
 	if (this.complianceLevel >= ClassFileConstants.JDK1_5) {
 		Map compilerOptions = getCompilerOptions();
 		compilerOptions.put(CompilerOptions.OPTION_ReportRedundantNullCheck, CompilerOptions.WARNING);
-		this.runConformTest(
-			new String[] {
+		AbstractRegressionTest.runConformTest(
+			this, new String[] {
 				"Test.java",
 				"public class Test {\n" +
 				"	void foo(Object a) {\n" +
@@ -14298,8 +14298,8 @@ public void testBug325229b() {
 	if (this.complianceLevel >= ClassFileConstants.JDK1_5) {
 		Map compilerOptions = getCompilerOptions();
 		compilerOptions.put(CompilerOptions.OPTION_ReportRedundantNullCheck, CompilerOptions.WARNING);
-		this.runConformTest(
-			new String[] {
+		AbstractRegressionTest.runConformTest(
+			this, new String[] {
 				"Test.java",
 				"public class Test {\n" +
 				"	boolean bar() {\n" +
@@ -14333,8 +14333,8 @@ public void testBug325229c() {
 	if (this.complianceLevel >= ClassFileConstants.JDK1_5) {
 		Map compilerOptions = getCompilerOptions();
 		compilerOptions.put(CompilerOptions.OPTION_ReportRedundantNullCheck, CompilerOptions.WARNING);
-		this.runConformTest(
-			new String[] {
+		AbstractRegressionTest.runConformTest(
+			this, new String[] {
 				"Test.java",
 				"public class Test {\n" +
 				"	boolean bar() {\n" +
@@ -14369,8 +14369,8 @@ public void testBug325229d() {
 	if (this.complianceLevel >= ClassFileConstants.JDK1_5) {
 		Map compilerOptions = getCompilerOptions();
 		compilerOptions.put(CompilerOptions.OPTION_ReportRedundantNullCheck, CompilerOptions.WARNING);
-		this.runConformTest(
-			new String[] {
+		AbstractRegressionTest.runConformTest(
+			this, new String[] {
 				"Test.java",
 				"public class Test {\n" +
 				"	void foo(Object a) {\n" +
@@ -14410,8 +14410,8 @@ public void testBug325342a() {
 	if (this.complianceLevel >= ClassFileConstants.JDK1_5) {
 		Map compilerOptions = getCompilerOptions();
 		compilerOptions.put(CompilerOptions.OPTION_IncludeNullInfoFromAsserts, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"Test.java",
 				"public class Test {\n" +
 				"	void foo(Object a, Object b, Object c) {\n" +
@@ -14462,8 +14462,8 @@ public void testBug325342b() {
 	if (this.complianceLevel >= ClassFileConstants.JDK1_5) {
 		Map compilerOptions = getCompilerOptions();
 		compilerOptions.put(CompilerOptions.OPTION_IncludeNullInfoFromAsserts, CompilerOptions.ENABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"Test.java",
 				"public class Test {\n" +
 				"	void foo(Object a, Object b, Object c) {\n" +
@@ -15038,8 +15038,8 @@ public void testBug332838() {
 	if (this.complianceLevel >= ClassFileConstants.JDK1_5) {
 		Map compilerOptions = getCompilerOptions();
 		compilerOptions.put(CompilerOptions.OPTION_IncludeNullInfoFromAsserts, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"Info.java",
 				"public class Info {\n" +
 				"	public void test(Info[] infos) {\n" +
@@ -15328,8 +15328,8 @@ public void testBug326950a() throws Exception {
 	options.put(CompilerOptions.OPTION_ReportNullReference, CompilerOptions.WARNING);
 	options.put(CompilerOptions.OPTION_ReportPotentialNullReference, CompilerOptions.WARNING);
 	options.put(CompilerOptions.OPTION_ReportRedundantNullCheck, CompilerOptions.WARNING);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	public static void main(String[] args) {\n" +
@@ -15362,7 +15362,7 @@ public void testBug326950a() throws Exception {
 		"    20  ldc <String \"Dead code, but don\'t optimize me out\"> [30]\n" +
 		"    22  invokevirtual java.io.PrintStream.println(java.lang.String) : void [24]\n" +
 		"    25  return\n";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=326950
 // Code marked dead due to if(false), etc. can be optimized out
@@ -15371,8 +15371,8 @@ public void testBug326950b() throws Exception {
 	options.put(CompilerOptions.OPTION_ReportNullReference, CompilerOptions.WARNING);
 	options.put(CompilerOptions.OPTION_ReportPotentialNullReference, CompilerOptions.WARNING);
 	options.put(CompilerOptions.OPTION_ReportRedundantNullCheck, CompilerOptions.WARNING);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	public static void main(String[] args) {\n" +
@@ -15400,7 +15400,7 @@ public void testBug326950b() throws Exception {
 		"    1  istore_1 [i]\n" +
 		"    2  iinc 1 1 [i]\n" +
 		"    5  return\n";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=326950
 // Free return should be generated for a method even if it ends with dead code
@@ -15409,8 +15409,8 @@ public void testBug326950c() throws Exception {
 	options.put(CompilerOptions.OPTION_ReportNullReference, CompilerOptions.WARNING);
 	options.put(CompilerOptions.OPTION_ReportPotentialNullReference, CompilerOptions.WARNING);
 	options.put(CompilerOptions.OPTION_ReportRedundantNullCheck, CompilerOptions.WARNING);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	public void foo(String[] args) {\n" +
@@ -15440,7 +15440,7 @@ public void testBug326950c() throws Exception {
 		"     9  return\n" +
 		"    10  iinc 3 1 [i]\n" +
 		"    13  return\n";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=326950
 // Free return should be generated for a constructor even if it ends with dead code
@@ -15449,8 +15449,8 @@ public void testBug326950d() throws Exception {
 	options.put(CompilerOptions.OPTION_ReportNullReference, CompilerOptions.WARNING);
 	options.put(CompilerOptions.OPTION_ReportPotentialNullReference, CompilerOptions.WARNING);
 	options.put(CompilerOptions.OPTION_ReportRedundantNullCheck, CompilerOptions.WARNING);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	X() {\n" +
@@ -15482,15 +15482,15 @@ public void testBug326950d() throws Exception {
 		"    13  return\n" +
 		"    14  iinc 2 1 [i]\n" +
 		"    17  return\n";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=339250
 // Check code gen
 public void testBug339250() throws Exception {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportRedundantNullCheck, CompilerOptions.WARNING);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	public static void main(String[] args) {\n" +
@@ -15889,8 +15889,8 @@ public void testBug256796() {
 	compilerOptions.put(CompilerOptions.OPTION_ReportUnnecessaryElse, CompilerOptions.IGNORE);
 	compilerOptions.put(CompilerOptions.OPTION_ReportDeadCode, CompilerOptions.WARNING);
 	compilerOptions.put(CompilerOptions.OPTION_ReportDeadCodeInTrivialIfStatement, CompilerOptions.DISABLED);
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"Bug.java",
 				"public class Bug {\n" +
 				"	private static final boolean TRUE = true;\n" +
@@ -15939,8 +15939,8 @@ public void testBug256796a() {
 	compilerOptions.put(CompilerOptions.OPTION_ReportUnnecessaryElse, CompilerOptions.IGNORE);
 	compilerOptions.put(CompilerOptions.OPTION_ReportDeadCode, CompilerOptions.WARNING);
 	compilerOptions.put(CompilerOptions.OPTION_ReportDeadCodeInTrivialIfStatement, CompilerOptions.ENABLED);
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"Bug.java",
 				"public class Bug {\n" +
 				"	private static final boolean TRUE = true;\n" +
@@ -16038,8 +16038,8 @@ public void testBug360328() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportNullReference, CompilerOptions.ERROR);
 	customOptions.put(CompilerOptions.OPTION_ReportRedundantNullCheck, CompilerOptions.ERROR);
-	runNegativeTest(
-		true, /* flushOutputDir */
+	AbstractRegressionTest.runNegativeTest(
+		this, true, /* flushOutputDir */
 		new String[] {
 			"X.java",
 			"public class X {\n" +
@@ -16102,8 +16102,8 @@ public void testBug360328b() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportNullReference, CompilerOptions.ERROR);
 	customOptions.put(CompilerOptions.OPTION_ReportRedundantNullCheck, CompilerOptions.ERROR);
-	runNegativeTest(
-		true, /* flushOutputDir */
+	AbstractRegressionTest.runNegativeTest(
+		this, true, /* flushOutputDir */
 		new String[] {
 			"X.java",
 			"public class X {\n" +
@@ -16173,8 +16173,8 @@ public void testBug360328c() {
 	customOptions.put(CompilerOptions.OPTION_ReportNullReference, CompilerOptions.ERROR);
 	customOptions.put(CompilerOptions.OPTION_ReportRedundantNullCheck, CompilerOptions.ERROR);
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.IGNORE);
-	runNegativeTest(
-		true, /* flushOutputDir */
+	AbstractRegressionTest.runNegativeTest(
+		this, true, /* flushOutputDir */
 		new String[] {
 			"X.java",
 			"public class X {\n" +
@@ -16243,8 +16243,8 @@ public void testBug360328d() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportNullReference, CompilerOptions.ERROR);
 	customOptions.put(CompilerOptions.OPTION_ReportRedundantNullCheck, CompilerOptions.ERROR);
-	runNegativeTest(
-		true, /* flushOutputDir */
+	AbstractRegressionTest.runNegativeTest(
+		this, true, /* flushOutputDir */
 		new String[] {
 			"X.java",
 			"public class X {\n" +
@@ -16422,8 +16422,8 @@ public void testBug384380_b() {
 public void testBug376263() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(JavaCore.COMPILER_PB_POTENTIAL_NULL_REFERENCE, JavaCore.ERROR);
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"Test.java",
 			"public class Test {\n" +
 			"    private int x;\n" +
@@ -17477,8 +17477,8 @@ public void testBug435528_orig() {
 	runner.runNegativeTest();
 }
 public void testBug435528_notaconstant() {
-	runConformTest(
-		true/*flush*/,
+	AbstractRegressionTest.runConformTest(
+		this, true/*flush*/,
 		new String[] {
 			"Test.java",
 			"public class Test\n" +
@@ -18289,7 +18289,7 @@ public void testBug536408() {
 	runner.runNegativeTest();
 }
 public void testBug542707_1() {
-	if (!checkPreviewAllowed()) return; // switch expression
+	if (!AbstractRegressionTest.checkPreviewAllowed(this)) return; // switch expression
 	Runner runner = new Runner();
 	runner.customOptions = new HashMap<>();
 	runner.customOptions.put(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, JavaCore.ENABLED);

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullTypeAnnotationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullTypeAnnotationTest.java
@@ -90,8 +90,8 @@ public class NullTypeAnnotationTest extends AbstractNullAnnotationTest {
 		Map customOptions = getCompilerOptions();
 		customOptions.put(JavaCore.COMPILER_NULLABLE_ANNOTATION_NAME, "org.foo.Nullable");
 		customOptions.put(JavaCore.COMPILER_NONNULL_ANNOTATION_NAME, "org.foo.NonNull");
-		runNegativeTest(
-			false /* skipJavac */,
+		AbstractRegressionTest.runNegativeTest(
+			this, false /* skipJavac */,
 			JavacTestOptions.Excuse.EclipseWarningConfiguredAsError,
 			new String[] {
 				CUSTOM_NULLABLE_NAME,
@@ -405,8 +405,8 @@ public class NullTypeAnnotationTest extends AbstractNullAnnotationTest {
 	}
 
 	public void testMissingAnnotationTypes_01() {
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"	public class U {}\n" +
@@ -900,8 +900,8 @@ public class NullTypeAnnotationTest extends AbstractNullAnnotationTest {
 
 	// https://bugs.eclipse.org/403457 - [1.8][compiler] NPE in WildcardBinding.signature
 	public void testBug403457_1() {
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"import java.lang.annotation.ElementType;\n" +
 				"import java.lang.annotation.Target;\n" +
@@ -935,8 +935,8 @@ public class NullTypeAnnotationTest extends AbstractNullAnnotationTest {
 	// https://bugs.eclipse.org/403457 - [1.8][compiler] NPE in WildcardBinding.signature
 	// variant with null annotations
 	public void testBug403457_2() {
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"// import java.util.Map;\n" +
 				"import org.eclipse.jdt.annotation.*;\n" +
@@ -2270,8 +2270,8 @@ public class NullTypeAnnotationTest extends AbstractNullAnnotationTest {
 
 	// illegal / unchecked for cast & instanceof with complex type
 	public void testUnsupportedLocation04() {
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"p/X.java",
 				"package p;\n" +
 				"import org.eclipse.jdt.annotation.*;\n" +
@@ -2810,8 +2810,8 @@ public class NullTypeAnnotationTest extends AbstractNullAnnotationTest {
 
 	// missing return type should not cause NPE
 	public void testBug415850_01() {
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"import org.eclipse.jdt.annotation.*;\n" +
 				"public class X {\n" +
@@ -2906,8 +2906,8 @@ public class NullTypeAnnotationTest extends AbstractNullAnnotationTest {
 
 	// don't let type annotations on array dimensions spoil type compatibility
 	public void testBug415850_05() {
-		runNegativeTest(
-			new String[]{
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[]{
 				"X.java",
 				"import java.lang.annotation.Target;\n" +
 				"import static java.lang.annotation.ElementType.*;\n" +
@@ -3216,8 +3216,8 @@ public class NullTypeAnnotationTest extends AbstractNullAnnotationTest {
 
 	// variant to challenge duplicate methods, though with different parameter annotations
 	public void testBug416176b() {
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"import org.eclipse.jdt.annotation.NonNull;\n" +
 				"import org.eclipse.jdt.annotation.Nullable;\n" +
@@ -4255,8 +4255,8 @@ public class NullTypeAnnotationTest extends AbstractNullAnnotationTest {
 	}
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=422134, [1.8] NPE in NullAnnotationMatching with inlined lambda expression used with a raw type
 	public void test422134() {
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"import java.util.ArrayList;\n" +
 				"import java.util.Collections;\n" +
@@ -4341,8 +4341,8 @@ public class NullTypeAnnotationTest extends AbstractNullAnnotationTest {
 	}
 
 public void testBug424637() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"import java.io.IOException;\n" +
 			"import java.nio.file.Files;\n" +
@@ -4730,8 +4730,8 @@ public void testTypeBounds4() {
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=429387, [1.8][compiler] AIOOBE in AbstractMethodDeclaration.createArgumentBindings
 public void test429387() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"import java.util.function.BiFunction;\n" +
 			"import java.util.function.Supplier;\n" +
@@ -4796,8 +4796,8 @@ public void testBug429403() {
 		"----------\n");
 }
 public void testBug430219() {
-    runNegativeTest(
-        new String[] {
+    AbstractRegressionTest.runNegativeTest(
+        this, new String[] {
             "X.java",
             "import org.eclipse.jdt.annotation.NonNullByDefault;\n" +
             "@NonNullByDefault\n" +
@@ -5505,8 +5505,8 @@ public void testDefault07_bin() {
 		"----------\n");
 }
 public void testBug431269() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"p/QField.java",
 			"package p;\n" +
 			"\n" +
@@ -7138,8 +7138,8 @@ public void testBug434582a() {
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=443467, [1.8][null]InternalError: Unexpected binding type
 public void test443467() throws Exception {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"BuildIdeMain.java",
 			"import java.nio.file.Path;\n" +
 			"import java.time.Instant;\n" +
@@ -7960,9 +7960,9 @@ public void testBug454182() {
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_NONNULL_BY_DEFAULT_ANNOTATION_NAME, "annot.NonNullByDefault");
 	String[] libs = this.LIBS.clone();
-	libs[libs.length-1] = this.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "Test454182.jar";
-	runConformTest(
-		new String[] {
+	libs[libs.length-1] = AbstractRegressionTest.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "Test454182.jar";
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"p/package-info.java",
 			"@annot.NonNullByDefault package p;\n"
 		},
@@ -7997,8 +7997,8 @@ public void testBug443870() {
 		"");
 }
 public void testBug437072() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"import org.eclipse.jdt.annotation.*;\n" +
 			"import java.util.List;\n" +
@@ -8479,8 +8479,8 @@ public void testBug466713c() {
 }
 // variant for https://bugs.eclipse.org/bugs/show_bug.cgi?id=466713#c5
 public void testBug466713d() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"MyAnnot.java",
 			"import java.lang.annotation.*;\n" +
 			"@Retention(RetentionPolicy.CLASS)\n" +
@@ -9571,8 +9571,8 @@ public void testMultipleAnnotations1() {
 	Map options1 = new HashMap<>(getCompilerOptions());
 	options1.put(JavaCore.COMPILER_NONNULL_ANNOTATION_NAME, "org.foo.NonNull");
 	options1.put(JavaCore.COMPILER_NULLABLE_ANNOTATION_NAME, "org.foo.Nullable");
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"org/foo/Nullable.java",
 			"package org.foo;\n" +
 			"import java.lang.annotation.*;\n" +
@@ -12585,8 +12585,8 @@ public void testBug489674() {
 	Map options = new HashMap<>(getCompilerOptions());
 	options.put(JavaCore.COMPILER_NONNULL_ANNOTATION_SECONDARY_NAMES, "org.foo.NonNull");
 	options.put(JavaCore.COMPILER_NULLABLE_ANNOTATION_SECONDARY_NAMES, "org.foo.Nullable");
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"org/foo/Nullable.java",
 			"package org.foo;\n" +
 			"import java.lang.annotation.*;\n" +
@@ -12801,8 +12801,8 @@ public void testBug496591() {
 	);
 }
 public void testBug497698() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"test/And.java",
 			"package test;\n" +
 			"\n" +
@@ -12839,8 +12839,8 @@ public void testBug497698() {
 	);
 }
 public void testBug497698raw() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"test/And.java",
 			"package test;\n" +
 			"\n" +
@@ -12883,8 +12883,8 @@ public void testBug497698raw() {
 	);
 }
 public void testBug497698nestedinraw() {
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"test/And.java",
 			"package test;\n" +
 			"\n" +
@@ -13379,8 +13379,8 @@ public void testBug501449() {
 	);
 }
 public void testBug502112() {
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"org/foo/Nullable.java",
 			"package org.foo;\n" +
 			"import java.lang.annotation.*;\n" +
@@ -13449,8 +13449,8 @@ public void testBug502112() {
 );
 }
 public void testBug502112b() {
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 		"org/foo/NonNull.java",
 		"package org.foo;\n" +
 		"import java.lang.annotation.*;\n" +
@@ -17984,8 +17984,8 @@ public void testBug536555() {
 	runner.runWarningTest();
 }
 public void testBug540264() {
-	runNegativeTest(
-		true,
+	AbstractRegressionTest.runNegativeTest(
+		this, true,
 		new String[] {
 			"example/Example.java",
 			"package example;\n" +
@@ -18020,7 +18020,7 @@ public void testBug540264() {
 	);
 }
 public void testBug542707_1() {
-	if (!checkPreviewAllowed()) return; // switch expression
+	if (!AbstractRegressionTest.checkPreviewAllowed(this)) return; // switch expression
 	// switch expression has a functional type with interesting type inference and various null issues:
 	Runner runner = new Runner();
 	runner.customOptions = getCompilerOptions();

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/OverloadResolutionTest8.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/OverloadResolutionTest8.java
@@ -770,8 +770,8 @@ public void test026() {
 			"----------\n");
 }
 public void test027() { // javac bug: 8b115 complains of ambiguity here.
-	this.runConformTest(
-			false /* skipJavac */,
+	AbstractRegressionTest.runConformTest(
+			this, false /* skipJavac */,
 			JavacTestOptions.Excuse.JavacDoesNotCompileCorrectSource,
 			new String[] {
 				"X.java",
@@ -1329,8 +1329,8 @@ public void test4008712h() {
 			"----------\n");
 }
 public void test4008712i() { // javac bug: 8b115 complains of ambiguity here.
-	this.runConformTest(
-			false /* skipJavac */,
+	AbstractRegressionTest.runConformTest(
+			this, false /* skipJavac */,
 			JavacTestOptions.Excuse.JavacDoesNotCompileCorrectSource,
 			new String[] {
 				"X.java",

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PatternMatching16Test.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PatternMatching16Test.java
@@ -54,7 +54,7 @@ public class PatternMatching16Test extends AbstractRegressionTest {
 	protected void runConformTest(String[] testFiles, String expectedOutput, Map<String, String> customOptions) {
 		if(!isJRE16Plus)
 			return;
-		runConformTest(testFiles, expectedOutput, customOptions, new String[] {"--enable-preview"}, JAVAC_OPTIONS);
+		AbstractRegressionTest.runConformTest(this, testFiles, expectedOutput, customOptions, new String[] {"--enable-preview"}, JAVAC_OPTIONS);
 	}
 	protected void runNegativeTest(
 			String[] testFiles,
@@ -76,8 +76,8 @@ public class PatternMatching16Test extends AbstractRegressionTest {
 		options.put(CompilerOptions.OPTION_Compliance, CompilerOptions.VERSION_15);
 		options.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_15);
 		options.put(CompilerOptions.OPTION_TargetPlatform, CompilerOptions.VERSION_15);
-		runNegativeTest(
-				new String[] {
+		AbstractRegressionTest.runNegativeTest(
+				this, new String[] {
 						"X1.java",
 						"public class X1 {\n" +
 						"  public void foo(Object obj) {\n" +
@@ -106,8 +106,8 @@ public class PatternMatching16Test extends AbstractRegressionTest {
 		options.put(CompilerOptions.OPTION_Compliance, CompilerOptions.VERSION_14);
 		options.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_14);
 		options.put(CompilerOptions.OPTION_TargetPlatform, CompilerOptions.VERSION_14);
-		runNegativeTest(
-				new String[] {
+		AbstractRegressionTest.runNegativeTest(
+				this, new String[] {
 						"X1.java",
 						"public class X1 {\n" +
 						"  public void foo(Object obj) {\n" +
@@ -1139,8 +1139,8 @@ public class PatternMatching16Test extends AbstractRegressionTest {
 	}
 	public void test022a() {
 		Map<String, String> options = getCompilerOptions(true);
-		runNegativeTest(
-				new String[] {
+		AbstractRegressionTest.runNegativeTest(
+				this, new String[] {
 						"X22a.java",
 						"@SuppressWarnings(\"preview\")\n" +
 						"public class X22a {\n" +
@@ -1177,8 +1177,8 @@ public class PatternMatching16Test extends AbstractRegressionTest {
 	}
 	public void test022b() {
 		Map<String, String> options = getCompilerOptions(true);
-		runNegativeTest(
-				new String[] {
+		AbstractRegressionTest.runNegativeTest(
+				this, new String[] {
 						"X22b.java",
 						"@SuppressWarnings(\"preview\")\n" +
 						"public class X22b {\n" +
@@ -3217,8 +3217,8 @@ public class PatternMatching16Test extends AbstractRegressionTest {
 	}
 	public void test069() {
 		Map<String, String> compilerOptions = getCompilerOptions(true);
-		runNegativeTest(
-				new String[] {
+		AbstractRegressionTest.runNegativeTest(
+				this, new String[] {
 						"X.java",
 						"@SuppressWarnings(\"preview\")\n"+
 						"class XPlus extends X {}\n"
@@ -3267,8 +3267,8 @@ public class PatternMatching16Test extends AbstractRegressionTest {
 	// Javac rejects the code on the IF itself (same as above)
 	public void test071() {
 		Map<String, String> compilerOptions = getCompilerOptions(true);
-		runNegativeTest(
-				new String[] {
+		AbstractRegressionTest.runNegativeTest(
+				this, new String[] {
 						"X.java",
 						"@SuppressWarnings(\"preview\")\n"+
 								"public class X {\n"
@@ -3295,8 +3295,8 @@ public class PatternMatching16Test extends AbstractRegressionTest {
 	// Javac rejects the code on the IF itself (same as above)
 	public void test072() {
 		Map<String, String> compilerOptions = getCompilerOptions(true);
-		runNegativeTest(
-				new String[] {
+		AbstractRegressionTest.runNegativeTest(
+				this, new String[] {
 						"X.java",
 						"@SuppressWarnings(\"preview\")\n"+
 								"public class X {\n"
@@ -3350,8 +3350,8 @@ public class PatternMatching16Test extends AbstractRegressionTest {
 	}
 	public void test074() {
 		Map<String, String> compilerOptions = getCompilerOptions(true);
-		runNegativeTest(
-				new String[] {
+		AbstractRegressionTest.runNegativeTest(
+				this, new String[] {
 						"X.java",
 						"@SuppressWarnings(\"preview\")\n"+
 								"public class X {\n"
@@ -3396,8 +3396,8 @@ public class PatternMatching16Test extends AbstractRegressionTest {
 	}
 	public void test076() {
 		Map<String, String> compilerOptions = getCompilerOptions(true);
-		runNegativeTest(
-				new String[] {
+		AbstractRegressionTest.runNegativeTest(
+				this, new String[] {
 						"X.java",
 						"@SuppressWarnings(\"preview\")\n"
 						+ "public class X {\n"
@@ -3445,8 +3445,8 @@ public class PatternMatching16Test extends AbstractRegressionTest {
 	// Test that a final pattern variable cannot be assigned again
 	public void test078() {
 		Map<String, String> compilerOptions = getCompilerOptions(true);
-		runNegativeTest(
-				new String[] {
+		AbstractRegressionTest.runNegativeTest(
+				this, new String[] {
 						"X.java",
 								"public class X {\n"
 								+ "    static void foo(Object o) {\n"
@@ -3471,8 +3471,8 @@ public class PatternMatching16Test extends AbstractRegressionTest {
 	}
 	public void test079() {
 		Map<String, String> compilerOptions = getCompilerOptions(true);
-		runNegativeTest(
-				new String[] {
+		AbstractRegressionTest.runNegativeTest(
+				this, new String[] {
 						"X.java",
 								"public class X {\n"
 								+ "    static void foo(Object o) {\n"
@@ -3517,8 +3517,8 @@ public class PatternMatching16Test extends AbstractRegressionTest {
 	}
 	public void test081() {
 		Map<String, String> compilerOptions = getCompilerOptions(true);
-		runNegativeTest(
-				new String[] {
+		AbstractRegressionTest.runNegativeTest(
+				this, new String[] {
 						"X.java",
 								"public class X<T> {\n"
 								+ "	public void foo(T o) {\n"
@@ -3600,8 +3600,8 @@ public class PatternMatching16Test extends AbstractRegressionTest {
 	}
 	public void testBug570831a() {
 		Map<String, String> compilerOptions = getCompilerOptions(true);
-		runNegativeTest(
-				new String[] {
+		AbstractRegressionTest.runNegativeTest(
+				this, new String[] {
 						"X.java",
 							"public class X {\n"
 							+ "	public static void run() {\n"
@@ -3631,8 +3631,8 @@ public class PatternMatching16Test extends AbstractRegressionTest {
 	}
 	public void testBug570831b() {
 		Map<String, String> compilerOptions = getCompilerOptions(true);
-		runNegativeTest(
-				new String[] {
+		AbstractRegressionTest.runNegativeTest(
+				this, new String[] {
 						"X.java",
 							"public class X {\n"
 							+ "	public static void run() {\n"
@@ -3867,8 +3867,8 @@ public class PatternMatching16Test extends AbstractRegressionTest {
 		if (this.complianceLevel < ClassFileConstants.JDK17)
 			return;
 		Map<String, String> compilerOptions = getCompilerOptions(true);
-		runNegativeTest(
-				new String[] {
+		AbstractRegressionTest.runNegativeTest(
+				this, new String[] {
 						"X.java",
 							"public class X {\n"
 							+ "	public void foo(Object o) {\n"
@@ -3985,7 +3985,7 @@ public class PatternMatching16Test extends AbstractRegressionTest {
     			"   #54 Test$Type,\n" +
     			"   #57 Test$Var\n" +
     			"}";
-    	checkClassFile("Test", source, expectedOutput, ClassFileBytesDisassembler.DETAILED | ClassFileBytesDisassembler.COMPACT);
+    	AbstractRegressionTest.checkClassFile(this, "Test", source, expectedOutput, ClassFileBytesDisassembler.DETAILED | ClassFileBytesDisassembler.COMPACT);
         runConformTest(
                 new String[] {
                         "Test.java",
@@ -3998,8 +3998,8 @@ public class PatternMatching16Test extends AbstractRegressionTest {
 	public void testBug578628_1() {
 		if (this.complianceLevel < ClassFileConstants.JDK18)
 			return;
-		runNegativeTest(
-				new String[] {
+		AbstractRegressionTest.runNegativeTest(
+				this, new String[] {
 						"X.java",
 							"public class X {\n"
 							+ "    public static Object str = \"a\";\n"
@@ -4194,8 +4194,8 @@ public class PatternMatching16Test extends AbstractRegressionTest {
 		if (this.complianceLevel < ClassFileConstants.JDK21)
 			return;
 
-		runNegativeTest(
-				new String[] {
+		AbstractRegressionTest.runNegativeTest(
+				this, new String[] {
 						"X.java",
 						"""
 						public class X {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PreviewFeatureTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PreviewFeatureTest.java
@@ -109,8 +109,8 @@ public class PreviewFeatureTest extends AbstractRegressionTest9 {
 		String old = options.get(CompilerOptions.OPTION_EnablePreviews);
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
 		try {
-			runNegativeTest(
-					new String[] {
+			AbstractRegressionTest.runNegativeTest(
+					this, new String[] {
 							"X.java",
 							"import p.*;\n"+
 							"public class X {\n"+
@@ -151,8 +151,8 @@ public class PreviewFeatureTest extends AbstractRegressionTest9 {
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
 		String[] classLibs = getClasspathWithPreviewAPI();
 		try {
-			runNegativeTest(
-					new String[] {
+			AbstractRegressionTest.runNegativeTest(
+					this, new String[] {
 							"X.java",
 							"import p.*;\n"+
 							"@SuppressWarnings(\"preview\")\n"+
@@ -188,8 +188,8 @@ public class PreviewFeatureTest extends AbstractRegressionTest9 {
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.ENABLED);
 		String[] classLibs = getClasspathWithPreviewAPI();
 		try {
-			runNegativeTest(
-					new String[] {
+			AbstractRegressionTest.runNegativeTest(
+					this, new String[] {
 							"X.java",
 							"import p.*;\n"+
 							"public class X {\n"+
@@ -224,8 +224,8 @@ public class PreviewFeatureTest extends AbstractRegressionTest9 {
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.ENABLED);
 		String[] classLibs = getClasspathWithPreviewAPI();
 		try {
-			runNegativeTest(
-					new String[] {
+			AbstractRegressionTest.runNegativeTest(
+					this, new String[] {
 							"X.java",
 							"import p.*;\n"+
 							"@SuppressWarnings(\"preview\")\n"+

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ProblemConstructorTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ProblemConstructorTest.java
@@ -32,8 +32,8 @@ public static Class testClass() {
 }
 
 public void test001() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"prs/Test1.java",
 			"package prs;	\n" +
 			"import java.io.IOException;	\n" +
@@ -55,8 +55,8 @@ public void test001() {
 		true,
 		false,
 		false);
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		false /* do not flush output directory */,
 		new String[] { /* test files */
 			"prs/Test2.java",
@@ -219,7 +219,7 @@ public void test005() {
 			"	}\n" +
 			"}\n"
 			};
-	if (!isMinimumCompliant(ClassFileConstants.JDK11)) {
+	if (!AbstractRegressionTest.isMinimumCompliant(this, ClassFileConstants.JDK11)) {
 		this.runNegativeTest(testFiles,
 				"----------\n" +
 				"1. WARNING in A.java (at line 3)\n" +
@@ -234,7 +234,7 @@ public void test005() {
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=265142, wrong unused warning reported. Test to ensure that
 //we DO complain about the constructor of B not being used when its base class has a no-arg constructor
 public void test006() {
-	String errMessage = isMinimumCompliant(ClassFileConstants.JDK11) ?
+	String errMessage = AbstractRegressionTest.isMinimumCompliant(this, ClassFileConstants.JDK11) ?
 			"----------\n" +
 			"1. WARNING in A.java (at line 8)\n" +
 			"	public B () { super(\"\"); }\n" +
@@ -341,8 +341,8 @@ public void test009() {
 public void test408038a() {
 	if (this.complianceLevel < ClassFileConstants.JDK1_6)
 		return;
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	private class Y {\n" +
@@ -373,8 +373,8 @@ public void test408038a() {
 public void test408038b() {
 	if (this.complianceLevel < ClassFileConstants.JDK1_6)
 		return;
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	private static class Y {\n" +
@@ -405,8 +405,8 @@ public void test408038b() {
 public void test408038c() {
 	if (this.complianceLevel < ClassFileConstants.JDK1_6)
 		return;
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"import java.io.Externalizable;\n" +
 			"import java.io.IOException;\n" +
@@ -444,8 +444,8 @@ public void test408038c() {
 public void test408038d() {
 	if (this.complianceLevel < ClassFileConstants.JDK1_6)
 		return;
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"import java.io.Externalizable;\n" +
 			"import java.io.IOException;\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ProblemTypeAndMethodTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ProblemTypeAndMethodTest.java
@@ -53,8 +53,8 @@ public static Class testClass() {
 	return ProblemTypeAndMethodTest.class;
 }
 public void test001() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"        interface Moosh { void foo(); }\n" +
@@ -93,7 +93,7 @@ public void test001() {
 		false /* do not show warning token */,
 		false  /* do not skip javac for this peculiar test */,
 		false  /* do not perform statements recovery */);
-	ClassFileReader reader = getClassFileReader(OUTPUT_DIR + File.separator  +"X$W.class", "X$W");
+	ClassFileReader reader = AbstractRegressionTest.getClassFileReader(OUTPUT_DIR + File.separator  +"X$W.class", "X$W");
 	IBinaryMethod[] methods = reader.getMethods();
 	assertEquals("Wrong size", 2, methods.length);
 	int counter = 0;
@@ -105,7 +105,7 @@ public void test001() {
 	}
 	assertEquals("Wrong number of foo method", 1, counter);
 
-	reader = getClassFileReader(OUTPUT_DIR + File.separator  +"X$Y.class", "X$Y");
+	reader = AbstractRegressionTest.getClassFileReader(OUTPUT_DIR + File.separator  +"X$Y.class", "X$Y");
 	methods = reader.getMethods();
 	assertEquals("Wrong size", 2, methods.length);
 	counter = 0;
@@ -117,7 +117,7 @@ public void test001() {
 	}
 	assertEquals("Wrong number of foo method", 1, counter);
 
-	reader = getClassFileReader(OUTPUT_DIR + File.separator  +"X$Z.class", "X$Z");
+	reader = AbstractRegressionTest.getClassFileReader(OUTPUT_DIR + File.separator  +"X$Z.class", "X$Z");
 	methods = reader.getMethods();
 	assertEquals("Wrong size", 2, methods.length);
 	counter = 0;
@@ -271,8 +271,8 @@ public void test004() {
 					"}\n",
 			},
 			"");
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 				"X.java", //-----------------------------------------------------------------------
 				"import p.OtherFoo;\n" +
 				"import q.Zork;\n" +
@@ -348,8 +348,8 @@ public void test004() {
 	// delete binary file Zork (i.e. simulate removing it from classpath for subsequent compile)
 	Util.delete(new File(OUTPUT_DIR, "q" + File.separator + "Zork.class"));
 
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 					"X.java", //-----------------------------------------------------------------------
 					"import p.OtherFoo;\n" +
 					"import q.Zork;\n" +
@@ -477,8 +477,8 @@ public void test005() {
 	// delete binary folder q1 (i.e. simulate removing it from classpath for subsequent compile)
 	Util.delete(new File(OUTPUT_DIR, "q1"));
 
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		false /* do not flush output directory */,
 		new String[] { /* test files */
 			"X.java", //-----------------------------------------------------------------------
@@ -538,8 +538,8 @@ public void test006() {
 	// delete binary folder q1 (i.e. simulate removing it from classpath for subsequent compile)
 	Util.delete(new File(OUTPUT_DIR, "q1"));
 
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		false /* do not flush output directory */,
 		new String[] { /* test files */
 			"X.java", //-----------------------------------------------------------------------
@@ -605,8 +605,8 @@ public void test007() {
 	// delete binary folder q1 (i.e. simulate removing it from classpath for subsequent compile)
 	Util.delete(new File(OUTPUT_DIR, "q1"));
 
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		false /* do not flush output directory */,
 		new String[] { /* test files */
 			"X.java", //-----------------------------------------------------------------------
@@ -672,8 +672,8 @@ public void test008() {
 	// delete binary folder q1 (i.e. simulate removing it from classpath for subsequent compile)
 	Util.delete(new File(OUTPUT_DIR, "q1"));
 
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		false /* do not flush output directory */,
 		new String[] { /* test files */
 			"X.java", //-----------------------------------------------------------------------
@@ -721,8 +721,8 @@ public void test009() {
 	// delete binary folder q1 (i.e. simulate removing it from classpath for subsequent compile)
 	Util.delete(new File(OUTPUT_DIR, "q1"));
 
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		false /* do not flush output directory */,
 		new String[] { /* test files */
 			"X.java", //-----------------------------------------------------------------------
@@ -775,8 +775,8 @@ public void test010() {
 	// delete binary folder q1 (i.e. simulate removing it from classpath for subsequent compile)
 	Util.delete(new File(OUTPUT_DIR, "q1"));
 
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		false /* do not flush output directory */,
 		new String[] { /* test files */
 			"X.java", //-----------------------------------------------------------------------
@@ -1147,8 +1147,8 @@ public void test019() {
 	// delete binary folder q1 (i.e. simulate removing it from classpath for subsequent compile)
 	Util.delete(new File(OUTPUT_DIR, "q1"));
 
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 					"X.java", //-----------------------------------------------------------------------
 					"public class X {\n" +
 					"	void foo(p.OtherFoo ofoo) {\n" + // triggers OtherFoo loading, and q1.q2 pkg creation (for unresolved binary type refs)
@@ -1195,8 +1195,8 @@ public void test020() {
 
 	// no need to delete Zork actually - any lazy reference would cause q1.q2 to be created as a package
 
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 					"X.java", //-----------------------------------------------------------------------
 					"public class X {\n" +
 					"	void foo(p.OtherFoo ofoo) {\n" + // triggers OtherFoo loading, and q1.q2 pkg creation (for unresolved binary type refs)
@@ -1275,8 +1275,8 @@ public void test022() {
 	// delete binary folder q1 (i.e. simulate removing it from classpath for subsequent compile)
 	Util.delete(new File(OUTPUT_DIR, "q1"));
 
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 					"X.java", //-----------------------------------------------------------------------
 					"public class X {\n" +
 					"	void foo(q1.q2.Missing1 m1) {\n" +
@@ -1326,8 +1326,8 @@ public void test023() {
 
 	// leave package behind
 
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 					"X.java", //-----------------------------------------------------------------------
 					"public class X {\n" +
 					"	void foo(q1.q2.Missing1 m1) {\n" +
@@ -1378,8 +1378,8 @@ public void test024() {
 	// delete binary folder q1/q2 (i.e. simulate removing it from classpath for subsequent compile)
 	Util.delete(new File(OUTPUT_DIR, "q1/q2"));
 
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 					"X.java", //-----------------------------------------------------------------------
 					"public class X {\n" +
 					"	void foo(q1.q2.Missing1 m1) {\n" +
@@ -1430,8 +1430,8 @@ public void test025() {
 	// delete binary folder q1/q2 (i.e. simulate removing it from classpath for subsequent compile)
 	Util.delete(new File(OUTPUT_DIR, "q1/q2"));
 
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 					"X.java", //-----------------------------------------------------------------------
 					"public class X {\n" +
 					"	void foo(q1.q2.Missing1 m1) {\n" +
@@ -1570,8 +1570,8 @@ public void test028() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=196200 - variation
 public void test029() throws Exception {
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"Y.java", //-----------------------------------------------------------------------
 				"public class Y extends Z {\n" +
 				"}\n",
@@ -1607,8 +1607,8 @@ public void test029() throws Exception {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=196200 - variation
 public void test030() {
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"Y.java", //-----------------------------------------------------------------------
 				"public class Y extends Z {\n" +
 				"}\n",
@@ -1626,8 +1626,8 @@ public void test030() {
 			false,
 			false);
 
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java", //-----------------------------------------------------------------------
 				"public class X extends Y {\n" +
 				"}\n",
@@ -1700,8 +1700,8 @@ public void test033() {
 	if (this.complianceLevel <= ClassFileConstants.JDK1_4) {
 		return;
 	}
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"Y.java", //-----------------------------------------------------------------------
 				"@Z public class Y {\n" +
 				"}\n",
@@ -1719,8 +1719,8 @@ public void test033() {
 			false,
 			false);
 
-	runConformTest(
-		// test directory preparation
+	AbstractRegressionTest.runConformTest(
+		this, // test directory preparation
 		false /* do not flush output directory */,
 		new String[] { /* test files */
 			"X.java", //-----------------------------------------------------------------------
@@ -1765,8 +1765,8 @@ public void test034() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=196200 - variation
 public void test035() {
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X1.java", //-----------------------------------------------------------------------
 				"public class X1 {\n" +
 				"	Zork bar() { return null; }	\n" +
@@ -1785,8 +1785,8 @@ public void test035() {
 			false,
 			false);
 
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java", //-----------------------------------------------------------------------
 				"public class X {\n" +
 				"	void foo(X1 x1) {\n" +
@@ -1837,8 +1837,8 @@ public void test036() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=196200 - variation
 public void test037() {
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X1.java", //-----------------------------------------------------------------------
 				"public class X1 {\n" +
 				"	Object bar(Zork z) { return null; }	\n" +
@@ -1857,8 +1857,8 @@ public void test037() {
 			false,
 			false);
 
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java", //-----------------------------------------------------------------------
 				"public class X {\n" +
 				"	void foo(X1 x1) {\n" +
@@ -1909,8 +1909,8 @@ public void test038() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=196200 - variation
 public void test039() {
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X1.java", //-----------------------------------------------------------------------
 				"public class X1 {\n" +
 				"	Object bar(Object o) throws Zork { return null; }	\n" +
@@ -1929,8 +1929,8 @@ public void test039() {
 			false,
 			false);
 
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java", //-----------------------------------------------------------------------
 				"public class X {\n" +
 				"	void foo(X1 x1) {\n" +
@@ -1981,8 +1981,8 @@ public void test040() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=196200 - variation
 public void test041() {
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X1.java", //-----------------------------------------------------------------------
 				"public class X1 {\n" +
 				"	public X1(Zork z) {}\n" +
@@ -2001,8 +2001,8 @@ public void test041() {
 			false,
 			false);
 
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java", //-----------------------------------------------------------------------
 				"public class X {\n" +
 				"	void foo(X1 x1) {\n" +
@@ -2053,8 +2053,8 @@ public void test042() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=196200 - variation
 public void test043() {
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X1.java", //-----------------------------------------------------------------------
 				"public class X1 {\n" +
 				"	public X1() throws Zork {}\n" +
@@ -2073,8 +2073,8 @@ public void test043() {
 			false,
 			false);
 
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java", //-----------------------------------------------------------------------
 				"public class X {\n" +
 				"	void foo(X1 x1) {\n" +
@@ -2125,8 +2125,8 @@ public void test044() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=196200 - variation
 public void test045() {
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X1.java", //-----------------------------------------------------------------------
 				"public class X1 {\n" +
 				"	public X1(Zork z) {}\n" +
@@ -2145,8 +2145,8 @@ public void test045() {
 			false,
 			false);
 
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java", //-----------------------------------------------------------------------
 				"public class X {\n" +
 				"	void foo(X1 x1) {\n" +
@@ -2197,8 +2197,8 @@ public void test046() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=196200 - variation
 public void test047() {
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X1.java", //-----------------------------------------------------------------------
 				"public class X1 {\n" +
 				"	public X1() throws Zork {}\n" +
@@ -2217,8 +2217,8 @@ public void test047() {
 			false,
 			false);
 
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java", //-----------------------------------------------------------------------
 				"public class X {\n" +
 				"	void foo(X1 x1) {\n" +
@@ -2269,8 +2269,8 @@ public void test048() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=196200 - variation
 public void test049() {
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X1.java", //-----------------------------------------------------------------------
 				"public class X1 {\n" +
 				"	public X1(Zork z) {}\n" +
@@ -2289,8 +2289,8 @@ public void test049() {
 			false,
 			false);
 
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java", //-----------------------------------------------------------------------
 				"public class X extends X1 {\n" +
 				"	X(X1 x1) {\n" +
@@ -2341,8 +2341,8 @@ public void test050() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=196200 - variation
 public void test051() {
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X1.java", //-----------------------------------------------------------------------
 				"public class X1 {\n" +
 				"	public X1() throws Zork {}\n" +
@@ -2361,8 +2361,8 @@ public void test051() {
 			false,
 			false);
 
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java", //-----------------------------------------------------------------------
 				"public class X extends X1 {\n" +
 				"	X(X1 x1) {\n" +
@@ -2582,8 +2582,8 @@ public void test054() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=196200 - variation
 public void test055() {
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X1.java", //-----------------------------------------------------------------------
 				"public class X1 {\n" +
 				"	public X1 next;\n" +
@@ -2603,8 +2603,8 @@ public void test055() {
 			false,
 			false);
 
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java", //-----------------------------------------------------------------------
 				"public class X {\n" +
 				"	void foo(X1 x1) {\n" +
@@ -2664,8 +2664,8 @@ public void test055() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=196200 - variation
 public void test056() {
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X1.java", //-----------------------------------------------------------------------
 				"public class X1 {\n" +
 				"	public X1 next;\n" +
@@ -2685,8 +2685,8 @@ public void test056() {
 			false,
 			false);
 
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java", //-----------------------------------------------------------------------
 				"public class X {\n" +
 				"	void bar(X1 x1) {\n" +
@@ -2746,8 +2746,8 @@ public void test056() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=196200 - variation
 public void test057() {
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X1.java", //-----------------------------------------------------------------------
 				"public class X1 {\n" +
 				"	public X1 next;\n" +
@@ -2767,8 +2767,8 @@ public void test057() {
 			false,
 			false);
 
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java", //-----------------------------------------------------------------------
 				"public class X {\n" +
 				"	void baz(X1 x1) {\n" +
@@ -4143,8 +4143,8 @@ public void test089() {
 	if (this.complianceLevel <= ClassFileConstants.JDK1_4) return;
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_DocCommentSupport, CompilerOptions.ENABLED);
-	this.runConformTest(
-			new String[] {
+	AbstractRegressionTest.runConformTest(
+			this, new String[] {
 					"com/foo/bar/baz/reporting/dom/ReportExceptionBase.java", // ================
 					"package com.foo.bar.baz.reporting.dom;\n" +
 					"public class ReportExceptionBase extends Exception  {\n" +
@@ -4800,8 +4800,8 @@ public void test091()  throws Exception {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=250297
 public void test092() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"p1/p2/X.java", // =================
 			"package p1.p2;\n" +
 			"public class X {\n" +
@@ -5037,7 +5037,7 @@ public void test098() {
 			"   }\n" +
 			"}\n"
 		};
-	runner.expectedCompilerLog = isMinimumCompliant(ClassFileConstants.JDK11) ?
+	runner.expectedCompilerLog = AbstractRegressionTest.isMinimumCompliant(this, ClassFileConstants.JDK11) ?
 		"----------\n" +
 		"1. WARNING in X.java (at line 3)\n" +
 		"	public void foo(int a) {\n" +
@@ -5171,7 +5171,7 @@ public void test099() {
 		    "   }\n" +
 			"}\n"
 		};
-	runner.expectedCompilerLog = isMinimumCompliant(ClassFileConstants.JDK11) ?
+	runner.expectedCompilerLog = AbstractRegressionTest.isMinimumCompliant(this, ClassFileConstants.JDK11) ?
 		"----------\n" +
 		"1. WARNING in X.java (at line 3)\n" +
 		"	public void foo(int a) {\n" +
@@ -5281,7 +5281,7 @@ public void test099a() {
 			"   }\n" +
 			"}\n"
 		};
-	runner.expectedCompilerLog = isMinimumCompliant(ClassFileConstants.JDK11) ?
+	runner.expectedCompilerLog = AbstractRegressionTest.isMinimumCompliant(this, ClassFileConstants.JDK11) ?
 		"----------\n" +
 		"1. WARNING in X.java (at line 23)\n" +
 		"	public void foo(double a) {\n" +
@@ -5391,7 +5391,7 @@ public void test099b() {
 		    "   }\n" +
 			"}\n"
 		};
-	if (!isMinimumCompliant(ClassFileConstants.JDK11)) {
+	if (!AbstractRegressionTest.isMinimumCompliant(this, ClassFileConstants.JDK11)) {
 		runner.javacTestOptions = JavacTestOptions.Excuse.EclipseHasSomeMoreWarnings;
 		runner.expectedCompilerLog =
 			"----------\n" +
@@ -5423,7 +5423,7 @@ public void test100() {
 			"    public class B extends A {}\n" +
 			"}"
 		};
-	if (!isMinimumCompliant(ClassFileConstants.JDK11)) {
+	if (!AbstractRegressionTest.isMinimumCompliant(this, ClassFileConstants.JDK11)) {
 
 		runner.expectedCompilerLog =
 				"----------\n" +
@@ -5452,7 +5452,7 @@ public void test101() {
 			"    public class B extends A {}\n" +
 			"}"
 		};
-	if (!isMinimumCompliant(ClassFileConstants.JDK11)) {
+	if (!AbstractRegressionTest.isMinimumCompliant(this, ClassFileConstants.JDK11)) {
 		runner.expectedCompilerLog =
 				"----------\n" +
 				"1. WARNING in X.java (at line 6)\n" +
@@ -5480,7 +5480,7 @@ public void test102() {
 			"    public class B extends A {}\n" +
 			"}"
 		};
-	runner.expectedCompilerLog = isMinimumCompliant(ClassFileConstants.JDK11) ?
+	runner.expectedCompilerLog = AbstractRegressionTest.isMinimumCompliant(this, ClassFileConstants.JDK11) ?
 		"----------\n" +
 		"1. WARNING in X.java (at line 3)\n" +
 		"	private void foo() {}\n" +
@@ -5527,7 +5527,7 @@ public void test103() {
 			"    private class B extends A {}\n" +
 			"}"
 		};
-	runner.expectedCompilerLog = isMinimumCompliant(ClassFileConstants.JDK11) ?
+	runner.expectedCompilerLog = AbstractRegressionTest.isMinimumCompliant(this, ClassFileConstants.JDK11) ?
 		"----------\n" +
 		"1. WARNING in X.java (at line 3)\n" +
 		"	public void foo() {}\n" +
@@ -5571,8 +5571,8 @@ public void test103() {
 	runner.runWarningTest();
 }
 public void test104() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"p/Bar.java", //-----------------------------------------------------------------------
 			"package p;\n" +
 			"import q.Zork;\n" +
@@ -5663,8 +5663,8 @@ public void test106() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=319425
 public void test107() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"p/OuterBogus.java", //-----------------------------------------------------------------------
 			"package p;\n" +
 			"abstract final class OuterBogus {\n" +
@@ -5716,7 +5716,7 @@ public void test107() {
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=321414
 public void test108() {
 	if (this.complianceLevel <= ClassFileConstants.JDK1_4) return;
-	String errMessage = isMinimumCompliant(ClassFileConstants.JDK11) ?
+	String errMessage = AbstractRegressionTest.isMinimumCompliant(this, ClassFileConstants.JDK11) ?
 			"----------\n" +
 			"1. WARNING in SyntheticConstructorTooManyArgs.java (at line 23)\n" +
 			"	@SuppressWarnings(\"synthetic-access\")\n" +
@@ -5981,7 +5981,7 @@ public void test110() {
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=321414
 public void test111() {
 	if (this.complianceLevel <= ClassFileConstants.JDK1_4) return;
-	String errMessage = isMinimumCompliant(ClassFileConstants.JDK11) ?
+	String errMessage = AbstractRegressionTest.isMinimumCompliant(this, ClassFileConstants.JDK11) ?
 			"----------\n" +
 			"1. WARNING in SyntheticConstructorTooManyArgs.java (at line 23)\n" +
 			"	@SuppressWarnings(\"synthetic-access\")\n" +
@@ -6997,8 +6997,8 @@ public void testBug335845a() {
 	compilerOptions.put(CompilerOptions.OPTION_ReportUnusedObjectAllocation, CompilerOptions.IGNORE);
 	compilerOptions.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.IGNORE);
 	compilerOptions.put(CompilerOptions.OPTION_ReportSyntheticAccessEmulation, CompilerOptions.IGNORE);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"	private class Bar {\n" +
@@ -7027,8 +7027,8 @@ public void testBug335845b() {
 	compilerOptions.put(CompilerOptions.OPTION_ReportUnusedObjectAllocation, CompilerOptions.IGNORE);
 	compilerOptions.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.IGNORE);
 	compilerOptions.put(CompilerOptions.OPTION_ReportSyntheticAccessEmulation, CompilerOptions.IGNORE);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"	private class Bar {\n" +
@@ -7094,8 +7094,8 @@ public void testBug335845d() {
 	compilerOptions.put(CompilerOptions.OPTION_ReportUnusedObjectAllocation, CompilerOptions.IGNORE);
 	compilerOptions.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.IGNORE);
 	compilerOptions.put(CompilerOptions.OPTION_ReportSyntheticAccessEmulation, CompilerOptions.IGNORE);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"	private class Bar {\n" +
@@ -7207,8 +7207,8 @@ public void testBug335845g() {
 				"}"
 		}
 	);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 				"p/Y.java",
 				"package p;\n" +
 				"public class Y extends X {\n" +
@@ -7233,8 +7233,8 @@ public void test124a() {
 	compilerOptions.put(CompilerOptions.OPTION_ReportMethodCanBeStatic, CompilerOptions.ERROR);
 	compilerOptions.put(CompilerOptions.OPTION_ReportMethodCanBePotentiallyStatic, CompilerOptions.ERROR);
 	compilerOptions.put(CompilerOptions.OPTION_ReportNonStaticAccessToStatic, CompilerOptions.IGNORE);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"	public void method1() {\n" + 	// don't warn
@@ -7262,8 +7262,8 @@ public void test124b() {
 	Map compilerOptions = getCompilerOptions();
 	compilerOptions.put(CompilerOptions.OPTION_ReportMethodCanBeStatic, CompilerOptions.ERROR);
 	compilerOptions.put(CompilerOptions.OPTION_ReportMethodCanBePotentiallyStatic, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"   public static X xField;" +
@@ -7368,8 +7368,8 @@ public void test360164() {
 	// delete binary file I (i.e. simulate removing it from classpath for subsequent compile)
 	Util.delete(new File(OUTPUT_DIR, "p" + File.separator + "I.class"));
 
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		false /* do not flush output directory */,
 		new String[] { /* test files */
 				"p/X.java",
@@ -7412,8 +7412,8 @@ public void test376550_1a() {
 	compilerOptions.put(CompilerOptions.OPTION_ReportMethodCanBeStatic, CompilerOptions.ERROR);
 	compilerOptions.put(CompilerOptions.OPTION_ReportMethodCanBePotentiallyStatic, CompilerOptions.ERROR);
 	compilerOptions.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.IGNORE);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"	int i = 1;\n" +
@@ -7518,8 +7518,8 @@ public void test376550_2b() {
 	compilerOptions.put(CompilerOptions.OPTION_ReportMethodCanBeStatic, CompilerOptions.ERROR);
 	compilerOptions.put(CompilerOptions.OPTION_ReportMethodCanBePotentiallyStatic, CompilerOptions.ERROR);
 	compilerOptions.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.IGNORE);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 				"X.java",
 				"public class X<T> {\n" +
 				"   public void upper1(){}\n" +
@@ -7548,8 +7548,8 @@ public void test376550_3a() {
 	compilerOptions.put(CompilerOptions.OPTION_ReportMethodCanBeStatic, CompilerOptions.ERROR);
 	compilerOptions.put(CompilerOptions.OPTION_ReportMethodCanBePotentiallyStatic, CompilerOptions.ERROR);
 	compilerOptions.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.IGNORE);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 				"X.java",
 				"public class X<T> {\n" +
 				"   public void upper1(){}\n" +
@@ -7654,8 +7654,8 @@ public void test376550_4b() {
 	compilerOptions.put(CompilerOptions.OPTION_ReportMethodCanBeStatic, CompilerOptions.ERROR);
 	compilerOptions.put(CompilerOptions.OPTION_ReportMethodCanBePotentiallyStatic, CompilerOptions.ERROR);
 	compilerOptions.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.IGNORE);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 				"X.java",
 				"public class X<T> {\n" +
 				"   int i1 = 1;\n" +
@@ -7763,8 +7763,8 @@ public void test376550_5b() {
 	compilerOptions.put(CompilerOptions.OPTION_ReportMethodCanBeStatic, CompilerOptions.ERROR);
 	compilerOptions.put(CompilerOptions.OPTION_ReportMethodCanBePotentiallyStatic, CompilerOptions.ERROR);
 	compilerOptions.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.IGNORE);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"   int i1 = 1;\n" +
@@ -7831,8 +7831,8 @@ public void test376550_6b() {
 	compilerOptions.put(CompilerOptions.OPTION_ReportMethodCanBeStatic, CompilerOptions.ERROR);
 	compilerOptions.put(CompilerOptions.OPTION_ReportMethodCanBePotentiallyStatic, CompilerOptions.ERROR);
 	compilerOptions.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.IGNORE);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"   int i1 = 1;\n" +
@@ -7901,8 +7901,8 @@ public void test376550_7b() {
 	compilerOptions.put(CompilerOptions.OPTION_ReportMethodCanBeStatic, CompilerOptions.ERROR);
 	compilerOptions.put(CompilerOptions.OPTION_ReportMethodCanBePotentiallyStatic, CompilerOptions.ERROR);
 	compilerOptions.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.IGNORE);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"   abstract class AbsUp{}\n" +
@@ -7969,8 +7969,8 @@ public void test376550_8b() {
 	compilerOptions.put(CompilerOptions.OPTION_ReportMethodCanBeStatic, CompilerOptions.ERROR);
 	compilerOptions.put(CompilerOptions.OPTION_ReportMethodCanBePotentiallyStatic, CompilerOptions.ERROR);
 	compilerOptions.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.IGNORE);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"   class AbsUp{ int a;}\n" +
@@ -8039,8 +8039,8 @@ public void test376550_9b() {
 	compilerOptions.put(CompilerOptions.OPTION_ReportMethodCanBeStatic, CompilerOptions.ERROR);
 	compilerOptions.put(CompilerOptions.OPTION_ReportMethodCanBePotentiallyStatic, CompilerOptions.ERROR);
 	compilerOptions.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.IGNORE);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"   X xup;\n" +
@@ -8111,8 +8111,8 @@ public void test376550_10b() {
 	compilerOptions.put(CompilerOptions.OPTION_ReportMethodCanBeStatic, CompilerOptions.ERROR);
 	compilerOptions.put(CompilerOptions.OPTION_ReportMethodCanBePotentiallyStatic, CompilerOptions.ERROR);
 	compilerOptions.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.IGNORE);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"   X xup;\n" +
@@ -8159,7 +8159,7 @@ public void test376550_11() {
 				"	}\n" +
 				"}"
 		};
-	runner.expectedCompilerLog = isMinimumCompliant(ClassFileConstants.JDK11) ?
+	runner.expectedCompilerLog = AbstractRegressionTest.isMinimumCompliant(this, ClassFileConstants.JDK11) ?
 		"----------\n" +
 		"1. WARNING in X.java (at line 6)\n" +
 		"	return new ArrayList<Object>() {\n" +
@@ -8272,8 +8272,8 @@ public void test376550_13() {
 	compilerOptions.put(CompilerOptions.OPTION_ReportMethodCanBeStatic, CompilerOptions.ERROR);
 	compilerOptions.put(CompilerOptions.OPTION_ReportMethodCanBePotentiallyStatic, CompilerOptions.ERROR);
 	compilerOptions.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.IGNORE);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 				"QualifiedSuper.java",
 				"public class QualifiedSuper {\n" +
 				"	class InnerS {\n" +
@@ -8306,8 +8306,8 @@ public void test379530() {
 	compilerOptions.put(CompilerOptions.OPTION_ReportMethodCanBeStatic, CompilerOptions.ERROR);
 	compilerOptions.put(CompilerOptions.OPTION_ReportMethodCanBePotentiallyStatic, CompilerOptions.ERROR);
 	compilerOptions.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.IGNORE);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 				"X.java",
 				"public class X<S> {\n" +
 				"   S s;\n" +
@@ -8331,8 +8331,8 @@ public void test393781() {
 	Object oldOption = compilerOptions.get(CompilerOptions.OPTION_ReportRawTypeReference);
 	compilerOptions.put(CompilerOptions.OPTION_ReportRawTypeReference, CompilerOptions.IGNORE);
 	try {
-		this.runNegativeTest(
-				new String[] {
+		AbstractRegressionTest.runNegativeTest(
+				this, new String[] {
 						"p/X.java",
 						"public class X {\n" +
 						"   public void foo(Map map, String str) {}\n" +
@@ -8381,8 +8381,8 @@ private void runStaticWarningConformTest(String fileName, String body) {
 	Map compilerOptions = getCompilerOptions();
 	compilerOptions.put(CompilerOptions.OPTION_ReportMethodCanBeStatic, CompilerOptions.ERROR);
 	compilerOptions.put(CompilerOptions.OPTION_ReportMethodCanBePotentiallyStatic, CompilerOptions.ERROR);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			fileName,
 			body
 		},
@@ -8786,7 +8786,7 @@ public void testBug542829() {
 public void testBug576735() {
 	if (this.complianceLevel < ClassFileConstants.JDK1_5) return;
 
-	String path = getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "lib576735.jar";
+	String path = AbstractRegressionTest.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "lib576735.jar";
 	String[] libs = getDefaultClassPaths();
 	int len = libs.length;
 	System.arraycopy(libs, 0, libs = new String[len+1], 0, len);

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ProgrammingProblemsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ProgrammingProblemsTest.java
@@ -99,7 +99,7 @@ void runTest(
 		    }
 		}
 	}
-	runTest(testFiles,
+	AbstractRegressionTest.runTest(this, testFiles,
 		expectingCompilerErrors,
 		expectedCompilerLog,
 		expectedOutputString,
@@ -1704,8 +1704,8 @@ public void test0046() {
 		return;
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedLocal, CompilerOptions.WARNING);
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X {\n" +
 				"    int foo() {\n" +
@@ -1744,8 +1744,8 @@ public void test0046_field() {
 		return;
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedLocal, CompilerOptions.WARNING);
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X {\n" +
 				"    private int i=1;\n" +
@@ -1783,8 +1783,8 @@ public void test0046_field_this_qualified() {
 		return;
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedLocal, CompilerOptions.WARNING);
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X {\n" +
 				"    private int i=1;\n" +
@@ -1823,8 +1823,8 @@ public void test0046_field_qualified() {
 		return;
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedLocal, CompilerOptions.WARNING);
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X {\n" +
 				"    private int i=1;\n" +
@@ -1863,8 +1863,8 @@ public void test0046_field_in_private_type() {
 		return;
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedLocal, CompilerOptions.WARNING);
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X {\n" +
 				"    private class Y {\n" +
@@ -1906,8 +1906,8 @@ public void test0047() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedParameter, CompilerOptions.WARNING);
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedLocal, CompilerOptions.WARNING);
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X {\n" +
 				"    void foo(int param1, int param2, Integer param3) {\n" +
@@ -1952,8 +1952,8 @@ public void test0048() {
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedParameter, CompilerOptions.WARNING);
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedParameterWhenImplementingAbstract, CompilerOptions.DISABLED);
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedLocal, CompilerOptions.WARNING);
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X extends A implements Y{\n" +
 				"   public void foo(int param1, int param2, Integer param3) {\n" + // implementing method, so dont warn
@@ -2017,8 +2017,8 @@ public void test0049() {
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedParameter, CompilerOptions.WARNING);
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedParameterWhenOverridingConcrete, CompilerOptions.DISABLED);
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedLocal, CompilerOptions.WARNING);
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X extends A {\n" +
 				"   public void foo(int param1, int param2, Integer param3) {\n" + // overriding method, so dont warn
@@ -2073,8 +2073,8 @@ public void test0050() {
 		return;
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedLocal, CompilerOptions.WARNING);
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X {\n" +
 				"    int foo() {\n" +
@@ -2115,8 +2115,8 @@ public void test0050() {
 public void test0051() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedParameter, CompilerOptions.WARNING);
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 					"X.java",
 					"class X {\n" +
 					"    X(int abc) {\n" +
@@ -2138,8 +2138,8 @@ public void test0051() {
 public void test0052() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.ERROR);
-	this.runConformTest(
-			new String[] {
+	AbstractRegressionTest.runConformTest(
+			this, new String[] {
 					"X.java",
 					"class X {\n" +
 					"    Y y = new Y();\n" +
@@ -2165,8 +2165,8 @@ public void test0052a() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.ERROR);
 	customOptions.put(CompilerOptions.OPTION_ReportSyntheticAccessEmulation, CompilerOptions.IGNORE);
-	this.runConformTest(
-			new String[] {
+	AbstractRegressionTest.runConformTest(
+			this, new String[] {
 					"Outer.java",
 					"class Outer {\n" +
 					"    private class Inner1 {\n" +
@@ -2189,8 +2189,8 @@ public void test0052b() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.ERROR);
 	customOptions.put(CompilerOptions.OPTION_ReportSyntheticAccessEmulation, CompilerOptions.IGNORE);
-	this.runConformTest(
-			new String[] {
+	AbstractRegressionTest.runConformTest(
+			this, new String[] {
 					"Outer.java",
 					"class Outer {\n" +
 					"    private class Inner1 {\n" +
@@ -2211,8 +2211,8 @@ public void test0052b() {
 public void test0053() throws Exception {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedLocal, CompilerOptions.WARNING);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"class X {\n" +
 			"    int foo() {\n" +
@@ -2238,14 +2238,14 @@ public void test0053() throws Exception {
 		"        [pc: 0, line: 5]\n" +
 		"      Local variable table:\n" +
 		"        [pc: 0, pc: 2] local: this index: 0 type: X\n";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=328519
 public void test0054() throws Exception {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedLocal, CompilerOptions.ERROR);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"class X {\n" +
 			"    int foo() {\n" +
@@ -2275,7 +2275,7 @@ public void test0054() throws Exception {
 		"      Local variable table:\n" +
 		"        [pc: 0, pc: 7] local: this index: 0 type: X\n" +
 		"        [pc: 2, pc: 7] local: i index: 1 type: int\n";
-	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+	AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 }
 
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=329613
@@ -2285,8 +2285,8 @@ public void test0055() {
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.IGNORE);
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedLocal, CompilerOptions.WARNING);
 	customOptions.put(CompilerOptions.OPTION_PreserveUnusedLocal, CompilerOptions.PRESERVE);
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 					"test1/E.java",
 					"package test1;\n" +
 					"public class E {\n" +
@@ -2315,8 +2315,8 @@ public void test0055() {
 public void test0056() throws Exception {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedLocal, CompilerOptions.ERROR);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"    static int foo() {\n" +
@@ -2340,8 +2340,8 @@ public void test0056() throws Exception {
 public void test0057() throws Exception {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedLocal, CompilerOptions.IGNORE);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"    public static void main (String args[]) {\n" +
@@ -2365,8 +2365,8 @@ public void test0057() throws Exception {
 public void _test0058() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedLocal, CompilerOptions.WARNING);
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"    void foo(String m) {\n" +
@@ -2397,8 +2397,8 @@ public void test0059() throws Exception {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedLocal, CompilerOptions.WARNING);
 	customOptions.put(CompilerOptions.OPTION_ReportDeadCode, CompilerOptions.WARNING);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"    public static void main(String[] args) {\n" +
@@ -2433,8 +2433,8 @@ public void test0059() throws Exception {
 public void test0060() throws Exception {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUninternedIdentityComparison, CompilerOptions.ENABLED);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"org/eclipse/jdt/internal/compiler/lookup/X.java",
 			"package org.eclipse.jdt.internal.compiler.lookup;\n" +
 			"class TypeBinding {\n" +
@@ -2515,8 +2515,8 @@ public void test0060() throws Exception {
 public void test0061() throws Exception {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUninternedIdentityComparison, CompilerOptions.ENABLED);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"org/eclipse/nonjdt/internal/compiler/lookup/X.java",
 			"package org.eclipse.nonjdt.internal.compiler.lookup;\n" +
 			"class TypeBinding {\n" +
@@ -2571,8 +2571,8 @@ public void test0061() throws Exception {
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=417803,  [internal] Build a build environment compiler to warn on TypeBinding comparisons
 public void test0062() throws Exception {
 	Map customOptions = getCompilerOptions();
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"org/eclipse/jdt/internal/compiler/lookup/X.java",
 			"package org.eclipse.jdt.internal.compiler.lookup;\n" +
 			"class TypeBinding {\n" +
@@ -2628,8 +2628,8 @@ public void test0062() throws Exception {
 public void test0063() throws Exception {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUninternedIdentityComparison, CompilerOptions.ENABLED);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"org/eclipse/jdt/core/dom/X.java",
 			"package org.eclipse.jdt.core.dom;\n" +
 			"interface ITypeBinding {\n" +
@@ -2795,8 +2795,8 @@ public void testBug410218b2() {
 		return;
 	Map customOptions = getCompilerOptions();
 	customOptions.put(JavaCore.COMPILER_PB_UNLIKELY_COLLECTION_METHOD_ARGUMENT_TYPE_STRICT, JavaCore.ENABLED);
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"import java.util.*;\n" +
 			"class X {\n" +
@@ -2893,8 +2893,8 @@ public void testBug410218d() {
 		return;
 	Map customOptions = getCompilerOptions();
 	customOptions.put(JavaCore.COMPILER_PB_UNLIKELY_COLLECTION_METHOD_ARGUMENT_TYPE, JavaCore.ERROR);
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"import java.util.*;\n" +
 			"interface NumberCollection extends Collection<Number> {}\n" +
@@ -2925,8 +2925,8 @@ public void testBug410218e() {
 		return;
 	Map customOptions = getCompilerOptions();
 	customOptions.put(JavaCore.COMPILER_PB_UNLIKELY_COLLECTION_METHOD_ARGUMENT_TYPE, JavaCore.WARNING);
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"import java.util.*;\n" +
 			"class X {\n" +
@@ -2959,8 +2959,8 @@ public void testBug410218f() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(JavaCore.COMPILER_PB_UNLIKELY_COLLECTION_METHOD_ARGUMENT_TYPE, JavaCore.WARNING);
 	customOptions.put(JavaCore.COMPILER_PB_UNLIKELY_EQUALS_ARGUMENT_TYPE, JavaCore.INFO);
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"test/TestUnlikely.java",
 			"package test;\n" +
 			"\n" +
@@ -3231,8 +3231,8 @@ public void testBug514956a() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(JavaCore.COMPILER_PB_UNLIKELY_COLLECTION_METHOD_ARGUMENT_TYPE, JavaCore.WARNING);
 	customOptions.put(JavaCore.COMPILER_PB_UNNECESSARY_TYPE_CHECK, JavaCore.ERROR);
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"Unlikely.java",
 			"import java.util.Map;\n" +
 			"\n" +
@@ -3250,8 +3250,8 @@ public void testBug514956b() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(JavaCore.COMPILER_PB_UNLIKELY_EQUALS_ARGUMENT_TYPE, JavaCore.WARNING);
 	customOptions.put(JavaCore.COMPILER_PB_UNNECESSARY_TYPE_CHECK, JavaCore.ERROR);
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"Unlikely.java",
 			"interface EObject {}\n" +
 			"public class Unlikely {\n" +
@@ -3266,8 +3266,8 @@ public void testBug514956c() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(JavaCore.COMPILER_PB_UNLIKELY_EQUALS_ARGUMENT_TYPE, JavaCore.WARNING);
 	customOptions.put(JavaCore.COMPILER_PB_UNNECESSARY_TYPE_CHECK, JavaCore.ERROR);
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"Unlikely.java",
 			"interface I1 {}\n" +
 			"interface I2 {}\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordPatternTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordPatternTest.java
@@ -67,7 +67,7 @@ public class RecordPatternTest extends AbstractRegressionTest9 {
 	@Override
 	protected INameEnvironment getNameEnvironment(final String[] testFiles, String[] classPaths, Map<String, String> options) {
 		this.classpaths = classPaths == null ? getDefaultClassPaths() : classPaths;
-		INameEnvironment[] classLibs = getClassLibs(false, options);
+		INameEnvironment[] classLibs = AbstractRegressionTest.getClassLibs(this, false, options);
 		for (INameEnvironment nameEnvironment : classLibs) {
 			((FileSystem) nameEnvironment).scanForModules(createParser());
 		}
@@ -81,7 +81,7 @@ public class RecordPatternTest extends AbstractRegressionTest9 {
 	protected void runConformTest(String[] testFiles, String expectedOutput, Map<String, String> customOptions) {
 		if(!isJRE21Plus)
 			return;
-		runConformTest(testFiles, expectedOutput, customOptions, new String[] {}, JAVAC_OPTIONS);
+		AbstractRegressionTest.runConformTest(this, testFiles, expectedOutput, customOptions, new String[] {}, JAVAC_OPTIONS);
 	}
 	protected void runConformTest(
 			String[] testFiles,
@@ -89,8 +89,8 @@ public class RecordPatternTest extends AbstractRegressionTest9 {
 			String[] classLibraries,
 			boolean shouldFlushOutputDirectory,
 			String[] vmArguments) {
-			runTest(
-		 		// test directory preparation
+			AbstractRegressionTest.runTest(
+		 		this, // test directory preparation
 				shouldFlushOutputDirectory /* should flush output directory */,
 				testFiles /* test files */,
 				// compiler options
@@ -726,7 +726,7 @@ public class RecordPatternTest extends AbstractRegressionTest9 {
 	}
 	// Nested record pattern with a simple (constant) 'when' clause
 	public void test22() {
-		runConformTest(new String[] {
+		AbstractRegressionTest.runConformTest(this, new String[] {
 				"X.java",
 					"public class X {\n"
 					+ "  public static void printLowerRight(Rectangle r) {\n"
@@ -888,8 +888,8 @@ public class RecordPatternTest extends AbstractRegressionTest9 {
 			},
 			this.extraLibPath,
 			JavaCore.VERSION_21);
-		this.runConformTest(
-				new String[] {
+		AbstractRegressionTest.runConformTest(
+				this, new String[] {
 						"p/X.java",
 						"package p;\n"
 						+ "public class X {\n"

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordsRestrictedClassTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordsRestrictedClassTest.java
@@ -86,7 +86,7 @@ public class RecordsRestrictedClassTest extends AbstractRegressionTest {
 	protected void runNegativeTest(String[] testFiles, String expectedCompilerLog) {
 		if (!isJRE16Plus)
 			return;
-		runNegativeTest(testFiles, expectedCompilerLog, JavacTestOptions.DEFAULT);
+		AbstractRegressionTest.runNegativeTest(this, testFiles, expectedCompilerLog, JavacTestOptions.DEFAULT);
 	}
 	protected void runWarningTest(String[] testFiles, String expectedCompilerLog) {
 		runWarningTest(testFiles, expectedCompilerLog, null);
@@ -2430,8 +2430,8 @@ public void testBug558718_001() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_15);
 	options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-	this.runNegativeTest(
-	new String[] {
+	AbstractRegressionTest.runNegativeTest(
+	this, new String[] {
 			"X.java",
 			"record R() {}\n",
 		},
@@ -2451,8 +2451,8 @@ public void testBug558718_002() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_13);
 	options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-	this.runNegativeTest(
-	new String[] {
+	AbstractRegressionTest.runNegativeTest(
+	this, new String[] {
 			"X.java",
 			"record R() {}\n",
 		},
@@ -2472,8 +2472,8 @@ public void testBug558718_003() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_14);
 	options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-	this.runNegativeTest(
-	new String[] {
+	AbstractRegressionTest.runNegativeTest(
+	this, new String[] {
 			"X.java",
 			"record R() {}\n",
 		},
@@ -2568,8 +2568,8 @@ public void testBug561528_004() {
 		"0");
 }
 public void testBug561528_005() {
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 					"X.java",
 					"class X {\n"+
 					"  public static void main(String[] args){\n"+
@@ -5982,8 +5982,8 @@ public void testBug564672b_001() {
 public void testBug564672b_002() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"class X extends record {\n"+
 			"  public static void main(String[] args){\n"+
@@ -6027,8 +6027,8 @@ public void testBug564672b_003() {
 public void testBug564672b_004() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"class X implements record {\n"+
 			"  public static void main(String[] args){\n"+
@@ -6074,8 +6074,8 @@ public void testBug564672b_005() {
 public void testBug564672b_006() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"class X {\n"+
 			"  class Y extends record {\n"+
@@ -6123,8 +6123,8 @@ public void testBug564672b_007() {
 public void testBug564672b_008() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"class X {\n"+
 			"  class Y implements record {\n"+
@@ -6172,8 +6172,8 @@ public void testBug564672b_009() {
 public void testBug564672b_010() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"interface Y extends record {\n"+
 			"}\n" +
@@ -6221,8 +6221,8 @@ public void testBug564672b_011() {
 public void testBug564672b_012() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"class X {\n"+
 			"  interface Y extends record {\n"+
@@ -6272,8 +6272,8 @@ public void testBug564672b_013() {
 public void testBug564672b_014() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"interface X {\n"+
 			"  class Y extends record {\n"+
@@ -6320,8 +6320,8 @@ public void testBug564672b_015() {
 public void testBug564672b_016() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"interface X {\n"+
 			"  class Y implements record {\n"+
@@ -6368,8 +6368,8 @@ public void testBug564672b_017() {
 public void testBug564672b_018() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"interface X {\n"+
 			"  interface Y extends record {\n"+
@@ -6391,8 +6391,8 @@ public void testBug564672b_018() {
 public void testBug564672b_019() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	static record a(int i, int j) {\n" +
@@ -6945,8 +6945,8 @@ public void testBug564672b_038() {
 public void testBug564672b_039() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"record Point(record x, int i) { }\n" +
 			"public class X {\n" +
@@ -7270,8 +7270,8 @@ public void testBug564672b_049() {
 public void testBug565388_001() {
 	if (this.complianceLevel < ClassFileConstants.JDK17) return;
 	Map<String, String> options = getCompilerOptionsWithPreviewIfApplicable();
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public non-sealed record X() {}\n"
 		},
@@ -7290,8 +7290,8 @@ public void testBug565388_001() {
 public void testBug565388_002() {
 	if (this.complianceLevel < ClassFileConstants.JDK17) return;
 	Map<String, String> options = getCompilerOptionsWithPreviewIfApplicable();
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public sealed record X() {}\n"
 		},
@@ -7331,8 +7331,8 @@ public void testBug565786_001() throws IOException, ClassFormatException {
 // report the warning on the record type.
 public void testBug563182_01() {
 	Map<String, String> customOptions = getCompilerOptions();
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"class X<T> {\n" +
 			"	record Point<T> (T ... args) { // 1\n" +
@@ -7356,8 +7356,8 @@ public void testBug563182_01() {
 public void testBug563182_02() {
 	getPossibleComplianceLevels();
 	Map<String, String> customOptions = getCompilerOptions();
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"class X<T> {\n" +
 			"	record Point<T> (T ... args) { // 1\n" +
@@ -7384,8 +7384,8 @@ public void testBug563182_02() {
 public void testBug563182_03() {
 	getPossibleComplianceLevels();
 	Map<String, String> customOptions = getCompilerOptions();
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"class X<T> {\n" +
 			"	record Point<T> (T ... args) { // 1\n" +
@@ -7407,8 +7407,8 @@ public void testBug563182_03() {
 //we don't report the warning on the compact canonical constructor but report on the record type
 public void testBug563182_04() {
 	Map<String, String> customOptions = getCompilerOptions();
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"class X<T> {\n" +
 			"	record Point<T> (T ... args) { // 1\n" +
@@ -7434,8 +7434,8 @@ public void testBug563182_04() {
 public void testBug563182_05() {
 	getPossibleComplianceLevels();
 	Map<String, String> customOptions = getCompilerOptions();
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"class X<T> {\n" +
 			"	record Point<T> (T ... args) { // 1\n" +
@@ -7456,8 +7456,8 @@ public void testBug563182_05() {
 //we don't report the warning on the non-canonical constructor but report on the record type
 public void testBug563182_06() {
 	Map<String, String> customOptions = getCompilerOptions();
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"class X<T> {\n" +
 			"	record Point<T> (T ... args) { // 1\n" +
@@ -7484,8 +7484,8 @@ public void testBug563182_06() {
 //we don't report the warning on the non-canonical constructor but report on the record type
 public void testBug563182_07() {
 	Map<String, String> customOptions = getCompilerOptions();
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"class X<T> {\n" +
 			"	record Point<T> (T ... args) { // 1\n" +
@@ -7548,8 +7548,8 @@ public void testBug563182_07() {
 			 "0");
 	}
 	public void testBug563186_03() {
-		runNegativeTest(
-				new String[] {
+		AbstractRegressionTest.runNegativeTest(
+				this, new String[] {
 					"X.java",
 					"public class X {\n"+
 					"  private record Point(int myInt){\n"+
@@ -7597,8 +7597,8 @@ public void testBug563182_07() {
 			 "0");
 	}
 	public void testBug565732_01() {
-		runNegativeTest(
-				new String[] {
+		AbstractRegressionTest.runNegativeTest(
+				this, new String[] {
 					"X.java",
 					"public record X {\n" +
 					"} "
@@ -7615,8 +7615,8 @@ public void testBug563182_07() {
 				getCompilerOptions());
 	}
 	public void testBug565732_02() {
-		runNegativeTest(
-				new String[] {
+		AbstractRegressionTest.runNegativeTest(
+				this, new String[] {
 					"X.java",
 					"public record X<T> {\n" +
 					"} "
@@ -7697,8 +7697,8 @@ public void testBug563182_07() {
 			 "record:");
 	}
 	public void testBug565732_07() {
-		runNegativeTest(
-				new String[] {
+		AbstractRegressionTest.runNegativeTest(
+				this, new String[] {
 					"X.java",
 					"public class X {\n" +
 					"	record R {};\n" +
@@ -7782,8 +7782,8 @@ public void testBug566063_001() {
 public void testBug566063_002() {
 	if (this.complianceLevel < ClassFileConstants.JDK17) return;
 	Map<String, String> options = getCompilerOptionsWithPreviewIfApplicable();
-	runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X {\n"+
 				"    void bar() throws Exception {\n"+
@@ -7816,8 +7816,8 @@ public void testBug566063_002() {
 public void testBug566063_003() {
 	if (this.complianceLevel < ClassFileConstants.JDK17) return;
 	Map<String, String> options = getCompilerOptionsWithPreviewIfApplicable();
-	runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X {\n"+
 				"    void bar() throws Exception {\n"+
@@ -7888,8 +7888,8 @@ public void testBug566418_001() {
 	options.put(CompilerOptions.OPTION_ReportUnnecessaryTypeCheck, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportUnusedWarningToken, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_SuppressOptionalErrors, CompilerOptions.ENABLED);
-	this.runNegativeTest(
-	new String[] {
+	AbstractRegressionTest.runNegativeTest(
+	this, new String[] {
 			"X.java",
 			"public class X {\n"+
 			" static void foo() {\n"+
@@ -8038,8 +8038,8 @@ public void testBug566554_04() {
 public void testBug567731_001() {
 	if (this.complianceLevel < ClassFileConstants.JDK17) return;
 	Map<String, String> options = getCompilerOptionsWithPreviewIfApplicable();
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  non-sealed record R() {}\n" +
@@ -8068,8 +8068,8 @@ public void testBug567731_001() {
 public void testBug567731_002() {
 	if (this.complianceLevel < ClassFileConstants.JDK17) return;
 	Map<String, String> options = getCompilerOptionsWithPreviewIfApplicable();
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"  sealed record R1() {}\n" +
@@ -8096,8 +8096,8 @@ public void testBug567731_002() {
 	options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
 }
 public void testBug566846_1() {
-	runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public record X;\n"
 			},
@@ -8113,8 +8113,8 @@ public void testBug566846_1() {
 			getCompilerOptions());
 }
 public void testBug566846_2() {
-	runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"
 				+ "} \n"
@@ -8144,8 +8144,8 @@ public void testBug566846_2() {
 public void testBug561199_001() {
 	Map<String, String> options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportMissingSerialVersion, CompilerOptions.ERROR);
-	runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"R.java",
 				"record R() implements java.io.Serializable {}\n",
 				"X.java",
@@ -8163,8 +8163,8 @@ public void testBug561199_001() {
 			options);
 }
 public void testBug568922_001() {
-	runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"+
 				" public static void main(String[] args) {\n"+
@@ -8934,8 +8934,8 @@ public void testBug572934_002() {
 	Map<String, String> options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportLocalVariableHiding, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportSpecialParameterHidingField, CompilerOptions.ENABLED);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public record X(int param) {\n" +
 			"	public X(int param) {\n" +
@@ -8963,8 +8963,8 @@ public void testBug572934_003() {
 	Map<String, String> options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportLocalVariableHiding, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportSpecialParameterHidingField, CompilerOptions.ENABLED);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public record X(int param) {\n" +
 			"	public X(int param) {\n" +
@@ -9143,8 +9143,8 @@ public void testBug577251_001() {
 public void testBug576806_001() {
 	Map<String, String> options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUndocumentedEmptyBlock, CompilerOptions.ERROR);
-	this.runNegativeTest(
-		false /* skipJavac */,
+	AbstractRegressionTest.runNegativeTest(
+		this, false /* skipJavac */,
 		new JavacTestOptions("Xlint:empty"),
 		new String[] {
 				"X.java",
@@ -9217,8 +9217,8 @@ public void testIssue365_001() throws Exception {
  */
 public void testRecordConstructorWithExceptionGh487() throws Exception {
 	getPossibleComplianceLevels();
-	runConformTest(
-			// test directory preparation
+	AbstractRegressionTest.runConformTest(
+			this, // test directory preparation
 			true /* should flush output directory */,
 			new String[] { /* test files */
 					"X.java",
@@ -9387,8 +9387,8 @@ public void testGH1092() throws Exception {
 public void testBug576719() {
 	Map<String, String> options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportParameterAssignment, CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"Rational.java",
@@ -9464,8 +9464,8 @@ public void testIssue1641_001() {
 	options.put(CompilerOptions.OPTION_Compliance, CompilerOptions.VERSION_17);
 	options.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_17);
 	options.put(CompilerOptions.OPTION_TargetPlatform, CompilerOptions.VERSION_17);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 		"X.java",
 		"""
 	record InterfaceInRecord() {
@@ -9504,8 +9504,8 @@ public void testIssue1641_002() {
 	options.put(CompilerOptions.OPTION_Compliance, CompilerOptions.VERSION_17);
 	options.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_17);
 	options.put(CompilerOptions.OPTION_TargetPlatform, CompilerOptions.VERSION_17);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 		"X.java",
 		"""
 			record InterfaceInRecord() {
@@ -9540,8 +9540,8 @@ public void testIssue1641_003() {
 	options.put(CompilerOptions.OPTION_Compliance, CompilerOptions.VERSION_17);
 	options.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_17);
 	options.put(CompilerOptions.OPTION_TargetPlatform, CompilerOptions.VERSION_17);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 		"X.java",
 		"""
 		enum InterfaceInEnum {
@@ -9577,8 +9577,8 @@ public void testIssue1641_004() {
 	options.put(CompilerOptions.OPTION_Compliance, CompilerOptions.VERSION_17);
 	options.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_17);
 	options.put(CompilerOptions.OPTION_TargetPlatform, CompilerOptions.VERSION_17);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 		"X.java",
 		"""
 		enum InterfaceInEnum {
@@ -9613,8 +9613,8 @@ public void testIssue1641_005() {
 	options.put(CompilerOptions.OPTION_Compliance, CompilerOptions.VERSION_17);
 	options.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_17);
 	options.put(CompilerOptions.OPTION_TargetPlatform, CompilerOptions.VERSION_17);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 		"X.java",
 		"""
 		interface I  {
@@ -9647,8 +9647,8 @@ public void testIssue1641_006() {
 	options.put(CompilerOptions.OPTION_Compliance, CompilerOptions.VERSION_17);
 	options.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_17);
 	options.put(CompilerOptions.OPTION_TargetPlatform, CompilerOptions.VERSION_17);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 		"X.java",
 		"""
 		interface I  {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RepeatableAnnotationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RepeatableAnnotationTest.java
@@ -278,8 +278,8 @@ public class RepeatableAnnotationTest extends AbstractComparableTest {
 	}
 	// Test that deprecation of container annotation is reflected in the repeated annotation (disabled until specification clarification is available)
 	public void _test009() {
-		this.runConformTest(
-			new String[] {
+		AbstractRegressionTest.runConformTest(
+			this, new String[] {
 				"Y.java",
 				"@java.lang.annotation.Repeatable(FooContainer.class) @interface Foo { int value(); }\n" +
 				"@Deprecated @interface FooContainer { Foo[] value(); }\n" +
@@ -428,8 +428,8 @@ public class RepeatableAnnotationTest extends AbstractComparableTest {
 					null,
 					false,
 					null);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"@Foo @Foo public class X { /* Problem since Foo now uses FooContainer which doesn't work anymore*/\n" +
 				"}\n"
@@ -539,8 +539,8 @@ public class RepeatableAnnotationTest extends AbstractComparableTest {
 					"@java.lang.annotation.Repeatable(FooContainer.class)\n" +
 					"public @interface Foo { }\n"
 				});
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"Foo.java",
 				"@java.lang.annotation.Repeatable(FooContainer.class)\n" +
 				"public @interface Foo { } // If omitted, retention is class\n"
@@ -569,8 +569,8 @@ public class RepeatableAnnotationTest extends AbstractComparableTest {
 				"@java.lang.annotation.Repeatable(FooContainer.class)\n" +
 				"public @interface Foo { }\n"
 			});
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"Foo.java",
 				"import java.lang.annotation.Retention;\n" +
 				"import java.lang.annotation.RetentionPolicy;\n" +
@@ -629,8 +629,8 @@ public class RepeatableAnnotationTest extends AbstractComparableTest {
 				"public @Target({ElementType.METHOD})\n" +
 				"@interface Foo { }\n"
 			});
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"Foo.java",
 				"import java.lang.annotation.Target;\n" +
 				"import java.lang.annotation.ElementType;\n" +
@@ -699,8 +699,8 @@ public class RepeatableAnnotationTest extends AbstractComparableTest {
 				"Foo.java",
 				"@interface Foo { }\n"
 			});
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"Foo.java",
 				"import java.lang.annotation.Target;\n" +
 				"import java.lang.annotation.ElementType;\n" +
@@ -1016,7 +1016,7 @@ public class RepeatableAnnotationTest extends AbstractComparableTest {
 				"            )\n" +
 				"        ]\n" +
 				"    )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "repeatable" + File.separator + "package-info.class", "package-info", expectedOutout, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "repeatable" + File.separator + "package-info.class", "package-info", expectedOutout, ClassFileBytesDisassembler.SYSTEM);
 	}
 	// 412149: [1.8][compiler] Emit repeated annotations into the designated container
 	// Test that repeated annotations show up on fields, methods, and parameters
@@ -1472,8 +1472,8 @@ public class RepeatableAnnotationTest extends AbstractComparableTest {
 
 	// 419209: [1.8] Repeating container annotations should be rejected in the presence of annotation it contains
 	public void testRepeatableWithContaining1() {
-		this.runNegativeTest(
-			false /* skipJavac */,
+		AbstractRegressionTest.runNegativeTest(
+			this, false /* skipJavac */,
 			JavacTestOptions.Excuse.EclipseHasSomeMoreWarnings,
 			new String[] {
 				"A.java",
@@ -1499,8 +1499,8 @@ public class RepeatableAnnotationTest extends AbstractComparableTest {
 	}
 	// 419209: [1.8] Repeating container annotations should be rejected in the presence of annotation it contains
 	public void testRepeatableWithContaining2() {
-		this.runNegativeTest(
-			false /* skipJavac */,
+		AbstractRegressionTest.runNegativeTest(
+			this, false /* skipJavac */,
 			JavacTestOptions.Excuse.EclipseHasSomeMoreWarnings,
 			new String[] {
 				"A.java",
@@ -1526,8 +1526,8 @@ public class RepeatableAnnotationTest extends AbstractComparableTest {
 	}
 	// 419209: [1.8] Repeating container annotations should be rejected in the presence of annotation it contains
 	public void testRepeatableWithContaining3() {
-		this.runNegativeTest(
-			false /* skipJavac */,
+		AbstractRegressionTest.runNegativeTest(
+			this, false /* skipJavac */,
 			JavacTestOptions.Excuse.EclipseHasSomeMoreWarnings,
 			new String[] {
 				"A.java",

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ResourceLeakTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ResourceLeakTests.java
@@ -76,19 +76,19 @@ void runTestsExpectingErrorsOnlyIn17(String[] testFiles, String errorsIn17, Map 
 	if (this.complianceLevel >= ClassFileConstants.JDK1_7)
 		runLeakTest(testFiles, errorsIn17, options);
 	else
-		runConformTest(testFiles, "", null, true, null, options, null);
+		AbstractRegressionTest.runConformTest(this, testFiles, "", null, true, null, options, null);
 }
 
 protected void runLeakTest(String[] testFiles, String expectedCompileError, Map options) {
-	runNegativeTest(testFiles, expectedCompileError, null, true, options, null, JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
+	AbstractRegressionTest.runNegativeTest(this, testFiles, expectedCompileError, null, true, options, null, JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 }
 
 protected void runLeakTest(String[] testFiles, String expectedCompileError, Map options, boolean shouldFlushOutput) {
-	runNegativeTest(testFiles, expectedCompileError, null, shouldFlushOutput, options, null, JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
+	AbstractRegressionTest.runNegativeTest(this, testFiles, expectedCompileError, null, shouldFlushOutput, options, null, JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 }
 
 protected void runLeakWarningTest(String[] testFiles, String expectedCompileError, Map options) {
-	runNegativeTest(testFiles, expectedCompileError, null, true, options, null, JavacTestOptions.Excuse.EclipseHasSomeMoreWarnings);
+	AbstractRegressionTest.runNegativeTest(this, testFiles, expectedCompileError, null, true, options, null, JavacTestOptions.Excuse.EclipseHasSomeMoreWarnings);
 }
 
 // === hooks for ResourceLeaksAnnotatedTests: ===
@@ -173,8 +173,8 @@ public void test056b() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"import java.io.File;\n" +
 			"import java.io.FileReader;\n" +
@@ -213,8 +213,8 @@ public void test056c() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.WARNING);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"import java.io.File;\n" +
 			"import java.io.FileReader;\n" +
@@ -298,7 +298,7 @@ public void test056d() {
 public void test056d_suppress() {
 	if (this.complianceLevel < ClassFileConstants.JDK1_5) return; // annotations used
 	Map options = getCompilerOptions();
-	enableAllWarningsForIrritants(options, IrritantSet.RESOURCE);
+	AbstractRegressionTest.enableAllWarningsForIrritants(options, IrritantSet.RESOURCE);
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.WARNING);
 	options.put(CompilerOptions.OPTION_SuppressOptionalErrors, CompilerOptions.ENABLED);
@@ -599,8 +599,8 @@ public void test056i_ignore() {
 	options.put(JavaCore.COMPILER_PB_UNCLOSED_CLOSEABLE, CompilerOptions.IGNORE);
 	options.put(JavaCore.COMPILER_PB_POTENTIALLY_UNCLOSED_CLOSEABLE, CompilerOptions.IGNORE);
 	options.put(JavaCore.COMPILER_PB_EXPLICITLY_CLOSED_AUTOCLOSEABLE, CompilerOptions.IGNORE);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"import java.io.File;\n" +
 			"import java.io.FileReader;\n" +
@@ -925,8 +925,8 @@ public void test056m() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"import java.io.File;\n" +
 			"import java.io.FileReader;\n" +
@@ -965,8 +965,8 @@ public void test056n() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"import java.io.File;\n" +
 			"import java.io.FileReader;\n" +
@@ -1011,8 +1011,8 @@ public void test056o() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"import java.io.File;\n" +
 			"import java.io.FileReader;\n" +
@@ -1190,8 +1190,8 @@ public void test056s() {
 	options.put(JavaCore.COMPILER_PB_UNCLOSED_CLOSEABLE, CompilerOptions.ERROR);
 	options.put(JavaCore.COMPILER_PB_POTENTIALLY_UNCLOSED_CLOSEABLE, CompilerOptions.WARNING);
 	options.put(JavaCore.COMPILER_PB_EXPLICITLY_CLOSED_AUTOCLOSEABLE, CompilerOptions.IGNORE);
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"import java.io.File;\n" +
 			"import java.io.FileReader;\n" +
@@ -1865,8 +1865,8 @@ public void test061a() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"import java.io.File;\n" +
 			"import java.io.BufferedInputStream;\n" +
@@ -1910,8 +1910,8 @@ public void test061b() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"import java.io.StringReader;\n" +
 			"import java.io.IOException;\n" +
@@ -1938,8 +1938,8 @@ public void test061c() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"import java.io.BufferedReader;\n" +
 			"import java.io.StringReader;\n" +
@@ -2022,8 +2022,8 @@ public void test061e() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"import java.io.File;\n" +
 			"import java.io.BufferedInputStream;\n" +
@@ -2073,8 +2073,8 @@ public void test061f() throws IOException {
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
 	URL url = FileLocator.toFileURL(FileLocator.find(Platform.getBundle("org.eclipse.jdt.core.tests.compiler"), new Path("META-INF/MANIFEST.MF"), null));
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"import java.io.InputStream;\n" +
 			"import java.io.InputStreamReader;\n" +
@@ -2121,8 +2121,8 @@ public void test061f2() throws IOException {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"import java.io.OutputStream;\n" +
 			"import java.io.FileOutputStream;\n" +
@@ -2351,8 +2351,8 @@ public void test061j() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"import java.io.InputStream;\n" +
 			"import java.io.BufferedInputStream;\n" +
@@ -2382,8 +2382,8 @@ public void test061k() throws IOException {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"import java.io.File;\n" +
 			"import java.io.FileInputStream;\n" +
@@ -2409,8 +2409,8 @@ public void test061l() throws IOException {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"import java.io.File;\n" +
 			"import java.io.FileInputStream;\n" +
@@ -2682,8 +2682,8 @@ public void test061p() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"import java.io.PrintWriter;\n" +
 			"import java.io.BufferedWriter;\n" +
@@ -2742,8 +2742,8 @@ public void test061r() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"import java.io.FileInputStream;\n" +
 			"import java.io.File;\n" +
@@ -2771,8 +2771,8 @@ public void test061s() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"import java.io.FileInputStream;\n" +
 			"import java.io.File;\n" +
@@ -2827,8 +2827,8 @@ public void test062b() throws IOException {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"import java.io.File;\n" +
 			"import java.io.FileOutputStream;\n" +
@@ -2952,8 +2952,8 @@ public void test063b() throws IOException {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"import java.io.FileInputStream;\n" +
 			"import java.io.BufferedInputStream;\n" +
@@ -3049,8 +3049,8 @@ public void test063e() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"import java.io.FileInputStream;\n" +
 			"import java.io.IOException;\n" +
@@ -3208,7 +3208,7 @@ public void _test065() {
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportMissingSerialVersion, CompilerOptions.IGNORE);
-	this.runConformTest(new String[] {
+	AbstractRegressionTest.runConformTest(this, new String[] {
 		"Test065.java",
 		"import java.io.*;\n" +
 		"class MyException extends Exception{}\n" +
@@ -3317,7 +3317,7 @@ public void _test067() {
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportMissingSerialVersion, CompilerOptions.IGNORE);
-	this.runConformTest(new String[] {
+	AbstractRegressionTest.runConformTest(this, new String[] {
 		"Test067.java",
 		"import java.io.*;\n" +
 		"public class Test067 {\n" +
@@ -3345,7 +3345,7 @@ public void test067b() {
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportMissingSerialVersion, CompilerOptions.IGNORE);
-	this.runConformTest(new String[] {
+	AbstractRegressionTest.runConformTest(this, new String[] {
 		"Test067.java",
 		"import java.io.*;\n" +
 		"public class Test067 {\n" +
@@ -3373,7 +3373,7 @@ public void test068() {
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportMissingSerialVersion, CompilerOptions.IGNORE);
-	this.runConformTest(new String[] {
+	AbstractRegressionTest.runConformTest(this, new String[] {
 		"Test068.java",
 		"import java.io.*;\n" +
 		"public class Test068 {\n" +
@@ -3410,7 +3410,7 @@ public void test069() {
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportMissingSerialVersion, CompilerOptions.IGNORE);
-	this.runConformTest(new String[] {
+	AbstractRegressionTest.runConformTest(this, new String[] {
 		"Test069.java",
 		"import java.io.*;\n" +
 		"import java.util.Collection;\n" +
@@ -3563,7 +3563,7 @@ public void test072() {
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportMissingSerialVersion, CompilerOptions.IGNORE);
-	this.runConformTest(new String[] {
+	AbstractRegressionTest.runConformTest(this, new String[] {
 		"Test072.java",
 		"import java.io.*;\n" +
 		"public class Test072 {\n" +
@@ -3602,7 +3602,7 @@ public void test073() {
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportMissingSerialVersion, CompilerOptions.IGNORE);
-	this.runConformTest(new String[] {
+	AbstractRegressionTest.runConformTest(this, new String[] {
 		"Test073.java",
 		"import java.io.*;\n" +
 		"public class Test073 {\n" +
@@ -3686,8 +3686,8 @@ public void test075() {
 public void testBug385415() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"import java.io.*;\n" +
 			"public class X {\n" +
@@ -3716,8 +3716,8 @@ public void testBug385415() {
 public void testBug361073c7() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"import java.io.*;\n" +
 			"public class X {\n" +
@@ -3754,8 +3754,8 @@ public void testBug361073c7() {
 public void _testBug386534() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"Bug.java",
 			"import java.io.FileNotFoundException;\n" +
 			"import java.io.IOException;\n" +
@@ -3807,8 +3807,8 @@ public void _testBug386534() {
 public void testBug388996() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"Bug.java",
 			"import java.io.*;\n" +
 			"public class Bug {\n" +
@@ -3849,8 +3849,8 @@ public void testBug388996() {
 public void testBug386534() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"Bug386534.java",
 			"import java.io.FileNotFoundException;\n" +
 			"import java.io.IOException;\n" +
@@ -3903,8 +3903,8 @@ public void testBug394768() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"Bug394768.java",
 			"import java.io.File;\n" +
 			"import java.io.FileInputStream;\n" +
@@ -3946,8 +3946,8 @@ public void testBug394768_1() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"Bug394768.java",
 			"import java.io.File;\n" +
 			"import java.io.FileInputStream;\n" +
@@ -4145,8 +4145,8 @@ public void testBug381445_3() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			GUAVA_CLOSEABLES_JAVA,
 			GUAVA_CLOSEABLES_CONTENT,
 			"Bug381445a.java",
@@ -4200,8 +4200,8 @@ public void testBug395977() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"WriterTest.java",
 			"import java.io.*;\n" +
 			"\n" +
@@ -4481,8 +4481,8 @@ public void testBug411098_test1() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"A.java",
 			"import java.io.*;\n" +
 			"\n" +
@@ -4561,8 +4561,8 @@ public void testBug411098_test4() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"A.java",
 			"import java.io.FileInputStream;\n" +
 			"class A {\n" +
@@ -4586,8 +4586,8 @@ public void testBug411098_test5() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"A.java",
 			"import java.io.FileInputStream;\n" +
 			"class A {\n" +
@@ -4607,8 +4607,8 @@ public void testBug411098_test6() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"A.java",
 			"import java.io.FileInputStream;\n" +
 			"class A {\n" +
@@ -4629,8 +4629,8 @@ public void testBug411098_test7() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"A.java",
 			"import java.io.*;\n" +
 			"class A {\n" +
@@ -4673,8 +4673,8 @@ public void testStream1() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"A.java",
 			"import java.util.*;\n" +
 			"import java.util.stream.Stream;\n" +
@@ -4695,8 +4695,8 @@ public void testStream1_Int() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"A.java",
 			"import java.util.stream.*;\n" +
 			"class A {\n" +
@@ -4718,8 +4718,8 @@ public void testStream1_Double_Long() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"A.java",
 			"import java.util.stream.*;\n" +
 			"class A {\n" +
@@ -4741,8 +4741,8 @@ public void testStreamEx_572707() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			STREAMEX_JAVA,
 			STREAMEX_CONTENT,
 			"Bug572707.java",
@@ -4820,8 +4820,8 @@ public void testStream4() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"A.java",
 			"import java.util.stream.Stream;\n" +
 			"import java.nio.file.*;\n" +
@@ -4842,8 +4842,8 @@ public void testBug415790_ex2() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"import java.io.*;\n" +
 			"public class X {\n" +
@@ -4871,8 +4871,8 @@ public void testBug415790_ex4() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"import java.io.*;\n" +
 			"public class X {\n" +
@@ -4953,8 +4953,8 @@ public void testBug371614_comment2() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"ResourceLeak.java",
 			"import java.io.FileInputStream;\n" +
 			"import java.io.IOException;\n" +
@@ -4998,8 +4998,8 @@ public void testBug371614_comment8() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"import java.io.*;\n" +
 			"import java.net.*;\n" +
@@ -5023,8 +5023,8 @@ public void testBug462371_orig() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"import java.io.*;\n" +
 			"interface IFile {\n" +
@@ -5112,8 +5112,8 @@ public void testBug421035() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"Test.java",
 			"import java.io.BufferedReader;\n" +
 			"import java.io.FileNotFoundException;\n" +
@@ -5139,8 +5139,8 @@ public void testBug444964() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"Bug444964.java",
 			"import java.io.*;\n" +
 			"\n" +
@@ -5171,8 +5171,8 @@ public void testBug397204() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"HostIdTest.java",
 			"import java.io.*;\n" +
 			"import java.net.InetAddress;\n" +
@@ -5232,8 +5232,8 @@ public void testBug397204_comment4() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"HostIdTest.java",
 			"import java.io.*;\n" +
 			"\n" +
@@ -5255,8 +5255,8 @@ public void testBug433510() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"Bug433510.java",
 			"import java.io.*;\n" +
 			"\n" +
@@ -5624,7 +5624,7 @@ public void testBug541705b() {
 	runner.runConformTest();
 }
 public void testBug542707_001() {
-	if (!checkPreviewAllowed()) return; // uses switch expression
+	if (!AbstractRegressionTest.checkPreviewAllowed(this)) return; // uses switch expression
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_UNCLOSED_CLOSEABLE, CompilerOptions.ERROR);
 	options.put(JavaCore.COMPILER_PB_POTENTIALLY_UNCLOSED_CLOSEABLE, CompilerOptions.ERROR);
@@ -5744,7 +5744,7 @@ public void testBug542707_002() {
 		options);
 }
 public void testBug542707_003() {
-	if (!checkPreviewAllowed()) return; // uses switch expression
+	if (!AbstractRegressionTest.checkPreviewAllowed(this)) return; // uses switch expression
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_UNCLOSED_CLOSEABLE, CompilerOptions.ERROR);
 	options.put(JavaCore.COMPILER_PB_POTENTIALLY_UNCLOSED_CLOSEABLE, CompilerOptions.ERROR);
@@ -5960,8 +5960,8 @@ public void testBug560460() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"import java.util.*;\n" +
 			"public class X {\n" +
@@ -5977,8 +5977,8 @@ public void testBug463320_comment19() {
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
 
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"Try17.java",
 			"import java.util.zip.*;\n" +
 			"import java.io.*;\n" +
@@ -6248,8 +6248,8 @@ public void testBug519740() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"Snippet.java",
 			"class Snippet {\n" +
 			"  static void foo() throws Exception {\n" +
@@ -6270,8 +6270,8 @@ public void testBug552441() {
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
 
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"Test.java",
 			"import java.io.BufferedOutputStream;\n" +
 			"import java.io.FileOutputStream;\n" +
@@ -6333,8 +6333,8 @@ public void testBug400523() {
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
 
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"LeakWarning.java",
 			"import java.sql.Connection;\n" +
 			"import java.sql.PreparedStatement;\n" +
@@ -6384,8 +6384,8 @@ public void testBug527761() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"class BAOSWrapper extends java.io.ByteArrayOutputStream {}\n" +
 			"public class X {\n" +
@@ -6411,8 +6411,8 @@ public void testBug527761_otherClose() {
 			"		baos.write(0);\n" +
 			"	}\n" +
 			"}\n";
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"BAOSWrapper.java",
 			"class BAOSWrapper<T> extends java.io.ByteArrayOutputStream {\n" +
 			"	public void close(java.util.List<?> l) {}\n" + // not relevant, param challenges treatment of unresolved types
@@ -6422,7 +6422,7 @@ public void testBug527761_otherClose() {
 		},
 		options);
 	// consume BAOSWrapper from .class:
-	runConformTest(false,
+	AbstractRegressionTest.runConformTest(this, false,
 			new String[] { "X.java", xSource },
 			"", "", "", null);
 }
@@ -6462,8 +6462,8 @@ public void testBug558759() {
 		"public class Y {\n" +
 		"	class YInner extends X<I> {}\n" +
 		"}\n";
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"I.java",
 			"import java.io.Closeable;\n" +
 			"public interface I extends Closeable {\n" +
@@ -6482,7 +6482,7 @@ public void testBug558759() {
 			ySource
 		},
 		options);
-	runConformTest(false,
+	AbstractRegressionTest.runConformTest(this, false,
 			new String[] { "Y.java", ySource },
 			"", "", "", null);
 }
@@ -6555,8 +6555,8 @@ public void testBug560671() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.WARNING);
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"import java.util.Scanner;\n" +
 			"public class X {\n" +
@@ -6573,8 +6573,8 @@ public void testBug560671b() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.WARNING);
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"import java.util.Scanner;\n" +
 			"public class X {\n" +
@@ -6595,8 +6595,8 @@ public void testBug561259() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.WARNING);
-	runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"import java.io.*;\n" +
 			"public class X {\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RuntimeTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RuntimeTests.java
@@ -51,8 +51,8 @@ public static Class testClass() {
 // see https://bugs.eclipse.org/bugs/show_bug.cgi?id=217078
 // memory exhaustion - try to allocate too big an instance
 public void _test0001_memory_exhaustion() {
-	runTest(
-		new String[] { /* testFiles */
+	AbstractRegressionTest.runTest(
+		this, new String[] { /* testFiles */
 			"X.java",
 			"public class X {\n" +
 			"  public static void main(String args[]) {\n" +
@@ -145,8 +145,8 @@ public void test0500_synchronization() {
 // reflection - access to a public method of a package visible
 // class through a public extending class
 public void test0600_reflection() {
-	runConformTest(
-		true,
+	AbstractRegressionTest.runConformTest(
+		this, true,
 		new String[] {
 			"X.java",
 			"import java.lang.reflect.*;\n" +
@@ -379,8 +379,8 @@ public void test1002_partial_rebuild() {
 			"}\n",
 			},
 		"1");
-	this.runConformTest(
-		false,
+	AbstractRegressionTest.runConformTest(
+		this, false,
 		new String[] {
 			"X.java",
 			"public class X {\n" +
@@ -445,8 +445,8 @@ public void test1003_partial_rebuild() {
 			"}\n",
 			},
 		"1");
-	this.runConformTest(
-		false, // do not purge output directory - pick old version of Z.class
+	AbstractRegressionTest.runConformTest(
+		this, false, // do not purge output directory - pick old version of Z.class
 		new String[] {
 			"X.java",
 			"public class X {\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SealedTypesTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SealedTypesTests.java
@@ -72,7 +72,7 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	}
 	@Override
 	protected void runNegativeTest(String[] testFiles, String expectedCompilerLog) {
-		runNegativeTest(testFiles, expectedCompilerLog, JavacTestOptions.forReleaseWithPreview("17"));
+		AbstractRegressionTest.runNegativeTest(this, testFiles, expectedCompilerLog, JavacTestOptions.forReleaseWithPreview("17"));
 	}
 	protected void runWarningTest(String[] testFiles, String expectedCompilerLog) {
 		runWarningTest(testFiles, expectedCompilerLog, null);
@@ -1383,8 +1383,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 		int len = libs.length;
 		System.arraycopy(libs, 0, libs = new String[len+1], 0, len);
 		libs[len] = lib1Path;
-		this.runNegativeTest(
-				new String[] {
+		AbstractRegressionTest.runNegativeTest(
+				this, new String[] {
 					"src/p/X.java",
 					"package p;\n" +
 					"public class X extends Y {\n" +
@@ -1670,8 +1670,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638_001() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class permits {\n"+
 				"  void foo() {\n" +
@@ -1721,8 +1721,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638_003() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X {\n"+
 				"  permits p;\n" +
@@ -1793,8 +1793,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638_005() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X<permits> {\n"+
 				"  void foo() {\n" +
@@ -1873,8 +1873,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638_008() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X extends permits {\n"+
 				"  void foo() {\n" +
@@ -1938,8 +1938,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638_010() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X implements permits {\n"+
 				"  void foo() {\n" +
@@ -2003,8 +2003,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638_012() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"interface X extends permits {\n"+
 				"  default void foo() {\n" +
@@ -2067,8 +2067,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638_014() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X {\n"+
 				"  permits foo() {\n" +
@@ -2119,8 +2119,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638_016() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X {\n"+
 				"  void foo() throws permits{\n" +
@@ -2185,8 +2185,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638_018() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X <T extends permits>{\n"+
 				"  <T> void foo(T extends permits) {\n" +
@@ -2253,8 +2253,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638_020() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"enum X {\n"+
 				"  ONE(1);\n" +
@@ -2310,8 +2310,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638_022() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X {\n"+
 				"  public static void main(String[] args) {\n" +
@@ -2363,8 +2363,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638_024() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X {\n"+
 				"  public void foo(permits this) {}\n" +
@@ -2400,8 +2400,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638_026() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X {\n"+
 				"  public void foo(permits this) {}\n" +
@@ -2444,8 +2444,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638_028() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X {\n"+
 				"  class permits {\n"+
@@ -2496,8 +2496,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638_030() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X {\n"+
 				"  public static void main(String[] args) {\n" +
@@ -2551,8 +2551,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638_032() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X {\n"+
 				"  public static void main(String[] args) {\n" +
@@ -2605,8 +2605,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638_034() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X {\n"+
 				"  public static void main(permits[] args) {\n" +
@@ -2661,8 +2661,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638_036() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X {\n"+
 				"       public static void main(String[] args) {\n"+
@@ -2722,8 +2722,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638_038() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X {\n"+
 				"       public static void main(String[] args) {\n"+
@@ -2775,8 +2775,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638_040() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"record X(permits p) {\n"+
 				"}\n",
@@ -2825,8 +2825,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638_042() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X {\n"+
 				"       public <T> X(T t) {}\n"+
@@ -2881,8 +2881,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638_044() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X {\n"+
 				"       public <T> X(T t) {}\n"+
@@ -2938,8 +2938,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638_046() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X {\n"+
 				"       public <T> void foo(T t) {}\n"+
@@ -2989,8 +2989,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638_048() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X {\n"+
 				"       public <T> void foo(T t) {}\n"+
@@ -3043,8 +3043,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638_050() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X {\n"+
 				"    public X() {\n"+
@@ -3102,8 +3102,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638_052() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X {\n"+
 				"  public X() {\n"+
@@ -3154,8 +3154,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638_054() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X {\n"+
 				" public static void main(String[] args) {\n"+
@@ -3206,8 +3206,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638_056() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X {\n"+
 				" private void foo(Object o) {\n"+
@@ -3258,8 +3258,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638_058() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X {\n"+
 				" public static void main(String[] args) {\n"+
@@ -3293,8 +3293,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638b_001() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class sealed {\n"+
 				"  void foo() {\n" +
@@ -3344,8 +3344,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638b_003() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X {\n"+
 				"  sealed p;\n" +
@@ -3416,8 +3416,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638b_005() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X<sealed> {\n"+
 				"  void foo() {\n" +
@@ -3496,8 +3496,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638b_008() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X extends sealed {\n"+
 				"  void foo() {\n" +
@@ -3561,8 +3561,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638b_010() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X implements sealed {\n"+
 				"  void foo() {\n" +
@@ -3626,8 +3626,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638b_012() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"interface X extends sealed {\n"+
 				"  default void foo() {\n" +
@@ -3690,8 +3690,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638b_014() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X {\n"+
 				"  sealed foo() {\n" +
@@ -3742,8 +3742,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638b_016() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X {\n"+
 				"  void foo() throws sealed{\n" +
@@ -3808,8 +3808,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638b_018() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X <T extends sealed>{\n"+
 				"  <T> void foo(T extends sealed) {\n" +
@@ -3876,8 +3876,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638b_020() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"enum X {\n"+
 				"  ONE(1);\n" +
@@ -3933,8 +3933,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638b_022() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X {\n"+
 				"  public static void main(String[] args) {\n" +
@@ -3986,8 +3986,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638b_024() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X {\n"+
 				"  public void foo(sealed this) {}\n" +
@@ -4023,8 +4023,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638b_026() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X {\n"+
 				"  public void foo(sealed this) {}\n" +
@@ -4067,8 +4067,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638b_028() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X {\n"+
 				"  class sealed {\n"+
@@ -4119,8 +4119,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638b_030() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X {\n"+
 				"  public static void main(String[] args) {\n" +
@@ -4174,8 +4174,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638b_032() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X {\n"+
 				"  public static void main(String[] args) {\n" +
@@ -4228,8 +4228,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638b_034() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X {\n"+
 				"  public static void main(sealed[] args) {\n" +
@@ -4284,8 +4284,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638b_036() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X {\n"+
 				"       public static void main(String[] args) {\n"+
@@ -4345,8 +4345,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638b_038() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X {\n"+
 				"       public static void main(String[] args) {\n"+
@@ -4398,8 +4398,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638b_040() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"record X(sealed p) {\n"+
 				"}\n",
@@ -4448,8 +4448,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638b_042() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X {\n"+
 				"       public <T> X(T t) {}\n"+
@@ -4504,8 +4504,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638b_044() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X {\n"+
 				"       public <T> X(T t) {}\n"+
@@ -4561,8 +4561,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638b_046() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X {\n"+
 				"       public <T> void foo(T t) {}\n"+
@@ -4612,8 +4612,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638b_048() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X {\n"+
 				"       public <T> void foo(T t) {}\n"+
@@ -4666,8 +4666,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638b_050() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X {\n"+
 				"    public X() {\n"+
@@ -4725,8 +4725,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638b_052() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X {\n"+
 				"  public X() {\n"+
@@ -4777,8 +4777,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638b_054() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X {\n"+
 				" public static void main(String[] args) {\n"+
@@ -4829,8 +4829,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638b_056() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X {\n"+
 				" private void foo(Object o) {\n"+
@@ -4881,8 +4881,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug564638b_058() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X {\n"+
 				" public static void main(String[] args) {\n"+
@@ -5067,8 +5067,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 		Map<String, String> options =getCompilerOptions();
 		options.put(CompilerOptions.OPTION_ReportPreviewFeatures, CompilerOptions.WARNING);
 
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public sealed class X  permits Y {" +
 				"Zork();\n" +
@@ -5096,8 +5096,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	@SuppressWarnings({ "rawtypes" })
 	public void testBug566979_001() {
 		Map options = getCompilerOptions();
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X {\n"+
 				"    public sealed void main(String[] args){ }\n"+
@@ -5118,8 +5118,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug566979_002() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X {\n"+
 				"    public sealed void main(String[] args){ }\n"+
@@ -5139,8 +5139,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	@SuppressWarnings({ "rawtypes" })
 	public void testBug566980_001() {
 		Map options = getCompilerOptions();
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X {\n"+
 				"    public permits void main(String[] args){ }\n"+
@@ -5161,8 +5161,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public void testBug566980_002() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"class X {\n"+
 				"    public permits void main(String[] args){ }\n"+
@@ -5182,8 +5182,8 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	@SuppressWarnings({ "rawtypes" })
 	public void testBug566846_001() {
 		Map options = getCompilerOptions();
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"record X;\n",
 			},

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SerialVersionUIDTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SerialVersionUIDTests.java
@@ -82,8 +82,8 @@ public void test002() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=101476
 public void test003() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X implements java.io.Serializable {\n" +
 			"	private void writeObject(java.io.ObjectOutputStream stream) throws java.io.IOException {}\n" +
@@ -100,8 +100,8 @@ public void test003() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=101476
 public void test004() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X implements java.io.Serializable {\n" +
 			"	private void readObject(java.io.ObjectInputStream stream) throws java.io.IOException {}\n" +
@@ -118,8 +118,8 @@ public void test004() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=101476
 public void test005() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X implements java.io.Serializable {\n" +
 			"}"
@@ -149,8 +149,8 @@ public void test006() {
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=116733
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=94352
 public void test007() {
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"abstract class A implements java.io.Serializable {}\n" +
 			"public class X extends A {}\n"
@@ -218,8 +218,8 @@ public void _test010() {
 public void test011() {
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_UNUSED_PRIVATE_MEMBER, JavaCore.ERROR);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	private static final long serialVersionUID = 1L;\n" +
@@ -241,8 +241,8 @@ public void test012() {
 	if (this.complianceLevel < ClassFileConstants.JDK1_5) return;
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_UNUSED_PRIVATE_MEMBER, JavaCore.ERROR);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X<T> {\n" +
 			"	private static final long serialVersionUID = 1L;\n" +
@@ -264,8 +264,8 @@ public void test013() {
 	if (this.complianceLevel < ClassFileConstants.JDK1_5) return;
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_UNUSED_PRIVATE_MEMBER, JavaCore.ERROR);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X<T> {\n" +
 			"	private static final long serialPersistentFields = 1L;\n" +
@@ -286,8 +286,8 @@ public void test013() {
 public void test014() {
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_UNUSED_PRIVATE_MEMBER, JavaCore.ERROR);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	private static final long serialPersistentFields = 1L;\n" +
@@ -309,8 +309,8 @@ public void test015() {
 	if (this.complianceLevel < ClassFileConstants.JDK1_5) return;
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_UNUSED_PRIVATE_MEMBER, JavaCore.ERROR);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"import java.io.ObjectStreamField;\n" +
 			"public class X<T> implements java.io.Serializable {\n" +
@@ -334,8 +334,8 @@ public void test015() {
 public void test016() {
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_UNUSED_PRIVATE_MEMBER, JavaCore.ERROR);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"import java.io.ObjectStreamField;\n" +
 			"public class X implements java.io.Serializable {\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SerializableLambdaTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SerializableLambdaTest.java
@@ -858,10 +858,10 @@ public class SerializableLambdaTest extends AbstractRegressionTest {
 					new String [] { "-Ddummy" }); // Not sure, unless we force the VM to not be reused by passing dummy vm argument, the generated program aborts midway through its execution.
 		String expectedOutput =
 			"  private static synthetic void lambda$0() throws java.lang.Exception;\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 		expectedOutput =
 			"  private static synthetic int lambda$1();\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test021_lambdaNamesVariants() throws Exception {
@@ -1847,8 +1847,8 @@ public class SerializableLambdaTest extends AbstractRegressionTest {
 	public void testbug494487() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_LocalVariableAttribute, CompilerOptions.DO_NOT_GENERATE);
-		this.runConformTest(
-			new String[]{
+		AbstractRegressionTest.runConformTest(
+			this, new String[]{
 				"Test.java",
 				"import java.io.IOException;\n" +
 				"import java.io.Serializable;\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/StackMapAttributeTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/StackMapAttributeTest.java
@@ -6210,7 +6210,7 @@ public class StackMapAttributeTest extends AbstractRegressionTest {
 			"  private java.lang.Object bar();\n" +
 			"     0  aload_0 [this]\n" +
 			"     1  " +
-			(isMinimumCompliant(ClassFileConstants.JDK11) ? "invokevirtual" : "invokespecial") +
+			(AbstractRegressionTest.isMinimumCompliant(this, ClassFileConstants.JDK11) ? "invokevirtual" : "invokespecial") +
 			" X.bar2() : java.lang.Object [25]\n" +
 			"     4  astore_1 [o]\n" +
 			"     5  aload_1 [o]\n" +
@@ -6230,7 +6230,7 @@ public class StackMapAttributeTest extends AbstractRegressionTest {
 			"        [pc: 5, pc: 16] local: o index: 1 type: java.lang.Object\n" +
 			"      Stack map table: number of frames 1\n" +
 			"        [pc: 14, append: {java.lang.Object}]\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+		AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 	}
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=251539
 	public void test041() throws Exception {
@@ -6278,7 +6278,7 @@ public class StackMapAttributeTest extends AbstractRegressionTest {
 			"  private java.lang.Object bar();\n" +
 			"     0  aload_0 [this]\n" +
 			"     1  " +
-			(isMinimumCompliant(ClassFileConstants.JDK11) ? "invokevirtual" : "invokespecial") +
+			(AbstractRegressionTest.isMinimumCompliant(this, ClassFileConstants.JDK11) ? "invokevirtual" : "invokespecial") +
 			" X.bar2() : java.lang.Object [31]\n" +
 			"     4  astore_1 [o]\n" +
 			"     5  aload_1 [o]\n" +
@@ -6298,7 +6298,7 @@ public class StackMapAttributeTest extends AbstractRegressionTest {
 			"        [pc: 5, pc: 16] local: o index: 1 type: java.lang.Object\n" +
 			"      Stack map table: number of frames 1\n" +
 			"        [pc: 14, append: {java.lang.Object}]\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+		AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 	}
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=260031
 	public void test042() throws Exception {
@@ -6333,7 +6333,7 @@ public class StackMapAttributeTest extends AbstractRegressionTest {
 			"      Stack map table: number of frames 2\n" +
 			"        [pc: 10, same_locals_1_stack_item, stack: {java.lang.Class}]\n" +
 			"        [pc: 11, full, stack: {java.lang.Class, int}, locals: {java.lang.String[]}]\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+		AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 	}
 
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=279183
@@ -6410,7 +6410,7 @@ public class StackMapAttributeTest extends AbstractRegressionTest {
 			"        [pc: 19, full, stack: {}, locals: {int, int, int}]\n" +
 			"        [pc: 25, same]\n" +
 			"        [pc: 34, full, stack: {}, locals: {int, _, int}]\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+		AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 	}
 
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=279183
@@ -6481,7 +6481,7 @@ public class StackMapAttributeTest extends AbstractRegressionTest {
 			"        [pc: 14, same]\n" +
 			"        [pc: 16, full, stack: {}, locals: {int, int, int}]\n" +
 			"        [pc: 25, full, stack: {}, locals: {int, _, int}]\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+		AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 	}
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=279183
 	public void test045() throws Exception {
@@ -6537,14 +6537,14 @@ public class StackMapAttributeTest extends AbstractRegressionTest {
 			"        [pc: 0, same]\n" +
 			"        [pc: 22, append: {int}]\n" +
 			"        [pc: 30, same]\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+		AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 	}
 	// 298250
 	public void test046() {
 		Map customOptions = getCompilerOptions();
 		customOptions.put(JavaCore.COMPILER_PB_UNUSED_PRIVATE_MEMBER, JavaCore.IGNORE);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"	class E1 extends RuntimeException {\n" +
@@ -6805,8 +6805,8 @@ public class StackMapAttributeTest extends AbstractRegressionTest {
 		Map customOptions = getCompilerOptions();
 		customOptions.put(JavaCore.COMPILER_PB_UNUSED_PRIVATE_MEMBER, JavaCore.IGNORE);
 		customOptions.put(JavaCore.COMPILER_PB_SYNTHETIC_ACCESS_EMULATION, JavaCore.IGNORE);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"	static {\n" +
@@ -7713,7 +7713,7 @@ public class StackMapAttributeTest extends AbstractRegressionTest {
 					"\n",
 					ClassFileBytesDisassembler.DETAILED);
 
-			String xBarCall = isMinimumCompliant(ClassFileConstants.JDK11) ?
+			String xBarCall = AbstractRegressionTest.isMinimumCompliant(this, ClassFileConstants.JDK11) ?
 					"invokevirtual X.bar() : int [18]\n" : "invokespecial X.bar() : int [18]\n";
 			String expectedOutput =
 					"  // Method descriptor #6 ()V\n" +
@@ -7836,7 +7836,7 @@ public class StackMapAttributeTest extends AbstractRegressionTest {
 					"\n",
 					ClassFileBytesDisassembler.DETAILED);
 
-			String xBarCall = (isMinimumCompliant(ClassFileConstants.JDK11) ?
+			String xBarCall = (AbstractRegressionTest.isMinimumCompliant(this, ClassFileConstants.JDK11) ?
 					"invokevirtual" : "invokespecial") + " X.bar() : int [28]\n";
 			String expectedOutput =
 					"  // Method descriptor #6 ()V\n" +
@@ -8261,8 +8261,8 @@ public class StackMapAttributeTest extends AbstractRegressionTest {
 		options.put(JavaCore.COMPILER_PB_NULL_SPECIFICATION_VIOLATION, JavaCore.ERROR);
 		options.put(JavaCore.COMPILER_PB_POTENTIAL_NULL_REFERENCE, JavaCore.WARNING);
 		options.put(JavaCore.COMPILER_PB_SUPPRESS_OPTIONAL_ERRORS, JavaCore.ENABLED);
-		this.runConformTest(
-				new String[] {
+		AbstractRegressionTest.runConformTest(
+				this, new String[] {
 					"X2.java",
 					"import java.util.*;\n" +
 					"\n" +
@@ -8320,7 +8320,7 @@ public class StackMapAttributeTest extends AbstractRegressionTest {
 					"}\n",
 				},
 				"",
-				getLibsWithNullAnnotations(ClassFileConstants.JDK1_7),
+				AbstractRegressionTest.getLibsWithNullAnnotations(this, ClassFileConstants.JDK1_7),
 				true/*flush*/,
 				null/*vmArgs*/,
 				options,
@@ -8418,8 +8418,8 @@ public class StackMapAttributeTest extends AbstractRegressionTest {
 		options.put(JavaCore.COMPILER_PB_NULL_SPECIFICATION_VIOLATION, JavaCore.ERROR);
 		options.put(JavaCore.COMPILER_PB_POTENTIAL_NULL_REFERENCE, JavaCore.WARNING);
 		options.put(JavaCore.COMPILER_PB_SUPPRESS_OPTIONAL_ERRORS, JavaCore.ENABLED);
-		this.runConformTest(
-				new String[] {
+		AbstractRegressionTest.runConformTest(
+				this, new String[] {
 					"X2.java",
 					"import java.util.LinkedList;\n" +
 					"\n" +
@@ -8442,7 +8442,7 @@ public class StackMapAttributeTest extends AbstractRegressionTest {
 					"}\n",
 				},
 				"",
-				getLibsWithNullAnnotations(ClassFileConstants.JDK1_7),
+				AbstractRegressionTest.getLibsWithNullAnnotations(this, ClassFileConstants.JDK1_7),
 				true/*flush*/,
 				null/*vmArgs*/,
 				options,
@@ -8535,8 +8535,8 @@ public class StackMapAttributeTest extends AbstractRegressionTest {
 		options.put(JavaCore.COMPILER_PB_NULL_SPECIFICATION_VIOLATION, JavaCore.ERROR);
 		options.put(JavaCore.COMPILER_PB_POTENTIAL_NULL_REFERENCE, JavaCore.WARNING);
 		options.put(JavaCore.COMPILER_PB_SUPPRESS_OPTIONAL_ERRORS, JavaCore.ENABLED);
-		this.runConformTest(
-				new String[] {
+		AbstractRegressionTest.runConformTest(
+				this, new String[] {
 					"X2.java",
 					"import java.util.LinkedList;\n" +
 					"\n" +
@@ -8559,7 +8559,7 @@ public class StackMapAttributeTest extends AbstractRegressionTest {
 					"}\n",
 				},
 				"",
-				getLibsWithNullAnnotations(ClassFileConstants.JDK1_7),
+				AbstractRegressionTest.getLibsWithNullAnnotations(this, ClassFileConstants.JDK1_7),
 				true/*flush*/,
 				null/*vmArgs*/,
 				options,

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/StaticImportTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/StaticImportTest.java
@@ -139,8 +139,8 @@ public class StaticImportTest extends AbstractComparableTest {
 			},
 			""
 		);
-		this.runConformTest(
-			new String[] {
+		AbstractRegressionTest.runConformTest(
+			this, new String[] {
 				"X.java",
 				"import static p.A.C;\n" +
 				"public class X { \n" +
@@ -1391,8 +1391,8 @@ public class StaticImportTest extends AbstractComparableTest {
 	}
 	//https://bugs.eclipse.org/bugs/show_bug.cgi?id=126564 - variation
 	public void test037() {
-		this.runConformTest(
-			new String[] {
+		AbstractRegressionTest.runConformTest(
+			this, new String[] {
 				"X.java",
 				"import static p.A.CONSTANT_I;\n" +
 				"import static p.A.CONSTANT_B;\n" +
@@ -1537,8 +1537,8 @@ public class StaticImportTest extends AbstractComparableTest {
 	}
 	//https://bugs.eclipse.org/bugs/show_bug.cgi?id=134118
 	public void test041() {
-		this.runConformTest(
-			true,
+		AbstractRegressionTest.runConformTest(
+			this, true,
 			new String[] {
 				"Test.java",
 				"import static p.I.*;\n" +
@@ -2189,8 +2189,8 @@ public class StaticImportTest extends AbstractComparableTest {
 		}
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=183211 - variation
 	public void test061() {
-		runConformTest(
-			// test directory preparation
+		AbstractRegressionTest.runConformTest(
+			this, // test directory preparation
 			true /* flush output directory */,
 			new String[] { /* test files */
 				"p/X.java",
@@ -2246,8 +2246,8 @@ public class StaticImportTest extends AbstractComparableTest {
 	}
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=183211 - variation
 	public void test063() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"p/X.java",
 				"package p;\n" +
 				"import static q.A.a;\n" +
@@ -2291,8 +2291,8 @@ public class StaticImportTest extends AbstractComparableTest {
 	}
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=183211 - variation
 	public void test064() {
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"p1/X.java",
 				"package p1;\n" +
 				"import static p2.A.M;\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/StringTemplateTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/StringTemplateTest.java
@@ -48,13 +48,13 @@ public class StringTemplateTest extends AbstractRegressionTest9 {
 		return defaultOptions;
 	}
 	protected void runConformTest(String[] testFiles, String expectedOutput) {
-		runConformTest(testFiles, expectedOutput, null, VMARGS, new JavacTestOptions("-source 21 --enable-preview"));
+		AbstractRegressionTest.runConformTest(this, testFiles, expectedOutput, null, VMARGS, new JavacTestOptions("-source 21 --enable-preview"));
 	}
 	@Override
 	protected void runConformTest(String[] testFiles, String expectedOutput, Map<String, String> customOptions) {
 		if(!isJRE21Plus)
 			return;
-		runConformTest(testFiles, expectedOutput, customOptions, VMARGS, JAVAC_OPTIONS);
+		AbstractRegressionTest.runConformTest(this, testFiles, expectedOutput, customOptions, VMARGS, JAVAC_OPTIONS);
 	}
 	protected void runNegativeTest(String[] testFiles, String expectedCompilerLog) {
 		Map<String, String> customOptions = getCompilerOptions(true);
@@ -786,8 +786,8 @@ public class StringTemplateTest extends AbstractRegressionTest9 {
 		String old1 = options.get(CompilerOptions.OPTION_ReportUnusedLocal);
 		options.put(CompilerOptions.OPTION_ReportUnusedLocal, CompilerOptions.ERROR);
 		try {
-			runNegativeTest(
-					new String[] {
+			AbstractRegressionTest.runNegativeTest(
+					this, new String[] {
 							"X.java",
 							"public class X {\n"
 							+ "  public static void main(String[] args) {\n"
@@ -816,8 +816,8 @@ public class StringTemplateTest extends AbstractRegressionTest9 {
 		String old1 = options.get(CompilerOptions.OPTION_ReportUnusedPrivateMember);
 		options.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.ERROR);
 		try {
-			runNegativeTest(
-					new String[] {
+			AbstractRegressionTest.runNegativeTest(
+					this, new String[] {
 							"X.java",
 							"public class X {\n"
 							+ "  private String abc = \"abc\"; // unused\n"
@@ -846,8 +846,8 @@ public class StringTemplateTest extends AbstractRegressionTest9 {
 		String old1 = options.get(CompilerOptions.OPTION_ReportUnusedPrivateMember);
 		options.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.ERROR);
 		try {
-			runNegativeTest(
-					new String[] {
+			AbstractRegressionTest.runNegativeTest(
+					this, new String[] {
 							"X.java",
 							"public class X {\n"
 							+ "  private String abc = \"abc\"; // unused\n"

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SuperTypeTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SuperTypeTest.java
@@ -291,8 +291,8 @@ public void test008() {
 public void test009() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportRedundantSuperinterface,  CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -319,8 +319,8 @@ public void test009() {
 public void test010() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportRedundantSuperinterface, CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -348,8 +348,8 @@ public void test010() {
 public void test011() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportRedundantSuperinterface,  CompilerOptions.ERROR);
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"public class X implements I {}\n" +
 			"class Y extends X {}\n" +
@@ -369,8 +369,8 @@ public void test011() {
 public void test012() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportRedundantSuperinterface,  CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -397,8 +397,8 @@ public void test013() {
 	if (this.complianceLevel < ClassFileConstants.JDK1_5) return;
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportRedundantSuperinterface,  CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -455,8 +455,8 @@ public void test013() {
 public void test014() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportRedundantSuperinterface,  CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -482,8 +482,8 @@ public void test014() {
 public void test015() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportRedundantSuperinterface,  CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -520,8 +520,8 @@ public void test015() {
 public void test016() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportRedundantSuperinterface,  CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -560,8 +560,8 @@ public void test016() {
 public void test017() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportRedundantSuperinterface,  CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -603,8 +603,8 @@ public void test017() {
 public void test018() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportRedundantSuperinterface,  CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchExpressionsYieldTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchExpressionsYieldTest.java
@@ -56,7 +56,7 @@ public class SwitchExpressionsYieldTest extends AbstractRegressionTest {
 	}
 	@Override
 	protected void runNegativeTest(String[] testFiles, String expectedCompilerLog) {
-		runNegativeTest(testFiles, expectedCompilerLog, JavacTestOptions.forRelease(JavaCore.VERSION_14));
+		AbstractRegressionTest.runNegativeTest(this, testFiles, expectedCompilerLog, JavacTestOptions.forRelease(JavaCore.VERSION_14));
 	}
 	protected void runWarningTest(String[] testFiles, String expectedCompilerLog) {
 		runWarningTest(testFiles, expectedCompilerLog, null);
@@ -448,8 +448,8 @@ public class SwitchExpressionsYieldTest extends AbstractRegressionTest {
 					"	^\n" +
 					"Preview features enabled at an invalid source release level "+CompilerOptions.VERSION_11+", preview can be enabled only at source level "+AbstractRegressionTest.PREVIEW_ALLOWED_LEVEL+"\n" +
 					"----------\n";
-			this.runNegativeTest(
-					testFiles,
+			AbstractRegressionTest.runNegativeTest(
+					this, testFiles,
 					expectedProblemLog,
 					null,
 					true,
@@ -3309,8 +3309,8 @@ public class SwitchExpressionsYieldTest extends AbstractRegressionTest {
 				"	^^^^^^^\n" +
 				"Arrow in case statement supported from Java 14 onwards only\n" +
 				"----------\n";
-		this.runNegativeTest(
-				testFiles,
+		AbstractRegressionTest.runNegativeTest(
+				this, testFiles,
 				expectedProblemLog,
 				null,
 				true,
@@ -3347,8 +3347,8 @@ public class SwitchExpressionsYieldTest extends AbstractRegressionTest {
 				"	^^^^^^^\n" +
 				"Arrow in case statement supported from Java 14 onwards only\n" +
 				"----------\n";
-		this.runNegativeTest(
-				testFiles,
+		AbstractRegressionTest.runNegativeTest(
+				this, testFiles,
 				expectedProblemLog,
 				null,
 				true,
@@ -3380,8 +3380,8 @@ public class SwitchExpressionsYieldTest extends AbstractRegressionTest {
 				"	^^^^^^^^^\n" +
 				"Multi-constant case labels supported from Java 14 onwards only\n" +
 				"----------\n";
-		this.runNegativeTest(
-				testFiles,
+		AbstractRegressionTest.runNegativeTest(
+				this, testFiles,
 				expectedProblemLog,
 				null,
 				true,

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchPatternTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchPatternTest.java
@@ -89,7 +89,7 @@ public class SwitchPatternTest extends AbstractRegressionTest9 {
 		runner.vmArguments = null;
 		runner.customOptions = getCompilerOptions();
 		runner.runNegativeTest();
-		runNegativeTest(testFiles, expectedCompilerLog, JavacTestOptions.forReleaseWithPreview(SwitchPatternTest.previewLevel));
+		AbstractRegressionTest.runNegativeTest(this, testFiles, expectedCompilerLog, JavacTestOptions.forReleaseWithPreview(SwitchPatternTest.previewLevel));
 	}
 	protected void runWarningTest(String[] testFiles, String expectedCompilerLog) {
 		runWarningTest(testFiles, expectedCompilerLog, null);
@@ -2114,8 +2114,8 @@ public class SwitchPatternTest extends AbstractRegressionTest9 {
 	public void testBug574564_010() {
 		Map<String, String> options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_Compliance, CompilerOptions.VERSION_20);
-		runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n"+
 				" private static void foo(Object o) {\n"+
@@ -4707,8 +4707,8 @@ public class SwitchPatternTest extends AbstractRegressionTest9 {
 				"----------\n");
 	}
 	public void testBug578553_7() {
-		runNegativeTest(
-				false /*skipJavac */,
+		AbstractRegressionTest.runNegativeTest(
+				this, false /*skipJavac */,
 				JavacTestOptions.JavacHasABug.JavacBug8299416,
 				new String[] {
 					"X.java",

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchTest.java
@@ -633,7 +633,7 @@ public void test013() throws Exception {
 public void test014() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportFallthroughCase, CompilerOptions.ERROR);
-	this.runNegativeTest(new String[] {
+	AbstractRegressionTest.runNegativeTest(this, new String[] {
 		"X.java",
 		"public class X {\n" +
 		"	void foo1(int i) {\n" +
@@ -676,7 +676,7 @@ public void test014() {
 public void test015() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportFallthroughCase, CompilerOptions.ERROR);
-	this.runNegativeTest(new String[] {
+	AbstractRegressionTest.runNegativeTest(this, new String[] {
 		"X.java",
 		"public class X {\n" +
 		"	void foo1(int i) {\n" +
@@ -719,7 +719,7 @@ public void test015() {
 public void test016() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportFallthroughCase, CompilerOptions.ERROR);
-	this.runNegativeTest(new String[] {
+	AbstractRegressionTest.runNegativeTest(this, new String[] {
 		"X.java",
 		"public class X {\n" +
 		"	void foo1(int i) {\n" +
@@ -748,7 +748,7 @@ public void test016() {
 public void test017() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportFallthroughCase, CompilerOptions.ERROR);
-	this.runNegativeTest(new String[] {
+	AbstractRegressionTest.runNegativeTest(this, new String[] {
 		"X.java",
 		"public class X {\n" +
 		"	void foo1(char previousChar) {\n" +
@@ -776,7 +776,7 @@ public void test017() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=286682
 public void test018() {
-	this.runConformTest(new String[] {
+	AbstractRegressionTest.runConformTest(this, new String[] {
 		"p/X.java",
 		"package p;\n" +
 		"public class X {\n" +
@@ -2167,8 +2167,8 @@ public void testFor356002_3() {
 public void testBug374605() {
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_SWITCH_MISSING_DEFAULT_CASE, JavaCore.WARNING);
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"p/X.java",
 				"package p;\n" +
 				"class X {\n" +
@@ -2546,8 +2546,8 @@ public void testBug381172() throws Exception {
 public void test383643() {
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_SWITCH_MISSING_DEFAULT_CASE, JavaCore.WARNING);
-	this.runNegativeTest(
-			new String[] {
+	AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 					"X.java",
 					"public class X {\n" +
 					"    void foo() {\n" +
@@ -2595,7 +2595,7 @@ public void test383643() {
 public void test387146a() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportFallthroughCase, CompilerOptions.ERROR);
-	this.runNegativeTest(new String[] {
+	AbstractRegressionTest.runNegativeTest(this, new String[] {
 		"X.java",
 		"public class X {\n" +
 		"	private Object someLock;\n" +
@@ -2624,7 +2624,7 @@ public void test387146a() {
 public void test387146b() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportFallthroughCase, CompilerOptions.ERROR);
-	this.runNegativeTest(new String[] {
+	AbstractRegressionTest.runNegativeTest(this, new String[] {
 		"X.java",
 		"public class X {\n" +
 		"	private boolean someFlag;\n" +
@@ -2707,7 +2707,7 @@ public void test410892() {
 	} else {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_PreserveUnusedLocal, CompilerOptions.OPTIMIZE_OUT);
-		this.runConformTest(sourceFiles, options);
+		AbstractRegressionTest.runConformTest(this, sourceFiles, options);
 	}
 }
 //JDK7: Strings in Switch.
@@ -2740,7 +2740,7 @@ public void test410892_2() {
 	} else {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_PreserveUnusedLocal, CompilerOptions.OPTIMIZE_OUT);
-		this.runConformTest(sourceFiles, options);
+		AbstractRegressionTest.runConformTest(this, sourceFiles, options);
 	}
 }
 //JDK7: Strings in Switch.
@@ -2774,7 +2774,7 @@ public void test410892_3() {
 	} else {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_PreserveUnusedLocal, CompilerOptions.OPTIMIZE_OUT);
-		this.runConformTest(sourceFiles, options);
+		AbstractRegressionTest.runConformTest(this, sourceFiles, options);
 	}
 }
 //JDK7: Strings in Switch.
@@ -2805,7 +2805,7 @@ public void test410892_4() {
 		"}",
 	};
 	if (this.complianceLevel >= JDKLevelSupportingStringSwitch) {
-		this.runNegativeTest(sourceFiles,
+		AbstractRegressionTest.runNegativeTest(this, sourceFiles,
 			errorMsg,
 			null,
 			true,
@@ -2840,7 +2840,7 @@ public void test410892_5() {
 		"}",
 	};
 	if (this.complianceLevel >= JDKLevelSupportingStringSwitch) {
-		this.runNegativeTest(sourceFiles,
+		AbstractRegressionTest.runNegativeTest(this, sourceFiles,
 			errorMsg,
 			null,
 			true,
@@ -2876,7 +2876,7 @@ public void test410892_6() {
 		"}",
 	};
 	if (this.complianceLevel >= JDKLevelSupportingStringSwitch) {
-		this.runNegativeTest(sourceFiles,
+		AbstractRegressionTest.runNegativeTest(this, sourceFiles,
 			errorMsg,
 			null,
 			true,
@@ -3218,7 +3218,7 @@ public void testBug443576_1() {
 	}
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportFallthroughCase, CompilerOptions.ERROR);
-	this.runNegativeTest(new String[] {
+	AbstractRegressionTest.runNegativeTest(this, new String[] {
 		"X.java",
 		"public class X {\n"
 		+ "    public enum E { A, B; }\n"
@@ -3261,7 +3261,7 @@ public void testBug443576_2() {
 	}
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportFallthroughCase, CompilerOptions.ERROR);
-	this.runNegativeTest(new String[] {
+	AbstractRegressionTest.runNegativeTest(this, new String[] {
 		"X.java",
 		"public class X {\n"
 		+ "    public enum E { A, B; }\n"

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TextBlockTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TextBlockTest.java
@@ -43,10 +43,10 @@ public class TextBlockTest extends AbstractRegressionTest {
 		return defaultOptions;
 	}
 	protected void runConformTest(String[] testFiles, String expectedOutput, Map<String, String> customOptions, String[] vmArguments) {
-		runConformTest(testFiles, expectedOutput, customOptions, vmArguments, new JavacTestOptions("-source 15 "));
+		AbstractRegressionTest.runConformTest(this, testFiles, expectedOutput, customOptions, vmArguments, new JavacTestOptions("-source 15 "));
 	}
 	protected void runConformTest(String[] testFiles, String expectedOutput, Map<String, String> customOptions) {
-		runConformTest(true, testFiles, null, expectedOutput, null, new JavacTestOptions("-source 15"));
+		AbstractRegressionTest.runConformTest(this, true, testFiles, null, expectedOutput, null, new JavacTestOptions("-source 15"));
 	}
 	protected void runConformTest(
 			// test directory preparation
@@ -63,8 +63,8 @@ public class TextBlockTest extends AbstractRegressionTest {
 			String[] vmarguments,
 			// javac options
 			JavacTestOptions javacTestOptions) {
-		runTest(
-			// test directory preparation
+		AbstractRegressionTest.runTest(
+			this, // test directory preparation
 			shouldFlushOutputDirectory /* should flush output directory */,
 			testFiles /* test files */,
 			// compiler options
@@ -682,8 +682,8 @@ public class TextBlockTest extends AbstractRegressionTest {
 				null);
 	}
 	public void test024() {
-		runConformTest(
-				true,
+		AbstractRegressionTest.runConformTest(
+				this, true,
 				new String[] {
 						"Main.java",
 						"@SuppressWarnings(\"preview\")\n" +
@@ -724,8 +724,8 @@ public class TextBlockTest extends AbstractRegressionTest {
 				JavacTestOptions.DEFAULT);
 	}
 	public void test025() {
-		runNegativeTest(
-				new String[] {
+		AbstractRegressionTest.runNegativeTest(
+				this, new String[] {
 						"X.java",
 						"public class X {\n" +
 						"		public static String textb = \"\"\"\n" +
@@ -900,8 +900,8 @@ public class TextBlockTest extends AbstractRegressionTest {
 				getCompilerOptions());
 	}
 	public void testBug551948_5() {
-		runNegativeTest(
-				new String[] {
+		AbstractRegressionTest.runNegativeTest(
+				this, new String[] {
 						"Cls2.java",
 						"@SuppressWarnings(\"preview\")\n" +
 						"public class Cls2 {\n" +
@@ -1290,8 +1290,8 @@ public class TextBlockTest extends AbstractRegressionTest {
 		copy.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_14);
 		copy.put(CompilerOptions.OPTION_TargetPlatform, CompilerOptions.VERSION_14);
 		copy.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		runNegativeTest(
-				new String[] {
+		AbstractRegressionTest.runNegativeTest(
+				this, new String[] {
 						"X.java",
 						"public class X {\n" +
 						"	public static String textb = \"\"\"\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TryStatementTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TryStatementTest.java
@@ -749,8 +749,8 @@ public void test022() {
 public void test023() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportHiddenCatchBlock, CompilerOptions.ERROR);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -889,8 +889,8 @@ public void test026() throws Exception {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_PreserveUnusedLocal, CompilerOptions.PRESERVE);
 
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"import java.util.*;\n" +
 			"\n" +
@@ -941,8 +941,8 @@ public void test027() throws Exception {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_PreserveUnusedLocal, CompilerOptions.PRESERVE);
 
-	this.runConformTest(
-		new String[] {
+	AbstractRegressionTest.runConformTest(
+		this, new String[] {
 			"X.java",
 			"import java.util.*;\n" +
 			"\n" +
@@ -1091,8 +1091,8 @@ public void test030() {
 public void test031() {
 	Map customOptions = getCompilerOptions();
 	customOptions.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.IGNORE);
-	runNegativeTest(
-		// test directory preparation
+	AbstractRegressionTest.runNegativeTest(
+		this, // test directory preparation
 		true /* flush output directory */,
 		new String[] { /* test files */
 			"X.java",
@@ -2385,8 +2385,8 @@ public void test042_not_shared() throws Exception {
 	customOptions.put(CompilerOptions.OPTION_ShareCommonFinallyBlocks, CompilerOptions.DISABLED);
 	customOptions.put(CompilerOptions.OPTION_InlineJsr, CompilerOptions.ENABLED);
 
-	this.runConformTest(
-			new String[] {
+	AbstractRegressionTest.runConformTest(
+			this, new String[] {
 				"X.java",
 				" public class X {\n" +
 				" public static void main(String[] args) {\n" +
@@ -6238,8 +6238,8 @@ public void testBug387612c() {
 			"    void foo(String a1, String a2) throws E;\n" +
 			"}\n"
 		});
-	runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"Client.java",
 			"public class Client {\n" +
 			"    void test() {\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TryWithResourcesStatementTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TryWithResourcesStatementTest.java
@@ -460,8 +460,8 @@ public void test013() {
 public void test014() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.WARNING);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	public static void main(String [] args) {    \n" +
@@ -548,8 +548,8 @@ public void test015() {
 public void test016() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.WARNING);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"	public static void main(String [] args) {    \n" +
@@ -3262,8 +3262,8 @@ public void test052() {
 	options.put(CompilerOptions.OPTION_Compliance, CompilerOptions.VERSION_1_5);
 	options.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_1_5);
 	options.put(CompilerOptions.OPTION_TargetPlatform, CompilerOptions.VERSION_1_5);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 					"    public static void main(String[] args) throws Throwable {\n" +
@@ -4186,7 +4186,7 @@ public void test380112d() {
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=380112
 //test380112a variant moving the Interface into a binary
 public void test380112e() {
-	String path = this.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "Test380112.jar";
+	String path = AbstractRegressionTest.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "Test380112.jar";
 	String[] defaultLibs = getDefaultClassPaths();
 	String[] libs = new String[defaultLibs.length + 1];
 	System.arraycopy(defaultLibs, 0, libs, 0, defaultLibs.length);
@@ -4246,8 +4246,8 @@ public void test394780() {
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=533187
 public void testBug533187() {
-	this.runConformTest(
-			true,
+	AbstractRegressionTest.runConformTest(
+			this, true,
 			new String[] {
 				"Stuck.java",
 				"public class Stuck {\n" +
@@ -4284,8 +4284,8 @@ public void testBug533187() {
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=467230
 public void testBug467230() {
-	this.runConformTest(
-			true,
+	AbstractRegressionTest.runConformTest(
+			this, true,
 			new String[] {
 				"Test.java",
 				"public class Test {\n" +
@@ -4322,8 +4322,8 @@ public void testBug467230() {
 }
 // https://github.com/eclipse-jdt/eclipse.jdt.core/issues/934
 public void _testGHIssue934() {
-	this.runConformTest(
-			true,
+	AbstractRegressionTest.runConformTest(
+			this, true,
 			new String[] {
 				"X.java",
 				"public class X {\n" +
@@ -4364,8 +4364,8 @@ public void _testGHIssue934() {
 // https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1063
 // Regression in code generation for try with resources with the fix for Issue # 934
 public void testGHIssue1063() {
-	this.runConformTest(
-			true,
+	AbstractRegressionTest.runConformTest(
+			this, true,
 			new String[] {
 				"X.java",
 				"import java.io.Closeable;\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TypeAnnotationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TypeAnnotationTest.java
@@ -163,7 +163,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"      target type = 0x0 CLASS_TYPE_PARAMETER\n" +
 			"      type parameter index = 0\n" +
 			"    )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test002_classTypeParameter_reflection() throws Exception {
@@ -226,7 +226,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 				"      target type = 0x0 CLASS_TYPE_PARAMETER\n" +
 				"      type parameter index = 1\n" +
 				"    )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test004_classTypeParameter_reflection() throws Exception {
@@ -298,7 +298,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"      target type = 0x0 CLASS_TYPE_PARAMETER\n" +
 			"      type parameter index = 0\n" +
 			"    )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test006_classTypeParameter() throws Exception {
@@ -340,7 +340,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"      target type = 0x0 CLASS_TYPE_PARAMETER\n" +
 			"      type parameter index = 2\n" +
 			"    )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test007_methodTypeParameter() throws Exception {
@@ -384,7 +384,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        target type = 0x1 METHOD_TYPE_PARAMETER\n" +
 			"        type parameter index = 0\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test008_methodTypeParameter() throws Exception {
@@ -428,7 +428,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        target type = 0x1 METHOD_TYPE_PARAMETER\n" +
 			"        type parameter index = 1\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test009_classExtends() throws Exception {
@@ -450,7 +450,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"      target type = 0x10 CLASS_EXTENDS\n" +
 			"      type index = -1\n" +
 			"    )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test010_classExtends() throws Exception {
@@ -473,7 +473,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"      target type = 0x10 CLASS_EXTENDS\n" +
 			"      type index = -1\n" +
 			"    )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test011_classExtends_reflection() throws Exception {
@@ -572,7 +572,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"      target type = 0x10 CLASS_EXTENDS\n" +
 			"      type index = 1\n" +
 			"    )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test014_classExtends_interfaces_reflection() throws Exception {
@@ -685,7 +685,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 				"      type index = -1\n" +
 				"      location = [TYPE_ARGUMENT(0)]\n" +
 				"    )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test017_classExtends() throws Exception {
@@ -711,7 +711,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 				"      type index = 0\n" +
 				"      location = [TYPE_ARGUMENT(0)]\n" +
 				"    )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test018_classExtends() throws Exception {
@@ -738,7 +738,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 				"      type index = 0\n" +
 				"      location = [TYPE_ARGUMENT(1)]\n" +
 				"    )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test019_classExtends() throws Exception {
@@ -768,7 +768,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 				"      type index = 0\n" +
 				"      location = [TYPE_ARGUMENT(0), TYPE_ARGUMENT(0)]\n" +
 				"    )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test020_classExtends() throws Exception {
@@ -795,7 +795,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 				"      type index = 0\n" +
 				"      location = [TYPE_ARGUMENT(0), ARRAY]\n" +
 				"    )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test021_classExtends() throws Exception {
@@ -822,7 +822,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 				"      type index = 0\n" +
 				"      location = [TYPE_ARGUMENT(0)]\n" +
 				"    )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test022_classExtends() throws Exception {
@@ -849,7 +849,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 				"      type index = 0\n" +
 				"      location = [TYPE_ARGUMENT(0), ARRAY]\n" +
 				"    )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test023_classExtends() throws Exception {
@@ -876,7 +876,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 				"      type index = 0\n" +
 				"      location = [TYPE_ARGUMENT(0), ARRAY, ARRAY, ARRAY]\n" +
 				"    )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 
@@ -940,7 +940,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"      target type = 0x10 CLASS_EXTENDS\n" +
 			"      type index = 1\n" +
 			"    )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test025_classTypeParameterBound() throws Exception {
@@ -963,7 +963,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"      target type = 0x11 CLASS_TYPE_PARAMETER_BOUND\n" +
 			"      type parameter index = 0 type parameter bound index = 0\n" +
 			"    )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test026_classTypeParameterBound() throws Exception {
@@ -1005,7 +1005,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"      target type = 0x11 CLASS_TYPE_PARAMETER_BOUND\n" +
 			"      type parameter index = 0 type parameter bound index = 1\n" +
 			"    )\n" ;
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test027_classTypeParameterBound_complex() throws Exception {
@@ -1064,7 +1064,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"      target type = 0x11 CLASS_TYPE_PARAMETER_BOUND\n" +
 			"      type parameter index = 1 type parameter bound index = 1\n" +
 			"    )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test028_methodTypeParameterBound() throws Exception {
@@ -1092,7 +1092,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        target type = 0x12 METHOD_TYPE_PARAMETER_BOUND\n" +
 			"        type parameter index = 0 type parameter bound index = 0\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test029_methodTypeParameterBound() throws Exception {
@@ -1138,7 +1138,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        target type = 0x12 METHOD_TYPE_PARAMETER_BOUND\n" +
 			"        type parameter index = 0 type parameter bound index = 1\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test030_methodTypeParameterBound() throws Exception {
@@ -1182,7 +1182,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        type parameter index = 0 type parameter bound index = 0\n" +
 			"        location = [TYPE_ARGUMENT(0), ARRAY, ARRAY]\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test031_methodTypeParameterBound_complex() throws Exception {
@@ -1245,7 +1245,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        target type = 0x12 METHOD_TYPE_PARAMETER_BOUND\n" +
 			"        type parameter index = 0 type parameter bound index = 1\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test032_field() throws Exception {
@@ -1269,7 +1269,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"      #8 @A(\n" +
 			"        target type = 0x13 FIELD\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test033_field() throws Exception {
@@ -1294,7 +1294,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        target type = 0x13 FIELD\n" +
 			"        location = [TYPE_ARGUMENT(0)]\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test034_field() throws Exception {
@@ -1336,7 +1336,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        #9 value=(int) 3 (constant type)\n" +
 			"        target type = 0x13 FIELD\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test035_field() throws Exception {
@@ -1361,7 +1361,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        target type = 0x13 FIELD\n" +
 			"        location = [TYPE_ARGUMENT(1)]\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test036_field() throws Exception {
@@ -1386,7 +1386,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        target type = 0x13 FIELD\n" +
 			"        location = [TYPE_ARGUMENT(0), ARRAY, ARRAY]\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test037_field() throws Exception {
@@ -1410,7 +1410,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        target type = 0x13 FIELD\n" +
 			"        location = [TYPE_ARGUMENT(0), WILDCARD]\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test038_field() throws Exception {
@@ -1435,7 +1435,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 				"        target type = 0x13 FIELD\n" +
 				"        location = [INNER_TYPE]\n" +
 				"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test038a_field() throws Exception {
@@ -1481,7 +1481,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 				"        target type = 0x13 FIELD\n" +
 				"        location = [ARRAY]\n" +
 				"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test039_field() throws Exception {
@@ -1525,7 +1525,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        target type = 0x13 FIELD\n" +
 			"        location = [ARRAY]\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test040_field_complex() throws Exception {
@@ -1691,7 +1691,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        target type = 0x13 FIELD\n" +
 			"        location = [TYPE_ARGUMENT(1), ARRAY, ARRAY]\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test041_field() throws Exception {
@@ -1761,7 +1761,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        target type = 0x13 FIELD\n" +
 			"        location = [ARRAY, ARRAY]\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test042_methodReturnType() throws Exception {
@@ -1803,7 +1803,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        #18 value=(int) 3 (constant type)\n" +
 			"        target type = 0x14 METHOD_RETURN\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test043_methodReceiver() throws Exception {
@@ -1842,7 +1842,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        #17 value=(int) 3 (constant type)\n" +
 			"        target type = 0x15 METHOD_RECEIVER\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test044_methodReceiver() throws Exception {
@@ -1882,7 +1882,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        target type = 0x15 METHOD_RECEIVER\n" +
 			"        location = [TYPE_ARGUMENT(0)]\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 
@@ -1916,7 +1916,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        target type = 0x16 METHOD_FORMAL_PARAMETER\n" +
 			"        method parameter index = 0\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test046_methodParameter() throws Exception {
@@ -1949,7 +1949,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        target type = 0x16 METHOD_FORMAL_PARAMETER\n" +
 			"        method parameter index = 2\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test047_methodParameterArray() throws Exception {
@@ -1999,7 +1999,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        method parameter index = 0\n" +
 			"        location = [ARRAY]\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test048_throws() throws Exception {
@@ -2064,7 +2064,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        target type = 0x17 THROWS\n" +
 			"        throws index = 2\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 
@@ -2121,7 +2121,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        local variable entries:\n" +
 			"          [pc: 31, pc: 39] index: 2\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test050_codeblocks_localVariable() throws Exception {
@@ -2194,7 +2194,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"          [pc: 5, pc: 46] index: 3\n" +
 			"        location = [ARRAY, ARRAY]\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test051_codeblocks_resourceVariable() throws Exception {
@@ -2240,7 +2240,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        local variable entries:\n" +
 			"          [pc: 21, pc: 135] index: 3\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test052_codeblocks_exceptionParameter() throws Exception {
@@ -2283,7 +2283,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        target type = 0x42 EXCEPTION_PARAMETER\n" +
 			"        exception table index = 0\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test053_codeblocks_exceptionParameter() throws Exception {
@@ -2333,7 +2333,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        target type = 0x42 EXCEPTION_PARAMETER\n" +
 			"        exception table index = 0\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test054_codeblocks_exceptionParameter() throws Exception {
@@ -2379,7 +2379,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        target type = 0x42 EXCEPTION_PARAMETER\n" +
 			"        exception table index = 1\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test055_codeblocks_exceptionParameterMultiCatch() throws Exception {
@@ -2434,7 +2434,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        target type = 0x42 EXCEPTION_PARAMETER\n" +
 			"        exception table index = 2\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test056_codeblocks_instanceof() throws Exception {
@@ -2467,10 +2467,10 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        target type = 0x43 INSTANCEOF\n" +
 			"        offset = 1\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 
 		expectedOutput = "     1  instanceof java.lang.String [16]\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test057_codeblocks_new() throws Exception {
@@ -2518,7 +2518,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        target type = 0x44 NEW\n" +
 			"        offset = 8\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test058_codeblocks_new2() throws Exception {
@@ -2550,7 +2550,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        offset = 8\n" +
 			"        location = [INNER_TYPE]\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test057_codeblocks_new3_415821() throws Exception {
@@ -2573,14 +2573,14 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        target type = 0x44 NEW\n" +
 			"        offset = 0\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "C.class", "C", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "C.class", "C", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 		expectedOutput =
 			"  RuntimeVisibleTypeAnnotations: \n" +
 			"    #28 @X(\n" +
 			"      target type = 0x10 CLASS_EXTENDS\n" +
 			"      type index = -1\n" +
 			"    )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "C$1.class", "C$1", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "C$1.class", "C$1", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test057_codeblocks_new4_415821() throws Exception {
@@ -2602,14 +2602,14 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        target type = 0x44 NEW\n" +
 			"        offset = 0\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "C.class", "C", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "C.class", "C", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 		expectedOutput =
 			"  RuntimeVisibleTypeAnnotations: \n" +
 			"    #31 @X(\n" +
 			"      target type = 0x10 CLASS_EXTENDS\n" +
 			"      type index = 0\n" +
 			"    )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "C$1.class", "C$1", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "C$1.class", "C$1", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test059_codeblocks_new_newArray() throws Exception {
@@ -2657,7 +2657,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        offset = 9\n" +
 			"        location = [ARRAY]\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test060_codeblocks_new_multiNewArray() throws Exception {
@@ -2687,7 +2687,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        offset = 10\n" +
 			"        location = [ARRAY, ARRAY]\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test060a_codeblocks_new_newArrayWithInitializer() throws Exception {
@@ -2744,7 +2744,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        location = [ARRAY]\n" +
 			"      )\n" +
 			"}";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test060b_codeblocks_new_multiNewArray() throws Exception {
@@ -2801,7 +2801,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        location = [ARRAY]\n" +
 			"      )\n" +
 			"}";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test060c_codeblocks_new_multiNewArray() throws Exception {
@@ -2871,7 +2871,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        location = [ARRAY, ARRAY]\n" +
 			"      )\n" +
 			"}";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test060d_codeblocks_new_arraysWithNestedTypes() throws Exception {
@@ -2914,7 +2914,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        target type = 0x44 NEW\n" +
 			"        offset = 9\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test060e_codeblocks_new_arraysWithNestedTypes() throws Exception {
@@ -2963,7 +2963,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        offset = 10\n" +
 			"        location = [ARRAY]\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test060f_codeblocks_new_arraysWithQualifiedNestedTypes() throws Exception {
@@ -3016,7 +3016,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        offset = 10\n" +
 			"        location = [ARRAY]\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "org" + File.separator + "foo" + File.separator + "bar" + File.separator + "X.class",
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "org" + File.separator + "foo" + File.separator + "bar" + File.separator + "X.class",
 				"org.foo.bar.X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
@@ -3065,7 +3065,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        offset = 9\n" +
 			"        location = [ARRAY]\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test062_codeblocks_newArray() throws Exception {
@@ -3113,7 +3113,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        offset = 9\n" +
 			// no type path expected here
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test062_codeblocks_newArrayWithInitializer() throws Exception {
@@ -3161,7 +3161,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        offset = 9\n" +
 			// no type path expected here
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test063_codeblocks_new_instanceof() throws Exception {
@@ -3232,7 +3232,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        offset = 6\n" +
 			"        location = [ARRAY]\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 
@@ -3267,7 +3267,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        target type = 0x45 CONSTRUCTOR_REFERENCE\n" +
 			"        offset = 8\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 
@@ -3302,7 +3302,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        target type = 0x46 METHOD_REFERENCE\n" +
 			"        offset = 8\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test066_codeblocks_methodReference() throws Exception {
@@ -3355,7 +3355,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        target type = 0x46 METHOD_REFERENCE\n" +
 			"        offset = 0\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test067_codeblocks_constructorReferenceTypeArgument() throws Exception {
@@ -3391,7 +3391,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        offset = 8\n" +
 			"        type argument index = 0\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test068_codeblocks_methodReferenceTypeArgument() throws Exception {
@@ -3426,7 +3426,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        offset = 8\n" +
 			"        type argument index = 0\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test069_codeblocks_cast() throws Exception {
@@ -3462,7 +3462,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        offset = 8\n" +
 			"        type argument index = 0\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test070_codeblocks_cast_complex() throws Exception {
@@ -3537,7 +3537,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        type argument index = 0\n" +
 			"        location = [ARRAY]\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test070a_codeblocks_castWithIntersectionCast() throws Exception {
@@ -3598,7 +3598,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 				"        offset = 9\n" +
 				"        type argument index = 1\n" +
 				"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test070b_codeblocks_castWithIntersectionCast() throws Exception {
@@ -3658,7 +3658,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 				"        type argument index = 0\n" +
 				"        location = [TYPE_ARGUMENT(0)]\n" +
 				"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test070c_codeblocks_castTwiceInExpression() throws Exception {
@@ -3714,7 +3714,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 				"        offset = 12\n" +
 				"        type argument index = 0\n" +
 				"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test070d_codeblocks_castDoubleIntersectionCastInExpression() throws Exception {
@@ -3775,7 +3775,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 				"        offset = 18\n" +
 				"        type argument index = 0\n" +
 				"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test071_codeblocks_constructorInvocationTypeArgument() throws Exception {
@@ -3826,7 +3826,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        offset = 5\n" +
 			"        type argument index = 0\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test072_codeblocks_constructorInvocationTypeArgument() throws Exception {
@@ -3899,7 +3899,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        offset = 6\n" +
 			"        type argument index = 1\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 	public void test073_codeblocks_constructorInvocationTypeArgument() throws Exception {
 		this.runConformTest(
@@ -3929,7 +3929,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        offset = 3\n" +
 			"        type argument index = 1\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test074_codeblocks_constructorInvocationTypeArgument() throws Exception {
@@ -3962,7 +3962,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        type argument index = 0\n" +
 			"        location = [TYPE_ARGUMENT(0)]\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test075_codeblocks_constructorInvocationTypeArgument() throws Exception {
@@ -3993,7 +3993,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        offset = 3\n" +
 			"        type argument index = 0\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test076_codeblocks_methodInvocationTypeArgument() throws Exception {
@@ -4063,7 +4063,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        offset = 13\n" +
 			"        type argument index = 1\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test077_codeblocks_methodInvocationTypeArgument() throws Exception {
@@ -4095,7 +4095,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        offset = 2\n" +
 			"        type argument index = 1\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test078_codeblocks_methodInvocationTypeArgument() throws Exception {
@@ -4128,7 +4128,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        type argument index = 0\n" +
 			"        location = [TYPE_ARGUMENT(0)]\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test079_codeblocks_methodInvocationTypeArgument() throws Exception {
@@ -4159,7 +4159,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        offset = 2\n" +
 			"        type argument index = 0\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 
@@ -4190,7 +4190,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        #18 value=(int) 1 (constant type)\n" +
 			"        target type = 0x14 METHOD_RETURN\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test081_multiuseAnnotations() throws Exception {
@@ -4217,7 +4217,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        #18 value=(int) 4 (constant type)\n" +
 			"        target type = 0x14 METHOD_RETURN\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	// When not annotated with any TYPE it assumes the Java7 set (i.e. not TYPE_USE/TYPE_PARAMETER)
@@ -4251,7 +4251,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        #17 value=(int) 4 (constant type)\n" +
 			"      )\n" +
 			"}";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	// as of https://bugs.openjdk.java.net/browse/JDK-8231435 no-@Target annotations are legal also in TYPE_USE/TYPE_PARAMETER position
@@ -4321,7 +4321,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 				"      type parameter index = 0\n" +
 				"    )\n" +
 				"}";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test100_pqtr() throws Exception { // PQTR (ParameterizedQualifiedTypeReference)
@@ -4345,7 +4345,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 					"        #11 value=(int) 2 (constant type)\n" +
 					"        target type = 0x13 FIELD\n" +
 					"      )\n";
-			checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+			AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test100a_pqtr() throws Exception {
@@ -4370,7 +4370,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 					"        target type = 0x13 FIELD\n" +
 					"        location = [ARRAY]\n" +
 					"      )\n";
-			checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+			AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test100b_pqtr() throws Exception {
@@ -4395,7 +4395,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 					"        target type = 0x13 FIELD\n" +
 					"        location = [ARRAY, TYPE_ARGUMENT(0)]\n" +
 					"      )\n";
-			checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+			AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test100c_pqtr() throws Exception {
@@ -4419,7 +4419,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 					"        #11 value=(int) 3 (constant type)\n" +
 					"        target type = 0x13 FIELD\n" +
 					"      )\n";
-			checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+			AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test100d_pqtr() throws Exception {
@@ -4458,7 +4458,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 					"        target type = 0x13 FIELD\n" +
 					"        location = [ARRAY, ARRAY, TYPE_ARGUMENT(0)]\n" +
 					"      )\n";
-			checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+			AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 
@@ -4483,7 +4483,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 				"        #11 value=(int) 2 (constant type)\n" +
 				"        target type = 0x13 FIELD\n" +
 				"      )\n";
-			checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+			AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test100f_pqtr() throws Exception {
@@ -4522,7 +4522,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 				"        target type = 0x13 FIELD\n" +
 				"        location = [INNER_TYPE, INNER_TYPE, INNER_TYPE]\n" +
 				"      )\n";
-			checkDisassembledClassFile(OUTPUT_DIR + File.separator + "one" + File.separator + "two" + File.separator + "three" + File.separator + "X.class", "one.two.three.X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+			AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "one" + File.separator + "two" + File.separator + "three" + File.separator + "X.class", "one.two.three.X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test100g_pqtr() throws Exception {
@@ -4561,7 +4561,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 				"        target type = 0x13 FIELD\n" +
 				"        location = [ARRAY, ARRAY, INNER_TYPE, INNER_TYPE, INNER_TYPE]\n" +
 				"      )\n";
-			checkDisassembledClassFile(OUTPUT_DIR + File.separator + "one" + File.separator + "two" + File.separator + "three" + File.separator + "X.class", "one.two.three.X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+			AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "one" + File.separator + "two" + File.separator + "three" + File.separator + "X.class", "one.two.three.X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test100h_pqtr() throws Exception {
@@ -4594,7 +4594,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 				"        target type = 0x13 FIELD\n" +
 				"        location = [ARRAY, ARRAY, INNER_TYPE, INNER_TYPE, INNER_TYPE]\n" +
 				"      )\n";
-			checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+			AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test100i_pqtr() throws Exception {
@@ -4622,7 +4622,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 				"        target type = 0x13 FIELD\n" +
 				"        location = [ARRAY, ARRAY, INNER_TYPE, INNER_TYPE, INNER_TYPE, TYPE_ARGUMENT(0)]\n" +
 				"      )\n";
-			checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+			AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test100j_pqtr() throws Exception {
@@ -4655,7 +4655,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 				"        target type = 0x13 FIELD\n" +
 				"        location = [ARRAY, ARRAY, INNER_TYPE, INNER_TYPE, INNER_TYPE, TYPE_ARGUMENT(0)]\n" +
 				"      )\n";
-			checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+			AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test100k_pqtr() throws Exception {
@@ -4693,7 +4693,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 				"        target type = 0x13 FIELD\n" +
 				"        location = [ARRAY, ARRAY, INNER_TYPE, INNER_TYPE, INNER_TYPE, TYPE_ARGUMENT(0)]\n" +
 				"      )\n";
-			checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+			AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test101a_qtr() throws Exception { // QTR (QualifiedTypeReference)
@@ -4721,7 +4721,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 					"        #9 value=(int) 2 (constant type)\n" +
 					"        target type = 0x13 FIELD\n" +
 					"      )\n";
-			checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+			AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 
@@ -4746,7 +4746,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 				"        #9 value=(int) 2 (constant type)\n" +
 				"        target type = 0x13 FIELD\n" +
 				"      )\n";
-			checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+			AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test101c_qtr() throws Exception { // QTR (QualifiedTypeReference)
@@ -4785,7 +4785,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 				"        target type = 0x13 FIELD\n" +
 				"        location = [INNER_TYPE, INNER_TYPE, INNER_TYPE]\n" +
 				"      )\n";
-			checkDisassembledClassFile(OUTPUT_DIR + File.separator + "one" + File.separator + "two" + File.separator + "three" + File.separator + "X.class", "one.two.three.X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+			AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "one" + File.separator + "two" + File.separator + "three" + File.separator + "X.class", "one.two.three.X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test102a_str() throws Exception { // STR (SingleTypeReference)
@@ -4809,7 +4809,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 					"        #9 value=(int) 1 (constant type)\n" +
 					"        target type = 0x13 FIELD\n" +
 					"      )\n";
-			checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+			AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test102b_str() throws Exception { // STR (SingleTypeReference)
@@ -4833,7 +4833,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 					"        #9 value=(int) 1 (constant type)\n" +
 					"        target type = 0x13 FIELD\n" +
 					"      )\n";
-			checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+			AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test103a_atr() throws Exception { // ATR (ArrayTypeReference)
@@ -4858,7 +4858,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 					"        target type = 0x13 FIELD\n" +
 					"        location = [ARRAY]\n" +
 					"      )\n";
-			checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+			AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test103b_atr() throws Exception { // ATR (ArrayTypeReference)
@@ -4882,7 +4882,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 					"        #9 value=(int) 2 (constant type)\n" +
 					"        target type = 0x13 FIELD\n" +
 					"      )\n";
-			checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+			AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test103c_atr() throws Exception { // ATR (ArrayTypeReference)
@@ -4907,7 +4907,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 					"        target type = 0x13 FIELD\n" +
 					"        location = [ARRAY]\n" +
 					"      )\n";
-			checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+			AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test103d_atr() throws Exception { // ATR (ArrayTypeReference)
@@ -4932,7 +4932,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 					"        target type = 0x13 FIELD\n" +
 					"        location = [ARRAY]\n" +
 					"      )\n";
-			checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+			AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test103e_atr() throws Exception { // ATR (ArrayTypeReference)
@@ -4962,7 +4962,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 					"        target type = 0x13 FIELD\n" +
 					"        location = [ARRAY]\n" +
 					"      )\n";
-			checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+			AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test104a_pstr() throws Exception { // PSTR (ParameterizedSingleTypeReference)
@@ -5001,7 +5001,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 				"        target type = 0x13 FIELD\n" +
 				"        location = [TYPE_ARGUMENT(2)]\n" +
 				"      )\n";
-			checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+			AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test104b_pstr() throws Exception { // PSTR (ParameterizedSingleTypeReference)
@@ -5035,7 +5035,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 				"        target type = 0x13 FIELD\n" +
 				"        location = [ARRAY, TYPE_ARGUMENT(0)]\n" +
 				"      )\n";
-			checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+			AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test105a_aqtr() throws Exception { // AQTR (ArrayQualifiedTypeReference)
@@ -5069,7 +5069,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 				"        target type = 0x13 FIELD\n" +
 				"        location = [ARRAY]\n" +
 				"      )\n";
-			checkDisassembledClassFile(OUTPUT_DIR + File.separator + "one" + File.separator + "two" + File.separator + "three" + File.separator +"X.class",
+			AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "one" + File.separator + "two" + File.separator + "three" + File.separator +"X.class",
 					"one.two.three.X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
@@ -5113,7 +5113,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 				"        target type = 0x13 FIELD\n" +
 				"        location = [ARRAY]\n" +
 				"      )\n";
-			checkDisassembledClassFile(OUTPUT_DIR + File.separator + "one" + File.separator + "two" + File.separator + "three" + File.separator +"X.class",
+			AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "one" + File.separator + "two" + File.separator + "three" + File.separator +"X.class",
 					"one.two.three.X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
@@ -5143,7 +5143,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 				"        target type = 0x13 FIELD\n" +
 				"        location = [TYPE_ARGUMENT(0), WILDCARD]\n" +
 				"      )\n";
-			checkDisassembledClassFile(OUTPUT_DIR + File.separator +"X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+			AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator +"X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test106b_wtr() throws Exception { // WTR (WildcardTypeReference)
@@ -5172,7 +5172,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 				"        target type = 0x13 FIELD\n" +
 				"        location = [TYPE_ARGUMENT(0), WILDCARD, ARRAY]\n" +
 				"      )\n";
-			checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+			AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=409244, [1.8][compiler] Type annotations on redundant casts dropped.
 	public void testAnnotatedRedundantCast() throws Exception {
@@ -5214,7 +5214,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 							"        type argument index = 0\n" +
 							"      )\n" +
 							"}";
-			checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+			AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=409244, [1.8][compiler] Type annotations on redundant casts dropped.
 	public void testAnnotatedRedundantCast2() throws Exception {
@@ -5249,7 +5249,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 							"      Local variable table:\n" +
 							"        [pc: 0, pc: 11] local: this index: 0 type: X\n" +
 							"}";
-			checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+			AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test055a_codeblocks_exceptionParameterNestedType() throws Exception {
@@ -5295,7 +5295,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        location = [INNER_TYPE]\n" +
 			"      )\n" +
 			"  \n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
  	}
 
 	public void test055b_codeblocks_exceptionParameterMultiCatchNestedType() throws Exception {
@@ -5355,7 +5355,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        exception table index = 1\n" +
 			"        location = [INNER_TYPE]\n" +
  			"      )\n";
- 		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+ 		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
  	}
 
 	public void test055c_codeblocks_exceptionParameterMultiCatch() throws Exception {
@@ -5408,7 +5408,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        target type = 0x42 EXCEPTION_PARAMETER\n" +
 			"        exception table index = 2\n" +
  			"      )\n";
- 		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+ 		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
  	}
 
 	public void test055d_codeblocks_exceptionParameterMultiCatch() throws Exception {
@@ -5483,7 +5483,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        target type = 0x42 EXCEPTION_PARAMETER\n" +
 			"        exception table index = 2\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test055e_codeblocks_exceptionParameterMultiCatch() throws Exception {
@@ -5558,7 +5558,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        target type = 0x42 EXCEPTION_PARAMETER\n" +
 			"        exception table index = 2\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test055f_codeblocks_exceptionParameterComplex() throws Exception {
@@ -5636,7 +5636,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			"        target type = 0x42 EXCEPTION_PARAMETER\n" +
 			"        exception table index = 5\n" +
 			"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void testBug415911() {
@@ -5780,7 +5780,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 				"          [pc: 6, pc: 28] index: 0\n" +
 				"        location = [ARRAY, ARRAY, ARRAY, ARRAY, TYPE_ARGUMENT(0)]\n" +
 				"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void testBug426616a() throws Exception {
@@ -5878,7 +5878,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 				"        location = [ARRAY, ARRAY, ARRAY]\n" +
 				"      )\n" +
 				"  \n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void testTypeVariable() {
@@ -6071,7 +6071,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 					"        target type = 0x14 METHOD_RETURN\n" +
 					"      )\n" +
 					"}";
-			checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+			AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=418347,  [1.8][compiler] Type annotations dropped during code generation.
@@ -6123,7 +6123,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 					"        location = [ARRAY, ARRAY, INNER_TYPE, TYPE_ARGUMENT(0)]\n" +
 					"      )\n" +
 					"  \n";
-			checkDisassembledClassFile(OUTPUT_DIR + File.separator + "Outer.class", "Outer", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+			AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "Outer.class", "Outer", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=418347,  [1.8][compiler] Type annotations dropped during code generation.
 	public void testPQTRArray2() throws Exception {
@@ -6191,7 +6191,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 					"        location = [ARRAY, ARRAY, INNER_TYPE, TYPE_ARGUMENT(1), INNER_TYPE]\n" +
 					"      )\n" +
 					"  \n";
-			checkDisassembledClassFile(OUTPUT_DIR + File.separator + "Outer.class", "Outer", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+			AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "Outer.class", "Outer", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=418347,  [1.8][compiler] Type annotations dropped during code generation.
 	public void testConstructorResult() throws Exception {
@@ -6249,8 +6249,8 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 					"        location = [INNER_TYPE]\n" +
 					"      )\n" +
 					"\n";
-			checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
-			checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X$Y.class", "Y", expectedOutForY, ClassFileBytesDisassembler.SYSTEM);
+			AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+			AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X$Y.class", "Y", expectedOutForY, ClassFileBytesDisassembler.SYSTEM);
 	}
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=418347,  [1.8][compiler] Type annotations dropped during code generation.
 	public void test418347() throws Exception {
@@ -6277,7 +6277,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 					"        location = [INNER_TYPE]\n" +
 					"      )\n" +
 					"\n";
-			checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+			AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=418347,  [1.8][compiler] Type annotations dropped during code generation.
 	public void test418347a() throws Exception {
@@ -6315,7 +6315,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 					"        location = [ARRAY, INNER_TYPE, INNER_TYPE]\n" +
 					"      )\n" +
 					"\n";
-			checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+			AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=418347,  [1.8][compiler] Type annotations dropped during code generation.
 	public void test418347b() throws Exception {
@@ -6346,12 +6346,12 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 					"        location = [ARRAY]\n" +
 					"      )\n" +
 					"}";
-			checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+			AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=419331, [1.8][compiler] Weird error on forward reference to type annotations from type parameter declarations
 	public void testForwardReference() {
-		this.runNegativeTest(
-			false /* skipJavac */,
+		AbstractRegressionTest.runNegativeTest(
+			this, false /* skipJavac */,
 			JavacTestOptions.Excuse.JavacHasWarningsEclipseNotConfigured,
 			new String[] {
 				"T.java",
@@ -6447,7 +6447,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 				"    #8 @T(\n" +
 				"    )\n" +
 				"}";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 	public void testHybridTargets2() throws Exception {
 		this.runConformTest(
@@ -6542,7 +6542,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 				"        target type = 0x14 METHOD_RETURN\n" +
 				"      )\n" +
 				"}";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 	public void testDeprecated() throws Exception {
 		this.runConformTest(
@@ -6594,7 +6594,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 				"        ]\n" +
 				"    )\n" +
 				"}";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=421148, [1.8][compiler] Verify error with annotated casts and unused locals.
 	public void test421148() {
@@ -6786,8 +6786,8 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 		Requestor requestor = new Requestor(false, null /*no custom requestor*/, false, /* show category */ false /* show warning token*/);
 		Map customOptions = getCompilerOptions();
 		customOptions.put(CompilerOptions.OPTION_Store_Annotations, CompilerOptions.ENABLED);
-		Compiler compiler = new Compiler(getNameEnvironment(new String[0], null), getErrorHandlingPolicy(),
-				new CompilerOptions(customOptions), requestor, getProblemFactory());
+		Compiler compiler = new Compiler(AbstractRegressionTest.getNameEnvironment(this, new String[0], null), AbstractRegressionTest.getErrorHandlingPolicy(),
+				new CompilerOptions(customOptions), requestor, AbstractRegressionTest.getProblemFactory());
 		char [][] compoundName = new char [][] { "test1".toCharArray(), "Base".toCharArray()};
 		ReferenceBinding type = compiler.lookupEnvironment.askForType(compoundName, compiler.lookupEnvironment.UnNamedModule);
 		assertNotNull(type);
@@ -6856,8 +6856,8 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 		Requestor requestor = new Requestor(false, null /*no custom requestor*/, false, /* show category */ false /* show warning token*/);
 		Map customOptions = getCompilerOptions();
 		customOptions.put(CompilerOptions.OPTION_Store_Annotations, CompilerOptions.ENABLED);
-		Compiler compiler = new Compiler(getNameEnvironment(new String[0], null), getErrorHandlingPolicy(),
-				new CompilerOptions(customOptions), requestor, getProblemFactory());
+		Compiler compiler = new Compiler(AbstractRegressionTest.getNameEnvironment(this, new String[0], null), AbstractRegressionTest.getErrorHandlingPolicy(),
+				new CompilerOptions(customOptions), requestor, AbstractRegressionTest.getProblemFactory());
 		char [][] compoundName = new char [][] { "test1".toCharArray(), "Base".toCharArray()};
 		ReferenceBinding type = compiler.lookupEnvironment.askForType(compoundName, compiler.lookupEnvironment.UnNamedModule);
 		assertNotNull(type);
@@ -6925,12 +6925,12 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 			Map customOptions = getCompilerOptions();
 			customOptions.put(CompilerOptions.OPTION_Store_Annotations, CompilerOptions.ENABLED);
 			String[] defaultClassPaths = getDefaultClassPaths();
-			String jarpath = this.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "bug492322-compiled-with-4.6.jar";
+			String jarpath = AbstractRegressionTest.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "bug492322-compiled-with-4.6.jar";
 			String[] paths = new String[defaultClassPaths.length + 1];
 			System.arraycopy(defaultClassPaths, 0, paths, 0, defaultClassPaths.length);
 			paths[defaultClassPaths.length] = jarpath;
-			Compiler compiler = new Compiler(getNameEnvironment(new String[0], paths), getErrorHandlingPolicy(),
-					new CompilerOptions(customOptions), requestor, getProblemFactory());
+			Compiler compiler = new Compiler(AbstractRegressionTest.getNameEnvironment(this, new String[0], paths), AbstractRegressionTest.getErrorHandlingPolicy(),
+					new CompilerOptions(customOptions), requestor, AbstractRegressionTest.getProblemFactory());
 			char [][] compoundName = new char [][] { "test1".toCharArray(), "Base".toCharArray()};
 			ReferenceBinding type = compiler.lookupEnvironment.askForType(compoundName, compiler.lookupEnvironment.UnNamedModule);
 			assertNotNull(type);
@@ -6958,7 +6958,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 
 		Requestor requestor = new Requestor(false, null, false, false);
 		Map<String, String> customOptions = getCompilerOptions(); customOptions.put(CompilerOptions.OPTION_Store_Annotations, CompilerOptions.ENABLED);
-		Compiler compiler = new Compiler(getNameEnvironment(new String[0], null), getErrorHandlingPolicy(), new CompilerOptions(customOptions), requestor, getProblemFactory());
+		Compiler compiler = new Compiler(AbstractRegressionTest.getNameEnvironment(this, new String[0], null), AbstractRegressionTest.getErrorHandlingPolicy(), new CompilerOptions(customOptions), requestor, AbstractRegressionTest.getProblemFactory());
 
 		ReferenceBinding type = compiler.lookupEnvironment.askForType(new char[][] {"p".toCharArray(), "C".toCharArray()}, compiler.lookupEnvironment.UnNamedModule);
 		assertNotNull(type);
@@ -6989,7 +6989,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 				"        target type = 0x1 METHOD_TYPE_PARAMETER\n" +
 				"        type parameter index = 1\n" +
 				"      )\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 
 		expectedOutput =
 				"  RuntimeVisibleTypeAnnotations: \n" +
@@ -6998,7 +6998,7 @@ public class TypeAnnotationTest extends AbstractRegressionTest {
 				"      type parameter index = 0\n" +
 				"    )\n" +
 				"}";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
+		AbstractRegressionTest.checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput, ClassFileBytesDisassembler.SYSTEM);
 	}
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=568240
 	// Method's annotation attribute is compiled as annotation on return type

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/UnderscoresInLiteralsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/UnderscoresInLiteralsTest.java
@@ -397,8 +397,8 @@ public class UnderscoresInLiteralsTest extends AbstractRegressionTest {
 		customedOptions.put(CompilerOptions.OPTION_Compliance, CompilerOptions.VERSION_1_6);
 		customedOptions.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_1_6);
 		customedOptions.put(CompilerOptions.OPTION_TargetPlatform, CompilerOptions.VERSION_1_6);
-		this.runNegativeTest(
-			new String[] {
+		AbstractRegressionTest.runNegativeTest(
+			this, new String[] {
 				"X.java",
 				"public class X {\n" +
 				"	public static void main(String[] args) {\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/Unicode11Test.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/Unicode11Test.java
@@ -42,8 +42,8 @@ public void test1() {
 public void test2() {
 	Map<String, String> options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_Compliance, CompilerOptions.VERSION_11);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"		public int a\\u0560; // new unicode character in unicode 11.0 \n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/Unicode12_1Test.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/Unicode12_1Test.java
@@ -42,8 +42,8 @@ public void test1() {
 public void test2() {
 	Map<String, String> options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_Compliance, CompilerOptions.VERSION_12);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"		public int a\\uA7BA; // new unicode character in unicode 12.0 \n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/Unicode18Test.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/Unicode18Test.java
@@ -45,8 +45,8 @@ public void test426214() {
 public void test426214_2() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_Compliance, CompilerOptions.VERSION_1_7);
-	this.runNegativeTest(
-		false /* skipJavac */,
+	AbstractRegressionTest.runNegativeTest(
+		this, false /* skipJavac */,
 		JavacTestOptions.Excuse.JavacCompilesIncorrectSource,
 		new String[] {
 			"X.java",
@@ -74,8 +74,8 @@ public void test426214_2() {
 public void test426214_3() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_Compliance, CompilerOptions.VERSION_1_6);
-	this.runNegativeTest(
-		false /* skipJavac */,
+	AbstractRegressionTest.runNegativeTest(
+		this, false /* skipJavac */,
 		JavacTestOptions.Excuse.JavacCompilesIncorrectSource,
 		new String[] {
 			"X.java",
@@ -103,8 +103,8 @@ public void test426214_3() {
 public void test426214_4() {
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_Compliance, CompilerOptions.VERSION_1_8);
-	this.runNegativeTest(
-		new String[] {
+	AbstractRegressionTest.runNegativeTest(
+		this, new String[] {
 			"X.java",
 			"public class X {\n" +
 			"		int a\\u061C = 0; // new unicode character in 6.3.0 \n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/UnnamedModuleTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/UnnamedModuleTest.java
@@ -76,7 +76,7 @@ public void testBug522326() {
 // Should compile successfully when the compilation unit contains a split package and
 // the option 'OPTION_IgnoreUnnamedModuleForSplitPackage' is turned on.
 public void testIgnoreUnnamedModule1() {
-	String path = this.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "ignore-unnamed-module-test.jar";
+	String path = AbstractRegressionTest.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "ignore-unnamed-module-test.jar";
 	String[] defaultLibs = getDefaultClassPaths();
 	int len = defaultLibs.length;
 	String[] libs = new String[len+1];
@@ -84,8 +84,8 @@ public void testIgnoreUnnamedModule1() {
 	libs[len] = path;
 	Map<String, String> compilerOptions = getCompilerOptions();
 	compilerOptions.put(CompilerOptions.OPTION_IgnoreUnnamedModuleForSplitPackage, CompilerOptions.ENABLED);
-	this.runConformTest(
-			true,
+	AbstractRegressionTest.runConformTest(
+			this, true,
 			new String[] {
 				"X.java",
 				"import org.xml.sax.SAXException;\n" +
@@ -103,7 +103,7 @@ public void testIgnoreUnnamedModule1() {
 			JavacTestOptions.DEFAULT);
 }
 public void testIgnoreUnnamedModule2() {
-	String path = this.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "ignore-unnamed-module-test.jar";
+	String path = AbstractRegressionTest.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "ignore-unnamed-module-test.jar";
 	String[] defaultLibs = getDefaultClassPaths();
 	int len = defaultLibs.length;
 	String[] libs = new String[len+1];
@@ -111,8 +111,8 @@ public void testIgnoreUnnamedModule2() {
 	libs[len] = path;
 	Map<String, String> compilerOptions = getCompilerOptions();
 	compilerOptions.put(CompilerOptions.OPTION_IgnoreUnnamedModuleForSplitPackage, CompilerOptions.ENABLED);
-	this.runConformTest(
-			true,
+	AbstractRegressionTest.runConformTest(
+			this, true,
 			new String[] {
 				"X.java",
 				"public class X {\n" +
@@ -129,7 +129,7 @@ public void testIgnoreUnnamedModule2() {
 			JavacTestOptions.DEFAULT);
 }
 public void testIgnoreUnnamedModule3() {
-	String path = this.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "ignore-unnamed-module-test.jar";
+	String path = AbstractRegressionTest.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "ignore-unnamed-module-test.jar";
 	String[] defaultLibs = getDefaultClassPaths();
 	int len = defaultLibs.length;
 	String[] libs = new String[len+1];
@@ -137,8 +137,8 @@ public void testIgnoreUnnamedModule3() {
 	libs[len] = path;
 	Map<String, String> compilerOptions = getCompilerOptions();
 	compilerOptions.put(CompilerOptions.OPTION_IgnoreUnnamedModuleForSplitPackage, CompilerOptions.ENABLED);
-	this.runConformTest(
-			true,
+	AbstractRegressionTest.runConformTest(
+			this, true,
 			new String[] {
 				"X.java",
 				"import static org.xml.sax.helpers.NamespaceSupport.XMLNS;\n" +
@@ -156,7 +156,7 @@ public void testIgnoreUnnamedModule3() {
 			JavacTestOptions.DEFAULT);
 }
 public void testIgnoreUnnamedModule4() {
-	String path = this.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "ignore-unnamed-module-test.jar";
+	String path = AbstractRegressionTest.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "ignore-unnamed-module-test.jar";
 	String[] defaultLibs = getDefaultClassPaths();
 	int len = defaultLibs.length;
 	String[] libs = new String[len+1];
@@ -164,8 +164,8 @@ public void testIgnoreUnnamedModule4() {
 	libs[len] = path;
 	Map<String, String> compilerOptions = getCompilerOptions();
 	compilerOptions.put(CompilerOptions.OPTION_IgnoreUnnamedModuleForSplitPackage, CompilerOptions.ENABLED);
-	this.runConformTest(
-			true,
+	AbstractRegressionTest.runConformTest(
+			this, true,
 			new String[] {
 				"X.java",
 				"public class X {\n" +
@@ -182,7 +182,7 @@ public void testIgnoreUnnamedModule4() {
 			JavacTestOptions.DEFAULT);
 }
 public void testConflictWithUnnamedModule() {
-	String path = this.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "ignore-unnamed-module-test.jar";
+	String path = AbstractRegressionTest.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "ignore-unnamed-module-test.jar";
 	String[] defaultLibs = getDefaultClassPaths();
 	int len = defaultLibs.length;
 	String[] libs = new String[len+1];

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/UnnammedPatternsAndVarsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/UnnammedPatternsAndVarsTest.java
@@ -70,7 +70,7 @@ public class UnnammedPatternsAndVarsTest extends AbstractRegressionTest9 {
 	@Override
 	protected INameEnvironment getNameEnvironment(final String[] testFiles, String[] classPaths, Map<String, String> options) {
 		this.classpaths = classPaths == null ? getDefaultClassPaths() : classPaths;
-		INameEnvironment[] classLibs = getClassLibs(false, options);
+		INameEnvironment[] classLibs = AbstractRegressionTest.getClassLibs(this, false, options);
 		for (INameEnvironment nameEnvironment : classLibs) {
 			((FileSystem) nameEnvironment).scanForModules(createParser());
 		}
@@ -84,7 +84,7 @@ public class UnnammedPatternsAndVarsTest extends AbstractRegressionTest9 {
 	protected void runConformTest(String[] testFiles, String expectedOutput, Map<String, String> customOptions) {
 		if(!isJRE21Plus)
 			return;
-		runConformTest(testFiles, expectedOutput, customOptions, new String[] {"--enable-preview"}, JAVAC_OPTIONS);
+		AbstractRegressionTest.runConformTest(this, testFiles, expectedOutput, customOptions, new String[] {"--enable-preview"}, JAVAC_OPTIONS);
 	}
 	protected void runConformTest(
 			String[] testFiles,
@@ -92,8 +92,8 @@ public class UnnammedPatternsAndVarsTest extends AbstractRegressionTest9 {
 			String[] classLibraries,
 			boolean shouldFlushOutputDirectory,
 			String[] vmArguments) {
-			runTest(
-		 		// test directory preparation
+			AbstractRegressionTest.runTest(
+		 		this, // test directory preparation
 				shouldFlushOutputDirectory /* should flush output directory */,
 				testFiles /* test files */,
 				// compiler options

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/VarargsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/VarargsTest.java
@@ -705,8 +705,8 @@ public class VarargsTest extends AbstractComparableTest {
 
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=83379
 	public void test011() {
-		runConformTest(
-			true,
+		AbstractRegressionTest.runConformTest(
+			this, true,
 			new String[] {
 				"X.java",
 				"public class X { void count(int ... values) {} }\n" +
@@ -822,8 +822,8 @@ public class VarargsTest extends AbstractComparableTest {
 		try {
 			System.setProperty("tolerateIllegalAmbiguousVarargsInvocation", "true");
 			if (this.complianceLevel >= ClassFileConstants.JDK1_7) {
-			this.runNegativeTest(
-					new String[] {
+			AbstractRegressionTest.runNegativeTest(
+					this, new String[] {
 							"X.java",
 							"public class X {\n" +
 							"	public static void main(String[] s) {\n" +
@@ -843,8 +843,8 @@ public class VarargsTest extends AbstractComparableTest {
 				"----------\n",
 				null, true, options);
 			} else {
-				this.runConformTest(
-					new String[] {
+				AbstractRegressionTest.runConformTest(
+					this, new String[] {
 							"X.java",
 							"public class X {\n" +
 							"	public static void main(String[] s) {\n" +
@@ -1302,8 +1302,8 @@ public class VarargsTest extends AbstractComparableTest {
 	}
  	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=102631
 	public void test033() {
-		this.runNegativeTest(
-			false /* skipJavac */,
+		AbstractRegressionTest.runNegativeTest(
+			this, false /* skipJavac */,
 			this.complianceLevel < ClassFileConstants.JDK1_7 ?
 					JavacTestOptions.Excuse.JavacCompilesIncorrectSource : null,
 			new String[] {
@@ -1377,8 +1377,8 @@ public class VarargsTest extends AbstractComparableTest {
 		try {
 			System.setProperty("tolerateIllegalAmbiguousVarargsInvocation", "true");
 			if (this.complianceLevel >= ClassFileConstants.JDK1_7) {
-				this.runNegativeTest(
-				false /* skipJavac */,
+				AbstractRegressionTest.runNegativeTest(
+				this, false /* skipJavac */,
 				this.complianceLevel < ClassFileConstants.JDK1_7 ?
 						JavacTestOptions.Excuse.JavacCompilesIncorrectSource : null,
 				new String[] {
@@ -1407,8 +1407,8 @@ public class VarargsTest extends AbstractComparableTest {
 					"----------\n",
 					null, true, options);
 			} else {
-				this.runConformTest(
-						new String[] {
+				AbstractRegressionTest.runConformTest(
+						this, new String[] {
 							"X.java",
 							"public class X {\n" +
 							"	void a(boolean b, Object... o) {System.out.print(1);}\n" +
@@ -2241,8 +2241,8 @@ public class VarargsTest extends AbstractComparableTest {
 		options.put(CompilerOptions.OPTION_Compliance, CompilerOptions.VERSION_1_5);
 		options.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_1_5);
 		options.put(CompilerOptions.OPTION_TargetPlatform, CompilerOptions.VERSION_1_4);
-		this.runConformTest(
-				new String[] {
+		AbstractRegressionTest.runConformTest(
+				this, new String[] {
 					"X.java",
 					"public class X {\n" +
 					"   public static String varargMethod( Object... objects ) {\r\n" +
@@ -2280,8 +2280,8 @@ public class VarargsTest extends AbstractComparableTest {
 		options.put(CompilerOptions.OPTION_Compliance, CompilerOptions.VERSION_1_5);
 		options.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_1_5);
 		options.put(CompilerOptions.OPTION_TargetPlatform, CompilerOptions.VERSION_1_5);
-		this.runConformTest(
-				new String[] {
+		AbstractRegressionTest.runConformTest(
+				this, new String[] {
 					"UseVararg.java",
 					"public class UseVararg {\r\n" +
 					"   public static void main( String[] args ) {\n" +
@@ -2361,7 +2361,7 @@ public class VarargsTest extends AbstractComparableTest {
 			"  // Method descriptor #10 (LX;Ljava/lang/Integer;[Ljava/lang/String;Ljava/lang/Float;)V\n" +
 			"  // Stack: 3, Locals: 5\n" +
 			"  X$1(X arg0, java.lang.Integer $anonymous0, java.lang.String... $anonymous1, java.lang.Float arg3);\n";
-		checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X$1.class", "X$1", expectedOutput);
+		AbstractRegressionTest.checkDisassembledClassFile(this, OUTPUT_DIR + File.separator + "X$1.class", "X$1", expectedOutput);
 	}
 	//safe varargs support
 	public void test063() throws Exception {
@@ -2381,8 +2381,8 @@ public class VarargsTest extends AbstractComparableTest {
 			"");
 		Map options = getCompilerOptions();
 		options.put(JavaCore.COMPILER_PB_UNCHECKED_TYPE_OPERATION, JavaCore.ERROR);
-		this.runConformTest(
-			new String[] {
+		AbstractRegressionTest.runConformTest(
+			this, new String[] {
 				"X.java",
 				"import java.util.ArrayList;\n" +
 				"import java.util.List;\n" +
@@ -2403,8 +2403,8 @@ public class VarargsTest extends AbstractComparableTest {
 		if (this.complianceLevel < ClassFileConstants.JDK1_7) return;
 		Map options = getCompilerOptions();
 		options.put(JavaCore.COMPILER_PB_UNCHECKED_TYPE_OPERATION, JavaCore.ERROR);
-		this.runConformTest(
-			new String[] {
+		AbstractRegressionTest.runConformTest(
+			this, new String[] {
 				"X.java",
 				"import java.util.ArrayList;\n" +
 				"import java.util.List;\n" +
@@ -2429,8 +2429,8 @@ public class VarargsTest extends AbstractComparableTest {
 		if (this.complianceLevel < ClassFileConstants.JDK1_7) return;
 		Map options = getCompilerOptions();
 		options.put(JavaCore.COMPILER_PB_UNCHECKED_TYPE_OPERATION, JavaCore.ERROR);
-		this.runConformTest(
-			new String[] {
+		AbstractRegressionTest.runConformTest(
+			this, new String[] {
 				"X.java",
 				"import java.util.ArrayList;\n" +
 				"import java.util.List;\n" +
@@ -2455,8 +2455,8 @@ public class VarargsTest extends AbstractComparableTest {
 	public void test066() {
 		Map options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_ReportMissingOverrideAnnotationForInterfaceMethodImplementation, CompilerOptions.DISABLED);
-		this.runNegativeTest(
-				new String[] {
+		AbstractRegressionTest.runNegativeTest(
+				this, new String[] {
 					"X.java",
 					"import java.util.Collection;\n" +
 					"import java.util.Iterator;\n" +
@@ -2825,8 +2825,8 @@ public class VarargsTest extends AbstractComparableTest {
 		try {
 			System.setProperty("tolerateIllegalAmbiguousVarargsInvocation", "true");
 			if (this.complianceLevel < ClassFileConstants.JDK1_7) {
-				this.runNegativeTest(
-					new String[] {
+				AbstractRegressionTest.runNegativeTest(
+					this, new String[] {
 						"X.java",
 						"public class X {\n" +
 						"        public static void foo(int ...i) {}\n" +
@@ -2845,8 +2845,8 @@ public class VarargsTest extends AbstractComparableTest {
 					"----------\n",
 					null, true, options);
 			} else {
-				this.runConformTest(
-						new String[] {
+				AbstractRegressionTest.runConformTest(
+						this, new String[] {
 							"X.java",
 							"public class X {\n" +
 							"        public static void foo(int ...i) {}\n" +
@@ -2873,8 +2873,8 @@ public class VarargsTest extends AbstractComparableTest {
 		try {
 			System.setProperty("tolerateIllegalAmbiguousVarargsInvocation", "true");
 			if (this.complianceLevel >= ClassFileConstants.JDK1_7) {
-				this.runNegativeTest(
-					false /* skipJavac */,
+				AbstractRegressionTest.runNegativeTest(
+					this, false /* skipJavac */,
 					this.complianceLevel == ClassFileConstants.JDK1_7 ?
 							JavacTestOptions.Excuse.JavacCompilesIncorrectSource : null,
 					new String[] {
@@ -2898,8 +2898,8 @@ public class VarargsTest extends AbstractComparableTest {
 					"----------\n",
 					null, true, options);
 			} else {
-				this.runConformTest(
-						new String[] {
+				AbstractRegressionTest.runConformTest(
+						this, new String[] {
 								"X.java",
 								"import java.util.Arrays;\n" +
 								"public class X {\n" +
@@ -2944,8 +2944,8 @@ public class VarargsTest extends AbstractComparableTest {
 		try {
 			System.setProperty("tolerateIllegalAmbiguousVarargsInvocation", "true");
 			if (this.complianceLevel < ClassFileConstants.JDK1_7) {
-				this.runNegativeTest(
-					new String[] {
+				AbstractRegressionTest.runNegativeTest(
+					this, new String[] {
 						"X.java",
 						"public class X {\n" +
 						"        public static <T> void foo(int ...i) {}\n" +
@@ -2964,8 +2964,8 @@ public class VarargsTest extends AbstractComparableTest {
 					"----------\n",
 					null, true, options);
 			} else {
-				this.runConformTest(
-						new String[] {
+				AbstractRegressionTest.runConformTest(
+						this, new String[] {
 							"X.java",
 							"public class X {\n" +
 							"        public static <T> void foo(int ...i) {}\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/XLargeTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/XLargeTest.java
@@ -59,8 +59,8 @@ public void test368435() {
 	}
 	sourceCode.append("}\n}\n}\n");
 
-	this.runConformTest(
-			new String[] {
+	AbstractRegressionTest.runConformTest(
+			this, new String[] {
 					"X.java",
 					sourceCode.toString()
 			},
@@ -90,8 +90,8 @@ public void test368435b() {
 	}
 	sourceCode.append("}\n}\n}\n");
 
-	this.runConformTest(
-			new String[] {
+	AbstractRegressionTest.runConformTest(
+			this, new String[] {
 					"X.java",
 					sourceCode.toString()
 			},
@@ -121,8 +121,8 @@ public void test368435c() {
 	}
 	sourceCode.append("}\n}\n}\n");
 
-	this.runConformTest(
-			new String[] {
+	AbstractRegressionTest.runConformTest(
+			this, new String[] {
 					"X.java",
 					sourceCode.toString()
 			},
@@ -886,8 +886,8 @@ public void test004() {
 }
 
 public void test005() {
-	runConformTest(
-		true,
+	AbstractRegressionTest.runConformTest(
+		this, true,
 		new String[] {
 		"p/X.java",
 		"package p;\n" +
@@ -1975,7 +1975,7 @@ public void test008() {
 	options.put(CompilerOptions.OPTION_LineNumberAttribute, CompilerOptions.DO_NOT_GENERATE);
 	options.put(CompilerOptions.OPTION_LocalVariableAttribute, CompilerOptions.DO_NOT_GENERATE);
 	options.put(CompilerOptions.OPTION_SourceFileAttribute, CompilerOptions.DO_NOT_GENERATE);
-	this.runConformTest(new String[] {
+	AbstractRegressionTest.runConformTest(this, new String[] {
 		"X.java",
 		"public class X extends B implements IToken {\n" +
 		"	public X( int t, int endOffset, char [] filename, int line  ) {\n" +
@@ -2653,8 +2653,8 @@ public void test008() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=126744
 public void test009() {
-	runConformTest(
-		true,
+	AbstractRegressionTest.runConformTest(
+		this, true,
 		new String[] {
 			"X.java",
 			"public class X {\n" +
@@ -3721,8 +3721,8 @@ public void test010() {
 			"abcdefghijklmnopqrstuvwxy12\";\n" +
 			"    }\n" +
 			"}");
-	this.runConformTest(
-		true,
+	AbstractRegressionTest.runConformTest(
+		this, true,
 		new String[] {
 			"X.java",
 			sourceCode.toString()
@@ -3790,8 +3790,8 @@ public void test012() {
 			"abcdefghijklmnopqrstuvwxy12\");\n" +
 			"    }\n" +
 			"}");
-	this.runConformTest(
-		true,
+	AbstractRegressionTest.runConformTest(
+		this, true,
 		new String[] {
 			"X.java",
 			sourceCode.toString()
@@ -3923,8 +3923,8 @@ public void test014() {
 public void test015() {
 	Map settings = getCompilerOptions();
 	settings.put(CompilerOptions.OPTION_ShareCommonFinallyBlocks, CompilerOptions.ENABLED);
-	runConformTest(
-		true,
+	AbstractRegressionTest.runConformTest(
+		this, true,
 		new String[] {
 		"X.java",
 		"public class X {\n" +
@@ -20738,8 +20738,8 @@ public void testIssue1164a() throws ClassFormatException, IOException {
 			"abcdefgh\");\n" +
 			"    }\n" +
 			"}");
-	this.runConformTest(
-		true,
+	AbstractRegressionTest.runConformTest(
+		this, true,
 		new String[] {
 			"X.java",
 			sourceCode.toString()
@@ -20942,12 +20942,12 @@ public void testIssue1164a() throws ClassFormatException, IOException {
 			+ "     282  aload_3 [c]\n"
 			+ "     283  aload 4 [d]\n"
 			+ "     285  invokedynamic 0 makeConcatWithConstants(String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String) : String [16]\n";
-	checkClassFile("X", sourceCode.toString(), expectedOutput, ClassFileBytesDisassembler.DETAILED | ClassFileBytesDisassembler.COMPACT);
+	AbstractRegressionTest.checkClassFile(this, "X", sourceCode.toString(), expectedOutput, ClassFileBytesDisassembler.DETAILED | ClassFileBytesDisassembler.COMPACT);
 	expectedOutput = "  31 : # 69 invokestatic java/lang/invoke/StringConcatFactory.makeConcatWithConstants:(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/invoke/CallSite;\n" +
 			"	Method arguments:\n" +
 			"		#78  ghijkpqrstuabcdef ghijkpqrstuabcdef ghijkpqrstuabcdef ghijkpqrstuabcdef ghijkpqrstuabcdef ghijkpqrstuabcdef ghijkpqrstuabcdef ghijkpqrstuabcdef ghijkpqrstuabcdef ghijkpqrstuabcdef ghijkpqrstuabcdef ghijkpqrstuabcdef ghijkpqrstuabcdef ghijkpqrstuabcdef ghijkpqrstuabcdef ghijkpqrstuabcdef ghijkpqrstuabcdef ghijkpqrstuabcdef ghijkpqrstuabcdef ghijkabcdefghabcdefgh\n" +
 			"}";
-	checkClassFile("X", sourceCode.toString(), expectedOutput, ClassFileBytesDisassembler.DETAILED | ClassFileBytesDisassembler.COMPACT);
+	AbstractRegressionTest.checkClassFile(this, "X", sourceCode.toString(), expectedOutput, ClassFileBytesDisassembler.DETAILED | ClassFileBytesDisassembler.COMPACT);
 }
 public void testIssue1164b() {
 	if (this.complianceLevel < ClassFileConstants.JDK9)
@@ -21013,8 +21013,8 @@ public void testIssue1164b() {
 			+ "ghijkpqrstuabcdefabcdefa ghijkpqrstuabcdefabcdefa ghijkpqrstuabcdefabcdefa ghijkpqrstuabcdefabcdefa ghijkpqrstuabcdefabcdefa "
 			+ "ghijkpqrstuabcdefabcdefa ghijkpqrstuabcdefabcdefa ghijkpqrstuabcdefabcdefa ghijkpqrstuabcdefabcdefa ghijkpqrstuabcdefabcdefa "
 			+ "ghijkpqrstuabcdefabcde ghijkabcdefghabcdefgh";
-	this.runConformTest(
-		true,
+	AbstractRegressionTest.runConformTest(
+		this, true,
 		new String[] {
 			"X.java",
 			sourceCode.toString()

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/XLargeTest2.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/XLargeTest2.java
@@ -114,8 +114,8 @@ public class XLargeTest2 extends AbstractRegressionTest {
 		}
 
 		// Javac can't compile such big enums
-		runConformTest(
-				true,
+		AbstractRegressionTest.runConformTest(
+				this, true,
 				JavacTestOptions.SKIP,
 				new String[] {
 						"X.java",


### PR DESCRIPTION
This is a dogfooding change demonstrating the "Make Static" refactoring recently added to JDT UI (eclipse-jdt/eclipse.jdt.ui#689). It is only supposed to be used for demonstration and validation purposes and is **not to be merged**.

The change consists of the applications of the refactoring to all methods within `org.eclipse.jdt.core.tests.compiler.regression.AbstractRegressionTest` that fulfill the refactoring's preconditions (in particular not being overwriting or overwritten methods).

The refactoring was used in the state with the to-be-integrated fix in eclipse-jdt/eclipse.jdt.ui#1085