### PR TITLE
Fix ASTRewriteAnalyzer.ListRewriter to remove end keyword

### DIFF
--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/ASTRewriteAnalyzer.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/ASTRewriteAnalyzer.java
@@ -761,7 +761,7 @@ public final class ASTRewriteAnalyzer extends ASTVisitor {
 						currPos= end;
 						prevEnd= currEnd;
 						// if all removed and we are removing last item - we must remove end keyword
-						if (nextIndex == total && lastNonDelete == -1 && endKeyword.length() > 0) {
+						if (nextIndex == total && lastNonDelete == -1 && endKeyword != null && endKeyword.length() > 0) {
 							try {
 								TokenScanner scanner = getScanner();
 								int tempOffset = scanner.getNextEndOffset(currPos, true);

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/ASTRewriteAnalyzer.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/ASTRewriteAnalyzer.java
@@ -760,6 +760,17 @@ public final class ASTRewriteAnalyzer extends ASTVisitor {
 						}
 						currPos= end;
 						prevEnd= currEnd;
+						// if all removed and we are removing last item - we must remove end keyword
+						if (nextIndex == total && lastNonDelete == -1 && endKeyword.length() > 0) {
+							try {
+								TokenScanner scanner = getScanner();
+								int tempOffset = scanner.getNextEndOffset(currPos, true);
+								doTextRemove(currPos, tempOffset - currPos, editGroup);
+								currPos = tempOffset;
+							} catch (CoreException e) {
+								// ignore
+							}
+						}
 						separatorState= NEW;
 					}
 				} else { // replaced or unchanged

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/ASTRewriteAnalyzer.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/ASTRewriteAnalyzer.java
@@ -603,6 +603,10 @@ public final class ASTRewriteAnalyzer extends ASTVisitor {
 			return true;
 		}
 
+		protected boolean mustRemoveEndKeywordWhenEmpty() {
+			return false;
+		}
+
 		private int rewriteList(
 				ASTNode parent,
 				StructuralPropertyDescriptor property,
@@ -761,7 +765,7 @@ public final class ASTRewriteAnalyzer extends ASTVisitor {
 						currPos= end;
 						prevEnd= currEnd;
 						// if all removed and we are removing last item - we must remove end keyword
-						if (nextIndex == total && lastNonDelete == -1 && endKeyword != null && endKeyword.length() > 0) {
+						if (mustRemoveEndKeywordWhenEmpty() && nextIndex == total && lastNonDelete == -1 && endKeyword != null && endKeyword.length() > 0) {
 							try {
 								TokenScanner scanner = getScanner();
 								int tempOffset = scanner.getNextEndOffset(currPos, true);
@@ -848,6 +852,13 @@ public final class ASTRewriteAnalyzer extends ASTVisitor {
 		public final int rewriteList(ASTNode parent, StructuralPropertyDescriptor property, int offset, String keyword, String endKeyword, String separator) {
 			this.constantSeparator= separator;
 			return rewriteList(parent, property, keyword, endKeyword, offset);
+		}
+	}
+
+	class ResourcesListRewriter extends ListRewriter {
+		@Override
+		protected boolean mustRemoveEndKeywordWhenEmpty() {
+			return true;
 		}
 	}
 
@@ -1371,6 +1382,14 @@ public final class ASTRewriteAnalyzer extends ASTVisitor {
 		RewriteEvent event= getEvent(parent, property);
 		if (event != null && event.getChangeKind() != RewriteEvent.UNCHANGED) {
 			return new ListRewriter().rewriteList(parent, property, pos, keyword, endKeyword, separator);
+		}
+		return doVisit(parent, property, pos);
+	}
+
+	private int rewriteResourcesNodeList(ASTNode parent, StructuralPropertyDescriptor property, int pos, String keyword, String endKeyword, String separator) {
+		RewriteEvent event= getEvent(parent, property);
+		if (event != null && event.getChangeKind() != RewriteEvent.UNCHANGED) {
+			return new ResourcesListRewriter().rewriteList(parent, property, pos, keyword, endKeyword, separator);
 		}
 		return doVisit(parent, property, pos);
 	}
@@ -4045,7 +4064,7 @@ public final class ASTRewriteAnalyzer extends ASTVisitor {
 				int indent= getIndent(node.getStartPosition());
 				String prefix= this.formatter.TRY_RESOURCES.getPrefix(indent);
 				String newParen = this.formatter.TRY_RESOURCES_PAREN.getPrefix(indent) + "("; //$NON-NLS-1$
-				pos= rewriteNodeList(node, desc, getPosAfterTry(pos), newParen, ")", ";" + prefix); //$NON-NLS-1$ //$NON-NLS-2$
+				pos= rewriteResourcesNodeList(node, desc, getPosAfterTry(pos), newParen, ")", ";" + prefix); //$NON-NLS-1$ //$NON-NLS-2$
 
 			} else {
 				pos= doVisit(node, desc, pos);


### PR DESCRIPTION
- when we remove all elements in list and we have an end keyword, we should remove the end keyword if it is specified
- fixes #2288

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes ASTRewriteAnalyzer.ListRewriter to remove end keyword if specified and we are removing all items

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
