### PR TITLE
ASTParser uses CompilationUnit options

### DIFF
--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ASTParser.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ASTParser.java
@@ -602,7 +602,9 @@ public class ASTParser {
 	 *
 	 * <p>This method automatically sets the project (and compiler
 	 * options) based on the given compilation unit, in a manner
-	 * equivalent to {@link #setProject(IJavaProject) setProject(source.getJavaProject())}.</p>
+	 * equivalent to {@link #setProject(IJavaProject) setProject(source.getJavaProject())}
+	 * and the custom compiler options supported by the compilation unit through
+	 * {@link ICompilationUnit#getCustomOptions() getCustomOptions()}.</p>
 	 *
 	 * <p>This source is not used when the AST is built using
 	 * {@link #createASTs(ICompilationUnit[], String[], ASTRequestor, IProgressMonitor)}.</p>
@@ -612,6 +614,9 @@ public class ASTParser {
 	 */
 	public void setSource(ICompilationUnit source) {
 		setSource((ITypeRoot)source);
+		if (source != null) {
+			setCompilerOptions(source.getOptions(true));
+		}
 	}
 
 	/**

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/CompilationUnit.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/CompilationUnit.java
@@ -1453,11 +1453,13 @@ public void setOptions(Map<String, String> newOptions) {
 
 @Override
 public Map<String, String> getCustomOptions() {
-	try {
-		Map<String, String> customOptions = this.getCompilationUnitElementInfo().getCustomOptions();
-		return customOptions == null ? Collections.emptyMap() : customOptions;
-	} catch (JavaModelException e) {
-		// do nothing
+	if (this.owner != null) {
+		try {
+			Map<String, String> customOptions = this.getCompilationUnitElementInfo().getCustomOptions();
+			return customOptions == null ? Collections.emptyMap() : customOptions;
+		} catch (JavaModelException e) {
+			// do nothing
+		}
 	}
 
 	return Collections.emptyMap();


### PR DESCRIPTION
Instead of parent project one, as the CompilationUnit may override some options.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does

Make that ASTParser honors ICompilationUnit compiler options, which may differ from the project options.

## How to test


## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
