### PR TITLE
IrritantSet needs unsigned right shift for GROUP4 and higher

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/impl/IrritantSet.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/impl/IrritantSet.java
@@ -224,7 +224,7 @@ public class IrritantSet {
 	}
 
 	public IrritantSet clear(int singleGroupIrritants) {
-		int group = (singleGroupIrritants & GROUP_MASK) >> GROUP_SHIFT;
+		int group = (singleGroupIrritants & GROUP_MASK) >>> GROUP_SHIFT;
 		this.bits[group] &= ~singleGroupIrritants;
 		return this;
 	}
@@ -242,7 +242,7 @@ public class IrritantSet {
 	public void initialize(int singleGroupIrritants) {
 		if (singleGroupIrritants == 0)
 			return;
-		int group = (singleGroupIrritants & GROUP_MASK) >> GROUP_SHIFT;
+		int group = (singleGroupIrritants & GROUP_MASK) >>> GROUP_SHIFT;
 		this.bits[group] = singleGroupIrritants & ~GROUP_MASK; // erase group information
 	}
 
@@ -280,14 +280,14 @@ public class IrritantSet {
 	}
 
 	public boolean isSet(int singleGroupIrritants) {
-		int group = (singleGroupIrritants & GROUP_MASK) >> GROUP_SHIFT;
+		int group = (singleGroupIrritants & GROUP_MASK) >>> GROUP_SHIFT;
 		return (this.bits[group] & singleGroupIrritants) != 0;
 	}
 	public int[] getBits() {
 		return this.bits;
 	}
 	public IrritantSet set(int singleGroupIrritants) {
-		int group = (singleGroupIrritants & GROUP_MASK) >> GROUP_SHIFT;
+		int group = (singleGroupIrritants & GROUP_MASK) >>> GROUP_SHIFT;
 		this.bits[group] |= (singleGroupIrritants & ~GROUP_MASK); // erase the group bits
 		return this;
 	}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/IrritantSetTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/IrritantSetTest.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2024 GK Software SE and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Stephan Herrmann - Initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.core.tests.compiler;
+
+import org.eclipse.jdt.core.tests.junit.extension.TestCase;
+import org.eclipse.jdt.internal.compiler.impl.IrritantSet;
+
+import junit.framework.Test;
+import junit.framework.TestSuite;
+
+public class IrritantSetTest extends TestCase {
+
+	public IrritantSetTest(String name) {
+		super(name);
+	}
+
+	public static Test suite() {
+		TestSuite suite = new TestSuite(IrritantSetTest.class.getPackageName());
+		suite.addTest(new TestSuite(IrritantSetTest.class));
+		return suite;
+	}
+
+	public void testGroup4() {
+		if (IrritantSet.GROUP_MAX <= 4) {
+			System.out.println("IrritantSetTest.testGroup4 will trigger once IrritantSet.GROUP_MAX exceeds 4.");
+			return;
+		}
+		@SuppressWarnings("unused") // dead code as of now
+		int singleIrritant = ( 4 << IrritantSet.GROUP_SHIFT /* group4 */) + 42;
+		IrritantSet irritantSet = new IrritantSet(singleIrritant);
+		assertTrue(irritantSet.isSet(singleIrritant));
+	}
+}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TestAll.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TestAll.java
@@ -25,7 +25,6 @@ package org.eclipse.jdt.core.tests.compiler.regression;
 
 import java.util.ArrayList;
 
-import org.eclipse.jdt.core.tests.compiler.IrritantSetTest;
 import org.eclipse.jdt.core.tests.compiler.util.HashtableOfObjectTest;
 import org.eclipse.jdt.core.tests.compiler.util.JrtUtilTest;
 import org.eclipse.jdt.core.tests.dom.StandAloneASTParserTest;
@@ -95,7 +94,6 @@ public static Test suite() {
 	standardTests.add(ResourceLeakTests.class);
 	standardTests.add(ResourceLeakAnnotatedTests.class);
 	standardTests.add(PackageBindingTest.class);
-	standardTests.add(IrritantSetTest.class);
 
 	// add all javadoc tests
 	for (int i=0, l=JavadocTest.ALL_CLASSES.size(); i<l; i++) {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TestAll.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TestAll.java
@@ -25,6 +25,7 @@ package org.eclipse.jdt.core.tests.compiler.regression;
 
 import java.util.ArrayList;
 
+import org.eclipse.jdt.core.tests.compiler.IrritantSetTest;
 import org.eclipse.jdt.core.tests.compiler.util.HashtableOfObjectTest;
 import org.eclipse.jdt.core.tests.compiler.util.JrtUtilTest;
 import org.eclipse.jdt.core.tests.dom.StandAloneASTParserTest;
@@ -94,6 +95,7 @@ public static Test suite() {
 	standardTests.add(ResourceLeakTests.class);
 	standardTests.add(ResourceLeakAnnotatedTests.class);
 	standardTests.add(PackageBindingTest.class);
+	standardTests.add(IrritantSetTest.class);
 
 	// add all javadoc tests
 	for (int i=0, l=JavadocTest.ALL_CLASSES.size(); i<l; i++) {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AllJavaModelTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AllJavaModelTests.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Method;
 
 import org.eclipse.jdt.core.tests.compiler.CharDeduplicationTest;
 import org.eclipse.jdt.core.tests.compiler.DeduplicationUtilTest;
+import org.eclipse.jdt.core.tests.compiler.IrritantSetTest;
 import org.eclipse.jdt.core.tests.compiler.map.CharArrayMapperTest;
 import org.eclipse.jdt.core.tests.junit.extension.TestCase;
 
@@ -240,6 +241,8 @@ private static Class[] getAllTestClasses() {
 		DeduplicationUtilTest.class,
 
 		RecordsElementTests.class,
+
+		IrritantSetTest.class,
 	};
 
 	Class[] deprecatedClasses = getDeprecatedJDOMTestClasses();


### PR DESCRIPTION
fixes #2006

* Apply the correct shift operator
* Add a test which will start running once IrritantSet.GROUP4 is enabled in JDT

To watch the effect: run the test against a tweaked IrritantSet.java:
* set GROUP_MAX to 5
* don't apply the correction in this PR
* AIOOBE will occur
