### PR TITLE
refactor JavaModel.getTarget()

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/DeltaProcessor.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/DeltaProcessor.java
@@ -1016,7 +1016,7 @@ public class DeltaProcessor {
 			boolean deltaContainsModifiedJar = false;
 			for (int j = 0; j < entries.length; j++){
 				if (entries[j].getEntryKind() == IClasspathEntry.CPE_LIBRARY) {
-					IPath entryPath = entries[j].getPath();
+					final IPath entryPath = entries[j].getPath();
 
 					if (!archivePathsToRefresh.contains(entryPath)) continue; // not supposed to be refreshed
 
@@ -1027,7 +1027,7 @@ public class DeltaProcessor {
 						this.manager.clearExternalFileState(entryPath);
 
 						// compute shared status
-						Object targetLibrary = JavaModel.getTarget(entryPath, true);
+						Object targetLibrary = JavaModel.getTarget(entries[j], true);
 
 						if (targetLibrary == null){ // missing JAR
 							if (this.state.getExternalLibTimeStamps().remove(entryPath) != null /* file was known*/

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JarEntryFile.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JarEntryFile.java
@@ -22,7 +22,6 @@ import java.util.zip.ZipFile;
 
 import org.eclipse.core.resources.IStorage;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.IPath;
 import org.eclipse.jdt.core.IJarEntryResource;
 import org.eclipse.jdt.core.IJavaModelStatusConstants;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
@@ -53,8 +52,7 @@ public class JarEntryFile  extends JarEntryResource {
 		IPackageFragmentRoot root = getPackageFragmentRoot();
 		if (Util.isJrt(root.getPath().toOSString())) {
 			try {
-				IPath rootPath = root.getPath();
-				Object target = JavaModel.getTarget(rootPath, false);
+				Object target = JavaModel.getTarget(root, false);
 				if (target != null && target instanceof File) {
 					return JRTUtil.getContentFromJrt((File) target, getEntryName(), root.getElementName());
 				}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JarPackageFragmentRoot.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JarPackageFragmentRoot.java
@@ -120,7 +120,7 @@ public class JarPackageFragmentRoot extends PackageFragmentRoot {
 			// always create the default package
 			rawPackageInfo.put(CharOperation.NO_STRINGS, new ArrayList[] { EMPTY_LIST, EMPTY_LIST });
 
-			Object file = JavaModel.getTarget(getPath(), true);
+			Object file = JavaModel.getTarget(this, true);
 			long classLevel = Util.getJdkLevel(file);
 			String projectCompliance = this.getJavaProject().getOption(JavaCore.COMPILER_COMPLIANCE, true);
 			long projectLevel = CompilerOptions.versionToJdkLevel(projectCompliance);

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModel.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModel.java
@@ -337,6 +337,15 @@ public static Object getTarget(IPath path, boolean checkResourceExistence) {
 		return target;
 	return getExternalTarget(path, checkResourceExistence);
 }
+/** Return same as calling {@link #getTarget(IPath, boolean)} for {@link IClasspathEntry#getPath()} */
+public static Object getTarget(IClasspathEntry entry, boolean checkResourceExistence) {
+	return getTarget(entry.getPath(), checkResourceExistence);
+}
+/** Return same as calling {@link #getTarget(IPath, boolean)} for {@link IPackageFragmentRoot#getPath()} */
+public static Object getTarget(IPackageFragmentRoot root, boolean checkResourceExistence) {
+	return getTarget(root.getPath(), checkResourceExistence);
+}
+
 
 /**
  * Helper method - returns the {@link IResource} corresponding to the provided {@link IPath},

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaProject.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaProject.java
@@ -720,7 +720,7 @@ public class JavaProject
 			case IClasspathEntry.CPE_SOURCE :
 
 				if (projectPath.isPrefixOf(entryPath)){
-					Object target = JavaModel.getTarget(entryPath, true/*check existency*/);
+					Object target = JavaModel.getTarget(resolvedEntry, true/*check existency*/);
 					if (target == null) return;
 
 					if (target instanceof IFolder || target instanceof IProject){
@@ -733,7 +733,7 @@ public class JavaProject
 			case IClasspathEntry.CPE_LIBRARY :
 				if (referringEntry != null  && !resolvedEntry.isExported())
 					return;
-				Object target = JavaModel.getTarget(entryPath, true/*check existency*/);
+				Object target = JavaModel.getTarget(resolvedEntry, true/*check existency*/);
 				if (target == null)
 					return;
 

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ModuleUpdater.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ModuleUpdater.java
@@ -142,7 +142,7 @@ public class ModuleUpdater {
 		}
 		for (IClasspathEntry e1 : expandedClasspath) {
 			if (e1.getEntryKind() == IClasspathEntry.CPE_PROJECT) {
-				Object target = JavaModel.getTarget(e1.getPath(), true);
+				Object target = JavaModel.getTarget(e1, true);
 				if (target instanceof IProject) {
 					IProject prereqProject = (IProject) target;
 					if (JavaProject.hasJavaNature(prereqProject)) {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SourceMapper.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SourceMapper.java
@@ -611,7 +611,7 @@ public class SourceMapper
 				manager.closeZipFile(zip); // handle null case
 			}
 		} else {
-			Object target = JavaModel.getTarget(root.getPath(), true);
+			Object target = JavaModel.getTarget(root, true);
 			if (target instanceof IResource) {
 				IResource resource = (IResource) target;
 				if (resource instanceof IContainer) {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/NameEnvironment.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/NameEnvironment.java
@@ -139,7 +139,7 @@ private void computeClasspathLocations(
 		}
 		ClasspathEntry entry = (ClasspathEntry) classpathEntries[i];
 		IPath path = entry.getPath();
-		Object target = JavaModel.getTarget(path, true);
+		Object target = JavaModel.getTarget(entry, true);
 		IPath externalAnnotationPath = entry.getExternalAnnotationPath(javaProject.getProject(), true);
 		if (target == null) continue nextEntry;
 		boolean isOnModulePath = isOnModulePath(entry);
@@ -208,7 +208,7 @@ private void computeClasspathLocations(
 						IPath srcExtAnnotPath = (externalAnnotationPath != null)
 							? externalAnnotationPath
 							: prereqEntry.getExternalAnnotationPath(javaProject.getProject(), true);
-						Object prereqTarget = JavaModel.getTarget(prereqEntry.getPath(), true);
+						Object prereqTarget = JavaModel.getTarget(prereqEntry, true);
 						if (!(prereqTarget instanceof IContainer)) continue nextPrereqEntry;
 						if (srcExtAnnotPath == null) {
 							// search in other sources contributing to the same binary location (that other loc will be skipped below, due to seen.contains()):

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/HierarchyScope.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/HierarchyScope.java
@@ -94,12 +94,11 @@ public class HierarchyScope extends AbstractSearchScope implements SuffixConstan
 		// resource path
 		IPackageFragmentRoot root = (IPackageFragmentRoot)type.getPackageFragment().getParent();
 		if (root.isArchive()) {
-			IPath jarPath = root.getPath();
-			Object target = JavaModel.getTarget(jarPath, true);
+			Object target = JavaModel.getTarget(root, true);
 			String zipFileName;
 			if (target instanceof IFile) {
 				// internal jar
-				zipFileName = jarPath.toString();
+				zipFileName = root.getPath().toString();
 			} else if (target instanceof File) {
 				// external jar
 				zipFileName = ((File)target).getPath();
@@ -161,7 +160,7 @@ public class HierarchyScope extends AbstractSearchScope implements SuffixConstan
 				// type in a jar
 				JarPackageFragmentRoot jar = (JarPackageFragmentRoot) root;
 				IPath jarPath = jar.getPath();
-				Object target = JavaModel.getTarget(jarPath, true);
+				Object target = JavaModel.getTarget(jar, true);
 				String zipFileName;
 				if (target instanceof IFile) {
 					// internal jar

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/JavaSearchScope.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/JavaSearchScope.java
@@ -158,7 +158,7 @@ void add(JavaProject javaProject, IPath pathToAdd, int includeMask, Set<JavaProj
 						if ((includeMask & APPLICATION_LIBRARIES) != 0) {
 							IPath path = entry.getPath();
 							if (pathToAdd == null || pathToAdd.equals(path)) {
-								Object target = JavaModel.getTarget(path, false/*don't check existence*/);
+								Object target = JavaModel.getTarget(entry, false/*don't check existence*/);
 								if (target instanceof IFolder) // case of an external folder
 									path = ((IFolder) target).getFullPath();
 								String pathToString = path.getDevice() == null ? path.toString() : path.toOSString();
@@ -183,7 +183,7 @@ void add(JavaProject javaProject, IPath pathToAdd, int includeMask, Set<JavaProj
 						}
 						IPath path = entry.getPath();
 						if (pathToAdd == null || pathToAdd.equals(path)) {
-							Object target = JavaModel.getTarget(path, false/*don't check existence*/);
+							Object target = JavaModel.getTarget(entry, false/*don't check existence*/);
 							if (target instanceof IFolder) // case of an external folder
 								path = ((IFolder) target).getFullPath();
 							String pathToString = path.getDevice() == null ? path.toString() : path.toOSString();

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/JavaWorkspaceScope.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/JavaWorkspaceScope.java
@@ -18,7 +18,6 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
-import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
@@ -100,10 +99,6 @@ public IPath[] enclosingProjectsAndJars() {
 			for (int j = 0, eLength = entries.length; j < eLength; j++) {
 				IClasspathEntry entry = entries[j];
 				if (entry.getEntryKind() == IClasspathEntry.CPE_LIBRARY) {
-					IPath path = entry.getPath();
-					Object target = JavaModel.getTarget(path, false/*don't check existence*/);
-					if (target instanceof IFolder) // case of an external folder
-						path = ((IFolder) target).getFullPath();
 					paths.add(entry.getPath());
 				}
 			}

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/JavaSearchNameEnvironment.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/JavaSearchNameEnvironment.java
@@ -284,7 +284,7 @@ private ClasspathLocation mapToClassPathLocation(JavaModelManager manager, Packa
 					ClasspathLocation.forJrtSystem(path.toOSString(), rawClasspathEntry.getAccessRuleSet(), null, compliance) :
 					ClasspathLocation.forLibrary(manager.getZipFile(path), rawClasspathEntry.getAccessRuleSet(), rawClasspathEntry.isModular(), compliance) ;
 		} else {
-			Object target = JavaModel.getTarget(path, true);
+			Object target = JavaModel.getTarget(root, true);
 			if (target != null) {
 				if (root.getKind() == IPackageFragmentRoot.K_SOURCE) {
 					cp = new ClasspathSourceDirectory((IContainer)target, root.fullExclusionPatternChars(), root.fullInclusionPatternChars());


### PR DESCRIPTION
to take heavy weight arguments.

As a preparation for performance fix:
For ClasspathEntry of type CPE_LIBRARY JavaModel.isExternalFile() is costly to compute and should be cached inside ClasspathEntry

https://github.com/eclipse-jdt/eclipse.jdt.core/issues/303

