### PR TITLE
Missing code implementation

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullReferenceTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullReferenceTest.java
@@ -18738,6 +18738,8 @@ public void testGH1461_d() {
 			""");
 }
 public void testGH1755() {
+	if (this.complianceLevel < ClassFileConstants.JDK1_8)
+		return;
 	runNegativeTest(
 		new String[] {
 			"X.java",


### PR DESCRIPTION
fixes #1755 after re-open:

disable test using lambda when below 1.8
