### PR TITLE
Do not sign inner jars

### DIFF
--- a/org.eclipse.jdt.compiler.apt.tests/pom.xml
+++ b/org.eclipse.jdt.compiler.apt.tests/pom.xml
@@ -25,6 +25,7 @@
   <properties>
   	<testSuite>${project.artifactId}</testSuite>
   	<testClass>org.eclipse.jdt.compiler.apt.tests.AllTests</testClass>
+  	<defaultSigning-excludeInnerJars>true</defaultSigning-excludeInnerJars>
   </properties>
 
 </project>


### PR DESCRIPTION
Much like in
https://github.com/eclipse-equinox/p2/blob/f682eb19414bfcdef31ea498f4b3bffb76166d5[…]bundles/org.eclipse.equinox.p2.tests.discovery/build.properties and https://github.com/eclipse-equinox/p2/blob/f682eb19414bfcdef31ea498f4b3bffb76166d58/bundles/org.eclipse.equinox.p2.tests/pom.xml#L23 signing inner jars is in general disabled in other places of the build as it's not enhancing the security (signature for the inner jar is in the outer one MANIFEST.MF)
Contributes to https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1781

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
