### PR TITLE
Avoid ClasspathChange during readOnly Operation #1249

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/DeltaProcessor.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/DeltaProcessor.java
@@ -2022,7 +2022,9 @@ public class DeltaProcessor {
 	 * Registers the given delta with this delta processor.
 	 */
 	public void registerJavaModelDelta(IJavaElementDelta delta) {
-		JavaModelManager.assertModelModifiable();
+		if (JavaModelManager.isReadOnly()) {
+			throw new IllegalStateException("Its not allow to modify JavaModel during ReadOnly action. delta=" + delta); //$NON-NLS-1$
+		}
 		this.javaModelDeltas.add(delta);
 	}
 	/*

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelManager.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelManager.java
@@ -5735,8 +5735,12 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 
 	private static ThreadLocal<Boolean> readOnly = ThreadLocal.withInitial(() -> Boolean.FALSE);
 
+	public static boolean isReadOnly() {
+		return readOnly.get().booleanValue();
+	}
+
 	public static void assertModelModifiable() {
-		if (readOnly.get().booleanValue()) {
+		if (isReadOnly()) {
 			throw new IllegalStateException("Its not allow to modify JavaModel during ReadOnly action."); //$NON-NLS-1$
 		}
 	}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SetContainerOperation.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SetContainerOperation.java
@@ -36,7 +36,8 @@ public class SetContainerOperation extends ChangeClasspathOperation {
 	 * Creates a new SetContainerOperation.
 	 */
 	public SetContainerOperation(IPath containerPath, IJavaProject[] affectedProjects, IClasspathContainer[] respectiveContainers) {
-		super(new IJavaElement[] {JavaModelManager.getJavaModelManager().getJavaModel()}, !ResourcesPlugin.getWorkspace().isTreeLocked());
+		super(new IJavaElement[] { JavaModelManager.getJavaModelManager().getJavaModel() },
+				!(ResourcesPlugin.getWorkspace().isTreeLocked() || JavaModelManager.isReadOnly()));
 		this.containerPath = containerPath;
 		this.affectedProjects = affectedProjects;
 		this.respectiveContainers = respectiveContainers;


### PR DESCRIPTION
And enhance Error Message with conflicting delta

https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1249
