### PR TITLE
ECJ fails to track operand stack size across branch edges

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/core/compiler/IProblem.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/core/compiler/IProblem.java
@@ -505,9 +505,7 @@ void setSourceStart(int sourceStart);
 	/** @since 3.38 */
 	int OperandStackExceeds64KLimit = Internal + 87;
 	/** @since 3.38 */
-	int OperandStackSizeNegative = Internal + 88;
-	/** @since 3.38 */
-	int OperandStackSizeInconsistent = Internal + 89;
+	int OperandStackSizeInappropriate = Internal + 88;
 
 	// variable hiding
 	/** @since 3.0 */

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/core/compiler/IProblem.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/core/compiler/IProblem.java
@@ -504,6 +504,10 @@ void setSourceStart(int sourceStart);
 	int BytecodeExceeds64KLimitForSwitchTable = Internal + 86;
 	/** @since 3.38 */
 	int OperandStackExceeds64KLimit = Internal + 87;
+	/** @since 3.38 */
+	int OperandStackSizeNegative = Internal + 88;
+	/** @since 3.38 */
+	int OperandStackSizeInconsistent = Internal + 89;
 
 	// variable hiding
 	/** @since 3.0 */

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AND_AND_Expression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AND_AND_Expression.java
@@ -171,7 +171,6 @@ public class AND_AND_Expression extends BinaryExpression {
 						codeStream.iconst_0();
 					} else {
 						codeStream.goto_(endLabel = new BranchLabel(codeStream));
-						codeStream.decrStackSize(1);
 						falseLabel.place();
 						codeStream.iconst_0();
 						endLabel.place();

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AbstractMethodDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AbstractMethodDeclaration.java
@@ -388,7 +388,7 @@ public abstract class AbstractMethodDeclaration
 				for (Statement stmt : this.statements) {
 					stmt.generateCode(this.scope, codeStream);
 					if (!this.compilationResult.hasErrors() && codeStream.stackDepth != 0) {
-						throw new AssertionError("Unexpected stack size change after statement"); //$NON-NLS-1$
+						this.scope.problemReporter().operandStackSizeInappropriate(this);
 					}
 				}
 			}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AbstractMethodDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AbstractMethodDeclaration.java
@@ -387,6 +387,9 @@ public abstract class AbstractMethodDeclaration
 			if (this.statements != null) {
 				for (Statement stmt : this.statements) {
 					stmt.generateCode(this.scope, codeStream);
+					if (!this.compilationResult.hasErrors() && codeStream.stackDepth != 0) {
+						throw new AssertionError("Unexpected stack size change after statement"); //$NON-NLS-1$
+					}
 				}
 			}
 			// if a problem got reported during code gen, then trigger problem method creation

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/BinaryExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/BinaryExpression.java
@@ -513,7 +513,6 @@ public void generateCode(BlockScope currentScope, CodeStream codeStream, boolean
 					codeStream.iconst_0();
 				} else {
 					codeStream.goto_(endLabel = new BranchLabel(codeStream));
-					codeStream.decrStackSize(1);
 					falseLabel.place();
 					codeStream.iconst_0();
 					endLabel.place();
@@ -536,7 +535,6 @@ public void generateCode(BlockScope currentScope, CodeStream codeStream, boolean
 					codeStream.iconst_0();
 				} else {
 					codeStream.goto_(endLabel = new BranchLabel(codeStream));
-					codeStream.decrStackSize(1);
 					falseLabel.place();
 					codeStream.iconst_0();
 					endLabel.place();
@@ -559,7 +557,6 @@ public void generateCode(BlockScope currentScope, CodeStream codeStream, boolean
 					codeStream.iconst_0();
 				} else {
 					codeStream.goto_(endLabel = new BranchLabel(codeStream));
-					codeStream.decrStackSize(1);
 					falseLabel.place();
 					codeStream.iconst_0();
 					endLabel.place();
@@ -582,7 +579,6 @@ public void generateCode(BlockScope currentScope, CodeStream codeStream, boolean
 					codeStream.iconst_0();
 				} else {
 					codeStream.goto_(endLabel = new BranchLabel(codeStream));
-					codeStream.decrStackSize(1);
 					falseLabel.place();
 					codeStream.iconst_0();
 					endLabel.place();

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Clinit.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Clinit.java
@@ -209,7 +209,6 @@ public class Clinit extends AbstractMethodDeclaration {
 			codeStream.ifne(falseLabel);
 			codeStream.iconst_1();
 			BranchLabel jumpLabel = new BranchLabel(codeStream);
-			codeStream.decrStackSize(1);
 			codeStream.goto_(jumpLabel);
 			falseLabel.place();
 			codeStream.iconst_0();

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ConditionalExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ConditionalExpression.java
@@ -300,18 +300,6 @@ public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext,
 				int position = codeStream.position;
 				codeStream.goto_(endifLabel);
 				codeStream.recordPositionsFrom(position, this.valueIfTrue.sourceEnd);
-				// Tune codestream stack size
-				if (valueRequired) {
-					switch(this.resolvedType.id) {
-						case TypeIds.T_long :
-						case TypeIds.T_double :
-							codeStream.decrStackSize(2);
-							break;
-						default :
-							codeStream.decrStackSize(1);
-							break;
-					}
-				}
 			}
 		}
 		if (needFalsePart) {
@@ -325,9 +313,6 @@ public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext,
 				falseLabel.place();
 			}
 			this.valueIfFalse.generateCode(currentScope, codeStream, valueRequired);
-			if (valueRequired) {
-				codeStream.recordExpressionType(this.resolvedType);
-			}
 			if (needTruePart) {
 				// End of if statement
 				endifLabel.place();

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ConstructorDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ConstructorDeclaration.java
@@ -451,6 +451,9 @@ private void internalGenerateCode(ClassScope classScope, ClassFile classFile) {
 		if (this.statements != null) {
 			for (Statement statement : this.statements) {
 				statement.generateCode(this.scope, codeStream);
+				if (!this.compilationResult.hasErrors() && codeStream.stackDepth != 0) {
+					throw new AssertionError("Unexpected stack size change after statement"); //$NON-NLS-1$
+				}
 			}
 		}
 		// if a problem got reported during code gen, then trigger problem method creation

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ConstructorDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ConstructorDeclaration.java
@@ -452,7 +452,7 @@ private void internalGenerateCode(ClassScope classScope, ClassFile classFile) {
 			for (Statement statement : this.statements) {
 				statement.generateCode(this.scope, codeStream);
 				if (!this.compilationResult.hasErrors() && codeStream.stackDepth != 0) {
-					throw new AssertionError("Unexpected stack size change after statement"); //$NON-NLS-1$
+					this.scope.problemReporter().operandStackSizeInappropriate(this);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/EqualExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/EqualExpression.java
@@ -366,7 +366,6 @@ public class EqualExpression extends BinaryExpression {
 					} else {
 						BranchLabel endLabel = new BranchLabel(codeStream);
 						codeStream.goto_(endLabel);
-						codeStream.decrStackSize(1);
 						// comparison is FALSE
 						falseLabel.place();
 						codeStream.iconst_1();
@@ -408,7 +407,6 @@ public class EqualExpression extends BinaryExpression {
 					} else {
 						BranchLabel endLabel = new BranchLabel(codeStream);
 						codeStream.goto_(endLabel);
-						codeStream.decrStackSize(1);
 						// comparison is FALSE
 						falseLabel.place();
 						codeStream.iconst_1();
@@ -446,7 +444,6 @@ public class EqualExpression extends BinaryExpression {
 				} else {
 					BranchLabel endLabel = new BranchLabel(codeStream);
 					codeStream.goto_(endLabel);
-					codeStream.decrStackSize(1);
 					// comparison is FALSE
 					falseLabel.place();
 					codeStream.iconst_0();
@@ -526,7 +523,6 @@ public class EqualExpression extends BinaryExpression {
 					} else {
 						BranchLabel endLabel = new BranchLabel(codeStream);
 						codeStream.goto_(endLabel);
-						codeStream.decrStackSize(1);
 						// comparison is FALSE
 						falseLabel.place();
 						codeStream.iconst_0();
@@ -556,7 +552,6 @@ public class EqualExpression extends BinaryExpression {
 					} else {
 						BranchLabel endLabel = new BranchLabel(codeStream);
 						codeStream.goto_(endLabel);
-						codeStream.decrStackSize(1);
 						// comparison is FALSE
 						falseLabel.place();
 						codeStream.iconst_0();
@@ -599,7 +594,6 @@ public class EqualExpression extends BinaryExpression {
 					} else {
 						BranchLabel endLabel = new BranchLabel(codeStream);
 						codeStream.goto_(endLabel);
-						codeStream.decrStackSize(1);
 						// comparison is FALSE
 						falseLabel.place();
 						codeStream.iconst_0();
@@ -629,7 +623,6 @@ public class EqualExpression extends BinaryExpression {
 				} else {
 					BranchLabel endLabel = new BranchLabel(codeStream);
 					codeStream.goto_(endLabel);
-					codeStream.decrStackSize(1);
 					// comparison is FALSE
 					falseLabel.place();
 					codeStream.iconst_0();
@@ -696,7 +689,6 @@ public class EqualExpression extends BinaryExpression {
 			} else {
 				BranchLabel endLabel = new BranchLabel(codeStream);
 				codeStream.goto_(endLabel);
-				codeStream.decrStackSize(1);
 				// comparison is FALSE
 				falseLabel.place();
 				codeStream.iconst_0();

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Expression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Expression.java
@@ -901,8 +901,6 @@ private void addArgumentToRecipe(BlockScope blockScope, CodeStream codeStream, S
 		recipe.delete(0, recipe.length());
 		recipe.append(TypeConstants.STRING_CONCAT_MARKER_1);
 		args.add(blockScope.getJavaLangString());
-		// We popped 190 and adding 1 for the invokeDynamic
-		codeStream.stackDepth -= 189;
 	}
 }
 public void buildStringForConcatation(BlockScope blockScope, CodeStream codeStream, int typeID, StringBuilder recipe, List<TypeBinding> argTypes) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/OR_OR_Expression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/OR_OR_Expression.java
@@ -179,7 +179,6 @@ public class OR_OR_Expression extends BinaryExpression {
 						codeStream.iconst_1();
 					} else {
 						codeStream.goto_(endLabel = new BranchLabel(codeStream));
-						codeStream.decrStackSize(1);
 						trueLabel.place();
 						codeStream.iconst_1();
 						endLabel.place();

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/StringTemplate.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/StringTemplate.java
@@ -62,27 +62,24 @@ public class StringTemplate extends Expression {
 
 	private void generateNewTemplateBootstrap(CodeStream codeStream) {
 		int index = codeStream.classFile.recordBootstrapMethod(this);
-		// Kludge, see if this can be moved to CodeStream
-		codeStream.stackDepth ++;
-		if (codeStream.stackDepth > codeStream.stackMax) {
-			codeStream.stackMax = codeStream.stackDepth;
-		}
 		StringBuilder signature = new StringBuilder("("); //$NON-NLS-1$
+		int argsSize = 0;
 		for (Expression exp : this.values) {
 			TypeBinding type = exp.resolvedType;
 			if (type == TypeBinding.NULL)
 				signature.append(ConstantPool.JavaLangObjectSignature);
 			else
 				signature.append(type.signature());
+			argsSize += TypeIds.getCategory(type.id);
 		}
 		signature.append(")Ljava/lang/StringTemplate;"); //$NON-NLS-1$
 		codeStream.invokeDynamic(index,
-				1, //
-				1, // int
+				argsSize, //
+				1, // Ljava/lang/StringTemplate;
 				ConstantPool.PROCESS,
 				signature.toString().toCharArray(),
 				TypeIds.T_int,
-				TypeBinding.INT);
+				TypeBinding.INT); // Todo: copy + paste error. INT is not the type here.
 	}
 	@Override
 	public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext, FlowInfo flowInfo) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
@@ -716,13 +716,6 @@ public class SwitchStatement extends Expression {
 				defaultCaseLabel.place();
 				defaultBranchLabel.place();
 			}
-			if (this.expectedType() != null) {
-				TypeBinding expectedType = this.expectedType().erasure();
-				boolean optimizedGoto = codeStream.lastAbruptCompletion == -1;
-				// if the last bytecode was an optimized goto (value is already on the stack) or an enum switch without default case, then we need to adjust the
-				// stack depth to reflect the fact that there is an value on the stack (return type of the switch expression)
-				codeStream.recordExpressionType(expectedType, optimizedGoto ? 0 : 1, optimizedGoto);
-			}
 			codeStream.recordPositionsFrom(pc, this.sourceStart);
 		} finally {
 			if (this.scope != null) this.scope.enclosingCase = null; // no longer inside switch case block
@@ -935,16 +928,6 @@ public class SwitchStatement extends Expression {
 				// we want to force an line number entry to get an end position after the switch statement
 				codeStream.recordPositionsFrom(codeStream.position, this.sourceEnd, true);
 				defaultLabel.place();
-			}
-			if (this instanceof SwitchExpression) {
-				TypeBinding switchResolveType = this.resolvedType;
-				if (this.expectedType() != null) {
-					switchResolveType = this.expectedType().erasure();
-				}
-				boolean optimizedGoto = codeStream.lastAbruptCompletion == -1;
-				// if the last bytecode was an optimized goto (value is already on the stack) or an enum switch without default case, then we need to adjust the
-				// stack depth to reflect the fact that there is an value on the stack (return type of the switch expression)
-				codeStream.recordExpressionType(switchResolveType, optimizedGoto ? 0 : 1, optimizedGoto || (isEnumSwitchWithoutDefaultCase && this instanceof SwitchExpression));
 			}
 			codeStream.recordPositionsFrom(pc, this.sourceStart);
 		} finally {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/UnaryExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/UnaryExpression.java
@@ -110,7 +110,6 @@ public class UnaryExpression extends OperatorExpression {
 							codeStream.iconst_0();
 							if (falseLabel.forwardReferenceCount() > 0) {
 								codeStream.goto_(endifLabel = new BranchLabel(codeStream));
-								codeStream.decrStackSize(1);
 								falseLabel.place();
 								codeStream.iconst_1();
 								endifLabel.place();

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/BranchLabel.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/BranchLabel.java
@@ -26,6 +26,7 @@ public class BranchLabel extends Label {
 
 	// Label tagbits
 	public int tagBits;
+	protected int targetStackDepth = -1;
 	public final static int WIDE = 1;
 	public final static int USED = 2;
 
@@ -116,7 +117,39 @@ public void becomeDelegateFor(BranchLabel otherLabel) {
 	this.forwardReferences = mergedForwardReferences;
 	this.forwardReferenceCount = indexInMerge;
 }
-
+private boolean shouldThrow = true;
+protected void trackStackDepth(boolean branch) {
+	/* Control can reach an instruction with a label in two ways: (1) via a branch using that label or (2) by falling through from the previous instruction.
+	   In both cases, we KNOW the stack depth at the instruction from which control flows to the instruction with the label.
+	   Control cannot reach the instruction with a label by falling through if the previous instruction completes abruptly via a goto/return/throw etc
+	   this.codeStream.lastAbruptCompletion == this.position ==> instruction prior to the one with the label is a goto/return/throw
+	*/
+	boolean sourceDepthKnown = branch || this.codeStream.lastAbruptCompletion != this.position;
+	if (this.targetStackDepth == -1) {
+		// First branch to this label || placement of this label
+		if (sourceDepthKnown) {
+			if (this.codeStream.stackDepth < 0) {
+				this.codeStream.classFile.referenceBinding.scope.problemReporter()
+						.operandStackSizeNegative(this.codeStream.classFile.referenceBinding.scope.referenceContext);
+				this.codeStream.stackDepth = 0; // fwiw
+				if (this.shouldThrow)
+					throw new AssertionError("Operand stack size negative!"); //$NON-NLS-1$
+			}
+			this.targetStackDepth = this.codeStream.stackDepth;
+		} // else: previous instruction completes abruptly via goto/return/throw: We can't use the stack depth there; Wait for a backward branch to be emitted.
+	} else {
+		// Stack depth known at label having encountered a previous branch and/or having fallen through to label
+		if (sourceDepthKnown) {
+			if (this.targetStackDepth != this.codeStream.stackDepth) {
+				this.codeStream.classFile.referenceBinding.scope.problemReporter().operandStackSizeInconsistent(
+						this.codeStream.classFile.referenceBinding.scope.referenceContext);
+				if (this.shouldThrow)
+					throw new AssertionError("Operand stack size inconsistent!"); //$NON-NLS-1$
+			}
+		}
+		this.codeStream.stackDepth = this.targetStackDepth;
+	}
+}
 /*
 * Put down  a reference to the array at the location in the codestream.
 */
@@ -137,6 +170,7 @@ void branch() {
 		 */
 		this.codeStream.writePosition(this);
 	}
+	trackStackDepth(true);
 }
 
 /*
@@ -157,6 +191,7 @@ void branchWide() {
 	} else { //Position is set. Write it!
 		this.codeStream.writeWidePosition(this);
 	}
+	trackStackDepth(true);
 }
 
 public int forwardReferenceCount() {
@@ -239,6 +274,7 @@ public void place() { // Currently lacking wide support.
 			this.codeStream.optimizeBranch(oldPosition, this);
 		}
 	}
+	trackStackDepth(false);
 }
 
 /**

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/BranchLabel.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/BranchLabel.java
@@ -117,7 +117,7 @@ public void becomeDelegateFor(BranchLabel otherLabel) {
 	this.forwardReferences = mergedForwardReferences;
 	this.forwardReferenceCount = indexInMerge;
 }
-private boolean shouldThrow = true;
+
 protected void trackStackDepth(boolean branch) {
 	/* Control can reach an instruction with a label in two ways: (1) via a branch using that label or (2) by falling through from the previous instruction.
 	   In both cases, we KNOW the stack depth at the instruction from which control flows to the instruction with the label.
@@ -130,23 +130,19 @@ protected void trackStackDepth(boolean branch) {
 		if (sourceDepthKnown) {
 			if (this.codeStream.stackDepth < 0) {
 				this.codeStream.classFile.referenceBinding.scope.problemReporter()
-						.operandStackSizeNegative(this.codeStream.classFile.referenceBinding.scope.referenceContext);
-				this.codeStream.stackDepth = 0; // fwiw
-				if (this.shouldThrow)
-					throw new AssertionError("Operand stack size negative!"); //$NON-NLS-1$
+						.operandStackSizeInappropriate(this.codeStream.classFile.referenceBinding.scope.referenceContext);
+				this.codeStream.stackDepth = 0; // FWIW
 			}
 			this.targetStackDepth = this.codeStream.stackDepth;
-		} // else: previous instruction completes abruptly via goto/return/throw: We can't use the stack depth there; Wait for a backward branch to be emitted.
+		} // else: previous instruction completes abruptly via goto/return/throw: Wait for a backward branch to be emitted.
 	} else {
 		// Stack depth known at label having encountered a previous branch and/or having fallen through to label
 		if (sourceDepthKnown) {
 			if (this.targetStackDepth != this.codeStream.stackDepth) {
-				this.codeStream.classFile.referenceBinding.scope.problemReporter().operandStackSizeInconsistent(
+				this.codeStream.classFile.referenceBinding.scope.problemReporter().operandStackSizeInappropriate(
 						this.codeStream.classFile.referenceBinding.scope.referenceContext);
 				if (this.targetStackDepth < this.codeStream.stackDepth)
-					this.targetStackDepth = this.codeStream.stackDepth; // fwiw, pick the higher water mark.
-				if (this.shouldThrow)
-					throw new AssertionError("Operand stack size inconsistent!"); //$NON-NLS-1$
+					this.targetStackDepth = this.codeStream.stackDepth; // FWIW, pick the higher water mark.
 			}
 		}
 		this.codeStream.stackDepth = this.targetStackDepth;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/BranchLabel.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/BranchLabel.java
@@ -143,6 +143,8 @@ protected void trackStackDepth(boolean branch) {
 			if (this.targetStackDepth != this.codeStream.stackDepth) {
 				this.codeStream.classFile.referenceBinding.scope.problemReporter().operandStackSizeInconsistent(
 						this.codeStream.classFile.referenceBinding.scope.referenceContext);
+				if (this.targetStackDepth < this.codeStream.stackDepth)
+					this.targetStackDepth = this.codeStream.stackDepth; // fwiw, pick the higher water mark.
 				if (this.shouldThrow)
 					throw new AssertionError("Operand stack size inconsistent!"); //$NON-NLS-1$
 			}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/CaseLabel.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/CaseLabel.java
@@ -42,6 +42,7 @@ void branch() {
 		 */
 		this.codeStream.writeSignedWord(this.position - this.instructionPosition);
 	}
+	trackStackDepth(true);
 }
 
 /*
@@ -79,6 +80,7 @@ public void place() {
 		// add the label in the codeStream labels collection
 		this.codeStream.addLabel(this);
 	}
+	trackStackDepth(false);
 }
 
 /*

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/CodeStream.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/CodeStream.java
@@ -832,10 +832,6 @@ public void ddiv() {
 	this.bCodeStream[this.classFileOffset++] = Opcodes.OPC_ddiv;
 }
 
-public void decrStackSize(int offset) {
-	this.stackDepth -= offset;
-}
-
 public void dload(int iArg) {
 	this.countLabels = 0;
 	this.stackDepth += 2;
@@ -2604,7 +2600,7 @@ public void invokeDynamicForStringConcat(StringBuilder recipe, List<TypeBinding>
 	signature.append(")Ljava/lang/String;"); //$NON-NLS-1$
 	this.invokeDynamic(invokeDynamicNumber,
 			argsSize,
-			1, // int
+			1, // Ljava/lang/String;
 			ConstantPool.ConcatWithConstants,
 			signature.toString().toCharArray(),
 			TypeIds.T_JavaLangObject,
@@ -2620,10 +2616,6 @@ public void invokeDynamicForStringConcat(StringBuilder recipe, List<TypeBinding>
 public void generateStringConcatenationAppend(BlockScope blockScope, Expression oper1, Expression oper2) {
 	if (this.targetLevel >= ClassFileConstants.JDK9 && blockScope.compilerOptions().useStringConcatFactory) {
 		this.countLabels = 0;
-		this.stackDepth++;
-		if (this.stackDepth > this.stackMax) {
-			this.stackMax = this.stackDepth;
-		}
 		StringBuilder recipe = new StringBuilder();
 		List<TypeBinding> arguments = new ArrayList<>();
 		if (oper1 == null) {
@@ -4793,7 +4785,7 @@ public void invoke(byte opcode, MethodBinding methodBinding, TypeBinding declari
 					SyntheticArgumentBinding[] syntheticArguments = nestedType.syntheticOuterLocalVariables();
 					if (syntheticArguments != null) {
 						for (SyntheticArgumentBinding syntheticArgument : syntheticArguments) {
-							switch (syntheticArgument.id)  {
+							switch (syntheticArgument.type.id)  {
 								case TypeIds.T_double :
 								case TypeIds.T_long :
 									receiverAndArgsSize += 2;
@@ -6956,12 +6948,6 @@ public void record(LocalVariableBinding local) {
 	local.initializationCount = 0;
 }
 
-public void recordExpressionType(TypeBinding typeBinding) {
-	// nothing to do
-}
-public void recordExpressionType(TypeBinding typeBinding, int delta, boolean adjustStackDepth) {
-	// nothing to do
-}
 public void recordPositionsFrom(int startPC, int sourcePos) {
 	this.recordPositionsFrom(startPC, sourcePos, false);
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/ExceptionLabel.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/ExceptionLabel.java
@@ -47,6 +47,7 @@ public void place() {
 	// register the handler inside the codeStream then normal place
 	this.codeStream.registerExceptionHandler(this);
 	this.position = this.codeStream.getPosition();
+	this.codeStream.stackDepth = 1;
 }
 
 public void placeEnd() {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/StackMapFrameCodeStream.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/StackMapFrameCodeStream.java
@@ -29,7 +29,6 @@ import org.eclipse.jdt.internal.compiler.lookup.LocalVariableBinding;
 import org.eclipse.jdt.internal.compiler.lookup.MethodBinding;
 import org.eclipse.jdt.internal.compiler.lookup.Scope;
 import org.eclipse.jdt.internal.compiler.lookup.TypeBinding;
-import org.eclipse.jdt.internal.compiler.lookup.TypeIds;
 import org.eclipse.jdt.internal.compiler.problem.AbortMethod;
 
 @SuppressWarnings({ "rawtypes", "unchecked" })
@@ -163,26 +162,6 @@ public class StackMapFrameCodeStream extends CodeStream {
 			record(localBinding);
 		}
 		localBinding.recordInitializationStartPC(this.position);
-	}
-
-	@Override
-	public void recordExpressionType(TypeBinding typeBinding, int delta, boolean adjustStackDepth) {
-		if (adjustStackDepth) {
-			// optimized goto
-			// the break label already adjusted the stack depth (-1 or -2 depending on the return type)
-			// we need to adjust back to what it was
-			switch (typeBinding.id) {
-				case TypeIds.T_long:
-				case TypeIds.T_double:
-					this.stackDepth += 2;
-					break;
-				case TypeIds.T_void:
-					break;
-				default:
-					this.stackDepth++;
-					break;
-			}
-		}
 	}
 
 	/**

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
@@ -1336,18 +1336,9 @@ public void operandStackExceeds64KLimit(ASTNode location) {
 			location.sourceStart,
 			location.sourceEnd);
 }
-public void operandStackSizeNegative(ASTNode location) {
+public void operandStackSizeInappropriate(ASTNode location) {
 	this.handle(
-		IProblem.OperandStackSizeNegative,
-		NoArgument,
-		NoArgument,
-		ProblemSeverities.Warning,
-		location.sourceStart,
-		location.sourceEnd);
-}
-public void operandStackSizeInconsistent(ASTNode location) {
-	this.handle(
-		IProblem.OperandStackSizeInconsistent,
+		IProblem.OperandStackSizeInappropriate,
 		NoArgument,
 		NoArgument,
 		ProblemSeverities.Warning,

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
@@ -1336,6 +1336,24 @@ public void operandStackExceeds64KLimit(ASTNode location) {
 			location.sourceStart,
 			location.sourceEnd);
 }
+public void operandStackSizeNegative(ASTNode location) {
+	this.handle(
+		IProblem.OperandStackSizeNegative,
+		NoArgument,
+		NoArgument,
+		ProblemSeverities.Warning,
+		location.sourceStart,
+		location.sourceEnd);
+}
+public void operandStackSizeInconsistent(ASTNode location) {
+	this.handle(
+		IProblem.OperandStackSizeInconsistent,
+		NoArgument,
+		NoArgument,
+		ProblemSeverities.Warning,
+		location.sourceStart,
+		location.sourceEnd);
+}
 public void bytecodeExceeds64KLimit(LambdaExpression location) {
 	bytecodeExceeds64KLimit(location.binding, location.sourceStart, location.diagnosticsSourceEnd());
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/messages.properties
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/messages.properties
@@ -121,8 +121,8 @@
 85 = The value of the exception parameter {0} is not used
 86 = The code for the switch table on enum {0} is exceeding the 65535 bytes limit
 87 = The operand stack is exceeding the 65535 bytes limit
-88 = Internal inconsistency: The operand stack size was found to be negative during translation of this class
-89 = Internal inconsistency: The operand stack size varies across different paths during translation of this class
+88 = Internal inconsistency: Inappropriate operand stack size encountered during translation
+
 90 = The local variable {0} is hiding another local variable defined in an enclosing scope
 91 = The local variable {0} is hiding a field from type {1}
 92 = The field {0}.{1} is hiding another local variable defined in an enclosing scope

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/messages.properties
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/messages.properties
@@ -121,7 +121,8 @@
 85 = The value of the exception parameter {0} is not used
 86 = The code for the switch table on enum {0} is exceeding the 65535 bytes limit
 87 = The operand stack is exceeding the 65535 bytes limit
-
+88 = Internal inconsistency: The operand stack size was found to be negative during translation of this class
+89 = Internal inconsistency: The operand stack size varies across different paths during translation of this class
 90 = The local variable {0} is hiding another local variable defined in an enclosing scope
 91 = The local variable {0} is hiding a field from type {1}
 92 = The field {0}.{1} is hiding another local variable defined in an enclosing scope

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/CompilerInvocationTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/CompilerInvocationTests.java
@@ -1340,8 +1340,7 @@ public void test011_problem_categories() {
 	    expectedProblemAttributes.put("UnnamedVariableMustHaveInitializer", new ProblemAttributes(CategorizedProblem.CAT_PREVIEW_RELATED));
 	    expectedProblemAttributes.put("NamedPatternVariablesDisallowedHere", new ProblemAttributes(CategorizedProblem.CAT_INTERNAL));
 	    expectedProblemAttributes.put("OperandStackExceeds64KLimit", new ProblemAttributes(CategorizedProblem.CAT_INTERNAL));
-	    expectedProblemAttributes.put("OperandStackSizeNegative", new ProblemAttributes(CategorizedProblem.CAT_INTERNAL));
-	    expectedProblemAttributes.put("OperandStackSizeInconsistent", new ProblemAttributes(CategorizedProblem.CAT_INTERNAL));
+	    expectedProblemAttributes.put("OperandStackSizeInappropriate", new ProblemAttributes(CategorizedProblem.CAT_INTERNAL));
 
 	    StringBuilder failures = new StringBuilder();
 		StringBuilder correctResult = new StringBuilder(70000);
@@ -2456,8 +2455,7 @@ public void test012_compiler_problems_tuning() {
 	    expectedProblemAttributes.put("UnnamedVariableMustHaveInitializer", SKIP);
 	    expectedProblemAttributes.put("NamedPatternVariablesDisallowedHere", SKIP);
 	    expectedProblemAttributes.put("OperandStackExceeds64KLimit", SKIP);
-	    expectedProblemAttributes.put("OperandStackSizeNegative", SKIP);
-	    expectedProblemAttributes.put("OperandStackSizeInconsistent", SKIP);
+	    expectedProblemAttributes.put("OperandStackSizeInappropriate", SKIP);
 
 
 	    Map constantNamesIndex = new HashMap();

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/CompilerInvocationTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/CompilerInvocationTests.java
@@ -1340,6 +1340,8 @@ public void test011_problem_categories() {
 	    expectedProblemAttributes.put("UnnamedVariableMustHaveInitializer", new ProblemAttributes(CategorizedProblem.CAT_PREVIEW_RELATED));
 	    expectedProblemAttributes.put("NamedPatternVariablesDisallowedHere", new ProblemAttributes(CategorizedProblem.CAT_INTERNAL));
 	    expectedProblemAttributes.put("OperandStackExceeds64KLimit", new ProblemAttributes(CategorizedProblem.CAT_INTERNAL));
+	    expectedProblemAttributes.put("OperandStackSizeNegative", new ProblemAttributes(CategorizedProblem.CAT_INTERNAL));
+	    expectedProblemAttributes.put("OperandStackSizeInconsistent", new ProblemAttributes(CategorizedProblem.CAT_INTERNAL));
 
 	    StringBuilder failures = new StringBuilder();
 		StringBuilder correctResult = new StringBuilder(70000);
@@ -2454,6 +2456,9 @@ public void test012_compiler_problems_tuning() {
 	    expectedProblemAttributes.put("UnnamedVariableMustHaveInitializer", SKIP);
 	    expectedProblemAttributes.put("NamedPatternVariablesDisallowedHere", SKIP);
 	    expectedProblemAttributes.put("OperandStackExceeds64KLimit", SKIP);
+	    expectedProblemAttributes.put("OperandStackSizeNegative", SKIP);
+	    expectedProblemAttributes.put("OperandStackSizeInconsistent", SKIP);
+
 
 	    Map constantNamesIndex = new HashMap();
 		Field[] fields = JavaCore.class.getFields();

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ConstantTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ConstantTest.java
@@ -435,7 +435,7 @@ public void test009() throws Exception {
 
 	String expectedOutput9OrLater =
 			"  // Method descriptor #15 ([Ljava/lang/String;)V\n" +
-			"  // Stack: 3, Locals: 4\n" +
+			"  // Stack: 2, Locals: 4\n" +
 			"  public static void main(java.lang.String[] args);\n" +
 			"     0  getstatic java.lang.System.out : java.io.PrintStream [16]\n" +
 			"     3  ldc <String \"1\"> [22]\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericTypeTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericTypeTest.java
@@ -36615,7 +36615,7 @@ public void test1066() throws Exception {
 	// 	check presence of checkcast
 	String expectedOutput;
 	if (this.complianceLevel >= ClassFileConstants.JDK9) {
-		expectedOutput = "  // Stack: 4, Locals: 8\n" +
+		expectedOutput = "  // Stack: 3, Locals: 8\n" +
 				"  public static void main(java.lang.String[] args);\n" +
 				"      0  new X [1]\n" +
 				"      3  dup\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JSR335ClassFileTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JSR335ClassFileTest.java
@@ -1336,7 +1336,7 @@ public void test009() throws Exception {
 				"        [pc: 0, pc: 14] local: this index: 0 type: X\n" +
 				"  \n" +
 				"  // Method descriptor #25 (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;\n" +
-				"  // Stack: 3, Locals: 2\n" +
+				"  // Stack: 2, Locals: 2\n" +
 				"  private static synthetic java.lang.String lambda$0(java.lang.String s1, java.lang.String s2);\n" +
 				"    0  aload_0 [s1]\n" +
 				"    1  aload_1 [s2]\n" +
@@ -1631,7 +1631,7 @@ public void test010() throws Exception {
 				"        [pc: 14, pc: 24] local: s0 index: 1 type: java.lang.String\n" +
 				"  \n" +
 				"  // Method descriptor #34 (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;\n" +
-				"  // Stack: 4, Locals: 3\n" +
+				"  // Stack: 3, Locals: 3\n" +
 				"  private static synthetic java.lang.String lambda$0(java.lang.String arg0, java.lang.String s1, java.lang.String s2);\n" +
 				"    0  aload_0 [arg0]\n" +
 				"    1  aload_1 [s1]\n" +
@@ -1928,7 +1928,7 @@ public void test011() throws Exception {
 				"        [pc: 14, pc: 24] local: s0 index: 1 type: java.lang.String\n" +
 				"  \n" +
 				"  // Method descriptor #34 (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;\n" +
-				"  // Stack: 4, Locals: 3\n" +
+				"  // Stack: 3, Locals: 3\n" +
 				"  private static synthetic java.lang.String lambda$0(java.lang.String arg0, java.lang.String s1, java.lang.String s2);\n" +
 				"    0  aload_0 [arg0]\n" +
 				"    1  aload_1 [s1]\n" +
@@ -3707,7 +3707,7 @@ public void test430035() throws IOException, ClassFormatException {
 				"        [pc: 30, pc: 41] local: i index: 3 type: I<java.lang.String>\n" +
 				"  \n" +
 				"  // Method descriptor #28 (Ljava/lang/String;Ljava/lang/String;)V\n" +
-				"  // Stack: 4, Locals: 2\n" +
+				"  // Stack: 3, Locals: 2\n" +
 				"  private static synthetic void lambda$0(java.lang.String s, java.lang.String u);\n" +
 				"     0  getstatic java.lang.System.out : java.io.PrintStream [57]\n" +
 				"     3  aload_0 [s]\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LocalEnumTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LocalEnumTest.java
@@ -4879,7 +4879,7 @@ public void test127() throws Exception {
 			"        [pc: 0, pc: 5] local: this index: 0 type: X\n" +
 			"  \n" +
 			"  // Method descriptor #15 ([Ljava/lang/String;)V\n" +
-			"  // Stack: 3, Locals: 1\n" +
+			"  // Stack: 2, Locals: 1\n" +
 			"  public static void main(java.lang.String[] args);\n" +
 			"     0  getstatic java.lang.System.out : java.io.PrintStream [16]\n" +
 			"     3  invokestatic X$1Y.values() : X$1Y[] [22]\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordPatternProjectTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordPatternProjectTest.java
@@ -1,0 +1,1600 @@
+/*******************************************************************************
+* Copyright (c) 2024 Advantest Europe GmbH and others.
+*
+* This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Srikanth Sankaran - initial implementation
+*******************************************************************************/
+
+package org.eclipse.jdt.core.tests.compiler.regression;
+
+import java.util.Map;
+
+import org.eclipse.jdt.internal.compiler.batch.FileSystem;
+import org.eclipse.jdt.internal.compiler.env.INameEnvironment;
+import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
+
+import junit.framework.Test;
+
+public class RecordPatternProjectTest extends AbstractRegressionTest9 {
+
+	private static final JavacTestOptions JAVAC_OPTIONS = new JavacTestOptions("-source 21");
+	static {
+//		TESTS_NUMBERS = new int [] { 40 };
+//		TESTS_RANGE = new int[] { 1, -1 };
+//		TESTS_NAMES = new String[] { "testIssue2160" };
+	}
+	private String extraLibPath;
+	public static Class<?> testClass() {
+		return RecordPatternProjectTest.class;
+	}
+	public static Test suite() {
+		return buildMinimalComplianceTestSuite(testClass(), F_21);
+	}
+	public RecordPatternProjectTest(String testName){
+		super(testName);
+	}
+	// Enables the tests to run individually
+	protected Map<String, String> getCompilerOptions(boolean preview) {
+		Map<String, String> defaultOptions = super.getCompilerOptions();
+		defaultOptions.put(CompilerOptions.OPTION_Compliance, CompilerOptions.VERSION_21);
+		defaultOptions.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_21);
+		defaultOptions.put(CompilerOptions.OPTION_TargetPlatform, CompilerOptions.VERSION_21);
+		return defaultOptions;
+	}
+
+	protected Map<String, String> getCompilerOptions() {
+		return getCompilerOptions(false);
+	}
+	protected String[] getDefaultClassPaths() {
+		String[] libs = DefaultJavaRuntimeEnvironment.getDefaultClassPaths();
+		if (this.extraLibPath != null) {
+			String[] l = new String[libs.length + 1];
+			System.arraycopy(libs, 0, l, 0, libs.length);
+			l[libs.length] = this.extraLibPath;
+			return l;
+		}
+		return libs;
+	}
+	@Override
+	protected INameEnvironment getNameEnvironment(final String[] testFiles, String[] classPaths, Map<String, String> options) {
+		this.classpaths = classPaths == null ? getDefaultClassPaths() : classPaths;
+		INameEnvironment[] classLibs = getClassLibs(false, options);
+		for (INameEnvironment nameEnvironment : classLibs) {
+			((FileSystem) nameEnvironment).scanForModules(createParser());
+		}
+		return new InMemoryNameEnvironment9(testFiles, this.moduleMap, classLibs);
+	}
+	@Override
+	protected void runConformTest(String[] testFiles, String expectedOutput) {
+		runConformTest(testFiles, expectedOutput, getCompilerOptions(false));
+	}
+	@Override
+	protected void runConformTest(String[] testFiles, String expectedOutput, Map<String, String> customOptions) {
+		if(!isJRE21Plus)
+			return;
+		runConformTest(testFiles, expectedOutput, customOptions, new String[] {}, JAVAC_OPTIONS);
+	}
+	protected void runConformTest(
+			String[] testFiles,
+			String expectedOutputString,
+			String[] classLibraries,
+			boolean shouldFlushOutputDirectory,
+			String[] vmArguments) {
+			runTest(
+		 		// test directory preparation
+				shouldFlushOutputDirectory /* should flush output directory */,
+				testFiles /* test files */,
+				// compiler options
+				classLibraries /* class libraries */,
+				null /* no custom options */,
+				false /* do not perform statements recovery */,
+				null /* no custom requestor */,
+				// compiler results
+				false /* expecting no compiler errors */,
+				null /* do not check compiler log */,
+				// runtime options
+				false /* do not force execution */,
+				vmArguments /* vm arguments */,
+				// runtime results
+				expectedOutputString /* expected output string */,
+				null /* do not check error string */,
+				// javac options
+				JavacTestOptions.DEFAULT /* default javac test options */);
+		}
+	protected void runNegativeTest(
+			String[] testFiles,
+			String expectedCompilerLog,
+			String javacLog,
+			String[] classLibraries,
+			boolean shouldFlushOutputDirectory,
+			Map<String, String> customOptions) {
+		Runner runner = new Runner();
+		runner.testFiles = testFiles;
+		runner.expectedCompilerLog = expectedCompilerLog;
+		runner.javacTestOptions = JAVAC_OPTIONS;
+		runner.customOptions = customOptions;
+		runner.expectedJavacOutputString = javacLog;
+		runner.runNegativeTest();
+	}
+
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2160
+	// VerifyError with code with record patterns and Optional
+	public void testIssue2160() {
+		runConformTest(new String[] {
+				"bug/Interpreter.java",
+				"""
+				package bug;
+
+				import java.util.Optional;
+				import java.util.List;
+
+				import bug.syntax.SyExpressionGetfield;
+				import bug.syntax.SyExpressionValue;
+				import bug.syntax.SyReferenceConstantSymbol;
+				import bug.syntax.SySymbol;
+				import bug.syntax.SySymbolField;
+				import bug.syntax.SyValue;
+				import bug.syntax.SyValueReferenceConstant;
+				import bug.syntax.SyDeclClassLit;
+				import bug.syntax.SyExpressionValue;
+				import bug.syntax.SyIntLit;
+				import bug.syntax.SyPrimitiveConstantInt;
+				import bug.syntax.SyProgramLit;
+				import bug.syntax.SyValuePrimitiveConstant;
+
+				public final class Interpreter {
+					public void step(Configuration J) {
+						var e = J.syExpression();
+						if (e instanceof SyExpressionGetfield syExpressionGetfield) {
+							if (syExpressionGetfield instanceof SyExpressionGetfield(SyExpressionValue(SyValueReferenceConstant(SyReferenceConstantSymbol Y)), String f)) {
+								final Optional<Objekt> maybeo = J.objectAt(Y);
+								maybeo.ifPresentOrElse(o -> {
+									//final Optional<SyValue> maybev = o.get(f); //works
+									final Optional<SyValue> maybev = o.get(syExpressionGetfield.fieldName()); //does not work
+									maybev.ifPresentOrElse(v -> {
+										freshSymbol(Y.sySymbol(), f);
+									}, () -> {});
+								}, () -> {});
+							}
+						}
+					}
+
+					private SySymbolField freshSymbol(SySymbol sySymbol, String fieldName) {
+						return null;
+					}
+
+					public static void main(String [] args) {
+						var C1 = new SyDeclClassLit("Object", "", List.of(), List.of());
+						var e = new SyExpressionValue(new SyValuePrimitiveConstant(new SyPrimitiveConstantInt(new SyIntLit(0))));
+						var p = new SyProgramLit(List.of(C1), e);
+						var J = new Configuration(p);
+						var I = new Interpreter();
+						I.step(J);
+						System.out.println("Finished!");
+					}
+				}
+				""",
+				"bug/Configuration.java",
+				"""
+				package bug;
+
+				import java.util.ArrayList;
+				import java.util.Collections;
+				import java.util.LinkedHashMap;
+				import java.util.List;
+				import java.util.Objects;
+				import java.util.Optional;
+
+				import bug.syntax.SyExpression;
+				import bug.syntax.SyLocLit;
+				import bug.syntax.SyProgram;
+				import bug.syntax.SyProgramLit;
+				import bug.syntax.SyReferenceConstant;
+				import bug.syntax.SyReferenceConstantLoc;
+				import bug.syntax.SyReferenceConstantSymbol;
+				import bug.syntax.SySymbol;
+				import bug.syntax.SyValue;
+				import bug.syntax.SyValueEq;
+				import bug.syntax.SyValueIte;
+				import bug.syntax.SyValueReferenceConstant;
+				import bug.syntax.SyValueUnassumed;
+
+				public final class Configuration {
+					private final SyProgramLit syProgramLit;
+					private final LinkedHashMap<SyReferenceConstant, Objekt> heap;
+					private final ArrayList<SyValue> pathCondition;
+					private SyExpression syExpression;
+					private int nextLocId = 0;
+
+					public Configuration(SyProgram syProgram) {
+						switch (syProgram) {
+							case SyProgramLit syProgramLit:
+								this.syProgramLit = syProgramLit;
+								break;
+							default: throw new AssertionError();
+						}
+						this.heap = new LinkedHashMap<>();
+						this.pathCondition = new ArrayList<>();
+						this.syExpression = this.syProgramLit.syExpression();
+					}
+
+					public Configuration(Configuration other) {
+						this.syProgramLit = other.syProgramLit;
+						this.heap = new LinkedHashMap<>();
+						for (var e : other.heap.sequencedEntrySet()) {
+							this.heap.put(e.getKey(), new Objekt(e.getValue()));
+						}
+						this.pathCondition = new ArrayList<>(other.pathCondition);
+						this.syExpression = other.syExpression;
+					}
+
+					public Optional<Objekt> objectAt(SyReferenceConstant syReferenceConstant) {
+						Objects.requireNonNull(syReferenceConstant);
+
+						return Optional.ofNullable(this.heap.get(syReferenceConstant));
+					}
+
+					public SyReferenceConstantLoc addObjectConcrete(Objekt semObject) {
+						Objects.requireNonNull(semObject);
+
+						var nextLoc = new SyReferenceConstantLoc(new SyLocLit(this.nextLocId++));
+						this.heap.put(nextLoc, semObject);
+						return nextLoc;
+					}
+
+					public void addObjectSymbolic(SySymbol sySymbol, Objekt semObject) {
+						Objects.requireNonNull(sySymbol);
+						Objects.requireNonNull(semObject);
+
+						this.heap.put(new SyReferenceConstantSymbol(sySymbol), semObject);
+					}
+
+					public SyProgramLit syProgramLit() {
+						return this.syProgramLit;
+					}
+
+					public SyExpression syExpression() {
+						return this.syExpression;
+					}
+
+
+					public void setSyExpression(SyExpression syExpression) {
+						Objects.requireNonNull(syExpression);
+
+						this.syExpression = syExpression;
+					}
+
+
+					public List<SyValue> pathCondition() {
+						return Collections.unmodifiableList(this.pathCondition);
+					}
+
+					public boolean unresolved(SySymbol sySymbol) {
+						Objects.requireNonNull(sySymbol);
+
+						return !this.heap.containsKey(new SyReferenceConstantSymbol(sySymbol));
+					}
+
+					public void addPathConditionClause(SyValue syValue) {
+						Objects.requireNonNull(syValue);
+
+						this.pathCondition.add(syValue);
+					}
+
+					public SyValue assume(SySymbol accessor, String fieldName, SyValue fresh) {
+						Objects.requireNonNull(accessor);
+						Objects.requireNonNull(fieldName);
+						Objects.requireNonNull(fresh);
+
+						SyValue retVal = fresh;
+						for (var e : this.heap.sequencedEntrySet()) {
+							if (e.getKey() instanceof SyReferenceConstantSymbol syReferenceConstantSymbol &&
+							    !accessor.equals(syReferenceConstantSymbol.sySymbol())) {
+								var o = e.getValue();
+								var v = o.get(fieldName);
+								if (v.isPresent() && !(v.get() instanceof SyValueUnassumed)) {
+									retVal = new SyValueIte(new SyValueEq(new SyValueReferenceConstant(new SyReferenceConstantSymbol(accessor)), new SyValueReferenceConstant(syReferenceConstantSymbol)), v.get(), retVal);
+								}
+							}
+						}
+						return retVal;
+					}
+				}
+				""",
+
+				"bug/Objekt.java",
+				"""
+				package bug;
+
+				import java.util.LinkedHashMap;
+				import java.util.Objects;
+				import java.util.Optional;
+
+				import bug.syntax.SyDeclClass;
+				import bug.syntax.SyDeclClassLit;
+				import bug.syntax.SyDeclVariable;
+				import bug.syntax.SyDeclVariableLit;
+				import bug.syntax.SyProgram;
+				import bug.syntax.SyProgramLit;
+				import bug.syntax.SyValue;
+				import bug.syntax.SyValueUnassumed;
+
+				public final class Objekt {
+					private final SyProgramLit syProgramLit;
+					private final LinkedHashMap<String, SyValue> memory;
+					private String className;
+
+					public Objekt(SyProgram syProgram, String className, boolean symbolic) {
+						Objects.requireNonNull(syProgram);
+						Objects.requireNonNull(className);
+
+						switch (syProgram) {
+						case SyProgramLit syProgramLit:
+							this.syProgramLit = syProgramLit;
+							var syDeclClassOptional = syProgramLit.cdecl(className);
+							var fields = syDeclClassOptional.map(c -> {
+								switch (c) {
+								case SyDeclClassLit syDeclClassLit:
+									return syDeclClassLit.fields();
+								default: throw new AssertionError();
+								}
+							}).orElseThrow(() -> { throw new RuntimeException("Class " + className + " does not exist."); });
+							this.memory = new LinkedHashMap<>();
+							this.className = className;
+							for (SyDeclVariable syDeclVariable : fields) {
+								switch (syDeclVariable) {
+								case SyDeclVariableLit syDeclVariableLit:
+									this.memory.put(syDeclVariableLit.variableName(), (symbolic ? new SyValueUnassumed() : syDeclVariableLit.syType().ini()));
+									break;
+								default: throw new AssertionError();
+								}
+							}
+							break;
+						default: throw new AssertionError();
+						}
+					}
+
+					public Objekt(Objekt other) {
+						this.syProgramLit = other.syProgramLit;
+						this.memory = new LinkedHashMap<>(other.memory);
+						this.className = other.className;
+					}
+
+					public Optional<SyValue> get(String fieldName) {
+						Objects.requireNonNull(fieldName);
+
+						return Optional.ofNullable(this.memory.get(fieldName));
+					}
+
+					public void upd(String fieldName, SyValue syValue) {
+						Objects.requireNonNull(fieldName);
+						Objects.requireNonNull(syValue);
+
+						if (this.memory.containsKey(fieldName)) {
+							this.memory.put(fieldName, syValue);
+						} else {
+							throw new RuntimeException("Tried to modify nonexistent field " + fieldName);
+						}
+					}
+
+					public void refine(String subclassName) {
+						Objects.requireNonNull(subclassName);
+
+						for (SyDeclClass syDeclClass : this.syProgramLit.classes()) {
+							switch (syDeclClass) {
+							case SyDeclClassLit syDeclClassLit:
+								if (this.syProgramLit.isSubclass(syDeclClassLit.className(), this.className) &&
+								    this.syProgramLit.isSubclass(subclassName, syDeclClassLit.className()) &&
+								    !this.className.equals(syDeclClassLit.className())) {
+									for (SyDeclVariable syDeclVariable : syDeclClassLit.fields()) {
+										switch (syDeclVariable) {
+										case SyDeclVariableLit syDeclVariableLit:
+											this.memory.put(syDeclVariableLit.variableName(), new SyValueUnassumed());
+											break;
+										default: throw new AssertionError();
+										}
+									}
+								}
+							default: throw new AssertionError();
+							}
+						}
+					}
+				}
+				""",
+				"bug/syntax/SyBoolFalse.java",
+				"""
+				package bug.syntax;
+
+				public record SyBoolFalse() implements SyBool {
+
+				}
+				""",
+				"bug/syntax/SyBool.java",
+				"""
+				package bug.syntax;
+
+				public sealed interface SyBool permits SyBoolTrue, SyBoolFalse {
+
+				}
+				""",
+				"bug/syntax/SyBoolTrue.java",
+				"""
+				package bug.syntax;
+
+				public record SyBoolTrue() implements SyBool {
+
+				}
+				""",
+				"bug/syntax/SyDeclClass.java",
+				"""
+				package bug.syntax;
+
+				public sealed interface SyDeclClass permits SyDeclClassLit {
+
+				}
+				""",
+				"bug/syntax/SyDeclClassLit.java",
+				"""
+				package bug.syntax;
+
+				import java.util.List;
+				import java.util.Objects;
+				import java.util.Optional;
+
+				public record SyDeclClassLit(String className, String superclassName, List<SyDeclVariable> fields, List<SyDeclMethod> methods) implements SyDeclClass {
+					public SyDeclClassLit {
+						Objects.requireNonNull(className);
+						Objects.requireNonNull(superclassName);
+						Objects.requireNonNull(fields);
+						Objects.requireNonNull(methods);
+						for (SyDeclVariable field : fields) {
+							Objects.requireNonNull(field);
+						}
+						for (SyDeclMethod method : methods) {
+							Objects.requireNonNull(method);
+						}
+					}
+
+					public boolean hasField(String possibleFieldName) {
+						Objects.requireNonNull(possibleFieldName);
+
+						for (SyDeclVariable field : this.fields) {
+							switch (field) {
+							case SyDeclVariableLit syDeclVariableLit:
+								if (possibleFieldName.equals(syDeclVariableLit.variableName())) {
+									return true;
+								}
+								break;
+							default: throw new AssertionError();
+							}
+						}
+						return false;
+					}
+
+					public boolean hasMethod(String possibleMethodName) {
+						Objects.requireNonNull(possibleMethodName);
+
+						for (SyDeclMethod method : this.methods) {
+							switch (method) {
+							case SyDeclMethodLit syDeclMethodLit:
+								if (possibleMethodName.equals(syDeclMethodLit.methodName())) {
+									return true;
+								}
+								break;
+							default: throw new AssertionError();
+							}
+						}
+						return false;
+					}
+
+					public Optional<SyDeclVariable> fdecl(String possibleFieldName) {
+						Objects.requireNonNull(possibleFieldName);
+
+						for (SyDeclVariable field : this.fields) {
+							switch (field) {
+							case SyDeclVariableLit syDeclVariableLit:
+								if (possibleFieldName.equals(syDeclVariableLit.variableName())) {
+									return Optional.of(syDeclVariableLit);
+								}
+								break;
+							default: throw new AssertionError();
+							}
+						}
+						return Optional.empty();
+					}
+
+					public Optional<SyDeclMethod> mdecl(String possibleMethodName) {
+						Objects.requireNonNull(possibleMethodName);
+
+						for (SyDeclMethod method : this.methods) {
+							switch (method) {
+							case SyDeclMethodLit syDeclMethodLit:
+								if (possibleMethodName.equals(syDeclMethodLit.methodName())) {
+									return Optional.of(syDeclMethodLit);
+								}
+								break;
+							default: throw new AssertionError();
+							}
+						}
+						return Optional.empty();
+					}
+				}
+				""",
+				"bug/syntax/SyDeclMethod.java",
+				"""
+				package bug.syntax;
+
+				public sealed interface SyDeclMethod permits SyDeclMethodLit {
+
+				}
+				""",
+				"bug/syntax/SyDeclMethodLit.java",
+				"""
+				package bug.syntax;
+
+				import java.util.Objects;
+
+				public record SyDeclMethodLit(SyType syType, String methodName, SyDeclVariable syDeclVariable, SyExpression syExpression) implements SyDeclMethod {
+					public SyDeclMethodLit {
+						Objects.requireNonNull(syType);
+						Objects.requireNonNull(methodName);
+						Objects.requireNonNull(syDeclVariable);
+						Objects.requireNonNull(syExpression);
+					}
+				}
+				""",
+				"bug/syntax/SyDeclVariable.java",
+				"""
+				package bug.syntax;
+
+				public sealed interface SyDeclVariable permits SyDeclVariableLit {
+
+				}
+				""",
+				"bug/syntax/SyDeclVariableLit.java",
+				"""
+				package bug.syntax;
+
+				import java.util.Objects;
+
+				public record SyDeclVariableLit(SyType syType, String variableName) implements SyDeclVariable {
+					public SyDeclVariableLit {
+						Objects.requireNonNull(syType);
+						Objects.requireNonNull(variableName);
+					}
+				}
+				""",
+				"bug/syntax/SyExpressionAdd.java",
+				"""
+				package bug.syntax;
+
+				import java.util.Objects;
+
+				public record SyExpressionAdd(SyExpression syExpressionFirst, SyExpression syExpressionSecond) implements SyExpression {
+					public SyExpressionAdd {
+						Objects.requireNonNull(syExpressionFirst);
+						Objects.requireNonNull(syExpressionSecond);
+					}
+
+					@Override
+					public SyExpressionAdd replace(String variableName, SyExpression syExpression) {
+						Objects.requireNonNull(variableName);
+						Objects.requireNonNull(syExpression);
+
+						var syExpressionFirstNew = this.syExpressionFirst.replace(variableName, syExpression);
+						var syExpressionSecondNew = this.syExpressionSecond.replace(variableName, syExpression);
+						return new SyExpressionAdd(syExpressionFirstNew, syExpressionSecondNew);
+					}
+				}
+				""",
+				"bug/syntax/SyExpressionAnd.java",
+				"""
+				package bug.syntax;
+
+				import java.util.Objects;
+
+				public record SyExpressionAnd(SyExpression syExpressionFirst, SyExpression syExpressionSecond) implements SyExpression {
+					public SyExpressionAnd {
+						Objects.requireNonNull(syExpressionFirst);
+						Objects.requireNonNull(syExpressionSecond);
+					}
+
+					@Override
+					public SyExpressionAnd replace(String variableName, SyExpression syExpression) {
+						Objects.requireNonNull(variableName);
+						Objects.requireNonNull(syExpression);
+
+						var syExpressionFirstNew = this.syExpressionFirst.replace(variableName, syExpression);
+						var syExpressionSecondNew = this.syExpressionSecond.replace(variableName, syExpression);
+						return new SyExpressionAnd(syExpressionFirstNew, syExpressionSecondNew);
+					}
+				}
+				""",
+				"bug/syntax/SyExpressionEq.java",
+				"""
+				package bug.syntax;
+
+				import java.util.Objects;
+
+				public record SyExpressionEq(SyExpression syExpressionFirst, SyExpression syExpressionSecond) implements SyExpression {
+					public SyExpressionEq {
+						Objects.requireNonNull(syExpressionFirst);
+						Objects.requireNonNull(syExpressionSecond);
+					}
+
+					@Override
+					public SyExpressionEq replace(String variableName, SyExpression syExpression) {
+						Objects.requireNonNull(variableName);
+						Objects.requireNonNull(syExpression);
+
+						var syExpressionFirstNew = this.syExpressionFirst.replace(variableName, syExpression);
+						var syExpressionSecondNew = this.syExpressionSecond.replace(variableName, syExpression);
+						return new SyExpressionEq(syExpressionFirstNew, syExpressionSecondNew);
+					}
+				}
+				""",
+				"bug/syntax/SyExpressionGetfield.java",
+				"""
+				package bug.syntax;
+
+				import java.util.Objects;
+
+				public record SyExpressionGetfield(SyExpression syExpression, String fieldName) implements SyExpression {
+					public SyExpressionGetfield {
+						Objects.requireNonNull(syExpression);
+						Objects.requireNonNull(fieldName);
+					}
+
+					@Override
+					public SyExpressionGetfield replace(String variableName, SyExpression syExpression) {
+						Objects.requireNonNull(variableName);
+						Objects.requireNonNull(syExpression);
+
+						var syExpressionNew = this.syExpression.replace(variableName, syExpression);
+						return new SyExpressionGetfield(syExpressionNew, this.fieldName);
+					}
+				}
+				""",
+				"bug/syntax/SyExpressionIf.java",
+				"""
+				package bug.syntax;
+
+				import java.util.Objects;
+
+				public record SyExpressionIf(SyExpression syExpressionCond, SyExpression syExpressionThen, SyExpression syExpressionElse) implements SyExpression {
+					public SyExpressionIf {
+						Objects.requireNonNull(syExpressionCond);
+						Objects.requireNonNull(syExpressionThen);
+						Objects.requireNonNull(syExpressionElse);
+					}
+
+					@Override
+					public SyExpressionIf replace(String variableName, SyExpression syExpression) {
+						Objects.requireNonNull(variableName);
+						Objects.requireNonNull(syExpression);
+
+						var syExpressionCondNew = this.syExpressionCond.replace(variableName, syExpression);
+						var syExpressionThenNew = this.syExpressionThen.replace(variableName, syExpression);
+						var syExpressionElseNew = this.syExpressionElse.replace(variableName, syExpression);
+						return new SyExpressionIf(syExpressionCondNew, syExpressionThenNew, syExpressionElseNew);
+					}
+				}
+				""",
+				"bug/syntax/SyExpressionInstanceof.java",
+				"""
+				package bug.syntax;
+
+				import java.util.Objects;
+
+				public record SyExpressionInstanceof(SyExpression syExpression, String className) implements SyExpression {
+					public SyExpressionInstanceof {
+						Objects.requireNonNull(syExpression);
+						Objects.requireNonNull(className);
+					}
+
+					@Override
+					public SyExpressionInstanceof replace(String variableName, SyExpression syExpression) {
+						Objects.requireNonNull(variableName);
+						Objects.requireNonNull(syExpression);
+
+						var syExpressionNew = this.syExpression.replace(variableName, syExpression);
+						return new SyExpressionInstanceof(syExpressionNew, this.className);
+					}
+				}
+				""",
+				"bug/syntax/SyExpressionInvoke.java",
+				"""
+				package bug.syntax;
+
+				import java.util.Objects;
+
+				public record SyExpressionInvoke(SyExpression syExpressionFirst, String methodName, SyExpression syExpressionSecond) implements SyExpression {
+					public SyExpressionInvoke {
+						Objects.requireNonNull(syExpressionFirst);
+						Objects.requireNonNull(methodName);
+						Objects.requireNonNull(syExpressionSecond);
+					}
+
+					@Override
+					public SyExpressionInvoke replace(String variableName, SyExpression syExpression) {
+						Objects.requireNonNull(variableName);
+						Objects.requireNonNull(syExpression);
+
+						var syExpressionFirstNew = this.syExpressionFirst.replace(variableName, syExpression);
+						var syExpressionSecondNew = this.syExpressionSecond.replace(variableName, syExpression);
+						return new SyExpressionInvoke(syExpressionFirstNew, this.methodName, syExpressionSecondNew);
+					}
+				}
+				""",
+				"bug/syntax/SyExpression.java",
+				"""
+				package bug.syntax;
+
+				public sealed interface SyExpression permits SyExpressionVariable, SyExpressionValue, SyExpressionNew,
+				SyExpressionGetfield, SyExpressionPutfield, SyExpressionLet, SyExpressionAdd, SyExpressionSub, SyExpressionLt,
+				SyExpressionAnd, SyExpressionOr, SyExpressionNot, SyExpressionEq, SyExpressionInstanceof, SyExpressionIf,
+				SyExpressionInvoke {
+					public SyExpression replace(String variableName, SyExpression syExpression);
+				}
+				""",
+				"bug/syntax/SyExpressionLet.java",
+				"""
+				package bug.syntax;
+
+				import java.util.Objects;
+
+				public record SyExpressionLet(String variableName, SyExpression syExpressionFirst, SyExpression syExpressionSecond) implements SyExpression {
+					public SyExpressionLet {
+						Objects.requireNonNull(variableName);
+						Objects.requireNonNull(syExpressionFirst);
+						Objects.requireNonNull(syExpressionSecond);
+					}
+
+					@Override
+					public SyExpressionLet replace(String variableName, SyExpression syExpression) {
+						Objects.requireNonNull(variableName);
+						Objects.requireNonNull(syExpression);
+
+						if (this.variableName.equals(variableName)) {
+							return this;
+						} else {
+							var syExpressionFirstNew = this.syExpressionFirst.replace(variableName, syExpression);
+							var syExpressionSecondNew = this.syExpressionSecond.replace(variableName, syExpression);
+							return new SyExpressionLet(this.variableName, syExpressionFirstNew, syExpressionSecondNew);
+						}
+					}
+				}
+				""",
+				"bug/syntax/SyExpressionLt.java",
+				"""
+				package bug.syntax;
+
+				import java.util.Objects;
+
+				public record SyExpressionLt(SyExpression syExpressionFirst, SyExpression syExpressionSecond) implements SyExpression {
+					public SyExpressionLt {
+						Objects.requireNonNull(syExpressionFirst);
+						Objects.requireNonNull(syExpressionSecond);
+					}
+
+					@Override
+					public SyExpressionLt replace(String variableName, SyExpression syExpression) {
+						Objects.requireNonNull(variableName);
+						Objects.requireNonNull(syExpression);
+
+						var syExpressionFirstNew = this.syExpressionFirst.replace(variableName, syExpression);
+						var syExpressionSecondNew = this.syExpressionSecond.replace(variableName, syExpression);
+						return new SyExpressionLt(syExpressionFirstNew, syExpressionSecondNew);
+					}
+				}
+				""",
+				"bug/syntax/SyExpressionNew.java",
+				"""
+				package bug.syntax;
+
+				import java.util.Objects;
+
+				public record SyExpressionNew(String className) implements SyExpression {
+					public SyExpressionNew {
+						Objects.requireNonNull(className);
+					}
+
+					@Override
+					public SyExpressionNew replace(String variableName, SyExpression syExpression) {
+						Objects.requireNonNull(variableName);
+						Objects.requireNonNull(syExpression);
+
+						return this;
+					}
+				}
+				""",
+				"bug/syntax/SyExpressionNot.java",
+				"""
+				package bug.syntax;
+
+				import java.util.Objects;
+
+				public record SyExpressionNot(SyExpression syExpression) implements SyExpression {
+					public SyExpressionNot {
+						Objects.requireNonNull(syExpression);
+					}
+
+					@Override
+					public SyExpressionNot replace(String variableName, SyExpression syExpression) {
+						Objects.requireNonNull(variableName);
+						Objects.requireNonNull(syExpression);
+
+						var syExpressionNew = this.syExpression.replace(variableName, syExpression);
+						return new SyExpressionNot(syExpressionNew);
+					}
+				}
+				""",
+				"bug/syntax/SyExpressionOr.java",
+				"""
+				package bug.syntax;
+
+				import java.util.Objects;
+
+				public record SyExpressionOr(SyExpression syExpressionFirst, SyExpression syExpressionSecond) implements SyExpression {
+					public SyExpressionOr {
+						Objects.requireNonNull(syExpressionFirst);
+						Objects.requireNonNull(syExpressionSecond);
+					}
+
+					@Override
+					public SyExpressionOr replace(String variableName, SyExpression syExpression) {
+						Objects.requireNonNull(variableName);
+						Objects.requireNonNull(syExpression);
+
+						var syExpressionFirstNew = this.syExpressionFirst.replace(variableName, syExpression);
+						var syExpressionSecondNew = this.syExpressionSecond.replace(variableName, syExpression);
+						return new SyExpressionOr(syExpressionFirstNew, syExpressionSecondNew);
+					}
+				}
+				""",
+				"bug/syntax/SyExpressionPutfield.java",
+				"""
+				package bug.syntax;
+
+				import java.util.Objects;
+
+				public record SyExpressionPutfield(SyExpression syExpressionFirst, String fieldName, SyExpression syExpressionSecond) implements SyExpression {
+					public SyExpressionPutfield {
+						Objects.requireNonNull(syExpressionFirst);
+						Objects.requireNonNull(fieldName);
+						Objects.requireNonNull(syExpressionSecond);
+					}
+
+					@Override
+					public SyExpressionPutfield replace(String variableName, SyExpression syExpression) {
+						Objects.requireNonNull(variableName);
+						Objects.requireNonNull(syExpression);
+
+						var syExpressionFirstNew = this.syExpressionFirst.replace(variableName, syExpression);
+						var syExpressionSecondNew = this.syExpressionSecond.replace(variableName, syExpression);
+						return new SyExpressionPutfield(syExpressionFirstNew, this.fieldName, syExpressionSecondNew);
+					}
+				}
+				""",
+				"bug/syntax/SyExpressionSub.java",
+				"""
+				package bug.syntax;
+
+				import java.util.Objects;
+
+				public record SyExpressionSub(SyExpression syExpressionFirst, SyExpression syExpressionSecond) implements SyExpression {
+					public SyExpressionSub {
+						Objects.requireNonNull(syExpressionFirst);
+						Objects.requireNonNull(syExpressionSecond);
+					}
+
+					@Override
+					public SyExpressionSub replace(String variableName, SyExpression syExpression) {
+						Objects.requireNonNull(variableName);
+						Objects.requireNonNull(syExpression);
+
+						var syExpressionFirstNew = this.syExpressionFirst.replace(variableName, syExpression);
+						var syExpressionSecondNew = this.syExpressionSecond.replace(variableName, syExpression);
+						return new SyExpressionSub(syExpressionFirstNew, syExpressionSecondNew);
+					}
+				}
+				""",
+				"bug/syntax/SyExpressionValue.java",
+				"""
+				package bug.syntax;
+
+				import java.util.Objects;
+
+				public record SyExpressionValue(SyValue syValue) implements SyExpression {
+					public SyExpressionValue {
+						Objects.requireNonNull(syValue);
+					}
+
+					@Override
+					public SyExpressionValue replace(String variableName, SyExpression syExpression) {
+						Objects.requireNonNull(variableName);
+						Objects.requireNonNull(syExpression);
+
+						return this;
+					}
+				}
+				""",
+				"bug/syntax/SyExpressionVariable.java",
+				"""
+				package bug.syntax;
+
+				import java.util.Objects;
+
+				public record SyExpressionVariable(String variableName) implements SyExpression {
+					public SyExpressionVariable {
+						Objects.requireNonNull(variableName);
+					}
+
+					@Override
+					public SyExpression replace(String variableName, SyExpression syExpression) {
+						Objects.requireNonNull(variableName);
+						Objects.requireNonNull(syExpression);
+
+						if (this.variableName.equals(variableName)) {
+							return syExpression;
+						} else {
+							return this;
+						}
+					}
+				}
+				""",
+				"bug/syntax/SyInt.java",
+				"""
+				package bug.syntax;
+
+				public sealed interface SyInt permits SyIntLit {
+
+				}
+				""",
+				"bug/syntax/SyIntLit.java",
+				"""
+				package bug.syntax;
+
+				public record SyIntLit(int value) implements SyInt {
+
+				}
+				""",
+				"bug/syntax/SyLoc.java",
+				"""
+				package bug.syntax;
+
+				public sealed interface SyLoc permits SyLocLit {
+
+				}
+				""",
+				"bug/syntax/SyLocLit.java",
+				"""
+				package bug.syntax;
+
+				public record SyLocLit(int position) implements SyLoc {
+
+				}
+				""",
+				"bug/syntax/SyPrimitiveConstantBool.java",
+				"""
+				package bug.syntax;
+
+				import java.util.Objects;
+
+				public record SyPrimitiveConstantBool(SyBool syBool) implements SyPrimitiveConstant {
+					public SyPrimitiveConstantBool {
+						Objects.requireNonNull(syBool);
+					}
+				}
+				""",
+				"bug/syntax/SyPrimitiveConstantInt.java",
+				"""
+				package bug.syntax;
+
+				import java.util.Objects;
+
+				public record SyPrimitiveConstantInt(SyInt syInt) implements SyPrimitiveConstant {
+					public SyPrimitiveConstantInt {
+						Objects.requireNonNull(syInt);
+					}
+				}
+				""",
+				"bug/syntax/SyPrimitiveConstant.java",
+				"""
+				package bug.syntax;
+
+				public sealed interface SyPrimitiveConstant permits SyPrimitiveConstantBool, SyPrimitiveConstantInt, SyPrimitiveConstantSymbol{
+
+				}
+				""",
+				"bug/syntax/SyPrimitiveConstantSymbol.java",
+				"""
+				package bug.syntax;
+
+				import java.util.Objects;
+
+				public record SyPrimitiveConstantSymbol(SySymbol sySymbol) implements SyPrimitiveConstant {
+					public SyPrimitiveConstantSymbol {
+						Objects.requireNonNull(sySymbol);
+					}
+				}
+				""",
+				"bug/syntax/SyProgram.java",
+				"""
+				package bug.syntax;
+
+				public sealed interface SyProgram permits SyProgramLit {
+
+				}
+				""",
+				"bug/syntax/SyProgramLit.java",
+				"""
+				package bug.syntax;
+
+				import java.lang.AssertionError;
+				import java.util.LinkedHashSet;
+				import java.util.List;
+				import java.util.Objects;
+				import java.util.Optional;
+				import java.util.Set;
+
+				public record SyProgramLit(List<SyDeclClass> classes, SyExpression syExpression) implements SyProgram {
+					public SyProgramLit {
+						Objects.requireNonNull(classes);
+						Objects.requireNonNull(syExpression);
+						for (SyDeclClass syDeclClass : classes) {
+							Objects.requireNonNull(syDeclClass);
+						}
+					}
+
+					public boolean isSubclass(String possibleSubclassName, String possibleSuperclassName) {
+						Objects.requireNonNull(possibleSubclassName);
+						Objects.requireNonNull(possibleSuperclassName);
+
+						for (SyDeclClass syDeclClass : this.classes) {
+							switch (syDeclClass) {
+							case SyDeclClassLit syDeclClassLit:
+								if (possibleSubclassName.equals(syDeclClassLit.className())) {
+									if (possibleSuperclassName.equals(syDeclClassLit.superclassName())) {
+										return true;
+									} else {
+										return isSubclass(syDeclClassLit.superclassName(), possibleSuperclassName);
+									}
+								}
+								break;
+							default: throw new AssertionError();
+							}
+						}
+						return false;
+					}
+
+					public boolean hasClass(String possibleClassName) {
+						Objects.requireNonNull(possibleClassName);
+
+						for (SyDeclClass syDeclClass : this.classes) {
+							switch (syDeclClass) {
+							case SyDeclClassLit syDeclClassLit:
+								if (possibleClassName.equals(syDeclClassLit.className())) {
+									return true;
+								}
+								break;
+							default: throw new AssertionError();
+							}
+						}
+						return false;
+					}
+
+					public Optional<SyDeclClass> cdecl(String possibleClassName) {
+						Objects.requireNonNull(possibleClassName);
+
+						for (SyDeclClass syDeclClass : this.classes) {
+							switch (syDeclClass) {
+							case SyDeclClassLit syDeclClassLit:
+								if (possibleClassName.equals(syDeclClassLit.className())) {
+									return Optional.of(syDeclClassLit);
+								}
+								break;
+							default: throw new AssertionError();
+							}
+						}
+						return Optional.empty();
+					}
+
+					public boolean seesMethod(String possibleMethodName, String possibleSubclassName, String possibleSuperclassName) {
+						Objects.requireNonNull(possibleMethodName);
+						Objects.requireNonNull(possibleSubclassName);
+						Objects.requireNonNull(possibleSuperclassName);
+
+						return isSubclass(possibleSubclassName, possibleSuperclassName) &&
+						       cdecl(possibleSuperclassName).map(c -> {
+									switch (c) {
+									case SyDeclClassLit syDeclClassLit:
+										return syDeclClassLit.hasMethod(possibleMethodName);
+									default: throw new AssertionError();
+									}
+						       }).orElse(false) &&
+						       this.classes.stream().allMatch(c -> {
+									switch (c) {
+									case SyDeclClassLit syDeclClassLit:
+										return possibleSubclassName.equals(syDeclClassLit.className()) ||
+										       possibleSuperclassName.equals(syDeclClassLit.className()) ||
+										       !isSubclass(syDeclClassLit.className(), possibleSuperclassName) ||
+										       !isSubclass(possibleSubclassName, syDeclClassLit.className()) ||
+										       !syDeclClassLit.hasMethod(possibleMethodName);
+									default: throw new AssertionError();
+									}
+						       });
+					}
+
+					public boolean recvMethod(String possibleMethodName, String possibleSubclassName, String possibleSuperclassName) {
+						Objects.requireNonNull(possibleMethodName);
+						Objects.requireNonNull(possibleSubclassName);
+						Objects.requireNonNull(possibleSuperclassName);
+
+						return (!possibleSubclassName.equals(possibleSuperclassName) &&
+						       seesMethod(possibleMethodName, possibleSubclassName, possibleSuperclassName)) ||
+						       (possibleSubclassName.equals(possibleSuperclassName) &&
+						       cdecl(possibleSubclassName).map(c -> {
+				                   switch (c) {
+				                   case SyDeclClassLit syDeclClassLit:
+				                       return syDeclClassLit.hasMethod(possibleMethodName);
+				                   default: throw new AssertionError();
+				                   }
+				               }).orElse(false));
+					}
+
+					public Optional<SyDeclClass> methodProvider(String possibleMethodName, String possibleSubclassName) {
+						Objects.requireNonNull(possibleMethodName);
+						Objects.requireNonNull(possibleSubclassName);
+
+						for (SyDeclClass syDeclClass : this.classes) {
+							switch (syDeclClass) {
+							case SyDeclClassLit syDeclClassLit:
+								if (recvMethod(possibleMethodName, possibleSubclassName, syDeclClassLit.className())) {
+									return Optional.of(syDeclClassLit);
+								}
+								break;
+							default: throw new AssertionError();
+							}
+						}
+						return Optional.empty();
+					}
+
+					public Optional<SyDeclClass> classWithField(String possibleFieldName) {
+						Objects.requireNonNull(possibleFieldName);
+
+						for (SyDeclClass syDeclClass : this.classes) {
+							switch (syDeclClass) {
+							case SyDeclClassLit syDeclClassLit:
+								if (syDeclClassLit.hasField(possibleFieldName)) {
+									return Optional.of(syDeclClassLit);
+								}
+								break;
+							default: throw new AssertionError();
+							}
+						}
+						return Optional.empty();
+					}
+
+					public Set<SyDeclClass> implementors(String possibleMethodName) {
+						Objects.requireNonNull(possibleMethodName);
+
+						final LinkedHashSet<SyDeclClass> retVal = new LinkedHashSet<>();
+						for (SyDeclClass syDeclClass : this.classes) {
+							switch (syDeclClass) {
+							case SyDeclClassLit syDeclClassLit:
+								if (syDeclClassLit.hasMethod(possibleMethodName)) {
+									retVal.add(syDeclClassLit);
+								}
+								break;
+							default: throw new AssertionError();
+							}
+						}
+						return retVal;
+					}
+
+					public Set<SyDeclClass> overriders(String possibleMethodName, String possibleSuperclassName) {
+						Objects.requireNonNull(possibleMethodName);
+						Objects.requireNonNull(possibleSuperclassName);
+
+						final LinkedHashSet<SyDeclClass> retVal = new LinkedHashSet<>();
+						for (SyDeclClass syDeclClass : this.classes) {
+							switch (syDeclClass) {
+							case SyDeclClassLit syDeclClassLit:
+								if (seesMethod(possibleMethodName, syDeclClassLit.className(), possibleSuperclassName) &&
+								    syDeclClassLit.hasMethod(possibleMethodName) &&
+								    !possibleSuperclassName.equals(syDeclClassLit.className())) {
+									retVal.add(syDeclClassLit);
+								}
+								break;
+							default: throw new AssertionError();
+							}
+						}
+						return retVal;
+					}
+				}
+				""",
+				"bug/syntax/SyReferenceConstant.java",
+				"""
+				package bug.syntax;
+
+				public sealed interface SyReferenceConstant permits SyReferenceConstantNull, SyReferenceConstantLoc, SyReferenceConstantSymbol {
+
+				}
+				""",
+				"bug/syntax/SyReferenceConstantLoc.java",
+				"""
+				package bug.syntax;
+
+				import java.util.Objects;
+
+				public record SyReferenceConstantLoc(SyLoc syLoc) implements SyReferenceConstant {
+					public SyReferenceConstantLoc {
+						Objects.requireNonNull(syLoc);
+					}
+				}
+				""",
+				"bug/syntax/SyReferenceConstantNull.java",
+				"""
+				package bug.syntax;
+
+				public record SyReferenceConstantNull() implements SyReferenceConstant {
+
+				}
+				""",
+				"bug/syntax/SyReferenceConstantSymbol.java",
+				"""
+				package bug.syntax;
+
+				import java.util.Objects;
+
+				public record SyReferenceConstantSymbol(SySymbol sySymbol) implements SyReferenceConstant {
+					public SyReferenceConstantSymbol {
+						Objects.requireNonNull(sySymbol);
+					}
+				}
+				""",
+				"bug/syntax/SySymbolExpression.java",
+				"""
+				package bug.syntax;
+
+				public record SySymbolExpression(int id) implements SySymbol {
+
+				}
+				""",
+				"bug/syntax/SySymbolField.java",
+				"""
+				package bug.syntax;
+
+				import java.util.List;
+				import java.util.Objects;
+
+				public record SySymbolField(int id, List<String> fieldNames) implements SySymbol {
+					public SySymbolField {
+						Objects.requireNonNull(fieldNames);
+						for (String fieldName : fieldNames) {
+							Objects.requireNonNull(fieldName);
+						}
+					}
+				}
+				""",
+				"bug/syntax/SySymbol.java",
+				"""
+				package bug.syntax;
+
+				public sealed interface SySymbol permits SySymbolExpression, SySymbolField {
+
+				}
+				""",
+				"bug/syntax/SyTypeBool.java",
+				"""
+				package bug.syntax;
+
+				public record SyTypeBool() implements SyType {
+					@Override
+					public boolean isReference() {
+						return false;
+					}
+
+					@Override
+					public SyValue ini() {
+						return new SyValuePrimitiveConstant(new SyPrimitiveConstantBool(new SyBoolFalse()));
+					}
+				}
+				""",
+				"bug/syntax/SyTypeClass.java",
+				"""
+				package bug.syntax;
+
+				import java.util.Objects;
+
+				public record SyTypeClass(String name) implements SyType {
+					public SyTypeClass {
+						Objects.requireNonNull(name);
+					}
+
+					@Override
+					public boolean isReference() {
+						return true;
+					}
+
+					@Override
+					public SyValue ini() {
+						return new SyValueReferenceConstant(new SyReferenceConstantNull());
+					}
+				}
+				""",
+				"bug/syntax/SyTypeInt.java",
+				"""
+				package bug.syntax;
+
+				public record SyTypeInt() implements SyType {
+					@Override
+					public boolean isReference() {
+						return false;
+					}
+
+					@Override
+					public SyValue ini() {
+						return new SyValuePrimitiveConstant(new SyPrimitiveConstantInt(new SyIntLit(0)));
+					}
+				}
+				""",
+				"bug/syntax/SyType.java",
+				"""
+				package bug.syntax;
+
+				public sealed interface SyType permits SyTypeBool, SyTypeInt, SyTypeClass {
+					public default boolean isPrimitive() { return !isReference(); }
+					public boolean isReference();
+					public SyValue ini();
+				}
+				""",
+				"bug/syntax/SyValueAdd.java",
+				"""
+				package bug.syntax;
+
+				import java.util.Objects;
+
+				public record SyValueAdd(SyValue syValueFirst, SyValue syValueSecond) implements SyValue {
+					public SyValueAdd {
+						Objects.requireNonNull(syValueFirst);
+						Objects.requireNonNull(syValueSecond);
+					}
+
+					@Override
+					public boolean isReference() {
+						return false;
+					}
+				}
+				""",
+				"bug/syntax/SyValueAnd.java",
+				"""
+				package bug.syntax;
+
+				import java.util.Objects;
+
+				public record SyValueAnd(SyValue syValueFirst, SyValue syValueSecond) implements SyValue {
+					public SyValueAnd {
+						Objects.requireNonNull(syValueFirst);
+						Objects.requireNonNull(syValueSecond);
+					}
+
+					@Override
+					public boolean isReference() {
+						return false;
+					}
+				}
+				""",
+				"bug/syntax/SyValueEq.java",
+				"""
+				package bug.syntax;
+
+				import java.util.Objects;
+
+				public record SyValueEq(SyValue syValueFirst, SyValue syValueSecond) implements SyValue {
+					public SyValueEq {
+						Objects.requireNonNull(syValueFirst);
+						Objects.requireNonNull(syValueSecond);
+					}
+
+					@Override
+					public boolean isReference() {
+						return false;
+					}
+				}
+				""",
+				"bug/syntax/SyValueFieldRel.java",
+				"""
+				package bug.syntax;
+
+				import java.util.Objects;
+
+				public record SyValueFieldRel(SySymbol sySymbolFirst, String fieldName, SySymbol sySymbolSecond) implements SyValue {
+					public SyValueFieldRel {
+						Objects.requireNonNull(sySymbolFirst);
+						Objects.requireNonNull(fieldName);
+						Objects.requireNonNull(sySymbolSecond);
+					}
+
+					@Override
+					public boolean isReference() {
+						return false;
+					}
+				}
+				""",
+				"bug/syntax/SyValueIte.java",
+				"""
+				package bug.syntax;
+
+				import java.util.Objects;
+
+				public record SyValueIte(SyValue syValueCond, SyValue syValueThen, SyValue syValueElse) implements SyValue {
+					public SyValueIte {
+						Objects.requireNonNull(syValueCond);
+						Objects.requireNonNull(syValueThen);
+						Objects.requireNonNull(syValueElse);
+					}
+
+					@Override
+					public boolean isReference() {
+						return this.syValueThen.isReference();
+					}
+				}
+				""",
+				"bug/syntax/SyValue.java",
+				"""
+				package bug.syntax;
+
+				public sealed interface SyValue permits SyValueUnassumed, SyValuePrimitiveConstant, SyValueReferenceConstant,
+				SyValueAdd, SyValueSub, SyValueLt, SyValueAnd, SyValueOr, SyValueNot, SyValueEq, SyValueSubtypeRel,
+				SyValueFieldRel, SyValueIte {
+					public default boolean isPrimitive() { return !isReference(); }
+					public boolean isReference();
+				}
+				""",
+				"bug/syntax/SyValueLt.java",
+				"""
+				package bug.syntax;
+
+				import java.util.Objects;
+
+				public record SyValueLt(SyValue syValueFirst, SyValue syValueSecond) implements SyValue {
+					public SyValueLt {
+						Objects.requireNonNull(syValueFirst);
+						Objects.requireNonNull(syValueSecond);
+					}
+
+					@Override
+					public boolean isReference() {
+						return false;
+					}
+				}
+				""",
+				"bug/syntax/SyValueNot.java",
+				"""
+				package bug.syntax;
+
+				import java.util.Objects;
+
+				public record SyValueNot(SyValue syValue) implements SyValue {
+					public SyValueNot {
+						Objects.requireNonNull(syValue);
+					}
+
+					@Override
+					public boolean isReference() {
+						return false;
+					}
+				}
+				""",
+				"bug/syntax/SyValueOr.java",
+				"""
+				package bug.syntax;
+
+				import java.util.Objects;
+
+				public record SyValueOr(SyValue syValueFirst, SyValue syValueSecond) implements SyValue {
+					public SyValueOr {
+						Objects.requireNonNull(syValueFirst);
+						Objects.requireNonNull(syValueSecond);
+					}
+
+					@Override
+					public boolean isReference() {
+						return false;
+					}
+				}
+				""",
+				"bug/syntax/SyValuePrimitiveConstant.java",
+				"""
+				package bug.syntax;
+
+				import java.util.Objects;
+
+				public record SyValuePrimitiveConstant(SyPrimitiveConstant syPrimitiveConstant) implements SyValue {
+					public SyValuePrimitiveConstant {
+						Objects.requireNonNull(syPrimitiveConstant);
+					}
+
+					@Override
+					public boolean isReference() {
+						return false;
+					}
+				}
+				""",
+				"bug/syntax/SyValueReferenceConstant.java",
+				"""
+				package bug.syntax;
+
+				import java.util.Objects;
+
+				public record SyValueReferenceConstant(SyReferenceConstant syReferenceConstant) implements SyValue {
+					public SyValueReferenceConstant {
+						Objects.requireNonNull(syReferenceConstant);
+					}
+
+					@Override
+					public boolean isReference() {
+						return true;
+					}
+				}
+				""",
+				"bug/syntax/SyValueSub.java",
+				"""
+				package bug.syntax;
+
+				import java.util.Objects;
+
+				public record SyValueSub(SyValue syValueFirst, SyValue syValueSecond) implements SyValue {
+					public SyValueSub {
+						Objects.requireNonNull(syValueFirst);
+						Objects.requireNonNull(syValueSecond);
+					}
+
+					@Override
+					public boolean isReference() {
+						return false;
+					}
+				}
+				""",
+				"bug/syntax/SyValueSubtypeRel.java",
+				"""
+				package bug.syntax;
+
+				import java.util.Objects;
+
+				public record SyValueSubtypeRel(SyValue syValue, SyType syType) implements SyValue {
+					public SyValueSubtypeRel {
+						Objects.requireNonNull(syValue);
+						Objects.requireNonNull(syType);
+					}
+
+					@Override
+					public boolean isReference() {
+						return false;
+					}
+				}
+				""",
+				"bug/syntax/SyValueUnassumed.java",
+				"""
+				package bug.syntax;
+
+				public record SyValueUnassumed() implements SyValue {
+					@Override
+					public boolean isReference() {
+						return false; //imprecise, not meant to be used
+					}
+				}
+				""",
+		},
+		"Finished!");
+	}
+}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/StringConcatTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/StringConcatTest.java
@@ -89,7 +89,7 @@ public class StringConcatTest extends AbstractComparableTest {
 				},
 				"one=1, two=2.0, three=3.0, four=4, five=5, six=6, seven=, boolean b=false."
 			);
-		String expectedOutput = "  // Stack: 11, Locals: 12\n" +
+		String expectedOutput = "  // Stack: 10, Locals: 12\n" +
 				"  public static void main(java.lang.String[] args);\n" +
 				"     0  iconst_1\n" +
 				"     1  istore_1 [one]\n" +
@@ -144,7 +144,7 @@ public class StringConcatTest extends AbstractComparableTest {
 				},
 				"one=1"
 			);
-		String expectedOutput = "  // Stack: 3, Locals: 3\n" +
+		String expectedOutput = "  // Stack: 2, Locals: 3\n" +
 				"  public void foo();\n" +
 				"     0  iconst_1\n" +
 				"     1  istore_1 [one]\n" +
@@ -183,7 +183,7 @@ public class StringConcatTest extends AbstractComparableTest {
 				},
 				"null,one=1, two=2.0, three=3.0, four=4, five=5, six=6, seven=, boolean b=false"
 			);
-		String expectedOutput = "  // Stack: 13, Locals: 11\n" +
+		String expectedOutput = "  // Stack: 12, Locals: 11\n" +
 				"  public void foo();\n" +
 				"     0  iconst_1\n" +
 				"     1  istore_1 [one]\n" +
@@ -242,7 +242,7 @@ public class StringConcatTest extends AbstractComparableTest {
 				},
 				"count=1"
 			);
-		String expectedOutput = "  // Stack: 3, Locals: 1\n" +
+		String expectedOutput = "  // Stack: 2, Locals: 1\n" +
 				"  public java.lang.String toString();\n" +
 				"     0  aload_0 [this]\n" +
 				"     1  getfield X.count : int [12]\n" +
@@ -277,7 +277,7 @@ public class StringConcatTest extends AbstractComparableTest {
 				},
 				"X 0 a 11 a 11 X 1 b 42 b 42 b 42 b 42"
 				);
-		String expectedOutput = "  // Stack: 7, Locals: 4\n"
+		String expectedOutput = "  // Stack: 6, Locals: 4\n"
 				+ "  public static void main(java.lang.String[] args);\n"
 				+ "     0  bipush 11\n"
 				+ "     2  istore_1 [first]\n"

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchTest.java
@@ -3320,7 +3320,7 @@ public void testGHI1782() throws Exception {
 
 	String expectedOutput =
 			"  // Method descriptor #15 ([Ljava/lang/String;)V\n" +
-			"  // Stack: 3, Locals: 4\n" +
+			"  // Stack: 2, Locals: 4\n" +
 			"  public static void main(java.lang.String[] args);\n" +
 			"     0  ldc <String \"Hello\"> [16]\n" +
 			"     2  astore_1 [hello]\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TestAll.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TestAll.java
@@ -238,8 +238,9 @@ public static Test suite() {
 	 since_21.add(SwitchPatternTest.class);
 	 since_21.add(SwitchPatternTest21.class);
 	 since_21.add(RecordPatternTest.class);
-	since_21.add(UnnamedPatternsAndVariablesTest.class);
-	since_21.add(UseOfUnderscoreWithPreviewTest.class);
+	 since_21.add(RecordPatternProjectTest.class);
+	 since_21.add(UnnamedPatternsAndVariablesTest.class);
+	 since_21.add(UseOfUnderscoreWithPreviewTest.class);
 	 since_21.add(NullAnnotationTests21.class);
 	 since_21.add(StringTemplateTest.class);
 	 since_21.add(BatchCompilerTest_21.class);

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/RunVariousPatternsTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/RunVariousPatternsTests.java
@@ -23,6 +23,7 @@ import org.eclipse.jdt.core.tests.compiler.regression.InstanceofExpressionTest;
 import org.eclipse.jdt.core.tests.compiler.regression.InstanceofPrimaryPatternTest;
 import org.eclipse.jdt.core.tests.compiler.regression.NullAnnotationTests21;
 import org.eclipse.jdt.core.tests.compiler.regression.PatternMatching16Test;
+import org.eclipse.jdt.core.tests.compiler.regression.RecordPatternProjectTest;
 import org.eclipse.jdt.core.tests.compiler.regression.RecordPatternTest;
 import org.eclipse.jdt.core.tests.compiler.regression.SwitchExpressionsYieldTest;
 import org.eclipse.jdt.core.tests.compiler.regression.SwitchPatternTest;
@@ -52,6 +53,7 @@ public class RunVariousPatternsTests extends TestCase {
 	public static Class[] getAllTestClasses() {
 		return new Class[] {
 				RecordPatternTest.class,
+				RecordPatternProjectTest.class,
 				SwitchPatternTest.class,
 				InstanceofPrimaryPatternTest.class,
 				PatternMatching16Test.class,


### PR DESCRIPTION
## What it does

* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2160
* Revert fix for https://bugs.eclipse.org/bugs/show_bug.cgi?id=544298 and refix
* Revert fix for https://bugs.eclipse.org/bugs/show_bug.cgi?id=544556 and refix
* Revert fix for https://bugs.eclipse.org/bugs/show_bug.cgi?id=544204 and refix
* Fix arbitrary and incorrect stack manipulation code in string concatenation invoke dynamic call
* Fix incorrect stack manipulation in string templates invoke dynamic call
* Fix argument and receiver size calculation error for captured outer locals
* Replace various ad-hoc stack adjustment calls with structured stack size tracking

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
