### PR TITLE
Improvements to CI GH action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,12 +34,12 @@ jobs:
         mvn-toolchain-id: |
           JavaSE-1.8
           JavaSE-17
-          JavaSE-20
+          JavaSE-21
         distribution: 'temurin'
     - name: Set up Maven
-      uses: stCarolas/setup-maven@07fbbe97d97ef44336b7382563d66743297e442f # v4.5
+      uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1 # v5
       with:
-        maven-version: 3.9.3
+        maven-version: 3.9.6
     - name: Build with Maven 🏗️
       run: |
         mvn clean install --batch-mode -f org.eclipse.jdt.core.compiler.batch -DlocalEcjVersion=99.99


### PR DESCRIPTION
## What it does
* Use latest setup-maven GH action
* Use latest maven version
* Sync java-version and mvn-toolchain-id

## How to test
CI GH action still workds

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
