### PR TITLE
ECJ mixes up between array types and primitive component type

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/CodeStream.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/CodeStream.java
@@ -6654,15 +6654,27 @@ public void new_(TypeReference typeReference, TypeBinding typeBinding) {
 	writeUnsignedShort(this.constantPool.literalIndexForType(typeBinding));
 }
 
-public void newarray(int array_Type) {
+public void newarray(int arrayTypeCode) {
 	this.countLabels = 0;
 	if (this.classFileOffset + 1 >= this.bCodeStream.length) {
 		resizeByteArray();
 	}
 	this.position += 2;
 	this.bCodeStream[this.classFileOffset++] = Opcodes.OPC_newarray;
-	this.bCodeStream[this.classFileOffset++] = (byte) array_Type;
-	pushTypeBinding(1, TypeBinding.wellKnownBaseType(array_Type));
+	this.bCodeStream[this.classFileOffset++] = (byte) arrayTypeCode;
+
+	ClassScope scope = this.classFile.referenceBinding.scope;
+	pushTypeBinding(1, switch (arrayTypeCode) {
+				case ClassFileConstants.INT_ARRAY -> scope.createArrayType(TypeBinding.INT, 1);
+				case ClassFileConstants.BYTE_ARRAY -> scope.createArrayType(TypeBinding.BYTE, 1);
+				case ClassFileConstants.BOOLEAN_ARRAY -> scope.createArrayType(TypeBinding.BOOLEAN, 1);
+				case ClassFileConstants.SHORT_ARRAY -> scope.createArrayType(TypeBinding.SHORT, 1);
+				case ClassFileConstants.CHAR_ARRAY -> scope.createArrayType(TypeBinding.CHAR, 1);
+				case ClassFileConstants.LONG_ARRAY -> scope.createArrayType(TypeBinding.LONG, 1);
+				case ClassFileConstants.FLOAT_ARRAY -> scope.createArrayType(TypeBinding.FLOAT, 1);
+				case ClassFileConstants.DOUBLE_ARRAY -> scope.createArrayType(TypeBinding.DOUBLE, 1);
+				default -> throw new UnsupportedOperationException("Unknown base type");	//$NON-NLS-1$
+			});
 }
 
 public void newArray(ArrayBinding arrayBinding) {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchExpressionsYieldTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchExpressionsYieldTest.java
@@ -2312,6 +2312,38 @@ public class SwitchExpressionsYieldTest extends AbstractRegressionTest {
 				"Syntax error on token \"2\", delete this token\n" +
 				"----------\n");
 	}
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2323
+	// [Switch Expression] Internal compiler error: java.lang.ClassCastException while compiling switch expression
+	public void testIssue2323() {
+		if (this.complianceLevel < ClassFileConstants.JDK14)
+			return;
+		this.runConformTest(
+				new String[] {
+				"X.java",
+				"""
+				public class X {
+					public static void f() {
+						int[] array = null;
+						(array = new int[1])[0] = 42;
+					}
+					public static int g() {
+						int[] array = null;
+						System.out.println(switch(10) {
+						default -> {
+							try {
+								yield 42;
+							} finally {
+
+							}
+						}
+					});
+						return (array = new int[1])[0];
+					}
+				}
+				"""
+				},
+				"");
+	}
 	public void testBug547891_01() {
 		this.runNegativeTest(
 				new String[] {


### PR DESCRIPTION
## What it does

* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2323

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
