### PR TITLE
Resorce Leak compiler error/warning (detection) has some problem

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LambdaExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LambdaExpression.java
@@ -617,12 +617,16 @@ public class LambdaExpression extends FunctionalExpression implements IPolyExpre
 					this.scope.problemReporter().shouldReturn(returnTypeBinding, this);
 				}
 			}
-		} else { // Expression
-			if (currentScope.compilerOptions().isAnnotationBasedNullAnalysisEnabled
-					&& lambdaInfo.reachMode() == FlowInfo.REACHABLE)
-			{
-				Expression expression = (Expression)this.body;
-				checkAgainstNullAnnotation(flowContext, expression, flowInfo, expression.nullStatus(lambdaInfo, flowContext));
+		} else if (this.body instanceof Expression expression ){
+			if (lambdaInfo.reachMode() == FlowInfo.REACHABLE) {
+				CompilerOptions compilerOptions = currentScope.compilerOptions();
+				if (compilerOptions.isAnnotationBasedNullAnalysisEnabled) {
+					checkAgainstNullAnnotation(flowContext, expression, flowInfo, expression.nullStatus(lambdaInfo, flowContext));
+				}
+				if (compilerOptions.analyseResourceLeaks) {
+					long owningTagBits = this.descriptor.tagBits & TagBits.AnnotationOwningMASK;
+					ReturnStatement.anylizeCloseableReturnExpression(expression, currentScope, owningTagBits, flowContext, flowInfo);
+				}
 			}
 		}
 		return flowInfo;

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ResourceLeakTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ResourceLeakTests.java
@@ -7147,4 +7147,30 @@ public void testGH1867() {
 		"----------\n",
 		options);
 }
+public void testGH2207_1() {
+	// relevant only since 19, where ExecutorService implements AutoCloseable
+	Map options = getCompilerOptions();
+	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
+	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
+	options.put(CompilerOptions.OPTION_ReportExplicitlyClosedAutoCloseable, CompilerOptions.ERROR);
+	runLeakTest(
+		new String[] {
+			"ResourceLeakTest.java",
+			"""
+			import java.util.Optional;
+			import java.util.concurrent.ExecutorService;
+			import java.util.concurrent.Executors;
+
+			public class ResourceLeakTest {
+				protected ExecutorService es;
+
+			    public ExecutorService t_supplier_lambda_returned(ExecutorService executor) {
+			        return Optional.ofNullable(executor).orElseGet(() -> Executors.newCachedThreadPool());
+			    }
+			}
+			"""
+		},
+		"",
+		options);
+}
 }


### PR DESCRIPTION
fixes #2207

+ treat body of an expression lambda like a return statement
+ fetch owning bits from the lambda descriptor

