### PR TITLE
Ensure CompilationUnitResolver.accept(...) uses right module

### DIFF
--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/CompilationUnitResolver.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/CompilationUnitResolver.java
@@ -183,7 +183,10 @@ class CompilationUnitResolver extends Compiler {
 		// Need to reparse the entire source of the compilation unit so as to get source positions
 		// (case of processing a source that was not known by beginToCompile (e.g. when asking to createBinding))
 		SourceTypeElementInfo sourceType = (SourceTypeElementInfo) sourceTypes[0];
+		var previousBinding = this.lookupEnvironment.module;
+		this.lookupEnvironment.module = packageBinding.enclosingModule;
 		accept((org.eclipse.jdt.internal.compiler.env.ICompilationUnit) sourceType.getHandle().getCompilationUnit(), accessRestriction);
+		this.lookupEnvironment.module = previousBinding;
 	}
 
 	@Override


### PR DESCRIPTION
Without this change, addType was always performed against the unnamed module (and some new package bindings & types were created) while it should look up on the current context module.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does

Fix CompilationUnitResolver so it properly resolve packages from the visible modules

## How to test

I plan to provide a unit test reproducing it in a near future. Basically start from the same structure as ModuleBuilderTests.testAutoModule3 , but instead of calling `getWorkingCopy("/mod.one/src/q/X.java", srcX, true)`, try calling ASTParser to generate the DOM CompilationUnit and check its `getProblems()`.

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
