### PR TITLE
Replace deprecated core.launcher.Main by equinox.launcher.Main

### DIFF
--- a/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/build/JdtApt.java
+++ b/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/build/JdtApt.java
@@ -37,7 +37,7 @@ import org.eclipse.jdt.apt.core.internal.build.Messages;
  */
 public class JdtApt extends Java {
 
-	private static final String APP_CLASSNAME = "org.eclipse.core.launcher.Main"; //$NON-NLS-1$
+	private static final String APP_CLASSNAME = "org.eclipse.equinox.launcher.Main"; //$NON-NLS-1$
     private static final String APP_PLUGIN = "org.eclipse.jdt.apt.core.aptBuild"; //$NON-NLS-1$
 
     private File workspace;


### PR DESCRIPTION
## What it does

Replace deprecated `core.launcher.Main` by `equinox.launcher.Main`.

Required for https://github.com/eclipse-equinox/equinox/pull/562

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
