### PR TITLE
Fix `Util.getSignature()` for `QualifiedType`

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/UtilTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/UtilTests.java
@@ -20,6 +20,8 @@ import org.eclipse.jdt.core.IJavaModelStatusConstants;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.NameQualifiedType;
+import org.eclipse.jdt.core.dom.QualifiedType;
+import org.eclipse.jdt.core.dom.SimpleType;
 import org.eclipse.jdt.internal.core.JavaModelManager;
 import org.eclipse.jdt.internal.core.JavaModelStatus;
 import org.eclipse.jdt.internal.core.util.Util;
@@ -113,6 +115,12 @@ public class UtilTests extends AbstractJavaModelTests {
 		AST ast = AST.newAST(AST.getJLSLatest(), false);
 		NameQualifiedType type = ast.newNameQualifiedType(ast.newName("qualifier"), ast.newSimpleName("id"));
 		assertEquals("Qqualifier.id;", Util.getSignature(type));
+	}
+	public void testQualifiedTypeTypeSignature() {
+		AST ast = AST.newAST(AST.getJLSLatest(), false);
+		SimpleType parentType = ast.newSimpleType(ast.newName("ParentType"));
+		QualifiedType qualifiedType = ast.newQualifiedType(parentType, ast.newSimpleName("ChildType"));
+		assertEquals("QParentType.ChildType;", Util.getSignature(qualifiedType));
 	}
 
 }

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/Util.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/Util.java
@@ -1304,7 +1304,10 @@ public class Util {
 				buffer.append(((PrimitiveType) type).getPrimitiveTypeCode().toString());
 				break;
 			case ASTNode.QUALIFIED_TYPE:
-				buffer.append(((QualifiedType) type).getName().getFullyQualifiedName());
+				QualifiedType qualifiedType = (QualifiedType)type;
+				getFullyQualifiedName(qualifiedType.getQualifier(), buffer);
+				buffer.append("."); //$NON-NLS-1$
+				buffer.append(qualifiedType.getName().getFullyQualifiedName());
 				break;
 			case ASTNode.SIMPLE_TYPE:
 				buffer.append(((SimpleType) type).getName().getFullyQualifiedName());
@@ -1323,7 +1326,7 @@ public class Util {
 				break;
 			case ASTNode.NAME_QUALIFIED_TYPE:
 				NameQualifiedType nameQualifiedType = (NameQualifiedType)type;
-				buffer.append(nameQualifiedType.getQualifier().toString() + '.' + nameQualifiedType.getName().toString()); 
+				buffer.append(nameQualifiedType.getQualifier().toString() + '.' + nameQualifiedType.getName().toString());
 				break;
 		}
 	}


### PR DESCRIPTION
Fixes #2074

Signed-off-by: David Thompson <davthomp@redhat.com>

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does

When using `Util.getSignature()` to get the type signature for a qualified type,
eg.
```java
public class X {
    public static void myFunc(A.B value) { // <-- get the type signature of A.B here
        System.out.println(value.myString);
    }
}
class A {
    static class B {
        public final String myString = "Hello, World!";
    }
}
```

The type signature now includes the qualifying type,
eg, the result is now `QA.B;` instead of `QB;`.

## How to test


## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
