### PR TITLE
Add source bundles into dedicated p2 repo.

### DIFF
--- a/repository/category.xml
+++ b/repository/category.xml
@@ -1,25 +1,48 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
 	<category-def name="org.eclipse.jdt.core.bundles" label="JDT Core bundles"/>
+	<category-def name="org.eclipse.jdt.core.bundles.source" label="JDT Core source bundles"/>
 	<bundle id="org.eclipse.jdt.annotation" version="0.0.0">
 		<category name="org.eclipse.jdt.core.bundles"/>
+	</bundle>
+	<bundle id="org.eclipse.jdt.annotation.source" version="0.0.0">
+		<category name="org.eclipse.jdt.core.bundles.source"/>
 	</bundle>
 	<bundle id="org.eclipse.jdt.apt.core" version="0.0.0">
 		<category name="org.eclipse.jdt.core.bundles"/>
 	</bundle>
+	<bundle id="org.eclipse.jdt.apt.core.source" version="0.0.0">
+		<category name="org.eclipse.jdt.core.bundles.source"/>
+	</bundle>
 	<bundle id="org.eclipse.jdt.apt.pluggable.core" version="0.0.0">
 		<category name="org.eclipse.jdt.core.bundles"/>
+	</bundle>
+	<bundle id="org.eclipse.jdt.apt.pluggable.core.source" version="0.0.0">
+		<category name="org.eclipse.jdt.core.bundles.source"/>
 	</bundle>
 	<bundle id="org.eclipse.jdt.apt.ui" version="0.0.0">
 		<category name="org.eclipse.jdt.core.bundles"/>
 	</bundle>
+	<bundle id="org.eclipse.jdt.apt.ui.source" version="0.0.0">
+		<category name="org.eclipse.jdt.core.bundles.source"/>
+	</bundle>
 	<bundle id="org.eclipse.jdt.core" version="0.0.0">
 		<category name="org.eclipse.jdt.core.bundles"/>
+	</bundle>
+	<bundle id="org.eclipse.jdt.core.source" version="0.0.0">
+		<category name="org.eclipse.jdt.core.bundles.source"/>
 	</bundle>
 	<bundle id="org.eclipse.jdt.core.compiler.batch" version="0.0.0">
 		<category name="org.eclipse.jdt.core.bundles"/>
 	</bundle>
+	<bundle id="org.eclipse.jdt.core.compiler.batch.source" version="0.0.0">
+		<category name="org.eclipse.jdt.core.bundles.source"/>
+	</bundle>
+
 	<bundle id="org.eclipse.jdt.core.formatterapp" version="0.0.0">
 		<category name="org.eclipse.jdt.core.bundles"/>
+	</bundle>
+	<bundle id="org.eclipse.jdt.core.formatterapp.source" version="0.0.0">
+		<category name="org.eclipse.jdt.core.bundles.source"/>
 	</bundle>
 </site>


### PR DESCRIPTION
At some point during the construction of https://github.com/eclipse-jdt/eclipse.jdt.core/pull/2141 , the underlying source bundles which were present in the original category were left out.

Before : https://github.com/eclipse-jdtls/eclipse-jdt-core-incubator/commit/9651b3ff68aa99cad0a9d86e46da0c786066c2c4#diff-8ccc007f81194cc47a96ef7f50b7ade2d6964e99ae8c42bc4407bc42e82e808f
After : https://github.com/eclipse-jdt/eclipse.jdt.core/pull/2141/files#diff-8ccc007f81194cc47a96ef7f50b7ade2d6964e99ae8c42bc4407bc42e82e808f

This just makes it easier for consumers of the repo (through `.target` files), like JDT-LS to ensure the sources can be used to explore (with `includeSource="true"`)