### PR TITLE
[CI] Run GH build/tests on Java 21 instead of 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         java-version: |
           8
           17
-          20
+          21
         mvn-toolchain-id: |
           JavaSE-1.8
           JavaSE-17


### PR DESCRIPTION
Since 21 is LTS and 20 is not.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does

[CI] Run GH build/tests on Java 21 instead of 20

## How to test

Verify GitHub action build runs on Java 21 when this is merged.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
