### PR TITLE
ASTParser.createAST looses ability to resolve some bindings

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter15Test.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter15Test.java
@@ -27,6 +27,7 @@ import junit.framework.Test;
 
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.BindingKey;
 import org.eclipse.jdt.core.IAnnotation;
@@ -7888,6 +7889,29 @@ public class ASTConverter15Test extends ConverterTestSetup {
 		typeBinding = typeBinding.getSuperclass();
 		IMethodBinding[] methodBindings = typeBinding.getDeclaredMethods();
 		assertNotNull("No method bindings", methodBindings);
+		assertEquals("wrong size", 2, methodBindings.length);
+	}
+
+	/*
+	 * https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1915
+	 */
+	public void test0238_ASTParser() throws JavaModelException, CoreException {
+		this.workingCopy = getWorkingCopy("/Converter15/src/test0238/X.java",
+			"""
+			package test0238;
+			public class X extends A {
+			}
+			""", true /*resolve*/);
+		ASTParser parser = ASTParser.newParser(AST.getJLSLatest());
+		parser.setBindingsRecovery(true);
+		parser.setResolveBindings(true);
+		parser.setStatementsRecovery(true);
+		parser.setSource(this.workingCopy);
+		parser.setProject(JavaCore.create(ResourcesPlugin.getWorkspace().getRoot().getProject("Converter15")));
+		CompilationUnit unit = (CompilationUnit) parser.createAST(null);
+		TypeDeclaration typeDeclaration = (TypeDeclaration) unit.types().get(0);
+		ITypeBinding superTypeBinding = typeDeclaration.resolveBinding().getSuperclass();
+		IMethodBinding[] methodBindings = superTypeBinding.getDeclaredMethods();
 		assertEquals("wrong size", 2, methodBindings.length);
 	}
 

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/CompilationUnitResolver.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/CompilationUnitResolver.java
@@ -816,6 +816,10 @@ class CompilationUnitResolver extends Compiler {
 				CancelableNameEnvironment cancelableNameEnvironment = (CancelableNameEnvironment) environment;
 				cancelableNameEnvironment.printTimeSpent();
 			}
+			if (unit != null && unit.scope != null && unit.scope.environment != null
+				&& unit.scope.environment.unitBeingCompleted == null) {
+				unit.scope.environment.unitBeingCompleted = unit;
+			}
 			return unit;
 		} finally {
 			if (environment != null) {


### PR DESCRIPTION
Keeping the lookupEnvironment intact as it can be necessary for further binding resolution.
The former "paranoia" seems not to be worried about as the referenced element in the environment is the unit, that does exist and is the root of the scope/environment. So this shouldn't consume more memory, and should cause a risk of memory leak.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1915

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does

Retain the necessary information in the CompilationUnitDeclaration.scope when building with ASTParser, so that all further bindings can resolve.

## How to test

Try the new `ASTConverter15Test.test0238_ASTParser` with and without the fix to see the fix turns the test ✅

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
