### PR TITLE
Fix IAE computing type signature for anonymous + var

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter10Test.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter10Test.java
@@ -13,20 +13,37 @@
  *******************************************************************************/
 package org.eclipse.jdt.core.tests.dom;
 
-import junit.framework.Test;
-
-import org.eclipse.jdt.core.dom.*;
-import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
-import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
-
 import java.io.IOException;
 import java.util.Hashtable;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.ILocalVariable;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.Signature;
 import org.eclipse.jdt.core.compiler.IProblem;
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.FileASTRequestor;
+import org.eclipse.jdt.core.dom.ForStatement;
+import org.eclipse.jdt.core.dom.IBinding;
+import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.IVariableBinding;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.Name;
+import org.eclipse.jdt.core.dom.NodeFinder;
+import org.eclipse.jdt.core.dom.SimpleName;
+import org.eclipse.jdt.core.dom.SimpleType;
+import org.eclipse.jdt.core.dom.Type;
+import org.eclipse.jdt.core.dom.VariableDeclarationExpression;
+import org.eclipse.jdt.core.dom.VariableDeclarationStatement;
+import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
+import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
+
+import junit.framework.Test;
 
 public class ASTConverter10Test extends ConverterTestSetup {
 
@@ -272,6 +289,28 @@ public class ASTConverter10Test extends ConverterTestSetup {
 		} finally {
 			if (jarPath != null)
 				deleteFile(jarPath);
+		}
+	}
+
+	public void testAnonymousTypeVarBindingToLocalVariable() throws Exception {
+		String filePath = "/Converter10/src/X.java";
+		try {
+			String contents = """
+				class X {
+					void m() {
+						var variable = new I() {};
+					}
+				}
+				interface I {}
+				""";
+			this.workingCopy = getCompilationUnit(filePath);
+			CompilationUnit dom = (CompilationUnit)buildAST(contents, this.workingCopy);
+			Name node = (Name)NodeFinder.perform(dom, contents.indexOf("variable"), "variable".length());
+			IVariableBinding binding = (IVariableBinding)node.resolveBinding();
+			ILocalVariable model = (ILocalVariable)binding.getJavaElement();
+			assertEquals("I", Signature.toString(model.getTypeSignature()));
+		} finally {
+			deleteFile(filePath);
 		}
 	}
 // Add new tests here

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/VariableBinding.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/VariableBinding.java
@@ -29,6 +29,7 @@ import org.eclipse.jdt.internal.compiler.lookup.FieldBinding;
 import org.eclipse.jdt.internal.compiler.lookup.LocalVariableBinding;
 import org.eclipse.jdt.internal.compiler.lookup.RecordComponentBinding;
 import org.eclipse.jdt.internal.compiler.lookup.TagBits;
+import org.eclipse.jdt.internal.compiler.lookup.TypeBinding;
 import org.eclipse.jdt.internal.compiler.lookup.TypeIds;
 import org.eclipse.jdt.internal.core.JavaElement;
 import org.eclipse.jdt.internal.core.LocalVariable;
@@ -267,7 +268,13 @@ class VariableBinding implements IVariableBinding {
 			}
 		}
 		int sourceEnd = sourceStart+sourceLength-1;
-		char[] typeSig = Signature.createTypeSignature(this.binding.type.signableName(), true).toCharArray();
+		TypeBinding signableType = this.binding.type;
+		if (signableType.isAnonymousType()) {
+			signableType = signableType.superInterfaces() != null && signableType.superInterfaces().length == 1 ?
+					signableType.superInterfaces()[0] :
+					signableType.superclass();
+		}
+		char[] typeSig = Signature.createTypeSignature(signableType.signableName(), true).toCharArray();
 		JavaElement parent = null;
 		IMethodBinding declaringMethod = getDeclaringMethod();
 		if (this.binding instanceof RecordComponentBinding) {


### PR DESCRIPTION
Unlike what's specified by TypeBinding.signableType(), the return value is incorrect for anonymous type and that leads to an exception such as

  java.lang.IllegalArgumentException: new I(){}
  	at org.eclipse.jdt.core.Signature.createCharArrayTypeSignature(Signature.java:1109)
  	at org.eclipse.jdt.core.Signature.createTypeSignature(Signature.java:1305)
  	at org.eclipse.jdt.core.dom.VariableBinding.getUnresolvedJavaElement(VariableBinding.java:277)

Some specific code is added here to handle that case.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does

Fixes an IllegalArgumentError

## How to test

Run provided test without patch to see the failure, then run with the fix to see the fix

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
