### PR TITLE
Capture all information of a source file into one SourceInfo record

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/SourceInfo.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/SourceInfo.java
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Christoph Läubrich.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Christoph Läubrich - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.internal.compiler.batch;
+
+/**
+ * Collects all information of a source file
+ */
+public record SourceInfo(int index, String filename, String encoding, String moduleName, String destinationPath) {
+
+}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/tool/EclipseCompilerImpl.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/tool/EclipseCompilerImpl.java
@@ -60,6 +60,7 @@ import org.eclipse.jdt.internal.compiler.batch.CompilationUnit;
 import org.eclipse.jdt.internal.compiler.batch.FileSystem;
 import org.eclipse.jdt.internal.compiler.batch.FileSystem.Classpath;
 import org.eclipse.jdt.internal.compiler.batch.Main;
+import org.eclipse.jdt.internal.compiler.batch.SourceInfo;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jdt.internal.compiler.lookup.TypeConstants;
@@ -173,11 +174,12 @@ public class EclipseCompilerImpl extends Main {
 							throw new IllegalArgumentException(this.bind("unit.missing", name)); //$NON-NLS-1$
 					}
 
+					SourceInfo sourceInfo = getSourceInfo(i);
 					CompilationUnit cu = new CompilationUnit(null,
 							name,
 							null,
-							this.destinationPaths[i],
-							shouldIgnoreOptionalProblems(this.ignoreOptionalProblemsFromFolders, name.toCharArray()), this.modNames[i]) {
+							sourceInfo.destinationPath(),
+							shouldIgnoreOptionalProblems(this.ignoreOptionalProblemsFromFolders, name.toCharArray()), sourceInfo.moduleName()) {
 
 							@Override
 							public char[] getContents() {
@@ -199,6 +201,7 @@ public class EclipseCompilerImpl extends Main {
 		units.toArray(result);
 		return result;
 	}
+
 	/*
 	 *  Low-level API performing the actual compilation
 	 */


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
To get a consistent compilation order that is independent of the order of arguments one needs to sort the files to process by name. As the name might be related to to other information all of these are first captured inside a SourceInfo record and are the sort this array by name, in the following code always this sorted array is used and possibly updated with additional information.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Relates to:
- https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1921

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
