### PR TITLE
Synchronize JDT core version with batch compiler version

### DIFF
--- a/org.eclipse.jdt.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core/META-INF/MANIFEST.MF
@@ -47,7 +47,7 @@ Require-Bundle: org.eclipse.core.resources;bundle-version="[3.18.0,4.0.0)",
  org.eclipse.core.filesystem;bundle-version="[1.7.0,2.0.0)",
  org.eclipse.text;bundle-version="[3.6.0,4.0.0)",
  org.eclipse.team.core;bundle-version="[3.1.0,4.0.0)";resolution:=optional,
- org.eclipse.jdt.core.compiler.batch;bundle-version="3.36.0";visibility:=reexport
+ org.eclipse.jdt.core.compiler.batch;bundle-version="[3.37.0,3.38.0)";visibility:=reexport
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Eclipse-ExtensibleAPI: true
 Bundle-ActivationPolicy: lazy


### PR DESCRIPTION
Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1987
