### PR TITLE
Cannot invoke "org.eclipse.jdt.internal.compiler.lookup.TypeBinding.hasNullTypeAnnotations()" because "providedType" is null

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/StringTemplate.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/StringTemplate.java
@@ -17,6 +17,7 @@ import org.eclipse.jdt.internal.compiler.codegen.CodeStream;
 import org.eclipse.jdt.internal.compiler.codegen.ConstantPool;
 import org.eclipse.jdt.internal.compiler.flow.FlowContext;
 import org.eclipse.jdt.internal.compiler.flow.FlowInfo;
+import org.eclipse.jdt.internal.compiler.impl.Constant;
 import org.eclipse.jdt.internal.compiler.lookup.BlockScope;
 import org.eclipse.jdt.internal.compiler.lookup.TypeBinding;
 import org.eclipse.jdt.internal.compiler.lookup.TypeIds;
@@ -52,6 +53,13 @@ public class StringTemplate extends Expression {
 			exp.resolveType(scope);
 		}
 	}
+
+	@Override
+	public TypeBinding resolveType(BlockScope scope) {
+		this.constant = Constant.NotAConstant;
+		return this.resolvedType = scope.getJavaLangStringTemplate();
+	}
+
 	private void generateNewTemplateBootstrap(CodeStream codeStream) {
 		int index = codeStream.classFile.recordBootstrapMethod(this);
 		// Kludge, see if this can be moved to CodeStream

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Scope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Scope.java
@@ -3051,6 +3051,13 @@ public abstract class Scope {
 		unitScope.recordQualifiedReference(TypeConstants.JAVA_LANG_STRINGBUILDER);
 		return unitScope.environment.getResolvedJavaBaseType(TypeConstants.JAVA_LANG_STRINGBUILDER, this);
 	}
+
+	public TypeBinding getJavaLangStringTemplate() {
+		CompilationUnitScope unitScope = compilationUnitScope();
+		unitScope.recordQualifiedReference(TypeConstants.JAVA_LANG_STRINGTEMPLATE);
+		return unitScope.environment.getResolvedJavaBaseType(TypeConstants.JAVA_LANG_STRINGTEMPLATE, this);
+	}
+
 	public final ReferenceBinding getJavaLangStringTemplateProcessor() {
 		CompilationUnitScope unitScope = compilationUnitScope();
 		unitScope.recordQualifiedReference(TypeConstants.JAVA_LANG_STRINGTEMPLATE_PROCESSOR);

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullAnnotationTests21.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullAnnotationTests21.java
@@ -997,4 +997,42 @@ public class NullAnnotationTests21 extends AbstractNullAnnotationTest {
 		runner.classLibraries = this.LIBS;
 		runner.runConformTest();
 	}
+
+	public void testGH1964() {
+		Runner runner = new Runner();
+		runner.customOptions = getCompilerOptions();
+		runner.customOptions.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.ENABLED);
+		runner.customOptions.put(CompilerOptions.OPTION_ReportPreviewFeatures, CompilerOptions.IGNORE);
+		runner.vmArguments = new String[] {"--enable-preview"};
+		runner.testFiles = new String[] {
+			"JDK21TestingMain.java",
+			"""
+			import static java.util.FormatProcessor.FMT;
+			import static java.lang.StringTemplate.RAW;
+
+			public final class JDK21TestingMain
+			{
+			  public static void main(final String[] args)
+			  {
+			    final int fourtyTwo = 42;
+			    final String str = FMT."\\{fourtyTwo}";
+
+			    final int x=1;
+			    final int y=2;
+			    final StringTemplate st = RAW."\\{x} + \\{y} = \\{x + y}";
+
+			    final var x1 = STR."Hello World";
+			    final var x2 = FMT."Hello World";
+			    final var x3 = RAW."Hello World";
+
+			    System.out.println(STR."Hello World");
+
+			    System.out.println();
+			  }
+			}
+			"""
+		};
+		runner.classLibraries = this.LIBS;
+		runner.runConformTest();
+	}
 }


### PR DESCRIPTION
fixes #1954