### PR TITLE
Cache JRT FileSystem instances created

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/ClasspathJep247.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/ClasspathJep247.java
@@ -44,21 +44,20 @@ import org.eclipse.jdt.internal.compiler.util.Util;
 public class ClasspathJep247 extends ClasspathJrt {
 
 	protected java.nio.file.FileSystem fs;
-	protected String compliance = null;
-	protected long jdklevel;
-	protected String releaseInHex = null;
-	protected String[] subReleases = null;
-	protected Path releasePath = null;
+	protected final String compliance;
+	protected final long jdklevel;
+	protected String releaseInHex;
+	protected String[] subReleases;
+	protected Path releasePath;
 	protected Set<String> packageCache;
-	protected File jdkHome;
-	protected String modulePath = null;
+	protected final File jdkHome;
+	protected String modulePath;
 
 	public ClasspathJep247(File jdkHome, String release, AccessRuleSet accessRuleSet) {
-		super(jdkHome, false, accessRuleSet, null);
+		super(new File(new File(jdkHome, "lib"), JRTUtil.JRT_FS_JAR), false, accessRuleSet, null); //$NON-NLS-1$
 		this.compliance = release;
 		this.jdklevel = CompilerOptions.releaseToJDKLevel(this.compliance);
 		this.jdkHome = jdkHome;
-		this.file = new File(new File(jdkHome, "lib"), "jrt-fs.jar"); //$NON-NLS-1$ //$NON-NLS-2$
 	}
 	@Override
 	public List<Classpath> fetchLinkedJars(FileSystem.ClasspathSectionProblemReporter problemReporter) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/ClasspathJrt.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/ClasspathJrt.java
@@ -46,9 +46,9 @@ import org.eclipse.jdt.internal.compiler.util.JRTUtil;
 
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class ClasspathJrt extends ClasspathLocation implements IMultiModuleEntry {
-	public File file;
+	public final File file;
 	protected ZipFile annotationZipFile;
-	protected boolean closeZipFileAtEnd;
+	protected final boolean closeZipFileAtEnd;
 	protected static Map<String, Map<String,IModule>> ModulesCache = new ConcurrentHashMap<>();
 	public final Set<String> moduleNamesCache;
 	//private Set<String> packageCache;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/FileSystem.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/FileSystem.java
@@ -325,7 +325,7 @@ public static Classpath getClasspath(String classpathName, String encoding,
 						convertPathSeparators(destinationPath));
 			} else if (destinationPath == null) {
 				// class file only mode
-				if (classpathName.endsWith(JRTUtil.JRT_FS_JAR)) {
+				if (Util.isJrt(classpathName)) {
 					if (JRT_CLASSPATH_CACHE == null) {
 						JRT_CLASSPATH_CACHE = new HashMap<>();
 					} else {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/tool/EclipseFileManager.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/tool/EclipseFileManager.java
@@ -959,7 +959,7 @@ public class EclipseFileManager implements StandardJavaFileManager {
 	}
 
 	private boolean isJrt(File f) {
-		return f.getName().equalsIgnoreCase(JrtFileSystem.BOOT_MODULE);
+		return Util.isJrt(f.getName());
 	}
 
 	/* (non-Javadoc)

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/tool/JrtFileSystem.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/tool/JrtFileSystem.java
@@ -21,14 +21,10 @@ import java.io.Reader;
 import java.io.Writer;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
-import java.net.URLClassLoader;
 import java.nio.charset.Charset;
-import java.nio.file.FileSystems;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -46,10 +42,6 @@ import org.eclipse.jdt.internal.compiler.util.JRTUtil;
 
 public class JrtFileSystem extends Archive {
 
-	private static URI JRT_URI = URI.create("jrt:/"); //$NON-NLS-1$
-
-	static final String BOOT_MODULE = "jrt-fs.jar"; //$NON-NLS-1$
-
 	public HashMap<String, Path> modulePathMap;
 	Path modules;
 	private java.nio.file.FileSystem jrtfs;
@@ -62,15 +54,9 @@ public class JrtFileSystem extends Archive {
 	public void initialize() throws IOException {
 		// initialize packages
 		this.modulePathMap = new HashMap<>();
-		URL jrtPath = null;
-
 		if (this.file.exists()) {
-			jrtPath = Paths.get(this.file.toPath().toString(), "lib", JRTUtil.JRT_FS_JAR).toUri().toURL(); //$NON-NLS-1$
-			try (URLClassLoader loader = new URLClassLoader(new URL[] { jrtPath })) {
-				HashMap<String, ?> env = new HashMap<>();
-				this.jrtfs = FileSystems.newFileSystem(JRT_URI, env, loader);
-				this.modules = this.jrtfs.getPath("/modules"); //$NON-NLS-1$
-			}
+			this.jrtfs = JRTUtil.getJrtFileSystem(this.file.getAbsolutePath());
+			this.modules = this.jrtfs.getPath(JRTUtil.MODULES_SUBDIR);
 		} else {
 			return;
 		}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/util/Util.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/util/Util.java
@@ -796,11 +796,10 @@ public class Util implements SuffixConstants {
 	}
 
 	/**
-	 * Returns true iff str.toLowerCase().endsWith("jrt-fs.jar")
-	 * implementation is not creating extra strings.
+	 * @return true if name.endsWith("jrt-fs.jar")
 	 */
 	public final static boolean isJrt(String name) {
-		return name.endsWith(JRTUtil.JRT_FS_JAR);
+		return name != null && name.endsWith(JRTUtil.JRT_FS_JAR);
 	}
 
 	public static void reverseQuickSort(char[][] list, int left, int right) {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/DefaultJavaRuntimeEnvironment.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/DefaultJavaRuntimeEnvironment.java
@@ -20,7 +20,6 @@ import java.util.Map.Entry;
 import org.eclipse.jdt.core.tests.util.Util;
 import org.eclipse.jdt.internal.compiler.batch.FileSystem;
 import org.eclipse.jdt.internal.compiler.env.INameEnvironment;
-import org.eclipse.jdt.internal.compiler.util.JRTUtil;
 
 public class DefaultJavaRuntimeEnvironment extends FileSystem {
 
@@ -42,7 +41,7 @@ public class DefaultJavaRuntimeEnvironment extends FileSystem {
 				defaultJreClassLibs = new INameEnvironment[1];
 				Classpath[] classpath = new Classpath[jreClasspaths.length];
 				for(int i = 0; i < classpath.length; i++) {
-					if (jreClasspaths[i].endsWith(JRTUtil.JRT_FS_JAR)) {
+					if (org.eclipse.jdt.internal.compiler.util.Util.isJrt(jreClasspaths[i])) {
 						File file = new File(jreClasspaths[0]);
 						classpath[i] = FileSystem.getOlderSystemRelease(file.getParentFile().getParent(), release, null);
 

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelManager.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelManager.java
@@ -145,7 +145,6 @@ import org.eclipse.jdt.internal.compiler.env.IElementInfo;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jdt.internal.compiler.lookup.TypeConstants;
 import org.eclipse.jdt.internal.compiler.util.HashtableOfObjectToInt;
-import org.eclipse.jdt.internal.compiler.util.JRTUtil;
 import org.eclipse.jdt.internal.compiler.util.ObjectVector;
 import org.eclipse.jdt.internal.core.DeltaProcessor.RootInfo;
 import org.eclipse.jdt.internal.core.JavaProjectElementInfo.ProjectCache;
@@ -2937,11 +2936,11 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 	}
 
 	public static boolean isJrt(IPath path) {
-		return path.toString().endsWith(JRTUtil.JRT_FS_JAR);
+		return org.eclipse.jdt.internal.compiler.util.Util.isJrt(path.lastSegment());
 	}
 
 	public static boolean isJrt(String path) {
-		return isJrt(new Path(path));
+		return org.eclipse.jdt.internal.compiler.util.Util.isJrt(path);
 	}
 
 	public void verifyArchiveContent(IPath path) throws CoreException {

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/IndexManager.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/IndexManager.java
@@ -14,6 +14,7 @@
 package org.eclipse.jdt.internal.core.search.indexing;
 
 import static org.eclipse.jdt.internal.core.JavaModelManager.trace;
+import static org.eclipse.jdt.internal.compiler.util.Util.isJrt;
 
 import java.io.BufferedWriter;
 import java.io.File;
@@ -63,7 +64,6 @@ import org.eclipse.jdt.internal.compiler.ISourceElementRequestor;
 import org.eclipse.jdt.internal.compiler.SourceElementParser;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jdt.internal.compiler.problem.DefaultProblemFactory;
-import org.eclipse.jdt.internal.compiler.util.JRTUtil;
 import org.eclipse.jdt.internal.compiler.util.SimpleLookupTable;
 import org.eclipse.jdt.internal.compiler.util.SimpleSet;
 import org.eclipse.jdt.internal.core.ClasspathEntry;
@@ -736,9 +736,6 @@ private IndexRequest getRequest(Object target, IPath jPath, IndexLocation indexF
 		new AddJarFileToIndex(jPath, indexFile, this, updateIndex);
 }
 
-private boolean isJrt(String fileName) {
-	return fileName != null && fileName.endsWith(JRTUtil.JRT_FS_JAR);
-}
 /**
  * Trigger addition of a library to an index
  * Note: the actual operation is performed in background


### PR DESCRIPTION
- Originally submitted as https://github.com/eclipse-jdt/eclipse.jdt.core/pull/2370
- Cleaned up code around new FileSystem creation for `jrt-fs.jar`
- Cleaned up / unified references to `jrt-fs` related code
