### PR TITLE
Modify grammar to create switch nodes after parsing expression

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTParserRecoveryTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTParserRecoveryTest.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.core.tests.dom;
+
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.ClassInstanceCreation;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.ExpressionStatement;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.TypeDeclaration;
+import org.junit.Test;
+
+public class ASTParserRecoveryTest extends org.eclipse.jdt.core.tests.junit.extension.TestCase {
+
+	public ASTParserRecoveryTest(String name) {
+		super(name);
+	}
+
+	public static ASTNode getAST(String source) {
+		@SuppressWarnings("deprecation")
+		ASTParser parser = ASTParser.newParser(AST.JLS8);
+		parser.setSource(source.toCharArray());
+		parser.setStatementsRecovery(true);
+		parser.setIgnoreMethodBodies(false);
+		return parser.createAST(new NullProgressMonitor());
+	}
+
+	@Test
+	public void testRecoverSwitchInAnonymousClassInMethod() {
+		ASTNode root = getAST(
+				"""
+				public class Test {
+					private static ILog test() {
+						return new ILog() {
+							@Override
+							public void log(String status) {
+								switch (status.length()) { // here
+								case
+								}
+							}
+						};
+					}
+				}
+				""");
+		assertTrue("root is compilationUnit", root instanceof CompilationUnit);
+		CompilationUnit compilationUnit = (CompilationUnit) root;
+		assertEquals("should have one type", 1, compilationUnit.types().size());
+		TypeDeclaration typeDeclaration = (TypeDeclaration)compilationUnit.types().get(0);
+		assertEquals("should have one method", 1, typeDeclaration.getMethods().length);
+		MethodDeclaration methodDeclaration = typeDeclaration.getMethods()[0];
+		assertEquals("method should have one statement", 1, methodDeclaration.getBody().statements().size());
+		ExpressionStatement returnStatement = (ExpressionStatement)methodDeclaration.getBody().statements().get(0);
+		assertTrue("return expression should be class instance creation", returnStatement.getExpression() instanceof ClassInstanceCreation);
+		ClassInstanceCreation anonymous = (ClassInstanceCreation)returnStatement.getExpression();
+		assertEquals("anonymous class has one body declaration", 1, anonymous.getAnonymousClassDeclaration().bodyDeclarations().size());
+		MethodDeclaration logMethodDeclaration = (MethodDeclaration) anonymous.getAnonymousClassDeclaration().bodyDeclarations().get(0);
+		assertEquals("anonymous class log method has one statement in it", 1, logMethodDeclaration.getBody().statements().size());
+	}
+
+}

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/RunAllTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/RunAllTests.java
@@ -13,7 +13,8 @@
  *******************************************************************************/
 package org.eclipse.jdt.core.tests.dom;
 
-import java.lang.reflect.*;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 
 import org.eclipse.jdt.core.tests.junit.extension.TestCase;
 
@@ -40,7 +41,8 @@ public static Class[] getAllTestClasses() {
 		org.eclipse.jdt.core.tests.rewrite.modifying.ASTRewritingModifyingTest.class,
 		ASTPositionsTest.class,
 		ASTNodeFinderTest.class,
-		org.eclipse.jdt.core.tests.dom.APIDocumentationTests.class
+		org.eclipse.jdt.core.tests.dom.APIDocumentationTests.class,
+		ASTParserRecoveryTest.class
 	};
 }
 public static Test suite() {


### PR DESCRIPTION
## What it does
Modifies the parser so that switch statements can be recovered in more cases, such as when they're in the body of a method in an anonymous class that's declared in a method.

Fixes #2155

Signed-off-by: David Thompson <davthomp@redhat.com>

## How to test
View the attached test case.

I expect that this will mostly be helpful for clients consuming `ASTParser`, since many cases within jdt.core that need recovered nodes use the `SelectionParser` or the `CompletionParser`, which do a much better job of recovering broken AST nodes.

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
