### PR TITLE
Fix for visit(PatternInstanceofExpression node) in NaiveASTFlattener

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter_RecordPattern_Test.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter_RecordPattern_Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2023 IBM Corporation and others.
+ * Copyright (c) 2020, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -21,6 +21,7 @@ import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ASTParser;
 import org.eclipse.jdt.core.dom.ASTVisitor;
 import org.eclipse.jdt.core.dom.AbstractTypeDeclaration;
 import org.eclipse.jdt.core.dom.CompilationUnit;
@@ -559,5 +560,31 @@ public class ASTConverter_RecordPattern_Test extends ConverterTestSetup {
 		assertEquals("incorrect type", ASTNode.GUARDED_PATTERN, ((Expression)caseStmt.expressions().get(0)).getNodeType());
 		GuardedPattern guardedPattern = (GuardedPattern)caseStmt.expressions().get(0);
 		assertEquals("There should be 1 Record Pattern", ASTNode.RECORD_PATTERN , guardedPattern.getPattern().getNodeType());
+	}
+	public void testVisitPattern() {
+        class NodeFinder extends ASTVisitor {
+            PatternInstanceofExpression patternInstanceofExpression;
+            public boolean visit(PatternInstanceofExpression node) {
+                this.patternInstanceofExpression = node;
+                return super.visit(node);
+            }
+        }
+        String content = """
+        		public class Foo {
+        			static boolean checkCollisionIfs(Object p1, Object p2) {
+        				if (p1 instanceof Point(int x1, int y1)) {
+        					return x1 == x2 && y1 == y2;
+        				}
+        			}
+        			record Point(int x, int y) {}
+        			record ColoredPoint(Point T, String color) {}
+        			record Decorator(Object obj) {}}""";
+
+        ASTParser parser = ASTParser.newParser(AST.JLS21);
+        parser.setSource(content.toCharArray());
+        CompilationUnit cunit = (CompilationUnit) parser.createAST(null);
+        NodeFinder astVisitor = new NodeFinder();
+        cunit.accept(astVisitor);
+        assertEquals("Wrong node", "p1 instanceof Point(int x1, int y1)", astVisitor.patternInstanceofExpression.toString());
 	}
 }

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/NaiveASTFlattener.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/NaiveASTFlattener.java
@@ -89,6 +89,14 @@ public class NaiveASTFlattener extends ASTVisitor {
 	private static final int JLS14 = AST.JLS14;
 
 	/**
+	 * Internal synonym for {@link AST#JLS21}. Use to alleviate
+	 * deprecation warnings.
+	 * @deprecated
+	 * @since 3.38
+	 */
+	private static final int JLS21 = AST.JLS21;
+
+	/**
 	 * The string buffer into which the serialized representation of the AST is
 	 * written.
 	 */
@@ -899,7 +907,11 @@ public class NaiveASTFlattener extends ASTVisitor {
 	public boolean visit(PatternInstanceofExpression node) {
 		node.getLeftOperand().accept(this);
 		this.buffer.append(" instanceof ");//$NON-NLS-1$
-		node.getRightOperand().accept(this);
+		if (node.getAST().apiLevel() >= JLS21) {
+			node.getPattern().accept(this);
+		} else {
+			node.getRightOperand().accept(this);
+		}
 		return false;
 	}
 

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/NaiveASTFlattener.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/NaiveASTFlattener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -92,7 +92,6 @@ public class NaiveASTFlattener extends ASTVisitor {
 	 * Internal synonym for {@link AST#JLS21}. Use to alleviate
 	 * deprecation warnings.
 	 * @deprecated
-	 * @since 3.38
 	 */
 	private static final int JLS21 = AST.JLS21;
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
The change resolves an issue with the "MISSING" string printed that is a result of parsing PatternInstanceofExpression.

## How to test


## Author checklist

+ I have thoroughly tested my changes
+ The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
+ I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
