### PR TITLE
Ensure pattern bindings and secret variables get reaped no later than they should be

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/grammar/java.g
+++ b/org.eclipse.jdt.core.compiler.batch/grammar/java.g
@@ -1250,9 +1250,9 @@ InstanceofClassic ::= 'instanceof' Modifiersopt Type
 /.$putCase consumeInstanceOfClassic(); $break ./
 /:$readableName InstanceofClassic:/
 
-InstanceofPattern -> 'instanceof' Pattern
+InstanceofPattern ::=  'instanceof' Pattern
+/.$putCase consumeInstanceofPattern(); $break ./
 /:$readableName InstanceofPattern:/
-
 
 Pattern -> TypePattern
 Pattern -> RecordPattern

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
@@ -4592,6 +4592,11 @@ protected void consumeInstanceOfClassic() {
 	consumeTypeReferenceWithModifiersAndAnnotations();
 	pushOnAstLengthStack(0); // signal no pattern
 }
+protected void consumeInstanceofPattern() {
+	// Only if we are not inside a block
+	if (this.realBlockPtr != -1)
+		blockReal();
+}
 protected void consumeInstanceOfExpressionWithName() {
 	// RelationalExpression_NotName ::= Name instanceof ReferenceType
 	//optimize the push/pop
@@ -7211,6 +7216,9 @@ protected void consumeRule(int act) {
 
     case 358 : if (DEBUG) { System.out.println("InstanceofClassic ::= instanceof Modifiersopt Type"); }  //$NON-NLS-1$
 		    consumeInstanceOfClassic(); 			break;
+
+    case 359 : if (DEBUG) { System.out.println("InstanceofPattern ::= instanceof Pattern"); }  //$NON-NLS-1$
+		    consumeInstanceofPattern(); 			break;
 
     case 362 : if (DEBUG) { System.out.println("TypePattern ::= Modifiersopt Type Identifier"); }  //$NON-NLS-1$
 		    consumeTypePattern(); 			break;


### PR DESCRIPTION
## What it does

* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2101

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
