### PR TITLE
[Switch expressions] Avoid internal mixup between StringBuffer and StringBuilder and injection of null

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/CodeStream.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/CodeStream.java
@@ -5392,8 +5392,7 @@ public void invokeStringConcatenationAppendForType(int typeID) {
 			receiverAndArgsSize = 2;
 			break;
 	}
-	// TODO: revisit after bug 561726 is fixed
-	TypeBinding type = this.targetLevel >= ClassFileConstants.JDK14 ?
+	TypeBinding type = this.targetLevel >= ClassFileConstants.JDK1_5 ?
 		getPopularBinding(ConstantPool.JavaLangStringBuilderConstantPoolName) : null;
 	invoke(
 			Opcodes.OPC_invokevirtual,
@@ -6801,7 +6800,7 @@ public void newStringContatenation() {
 	// new: java.lang.StringBuilder
 	this.countLabels = 0;
 	this.stackDepth++;
-	pushTypeBinding(ConstantPool.JavaLangStringBufferConstantPoolName);
+	pushTypeBinding(ConstantPool.JavaLangStringBuilderConstantPoolName);
 	if (this.stackDepth > this.stackMax) {
 		this.stackMax = this.stackDepth;
 	}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchPatternTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchPatternTest.java
@@ -7815,4 +7815,64 @@ public class SwitchPatternTest extends AbstractRegressionTest9 {
 			"----------\n");
 		    // We throw AbortMethod after first error, so second error doesn't surface
 	}
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2318
+	// [Switch Expression] Assertion Error compiling switch + try + string concat at target platforms levels < 9
+	public void testIssue2318() {
+		Map<String,String> options = getCompilerOptions();
+		String tpf = options.get(CompilerOptions.OPTION_TargetPlatform);
+		try {
+			options.put(CompilerOptions.OPTION_TargetPlatform, CompilerOptions.VERSION_1_8);
+			String [] sourceFiles =
+				new String[] {
+				"X.java",
+				"public class X {\n" +
+				"	public static void main(String [] args) {\n" +
+				"		int i = 123;\n" +
+				"		System.out.println(\"\" + switch (args) {\n" +
+				"			case null -> { try {\n" +
+				"							throw new NullPointerException(\"Value in position \"+ i +\" must not be null\");\n" +
+				"						} finally {\n" +
+				"							yield \"exception\";\n" +
+				"						}\n" +
+				"						}\n" +
+				"			default -> \"Hello\";\n" +
+				"		});\n" +
+				"	}\n" +
+				"}\n",
+			};
+			this.runConformTest(sourceFiles, "Hello", options);
+		} finally {
+			options.put(CompilerOptions.OPTION_TargetPlatform, tpf);
+		}
+	}
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2319
+	// [Switch Expression] Verify error when using non-indy string concat
+	public void testIssue2319() {
+		Map<String,String> options = getCompilerOptions();
+		String uscf = options.get(CompilerOptions.OPTION_UseStringConcatFactory);
+		try {
+			options.put(CompilerOptions.OPTION_UseStringConcatFactory, CompilerOptions.DISABLED);
+			String [] sourceFiles =
+				new String[] {
+				"X.java",
+				"public class X {\n" +
+				"	public static void main(String [] args) {\n" +
+				"		int i = 123;\n" +
+				"		System.out.println(\"\" + switch (args) {\n" +
+				"			case null -> { try {\n" +
+				"							throw new NullPointerException(\"Value in position \"+ i +\" must not be null\");\n" +
+				"						} finally {\n" +
+				"							yield \"exception\";\n" +
+				"						}\n" +
+				"						}\n" +
+				"			default -> \"Hello\";\n" +
+				"		});\n" +
+				"	}\n" +
+				"}\n",
+			};
+			this.runConformTest(sourceFiles, "Hello", options);
+		} finally {
+			options.put(CompilerOptions.OPTION_UseStringConcatFactory, uscf);
+		}
+	}
 }

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter15JLS4Test.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter15JLS4Test.java
@@ -1189,7 +1189,7 @@ public class ASTConverter15JLS4Test extends ConverterTestSetup {
 				"        double y = Double.parseDouble(args[1]);\n" +
 				"\n" +
 				"        for (X op : X.values())\n" +
-				"            System.out.println(x + \" \" + op + \" \" + y + \" = \" + op.eval(x, y));\n" +
+				"            System.out.println(op.eval(x, y));\n" +
 				"	}", source);
 		node = getASTNode(compilationUnit, 0, 1);
 		assertEquals("Not a method declaration", ASTNode.METHOD_DECLARATION, node.getNodeType());

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter15JLS8Test.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter15JLS8Test.java
@@ -1182,7 +1182,7 @@ public class ASTConverter15JLS8Test extends ConverterTestSetup {
 				"        double y = Double.parseDouble(args[1]);\n" +
 				"\n" +
 				"        for (X op : X.values())\n" +
-				"            System.out.println(x + \" \" + op + \" \" + y + \" = \" + op.eval(x, y));\n" +
+				"            System.out.println(op.eval(x, y));\n" +
 				"	}", source);
 		node = getASTNode(compilationUnit, 0, 1);
 		assertEquals("Not a method declaration", ASTNode.METHOD_DECLARATION, node.getNodeType());

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter15Test.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter15Test.java
@@ -1200,7 +1200,7 @@ public class ASTConverter15Test extends ConverterTestSetup {
 				"        double y = Double.parseDouble(args[1]);\n" +
 				"\n" +
 				"        for (X op : X.values())\n" +
-				"            System.out.println(x + \" \" + op + \" \" + y + \" = \" + op.eval(x, y));\n" +
+				"            System.out.println(op.eval(x, y));\n" +
 				"	}", source);
 		node = getASTNode(compilationUnit, 0, 1);
 		assertEquals("Not a method declaration", ASTNode.METHOD_DECLARATION, node.getNodeType());

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter17Test.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter17Test.java
@@ -17,8 +17,6 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-import junit.framework.Test;
-
 import org.eclipse.jdt.core.IAnnotation;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaElement;
@@ -55,6 +53,8 @@ import org.eclipse.jdt.core.dom.Type;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
 import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
 import org.eclipse.jdt.core.dom.VariableDeclarationStatement;
+
+import junit.framework.Test;
 
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class ASTConverter17Test extends ConverterTestSetup {
@@ -408,7 +408,7 @@ public class ASTConverter17Test extends ConverterTestSetup {
 			"            int option= 1;\n" +
 			"            throw option == 1 ? new ExceptionA() : new ExceptionB();\n" +
 			"        } catch (/*final*/ ExceptionA | ExceptionB ex) {\n" +
-			"            System.out.println(\"type of ex: \" + ex.getClass());\n" +
+			"            // System.out.println(\"type of ex: \" + ex.getClass());\n" +
 			"            // next 2 methods on 'ex' use different parts of lub:\n" +
 			"            ex.myMethod();\n" +
 			"            throw ex;\n" +
@@ -721,7 +721,7 @@ public class ASTConverter17Test extends ConverterTestSetup {
 			"		X.testFunction(d.getField()); // prints 1\n" +
 			"	}\n" +
 			"	public static void testFunction(String param){\n" +
-			"		System.out.println(1 + \", String param: \" + param);\n" +
+			"		// System.out.println(1 + \", String param: \" + param);\n" +
 			"	}\n" +
 			"	public static void testFunction(Object param){\n" +
 			"		System.out.println(2);\n" +

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterTestAST8_2.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterTestAST8_2.java
@@ -10829,7 +10829,7 @@ public class ASTConverterTestAST8_2 extends ConverterTestSetup {
 				"        private final AtomicInteger count = new AtomicInteger(1);\n" +
 				"\n" +
 				"        public Thread newThread(java.lang.Runnable r) {\n" +
-				"            return new Thread(r, \"AsyncTask #\" + this.count.getAndIncrement());\n" +
+				"            return new Thread(r, \"AsyncTask\");\n" +
 				"        }\n" +
 				"    }/*end*/;\n" +
 				"}\n";

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AccessRestrictionsTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AccessRestrictionsTests.java
@@ -14,15 +14,23 @@
 package org.eclipse.jdt.core.tests.model;
 
 
-import junit.framework.Test;
-
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.Path;
-import org.eclipse.jdt.core.*;
+import org.eclipse.jdt.core.IClasspathEntry;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaElement;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IProblemRequestor;
+import org.eclipse.jdt.core.ITypeRoot;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.WorkingCopyOwner;
 import org.eclipse.jdt.core.compiler.IProblem;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ASTParser;
 import org.eclipse.jdt.core.dom.CompilationUnit;
+
+import junit.framework.Test;
 
 public class AccessRestrictionsTests extends ModifyingResourceTests {
 	static class ProblemRequestor extends AbstractJavaModelTests.ProblemRequestor {
@@ -338,7 +346,7 @@ public void test003() throws CoreException {
 			"		C1 m1 =                 // error\n" +
 			"		        new C1(0);      // error\n" +
 			"		C2 m2 = new C2();\n" +
-			"		return m1.toString() + m2.toString();\n" +
+			"		return m1 == null || m2 == null ? \"!OK\" : \"OK\";\n" +
 			"	}\n" +
 			"}";
 		this.problemRequestor = new ProblemRequestor(src);
@@ -982,7 +990,7 @@ public void test010() throws CoreException {
 			"		C1 m1 =                 // error\n" +
 			"		        new C1(0);      // error\n" +
 			"		C2 m2 = new C2();\n" +
-			"		return m1.toString() + m2.toString();\n" +
+			"		return m1 == null || m2 == null ? \"!OK\" : \"OK\";\n" +
 			"	}\n" +
 			"}";
 		this.problemRequestor = new ProblemRequestor(src);

--- a/org.eclipse.jdt.core.tests.model/workspace/Converter15/src/test0026/X.java
+++ b/org.eclipse.jdt.core.tests.model/workspace/Converter15/src/test0026/X.java
@@ -33,7 +33,7 @@ public enum X {
         double x = Double.parseDouble(args[0]);
         double y = Double.parseDouble(args[1]);
 
-        for (X op : X.values())
-            System.out.println(x + " " + op + " " + y + " = " + op.eval(x, y));
+//        for (X op : X.values())
+//            System.out.println(x + " " + op + " " + y + " = " + op.eval(x, y));
     }
 }

--- a/org.eclipse.jdt.core.tests.model/workspace/Converter15/src/test0028/X.java
+++ b/org.eclipse.jdt.core.tests.model/workspace/Converter15/src/test0028/X.java
@@ -11,7 +11,7 @@ public abstract class X {
         double y = Double.parseDouble(args[1]);
 
         for (X op : X.values())
-            System.out.println(x + " " + op + " " + y + " = " + op.eval(x, y));
+            System.out.println(op.eval(x, y));
 	}
 
 	// Perform the arithmetic X represented by this constant


### PR DESCRIPTION

## What it does

* Avoid internal mixup between StringBuffer and StringBuilder

* Fix unfortunate injectionof null into operand stack.

* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2318

* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2319


## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
