### PR TITLE
[Switch] Various code cleanups in switch expressions/statements

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Expression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Expression.java
@@ -1118,10 +1118,6 @@ public void resolve(BlockScope scope) {
 	this.resolveType(scope);
 	return;
 }
-@Override
-public TypeBinding resolveExpressionType(BlockScope scope) {
-	return resolveType(scope);
-}
 
 public TypeBinding resolveTypeWithBindings(LocalVariableBinding[] bindings, BlockScope scope) {
 	scope.include(bindings);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Statement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Statement.java
@@ -500,13 +500,7 @@ public void resolveWithBindings(LocalVariableBinding[] bindings, BlockScope scop
 		scope.exclude(bindings);
 	}
 }
-/**
- * Returns the resolved expression if any associated to this statement - used
- * parameter statement has to be either a SwitchStatement or a SwitchExpression
- */
-public TypeBinding resolveExpressionType(BlockScope scope) {
-	return null;
-}
+
 
 public boolean containsPatternVariable() {
 	return containsPatternVariable(false);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchExpression.java
@@ -59,8 +59,6 @@ public class SwitchExpression extends SwitchStatement implements IPolyExpression
 	public List<Expression> resultExpressions;
 	public boolean resolveAll;
 	/* package */ List<Integer> resultExpressionNullStatus;
-	LocalVariableBinding hiddenYield;
-	/* package */ int hiddenYieldResolvedPosition = -1;
 	public boolean containsTry = false;
 	private static Map<TypeBinding, TypeBinding[]> type_map;
 	static final char[] SECRET_YIELD_VALUE_NAME = " yieldValue".toCharArray(); //$NON-NLS-1$
@@ -387,10 +385,12 @@ public class SwitchExpression extends SwitchStatement implements IPolyExpression
 	}
 
 	@Override
-	public TypeBinding resolveType(BlockScope upperScope) {
-		return resolveTypeInternal(upperScope);
+	public void resolve(BlockScope upperScope) {
+		resolveType(upperScope);
 	}
-	public TypeBinding resolveTypeInternal(BlockScope upperScope) {
+
+	@Override
+	public TypeBinding resolveType(BlockScope upperScope) {
 		try {
 			int resultExpressionsCount;
 			if (this.constant != Constant.NotAConstant) {
@@ -409,7 +409,7 @@ public class SwitchExpression extends SwitchStatement implements IPolyExpression
 
 				if (this.originalTypeMap == null)
 					this.originalTypeMap = new HashMap<>();
-				resolve(upperScope);
+				super.resolve(upperScope);
 
 				if (this.statements == null || this.statements.length == 0) {
 					//	Report Error JLS 13 15.28.1  The switch block must not be empty.
@@ -632,21 +632,7 @@ public class SwitchExpression extends SwitchStatement implements IPolyExpression
 		computeNullStatus(flowInfo, flowContext);
 		return flowInfo;
 	}
-	@Override
-	protected void addSecretTryResultVariable() {
-		if (this.containsTry) {
-			this.hiddenYield =
-					new LocalVariableBinding(
-						SwitchExpression.SECRET_YIELD_VALUE_NAME,
-						null,
-						ClassFileConstants.AccDefault,
-						false);
-			this.hiddenYield.setConstant(Constant.NotAConstant);
-			this.hiddenYield.useFlag = LocalVariableBinding.USED;
-			this.scope.addLocalVariable(this.hiddenYield);
-			this.hiddenYield.declaration = new LocalDeclaration(SECRET_YIELD_VALUE_NAME, 0, 0);
-		}
-	}
+
 	private TypeBinding check_csb(Set<TypeBinding> typeSet, TypeBinding candidate) {
 		if (!typeSet.contains(candidate))
 			return null;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
@@ -466,7 +466,7 @@ public class SwitchStatement extends Expression {
 						complaintLevel = initialComplaintLevel; // reset complaint
 						fallThroughState = this.containsPatterns ? FALLTHROUGH : CASE;
 					} else {
-						if (!(this instanceof SwitchExpression) &&
+						if (!isTrulyExpression() &&
 							compilerOptions.complianceLevel >= ClassFileConstants.JDK14 &&
 							statement instanceof YieldStatement &&
 							((YieldStatement) statement).isImplicit) {
@@ -1058,10 +1058,8 @@ public class SwitchStatement extends Expression {
 		}
 		return n;
 	}
-	protected void addSecretTryResultVariable() {
-		// do nothing
-	}
-	/* package */ boolean isAllowedType(TypeBinding type) {
+
+	boolean isAllowedType(TypeBinding type) {
 		if (type == null)
 			return false;
 		switch (type.id) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/messages.properties
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/messages.properties
@@ -69,7 +69,7 @@ constant_cannotConvertedTo = {0} constant cannot be converted to {1}
 ### Java Language Features
 switch_expression = Switch Expressions
 text_block = Text Blocks
-pattern_matching_instanceof = Pattern Matching in instanceof Expressions
+pattern_matching_instanceof = Type Patterns
 records = Records
 sealed_types = Sealed Types
 pattern_matching_switch = Pattern Matching in Switch

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
@@ -161,8 +161,7 @@ public class Parser implements TerminalTokens, ParserBasicInformation, Conflicte
 	}
 
 	protected enum CaseLabelKind {
-		CASE_EXPRESSION,
-		CASE_NULL,
+		CASE_EXPRESSION,  // case null is subsumed by CASE_EXPRESSION
 		CASE_DEFAULT,
 		CASE_PATTERN
 	}
@@ -9673,23 +9672,29 @@ protected void consumeConstantExpression() {
 	// do nothing for now.
 }
 protected void consumeCaseLabelElement(CaseLabelKind kind) {
+	Expression pattern = null;
 	switch (kind) {
-		case CASE_PATTERN:
-			this.astLengthPtr--;
-			Pattern pattern = (Pattern) this.astStack[this.astPtr--];
-			pushOnExpressionStack(pattern);
-			this.recordPatternSwitches.put(this.switchNestingLevel, Boolean.TRUE);
-			break;
-		case CASE_EXPRESSION:
-			if (this.expressionPtr >= 0 && this.expressionStack[this.expressionPtr] instanceof NullLiteral)
-				this.recordNullSwitches.put(this.switchNestingLevel, Boolean.TRUE);
-			break;
-		case CASE_DEFAULT:
-			int end = this.intStack[this.intPtr--];
-			int start = this.intStack[this.intPtr--];
-			pushOnExpressionStack(new FakeDefaultLiteral(start, end));
-			break;
-		default : break;
+		case CASE_PATTERN -> {
+				this.astLengthPtr--;
+				pattern = (Pattern) this.astStack[this.astPtr--];
+				pushOnExpressionStack(pattern);
+				this.recordPatternSwitches.put(this.switchNestingLevel, Boolean.TRUE);
+			}
+		case CASE_EXPRESSION -> {
+				if ((pattern = this.expressionStack[this.expressionPtr]) instanceof NullLiteral) {
+					this.recordNullSwitches.put(this.switchNestingLevel, Boolean.TRUE);
+				} else {
+					pattern = null;
+				}
+			}
+		case CASE_DEFAULT -> {
+				int end = this.intStack[this.intPtr--];
+				int start = this.intStack[this.intPtr--];
+				pushOnExpressionStack(pattern = new FakeDefaultLiteral(start, end));
+			}
+	}
+	if (pattern != null) {
+		problemReporter().validateJavaFeatureSupport(JavaFeature.PATTERN_MATCHING_IN_SWITCH, pattern.sourceStart, pattern.sourceEnd);
 	}
 	this.scanner.multiCaseLabelComma = this.currentToken == TerminalTokens.TokenNameCOMMA;
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/parser/ComplianceDiagnoseTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/parser/ComplianceDiagnoseTest.java
@@ -516,6 +516,313 @@ public void test0009() {
 			JavacTestOptions.Excuse.EclipseHasSomeMoreWarnings);
 	}
 }
+
+public void testPatternsInCase() {
+	String[] testFiles = new String[] {
+		"X.java",
+		"""
+		public class X {
+		    public static void main(String [] args) {
+		        Object o = null;
+		        switch (o) {
+		            case X x, null:
+		                break;
+		            case String s, default :
+		               break;
+		        }
+		    }
+	    }
+		"""
+	};
+
+	String expectedProblemLogFrom1_1_6 =
+					"----------\n" +
+					"1. ERROR in X.java (at line 4)\n" +
+					"	switch (o) {\n" +
+					"	        ^\n" +
+					"Cannot switch on a value of type Object. Only convertible int values or enum variables are permitted\n" +
+					"----------\n" +
+					"2. ERROR in X.java (at line 5)\n" +
+					"	case X x, null:\n" +
+					"	^^^^^^^^^^^^^^\n" +
+					"Multi-constant case labels supported from Java 14 onwards only\n" +
+					"----------\n" +
+					"3. ERROR in X.java (at line 5)\n" +
+					"	case X x, null:\n" +
+					"	     ^^^\n" +
+					"The Java feature 'Type Patterns' is only available with source level 16 and above\n" +
+					"----------\n" +
+					"4. ERROR in X.java (at line 5)\n" +
+					"	case X x, null:\n" +
+					"	     ^^^\n" +
+					"The Java feature 'Pattern Matching in Switch' is only available with source level 21 and above\n" +
+					"----------\n" +
+					"5. ERROR in X.java (at line 5)\n" +
+					"	case X x, null:\n" +
+					"	          ^^^^\n" +
+					"The Java feature 'Pattern Matching in Switch' is only available with source level 21 and above\n" +
+					"----------\n" +
+					"6. ERROR in X.java (at line 5)\n" +
+					"	case X x, null:\n" +
+					"	          ^^^^\n" +
+					"Cannot mix pattern with other case labels\n" +
+					"----------\n" +
+					"7. ERROR in X.java (at line 5)\n" +
+					"	case X x, null:\n" +
+					"	          ^^^^\n" +
+					"A null case label has to be either the only expression in a case label or the first expression followed only by a default\n" +
+					"----------\n" +
+					"8. ERROR in X.java (at line 7)\n" +
+					"	case String s, default :\n" +
+					"	^^^^^^^^^^^^^^^^^^^^^^\n" +
+					"Multi-constant case labels supported from Java 14 onwards only\n" +
+					"----------\n" +
+					"9. ERROR in X.java (at line 7)\n" +
+					"	case String s, default :\n" +
+					"	     ^^^^^^^^\n" +
+					"The Java feature 'Type Patterns' is only available with source level 16 and above\n" +
+					"----------\n" +
+					"10. ERROR in X.java (at line 7)\n" +
+					"	case String s, default :\n" +
+					"	     ^^^^^^^^\n" +
+					"The Java feature 'Pattern Matching in Switch' is only available with source level 21 and above\n" +
+					"----------\n" +
+					"11. ERROR in X.java (at line 7)\n" +
+					"	case String s, default :\n" +
+					"	               ^^^^^^^\n" +
+					"The Java feature 'Pattern Matching in Switch' is only available with source level 21 and above\n" +
+					"----------\n" +
+					"12. ERROR in X.java (at line 7)\n" +
+					"	case String s, default :\n" +
+					"	               ^^^^^^^\n" +
+					"Cannot mix pattern with other case labels\n" +
+					"----------\n" +
+					"13. ERROR in X.java (at line 7)\n" +
+					"	case String s, default :\n" +
+					"	               ^^^^^^^\n" +
+					"A 'default' can occur after 'case' only as a second case label expression and that too only if 'null' precedes  in 'case null, default' \n" +
+					"----------\n";
+
+	String expectedProblemLogFrom7_13 =
+			"----------\n" +
+			"1. ERROR in X.java (at line 4)\n" +
+			"	switch (o) {\n" +
+			"	        ^\n" +
+			"Cannot switch on a value of type Object. Only convertible int values, strings or enum variables are permitted\n" +
+			"----------\n" +
+			"2. ERROR in X.java (at line 5)\n" +
+			"	case X x, null:\n" +
+			"	^^^^^^^^^^^^^^\n" +
+			"Multi-constant case labels supported from Java 14 onwards only\n" +
+			"----------\n" +
+			"3. ERROR in X.java (at line 5)\n" +
+			"	case X x, null:\n" +
+			"	     ^^^\n" +
+			"The Java feature 'Type Patterns' is only available with source level 16 and above\n" +
+			"----------\n" +
+			"4. ERROR in X.java (at line 5)\n" +
+			"	case X x, null:\n" +
+			"	     ^^^\n" +
+			"The Java feature 'Pattern Matching in Switch' is only available with source level 21 and above\n" +
+			"----------\n" +
+			"5. ERROR in X.java (at line 5)\n" +
+			"	case X x, null:\n" +
+			"	          ^^^^\n" +
+			"The Java feature 'Pattern Matching in Switch' is only available with source level 21 and above\n" +
+			"----------\n" +
+			"6. ERROR in X.java (at line 5)\n" +
+			"	case X x, null:\n" +
+			"	          ^^^^\n" +
+			"Cannot mix pattern with other case labels\n" +
+			"----------\n" +
+			"7. ERROR in X.java (at line 5)\n" +
+			"	case X x, null:\n" +
+			"	          ^^^^\n" +
+			"A null case label has to be either the only expression in a case label or the first expression followed only by a default\n" +
+			"----------\n" +
+			"8. ERROR in X.java (at line 7)\n" +
+			"	case String s, default :\n" +
+			"	^^^^^^^^^^^^^^^^^^^^^^\n" +
+			"Multi-constant case labels supported from Java 14 onwards only\n" +
+			"----------\n" +
+			"9. ERROR in X.java (at line 7)\n" +
+			"	case String s, default :\n" +
+			"	     ^^^^^^^^\n" +
+			"The Java feature 'Type Patterns' is only available with source level 16 and above\n" +
+			"----------\n" +
+			"10. ERROR in X.java (at line 7)\n" +
+			"	case String s, default :\n" +
+			"	     ^^^^^^^^\n" +
+			"The Java feature 'Pattern Matching in Switch' is only available with source level 21 and above\n" +
+			"----------\n" +
+			"11. ERROR in X.java (at line 7)\n" +
+			"	case String s, default :\n" +
+			"	               ^^^^^^^\n" +
+			"The Java feature 'Pattern Matching in Switch' is only available with source level 21 and above\n" +
+			"----------\n" +
+			"12. ERROR in X.java (at line 7)\n" +
+			"	case String s, default :\n" +
+			"	               ^^^^^^^\n" +
+			"Cannot mix pattern with other case labels\n" +
+			"----------\n" +
+			"13. ERROR in X.java (at line 7)\n" +
+			"	case String s, default :\n" +
+			"	               ^^^^^^^\n" +
+			"A 'default' can occur after 'case' only as a second case label expression and that too only if 'null' precedes  in 'case null, default' \n" +
+			"----------\n";
+
+	String expectedProblemLogFrom14_15 =
+			"----------\n" +
+			"1. ERROR in X.java (at line 4)\n" +
+			"	switch (o) {\n" +
+			"	        ^\n" +
+			"Cannot switch on a value of type Object. Only convertible int values, strings or enum variables are permitted\n" +
+			"----------\n" +
+			"2. ERROR in X.java (at line 5)\n" +
+			"	case X x, null:\n" +
+			"	     ^^^\n" +
+			"The Java feature 'Type Patterns' is only available with source level 16 and above\n" +
+			"----------\n" +
+			"3. ERROR in X.java (at line 5)\n" +
+			"	case X x, null:\n" +
+			"	     ^^^\n" +
+			"The Java feature 'Pattern Matching in Switch' is only available with source level 21 and above\n" +
+			"----------\n" +
+			"4. ERROR in X.java (at line 5)\n" +
+			"	case X x, null:\n" +
+			"	          ^^^^\n" +
+			"The Java feature 'Pattern Matching in Switch' is only available with source level 21 and above\n" +
+			"----------\n" +
+			"5. ERROR in X.java (at line 5)\n" +
+			"	case X x, null:\n" +
+			"	          ^^^^\n" +
+			"Cannot mix pattern with other case labels\n" +
+			"----------\n" +
+			"6. ERROR in X.java (at line 5)\n" +
+			"	case X x, null:\n" +
+			"	          ^^^^\n" +
+			"A null case label has to be either the only expression in a case label or the first expression followed only by a default\n" +
+			"----------\n" +
+			"7. ERROR in X.java (at line 7)\n" +
+			"	case String s, default :\n" +
+			"	     ^^^^^^^^\n" +
+			"The Java feature 'Type Patterns' is only available with source level 16 and above\n" +
+			"----------\n" +
+			"8. ERROR in X.java (at line 7)\n" +
+			"	case String s, default :\n" +
+			"	     ^^^^^^^^\n" +
+			"The Java feature 'Pattern Matching in Switch' is only available with source level 21 and above\n" +
+			"----------\n" +
+			"9. ERROR in X.java (at line 7)\n" +
+			"	case String s, default :\n" +
+			"	               ^^^^^^^\n" +
+			"The Java feature 'Pattern Matching in Switch' is only available with source level 21 and above\n" +
+			"----------\n" +
+			"10. ERROR in X.java (at line 7)\n" +
+			"	case String s, default :\n" +
+			"	               ^^^^^^^\n" +
+			"Cannot mix pattern with other case labels\n" +
+			"----------\n" +
+			"11. ERROR in X.java (at line 7)\n" +
+			"	case String s, default :\n" +
+			"	               ^^^^^^^\n" +
+			"A 'default' can occur after 'case' only as a second case label expression and that too only if 'null' precedes  in 'case null, default' \n" +
+			"----------\n";
+
+	String expectedProblemLogFrom16_20 =
+			"----------\n" +
+			"1. ERROR in X.java (at line 4)\n" +
+			"	switch (o) {\n" +
+			"	        ^\n" +
+			"Cannot switch on a value of type Object. Only convertible int values, strings or enum variables are permitted\n" +
+			"----------\n" +
+			"2. ERROR in X.java (at line 5)\n" +
+			"	case X x, null:\n" +
+			"	     ^^^\n" +
+			"The Java feature 'Pattern Matching in Switch' is only available with source level 21 and above\n" +
+			"----------\n" +
+			"3. ERROR in X.java (at line 5)\n" +
+			"	case X x, null:\n" +
+			"	          ^^^^\n" +
+			"The Java feature 'Pattern Matching in Switch' is only available with source level 21 and above\n" +
+			"----------\n" +
+			"4. ERROR in X.java (at line 5)\n" +
+			"	case X x, null:\n" +
+			"	          ^^^^\n" +
+			"Cannot mix pattern with other case labels\n" +
+			"----------\n" +
+			"5. ERROR in X.java (at line 5)\n" +
+			"	case X x, null:\n" +
+			"	          ^^^^\n" +
+			"A null case label has to be either the only expression in a case label or the first expression followed only by a default\n" +
+			"----------\n" +
+			"6. ERROR in X.java (at line 7)\n" +
+			"	case String s, default :\n" +
+			"	     ^^^^^^^^\n" +
+			"The Java feature 'Pattern Matching in Switch' is only available with source level 21 and above\n" +
+			"----------\n" +
+			"7. ERROR in X.java (at line 7)\n" +
+			"	case String s, default :\n" +
+			"	               ^^^^^^^\n" +
+			"The Java feature 'Pattern Matching in Switch' is only available with source level 21 and above\n" +
+			"----------\n" +
+			"8. ERROR in X.java (at line 7)\n" +
+			"	case String s, default :\n" +
+			"	               ^^^^^^^\n" +
+			"Cannot mix pattern with other case labels\n" +
+			"----------\n" +
+			"9. ERROR in X.java (at line 7)\n" +
+			"	case String s, default :\n" +
+			"	               ^^^^^^^\n" +
+			"A 'default' can occur after 'case' only as a second case label expression and that too only if 'null' precedes  in 'case null, default' \n" +
+			"----------\n";
+
+	String expectedProblemLogFrom21 =
+			"----------\n" +
+			"1. ERROR in X.java (at line 5)\n" +
+			"	case X x, null:\n" +
+			"	          ^^^^\n" +
+			"Cannot mix pattern with other case labels\n" +
+			"----------\n" +
+			"2. ERROR in X.java (at line 5)\n" +
+			"	case X x, null:\n" +
+			"	          ^^^^\n" +
+			"A null case label has to be either the only expression in a case label or the first expression followed only by a default\n" +
+			"----------\n" +
+			"3. ERROR in X.java (at line 7)\n" +
+			"	case String s, default :\n" +
+			"	               ^^^^^^^\n" +
+			"Cannot mix pattern with other case labels\n" +
+			"----------\n" +
+			"4. ERROR in X.java (at line 7)\n" +
+			"	case String s, default :\n" +
+			"	               ^^^^^^^\n" +
+			"A 'default' can occur after 'case' only as a second case label expression and that too only if 'null' precedes  in 'case null, default' \n" +
+			"----------\n";
+
+	if (this.complianceLevel < ClassFileConstants.JDK1_7) {  // before switching on strings
+		runNegativeTest(
+			testFiles,
+			expectedProblemLogFrom1_1_6);
+	}
+	else if (this.complianceLevel < ClassFileConstants.JDK14) { // before multi case
+		runNegativeTest(
+				testFiles,
+				expectedProblemLogFrom7_13);
+	} else if (this.complianceLevel < ClassFileConstants.JDK16) { // before type patterns
+			runNegativeTest(
+					testFiles,
+					expectedProblemLogFrom14_15);
+	} else if (this.complianceLevel < ClassFileConstants.JDK21) { // before case patterns
+		runNegativeTest(
+				testFiles,
+				expectedProblemLogFrom16_20);
+	} else {
+		runNegativeTest(
+				testFiles,
+				expectedProblemLogFrom21);
+	}
+}
 public void test0010() {
 	String[] testFiles = new String[] {
 		"X.java",

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PatternMatching16Test.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PatternMatching16Test.java
@@ -90,7 +90,7 @@ public class PatternMatching16Test extends AbstractRegressionTest {
 				"1. ERROR in X1.java (at line 3)\n" +
 				"	if (obj instanceof String s) {\n" +
 				"	                   ^^^^^^^^\n" +
-				"The Java feature 'Pattern Matching in instanceof Expressions' is only available with source level 16 and above\n" +
+				"The Java feature 'Type Patterns' is only available with source level 16 and above\n" +
 				"----------\n",
 				null,
 				true,

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/RunVariousSwitchTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/RunVariousSwitchTests.java
@@ -17,6 +17,7 @@ package org.eclipse.jdt.core.tests;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
+import org.eclipse.jdt.core.tests.compiler.parser.ComplianceDiagnoseTest;
 import org.eclipse.jdt.core.tests.compiler.regression.InstanceofPrimaryPatternTest;
 import org.eclipse.jdt.core.tests.compiler.regression.PatternMatching16Test;
 import org.eclipse.jdt.core.tests.compiler.regression.RecordPatternTest;
@@ -57,6 +58,7 @@ public class RunVariousSwitchTests extends TestCase {
 				JavaSearchBugs14SwitchExpressionTests.class,
 				ASTRewritingSwitchExpressionsTest.class,
 				ASTRewritingSwitchPatternTest.class,
+				ComplianceDiagnoseTest.class,
 
 		};
 	}


### PR DESCRIPTION
## What it does

* Get rid of `org.eclipse.jdt.internal.compiler.ast.Statement.resolveExpressionType(BlockScope)` and its overrides - these are not used anywhere
* Get rid of `org.eclipse.jdt.internal.compiler.parser.Parser.CaseLabelKind.CASE_NULL` - this is not used being subsumed by `org.eclipse.jdt.internal.compiler.parser.Parser.CaseLabelKind.CASE_EXPRESSION`
* Ger id of `org.eclipse.jdt.internal.compiler.ast.SwitchStatement.addSecretTryResultVariable()` and its overrides - these are not used anywhere
* Get rid of `org.eclipse.jdt.internal.compiler.ast.SwitchExpression.hiddenYield` and `org.eclipse.jdt.internal.compiler.ast.SwitchExpression.hiddenYieldResolvedPosition` - these are not used anywhere
* Implement standardized resolution API points in `SwitchExpression`
* Get rid of `org.eclipse.jdt.internal.compiler.ast.CaseStatement.getFirstValidExpression(BlockScope, SwitchStatement)` as a first class operation and subsume its behavior into `org.eclipse.jdt.internal.compiler.ast.CaseStatement.resolveCase(BlockScope, TypeBinding, SwitchStatement)`
* Eliminate redundant null checks for `org.eclipse.jdt.internal.compiler.ast.YieldStatement.expression` - it cannot be `null`
* Merge into one, the mostly identical methods `org.eclipse.jdt.internal.compiler.ast.YieldStatement.generateCode(BlockScope, CodeStream)` and `org.eclipse.jdt.internal.compiler.ast.YieldStatement.generateExpressionResultCodeExpanded(BlockScope, CodeStream)` 

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
