### PR TITLE
Fix capture conversion for method references

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ReferenceExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ReferenceExpression.java
@@ -957,18 +957,13 @@ public class ReferenceExpression extends FunctionalExpression implements IPolyEx
 		if (this.descriptor == null || this.descriptor.parameters == null || this.descriptor.parameters.length == 0)
 			return Binding.NO_PARAMETERS;
 
-		/* 15.13.1, " ... method reference is treated as if it were an invocation with argument expressions of types P1, ..., Pn;"
-		   This implies/requires wildcard capture. This creates interesting complications, we can't just take the descriptor parameters
-		   and apply captures - where a single wildcard type got "fanned out" and propagated into multiple locations through type variable
-		   substitutions, we will end up creating distinct captures defeating the very idea of capture. We need to first capture and then
-		   fan out. See https://bugs.eclipse.org/bugs/show_bug.cgi?id=432759.
-		*/
-		if (this.expectedType.isParameterizedType()) {
-			ParameterizedTypeBinding type = (ParameterizedTypeBinding) this.expectedType;
-			MethodBinding method = type.getSingleAbstractMethod(this.enclosingScope, true, this.sourceStart, this.sourceEnd);
-			return method.parameters;
+		TypeBinding[] parameters = this.descriptor.parameters;
+		TypeBinding[] result = new TypeBinding[parameters.length];
+
+		for (int i = 0, length = result.length; i < length; i++) {
+			result[i] = parameters[i].capture(this.enclosingScope, this.sourceStart, this.sourceEnd);
 		}
-		return this.descriptor.parameters;
+		return result;
 	}
 
 	private boolean contextHasSyntaxError() {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LambdaExpressionsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LambdaExpressionsTest.java
@@ -8533,6 +8533,31 @@ public void testIssue2065() {
 			"");
 }
 
+public void testGHIssue2302() {
+    this.runConformTest(
+            new String[] {
+                "TestRecord.java",
+                """
+                public class TestRecord {
+                    public void test() {
+                        A<B<?>> a = null;
+                        call(a, this::error);
+                    }
+
+                    public void error(A<B<?>> a) {
+                    }
+
+                    public <T> void call(A<T> a, C<T> c) {}
+
+                    private static interface C<T> {
+                        void run(A<T> arg);
+                    }
+                    private static class A<T> {}
+                    private static class B<T> {}
+                }
+                """});
+}
+
 
 public static Class testClass() {
 	return LambdaExpressionsTest.class;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
Fixes #2302 by applying capture conversion at the parameter level.

If capture conversion were to apply only to type arguments then
```java
    private static interface C<T> {
        void run(A<T> arg);
    }
```
would be invalid with `void method(A<B<?>> a);` due to capture conversion making the wildcard a capture.

```java
    private static interface C<T> {
        void run(A<?> a, A<?> b);
    }
```
would be valid with `<T> void method(A<T> a, A<T> b)` which should be invalid due to the interface not requiring the type arguments of `a` and `b` to be the same.

and about "fanned out"
```java
    private static interface C<T> {
        void run(T a, T b);
    }
```
would be valid with `<T> void method(A<T> a, A<T> b)` and `C<A<?>> c = this::method` which should be invalid due to `c` not requiring the type arguments of `a` and `b` to be the same.

## How to test
Attempt to compile:
```java
public class TestRecord {
    public void test() {
        A<B<?>> a = null;
        call(a, this::error);
    }

    public void error(A<B<?>> a) {
    }

    public <T> void call(A<T> a, C<T> c) {}

    private static interface C<T> {
        void run(A<T> arg);
    }
    private static class A<T> {}
    private static class B<T> {}
}
```
Fails with `The type TestRecord does not define error(TestRecord.A<TestRecord.B<capture#1-of ?>>) that is applicable here` without this change but successfully compiles with this change.

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)

## Additional information
While working on this I also found that `createCapturedWildcard` reuses the same capture binding for each wildcard of a method reference due to the `contextType` being the containing class along with `start` and `end` being the start and end of the method reference so the same capture binding will be reused for each wildcard in the parameters of the method reference.
