### PR TITLE
Adopt release detection code to consider ct.sym changes in Java 22

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/util/CtSym.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/util/CtSym.java
@@ -399,9 +399,8 @@ public class CtSym {
 				}
 				try {
 					char releaseCode = rel.charAt(0);
-					// If a release directory contains "system-modules" file, it is a flag
-					// that this is the *current* release
-					if (releaseCode > JAVA_11 && Files.exists(this.fs.getPath(rel, "system-modules"))) { //$NON-NLS-1$
+					// If any release directory letter is higher 11 we are fine
+					if (releaseCode > JAVA_11) {
 						return true;
 					}
 				} catch (NumberFormatException e) {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchBugs16Tests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchBugs16Tests.java
@@ -632,8 +632,6 @@ public class JavaSearchBugs16Tests extends AbstractJavaSearchTests {
 	 * https://github.com/eclipse-jdt/eclipse.jdt.core/issues/790
 	 */
 	public void testAIOOBEForRecordClassGh790() throws Exception {
-		if (isJRE22)
-			return;
 		String testProjectName = "gh790AIOOBEForRecordClass";
 		try {
 			IJavaProject project = createJava16Project(testProjectName, new String[] {"src"});

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchBugs9Tests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchBugs9Tests.java
@@ -4759,8 +4759,6 @@ public void testBug547095_type_patter_search_modular() throws Exception {
  * https://github.com/eclipse-jdt/eclipse.jdt.core/issues/740
  */
 public void testMethodReferenceForTypeFromJREModuleBugGh740() throws Exception {
-	if (isJRE22) // Fix this - StackWalker
-		return;
 	String projectName = "gh740MethodReferenceForTypeParameterFromModuleBug";
 	try {
 		IJavaProject project = createJavaProject(projectName, new String[] {"src"}, new String[] {}, "bin", "11");
@@ -4804,8 +4802,6 @@ public void testMethodReferenceForTypeFromJREModuleBugGh740() throws Exception {
 }
 
 public void testGH902_whenTypeReferenceIsUnknown_expectToBeFound() throws CoreException {
-	if (isJRE22) // Fix this - StackWalker
-		return;
 	try {
 		IJavaProject project = createJava9Project("JavaSearchBugs9");
 		project.open(null);
@@ -4831,8 +4827,6 @@ public void testGH902_whenTypeReferenceIsUnknown_expectToBeFound() throws CoreEx
 }
 
 public void testGH902_whenTypeReferenceIsUnknownButQualified_expectToBeFound() throws CoreException {
-	if (isJRE22) // Fix this - StackWalker
-		return;
 	try {
 		IJavaProject project = createJava9Project("JavaSearchBugs9");
 		project.open(null);
@@ -4858,8 +4852,6 @@ public void testGH902_whenTypeReferenceIsUnknownButQualified_expectToBeFound() t
 }
 
 public void testGH902_whenTypeReferenceIsUnknownButQualifiedNested_expectToBeFound() throws CoreException {
-	if (isJRE22) // Fix this - StackWalker
-		return;
 	try {
 		IJavaProject project = createJava9Project("JavaSearchBugs9");
 		project.open(null);
@@ -4885,8 +4877,6 @@ public void testGH902_whenTypeReferenceIsUnknownButQualifiedNested_expectToBeFou
 }
 
 public void testGH902_whenTypeReferenceIsUnknownButNested_expectToBeFound() throws CoreException {
-	if (isJRE22) // Fix this - StackWalker
-		return;
 	try {
 		IJavaProject project = createJava9Project("JavaSearchBugs9");
 		project.open(null);

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchTests.java
@@ -4609,8 +4609,6 @@ public void testAnonymousTypeMethodReferenceJarSearchGh375() throws Exception {
  * https://github.com/eclipse-jdt/eclipse.jdt.core/issues/432
  */
 public void testAnonymousTypeMethodReferenceSearchGh432() throws Exception {
-	if (isJRE22)
-		return;
 	String testProjectName = "gh432MethodReferencesSearchBug";
 	String snippet1 = "package p;\n" +
 			"public class TestGh432 {\n" +

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ModuleBuilderTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ModuleBuilderTests.java
@@ -701,8 +701,6 @@ public class ModuleBuilderTests extends ModifyingResourceTests {
 		}
 	}
 	public void testConvertToModule() throws CoreException, IOException {
-		if (isJRE22) // TODO: Fix Issue #1874
-			return;
 		Hashtable<String, String> javaCoreOptions = JavaCore.getOptions();
 		try {
 			IJavaProject project = setUpJavaProject("ConvertToModule");
@@ -738,8 +736,6 @@ public class ModuleBuilderTests extends ModifyingResourceTests {
 		}
 	}
 	public void testConvertToModuleWithRelease9() throws CoreException, IOException {
-		if (isJRE22) // TODO: Fix Issue #1874
-			return;
 		Hashtable<String, String> javaCoreOptions = JavaCore.getOptions();
 		try {
 			IJavaProject project = setUpJavaProject("ConvertToModule");
@@ -3902,9 +3898,6 @@ public class ModuleBuilderTests extends ModifyingResourceTests {
 		}
 	}
 	public void testBug512053() throws CoreException, IOException {
-		if (isJRE22) // TODO: Fix Issue #1874
-			return;
-
 		Hashtable<String, String> javaCoreOptions = JavaCore.getOptions();
 		this.sourceWorkspacePath = super.getSourceWorkspacePath() + java.io.File.separator + "bug512053";
 		try {
@@ -7020,8 +7013,6 @@ public class ModuleBuilderTests extends ModifyingResourceTests {
 		}
 	}
 	public void testBug527569c() throws CoreException {
-		if (isJRE22) // TODO: Fix Issue #1874
-			return;
 		if (!isJRE19) return;
 		IJavaProject p1 = createJava9Project("Bug527569", "17");
 		Map<String, String> options = new HashMap<>();
@@ -8274,9 +8265,6 @@ public class ModuleBuilderTests extends ModifyingResourceTests {
 	}
 
 	public void testReleaseOption1() throws Exception {
-		if (isJRE22) // TODO: Fix Issue #1874
-			return;
-
 		Hashtable<String, String> options = JavaCore.getOptions();
 		IJavaProject p = createJava9Project("p");
 		p.setOption(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_11);
@@ -8372,9 +8360,6 @@ public class ModuleBuilderTests extends ModifyingResourceTests {
 		}
 	}
 	public void testReleaseOption4() throws Exception {
-		if (isJRE22) // TODO: Fix Issue #1874
-			return;
-
 		Hashtable<String, String> options = JavaCore.getOptions();
 		IJavaProject p = createJava9Project("p");
 		p.setOption(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_8);
@@ -8406,9 +8391,6 @@ public class ModuleBuilderTests extends ModifyingResourceTests {
 		}
 	}
 	public void testReleaseOption5() throws Exception {
-		if (isJRE22) // TODO: Fix Issue #1874
-			return;
-
 		if (!isJRE19) return;
 		Hashtable<String, String> options = JavaCore.getOptions();
 		IJavaProject p = createJava9Project("p");
@@ -8520,9 +8502,6 @@ public class ModuleBuilderTests extends ModifyingResourceTests {
 		}
 	}
 	public void testReleaseOption8() throws Exception {
-		if (isJRE22) // TODO: Fix Issue #1874
-			return;
-
 		Hashtable<String, String> options = JavaCore.getOptions();
 		IJavaProject p = createJava9Project("p");
 		p.setOption(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_9);
@@ -8552,9 +8531,6 @@ public class ModuleBuilderTests extends ModifyingResourceTests {
 		}
 	}
 	public void testReleaseOption9() throws Exception {
-		if (isJRE22) // TODO: Fix Issue #1874
-			return;
-
 		if (!isJRE10) return;
 		Hashtable<String, String> options = JavaCore.getOptions();
 		IJavaProject p = createJava9Project("p");
@@ -8621,9 +8597,6 @@ public class ModuleBuilderTests extends ModifyingResourceTests {
 		}
 	}
 	public void testReleaseOption11() throws Exception {
-		if (isJRE22) // TODO: Fix Issue #1874
-			return;
-
 		Hashtable<String, String> options = JavaCore.getOptions();
 		IJavaProject p = createJava9Project("p");
 		p.setOption(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_1_8);
@@ -8660,9 +8633,6 @@ public class ModuleBuilderTests extends ModifyingResourceTests {
 		}
 	}
 	public void testReleaseOption12() throws Exception {
-		if (isJRE22) // TODO: Fix Issue #1874
-			return;
-
 		if (!isJRE16)
 			return;
 		Hashtable<String, String> options = JavaCore.getOptions();
@@ -8704,9 +8674,6 @@ public class ModuleBuilderTests extends ModifyingResourceTests {
 		}
 	}
 	public void testReleaseOption13() throws Exception {
-		if (isJRE22) // TODO: Fix Issue #1874
-			return;
-
 		if (!isJRE12)
 			return;
 		Hashtable<String, String> options = JavaCore.getOptions();

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/TypeHierarchyTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/TypeHierarchyTests.java
@@ -3580,9 +3580,6 @@ public void testIndexQualificationJavaLangReferences() throws Exception {
 }
 
 public void testIndexQualificationLambdaReferences_AsReturnTypes() throws Exception {
-	if (isJRE22)	//TODO: Fix Issue 1875
-		return;
-
 	setupQualifierProject();
 	waitUntilIndexesReady();
 	try {
@@ -3597,9 +3594,6 @@ public void testIndexQualificationLambdaReferences_AsReturnTypes() throws Except
 }
 
 public void testIndexQualificationLambdaReferences_AsParameters() throws Exception {
-	if (isJRE22)	//TODO: Fix Issue 1875
-		return;
-
 	setupQualifierProject();
 	waitUntilIndexesReady();
 	try {


### PR DESCRIPTION
Adopt release detection code to consider ct.sym changes in Java 22

The ct.sym file contains with Java 22 no "system-modules" file in the "current" release directory anymore.

The structure of the root level of ct.sym file indicates that the release contents are in single letter directories and all diffs between releases seem to be in multiple letter directories.

To answer a question whether current JDK is 12+ or not it is enough to check that any single letter directory name is higher then 'B' (== Java 11) and we don't need to rely on existence of the "system-modules" file.

Additionally re-enabled few tests that were disabled in 31ef12dd145f22210d90dc53596f0799d420482b.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2284
Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1875
Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1874