### PR TITLE
Fix scanning text block when unicode is present and double back-slashes

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Scanner.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Scanner.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -2066,6 +2066,9 @@ protected int scanForTextBlock() throws InvalidInputException {
 						continue;
 					case '\\' :
 						if (!this.unicodeAsBackSlash) {
+							if (this.withoutUnicodePtr != 0) {
+								unicodeStore();
+							}
 							this.currentPosition++;
 							break;
 						}


### PR DESCRIPTION
- fix Scanner.scanForTextBlock() to add both back-slashes to the withoutUnicodeBuffer instead of eating one as the TextBlock code will be passed the withoutUnicodeBuffer as lines and then will erroneously parse and treat a "\\n" in the code as a newline
- fixes #2315

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes JDT core creation of a text block that has unicode characters specified and also uses double back-slashes such as "\\n".  The present code was writing "\n" to a unicode buffer that when used to build a TextBlock, it gets treated as a newline.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
