### PR TITLE
Touch bundle affected by changed project settings

### DIFF
--- a/org.eclipse.jdt.compiler.tool.tests/forceQualifierUpdate.txt
+++ b/org.eclipse.jdt.compiler.tool.tests/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@
 Bug 566471 - I20200828-0150 - Comparator Errors Found
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1184
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1793


### PR DESCRIPTION
See https://github.com/eclipse-jdt/eclipse.jdt.core/pull/1974

Fixes https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1793
