### PR TITLE
Resorce Leak compiler error/warning (detection) has some problem

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ResourceLeakAnnotatedTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ResourceLeakAnnotatedTests.java
@@ -1461,6 +1461,8 @@ public void testConsumingMethodUse_binary() {
 			false);
 }
 public void testGH2207_2() {
+	if (this.complianceLevel < ClassFileConstants.JDK1_8)
+		return;
 	Map<String, String> options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
@@ -1504,6 +1506,8 @@ public void testGH2207_2() {
 		options);
 }
 public void testGH2207_3() {
+	if (this.complianceLevel < ClassFileConstants.JDK1_8)
+		return;
 	Map<String, String> options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
@@ -1543,6 +1547,8 @@ public void testGH2207_3() {
 		options);
 }
 public void testGH2207_4() {
+	if (this.complianceLevel < ClassFileConstants.JDK1_8)
+		return;
 	Map<String, String> options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
 	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ResourceLeakTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ResourceLeakTests.java
@@ -7148,6 +7148,8 @@ public void testGH1867() {
 		options);
 }
 public void testGH2207_1() {
+	if (this.complianceLevel < ClassFileConstants.JDK1_8)
+		return;
 	// relevant only since 19, where ExecutorService implements AutoCloseable
 	Map options = getCompilerOptions();
 	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);


### PR DESCRIPTION
fixes #2207 re-opened

Don't run tests using lambda below compliance 1.8
