### PR TITLE
[Switch-Expression] Assertion failure while compiling enum class that uses switch expression with try block

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/CodeStream.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/CodeStream.java
@@ -7737,6 +7737,15 @@ private TypeBinding retrieveLocalType(int currentPC, int resolvedPosition) {
 	int enumOffset = declaringClass.isEnum() ? 2 : 0; // String name, int ordinal
 	int argSlotSize = 1 + enumOffset; // this==aload0
 	if (this.methodDeclaration.binding.isConstructor()) {
+		if (declaringClass.isEnum()) {
+			switch (resolvedPosition) {
+				case 1:
+					return this.methodDeclaration.scope.getJavaLangString();
+				case 2:
+					return TypeBinding.INT;
+				default: break;
+			}
+		}
 		if (declaringClass.isNestedType()) {
 			ReferenceBinding[] enclosingTypes = declaringClass.syntheticEnclosingInstanceTypes();
 			if (enclosingTypes != null) {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchExpressionsYieldTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchExpressionsYieldTest.java
@@ -7098,5 +7098,36 @@ public class SwitchExpressionsYieldTest extends AbstractRegressionTest {
 				"Finally\n"
 				+ "Switch Expr = 10");
 	}
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2233
+	// [Switch-Expression] Assertion failure while compiling enum class that uses switch expression with try block
+	public void testIssue2233() {
+		if (this.complianceLevel < ClassFileConstants.JDK16)
+			return;
+		this.runConformTest(
+				new String[] {
+				"X.java",
+				"""
+				public enum X {
+					PARAMETER, FIELD, METHOD;
+					X() {
+						System.out.println(switch (this) {
+												default -> {
+													try {
+														yield 10;
+													} finally {
 
+													}
+												}
+											});
+					}
+
+				    public static void notmain(String [] args) {
+				        X x = PARAMETER;
+				        System.out.println(x);
+				    }
+				}
+				"""
+				},
+				"");
+	}
 }


### PR DESCRIPTION


## What it does
* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2233

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
