### PR TITLE
Fix wrong type binding push on operand stack

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/CodeStream.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/CodeStream.java
@@ -3980,7 +3980,7 @@ public void i2c() {
 public void i2d() {
 	this.countLabels = 0;
 	this.stackDepth++;
-	pushTypeBinding(1, TypeBinding.INT);
+	pushTypeBinding(1, TypeBinding.DOUBLE);
 	if (this.stackDepth > this.stackMax)
 		this.stackMax = this.stackDepth;
 	if (this.classFileOffset >= this.bCodeStream.length) {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchExpressionsYieldTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchExpressionsYieldTest.java
@@ -7130,4 +7130,35 @@ public class SwitchExpressionsYieldTest extends AbstractRegressionTest {
 				},
 				"");
 	}
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2322
+	// [Switch Expression] Internal compiler error: java.util.EmptyStackException at java.base/java.util.Stack.peek
+	public void testIssue2322() {
+		if (this.complianceLevel < ClassFileConstants.JDK14)
+			return;
+		this.runConformTest(
+				new String[] {
+				"X.java",
+				"""
+				public class X {
+					public static void main(String [] args) {
+				    int lineCount = 10;
+				    long time = 1000;
+				    print((int) (lineCount * 10000.0 / time));
+				    print((double) (lineCount * 10000.0 / time));
+				    System.out.println(switch(lineCount) {
+				        default -> {
+				    	try {
+				    		yield "OK";
+				    	} finally {
+
+				    	}
+				        }
+				    });
+				  }
+				  static void print(double d) {}
+				}
+				"""
+				},
+				"OK");
+	}
 }


### PR DESCRIPTION

## What it does
* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2322

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
