### PR TITLE
Collect artifact comparison delta

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,12 +39,13 @@ pipeline {
 						-Dtycho.surefire.argLine="--add-modules ALL-SYSTEM -Dcompliance=1.8,11,17,20,21 -Djdt.performance.asserts=disabled" \
 						-DDetectVMInstallationsJob.disabled=true \
 						-Dtycho.apitools.debug \
+						-Dtycho.debug.artifactcomparator \
 						-Dcbi-ecj-version=99.99
 					"""
 			}
 			post {
 				always {
-					archiveArtifacts artifacts: '*.log,*/target/work/data/.metadata/*.log,*/tests/target/work/data/.metadata/*.log,apiAnalyzer-workspace/.metadata/*.log,repository/target/repository/**', allowEmptyArchive: true
+					archiveArtifacts artifacts: '*.log,*/target/work/data/.metadata/*.log,*/tests/target/work/data/.metadata/*.log,apiAnalyzer-workspace/.metadata/*.log,repository/target/repository/**,**/target/artifactcomparison/**', allowEmptyArchive: true
 					// The following lines use the newest build on master that did not fail a reference
 					// To not fail master build on failed test maven needs to be started with "-Dmaven.test.failure.ignore=true" it will then only marked unstable.
 					// To not fail the build also "unstable: true" is used to only mark the build unstable instead of failing when qualityGates are missed


### PR DESCRIPTION
This enables Tycho do produce comporator logs like in aggregators builds and make them available as downloads from the jenkins

This will only show up *after* a merge, if one likes to test this a committer needs to go to the job, copy the contents of my change Jenkins file and choose "Replay" then paste the change Jenkinsfile there.

FYI @iloveeclipse @srikanth-sankaran 