### PR TITLE
Sort filename (if given) by name for consistent output

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/Main.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/Main.java
@@ -72,6 +72,7 @@ import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.function.Function;
+import java.util.stream.IntStream;
 
 import org.eclipse.jdt.core.compiler.CategorizedProblem;
 import org.eclipse.jdt.core.compiler.CharOperation;
@@ -3362,9 +3363,13 @@ public CompilationUnit[] getCompilationUnits() {
 	String defaultEncoding = this.options.get(CompilerOptions.OPTION_Encoding);
 	if (Util.EMPTY_STRING.equals(defaultEncoding))
 		defaultEncoding = null;
-
+	// sort index by file names so we have a consistent order of compiling / handling them
+	// this is important as the order can influence the way for example lamda numbers are generated
+	int[] orderedIndex = IntStream.range(0, fileCount).boxed().sorted((i1, i2) -> {
+		return this.filenames[i1].compareTo(this.filenames[i2]);
+	}).mapToInt(i -> i).toArray();
 	for (int round = 0; round < 2; round++) {
-		for (int i = 0; i < fileCount; i++) {
+		for (int i : orderedIndex) {
 			char[] charName = this.filenames[i].toCharArray();
 			boolean isModuleInfo = CharOperation.endsWith(charName, TypeConstants.MODULE_INFO_FILE_NAME);
 			if (isModuleInfo == (round==0)) { // 1st round: modules, 2nd round others (to ensure populating pathToModCU well in time)


### PR DESCRIPTION
Currently the generation of lamdas can change depending on when the source file is processed.

## What it does

This sorts the array of files (if given) to always have a predictable order independent of order given on the commandline / arguments.

Relates to https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1921

## How to test
Use this project:
- https://github.com/eclipse-pde/eclipse.pde/tree/master/ui/org.eclipse.pde.launching
- pass the source files in different order to the batch compiler
- see that depending on the order you get different lamda namings for the same code
- with this patch the ordering of source file arguments do not matter

See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1921 for detailed compiler arguments, logs and example class files showing the difference.

## Author checklist

- [x] I have tested my changes in a debugger with a Tycho build by manipulating the passed source files order
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
