### PR TITLE
BinaryType.equals() shortcut

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/BinaryType.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/BinaryType.java
@@ -170,7 +170,12 @@ public IType createType(String contents, IJavaElement sibling, boolean force, IP
 }
 @Override
 public boolean equals(Object o) {
-	if (!(o instanceof BinaryType)) return false;
+	if (o == this) {
+		return true;
+	}
+	if (!(o instanceof BinaryType)) {
+		return false;
+	}
 	return super.equals(o);
 }
 


### PR DESCRIPTION
inspired by eclipse.jdt.ui/issues/1192, the shortcut is taken sometimes
