### PR TITLE
Prevent StackOverflow when parsing working copy of module declaration

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/LookupEnvironment.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/LookupEnvironment.java
@@ -498,7 +498,7 @@ public void buildTypeBindings(CompilationUnitDeclaration unit, AccessRestriction
 		scope = new CompilationUnitScope(unit, this.globalOptions);
 		unitModule = unit.moduleDeclaration.setBinding(new SourceModuleBinding(moduleName, scope, this.root));
 	} else {
-		if (this.globalOptions.sourceLevel >= ClassFileConstants.JDK9) {
+		if (this.globalOptions.sourceLevel >= ClassFileConstants.JDK9 && !unit.isModuleInfo()) {
 			unitModule = unit.module(this);
 		}
 		scope = new CompilationUnitScope(unit, unitModule != null ? unitModule.environment : this);

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter9Test.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter9Test.java
@@ -13,31 +13,23 @@
  *******************************************************************************/
 package org.eclipse.jdt.core.tests.dom;
 
-import junit.framework.Test;
-
-import org.eclipse.jdt.core.dom.*;
-import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
-import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
-import org.eclipse.jdt.internal.core.JrtPackageFragmentRoot;
-import org.eclipse.jdt.internal.core.SourceModule;
-
 import java.util.List;
 import java.util.function.Consumer;
 
 import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Path;
-import org.eclipse.jdt.core.IClasspathAttribute;
-import org.eclipse.jdt.core.ICompilationUnit;
-import org.eclipse.jdt.core.IJavaElement;
-import org.eclipse.jdt.core.IJavaProject;
-import org.eclipse.jdt.core.IModularClassFile;
-import org.eclipse.jdt.core.IModuleDescription;
-import org.eclipse.jdt.core.IPackageFragmentRoot;
-import org.eclipse.jdt.core.IType;
-import org.eclipse.jdt.core.JavaCore;
-import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.*;
 import org.eclipse.jdt.core.compiler.IProblem;
+import org.eclipse.jdt.core.dom.*;
+import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
+import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
+import org.eclipse.jdt.internal.core.JrtPackageFragmentRoot;
+import org.eclipse.jdt.internal.core.SourceModule;
+import org.eclipse.text.edits.ReplaceEdit;
+
+import junit.framework.Test;
 
 @SuppressWarnings({"rawtypes"})
 public class ASTConverter9Test extends ConverterTestSetup {
@@ -1473,6 +1465,53 @@ public class ASTConverter9Test extends ConverterTestSetup {
 					problems, source.toCharArray());
 		} finally {
 			deleteProject(p);
+		}
+	}
+	public void testStackOverflowInEmptiedModuleDeclarationParsing() throws JavaModelException, CoreException {
+		try {
+			IJavaProject project1 = createJavaProject("ASTParserModelTests", new String[] { "src" },
+					new String[] { "CONVERTER_JCL9_LIB" }, "bin", "9");
+			project1.open(null);
+			addClasspathEntry(project1, JavaCore.newContainerEntry(new Path("org.eclipse.jdt.MODULE_PATH")));
+			String content = """
+			module first {
+				requires transitive static second.third;
+				exports pack1.X11 to org.eclipse.jdt;
+			}
+			""";
+			createFile("/ASTParserModelTests/src/module-info.java", content);
+			this.workingCopy = getCompilationUnit("/ASTParserModelTests/src/module-info.java");
+			this.workingCopy.getBuffer().setContents("");
+
+			ASTParser astParser = ASTParser.newParser(AST.getJLSLatest());
+			astParser.setSource(this.workingCopy);
+			astParser.setResolveBindings(true);
+			astParser.setStatementsRecovery(true);
+			ASTNode astNode = astParser.createAST(new NullProgressMonitor());
+			assertEquals("", astNode.toString());
+		} finally {
+			deleteProject("ASTParserModelTests");
+		}
+	}
+	public void testClassCastExceptionWhenOpeningModuleInfoWithClass() throws JavaModelException, CoreException {
+		try {
+			IJavaProject project1 = createJavaProject("ASTParserModelTests", new String[] { "src" },
+					new String[] { "CONVERTER_JCL9_LIB" }, "bin", "9");
+			project1.open(null);
+			addClasspathEntry(project1, JavaCore.newContainerEntry(new Path("org.eclipse.jdt.MODULE_PATH")));
+			String content = """
+			module first {
+			}
+			""";
+			createFile("/ASTParserModelTests/src/module-info.java", content);
+			this.workingCopy = getCompilationUnit("/ASTParserModelTests/src/module-info.java");
+			this.workingCopy.becomeWorkingCopy(null);
+			this.workingCopy.applyTextEdit(new ReplaceEdit(0, 6, "class"), null);
+			this.workingCopy.reconcile(AST.getJLSLatest(), true, false, null, null);
+			project1.getProject().build(IncrementalProjectBuilder.INCREMENTAL_BUILD, null);
+			assertEquals(0, this.workingCopy.getChildren().length);
+		} finally {
+			deleteProject("ASTParserModelTests");
 		}
 	}
 // Add new tests here

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/compiler/SourceElementNotifier.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/compiler/SourceElementNotifier.java
@@ -484,7 +484,7 @@ public void notifySourceElementRequestor(
 					} else {
 						notifySourceElementRequestor(importRef, false);
 					}
-				} else if (node instanceof TypeDeclaration) {
+				} else if (node instanceof TypeDeclaration && !new String(parsedUnit.getFileName()).endsWith(TypeConstants.MODULE_INFO_FILE_NAME_STRING)) {
 					notifySourceElementRequestor((TypeDeclaration)node, true, null, currentPackage);
 				} else if (node instanceof ModuleDeclaration) {
 					notifySourceElementRequestor(parsedUnit.moduleDeclaration);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
If you use `ASTParser` to parse the working copy of a module declaration with resolveBinding enabled, and the copy of the module-info.java on disk is a valid module declaration but the working copy is the empty string, this causes a stack overflow. I've included an integration test that replicates this issue.

This PR prevents the stack overflow.

This pr also fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2280 , which also triggers the same StackOverflow, and addresses a ClassCastException that this uncovers.

## How to test
See the steps listed in https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2280 and verify no exceptions occur.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
