### PR TITLE
Rectify type compatibility check that incorrectly excludes array types

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/CaseStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/CaseStatement.java
@@ -375,7 +375,7 @@ public Constant resolveConstantExpression(BlockScope scope,
 			return resolveConstantExpression(scope, caseType, switchType,
 					switchStatement,(Pattern) expression);
 		} else if (expression instanceof NullLiteral) {
-			if (!(switchType instanceof ReferenceBinding)) {
+			if (!caseType.isCompatibleWith(switchType, scope)) {
 				scope.problemReporter().typeMismatchError(TypeBinding.NULL, switchType, expression, null);
 			}
 			switchStatement.switchBits |= SwitchStatement.NullCase;

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchTest.java
@@ -3365,6 +3365,36 @@ public void testGHI1782() throws Exception {
 		assertEquals("Wrong contents", expectedOutput, result);
 	}
 }
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2190
+// [Enhanced switch] Case null disallowed when switching on arrays
+public void testIssue2190() throws Exception {
+	if (this.complianceLevel < ClassFileConstants.JDK21)
+		return;
+
+	this.runConformTest(new String[] {
+		"X.java",
+		"""
+		public class X {
+			public static void main(String[] args) {
+				int[] aa = {1};
+				switch (aa) {
+				    case null -> System.out.println("AA");
+				    default -> System.out.println("BB");
+				}
+
+				int[] cc = null;
+				switch (cc) {
+				    case null -> System.out.println("AA");
+				    default -> System.out.println("BB");
+				}
+			}
+		}
+		""",
+	},
+	"BB\n"
+	+ "AA");
+}
+
 public static Class testClass() {
 	return SwitchTest.class;
 }


### PR DESCRIPTION

## What it does

* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2190

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
