### PR TITLE
Touch bundles affected by compiler implementation change

### DIFF
--- a/org.eclipse.jdt.compiler.apt.tests/forceQualifierUpdate.txt
+++ b/org.eclipse.jdt.compiler.apt.tests/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 566471 - I20200828-0150 - Comparator Errors Found
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1781

--- a/org.eclipse.jdt.core.tests.builder/forceQualifierUpdate.txt
+++ b/org.eclipse.jdt.core.tests.builder/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 480835 - Failures in build due to changes not being picked up by tests
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1781

--- a/org.eclipse.jdt.core/forceQualifierUpdate.txt
+++ b/org.eclipse.jdt.core/forceQualifierUpdate.txt
@@ -12,3 +12,4 @@ Bug 566471 - I20200828-0150 - Comparator Errors Found
 Bug 573283 - don't include javax15api.jar in jdt binaries
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1781


### PR DESCRIPTION
See https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1781
