### PR TITLE
Stop gap (but valid) fix for https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1792

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/InstanceOfExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/InstanceOfExpression.java
@@ -257,8 +257,8 @@ public StringBuilder printExpressionNoParenthesis(int indent, StringBuilder outp
 
 @Override
 public void addPatternVariables(BlockScope currentScope, CodeStream codeStream) {
-	if (this.elementVariable != null) {
-		codeStream.addVisibleLocalVariable(this.elementVariable.binding);
+	for (LocalVariableBinding local: bindingsWhenTrue()) {
+		codeStream.addVisibleLocalVariable(local);
 	}
 }
 @Override

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordPatternTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordPatternTest.java
@@ -3329,6 +3329,33 @@ public class RecordPatternTest extends AbstractRegressionTest9 {
 				"An enhanced switch statement should be exhaustive; a default label expected\n" +
 				"----------\n");
 	}
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1792
+	// [Patterns][records] Error in JDT Core during AST creation: info cannot be null
+	public void testGH1792() {
+		runConformTest(
+				new String[] {
+				"X.java",
+				"""
+				public class X {
+				    private record R(Object o) {}
+				    static void f(R [] rs) {
+				        int i = 0;
+				        while (rs[i++] instanceof R(String o)) {
+				            System.out.println(o);
+				        }
+				    }
+				    public static void main(String [] args) {
+				    	R [] rs = { new R("So"), new R("far"), new R("so"), new R("good!"), null };
+				    	f(rs);
+				    }
+				}
+				"""
+				},
+				"So\n" +
+				"far\n" +
+				"so\n" +
+				"good!");
+	}
 	public void testIssue1336_1() {
 		runConformTest(
 				new String[] {


### PR DESCRIPTION


## What it does

* Ensure pattern bindings are seen by the code generator
* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1792

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
