### PR TITLE
ecj: Duplicate resource leak warnings

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/FakedTrackingVariable.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/FakedTrackingVariable.java
@@ -552,7 +552,7 @@ public class FakedTrackingVariable extends LocalDeclaration {
 		}
 	}
 
-	private static boolean isFluentMethod(MethodBinding binding) {
+	static boolean isFluentMethod(MethodBinding binding) {
 		if (binding.isStatic())
 			return false;
 		ReferenceBinding declaringClass = binding.declaringClass;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/MessageSend.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/MessageSend.java
@@ -265,8 +265,12 @@ public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext, Fl
 		//               NullReferenceTest#test0510
 	}
 	// after having analysed exceptions above start tracking newly allocated resource:
-	if (analyseResources && FakedTrackingVariable.isAnyCloseable(this.resolvedType))
-		flowInfo = FakedTrackingVariable.analyseCloseableAcquisition(currentScope, flowInfo, flowContext, this);
+	if (analyseResources) {
+		if (FakedTrackingVariable.isAnyCloseable(this.resolvedType))
+			flowInfo = FakedTrackingVariable.analyseCloseableAcquisition(currentScope, flowInfo, flowContext, this);
+		if (!FakedTrackingVariable.isFluentMethod(this.binding))
+			FakedTrackingVariable.cleanUpUnassigned(currentScope, this.receiver, flowInfo, false);
+	}
 
 	manageSyntheticAccessIfNecessary(currentScope, flowInfo);
 	// account for pot. exceptions thrown by method execution


### PR DESCRIPTION
fixes #1867

Detect the leak already when analyzing the MessageSend whose receiver is the leaking expression.
