### PR TITLE
Add Java 23 constants

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/ClassFileConstants.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/ClassFileConstants.java
@@ -139,6 +139,7 @@ public interface ClassFileConstants {
 	int MAJOR_VERSION_20 = 64;
 	int MAJOR_VERSION_21 = 65;
 	int MAJOR_VERSION_22 = 66;
+	int MAJOR_VERSION_23 = 67;
 
 	int MAJOR_VERSION_0 = 44;
 	int MAJOR_LATEST_VERSION = MAJOR_VERSION_22;
@@ -174,6 +175,7 @@ public interface ClassFileConstants {
 	long JDK20 = ((long)ClassFileConstants.MAJOR_VERSION_20 << 16) + ClassFileConstants.MINOR_VERSION_0;
 	long JDK21 = ((long)ClassFileConstants.MAJOR_VERSION_21 << 16) + ClassFileConstants.MINOR_VERSION_0;
 	long JDK22 = ((long)ClassFileConstants.MAJOR_VERSION_22 << 16) + ClassFileConstants.MINOR_VERSION_0;
+	long JDK23 = ((long)ClassFileConstants.MAJOR_VERSION_23 << 16) + ClassFileConstants.MINOR_VERSION_0;
 
 	public static long getLatestJDKLevel() {
 		return ((long)ClassFileConstants.MAJOR_LATEST_VERSION << 16) + ClassFileConstants.MINOR_VERSION_0;

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/core/JavaCore.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/core/JavaCore.java
@@ -3312,6 +3312,12 @@ public final class JavaCore extends Plugin {
 	public static final String VERSION_22 = "22"; //$NON-NLS-1$
 	/**
 	 * Configurable option value: {@value}.
+	 * @since 3.38
+	 * @category OptionValue
+	 */
+	public static final String VERSION_23 = "23"; //$NON-NLS-1$
+	/**
+	 * Configurable option value: {@value}.
 	 * @since 3.4
 	 * @category OptionValue
 	 */


### PR DESCRIPTION
## What it does
Adds Java 23 constants for runtime detection and launching of Java 23 as detected in https://github.com/eclipse-pde/eclipse.pde/issues/1227 and https://github.com/eclipse-jdt/eclipse.jdt.debug/pull/426 .

## How to test
System packages resolve proper will need extra change in jdt.debug (https://github.com/eclipse-pde/eclipse.pde/issues/1227).

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
