### PR TITLE
Fix NPE - synthetic methods don't have a source method. Don't reach for one

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
@@ -9324,9 +9324,12 @@ public void unsafeReturnTypeOverride(MethodBinding currentMethod, MethodBinding 
 	int start = type.sourceStart();
 	int end = type.sourceEnd();
 	if (TypeBinding.equalsEquals(currentMethod.declaringClass, type)) {
-		ASTNode location = ((MethodDeclaration) currentMethod.sourceMethod()).returnType;
-		start = location.sourceStart();
-		end = location.sourceEnd();
+		MethodDeclaration md = (MethodDeclaration) currentMethod.sourceMethod();
+		if (md != null) { // synthetics have no source method, don't npe
+			ASTNode location = md.returnType;
+			start = location.sourceStart();
+			end = location.sourceEnd();
+		}
 	}
 	this.handle(
 			IProblem.UnsafeReturnTypeOverride,

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordsRestrictedClassTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordsRestrictedClassTest.java
@@ -9707,4 +9707,29 @@ public void testGH1806() {
 			},
 		"true");
 }
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1939
+// [records] Class MethodBinding has a NullPointerException
+public void testGH1939() {
+	runConformTest(
+			new String[] {
+					"X.java",
+					"""
+					public class X {
+
+					    interface Foo {}
+
+					    interface A {
+					        <T extends Foo> Class<T> clazz() ;
+					    }
+
+					    record AA<T extends Foo>( Class<T> clazz ) implements A {}
+
+					    public static void main(String [] args) {
+					        System.out.println("OK!");
+					    }
+					}
+					"""
+			},
+		"OK!");
+}
 }


### PR DESCRIPTION
## What it does

* Don't dereference null.
* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1939

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
