### PR TITLE
Content assist does not activate, inside if() within a switch

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests14.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests14.java
@@ -983,4 +983,114 @@ public class CompletionTests14 extends AbstractJavaModelCompletionTests {
 				"implementMe[METHOD_DECLARATION]{public void implementMe(), LBaseInterface;, ()V, implementMe, null, " + (R_DEFAULT + R_RESOLVED + R_INTERESTING + R_CASE + R_ABSTRACT_METHOD + R_UNQUALIFIED + R_NON_RESTRICTED) + "}",
 				requestor.getResults());
 	}
+	public void testGH1561_CompletionInIfConditionInsideASwitchStatement() throws JavaModelException {
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy("/Completion/src/SwitchIf.java",
+				"""
+					public class SwitchIf {
+							final String name = "test";
+							boolean namedFlag;
+							enum Type { A }
+							private void foo(Type input) {
+								switch (input) {
+								case A:
+									if (nam)
+									break;
+								}
+							}
+					}
+					""");
+		CompletionTestsRequestor2 requestor = new CompletionTestsRequestor2(true, true, true, false);
+		String str = this.workingCopies[0].getSource();
+		String completeBehind = "if (nam";
+		int cursorLocation = str.lastIndexOf(completeBehind) + completeBehind.length();
+		this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner);
+		assertResults(
+				"name[FIELD_REF]{name, LSwitchIf;, Ljava.lang.String;, null, null, name, null, [165, 168], "
+						+ (R_DEFAULT + R_RESOLVED + R_INTERESTING + R_CASE + R_UNQUALIFIED + R_NON_RESTRICTED) + "}\n" +
+				"namedFlag[FIELD_REF]{namedFlag, LSwitchIf;, Z, null, null, namedFlag, null, [165, 168], "
+						+ (R_DEFAULT + R_RESOLVED + R_INTERESTING + R_CASE + R_UNQUALIFIED + R_NON_RESTRICTED + R_EXACT_EXPECTED_TYPE)+"}",
+				requestor.getResults());
+	}
+
+	public void testGH1561_CompletionInWhileConditionInsideASwitchStatement() throws JavaModelException {
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy("/Completion/src/SwitchIf.java",
+				"""
+					public class SwitchIf {
+							final String name = "test";
+							enum Type { A }
+							private void foo(Type input) {
+								switch (input) {
+								case A:
+									while (nam)
+									break;
+								}
+							}
+					}
+					""");
+		CompletionTestsRequestor2 requestor = new CompletionTestsRequestor2(true, true, true, false);
+		String str = this.workingCopies[0].getSource();
+		String completeBehind = "while (nam";
+		int cursorLocation = str.lastIndexOf(completeBehind) + completeBehind.length();
+		this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner);
+		assertResults(
+				"name[FIELD_REF]{name, LSwitchIf;, Ljava.lang.String;, null, null, name, null, [147, 150], "
+						+ (R_DEFAULT + R_RESOLVED + R_INTERESTING + R_CASE + R_UNQUALIFIED + R_NON_RESTRICTED) + "}",
+				requestor.getResults());
+	}
+
+	public void testGH1561_CompletionInForConditionInsideASwitchStatement() throws JavaModelException {
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy("/Completion/src/SwitchIf.java",
+				"""
+					public class SwitchIf {
+							final String name = "test";
+							enum Type { A }
+							private void foo(Type input) {
+								switch (input) {
+								case A:
+									for (int i = 0; i < nam)
+									break;
+								}
+							}
+					}
+					""");
+		CompletionTestsRequestor2 requestor = new CompletionTestsRequestor2(true, true, true, false);
+		String str = this.workingCopies[0].getSource();
+		String completeBehind = "for (int i = 0; i < nam";
+		int cursorLocation = str.lastIndexOf(completeBehind) + completeBehind.length();
+		this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner);
+		assertResults(
+				"name[FIELD_REF]{name, LSwitchIf;, Ljava.lang.String;, null, null, name, null, [160, 163], "
+						+ (R_DEFAULT + R_RESOLVED + R_INTERESTING + R_CASE + R_UNQUALIFIED + R_NON_RESTRICTED) + "}",
+				requestor.getResults());
+	}
+
+	public void testGH1561_CompletionInSwitchInsideASwitchStatement() throws JavaModelException {
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy("/Completion/src/SwitchIf.java",
+				"""
+					public class SwitchIf {
+							final String name = "test";
+							enum Type { A }
+							private void foo(Type input) {
+								switch (input) {
+								case A:
+									switch (nam
+									break;
+								}
+							}
+					}
+					""");
+		CompletionTestsRequestor2 requestor = new CompletionTestsRequestor2(true, true, true, false);
+		String str = this.workingCopies[0].getSource();
+		String completeBehind = "switch (nam";
+		int cursorLocation = str.lastIndexOf(completeBehind) + completeBehind.length();
+		this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner);
+		assertResults(
+				"name[FIELD_REF]{name, LSwitchIf;, Ljava.lang.String;, null, null, name, null, [148, 151], "
+						+ (R_DEFAULT + R_RESOLVED + R_INTERESTING + R_CASE + R_UNQUALIFIED + R_NON_RESTRICTED) + "}",
+				requestor.getResults());
+	}
 }

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests14.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests14.java
@@ -983,6 +983,7 @@ public class CompletionTests14 extends AbstractJavaModelCompletionTests {
 				"implementMe[METHOD_DECLARATION]{public void implementMe(), LBaseInterface;, ()V, implementMe, null, " + (R_DEFAULT + R_RESOLVED + R_INTERESTING + R_CASE + R_ABSTRACT_METHOD + R_UNQUALIFIED + R_NON_RESTRICTED) + "}",
 				requestor.getResults());
 	}
+	
 	public void testGH1561_CompletionInIfConditionInsideASwitchStatement() throws JavaModelException {
 		this.workingCopies = new ICompilationUnit[1];
 		this.workingCopies[0] = getWorkingCopy("/Completion/src/SwitchIf.java",
@@ -1092,5 +1093,37 @@ public class CompletionTests14 extends AbstractJavaModelCompletionTests {
 				"name[FIELD_REF]{name, LSwitchIf;, Ljava.lang.String;, null, null, name, null, [148, 151], "
 						+ (R_DEFAULT + R_RESOLVED + R_INTERESTING + R_CASE + R_UNQUALIFIED + R_NON_RESTRICTED) + "}",
 				requestor.getResults());
+	}
+
+	public void testGH1561_CompletionInForInsideASwitchStatement() throws JavaModelException {
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy("/Completion/src/SwitchIf.java",
+				"""
+					public class SwitchIf {
+							final String name = "test";
+							enum Type { A }
+							private void foo(Type input) {
+								switch (input) {
+								case A:
+									for (int i = 0; nam)
+									break;
+								}
+							}
+							private boolean nameContains(String name) {
+								return false;
+							}
+					}
+					""");
+		CompletionTestsRequestor2 requestor = new CompletionTestsRequestor2(true, true, true, false);
+		String str = this.workingCopies[0].getSource();
+		String completeBehind = "for (int i = 0; nam";
+		int cursorLocation = str.lastIndexOf(completeBehind) + completeBehind.length();
+		this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner);
+		assertResults("name[FIELD_REF]{name, LSwitchIf;, Ljava.lang.String;, null, null, name, null, [156, 159], "
+				+ (R_DEFAULT + R_RESOLVED + R_INTERESTING + R_CASE + R_UNQUALIFIED + R_NON_RESTRICTED) + "}\n"
+				+ "nameContains[METHOD_REF]{nameContains(), LSwitchIf;, (Ljava.lang.String;)Z, null, null, nameContains, (name), [156, 159], "
+				+ (R_DEFAULT + R_RESOLVED + R_INTERESTING + R_CASE + R_UNQUALIFIED + R_NON_RESTRICTED
+						+ R_EXACT_EXPECTED_TYPE)
+				+ "}", requestor.getResults());
 	}
 }

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests18.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests18.java
@@ -5950,8 +5950,10 @@ public void testBug574823_completeOn_methodInvocationWithParams_inIfConidtion_in
 	this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner);
 
 	String result = requestor.getResults();
-    assertTrue(String.format("Result doesn't contain method forEach (%s)", result),
-    		result.contains("forEach[METHOD_REF]{forEach(), Ljava.lang.Iterable<Ljava.lang.String;>;, (Ljava.util.function.Consumer<-Ljava.lang.String;>;)V, null, null, forEach, (arg0), replace[149, 149], token[149, 149], 55}"));
+	int relevance = R_DEFAULT + R_RESOLVED + R_INTERESTING + R_CASE + R_VOID + R_NON_STATIC + R_NON_RESTRICTED;
+	assertTrue(String.format("Result doesn't contain method forEach (%s)", result),
+			result.contains("forEach[METHOD_REF]{forEach(), Ljava.lang.Iterable<Ljava.lang.String;>;, (Ljava.util.function.Consumer<-Ljava.lang.String;>;)V," +
+					" null, null, forEach, (arg0), replace[149, 149], token[149, 149], "+relevance+"}"));
 }
 public void testBug574823_completeOn_methodInvocationWithParams_inIfConidtion_insideIf_followedByChainedStatment() throws Exception {
 	this.workingCopies = new ICompilationUnit[1];
@@ -5974,8 +5976,10 @@ public void testBug574823_completeOn_methodInvocationWithParams_inIfConidtion_in
 	this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner);
 
 	String result = requestor.getResults();
-    assertTrue(String.format("Result doesn't contain method forEach (%s)", result),
-    		result.contains("forEach[METHOD_REF]{forEach(), Ljava.lang.Iterable<Ljava.lang.String;>;, (Ljava.util.function.Consumer<-Ljava.lang.String;>;)V, null, null, forEach, (arg0), replace[149, 149], token[149, 149], 55}"));
+	int relevance = R_DEFAULT + R_RESOLVED + R_INTERESTING + R_CASE + R_VOID + R_NON_STATIC + R_NON_RESTRICTED;
+	assertTrue(String.format("Result doesn't contain method forEach (%s)", result),
+			result.contains("forEach[METHOD_REF]{forEach(), Ljava.lang.Iterable<Ljava.lang.String;>;, (Ljava.util.function.Consumer<-Ljava.lang.String;>;)V," +
+					" null, null, forEach, (arg0), replace[149, 149], token[149, 149], "+relevance+"}"));
 }
 public void testBug574823_completeOn_methodInvocationWithParams_inWhileConidtion_insideWhileBlock_followedByChainedStatment() throws Exception {
 	this.workingCopies = new ICompilationUnit[1];
@@ -5999,8 +6003,10 @@ public void testBug574823_completeOn_methodInvocationWithParams_inWhileConidtion
 	this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner);
 
 	String result = requestor.getResults();
-    assertTrue(String.format("Result doesn't contain method forEach (%s)", result),
-    		result.contains("forEach[METHOD_REF]{forEach(), Ljava.lang.Iterable<Ljava.lang.String;>;, (Ljava.util.function.Consumer<-Ljava.lang.String;>;)V, null, null, forEach, (arg0), replace[152, 152], token[152, 152], 55}"));
+	int relevance = R_DEFAULT + R_RESOLVED + R_INTERESTING + R_CASE + R_VOID + R_NON_STATIC + R_NON_RESTRICTED;
+	assertTrue(String.format("Result doesn't contain method forEach (%s)", result),
+		result.contains("forEach[METHOD_REF]{forEach(), Ljava.lang.Iterable<Ljava.lang.String;>;, (Ljava.util.function.Consumer<-Ljava.lang.String;>;)V," +
+				" null, null, forEach, (arg0), replace[152, 152], token[152, 152], "+relevance+"}"));
 }
 public void testBug574823_completeOn_methodInvocationWithParams_inIfConidtionWithExpression_insideIfBlock_followedByChainedStatment() throws Exception {
 	this.workingCopies = new ICompilationUnit[1];

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests18.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests18.java
@@ -5951,7 +5951,7 @@ public void testBug574823_completeOn_methodInvocationWithParams_inIfConidtion_in
 
 	String result = requestor.getResults();
     assertTrue(String.format("Result doesn't contain method forEach (%s)", result),
-    		result.contains("forEach[METHOD_REF]{forEach(), Ljava.lang.Iterable<Ljava.lang.String;>;, (Ljava.util.function.Consumer<-Ljava.lang.String;>;)V, null, null, forEach, (arg0), replace[149, 149], token[149, 149], 60}"));
+    		result.contains("forEach[METHOD_REF]{forEach(), Ljava.lang.Iterable<Ljava.lang.String;>;, (Ljava.util.function.Consumer<-Ljava.lang.String;>;)V, null, null, forEach, (arg0), replace[149, 149], token[149, 149], 55}"));
 }
 public void testBug574823_completeOn_methodInvocationWithParams_inIfConidtion_insideIf_followedByChainedStatment() throws Exception {
 	this.workingCopies = new ICompilationUnit[1];
@@ -5975,7 +5975,7 @@ public void testBug574823_completeOn_methodInvocationWithParams_inIfConidtion_in
 
 	String result = requestor.getResults();
     assertTrue(String.format("Result doesn't contain method forEach (%s)", result),
-    		result.contains("forEach[METHOD_REF]{forEach(), Ljava.lang.Iterable<Ljava.lang.String;>;, (Ljava.util.function.Consumer<-Ljava.lang.String;>;)V, null, null, forEach, (arg0), replace[149, 149], token[149, 149], 60}"));
+    		result.contains("forEach[METHOD_REF]{forEach(), Ljava.lang.Iterable<Ljava.lang.String;>;, (Ljava.util.function.Consumer<-Ljava.lang.String;>;)V, null, null, forEach, (arg0), replace[149, 149], token[149, 149], 55}"));
 }
 public void testBug574823_completeOn_methodInvocationWithParams_inWhileConidtion_insideWhileBlock_followedByChainedStatment() throws Exception {
 	this.workingCopies = new ICompilationUnit[1];
@@ -6000,7 +6000,7 @@ public void testBug574823_completeOn_methodInvocationWithParams_inWhileConidtion
 
 	String result = requestor.getResults();
     assertTrue(String.format("Result doesn't contain method forEach (%s)", result),
-    		result.contains("forEach[METHOD_REF]{forEach(), Ljava.lang.Iterable<Ljava.lang.String;>;, (Ljava.util.function.Consumer<-Ljava.lang.String;>;)V, null, null, forEach, (arg0), replace[152, 152], token[152, 152], 60}"));
+    		result.contains("forEach[METHOD_REF]{forEach(), Ljava.lang.Iterable<Ljava.lang.String;>;, (Ljava.util.function.Consumer<-Ljava.lang.String;>;)V, null, null, forEach, (arg0), replace[152, 152], token[152, 152], 55}"));
 }
 public void testBug574823_completeOn_methodInvocationWithParams_inIfConidtionWithExpression_insideIfBlock_followedByChainedStatment() throws Exception {
 	this.workingCopies = new ICompilationUnit[1];


### PR DESCRIPTION
fixes #1561

Simpler approach, using new tests from #1625 

@gayanper I tried to explain with minimal code comments. LMK if this is sufficient to understand the approach.

This change is not quite complete yet:
* no explanation for changed relevance in three tests
* may need to cover more control statements: only implemented for those that are covered by tests from [#1625](https://github.com/eclipse-jdt/eclipse.jdt.core/pull/1625)
