### PR TITLE
Sort by (CU) filename (if given) by for consistent output

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/Compiler.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/Compiler.java
@@ -389,7 +389,8 @@ public class Compiler implements ITypeRequestor, ProblemSeverities {
 		int maxUnits = sourceUnits.length;
 		this.totalUnits = 0;
 		this.unitsToProcess = new CompilationUnitDeclaration[maxUnits];
-
+		//compare by name to get a deterministic order of processing independent of initial array order given
+		Arrays.sort(sourceUnits, Comparator.comparing(ICompilationUnit::getFileName, Arrays::compare));
 		internalBeginToCompile(sourceUnits, maxUnits);
 	}
 


### PR DESCRIPTION
Currently the generation of lamdas can change depending on when the source file is processed.

This sorts the array of CUs by file name (if given) to always have a predictable order independent of order given on the arguments.

Relates to https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1921
