### PR TITLE
Apt tests shouldn't need o.e.pde.core

### DIFF
--- a/org.eclipse.jdt.apt.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.apt.tests/META-INF/MANIFEST.MF
@@ -39,8 +39,7 @@ Require-Bundle: org.junit,
  org.eclipse.jdt.core.tests.model,
  org.eclipse.core.resources,
  org.eclipse.core.runtime,
- org.eclipse.test.performance,
- org.eclipse.pde.core
+ org.eclipse.test.performance
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-Vendor: %providerName

--- a/org.eclipse.jdt.apt.tests/plugin.xml
+++ b/org.eclipse.jdt.apt.tests/plugin.xml
@@ -88,5 +88,13 @@
 	      <factory class="org.eclipse.jdt.apt.tests.annotations.annotationvalue.AnnotationValueProcessorFactory"/>
 	   </factories>
    </extension>
+    <extension
+         point="org.eclipse.jdt.core.classpathVariableInitializer">
+      <classpathVariableInitializer
+            class="org.eclipse.jdt.apt.tests.EclipseHomeInitializer"
+            readOnly="true"
+            variable="TEST_ECLIPSE_HOME">
+      </classpathVariableInitializer>
+   </extension>
 
 </plugin>

--- a/org.eclipse.jdt.apt.tests/src-annotations/org/eclipse/jdt/apt/tests/annotations/mirrortest/MirrorUtilTestAnnotationProcessor.java
+++ b/org.eclipse.jdt.apt.tests/src-annotations/org/eclipse/jdt/apt/tests/annotations/mirrortest/MirrorUtilTestAnnotationProcessor.java
@@ -67,9 +67,9 @@ public class MirrorUtilTestAnnotationProcessor extends BaseProcessor
 		"%NOSUCH/VARNAME%",
 		"%ROOT%/someOtherProject/foo/nonexistent.txt",
 			// expected-translation
-		"%ECLIPSE_HOME%",
-		"%ECLIPSE_HOME%/plugins",
-		"%ECLIPSE_HOME%/configuration/config.ini",
+		"%TEST_ECLIPSE_HOME%",
+		"%TEST_ECLIPSE_HOME%/plugins",
+		"%TEST_ECLIPSE_HOME%/configuration/config.ini",
 		"%ROOT%/org.eclipse.jdt.apt.tests.MirrorUtilTestsProject",
 		"%ROOT%/org.eclipse.jdt.apt.tests.MirrorUtilTestsProject/.classpath",
 		"%PROJECT.DIR%/.classpath"

--- a/org.eclipse.jdt.apt.tests/src/org/eclipse/jdt/apt/tests/EclipseHomeInitializer.java
+++ b/org.eclipse.jdt.apt.tests/src/org/eclipse/jdt/apt/tests/EclipseHomeInitializer.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jdt.apt.tests;
+
+import java.net.URL;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.jdt.core.ClasspathVariableInitializer;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.osgi.service.datalocation.Location;
+
+public class EclipseHomeInitializer extends ClasspathVariableInitializer {
+
+	public static final String ECLIPSE_HOME_VARIABLE = "TEST_ECLIPSE_HOME"; //$NON-NLS-1$
+
+	@Override
+	public void initialize(String variable) {
+		resetEclipseHomeVariable();
+	}
+
+	private static void resetEclipseHomeVariable() {
+		try {
+			JavaCore.setClasspathVariable(ECLIPSE_HOME_VARIABLE, IPath.fromOSString(getDefaultLocation()), null);
+		} catch (CoreException e) {
+		}
+	}
+	
+	private static String getDefaultLocation() {
+		Location location = Platform.getInstallLocation();
+		if (location != null) {
+			URL url = Platform.getInstallLocation().getURL();
+			IPath path = IPath.fromOSString(url.getFile()).removeTrailingSeparator();
+			return path.toOSString();
+		}
+		return ""; //$NON-NLS-1$
+	}
+}


### PR DESCRIPTION
## What it does
Introduce new classpath variable in the test project to not rely on the pde.core one.
Result of discussion in
https://github.com/eclipse-jdt/eclipse.jdt.core/pull/1918

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
