### PR TITLE
[Releng] optionally build dedicated p2 repo

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,7 +32,7 @@ pipeline {
 					mvn clean install -f org.eclipse.jdt.core.compiler.batch -DlocalEcjVersion=99.99 -Dmaven.repo.local=$WORKSPACE/.m2/repository -DcompilerBaselineMode=disable -DcompilerBaselineReplace=none
 					
 					mvn -U clean verify --batch-mode --fail-at-end -Dmaven.repo.local=$WORKSPACE/.m2/repository \
-						-Ptest-on-javase-21 -Pbree-libs -Papi-check -Pjavadoc \
+						-Ptest-on-javase-21 -Pbree-libs -Papi-check -Pjavadoc -Pp2-repo \
 						-Dmaven.test.failure.ignore=true \
 						-Dcompare-version-with-baselines.skip=false \
 						-Djava.io.tmpdir=$WORKSPACE/tmp -Dproject.build.sourceEncoding=UTF-8 \
@@ -44,7 +44,7 @@ pipeline {
 			}
 			post {
 				always {
-					archiveArtifacts artifacts: '*.log,*/target/work/data/.metadata/*.log,*/tests/target/work/data/.metadata/*.log,apiAnalyzer-workspace/.metadata/*.log', allowEmptyArchive: true
+					archiveArtifacts artifacts: '*.log,*/target/work/data/.metadata/*.log,*/tests/target/work/data/.metadata/*.log,apiAnalyzer-workspace/.metadata/*.log,repository/target/repository/**', allowEmptyArchive: true
 					// The following lines use the newest build on master that did not fail a reference
 					// To not fail master build on failed test maven needs to be started with "-Dmaven.test.failure.ignore=true" it will then only marked unstable.
 					// To not fail the build also "unstable: true" is used to only mark the build unstable instead of failing when qualityGates are missed

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,12 @@
         </repository>
       </repositories>
     </profile>
+    <profile>
+      <id>p2-repo</id>
+      <modules>
+        <module>repository</module>
+      </modules>
+    </profile>
   </profiles>
 
   <modules>

--- a/repository/category.xml
+++ b/repository/category.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<site>
+	<category-def name="org.eclipse.jdt.core.bundles" label="JDT Core bundles"/>
+	<bundle id="org.eclipse.jdt.annotation" version="0.0.0">
+		<category name="org.eclipse.jdt.core.bundles"/>
+	</bundle>
+	<bundle id="org.eclipse.jdt.apt.core" version="0.0.0">
+		<category name="org.eclipse.jdt.core.bundles"/>
+	</bundle>
+	<bundle id="org.eclipse.jdt.apt.pluggable.core" version="0.0.0">
+		<category name="org.eclipse.jdt.core.bundles"/>
+	</bundle>
+	<bundle id="org.eclipse.jdt.apt.ui" version="0.0.0">
+		<category name="org.eclipse.jdt.core.bundles"/>
+	</bundle>
+	<bundle id="org.eclipse.jdt.core" version="0.0.0">
+		<category name="org.eclipse.jdt.core.bundles"/>
+	</bundle>
+	<bundle id="org.eclipse.jdt.core.compiler.batch" version="0.0.0">
+		<category name="org.eclipse.jdt.core.bundles"/>
+	</bundle>
+	<bundle id="org.eclipse.jdt.core.formatterapp" version="0.0.0">
+		<category name="org.eclipse.jdt.core.bundles"/>
+	</bundle>
+</site>


### PR DESCRIPTION
with JDT Core content, to facilitate testing with downstream consumers.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2138

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does

Allows to create a p2 repo with the newly built artfact, when using the `-Pp2-repo` flag in Maven build.

## How to test

Build with `mvn clean verify -DskipTests` to verify it doesn't take more time than it already does without this change. Then build  `mvn clean verify -DskipTests -Pp2-repo` and try to load the output of `repository/target/repository` in the Eclipse IDE software installation dialog.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
