### PR TITLE
[22] VerifyError when String template expression is used as part of condition #2121

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TemplateExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TemplateExpression.java
@@ -80,6 +80,8 @@ public class TemplateExpression extends Expression {
 		codeStream.checkcast(this.invocation.binding.returnType);
 		if (!valueRequired) {
 			codeStream.pop();
+		} else {
+			codeStream.generateImplicitConversion(this.implicitConversion);
 		}
 	}
 	@Override

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/StringTemplateTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/StringTemplateTest.java
@@ -1930,4 +1930,50 @@ s
 				"hello"
 		);
 	}
+	public void testIssue2121_02() {
+		runConformTest(
+				new String[] {
+					"X.java",
+					"""
+						interface TemplateProcessor extends java.lang.StringTemplate.Processor<Boolean, RuntimeException> {
+						    Boolean process(StringTemplate st);
+						}
+
+						public class X {
+						    public static void main(String argv[]) {
+						        TemplateProcessor STR = st -> st.interpolate().equals("abc");
+					   			int  i = 0;
+					   			while ((STR."abc") && i < 1) {
+					   				i++;
+						        	System.out.println("hello");
+						        }
+						    }
+						}
+					"""
+				},
+				"hello"
+		);
+	}
+	public void testIssue2121_03() {
+		runConformTest(
+				new String[] {
+					"X.java",
+					"""
+						interface TemplateProcessor extends java.lang.StringTemplate.Processor<Boolean, RuntimeException> {
+						    Boolean process(StringTemplate st);
+						}
+
+						public class X {
+						    public static void main(String argv[]) {
+						        TemplateProcessor STR = st -> st.interpolate().equals("abc");
+					   			for ( int i = 0; (STR."abc") && i < 1; i++) {
+						        	System.out.println("hello");
+						        }
+						    }
+						}
+					"""
+				},
+				"hello"
+		);
+	}
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/StringTemplateTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/StringTemplateTest.java
@@ -1908,4 +1908,26 @@ s
 				\\{} plus \\{} equals \\{}
 				[10, 20, 30]""");
 	}
+	public void testIssue2121_01() {
+		runConformTest(
+				new String[] {
+					"X.java",
+					"""
+						interface TemplateProcessor extends java.lang.StringTemplate.Processor<Boolean, RuntimeException> {
+						    Boolean process(StringTemplate st);
+						}
+
+						public class X {
+						    public static void main(String argv[]) {
+						        TemplateProcessor STR = st -> st.interpolate().equals("abc");
+						        if (STR."abc") {
+						        	System.out.println("hello");
+						        }
+						    }
+						}
+					"""
+				},
+				"hello"
+		);
+	}
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
Fixes #2121

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
