### PR TITLE
Fix Util.getSignature for union/intersection

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/UtilTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/UtilTests.java
@@ -19,9 +19,11 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.jdt.core.IJavaModelStatusConstants;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.IntersectionType;
 import org.eclipse.jdt.core.dom.NameQualifiedType;
 import org.eclipse.jdt.core.dom.QualifiedType;
 import org.eclipse.jdt.core.dom.SimpleType;
+import org.eclipse.jdt.core.dom.UnionType;
 import org.eclipse.jdt.internal.core.JavaModelManager;
 import org.eclipse.jdt.internal.core.JavaModelStatus;
 import org.eclipse.jdt.internal.core.util.Util;
@@ -121,6 +123,20 @@ public class UtilTests extends AbstractJavaModelTests {
 		SimpleType parentType = ast.newSimpleType(ast.newName("ParentType"));
 		QualifiedType qualifiedType = ast.newQualifiedType(parentType, ast.newSimpleName("ChildType"));
 		assertEquals("QParentType.ChildType;", Util.getSignature(qualifiedType));
+	}
+	public void testIntersectionTypeSignature() {
+		AST ast = AST.newAST(AST.getJLSLatest(), false);
+		IntersectionType type = ast.newIntersectionType();
+		type.types().add(ast.newSimpleType(ast.newSimpleName("A")));
+		type.types().add(ast.newSimpleType(ast.newSimpleName("B")));
+		assertEquals("|QA;:QB;", Util.getSignature(type));
+	}
+	public void testUnionTypeSignature() {
+		AST ast = AST.newAST(AST.getJLSLatest(), false);
+		UnionType type = ast.newUnionType();
+		type.types().add(ast.newSimpleType(ast.newSimpleName("A")));
+		type.types().add(ast.newSimpleType(ast.newSimpleName("B")));
+		assertEquals("&QA;:QB;", Util.getSignature(type));
 	}
 
 }

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/Util.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/Util.java
@@ -34,12 +34,14 @@ import org.eclipse.jdt.core.*;
 import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ArrayType;
+import org.eclipse.jdt.core.dom.IntersectionType;
 import org.eclipse.jdt.core.dom.NameQualifiedType;
 import org.eclipse.jdt.core.dom.ParameterizedType;
 import org.eclipse.jdt.core.dom.PrimitiveType;
 import org.eclipse.jdt.core.dom.QualifiedType;
 import org.eclipse.jdt.core.dom.SimpleType;
 import org.eclipse.jdt.core.dom.Type;
+import org.eclipse.jdt.core.dom.UnionType;
 import org.eclipse.jdt.core.dom.WildcardType;
 import org.eclipse.jdt.core.util.IClassFileAttribute;
 import org.eclipse.jdt.core.util.IClassFileReader;
@@ -1209,6 +1211,16 @@ public class Util {
 	 * Returns the signature of the given type.
 	 */
 	public static String getSignature(Type type) {
+		if (type instanceof UnionType union) {
+			return Signature.createUnionTypeSignature(((List<Type>)union.types()).stream()
+				.map(Util::getSignature)
+				.toArray(String[]::new));
+		}
+		if (type instanceof IntersectionType intersection) {
+			return Signature.createIntersectionTypeSignature(((List<Type>)intersection.types()).stream()
+				.map(Util::getSignature)
+				.toArray(String[]::new));
+		}
 		StringBuilder buffer = new StringBuilder();
 		getFullyQualifiedName(type, buffer);
 		return Signature.createTypeSignature(buffer.toString(), false/*not resolved in source*/);


### PR DESCRIPTION
Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2153

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does

Fix Util.getSignature for union/intersection

## How to test

Try newly added tests with/without fix: with -> success; without -> IllegalArgumentException

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
