### PR TITLE
Fix NPE in SourceRangeVerifier (when debugging)

### DIFF
--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/SourceRangeVerifier.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/SourceRangeVerifier.java
@@ -57,6 +57,9 @@ public class SourceRangeVerifier extends ASTVisitor {
 		ASTNode previous = null;
 
 		List properties = node.structuralPropertiesForType();
+		if (properties == null) { // happens for some nodes that aren't usually available at AST level
+			return false;
+		}
 		for (Object p : properties) {
 			StructuralPropertyDescriptor property = (StructuralPropertyDescriptor) p;
 			if (property.isChildProperty()) {


### PR DESCRIPTION
Some nodes may return null for structuralFeatures if those nodes are usually not available at given AST/Preview level (eg StringTemplateExpression.propertyDescriptors(apiLevel, previewEnabled). So let's handle this possible null case more gracefully.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does

Prevents a NPE

## How to test

Build an AST using StringTemplates via ASTParser, but without enabling preview, the AST is generated and reports some problem, but if SourceVerifier.DEBUG is enabled, then a NPE will be thrown.
The logic of the test would be relatively hard to maintain, as the example above will change, and thus test will either become irrelevant or fail for no good reason, when the StringTemplate become non-preview.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
