### PR TITLE
Run o.e.jdt.core.tests.builder with Java 22 compatibility too

### DIFF
--- a/org.eclipse.jdt.core.tests.builder/pom.xml
+++ b/org.eclipse.jdt.core.tests.builder/pom.xml
@@ -84,6 +84,27 @@
 			<tycho.surefire.argLine>--add-modules ALL-SYSTEM -Dcompliance=1.4,1.7,1.8,21</tycho.surefire.argLine>
 		</properties>
 	</profile>
+	<profile>
+		<id>test-on-javase-22</id>
+		<build>
+			<plugins>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-toolchains-plugin</artifactId>
+					<configuration>
+						<toolchains>
+							<jdk>
+								<id>JavaSE-22</id>
+							</jdk>
+						</toolchains>
+					</configuration>
+				</plugin>
+			</plugins>
+		</build>
+		<properties>
+			<tycho.surefire.argLine>--add-modules ALL-SYSTEM -Dcompliance=1.4,1.7,1.8,21,22</tycho.surefire.argLine>
+		</properties>
+	</profile>
   </profiles>
 
 </project>


### PR DESCRIPTION
## What it does
Runs some more tests with Java 22 compatibility. Uncovered that tests were not failing with
https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2284 but failed in I-build.

## How to test
Tests are run with Java 22

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
