### PR TITLE
Rectify missing adjustment to expression length stack pointer

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
@@ -4518,12 +4518,15 @@ private void consumeTemplateExpression(Expression expression, Expression process
 }
 protected void consumeTemplateExpressionWithPrimary() {
 	Expression template = this.expressionStack[this.expressionPtr--];
+	this.expressionLengthPtr--;
 	Expression processor = this.expressionStack[this.expressionPtr--];
+	this.expressionLengthPtr--;
 	consumeTemplateExpression(template, processor);
 }
 protected void consumeTemplateExpressionWithName() {
 	NameReference processor = getUnspecifiedReference(true);
 	Expression template = this.expressionStack[this.expressionPtr--];
+	this.expressionLengthPtr--;
 	consumeTemplateExpression(template, processor);
 }
 protected void consumeInstanceOfExpression() {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/StringTemplateTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/StringTemplateTest.java
@@ -1658,6 +1658,114 @@ s
 				"Hello Changed Changed!"
 		);
 	}
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2125
+	// [String Templates] Compilation error when Template Processor used in unconditional for loop
+	public void testIssue2125() {
+		runConformTest(
+				new String[] {
+					"X.java",
+					"""
+					import java.lang.StringTemplate.Processor;
+
+					public class X implements Processor<String, RuntimeException> {
+					  public static void main(String [] args) {
+					    for(;;) {
+					      System.out.println(new X()."SELECT * FROM");
+					      break;
+					    }
+					  }
+
+					  @Override
+					  public String process(StringTemplate stringTemplate) throws RuntimeException {
+					    return STR.process(stringTemplate);
+					  }
+					}
+					"""
+				},
+				"SELECT * FROM"
+		);
+	}
+	public void testIssue2125_2() {
+		runConformTest(
+				new String[] {
+					"X.java",
+					"""
+					import java.lang.StringTemplate.Processor;
+
+					public class X implements Processor<String, RuntimeException> {
+					  public static void main(String [] args) {
+					    for (int i = 0; i < 3; i++) {
+					      System.out.println(new X()."SELECT * FROM");
+					    }
+					  }
+
+					  @Override
+					  public String process(StringTemplate stringTemplate) throws RuntimeException {
+					    return STR.process(stringTemplate);
+					  }
+					}
+					"""
+				},
+				"SELECT * FROM\n"
+				+ "SELECT * FROM\n"
+				+ "SELECT * FROM"
+		);
+	}
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2125
+	// [String Templates] Compilation error when Template Processor used in unconditional for loop
+	public void testIssue2125_3() {
+		runConformTest(
+				new String[] {
+					"X.java",
+					"""
+					import java.lang.StringTemplate.Processor;
+
+					public class X implements Processor<String, RuntimeException> {
+					  public static void main(String [] args) {
+					    for(;;) {
+					      System.out.println(STR."SELECT * FROM");
+					      break;
+					    }
+					  }
+
+					  @Override
+					  public String process(StringTemplate stringTemplate) throws RuntimeException {
+					    return STR.process(stringTemplate);
+					  }
+					}
+					"""
+				},
+				"SELECT * FROM"
+		);
+	}
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2125
+	// [String Templates] Compilation error when Template Processor used in unconditional for loop
+	public void testIssue2125_4() {
+		runConformTest(
+				new String[] {
+					"X.java",
+					"""
+					import java.lang.StringTemplate.Processor;
+
+					public class X implements Processor<String, RuntimeException> {
+					  public static void main(String [] args) {
+					    for (int i = 0; i < 3; i++) {
+					      System.out.println(STR."SELECT * FROM");
+					    }
+					  }
+
+					  @Override
+					  public String process(StringTemplate stringTemplate) throws RuntimeException {
+					    return STR.process(stringTemplate);
+					  }
+					}
+					"""
+				},
+				"SELECT * FROM\n"
+				+ "SELECT * FROM\n"
+				+ "SELECT * FROM"
+		);
+	}
 	// Test with read of the outer string literal inside the template expression
 	public void test0060() {
 		runNegativeTest(


### PR DESCRIPTION

## What it does

* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2125

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
