### PR TITLE
Erroneous "Cannot infer type arguments" error

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Scope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Scope.java
@@ -5382,7 +5382,9 @@ public abstract class Scope {
 						}
 				}
 			}
-			staticFactory.returnType = environment.createParameterizedType(genericType, Scope.substitute(substitution, genericType.typeVariables()), originalEnclosingType);
+			staticFactory.returnType = environment.createParameterizedType(genericType,
+					Scope.substitute(substitution, genericType.typeVariables()),
+					(ReferenceBinding) Scope.substitute(substitution, originalEnclosingType));
 			staticFactory.parameters = Scope.substitute(substitution, method.parameters);
 			staticFactory.thrownExceptions = Scope.substitute(substitution, method.thrownExceptions);
 			if (staticFactory.thrownExceptions == null) {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_1_8.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_1_8.java
@@ -10682,4 +10682,32 @@ public void testBug508834_comment0() {
 			"----------\n",
 			null, true, customOptions);
 	}
+	public void testGH1475() {
+		runConformTest(
+			new String[] {
+				"CannotInferTypeArguments.java",
+				"""
+				public class CannotInferTypeArguments<V extends java.util.concurrent.Semaphore> {
+					class Fish {
+						public V getFlavour() {
+							return null;
+						}
+					}
+
+					class Shark<E extends Fish> {
+					}
+
+					<E extends Fish> Shark<E> fish() {
+						// This compiles fine with javac, but will only work in Eclipse with new Shark<E>();
+						return new Shark<>();
+					}
+
+					<E extends Fish> Shark<E> fish2() {
+						Shark<E> s = new Shark<>();
+						return s;
+					}
+				}
+				"""
+			});
+	}
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_1_8.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_1_8.java
@@ -10710,4 +10710,111 @@ public void testBug508834_comment0() {
 				"""
 			});
 	}
+
+	public void testBug569231() {
+		runConformTest(
+			new String[] {
+				"GenericsBug.java",
+				"""
+				import java.util.function.Function;
+				import java.util.function.Predicate;
+
+				public class GenericsBug<S> {
+					public static interface MyInterface<U> {}
+
+					public static class SubClass<U,V> implements MyInterface<V>{
+						public SubClass(Function<U,V> g, MyInterface<V>... i) { }
+					}
+
+					public static class OptSubClass<U> implements MyInterface<U> {
+						public OptSubClass(String s, Predicate<U> p, MyInterface<U>... i) { }
+
+					}
+
+					public static class ParamClass<T> {
+						public T    getU()    { return null;}
+					}
+
+					GenericsBug(MyInterface<S> in1, MyInterface<S> in2) { }
+
+
+					public static class MySubClass extends SubClass<ParamClass<Boolean>,Boolean> {
+						public MySubClass() {
+							super(ParamClass::getU);
+						}
+					}
+
+					public static void foo() {
+						SubClass<ParamClass<Boolean>,Boolean> sc = new SubClass<>(ParamClass::getU);
+						new GenericsBug<>(new MySubClass(),
+										  new OptSubClass<>("foo", t->t, sc));
+					}
+				};
+				"""
+			});
+	}
+
+	public void testBug566989() {
+		runConformTest(
+			new String[] {
+				"InferTypeTest.java",
+				"""
+				import java.util.*;
+				public class InferTypeTest<T> {
+
+					@FunctionalInterface
+					interface DataLoader<T> {
+						List<T> loadData(int offset, int limit);
+					}
+
+					class DataList<T> extends ArrayList<T>{
+						public DataList(DataLoader<T> dataLoader) {
+						}
+					}
+
+					void testDataList() {
+						List<String> list = new ArrayList<>(new DataList<>((offset, limit) -> Collections.emptyList()));
+					}
+
+				}
+				"""
+			});
+	}
+
+	public void testBug509848() {
+		runConformTest(
+			new String[] {
+				"Generics.java",
+				"""
+				public class Generics {
+
+					public MyGeneric<?> test() {
+						boolean maybe = false;
+
+						return lambda((String result) -> {
+							if (maybe) {
+								return new MyGeneric<>(MyGeneric.of(null));
+							}
+							else {
+								return new MyGeneric<>(MyGeneric.of(""));
+							}
+						});
+					}
+
+					static class MyGeneric <T> {
+						T t;
+						public MyGeneric(MyGeneric<T> t) {
+						}
+						public static <R> MyGeneric<R> of(R t) {
+							return null;
+						}
+					}
+
+					public <R> MyGeneric<R> lambda(java.util.function.Function<String, MyGeneric<R>> mapper) {
+						return null;
+					}
+				}
+				"""
+			});
+	}
 }


### PR DESCRIPTION
fixes #1475

Implementation of JLS 15.9.3. failed to substitute an enclosing type in
>  - The return type of mj is θj applied to D<F1, ..., Fp>.

