### PR TITLE
Avoid silent CoreExceptions while project is closed

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/DeltaProcessor.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/DeltaProcessor.java
@@ -2072,22 +2072,16 @@ public class DeltaProcessor {
 
 		switch(eventType){
 			case IResourceChangeEvent.PRE_DELETE :
-				try {
-					if(resource.getType() == IResource.PROJECT
-						&& ((IProject) resource).hasNature(JavaCore.NATURE_ID)) {
-
-						deleting((IProject)resource);
-					}
-				} catch(CoreException e){
-					// project doesn't exist or is not open: ignore
+				if(resource  instanceof IProject prj && JavaProject.hasJavaNature(prj)) {
+					deleting(prj);
 				}
 				return;
 
 			case IResourceChangeEvent.PRE_REFRESH:
 				IProject [] projects = null;
 				Object o = event.getSource();
-				if (o instanceof IProject) {
-					projects = new IProject[] { (IProject) o };
+				if (o instanceof IProject prj) {
+					projects = new IProject[] { prj };
 				} else if (o instanceof IWorkspace) {
 					// https://bugs.eclipse.org/bugs/show_bug.cgi?id=261594. The single workspace refresh
 					// notification we see, implies that all projects are about to be refreshed.

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaProject.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaProject.java
@@ -398,11 +398,14 @@ public class JavaProject
 	 * @return boolean
 	 */
 	public static boolean hasJavaNature(IProject project) {
+		if (ExternalJavaProject.EXTERNAL_PROJECT_NAME.equals(project.getName())){
+			return true;
+		}
 		try {
-			return project.hasNature(JavaCore.NATURE_ID);
+			if (project.isOpen()) {
+				return project.hasNature(JavaCore.NATURE_ID);
+			}
 		} catch (CoreException e) {
-			if (ExternalJavaProject.EXTERNAL_PROJECT_NAME.equals(project.getName()))
-				return true;
 			// project does not exist or is not open
 		}
 		return false;


### PR DESCRIPTION
which is the case in Tests like BasicAliasTest
