### PR TITLE
[memory] Deduplicate new Strings #2054

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/AnnotationInfo.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/AnnotationInfo.java
@@ -22,6 +22,7 @@ import org.eclipse.jdt.internal.compiler.codegen.ConstantPool;
 import org.eclipse.jdt.internal.compiler.env.*;
 import org.eclipse.jdt.internal.compiler.impl.*;
 import org.eclipse.jdt.internal.compiler.lookup.TagBits;
+import org.eclipse.jdt.internal.compiler.util.CharDeduplication;
 import org.eclipse.jdt.internal.compiler.util.Util;
 
 public class AnnotationInfo extends ClassFileStruct implements IBinaryAnnotation {
@@ -57,7 +58,7 @@ AnnotationInfo(byte[] classFileBytes, int[] contantPoolOffsets, int offset, bool
 private void decodeAnnotation() {
 	this.readOffset = 0;
 	int utf8Offset = this.constantPoolOffsets[u2At(0)] - this.structOffset;
-	this.typename = utf8At(utf8Offset + 3, u2At(utf8Offset + 1));
+	this.typename = CharDeduplication.intern(utf8At(utf8Offset + 3, u2At(utf8Offset + 1)));
 	int numberOfPairs = u2At(2);
 	// u2 type_index + u2 num_member_value_pair
 	this.readOffset += 4;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/FieldInfo.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/FieldInfo.java
@@ -23,6 +23,7 @@ import org.eclipse.jdt.internal.compiler.env.IBinaryTypeAnnotation;
 import org.eclipse.jdt.internal.compiler.impl.*;
 import org.eclipse.jdt.internal.compiler.lookup.TagBits;
 import org.eclipse.jdt.internal.compiler.lookup.TypeIds;
+import org.eclipse.jdt.internal.compiler.util.CharDeduplication;
 import org.eclipse.jdt.internal.compiler.util.Util;
 
 @SuppressWarnings("rawtypes")
@@ -191,7 +192,7 @@ public char[] getGenericSignature() {
 	if (this.signatureUtf8Offset != -1) {
 		if (this.signature == null) {
 			// decode the signature
-			this.signature = utf8At(this.signatureUtf8Offset + 3, u2At(this.signatureUtf8Offset + 1));
+			this.signature = CharDeduplication.intern(utf8At(this.signatureUtf8Offset + 3, u2At(this.signatureUtf8Offset + 1)));
 		}
 		return this.signature;
 	}
@@ -221,7 +222,7 @@ public char[] getName() {
 	if (this.name == null) {
 		// read the name
 		int utf8Offset = this.constantPoolOffsets[u2At(2)] - this.structOffset;
-		this.name = utf8At(utf8Offset + 3, u2At(utf8Offset + 1));
+		this.name = CharDeduplication.intern(utf8At(utf8Offset + 3, u2At(utf8Offset + 1)));
 	}
 	return this.name;
 }
@@ -245,7 +246,7 @@ public char[] getTypeName() {
 	if (this.descriptor == null) {
 		// read the signature
 		int utf8Offset = this.constantPoolOffsets[u2At(4)] - this.structOffset;
-		this.descriptor = utf8At(utf8Offset + 3, u2At(utf8Offset + 1));
+		this.descriptor = CharDeduplication.intern(utf8At(utf8Offset + 3, u2At(utf8Offset + 1)));
 	}
 	return this.descriptor;
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/InnerClassInfo.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/InnerClassInfo.java
@@ -14,6 +14,7 @@
 package org.eclipse.jdt.internal.compiler.classfmt;
 
 import org.eclipse.jdt.internal.compiler.env.IBinaryNestedType;
+import org.eclipse.jdt.internal.compiler.util.CharDeduplication;
 
 /**
  * Describes one entry in the classes table of the InnerClasses attribute.
@@ -48,7 +49,7 @@ public char[] getEnclosingTypeName() {
 				this.constantPoolOffsets[u2At(
 					this.constantPoolOffsets[this.outerClassNameIndex] - this.structOffset + 1)]
 					- this.structOffset;
-			this.outerClassName = utf8At(utf8Offset + 3, u2At(utf8Offset + 1));
+			this.outerClassName = CharDeduplication.intern(utf8At(utf8Offset + 3, u2At(utf8Offset + 1)));
 		}
 		this.readOuterClassName = true;
 
@@ -72,7 +73,7 @@ public char[] getName() {
 		if (this.innerClassNameIndex != 0) {
 			int  classOffset = this.constantPoolOffsets[this.innerClassNameIndex] - this.structOffset;
 			int utf8Offset = this.constantPoolOffsets[u2At(classOffset + 1)] - this.structOffset;
-			this.innerClassName = utf8At(utf8Offset + 3, u2At(utf8Offset + 1));
+			this.innerClassName = CharDeduplication.intern(utf8At(utf8Offset + 3, u2At(utf8Offset + 1)));
 		}
 		this.readInnerClassName = true;
 	}
@@ -88,7 +89,7 @@ public char[] getSourceName() {
 	if (!this.readInnerName) {
 		if (this.innerNameIndex != 0) {
 			int utf8Offset = this.constantPoolOffsets[this.innerNameIndex] - this.structOffset;
-			this.innerName = utf8At(utf8Offset + 3, u2At(utf8Offset + 1));
+			this.innerName = CharDeduplication.intern(utf8At(utf8Offset + 3, u2At(utf8Offset + 1)));
 		}
 		this.readInnerName = true;
 	}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/MethodInfo.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/MethodInfo.java
@@ -24,11 +24,10 @@ import org.eclipse.jdt.internal.compiler.env.IBinaryAnnotation;
 import org.eclipse.jdt.internal.compiler.env.IBinaryMethod;
 import org.eclipse.jdt.internal.compiler.env.IBinaryTypeAnnotation;
 import org.eclipse.jdt.internal.compiler.lookup.TagBits;
+import org.eclipse.jdt.internal.compiler.util.CharDeduplication;
 
 @SuppressWarnings("rawtypes")
 public class MethodInfo extends ClassFileStruct implements IBinaryMethod, Comparable {
-	static private final char[][] noException = CharOperation.NO_CHAR_CHAR;
-	static private final char[][] noArgumentNames = CharOperation.NO_CHAR_CHAR;
 	static private final char[] ARG = "arg".toCharArray();  //$NON-NLS-1$
 	protected int accessFlags;
 	protected int attributeBytes;
@@ -281,7 +280,7 @@ public char[] getGenericSignature() {
 	if (this.signatureUtf8Offset != -1) {
 		if (this.signature == null) {
 			// decode the signature
-			this.signature = utf8At(this.signatureUtf8Offset + 3, u2At(this.signatureUtf8Offset + 1));
+			this.signature = CharDeduplication.intern(utf8At(this.signatureUtf8Offset + 3, u2At(this.signatureUtf8Offset + 1)));
 		}
 		return this.signature;
 	}
@@ -293,7 +292,7 @@ public char[] getMethodDescriptor() {
 	if (this.descriptor == null) {
 		// read the name
 		int utf8Offset = this.constantPoolOffsets[u2At(4)] - this.structOffset;
-		this.descriptor = utf8At(utf8Offset + 3, u2At(utf8Offset + 1));
+		this.descriptor = CharDeduplication.intern(utf8At(utf8Offset + 3, u2At(utf8Offset + 1)));
 	}
 	return this.descriptor;
 }
@@ -329,7 +328,7 @@ public char[] getSelector() {
 	if (this.name == null) {
 		// read the name
 		int utf8Offset = this.constantPoolOffsets[u2At(2)] - this.structOffset;
-		this.name = utf8At(utf8Offset + 3, u2At(utf8Offset + 1));
+		this.name = CharDeduplication.intern(utf8At(utf8Offset + 3, u2At(utf8Offset + 1)));
 	}
 	return this.name;
 }
@@ -386,7 +385,7 @@ private synchronized void readExceptionAttributes() {
 			// place the readOffset at the beginning of the exceptions table
 			readOffset += 8;
 			if (entriesNumber == 0) {
-				names = noException;
+				names = CharOperation.NO_CHAR_CHAR;
 			} else {
 				names = new char[entriesNumber][];
 				for (int j = 0; j < entriesNumber; j++) {
@@ -403,7 +402,7 @@ private synchronized void readExceptionAttributes() {
 		}
 	}
 	if (names == null) {
-		this.exceptionNames = noException;
+		this.exceptionNames = CharOperation.NO_CHAR_CHAR;
 	} else {
 		this.exceptionNames = names;
 	}
@@ -470,8 +469,8 @@ private synchronized void readCodeAttribute() {
 			char[] attributeName = utf8At(utf8Offset + 3, u2At(utf8Offset + 1));
 			if (CharOperation.equals(attributeName, AttributeNamesConstants.CodeName)) {
 				decodeCodeAttribute(readOffset);
-				if (this.argumentNames == null) {
-					this.argumentNames = noArgumentNames;
+				if (this.argumentNames == null || this.argumentNames.length == 0) {
+					this.argumentNames = CharOperation.NO_CHAR_CHAR;
 				}
 				return;
 			} else {
@@ -479,7 +478,7 @@ private synchronized void readCodeAttribute() {
 			}
 		}
 	}
-	this.argumentNames = noArgumentNames;
+	this.argumentNames = CharOperation.NO_CHAR_CHAR;
 }
 private void decodeCodeAttribute(int offset) {
 	int readOffset = offset + 10;
@@ -517,7 +516,7 @@ private void decodeLocalVariableAttribute(int offset, int codeLength) {
 				int utf8Offset = this.constantPoolOffsets[nameIndex] - this.structOffset;
 				char[] localVariableName = utf8At(utf8Offset + 3, u2At(utf8Offset + 1));
 				if (!CharOperation.equals(localVariableName, ConstantPool.This)) {
-					names[argumentNamesIndex++] = localVariableName;
+					names[argumentNamesIndex++] = CharDeduplication.intern(localVariableName);
 				}
 			} else {
 				break;
@@ -542,7 +541,7 @@ private void decodeMethodParameters(int offset, MethodInfo methodInfo) {
 			if (nameIndex != 0) {
 				int utf8Offset = this.constantPoolOffsets[nameIndex] - this.structOffset;
 				char[] parameterName = utf8At(utf8Offset + 3, u2At(utf8Offset + 1));
-				names[i] = parameterName;
+				names[i] = CharDeduplication.intern(parameterName);
 			} else {
 				names[i] = CharOperation.concat(ARG, String.valueOf(i).toCharArray());
 			}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/RecordComponentInfo.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/RecordComponentInfo.java
@@ -20,6 +20,7 @@ import org.eclipse.jdt.internal.compiler.env.IBinaryTypeAnnotation;
 import org.eclipse.jdt.internal.compiler.env.IRecordComponent;
 import org.eclipse.jdt.internal.compiler.impl.Constant;
 import org.eclipse.jdt.internal.compiler.lookup.TagBits;
+import org.eclipse.jdt.internal.compiler.util.CharDeduplication;
 
 /*
  * TODO: Refactor common code from FieldInfo since this mirrors field info mostly except for
@@ -175,7 +176,7 @@ public char[] getGenericSignature() {
 	if (this.signatureUtf8Offset != -1) {
 		if (this.signature == null) {
 			// decode the signature
-			this.signature = utf8At(this.signatureUtf8Offset + 3, u2At(this.signatureUtf8Offset + 1));
+			this.signature = CharDeduplication.intern(utf8At(this.signatureUtf8Offset + 3, u2At(this.signatureUtf8Offset + 1)));
 		}
 		return this.signature;
 	}
@@ -190,7 +191,7 @@ public char[] getName() {
 	if (this.name == null) {
 		// read the name
 		int utf8Offset = this.constantPoolOffsets[u2At(0)] - this.structOffset;
-		this.name = utf8At(utf8Offset + 3, u2At(utf8Offset + 1));
+		this.name = CharDeduplication.intern(utf8At(utf8Offset + 3, u2At(utf8Offset + 1)));
 	}
 	return this.name;
 }
@@ -214,7 +215,7 @@ public char[] getTypeName() {
 	if (this.descriptor == null) {
 		// read the signature
 		int utf8Offset = this.constantPoolOffsets[u2At(2)] - this.structOffset;
-		this.descriptor = utf8At(utf8Offset + 3, u2At(utf8Offset + 1));
+		this.descriptor = CharDeduplication.intern(utf8At(utf8Offset + 3, u2At(utf8Offset + 1)));
 	}
 	return this.descriptor;
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/util/CharDeduplication.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/util/CharDeduplication.java
@@ -64,6 +64,10 @@ public class CharDeduplication {
 		Arrays.fill(this.circularBufferPointer, 0);
 	}
 
+	public static char[] intern(char[] source) {
+		return getThreadLocalInstance().sharedCopyOfRange(source, 0, source.length);
+	}
+
 	/**
 	 * like Arrays.copyOfRange(source, from, to) but returns a cached instance of the former result if
 	 * available

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/CompletionUnitStructureRequestor.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/CompletionUnitStructureRequestor.java
@@ -55,12 +55,12 @@ import org.eclipse.jdt.internal.core.ImportContainer;
 import org.eclipse.jdt.internal.core.ImportDeclaration;
 import org.eclipse.jdt.internal.core.Initializer;
 import org.eclipse.jdt.internal.core.JavaElement;
-import org.eclipse.jdt.internal.core.JavaModelManager;
 import org.eclipse.jdt.internal.core.PackageDeclaration;
 import org.eclipse.jdt.internal.core.SourceField;
 import org.eclipse.jdt.internal.core.SourceMethod;
 import org.eclipse.jdt.internal.core.SourceType;
 import org.eclipse.jdt.internal.core.TypeParameter;
+import org.eclipse.jdt.internal.core.util.DeduplicationUtil;
 
 public class CompletionUnitStructureRequestor extends CompilationUnitStructureRequestor {
 	private final ASTNode assistNode;
@@ -93,7 +93,7 @@ public class CompletionUnitStructureRequestor extends CompilationUnitStructureRe
 
 	@Override
 	protected SourceField createField(JavaElement parent, FieldInfo fieldInfo) {
-		String fieldName = JavaModelManager.getJavaModelManager().intern(new String(fieldInfo.name));
+		String fieldName = DeduplicationUtil.toString(fieldInfo.name);
 		AssistSourceField field = new AssistSourceField(parent, fieldName, this.bindingCache, this.newElements);
 		FieldDeclaration decl = (FieldDeclaration) (fieldInfo.node);
 		if (decl.binding != null) {
@@ -106,7 +106,7 @@ public class CompletionUnitStructureRequestor extends CompilationUnitStructureRe
 	}
 	@Override
 	protected SourceField createRecordComponent(JavaElement parent, FieldInfo compInfo) {
-		String compName = JavaModelManager.getJavaModelManager().intern(new String(compInfo.name));
+		String compName = DeduplicationUtil.toString(compInfo.name);
 		SourceField comp = new AssistSourceField(parent, compName, this.bindingCache, this.newElements) {
 			@Override
 			public boolean isRecordComponent() throws JavaModelException {
@@ -140,7 +140,7 @@ public class CompletionUnitStructureRequestor extends CompilationUnitStructureRe
 
 	@Override
 	protected SourceMethod createMethodHandle(JavaElement parent, MethodInfo methodInfo) {
-		String selector = JavaModelManager.getJavaModelManager().intern(new String(methodInfo.name));
+		String selector = DeduplicationUtil.toString(methodInfo.name);
 		String[] parameterTypeSigs = convertTypeNamesToSigs(methodInfo.parameterTypes);
 		AssistSourceMethod method = new AssistSourceMethod(parent, selector, parameterTypeSigs, this.bindingCache, this.newElements);
 		if (methodInfo.node.binding != null) {

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/InternalExtendedCompletionContext.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/InternalExtendedCompletionContext.java
@@ -69,6 +69,7 @@ import org.eclipse.jdt.internal.compiler.util.ObjectVector;
 import org.eclipse.jdt.internal.core.CompilationUnitElementInfo;
 import org.eclipse.jdt.internal.core.JavaElement;
 import org.eclipse.jdt.internal.core.LocalVariable;
+import org.eclipse.jdt.internal.core.util.DeduplicationUtil;
 import org.eclipse.jdt.internal.core.util.Util;
 
 public class InternalExtendedCompletionContext {
@@ -282,7 +283,7 @@ public class InternalExtendedCompletionContext {
 
 		return new LocalVariable(
 				parent,
-				new String(local.name),
+				DeduplicationUtil.toString(local.name),
 				local.declarationSourceStart,
 				local.declarationSourceEnd,
 				local.sourceStart,

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/AbstractModule.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/AbstractModule.java
@@ -96,7 +96,7 @@ public interface AbstractModule extends IModuleDescription {
 			}
 			return result.toArray(new String[result.size()]);
 		}
-		return new String[0];
+		return JavaElement.NO_STRINGS;
 	}
 	@Override
 	default String[] getOpenedPackageNames(IModuleDescription targetModule) throws JavaModelException {
@@ -112,7 +112,7 @@ public interface AbstractModule extends IModuleDescription {
 			}
 			return result.toArray(new String[result.size()]);
 		}
-		return new String[0];
+		return JavaElement.NO_STRINGS;
 	}
 	default IModuleReference[] getRequiredModules() throws JavaModelException {
 		return getModuleInfo().requires();
@@ -130,7 +130,7 @@ public interface AbstractModule extends IModuleDescription {
 		for (IService service : services) {
 			results.add(new String(service.name()));
 		}
-		return results.toArray(new String[0]);
+		return results.toArray(String[]::new);
 
 	}
 	default char[][] getUsedServices() throws JavaModelException {
@@ -144,7 +144,7 @@ public interface AbstractModule extends IModuleDescription {
 			char[] service = services[i];
 			results.add(new String(service));
 		}
-		return results.toArray(new String[0]);
+		return results.toArray(String[]::new);
 	}
 	default IPackageExport[] getOpenedPackages() throws JavaModelException {
 		return getModuleInfo().opens();

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/BinaryModule.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/BinaryModule.java
@@ -28,6 +28,7 @@ import org.eclipse.jdt.internal.compiler.env.IBinaryModule;
 import org.eclipse.jdt.internal.compiler.env.IModule;
 import org.eclipse.jdt.internal.compiler.lookup.TagBits;
 import org.eclipse.jdt.internal.core.JavaModelManager.PerProjectInfo;
+import org.eclipse.jdt.internal.core.util.DeduplicationUtil;
 
 public class BinaryModule extends BinaryMember implements AbstractModule {
 
@@ -39,7 +40,7 @@ public class BinaryModule extends BinaryMember implements AbstractModule {
 	}
 	/** For creating a populated handle from a class file. */
 	public BinaryModule(JavaElement parent, IBinaryModule info) {
-		super(parent, String.valueOf(info.name()));
+		super(parent, DeduplicationUtil.toString(info.name()));
 		this.info = info;
 	}
 	@Override

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/BinaryType.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/BinaryType.java
@@ -35,6 +35,7 @@ import org.eclipse.jdt.internal.compiler.lookup.Binding;
 import org.eclipse.jdt.internal.compiler.util.SuffixConstants;
 import org.eclipse.jdt.internal.core.JavaModelManager.PerProjectInfo;
 import org.eclipse.jdt.internal.core.hierarchy.TypeHierarchy;
+import org.eclipse.jdt.internal.core.util.DeduplicationUtil;
 import org.eclipse.jdt.internal.core.util.MementoTokenizer;
 import org.eclipse.jdt.internal.core.util.Messages;
 import org.eclipse.jdt.internal.core.util.Util;
@@ -285,7 +286,7 @@ public IType getDeclaringType() {
 			return
 				new BinaryType(
 					(JavaElement)getPackageFragment().getClassFile(enclosingClassFileName),
-					Util.localTypeName(enclosingName, enclosingName.lastIndexOf('$'), enclosingName.length()));
+					DeduplicationUtil.intern(Util.localTypeName(enclosingName, enclosingName.lastIndexOf('$'), enclosingName.length())));
 		}
 	}
 }
@@ -980,7 +981,7 @@ public ITypeHierarchy newTypeHierarchy(
 }
 @Override
 public ResolvedBinaryType resolved(Binding binding) {
-	return new ResolvedBinaryType(this.getParent(), this.name, new String(binding.computeUniqueKey()), this.getOccurrenceCount());
+	return new ResolvedBinaryType(this.getParent(), this.name, DeduplicationUtil.toString(binding.computeUniqueKey()), this.getOccurrenceCount());
 }
 /*
  * Returns the source file name as defined in the given info.

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ClassFile.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ClassFile.java
@@ -58,6 +58,7 @@ import org.eclipse.jdt.internal.compiler.env.IModule;
 import org.eclipse.jdt.internal.compiler.util.SuffixConstants;
 import org.eclipse.jdt.internal.core.nd.java.model.BinaryTypeDescriptor;
 import org.eclipse.jdt.internal.core.nd.java.model.BinaryTypeFactory;
+import org.eclipse.jdt.internal.core.util.DeduplicationUtil;
 import org.eclipse.jdt.internal.core.util.MementoTokenizer;
 import org.eclipse.jdt.internal.core.util.Util;
 
@@ -70,12 +71,15 @@ public class ClassFile extends AbstractClassFile implements IOrdinaryClassFile {
 	protected BinaryType binaryType = null;
 
 	private IPath externalAnnotationBase;
-
+	final String typeName;
 /*
  * Creates a handle to a class file.
  */
 protected ClassFile(PackageFragment parent, String nameWithoutExtension) {
 	super(parent, nameWithoutExtension);
+	// Internal class file name doesn't contain ".class" file extension
+	int lastDollar = this.name.lastIndexOf('$');
+	this.typeName = lastDollar > -1 ? DeduplicationUtil.intern(Util.localTypeName(this.name, lastDollar, this.name.length())) : this.name;
 }
 
 /**
@@ -386,8 +390,8 @@ public IJavaElement getHandleFromMemento(String token, MementoTokenizer memento,
 	switch (token.charAt(0)) {
 		case JEM_TYPE:
 			if (!memento.hasMoreTokens()) return this;
-			String typeName = memento.nextToken();
-			JavaElement type = new BinaryType(this, typeName);
+			String newtypeName = memento.nextToken();
+			JavaElement type = new BinaryType(this, DeduplicationUtil.intern(newtypeName));
 			return type.getHandleFromMemento(memento, owner);
 	}
 	return null;
@@ -423,9 +427,7 @@ public IType getType() {
 	return this.binaryType;
 }
 public String getTypeName() {
-	// Internal class file name doesn't contain ".class" file extension
-	int lastDollar = this.name.lastIndexOf('$');
-	return lastDollar > -1 ? Util.localTypeName(this.name, lastDollar, this.name.length()) : this.name;
+	return this.typeName;
 }
 /*
  * @see IClassFile

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ClassFileInfo.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ClassFileInfo.java
@@ -30,6 +30,7 @@ import org.eclipse.jdt.internal.compiler.env.IRecordComponent;
 import org.eclipse.jdt.internal.compiler.lookup.TagBits;
 import org.eclipse.jdt.internal.compiler.lookup.TypeConstants;
 import org.eclipse.jdt.internal.compiler.util.SuffixConstants;
+import org.eclipse.jdt.internal.core.util.DeduplicationUtil;
 
 /**
  * Element info for <code>ClassFile</code> handles.
@@ -165,14 +166,13 @@ private void generateFieldInfos(IType type, IBinaryType typeInfo, Map<IJavaEleme
 	if (fields == null) {
 		return;
 	}
-	JavaModelManager manager = JavaModelManager.getJavaModelManager();
 	for (int i = 0, fieldCount = fields.length; i < fieldCount; i++) {
 		IBinaryField fieldInfo = fields[i];
 		// If the type is a record and this is an instance field, it can only be a record component
 		// Filter out
 		if (typeInfo.isRecord() && (fieldInfo.getModifiers() & ClassFileConstants.AccStatic) == 0)
 			continue;
-		BinaryField field = new BinaryField((JavaElement)type, manager.intern(new String(fieldInfo.getName())));
+		BinaryField field = new BinaryField((JavaElement)type, DeduplicationUtil.toString(fieldInfo.getName()));
 		newElements.put(field, fieldInfo);
 		childrenHandles.add(field);
 		generateAnnotationsInfos(field, fieldInfo.getAnnotations(), fieldInfo.getTagBits(), newElements);
@@ -188,10 +188,9 @@ private void generateRecordComponentInfos(IType type, IBinaryType typeInfo, Map<
 	if (components == null) {
 		return;
 	}
-	JavaModelManager manager = JavaModelManager.getJavaModelManager();
 	for (int i = 0, fieldCount = components.length; i < fieldCount; i++) {
 		IRecordComponent componentInfo = components[i];
-		BinaryField component = new BinaryField((JavaElement)type, manager.intern(new String(componentInfo.getName()))) {
+		BinaryField component = new BinaryField((JavaElement)type, DeduplicationUtil.toString(componentInfo.getName())) {
 			@Override
 			public boolean isRecordComponent() throws JavaModelException {
 				return true;
@@ -217,7 +216,7 @@ private void generateInnerClassHandles(IType type, IBinaryType typeInfo, ArrayLi
 		for (int i = 0, typeCount = innerTypes.length; i < typeCount; i++) {
 			IBinaryNestedType binaryType = innerTypes[i];
 			IClassFile parentClassFile= pkg.getClassFile(new String(ClassFile.unqualifiedName(binaryType.getName())) + SUFFIX_STRING_class);
-			BinaryType innerType = new BinaryType((JavaElement) parentClassFile, ClassFile.simpleName(binaryType.getName()));
+			BinaryType innerType = new BinaryType((JavaElement) parentClassFile, DeduplicationUtil.intern(ClassFile.simpleName(binaryType.getName())));
 			childrenHandles.add(innerType);
 		}
 	}
@@ -284,10 +283,9 @@ private void generateMethodInfos(IType type, IBinaryType typeInfo, Map<IJavaElem
 			paramNames[j]= pNames[j].toCharArray();
 		}
 		char[][] parameterTypes = ClassFile.translatedNames(paramNames);
-		JavaModelManager manager = JavaModelManager.getJavaModelManager();
-		selector =  manager.intern(selector);
+		selector =  DeduplicationUtil.intern(selector);
 		for (int j= 0; j < pNames.length; j++) {
-			pNames[j]= manager.intern(new String(parameterTypes[j]));
+			pNames[j]= DeduplicationUtil.toString(parameterTypes[j]);
 		}
 		int occurrenceCount = 0;
 		BinaryMethod method;
@@ -326,7 +324,7 @@ private void generateMethodInfos(IType type, IBinaryType typeInfo, Map<IJavaElem
 			if (parameterAnnotations != null) {
 				LocalVariable localVariable = new LocalVariable(
 						method,
-						new String(argumentNames[j]),
+						DeduplicationUtil.toString(argumentNames[j]),
 						0,
 						-1,
 						0,

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ClasspathAccessRule.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ClasspathAccessRule.java
@@ -18,6 +18,7 @@ import org.eclipse.core.runtime.Path;
 import org.eclipse.jdt.core.IAccessRule;
 import org.eclipse.jdt.core.compiler.IProblem;
 import org.eclipse.jdt.internal.compiler.env.AccessRule;
+import org.eclipse.jdt.internal.core.util.DeduplicationUtil;
 
 public class ClasspathAccessRule extends AccessRule implements IAccessRule {
 
@@ -30,7 +31,7 @@ public class ClasspathAccessRule extends AccessRule implements IAccessRule {
 	}
 
 	public ClasspathAccessRule(char[] pattern, int problemId) {
-		super(JavaModelManager.getJavaModelManager().intern(pattern), problemId);
+		super(DeduplicationUtil.intern(pattern), problemId);
 	}
 
 	private static int toProblemId(int kind) {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ClasspathEntry.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ClasspathEntry.java
@@ -73,6 +73,7 @@ import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jdt.internal.compiler.lookup.TypeConstants;
 import org.eclipse.jdt.internal.compiler.util.ManifestAnalyzer;
 import org.eclipse.jdt.internal.core.index.DiskIndex;
+import org.eclipse.jdt.internal.core.util.DeduplicationUtil;
 import org.eclipse.jdt.internal.core.util.Messages;
 import org.eclipse.jdt.internal.core.util.Util;
 import org.w3c.dom.DOMException;
@@ -157,7 +158,7 @@ public class ClasspathEntry implements IClasspathEntry {
 	 * 	registered), and the remaining segments are used as additional hints for resolving the container entry to
 	 * 	an actual <code>IClasspathContainer</code>.</li>
 	 */
-	public IPath path;
+	public final IPath path;
 
 	/**
 	 * Patterns allowing to include/exclude portions of the resource tree denoted by this entry path.
@@ -311,17 +312,16 @@ public class ClasspathEntry implements IClasspathEntry {
 			System.arraycopy(accessRules, 0, rules, 0, length);
 			byte classpathEntryType;
 			String classpathEntryName;
-			JavaModelManager manager = JavaModelManager.getJavaModelManager();
 			if (this.entryKind == CPE_PROJECT || this.entryKind == CPE_SOURCE) { // can be remote source entry when reconciling
 				classpathEntryType = AccessRestriction.PROJECT;
-				classpathEntryName = manager.intern(getPath().segment(0));
+				classpathEntryName = DeduplicationUtil.intern(getPath().segment(0));
 			} else {
 				classpathEntryType = AccessRestriction.LIBRARY;
 				Object target = JavaModel.getWorkspaceTarget(path);
 				if (target == null) {
-					classpathEntryName = manager.intern(path.toOSString());
+					classpathEntryName = DeduplicationUtil.intern(path.toOSString());
 				} else {
-					classpathEntryName = manager.intern(path.makeRelative().toString());
+					classpathEntryName = DeduplicationUtil.intern(path.makeRelative().toString());
 				}
 			}
 			this.accessRuleSet = new AccessRuleSet(rules, classpathEntryType, classpathEntryName);

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/CompilationUnit.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/CompilationUnit.java
@@ -33,6 +33,7 @@ import org.eclipse.jdt.internal.compiler.lookup.TypeConstants;
 import org.eclipse.jdt.internal.compiler.problem.AbortCompilationUnit;
 import org.eclipse.jdt.internal.compiler.problem.DefaultProblemFactory;
 import org.eclipse.jdt.internal.compiler.util.SuffixConstants;
+import org.eclipse.jdt.internal.core.util.DeduplicationUtil;
 import org.eclipse.jdt.internal.core.util.MementoTokenizer;
 import org.eclipse.jdt.internal.core.util.Messages;
 import org.eclipse.jdt.internal.core.util.Util;
@@ -587,7 +588,7 @@ public IJavaElement[] findElements(IJavaElement element) {
  */
 @Override
 public IType findPrimaryType() {
-	String typeName = Util.getNameWithoutJavaLikeExtension(getElementName());
+	String typeName = DeduplicationUtil.intern(Util.getNameWithoutJavaLikeExtension(getElementName()));
 	IType primaryType= getType(typeName);
 	if (primaryType.exists()) {
 		return primaryType;

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JarPackageFragment.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JarPackageFragment.java
@@ -29,6 +29,7 @@ import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaModelStatusConstants;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.internal.compiler.lookup.TypeConstants;
+import org.eclipse.jdt.internal.core.util.DeduplicationUtil;
 import org.eclipse.jdt.internal.core.util.Util;
 
 /**
@@ -79,7 +80,7 @@ private IJavaElement[] computeChildren(ArrayList namesWithoutExtension) {
 		if (TypeConstants.MODULE_INFO_NAME_STRING.equals(nameWithoutExtension))
 			children[i] = new ModularClassFile(this);
 		else
-			children[i] = new ClassFile(this, nameWithoutExtension);
+			children[i] = new ClassFile(this, DeduplicationUtil.intern(nameWithoutExtension));
 	}
 	return children;
 }

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JarPackageFragmentRoot.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JarPackageFragmentRoot.java
@@ -42,6 +42,7 @@ import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jdt.internal.compiler.lookup.TypeConstants;
 import org.eclipse.jdt.internal.core.JavaModelManager.PerProjectInfo;
+import org.eclipse.jdt.internal.core.util.DeduplicationUtil;
 import org.eclipse.jdt.internal.core.util.HashtableOfArrayToObject;
 import org.eclipse.jdt.internal.core.util.Util;
 
@@ -366,12 +367,11 @@ public class JarPackageFragmentRoot extends PackageFragmentRoot {
 			if (existing != null) break;
 			existingLength--;
 		}
-		JavaModelManager manager = JavaModelManager.getJavaModelManager();
 		for (int i = existingLength; i < length; i++) {
 			// sourceLevel must be null because we know nothing about it based on a jar file
 			if (Util.isValidFolderNameForPackage(pkgName[i], null, compliance)) {
 				System.arraycopy(existing, 0, existing = new String[i+1], 0, i);
-				existing[i] = manager.intern(pkgName[i]);
+				existing[i] = DeduplicationUtil.intern(pkgName[i]);
 				rawPackageInfo.put(existing, new ArrayList[] { EMPTY_LIST, EMPTY_LIST });
 			} else {
 				// non-Java resource folder

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaElement.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaElement.java
@@ -130,7 +130,7 @@ public abstract class JavaElement extends PlatformObject implements IJavaElement
 	/** cached result */
 	private int hashCode;
 
-	protected static final String[] NO_STRINGS = new String[0];
+	public static final String[] NO_STRINGS = new String[0];
 	protected static final JavaElement[] NO_ELEMENTS = new JavaElement[0];
 	protected static final Object NO_INFO = new Object();
 

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelManager.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelManager.java
@@ -3488,14 +3488,6 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 		((IEclipsePreferences) this.preferencesLookup[PREF_DEFAULT].parent()).addNodeChangeListener(this.defaultNodeListener);
 	}
 
-	public char[] intern(char[] array) {
-		return DeduplicationUtil.intern(array);
-	}
-
-	public String intern(String s) {
-		return DeduplicationUtil.intern(s);
-	}
-
 	void touchProjectsAsync(final IProject[] projectsToTouch) throws JavaModelException {
 		for (IProject iProject : projectsToTouch) {
 			this.touchQueue.add(iProject);
@@ -5166,10 +5158,10 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 		IRestrictedAccessTypeRequestor nameRequestor = new IRestrictedAccessTypeRequestor() {
 			@Override
 			public void acceptType(int modifiers, char[] packageName, char[] simpleTypeName, char[][] enclosingTypeNames, String path, AccessRestriction access) {
-				String key = packageName==null ? "" : new String(packageName); //$NON-NLS-1$
+				String key = packageName==null ? "" : DeduplicationUtil.toString(packageName); //$NON-NLS-1$
 				Map<String, String> types = secondaryTypesSearch.get(key);
 				if (types == null) types = new HashMap<>(3);
-				types.put(new String(simpleTypeName), path);
+				types.put(DeduplicationUtil.toString(simpleTypeName), path);
 				secondaryTypesSearch.put(key, types);
 			}
 		};

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/LambdaExpression.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/LambdaExpression.java
@@ -31,6 +31,7 @@ import org.eclipse.jdt.internal.compiler.lookup.Scope;
 import org.eclipse.jdt.internal.compiler.lookup.Substitution;
 import org.eclipse.jdt.internal.compiler.lookup.TypeBinding;
 import org.eclipse.jdt.internal.compiler.lookup.TypeVariableBinding;
+import org.eclipse.jdt.internal.core.util.DeduplicationUtil;
 import org.eclipse.jdt.internal.core.util.MementoTokenizer;
 import org.eclipse.jdt.internal.core.util.Util;
 
@@ -54,7 +55,7 @@ public class LambdaExpression extends SourceType {
 		this.arrowPosition = lambdaExpression.arrowPosition;
 
 		TypeBinding supertype = findLambdaSuperType(lambdaExpression);
-		this.interphase = new String(CharOperation.replaceOnCopy(supertype.genericTypeSignature(), '/', '.'));
+		this.interphase = DeduplicationUtil.toString(CharOperation.replaceOnCopy(supertype.genericTypeSignature(), '/', '.'));
 		this.elementInfo = makeTypeElementInfo(this, this.interphase, this.sourceStart, this.sourceEnd, this.arrowPosition);
 		this.lambdaMethod = LambdaFactory.createLambdaMethod(this, lambdaExpression);
 		this.elementInfo.children = new IJavaElement[] { this.lambdaMethod };
@@ -134,8 +135,7 @@ public class LambdaExpression extends SourceType {
 		elementInfo.setSuperclassName(null);
 		elementInfo.addCategories(handle, null);
 
-		JavaModelManager manager = JavaModelManager.getJavaModelManager();
-		char[][] superinterfaces = new char [][] { manager.intern(Signature.toString(interphase).toCharArray()) }; // drops marker interfaces - to fix.
+		char[][] superinterfaces = new char [][] { DeduplicationUtil.intern(Signature.toString(interphase).toCharArray()) }; // drops marker interfaces - to fix.
 		elementInfo.setSuperInterfaceNames(superinterfaces);
 		return elementInfo;
 	}
@@ -257,7 +257,7 @@ public class LambdaExpression extends SourceType {
 
 	@Override
 	public ResolvedLambdaExpression resolved(Binding binding) {
-		return new ResolvedLambdaExpression(this.getParent(), this, new String(binding.computeUniqueKey()));
+		return new ResolvedLambdaExpression(this.getParent(), this, DeduplicationUtil.toString(binding.computeUniqueKey()));
 	}
 
 	public IMethod getMethod() {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/LambdaMethod.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/LambdaMethod.java
@@ -19,6 +19,7 @@ import org.eclipse.jdt.core.ILocalVariable;
 import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.Signature;
+import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.internal.compiler.lookup.Binding;
 import org.eclipse.jdt.internal.core.util.Util;
 
@@ -33,7 +34,8 @@ public class LambdaMethod extends SourceMethod {
 	LambdaMethod(JavaElement parent, String name, String key, int sourceStart, String [] parameterTypes, String [] parameterNames, String returnType, SourceMethodElementInfo elementInfo) {
 		super(parent, name, parameterTypes);
 		this.sourceStart = sourceStart;
-		this.parameterNameStrings = parameterNames;
+		this.parameterNameStrings = (parameterNames == null || parameterNames.length == 0) ? CharOperation.NO_STRINGS
+				: parameterNames;
 		this.returnTypeString = returnType;
 		this.elementInfo = elementInfo;
 		this.key = key;

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/NameLookup.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/NameLookup.java
@@ -48,6 +48,7 @@ import org.eclipse.jdt.internal.compiler.parser.ScannerHelper;
 import org.eclipse.jdt.internal.compiler.util.HashtableOfObjectToInt;
 import org.eclipse.jdt.internal.compiler.util.SuffixConstants;
 import org.eclipse.jdt.internal.core.AbstractModule.AutoModule;
+import org.eclipse.jdt.internal.core.util.DeduplicationUtil;
 import org.eclipse.jdt.internal.core.util.HashtableOfArrayToObject;
 import org.eclipse.jdt.internal.core.util.Messages;
 import org.eclipse.jdt.internal.core.util.Util;
@@ -1096,7 +1097,7 @@ public class NameLookup implements SuffixConstants {
 		while (dot != -1) {
 			int start = dot+1;
 			dot = name.indexOf('.', start);
-			String typeName = name.substring(start, dot == -1 ? name.length() : dot);
+			String typeName = DeduplicationUtil.intern(name.substring(start, dot == -1 ? name.length() : dot));
 			type = type.getType(typeName);
 		}
 		return type;
@@ -1446,7 +1447,7 @@ public class NameLookup implements SuffixConstants {
 			// look in model
 			switch (packageFlavor) {
 				case IPackageFragmentRoot.K_BINARY :
-					matchName= matchName.replace('.', '$');
+					matchName= DeduplicationUtil.intern(matchName.replace('.', '$'));
 					seekTypesInBinaryPackage(matchName, pkg, partialMatch, acceptFlags, requestor);
 					break;
 				case IPackageFragmentRoot.K_SOURCE :
@@ -1471,6 +1472,7 @@ public class NameLookup implements SuffixConstants {
 	 * Performs type search in a binary package.
 	 */
 	protected void seekTypesInBinaryPackage(String name, IPackageFragment pkg, boolean partialMatch, int acceptFlags, IJavaElementRequestor requestor) {
+		name= DeduplicationUtil.intern(name);
 		long start = -1;
 		if (VERBOSE)
 			start = System.currentTimeMillis();
@@ -1537,7 +1539,8 @@ public class NameLookup implements SuffixConstants {
 			String topLevelTypeName,
 			int acceptFlags,
 			IJavaElementRequestor requestor) {
-
+		name= DeduplicationUtil.intern(name);
+		topLevelTypeName= DeduplicationUtil.intern(topLevelTypeName);
 		long start = -1;
 		if (VERBOSE)
 			start = System.currentTimeMillis();

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/PackageFragment.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/PackageFragment.java
@@ -45,6 +45,7 @@ import org.eclipse.jdt.core.WorkingCopyOwner;
 import org.eclipse.jdt.internal.compiler.lookup.TypeConstants;
 import org.eclipse.jdt.internal.compiler.util.SuffixConstants;
 import org.eclipse.jdt.internal.core.JavaModelManager.PerProjectInfo;
+import org.eclipse.jdt.internal.core.util.DeduplicationUtil;
 import org.eclipse.jdt.internal.core.util.MementoTokenizer;
 import org.eclipse.jdt.internal.core.util.Messages;
 import org.eclipse.jdt.internal.core.util.Util;
@@ -97,7 +98,7 @@ protected boolean buildStructure(OpenableElementInfo info, IProgressMonitor pm, 
 						&& !Util.isExcluded(child, inclusionPatterns, exclusionPatterns)) {
 					IJavaElement childElement;
 					if (kind == IPackageFragmentRoot.K_SOURCE && Util.isValidCompilationUnitName(child.getName(), sourceLevel, complianceLevel)) {
-						childElement = new CompilationUnit(this, child.getName(), DefaultWorkingCopyOwner.PRIMARY);
+						childElement = new CompilationUnit(this, DeduplicationUtil.intern(child.getName()), DefaultWorkingCopyOwner.PRIMARY);
 						vChildren.add(childElement);
 					} else if (kind == IPackageFragmentRoot.K_BINARY && Util.isValidClassFileName(child.getName(), sourceLevel, complianceLevel)) {
 						childElement = getClassFile(child.getName());
@@ -218,7 +219,7 @@ public IOrdinaryClassFile getOrdinaryClassFile(String classFileName) {
 	int length = classFileName.length() - 6;
 	char[] nameWithoutExtension = new char[length];
 	classFileName.getChars(0, length, nameWithoutExtension, 0);
-	return new ClassFile(this, new String(nameWithoutExtension));
+	return new ClassFile(this, DeduplicationUtil.toString(nameWithoutExtension));
 }
 /**
  * @see IPackageFragment#getClassFile(String)

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/PackageFragmentRoot.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/PackageFragmentRoot.java
@@ -26,6 +26,7 @@ import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 import org.eclipse.jdt.internal.compiler.env.AutomaticModuleNaming;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jdt.internal.compiler.lookup.TypeConstants;
+import org.eclipse.jdt.internal.core.util.DeduplicationUtil;
 import org.eclipse.jdt.internal.core.util.MementoTokenizer;
 import org.eclipse.jdt.internal.core.util.Messages;
 import org.eclipse.jdt.internal.core.util.Util;
@@ -251,7 +252,6 @@ protected void computeFolderChildren(IContainer folder, boolean isIncluded, Stri
 			String sourceLevel = otherJavaProject.getOption(JavaCore.COMPILER_SOURCE, true);
 			String complianceLevel = otherJavaProject.getOption(JavaCore.COMPILER_COMPLIANCE, true);
 			JavaProject javaProject = getJavaProject();
-			JavaModelManager manager = JavaModelManager.getJavaModelManager();
 			for (int i = 0; i < length; i++) {
 				IResource member = members[i];
 				String memberName = member.getName();
@@ -264,7 +264,7 @@ protected void computeFolderChildren(IContainer folder, boolean isIncluded, Stri
 			    		if (Util.isValidFolderNameForPackage(memberName, sourceLevel, complianceLevel)) {
 			    			// eliminate binary output only if nested inside direct subfolders
 			    			if (javaProject.contains(member)) {
-			    				String[] newNames = Util.arrayConcat(pkgName, manager.intern(memberName));
+			    				String[] newNames = Util.arrayConcat(pkgName, DeduplicationUtil.intern(memberName));
 			    				boolean isMemberIncluded = !Util.isExcluded(member, inclusionPatterns, exclusionPatterns);
 			    				computeFolderChildren((IFolder) member, isMemberIncluded, newNames, vChildren, inclusionPatterns, exclusionPatterns);
 			    			}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SearchableEnvironment.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SearchableEnvironment.java
@@ -59,6 +59,7 @@ import org.eclipse.jdt.internal.core.search.IRestrictedAccessConstructorRequesto
 import org.eclipse.jdt.internal.core.search.IRestrictedAccessTypeRequestor;
 import org.eclipse.jdt.internal.core.search.indexing.IndexManager;
 import org.eclipse.jdt.internal.core.search.processing.IJob;
+import org.eclipse.jdt.internal.core.util.DeduplicationUtil;
 import org.eclipse.jdt.internal.core.util.Util;
 
 /**
@@ -526,7 +527,7 @@ private void findPackagesFromRequires(char[] prefix, boolean isMatchAllPrefix, I
 		System.arraycopy(compoundTypeName, 0, packageName, 0, lengthM1);
 
 		return find(
-			new String(compoundTypeName[lengthM1]),
+			DeduplicationUtil.toString(compoundTypeName[lengthM1]),
 			CharOperation.toString(packageName),
 			moduleLocations);
 	}
@@ -541,8 +542,8 @@ private void findPackagesFromRequires(char[] prefix, boolean isMatchAllPrefix, I
 		boolean isNamedStrategy = LookupStrategy.get(moduleName) == LookupStrategy.Named;
 		IPackageFragmentRoot[] moduleLocations = isNamedStrategy ? findModuleContext(moduleName) : null;
 		return find(
-			new String(name),
-			packageName == null || packageName.length == 0 ? null : CharOperation.toString(packageName),
+				DeduplicationUtil.toString(name),
+				packageName == null || packageName.length == 0 ? null : CharOperation.toString(packageName),
 			moduleLocations);
 	}
 

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SelectionRequestor.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SelectionRequestor.java
@@ -53,6 +53,7 @@ import org.eclipse.jdt.internal.compiler.lookup.TypeBinding;
 import org.eclipse.jdt.internal.compiler.lookup.TypeConstants;
 import org.eclipse.jdt.internal.compiler.lookup.TypeVariableBinding;
 import org.eclipse.jdt.internal.core.NameLookup.Answer;
+import org.eclipse.jdt.internal.core.util.DeduplicationUtil;
 import org.eclipse.jdt.internal.core.util.HandleFactory;
 import org.eclipse.jdt.internal.core.util.Util;
 
@@ -444,7 +445,7 @@ public void acceptLocalVariable(LocalVariableBinding binding, org.eclipse.jdt.in
 		}
 		localVar = new LocalVariable(
 				(JavaElement)parent,
-				new String(local.name),
+				DeduplicationUtil.toString(local.name),
 				local.declarationSourceStart,
 				local.declarationSourceEnd,
 				local.sourceStart,

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SourceType.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SourceType.java
@@ -26,6 +26,7 @@ import org.eclipse.jdt.internal.codeassist.CompletionEngine;
 import org.eclipse.jdt.internal.compiler.ast.TypeDeclaration;
 import org.eclipse.jdt.internal.compiler.lookup.Binding;
 import org.eclipse.jdt.internal.core.hierarchy.TypeHierarchy;
+import org.eclipse.jdt.internal.core.util.DeduplicationUtil;
 import org.eclipse.jdt.internal.core.util.MementoTokenizer;
 import org.eclipse.jdt.internal.core.util.Messages;
 
@@ -954,7 +955,8 @@ public ITypeHierarchy newTypeHierarchy(
 }
 @Override
 public JavaElement resolved(Binding binding) {
-	ResolvedSourceType resolvedHandle = new ResolvedSourceType(this.getParent(), this.name, new String(binding.computeUniqueKey()), this.getOccurrenceCount());
+	ResolvedSourceType resolvedHandle = new ResolvedSourceType(this.getParent(), this.name,
+			DeduplicationUtil.toString(binding.computeUniqueKey()), this.getOccurrenceCount());
 	resolvedHandle.localOccurrenceCount = this.localOccurrenceCount;
 	return resolvedHandle;
 }

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/State.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/State.java
@@ -56,6 +56,7 @@ import org.eclipse.jdt.internal.compiler.env.IUpdatableModule.UpdateKind;
 import org.eclipse.jdt.internal.compiler.util.SimpleLookupTable;
 import org.eclipse.jdt.internal.compiler.util.Util;
 import org.eclipse.jdt.internal.core.JavaModelManager;
+import org.eclipse.jdt.internal.core.util.DeduplicationUtil;
 
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class State {
@@ -489,7 +490,7 @@ private static AccessRuleSet readRestriction(CompressedReader in) throws IOExcep
 		int problemId = in.readIntWithHint(PROBLEM_IDS);
 		accessRules[i] = manager.getAccessRuleForProblemId(pattern, problemId);
 	}
-	return new AccessRuleSet(accessRules, in.readByte(), manager.intern(in.readStringUsingDictionary()));
+	return new AccessRuleSet(accessRules, in.readByte(), DeduplicationUtil.intern(in.readStringUsingDictionary()));
 }
 
 void tagAsNoopBuild() {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/hierarchy/HierarchyBuilder.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/hierarchy/HierarchyBuilder.java
@@ -42,6 +42,7 @@ import org.eclipse.jdt.internal.core.ResolvedBinaryType;
 import org.eclipse.jdt.internal.core.SearchableEnvironment;
 import org.eclipse.jdt.internal.core.SourceTypeElementInfo;
 import org.eclipse.jdt.internal.core.nd.java.model.BinaryTypeFactory;
+import org.eclipse.jdt.internal.core.util.DeduplicationUtil;
 import org.eclipse.jdt.internal.core.util.ResourceCompilationUnit;
 import org.eclipse.jdt.internal.core.util.Util;
 
@@ -222,7 +223,8 @@ public abstract class HierarchyBuilder {
 				classFile = (ClassFile) handle.getParent();
 				this.infoToHandle.put(genericType, classFile);
 			}
-			return new ResolvedBinaryType(classFile, classFile.getTypeName(), new String(binding.computeUniqueKey()));
+			return new ResolvedBinaryType(classFile, classFile.getTypeName(),
+					DeduplicationUtil.toString(binding.computeUniqueKey()));
 		} else if (genericType instanceof SourceTypeElementInfo) {
 			IType handle = ((SourceTypeElementInfo) genericType).getHandle();
 			return (IType) ((JavaElement) handle).resolved(binding);

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/hierarchy/HierarchyResolver.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/hierarchy/HierarchyResolver.java
@@ -67,6 +67,7 @@ import org.eclipse.jdt.internal.compiler.problem.ProblemReporter;
 import org.eclipse.jdt.internal.compiler.util.Messages;
 import org.eclipse.jdt.internal.core.*;
 import org.eclipse.jdt.internal.core.util.ASTNodeFinder;
+import org.eclipse.jdt.internal.core.util.DeduplicationUtil;
 import org.eclipse.jdt.internal.core.util.HandleFactory;
 
 @SuppressWarnings({"rawtypes", "unchecked"})
@@ -504,7 +505,7 @@ private void rememberAllTypes(CompilationUnitDeclaration parsedUnit, org.eclipse
 	if (types != null) {
 		for (int i = 0, length = types.length; i < length; i++) {
 			TypeDeclaration type = types[i];
-			rememberWithMemberTypes(type, cu.getType(new String(type.name)));
+			rememberWithMemberTypes(type, cu.getType(DeduplicationUtil.toString(type.name)));
 		}
 	}
 	if (!includeLocalTypes || (parsedUnit.localTypes.isEmpty() && parsedUnit.functionalExpressions == null))
@@ -539,7 +540,7 @@ private void rememberWithMemberTypes(TypeDeclaration typeDecl, IType typeHandle)
 	if (memberTypes != null) {
 		for (int i = 0, length = memberTypes.length; i < length; i++) {
 			TypeDeclaration memberType = memberTypes[i];
-			rememberWithMemberTypes(memberType, typeHandle.getType(new String(memberType.name)));
+			rememberWithMemberTypes(memberType, typeHandle.getType(DeduplicationUtil.toString(memberType.name)));
 		}
 	}
 }

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/DeduplicationUtil.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/DeduplicationUtil.java
@@ -15,6 +15,8 @@
 
 package org.eclipse.jdt.internal.core.util;
 
+import org.eclipse.jdt.internal.core.JavaElement;
+
 /** Utility to provide deduplication by best effort. **/
 public final class DeduplicationUtil {
 	private DeduplicationUtil() {
@@ -37,12 +39,33 @@ public final class DeduplicationUtil {
 		}
 	}
 
+	public static String toString(char[] array) {
+		synchronized (stringSymbols) {
+			return stringSymbols.add(new String(array));
+		}
+	}
+
 	/*
 	 * Used as a replacement for String#intern() that could prevent garbage collection of strings on some VMs.
 	 */
 	public static String intern(String s) {
+		if (s == null) {
+			return null;
+		}
 		synchronized (stringSymbols) {
 			return stringSymbols.add(s);
+		}
+	}
+
+	public static String[] intern(String[] a) {
+		if (a.length == 0) {
+			return JavaElement.NO_STRINGS;
+		}
+		synchronized (stringSymbols) {
+			for (int j = 0; j < a.length; j++) {
+				a[j] = a[j] == null ? null : stringSymbols.add(a[j]);
+			}
+			return a;
 		}
 	}
 }

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/HandleFactory.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/HandleFactory.java
@@ -155,7 +155,7 @@ public class HandleFactory {
 				pkgFragment= this.lastPkgFragmentRoot.getPackageFragment(pkgName);
 				this.packageHandles.put(pkgName, pkgFragment);
 			}
-			String simpleName= simpleNames[length];
+			String simpleName= DeduplicationUtil.intern(simpleNames[length]);
 			if (org.eclipse.jdt.internal.core.util.Util.isJavaLikeFileName(simpleName)) {
 				ICompilationUnit unit= pkgFragment.getCompilationUnit(simpleName);
 				return (Openable) unit;
@@ -209,10 +209,10 @@ public class HandleFactory {
 				IJavaElement parentElement = createElement(scope.parent, elementPosition, unit, existingElements, knownScopes);
 				switch (parentElement.getElementType()) {
 					case IJavaElement.COMPILATION_UNIT :
-						newElement = ((ICompilationUnit)parentElement).getType(new String(scope.enclosingSourceType().sourceName));
+						newElement = ((ICompilationUnit)parentElement).getType(DeduplicationUtil.toString(scope.enclosingSourceType().sourceName));
 						break;
 					case IJavaElement.TYPE :
-						newElement = ((IType)parentElement).getType(new String(scope.enclosingSourceType().sourceName));
+						newElement = ((IType)parentElement).getType(DeduplicationUtil.toString(scope.enclosingSourceType().sourceName));
 						break;
 					case IJavaElement.FIELD :
 					case IJavaElement.INITIALIZER :
@@ -221,7 +221,7 @@ public class HandleFactory {
 					    if (member.isBinary()) {
 					        return null;
 					    } else {
-							String name = new String(scope.enclosingSourceType().sourceName);
+							String name = DeduplicationUtil.toString(scope.enclosingSourceType().sourceName);
 							int occurrenceCount = 0;
 							do {
 								newElement = member.getType(name, ++occurrenceCount);
@@ -259,7 +259,7 @@ public class HandleFactory {
 							switch (field.getKind()) {
 								case AbstractVariableDeclaration.FIELD :
 								case AbstractVariableDeclaration.ENUM_CONSTANT :
-									newElement = parentType.getField(new String(field.name));
+									newElement = parentType.getField(DeduplicationUtil.toString(field.name));
 									break;
 								case AbstractVariableDeclaration.INITIALIZER :
 									newElement = parentType.getInitializer(occurenceCount);
@@ -273,7 +273,7 @@ public class HandleFactory {
 				} else {
 					// method element
 					AbstractMethodDeclaration method = methodScope.referenceMethod();
-					newElement = parentType.getMethod(new String(method.selector), Util.typeParameterSignatures(method));
+					newElement = parentType.getMethod(DeduplicationUtil.toString(method.selector), Util.typeParameterSignatures(method));
 					if (newElement != null) {
 						knownScopes.put(scope, newElement);
 					}

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/ClassFileMatchLocator.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/ClassFileMatchLocator.java
@@ -23,6 +23,7 @@ import org.eclipse.jdt.internal.compiler.lookup.*;
 import org.eclipse.jdt.internal.core.BinaryType;
 import org.eclipse.jdt.internal.core.*;
 import org.eclipse.jdt.internal.core.search.indexing.IIndexConstants;
+import org.eclipse.jdt.internal.core.util.DeduplicationUtil;
 
 public class ClassFileMatchLocator implements IIndexConstants {
 
@@ -351,13 +352,14 @@ public void locateMatches(MatchLocator locator, ClassFile classFile, IBinaryType
 			} else {
 				name = method.getSelector();
 			}
-			String selector = new String(name);
+			String selector = DeduplicationUtil.toString(name);
 			char[] methodSignature = binaryMethodSignatures == null ? null : binaryMethodSignatures[i];
 			if (methodSignature == null) {
 				methodSignature = method.getGenericSignature();
 				if (methodSignature == null) methodSignature = method.getMethodDescriptor();
 			}
-			String[] parameterTypes = CharOperation.toStrings(Signature.getParameterTypes(convertClassFileFormat(methodSignature)));
+			String[] parameterTypes =  DeduplicationUtil.intern(CharOperation.toStrings(Signature.getParameterTypes(convertClassFileFormat(methodSignature))));
+
 			IMethod methodHandle = binaryType.getMethod(selector, parameterTypes);
 			methodHandle = new ResolvedBinaryMethod(binaryType, selector, parameterTypes, methodHandle.getKey());
 			locator.reportBinaryMemberDeclaration(null, methodHandle, null, info, accuracy);

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/MatchLocator.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/MatchLocator.java
@@ -99,6 +99,7 @@ import org.eclipse.jdt.internal.core.search.*;
 import org.eclipse.jdt.internal.core.search.indexing.QualifierQuery;
 import org.eclipse.jdt.internal.core.search.processing.JobManager;
 import org.eclipse.jdt.internal.core.util.ASTNodeFinder;
+import org.eclipse.jdt.internal.core.util.DeduplicationUtil;
 import org.eclipse.jdt.internal.core.util.HandleFactory;
 import org.eclipse.jdt.internal.core.util.Util;
 
@@ -583,7 +584,7 @@ protected IJavaElement createHandle(AbstractMethodDeclaration method, IJavaEleme
 		}
 	}
 
-	return createMethodHandle(type, new String(method.selector), parameterTypeSignatures);
+	return createMethodHandle(type, DeduplicationUtil.toString(method.selector), parameterTypeSignatures);
 }
 /*
  * Create binary method handle
@@ -610,7 +611,7 @@ IMethod createBinaryMethodHandle(IType type, char[] methodSelector, char[][] arg
 							parameterTypes[j] = parameterTypeName;
 						}
 					}
-					return (IMethod) createMethodHandle(type, new String(selector), CharOperation.toStrings(parameterTypes));
+					return (IMethod) createMethodHandle(type,DeduplicationUtil.toString(selector), CharOperation.toStrings(parameterTypes));
 				}
 			}
 		}
@@ -641,7 +642,7 @@ protected IJavaElement createHandle(FieldDeclaration fieldDeclaration, TypeDecla
 	switch (fieldDeclaration.getKind()) {
 		case AbstractVariableDeclaration.FIELD :
 		case AbstractVariableDeclaration.ENUM_CONSTANT :
-			return ((IType) parent).getField(new String(fieldDeclaration.name));
+			return ((IType) parent).getField(DeduplicationUtil.toString(fieldDeclaration.name));
 	}
 	if (type.isBinary()) {
 		// do not return initializer for binary types
@@ -677,7 +678,7 @@ protected IJavaElement createHandle(AbstractVariableDeclaration variableDeclarat
 					variableDeclaration.declarationSourceEnd,
 					variableDeclaration.sourceStart,
 					variableDeclaration.sourceEnd,
-					new String(variableDeclaration.type.resolvedType.signature()),
+					DeduplicationUtil.toString(variableDeclaration.type.resolvedType.signature()),
 					variableDeclaration.annotations,
 					variableDeclaration.modifiers,
 					isParameter,
@@ -3147,15 +3148,15 @@ protected void reportMatching(TypeDeclaration type, IJavaElement parent, int acc
 	// create type handle
 	IJavaElement enclosingElement = parent;
 	if (enclosingElement == null) {
-		enclosingElement = createTypeHandle(new String(type.name));
+		enclosingElement = createTypeHandle(DeduplicationUtil.toString(type.name));
 	} else if (enclosingElement instanceof IType) {
-		enclosingElement = ((IType) parent).getType(new String(type.name));
+		enclosingElement = ((IType) parent).getType(DeduplicationUtil.toString(type.name));
 	} else if (enclosingElement instanceof IMember) {
 	    IMember member = (IMember) parent;
 		if (member.isBinary())  {
 			enclosingElement = ((IOrdinaryClassFile)this.currentPossibleMatch.openable).getType();
 		} else {
-			enclosingElement = member.getType(new String(type.name), occurrenceCount);
+			enclosingElement = member.getType(DeduplicationUtil.toString(type.name), occurrenceCount);
 		}
 	}
 	if (enclosingElement == null) return;

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/PossibleMatch.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/PossibleMatch.java
@@ -22,6 +22,7 @@ import org.eclipse.jdt.internal.compiler.env.IBinaryType;
 import org.eclipse.jdt.internal.compiler.env.ICompilationUnit;
 import org.eclipse.jdt.internal.compiler.lookup.TypeConstants;
 import org.eclipse.jdt.internal.core.*;
+import org.eclipse.jdt.internal.core.util.DeduplicationUtil;
 import org.eclipse.jdt.internal.core.util.Util;
 
 public class PossibleMatch implements ICompilationUnit {
@@ -131,7 +132,7 @@ private char[] getQualifiedName() {
 		// get main type name
 		char[] mainTypeName = Util.getNameWithoutJavaLikeExtension(fileName).toCharArray();
 		CompilationUnit cu = (CompilationUnit) this.openable;
-		return cu.getType(new String(mainTypeName)).getFullyQualifiedName().toCharArray();
+		return cu.getType(DeduplicationUtil.toString(mainTypeName)).getFullyQualifiedName().toCharArray();
 	} else if (this.openable instanceof ClassFile) {
 		String fileName = getSourceFileName();
 		if (fileName == NO_SOURCE_FILE_NAME)


### PR DESCRIPTION
Reduces memory used by type hierarchy / call hierarchy. Stored for example in ResolvedBinaryType.uniqueKey

https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2054

