### PR TITLE
[Patterns] Scope of pattern binding extends illegally

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ASTNode.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ASTNode.java
@@ -349,6 +349,7 @@ public abstract class ASTNode implements TypeConstants, TypeIds {
 	public static final Argument [] NO_ARGUMENTS = new Argument [0];
 	public static final RecordComponent [] NO_RECORD_COMPONENTS = new RecordComponent [0];
 	public static final TypePattern[] NO_TYPE_PATTERNS = new TypePattern[0];
+	public static final LocalVariableBinding[] NO_VARIABLES = new LocalVariableBinding[0];
 
 	public ASTNode() {
 
@@ -717,6 +718,28 @@ public abstract class ASTNode implements TypeConstants, TypeIds {
 		if ((modifiers & ExtraCompilerModifiers.AccSealed) != 0)
 			output.append("sealed "); //$NON-NLS-1$
 		return output;
+	}
+
+	public static void resolveStatements(Statement[] statements, BlockScope scope) {
+		LocalVariableBinding [] livePatternVariables = NO_VARIABLES;
+		for (int i = 0, length = statements.length; i < length; i++) {
+			final Statement stmt = statements[i];
+			stmt.resolveWithPatternVariablesInScope(livePatternVariables, scope);
+			LocalVariableBinding[] newVariables = stmt.getPatternVariablesLiveUponCompletion();
+			if (newVariables != null && newVariables.length > 0) {
+				int livePatternVariableCount = livePatternVariables.length;
+				System.arraycopy(livePatternVariables,
+						                            0,
+						         livePatternVariables = new LocalVariableBinding[livePatternVariableCount + newVariables.length],
+						                            0,
+						         livePatternVariableCount);
+				System.arraycopy(newVariables,
+                                        0,
+                             livePatternVariables,
+                             livePatternVariableCount,
+                             newVariables.length);
+			}
+		}
 	}
 
 	/**

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AbstractMethodDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AbstractMethodDeclaration.java
@@ -707,10 +707,7 @@ public abstract class AbstractMethodDeclaration
 	public void resolveStatements() {
 
 		if (this.statements != null) {
- 			for (int i = 0, length = this.statements.length; i < length; i++) {
- 				Statement stmt = this.statements[i];
- 				stmt.resolve(this.scope);
-			}
+			resolveStatements(this.statements, this.scope);
  			this.recPatCatchVar = RecordPattern.getRecPatternCatchVar(0, this.scope);
 		} else if ((this.bits & UndocumentedEmptyBlock) != 0) {
 			if (!this.isConstructor() || this.arguments != null) { // https://bugs.eclipse.org/bugs/show_bug.cgi?id=319626

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Block.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Block.java
@@ -126,10 +126,7 @@ public void resolve(BlockScope upperScope) {
 			this.explicitDeclarations == 0
 				? upperScope
 				: new BlockScope(upperScope, this.explicitDeclarations);
-		for (int i = 0, length = this.statements.length; i < length; i++) {
-			final Statement stmt = this.statements[i];
-			stmt.resolve(this.scope);
-		}
+		resolveStatements(this.statements, this.scope);
 	}
 }
 
@@ -140,9 +137,7 @@ public void resolveUsing(BlockScope givenScope) {
 	// this optimized resolve(...) is sent only on none empty blocks
 	this.scope = givenScope;
 	if (this.statements != null) {
-		for (int i = 0, length = this.statements.length; i < length; i++) {
-			this.statements[i].resolve(this.scope);
-		}
+		resolveStatements(this.statements, this.scope);
 	}
 }
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/DoStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/DoStatement.java
@@ -225,22 +225,18 @@ public StringBuilder printStatement(int indent, StringBuilder output) {
 }
 
 @Override
+public LocalVariableBinding[] getPatternVariablesLiveUponCompletion() {
+	return this.condition.containsPatternVariable() && this.action != null && !this.action.breaksOut(null) ?
+			this.condition.getPatternVariablesWhenFalse() : NO_VARIABLES;
+}
+
+@Override
 public void resolve(BlockScope scope) {
-	if (containsPatternVariable()) {
-		this.condition.collectPatternVariablesToScope(null, scope);
-		LocalVariableBinding[] patternVariablesInFalseScope = this.condition.getPatternVariablesWhenFalse();
-		TypeBinding type = this.condition.resolveTypeExpecting(scope, TypeBinding.BOOLEAN);
-		this.condition.computeConversion(scope, type, type);
-		if (this.action != null) {
-			this.action.resolve(scope);
-			this.action.promotePatternVariablesIfApplicable(patternVariablesInFalseScope,
-					() -> !this.action.breaksOut(null));
-		}
-	} else {
-		TypeBinding type = this.condition.resolveTypeExpecting(scope, TypeBinding.BOOLEAN);
-		this.condition.computeConversion(scope, type, type);
-		if (this.action != null)
-			this.action.resolve(scope);
+	this.condition.collectPatternVariablesToScope(null, scope);
+	TypeBinding type = this.condition.resolveTypeExpecting(scope, TypeBinding.BOOLEAN);
+	this.condition.computeConversion(scope, type, type);
+	if (this.action != null) {
+		this.action.resolve(scope);
 	}
 }
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Expression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Expression.java
@@ -790,6 +790,9 @@ public LocalDeclaration getPatternVariable() {
 	return null;
 }
 public void collectPatternVariablesToScope(LocalVariableBinding[] variables, BlockScope scope) {
+	if (variables == null || variables.length == 0)
+		return;
+
 	new ASTVisitor() {
 		LocalVariableBinding[] patternVariablesInScope;
 		@Override

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/IfStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/IfStatement.java
@@ -300,37 +300,30 @@ public StringBuilder printStatement(int indent, StringBuilder output) {
 	}
 	return output;
 }
-private void resolveIfStatement(BlockScope scope) {
-	TypeBinding type = this.condition.resolveTypeExpecting(scope, TypeBinding.BOOLEAN);
-	this.condition.computeConversion(scope, type, type);
-	if (this.thenStatement != null)
-		this.thenStatement.resolve(scope);
-	if (this.elseStatement != null)
-		this.elseStatement.resolve(scope);
+
+@Override
+public LocalVariableBinding[] getPatternVariablesLiveUponCompletion() {
+	if (!this.condition.containsPatternVariable() || doesNotCompleteNormally())
+		return NO_VARIABLES;
+	if (this.thenStatement != null && this.thenStatement.doesNotCompleteNormally())
+		return this.condition.getPatternVariablesWhenFalse();
+	if (this.elseStatement != null && this.elseStatement.doesNotCompleteNormally())
+		return this.condition.getPatternVariablesWhenTrue();
+	return NO_VARIABLES;
 }
 @Override
 public void resolve(BlockScope scope) {
-	if (containsPatternVariable()) {
-		this.condition.collectPatternVariablesToScope(null, scope);
-		LocalVariableBinding[] patternVariablesInTrueScope = this.condition.getPatternVariablesWhenTrue();
-		LocalVariableBinding[] patternVariablesInFalseScope = this.condition.getPatternVariablesWhenFalse();
-		TypeBinding type = this.condition.resolveTypeExpecting(scope, TypeBinding.BOOLEAN);
-		this.condition.computeConversion(scope, type, type);
+	this.condition.collectPatternVariablesToScope(null, scope);
+	LocalVariableBinding[] patternVariablesInTrueScope = this.condition.getPatternVariablesWhenTrue();
+	LocalVariableBinding[] patternVariablesInFalseScope = this.condition.getPatternVariablesWhenFalse();
+	TypeBinding type = this.condition.resolveTypeExpecting(scope, TypeBinding.BOOLEAN);
+	this.condition.computeConversion(scope, type, type);
 
-		if (this.thenStatement != null) {
-			this.thenStatement.resolveWithPatternVariablesInScope(patternVariablesInTrueScope, scope);
-		}
-		if (this.elseStatement != null) {
-			this.elseStatement.resolveWithPatternVariablesInScope(patternVariablesInFalseScope, scope);
-		}
-		if (this.thenStatement != null)
-			this.thenStatement.promotePatternVariablesIfApplicable(patternVariablesInFalseScope,
-				this.thenStatement::doesNotCompleteNormally);
-		if (this.elseStatement != null)
-			this.elseStatement.promotePatternVariablesIfApplicable(patternVariablesInTrueScope,
-					this.elseStatement::doesNotCompleteNormally);
-	} else {
-		resolveIfStatement(scope);
+	if (this.thenStatement != null) {
+		this.thenStatement.resolveWithPatternVariablesInScope(patternVariablesInTrueScope, scope);
+	}
+	if (this.elseStatement != null) {
+		this.elseStatement.resolveWithPatternVariablesInScope(patternVariablesInFalseScope, scope);
 	}
 }
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/OR_OR_Expression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/OR_OR_Expression.java
@@ -295,14 +295,6 @@ public class OR_OR_Expression extends BinaryExpression {
 		this.right.collectPatternVariablesToScope(newArray, scope);
 		variables = this.right.getPatternVariablesWhenFalse();
 		this.addPatternVariablesWhenFalse(variables);
-
-		// do this at the end, otherwise we will end up with
-		// same variable we just added from left to right
-		variables = this.left.getPatternVariablesWhenTrue();
-		this.right.addPatternVariablesWhenFalse(variables);
-
-		variables = this.left.getPatternVariablesWhenFalse();
-		this.right.addPatternVariablesWhenTrue(variables);
 	}
 	@Override
 	public boolean isCompactableOperation() {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Statement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Statement.java
@@ -41,8 +41,6 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.compiler.ast;
 
-import java.util.function.BooleanSupplier;
-
 import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.internal.compiler.ASTVisitor;
 import org.eclipse.jdt.internal.compiler.ast.NullAnnotationMatching.CheckMode;
@@ -124,6 +122,7 @@ public boolean continueCompletes() {
 	public static final int NOT_COMPLAINED = 0;
 	public static final int COMPLAINED_FAKE_REACHABLE = 1;
 	public static final int COMPLAINED_UNREACHABLE = 2;
+
 	LocalVariableBinding[] patternVarsWhenTrue;
 	LocalVariableBinding[] patternVarsWhenFalse;
 
@@ -491,6 +490,9 @@ public LocalVariableBinding[] getPatternVariablesWhenTrue() {
 public LocalVariableBinding[] getPatternVariablesWhenFalse() {
 	return this.patternVarsWhenFalse;
 }
+public LocalVariableBinding[] getPatternVariablesLiveUponCompletion() {
+	return NO_VARIABLES;
+}
 public void addPatternVariablesWhenTrue(LocalVariableBinding[] vars) {
 	if (vars == null || vars.length == 0) return;
 	if (this.patternVarsWhenTrue == vars) return;
@@ -518,24 +520,18 @@ private LocalVariableBinding[] addPatternVariables(LocalVariableBinding[] curren
 	}
 	return current;
 }
-public void promotePatternVariablesIfApplicable(LocalVariableBinding[] patternVariablesInScope, BooleanSupplier condition) {
-	if (patternVariablesInScope != null && condition.getAsBoolean()) {
-		for (LocalVariableBinding binding : patternVariablesInScope) {
-			binding.modifiers &= ~ExtraCompilerModifiers.AccPatternVariable;
-		}
-	}
-}
+
 public void resolveWithPatternVariablesInScope(LocalVariableBinding[] patternVariablesInScope, BlockScope scope) {
 	if (patternVariablesInScope != null) {
 		for (LocalVariableBinding binding : patternVariablesInScope) {
 			binding.modifiers &= ~ExtraCompilerModifiers.AccPatternVariable;
 		}
-		this.resolve(scope);
+	}
+	this.resolve(scope);
+	if (patternVariablesInScope != null) {
 		for (LocalVariableBinding binding : patternVariablesInScope) {
 			binding.modifiers |= ExtraCompilerModifiers.AccPatternVariable;
 		}
-	} else {
-		resolve(scope);
 	}
 }
 /**

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
@@ -1209,7 +1209,7 @@ public class SwitchStatement extends Expression {
 				int caseCounter = 0;
 				Pattern[] patterns = new Pattern[this.nConstants];
 				int[] caseIndex = new int[this.nConstants];
-				LocalVariableBinding[] patternVariables = null;
+				LocalVariableBinding[] patternVariables = NO_VARIABLES;
 				boolean caseNullDefaultFound = false;
 				boolean defaultFound = false;
 				for (int i = 0; i < length; i++) {
@@ -1234,10 +1234,24 @@ public class SwitchStatement extends Expression {
 								}
 							}
 						} else {
-							patternVariables = null; // Probably redundant?
+							patternVariables = NO_VARIABLES;
 						}
 					} else {
 						statement.resolveWithPatternVariablesInScope(patternVariables, this.scope);
+						LocalVariableBinding[] newVariables = statement.getPatternVariablesLiveUponCompletion();
+						if (newVariables != null && newVariables.length > 0) {
+							int livePatternVariableCount = patternVariables.length;
+							System.arraycopy(patternVariables,
+									                            0,
+									         patternVariables = new LocalVariableBinding[livePatternVariableCount + newVariables.length],
+									                            0,
+									         livePatternVariableCount);
+							System.arraycopy(newVariables,
+			                                        0,
+			                             patternVariables,
+			                             livePatternVariableCount,
+			                             newVariables.length);
+						}
 						continue;
 					}
 					CaseStatement caseStmt = (CaseStatement) statement;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/WhileStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/WhileStatement.java
@@ -275,30 +275,19 @@ public class WhileStatement extends Statement {
 
 	@Override
 	public void resolve(BlockScope scope) {
-		if (containsPatternVariable()) {
-			this.condition.collectPatternVariablesToScope(null, scope);
-			LocalVariableBinding[] patternVariablesInTrueScope = this.condition.getPatternVariablesWhenTrue();
-			LocalVariableBinding[] patternVariablesInFalseScope = this.condition.getPatternVariablesWhenFalse();
+		this.condition.collectPatternVariablesToScope(null, scope);
+		LocalVariableBinding[] patternVariablesInTrueScope = this.condition.getPatternVariablesWhenTrue();
 
-			TypeBinding type = this.condition.resolveTypeExpecting(scope, TypeBinding.BOOLEAN);
-			this.condition.computeConversion(scope, type, type);
-			if (this.action != null) {
-				this.action.resolveWithPatternVariablesInScope(patternVariablesInTrueScope, scope);
-				this.action.promotePatternVariablesIfApplicable(patternVariablesInFalseScope,
-						() -> !this.action.breaksOut(null));
-			}
-		} else {
-			TypeBinding type = this.condition.resolveTypeExpecting(scope, TypeBinding.BOOLEAN);
-			this.condition.computeConversion(scope, type, type);
-			if (this.action != null)
-				this.action.resolve(scope);
+		TypeBinding type = this.condition.resolveTypeExpecting(scope, TypeBinding.BOOLEAN);
+		this.condition.computeConversion(scope, type, type);
+		if (this.action != null) {
+			this.action.resolveWithPatternVariablesInScope(patternVariablesInTrueScope, scope);
 		}
-
 	}
 
 	@Override
 	public boolean containsPatternVariable() {
-		return this.condition != null && this.condition.containsPatternVariable();
+		return this.condition.containsPatternVariable();
 	}
 
 	@Override
@@ -324,6 +313,12 @@ public class WhileStatement extends Statement {
 				this.action.traverse(visitor, blockScope);
 		}
 		visitor.endVisit(this, blockScope);
+	}
+
+	@Override
+	public LocalVariableBinding[] getPatternVariablesLiveUponCompletion() {
+		return this.condition.containsPatternVariable() && this.action != null && !this.action.breaksOut(null) ?
+								this.condition.getPatternVariablesWhenFalse() : NO_VARIABLES;
 	}
 
 	@Override

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/InstanceofPrimaryPatternTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/InstanceofPrimaryPatternTest.java
@@ -284,4 +284,368 @@ public class InstanceofPrimaryPatternTest extends AbstractRegressionTest {
 			"OK",
 			getCompilerOptions());
 	}
+	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=577415
+	// Bug in Eclipse Pattern Matching Instanceof Variable Scope
+	public void test577415() {
+		runNegativeTest(
+			new String[] {
+				"X.java",
+				"""
+				public class X {
+					public static void main(String[] args) {
+						Object obj = new Object();
+						if (obj instanceof Integer r) {
+						    System.out.println();
+						} else if (obj instanceof Double c) {
+						    System.out.println();
+						} else {
+						    throw new IllegalArgumentException("invalid type"); // works OK without this line
+						}
+
+						if (obj instanceof Integer r) {
+						    System.out.println();
+						} else if (obj instanceof Double c) { // Eclipse Compilation Error: Duplicate variable c
+						    System.out.println();
+						}
+						zork();
+					}
+				}
+				"""
+			},
+			"----------\n"
+			+ "1. ERROR in X.java (at line 17)\n"
+			+ "	zork();\n"
+			+ "	^^^^\n"
+			+ "The method zork() is undefined for the type X\n"
+			+ "----------\n");
+	}
+	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=577415
+	// Bug in Eclipse Pattern Matching Instanceof Variable Scope
+	public void test577415_1() {
+		runNegativeTest(
+			new String[] {
+				"X.java",
+				"""
+				public class X {
+					public static void main(String[] args) {
+						Object obj = new Object();
+						if (obj instanceof Double c) {
+						    System.out.println();
+						} else {
+						    throw new IllegalArgumentException("invalid type"); // works OK without this line
+						}
+
+						if (obj instanceof Integer r) {
+						    System.out.println();
+						} else if (obj instanceof Double c) { // Eclipse Compilation Error: Duplicate variable c
+						    System.out.println();
+						}
+					}
+				}
+				"""
+			},
+			"----------\n"
+			+ "1. ERROR in X.java (at line 12)\n"
+			+ "	} else if (obj instanceof Double c) { // Eclipse Compilation Error: Duplicate variable c\n"
+			+ "	                                 ^\n"
+			+ "Duplicate local variable c\n"
+			+ "----------\n");
+	}
+	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=577415
+	// Bug in Eclipse Pattern Matching Instanceof Variable Scope
+	public void test577415_2() {
+		runNegativeTest(
+			new String[] {
+				"X.java",
+				"""
+				public class X {
+					public static void main(String[] args) {
+						if (args != null) {
+							Object obj = new Object();
+							if (obj instanceof Integer r) {
+							    System.out.println();
+							} else if (obj instanceof Double c) {
+							    System.out.println();
+							} else {
+							    throw new IllegalArgumentException("invalid type"); // works OK without this line
+							}
+
+							if (obj instanceof Integer r) {
+							    System.out.println();
+							} else if (obj instanceof Double c) { // Eclipse Compilation Error: Duplicate variable c
+							    System.out.println();
+							}
+						}
+						zork();
+					}
+				}
+				"""
+			},
+			"----------\n"
+			+ "1. ERROR in X.java (at line 19)\n"
+			+ "	zork();\n"
+			+ "	^^^^\n"
+			+ "The method zork() is undefined for the type X\n"
+			+ "----------\n");
+	}
+	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=577415
+	// Bug in Eclipse Pattern Matching Instanceof Variable Scope
+	public void test577415_3() {
+		runNegativeTest(
+			new String[] {
+				"X.java",
+				"""
+				public class X {
+					public static void main(String[] args) {
+						if (args != null) {
+							Object obj = new Object();
+							if (obj instanceof Double c) {
+							    System.out.println();
+							} else {
+							    throw new IllegalArgumentException("invalid type"); // works OK without this line
+							}
+
+							if (obj instanceof Integer r) {
+							    System.out.println();
+							} else if (obj instanceof Double c) { // Eclipse Compilation Error: Duplicate variable c
+							    System.out.println();
+							}
+						}
+					}
+				}
+				"""
+			},
+			"----------\n"
+			+ "1. ERROR in X.java (at line 13)\n"
+			+ "	} else if (obj instanceof Double c) { // Eclipse Compilation Error: Duplicate variable c\n"
+			+ "	                                 ^\n"
+			+ "Duplicate local variable c\n"
+			+ "----------\n");
+	}
+	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=577415
+	// Bug in Eclipse Pattern Matching Instanceof Variable Scope
+	public void test577415_4() {
+		runNegativeTest(
+			new String[] {
+				"X.java",
+				"""
+				public class X {
+					public static void main(String[] args) {
+						try {
+							Object obj = new Object();
+							if (obj instanceof Double c) {
+							    System.out.println();
+							} else {
+							    throw new IllegalArgumentException("invalid type"); // works OK without this line
+							}
+
+							if (obj instanceof Integer r) {
+							    System.out.println();
+							} else if (obj instanceof Double c) { // Eclipse Compilation Error: Duplicate variable c
+							    System.out.println();
+							}
+						} catch (Exception e) {
+							Object obj = new Object();
+							if (obj instanceof Double c) {
+							    System.out.println();
+							} else {
+							    throw new IllegalArgumentException("invalid type"); // works OK without this line
+							}
+
+							if (obj instanceof Integer r) {
+							    System.out.println();
+							} else if (obj instanceof Double c) { // Eclipse Compilation Error: Duplicate variable c
+							    System.out.println();
+							}
+						} finally {
+							Object obj = new Object();
+							if (obj instanceof Double c) {
+							    System.out.println();
+							} else {
+							    throw new IllegalArgumentException("invalid type"); // works OK without this line
+							}
+
+							if (obj instanceof Integer r) {
+							    System.out.println();
+							} else if (obj instanceof Double c) { // Eclipse Compilation Error: Duplicate variable c
+							    System.out.println();
+							}
+						}
+					}
+				}
+				"""
+			},
+			"----------\n" +
+			"1. ERROR in X.java (at line 13)\n" +
+			"	} else if (obj instanceof Double c) { // Eclipse Compilation Error: Duplicate variable c\n" +
+			"	                                 ^\n" +
+			"Duplicate local variable c\n" +
+			"----------\n" +
+			"2. ERROR in X.java (at line 26)\n" +
+			"	} else if (obj instanceof Double c) { // Eclipse Compilation Error: Duplicate variable c\n" +
+			"	                                 ^\n" +
+			"Duplicate local variable c\n" +
+			"----------\n" +
+			"3. ERROR in X.java (at line 39)\n" +
+			"	} else if (obj instanceof Double c) { // Eclipse Compilation Error: Duplicate variable c\n" +
+			"	                                 ^\n" +
+			"Duplicate local variable c\n" +
+			"----------\n");
+	}
+	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=577415
+	// Bug in Eclipse Pattern Matching Instanceof Variable Scope
+	public void test577415_5() {
+		runNegativeTest(
+			new String[] {
+				"X.java",
+				"""
+				public class X {
+					public static void main(String[] args) {
+						synchronized(args) {
+							Object obj = new Object();
+							if (obj instanceof Double c) {
+							    System.out.println();
+							} else {
+							    throw new IllegalArgumentException("invalid type"); // works OK without this line
+							}
+
+							if (obj instanceof Integer r) {
+							    System.out.println();
+							} else if (obj instanceof Double c) { // Eclipse Compilation Error: Duplicate variable c
+							    System.out.println();
+							}
+						}
+					}
+				}
+				"""
+			},
+			"----------\n" +
+			"1. ERROR in X.java (at line 13)\n" +
+			"	} else if (obj instanceof Double c) { // Eclipse Compilation Error: Duplicate variable c\n" +
+			"	                                 ^\n" +
+			"Duplicate local variable c\n" +
+			"----------\n");
+	}
+	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=577415
+	// Bug in Eclipse Pattern Matching Instanceof Variable Scope
+	public void test577415_6() {
+		runConformTest(
+			new String[] {
+				"X.java",
+				"""
+				public class X {
+					public static void main(String[] args) {
+					    try {
+					        gain(args);
+					    } catch (IllegalArgumentException iae) {
+					        if (iae.getMessage().equals("invalid type"))
+					            System.out.println("All well");
+					    }
+					}
+					public static void gain(String[] args) {
+						Object obj = new Object();
+						if (obj instanceof Integer r) {
+						    System.out.println();
+						} else if (obj instanceof Double c) {
+						    System.out.println();
+						} else {
+						    throw new IllegalArgumentException("invalid type"); // works OK without this line
+						}
+
+						if (obj instanceof Integer r) {
+						    System.out.println();
+						} else if (obj instanceof Double c) { // Eclipse Compilation Error: Duplicate variable c
+						    System.out.println();
+						}
+					}
+				}
+				"""
+			},
+			"All well",
+			getCompilerOptions());
+	}
+	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=577415
+	// Bug in Eclipse Pattern Matching Instanceof Variable Scope
+	public void test577415_7() {
+		runConformTest(
+			new String[] {
+				"X.java",
+				"""
+				public class X {
+					public static void main(String[] args) {
+					    try {
+					        gain(new String[] {"Hello"});
+					    } catch (IllegalArgumentException iae) {
+					        if (iae.getMessage().equals("invalid type"))
+					            System.out.println("All well");
+					    }
+					}
+					public static void gain(String[] args) {
+						switch(args[0]) {
+							case "Hello" :
+								Object obj = new Object();
+								if (obj instanceof Integer r) {
+								    System.out.println();
+								} else if (obj instanceof Double c) {
+								    System.out.println();
+								} else {
+								    throw new IllegalArgumentException("invalid type"); // works OK without this line
+								}
+
+								if (obj instanceof Integer r) {
+								    System.out.println();
+								} else if (obj instanceof Double c) { // Eclipse Compilation Error: Duplicate variable c
+								    System.out.println();
+								}
+						}
+					}
+				}
+				"""
+			},
+			"All well",
+			getCompilerOptions());
+	}
+	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=577415
+	// Bug in Eclipse Pattern Matching Instanceof Variable Scope
+	public void test577415_8() {
+		runNegativeTest(
+			new String[] {
+				"X.java",
+				"""
+				public class X {
+					public static void main(String[] args) {
+					    try {
+					        gain(new String[] {"Hello"});
+					    } catch (IllegalArgumentException iae) {
+					        if (iae.getMessage().equals("invalid type"))
+					            System.out.println("All well");
+					    }
+					}
+					public static void gain(String[] args) {
+						switch(args[0]) {
+							case "Hello" :
+								Object obj = new Object();
+								if (obj instanceof Double c) {
+								    System.out.println();
+								} else {
+								    throw new IllegalArgumentException("invalid type"); // works OK without this line
+								}
+
+								if (obj instanceof Integer r) {
+								    System.out.println();
+								} else if (obj instanceof Double c) { // Eclipse Compilation Error: Duplicate variable c
+								    System.out.println();
+								}
+						}
+					}
+				}
+				"""
+			},
+			"----------\n"
+			+ "1. ERROR in X.java (at line 22)\n"
+			+ "	} else if (obj instanceof Double c) { // Eclipse Compilation Error: Duplicate variable c\n"
+			+ "	                                 ^\n"
+			+ "Duplicate local variable c\n"
+			+ "----------\n");
+	}
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchPatternTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchPatternTest.java
@@ -7121,6 +7121,32 @@ public class SwitchPatternTest extends AbstractRegressionTest9 {
 				+ "shape : 100.0\n"
 				+ "NULL");
 	}
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1853
+	// [switch][pattern] Scope of pattern binding extends illegally resulting in wrong diagnostic
+	public void testGH1853() {
+		runConformTest(
+			new String[] {
+				"X.java",
+				"""
+				public class X {
+				    public static void main(String[] args) {
+						Object o = new Object();
+						switch (o) {
+						case String s :
+							if (!(o instanceof String str))
+								throw new RuntimeException();
+						case null :
+							if (!(o instanceof String str))
+								throw new RuntimeException();
+						default:
+				            System.out.println("Default");
+						}
+					}
+				}
+				"""
+			},
+			"Default");
+	}
 	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1856
 	// [switch][record patterns] NPE: Cannot invoke "org.eclipse.jdt.internal.compiler.lookup.MethodBinding.isStatic()"
 	public void testGHI1856() {


### PR DESCRIPTION

## What it does

Ensure pattern bindings don't leak beyond their scope

* Fixes https://bugs.eclipse.org/bugs/show_bug.cgi?id=577415
* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1853


## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
