### PR TITLE
Fix VariableBinding.getJavaElement() type signature

### DIFF
--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/VariableBinding.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/VariableBinding.java
@@ -19,6 +19,7 @@ package org.eclipse.jdt.core.dom;
 
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.Signature;
 import org.eclipse.jdt.core.util.IModifierConstants;
 import org.eclipse.jdt.internal.compiler.ast.TypeDeclaration;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
@@ -266,7 +267,7 @@ class VariableBinding implements IVariableBinding {
 			}
 		}
 		int sourceEnd = sourceStart+sourceLength-1;
-		char[] typeSig = this.binding.type.genericTypeSignature();
+		char[] typeSig = Signature.createTypeSignature(this.binding.type.signableName(), true).toCharArray();
 		JavaElement parent = null;
 		IMethodBinding declaringMethod = getDeclaringMethod();
 		if (this.binding instanceof RecordComponentBinding) {


### PR DESCRIPTION
Make signature format returned by the binding match the usual signature format for  IJavaElement.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2036

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## How to test

Run provided unit test with/without fix to check fixes makes test pass.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
