### PR TITLE
Fix tests effected by java 22

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchBugs9Tests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchBugs9Tests.java
@@ -4840,6 +4840,7 @@ public void testGH902_whenTypeReferenceIsUnknownButQualified_expectToBeFound() t
 				""");
 
 		refresh(project);
+		waitUntilIndexesReady();
 
 		IType type = project.findType("java.lang.StackWalker");
 		assertNotNull("type should not be null", type);
@@ -4865,6 +4866,7 @@ public void testGH902_whenTypeReferenceIsUnknownButQualifiedNested_expectToBeFou
 				""");
 
 		refresh(project);
+		waitUntilIndexesReady();
 
 		IType type = project.findType("java.util.Map.Entry");
 		assertNotNull("type should not be null", type);
@@ -4890,6 +4892,7 @@ public void testGH902_whenTypeReferenceIsUnknownButNested_expectToBeFound() thro
 					}
 				""");
 		refresh(project);
+		waitUntilIndexesReady();
 
 		IType type = project.findType("java.util.Map.Entry");
 		assertNotNull("type should not be null", type);


### PR DESCRIPTION
## What it does
Fix the following tests which are failing in Java22

- org.eclipse.jdt.core.tests.model.JavaSearchBugs16Tests
- org.eclipse.jdt.core.tests.model.JavaSearchTests
- org.eclipse.jdt.core.tests.model.JavaSearchBugs9Tests

## How to test
Run above tests in Java 22

Linked Issue : https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1871

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
