### PR TITLE
ECJ writes incorrect enclosing method for doubly-nested anonymous class

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ClassScope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ClassScope.java
@@ -1735,6 +1735,24 @@ public class ClassScope extends Scope {
 		return this.referenceContext;
 	}
 
+	public final MethodBinding enclosingMethod() {
+		Scope scope = this;
+		while ((scope = scope.parent) != null) {
+			if (scope instanceof MethodScope) {
+				MethodScope methodScope = (MethodScope) scope;
+				/* 4.7.7 The EnclosingMethod Attribute: ... In particular, method_index must be zero if the current class
+				 * was immediately enclosed in source code by an instance initializer, static initializer, instance variable initializer, or
+				 * class variable initializer....
+				 */
+				if (methodScope.referenceContext instanceof TypeDeclaration)
+					return null;
+				if (methodScope.referenceContext instanceof AbstractMethodDeclaration)
+					return ((MethodScope) scope).referenceMethodBinding();
+			}
+		}
+		return null; // may answer null if no method around
+	}
+
 	@Override
 	public boolean hasDefaultNullnessFor(int location, int sourceStart) {
 		int nonNullByDefaultValue = localNonNullByDefaultValue(sourceStart);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/LocalTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/LocalTypeBinding.java
@@ -46,8 +46,7 @@ public LocalTypeBinding(ClassScope scope, SourceTypeBinding enclosingType, CaseS
 	}
 	this.enclosingCase = switchCase;
 	this.sourceStart = typeDeclaration.sourceStart;
-	MethodScope methodScope = scope.lexicallyEnclosingMethodScope();
-	MethodBinding methodBinding = methodScope != null ? methodScope.referenceMethodBinding() : null;
+	MethodBinding methodBinding = scope.enclosingMethod();
 	if (methodBinding != null) {
 		this.enclosingMethod = methodBinding;
 	}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Scope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Scope.java
@@ -1160,20 +1160,6 @@ public abstract class Scope {
 		return null; // may answer null if no method around
 	}
 
-	public final MethodScope lexicallyEnclosingMethodScope() {
-		Scope scope = this;
-		while ((scope = scope.parent) != null) {
-			if (scope instanceof MethodScope) {
-				MethodScope methodScope = (MethodScope) scope;
-				if (methodScope.referenceContext instanceof AbstractMethodDeclaration)
-					return (MethodScope) scope;
-				if (methodScope.referenceContext instanceof TypeDeclaration)
-					return null;
-			}
-		}
-		return null; // may answer null if no method around
-	}
-
 	public final MethodScope enclosingLambdaScope() {
 		Scope scope = this;
 		while ((scope = scope.parent) != null) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Scope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Scope.java
@@ -1167,6 +1167,8 @@ public abstract class Scope {
 				MethodScope methodScope = (MethodScope) scope;
 				if (methodScope.referenceContext instanceof AbstractMethodDeclaration)
 					return (MethodScope) scope;
+				if (methodScope.referenceContext instanceof TypeDeclaration)
+					return null;
 			}
 		}
 		return null; // may answer null if no method around


### PR DESCRIPTION
## What it does

* Do not traverse past enclosing type declaration to compute enclosing method
* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1905

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
