### PR TITLE
JavaModelManager: do not use temporaryCache for callReadOnly

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelManager.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelManager.java
@@ -5805,22 +5805,9 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 		} else {
 			try {
 				readOnly.set(Boolean.TRUE);
-				return JavaModelManager.getJavaModelManager().callReadOnlyUnchecked(callable);
+				return JavaModelManager.cacheZipFiles(callable);
 			} finally {
 				readOnly.set(Boolean.FALSE);
-			}
-		}
-	}
-
-	private <T, E extends Exception> T callReadOnlyUnchecked(JavaCallable<T, E> callable) throws E {
-		boolean hadTemporaryCache = hasTemporaryCache();
-		try {
-			getTemporaryCache();
-
-			return cacheZipFiles(callable);
-		} finally {
-			if (!hadTemporaryCache) {
-				resetTemporaryCache();
 			}
 		}
 	}


### PR DESCRIPTION
The JavaModelManager.temporaryCache is used for more then just a cache.

fixes
https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1118

partially reverts 9fb036c285a793408dcfdd03b2edbc5c3f771170
