### PR TITLE
Scan '_' as identifier rather than as token type underscore till source level 20.

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Scanner.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Scanner.java
@@ -3083,7 +3083,8 @@ public int scanIdentifierOrKeyword() {
 		//only one char....
 		if ((length = this.currentPosition - this.startPosition) == 1) {
 			if (this.source[this.startPosition] == '_') {
-				return TokenNameUNDERSCORE;
+				return JavaFeature.UNNAMMED_PATTERNS_AND_VARS.isSupported(this.sourceLevel, this.previewEnabled) ?
+											TokenNameUNDERSCORE : TokenNameIdentifier;
 			}
 			return TokenNameIdentifier;
 		}
@@ -3092,7 +3093,8 @@ public int scanIdentifierOrKeyword() {
 	} else {
 		if ((length = this.withoutUnicodePtr) == 1) {
 			if (this.withoutUnicodeBuffer[0] == '_') {
-				return TokenNameUNDERSCORE;
+				return JavaFeature.UNNAMMED_PATTERNS_AND_VARS.isSupported(this.sourceLevel, this.previewEnabled) ?
+						TokenNameUNDERSCORE : TokenNameIdentifier;
 			}
 			return TokenNameIdentifier;
 		}


### PR DESCRIPTION

## What it does

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2008

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
