### PR TITLE
ResourceLeakTests & ResourceLeakAnnotatedTests fail in some compliance levels when run locally via RunJDTCoreTests

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ResourceLeakTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ResourceLeakTests.java
@@ -7036,6 +7036,8 @@ public void testBug499037_010_since_9() {
 		options);
 }
 public void testGH1762() {
+	if (this.complianceLevel < ClassFileConstants.JDK1_7)
+		return; // uses t-w-r
 	runLeakTest(
 		new String[] {
 			"X.java",

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TestAll.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TestAll.java
@@ -92,7 +92,6 @@ public static Test suite() {
 	standardTests.add(ManifestAnalyzerTest.class);
 	standardTests.add(InitializationTests.class);
 	standardTests.add(ResourceLeakTests.class);
-	standardTests.add(ResourceLeakAnnotatedTests.class);
 	standardTests.add(PackageBindingTest.class);
 
 	// add all javadoc tests
@@ -137,6 +136,8 @@ public static Test suite() {
 	since_1_7.add(PolymorphicSignatureTest.class);
 	since_1_7.add(Compliance_1_7.class);
 	since_1_7.add(MethodHandleTest.class);
+	since_1_7.add(ResourceLeakAnnotatedTests.class);
+
 
 	ArrayList since_1_8 = new ArrayList();
 	since_1_8.add(NegativeTypeAnnotationTest.class);


### PR DESCRIPTION
fixes #2041

Don't try to run affected Tests below 1.7 (not designed to do so)
