### PR TITLE
Avoid expensive calls to Path.toRealPath() in JRTUtil

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/util/JRTUtil.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/util/JRTUtil.java
@@ -150,7 +150,7 @@ public class JRTUtil {
 	 */
 	public static FileSystem getJrtFileSystem(Path path) throws IOException {
 		try {
-			FileSystem fs = JRT_FILE_SYSTEMS.computeIfAbsent(path.toRealPath(), p -> {
+			FileSystem fs = JRT_FILE_SYSTEMS.computeIfAbsent(path.toAbsolutePath().normalize(), p -> {
 				try {
 					return FileSystems.newFileSystem(JRTUtil.JRT_URI, Map.of("java.home", p.toString())); //$NON-NLS-1$
 				} catch (IOException e) {
@@ -196,7 +196,7 @@ public class JRTUtil {
 	public static CtSym getCtSym(Path jdkHome) throws IOException {
 		CtSym ctSym;
 		try {
-			ctSym = ctSymFiles.compute(jdkHome.toRealPath(), (Path x, CtSym current) -> {
+			ctSym = ctSymFiles.compute(jdkHome.toAbsolutePath().normalize(), (Path x, CtSym current) -> {
 				if (current == null || !current.getFs().isOpen()) {
 					try {
 						return new CtSym(x);
@@ -440,7 +440,7 @@ class Jdk {
 	public Jdk(File jrt) throws IOException {
 		this.path = toJdkHome(jrt);
 		try {
-			this.release = pathToRelease.computeIfAbsent(this.path.toRealPath(), p -> {
+			this.release = pathToRelease.computeIfAbsent(this.path, p -> {
 				try {
 					return readJdkReleaseFile(p);
 				} catch (IOException e) {
@@ -477,7 +477,7 @@ class Jdk {
 
 	static Path toJdkHome(File jrt) {
 		Path home;
-		Path normalized = jrt.toPath().normalize();
+		Path normalized = jrt.toPath().toAbsolutePath().normalize();
 		if (jrt.getName().equals(JRTUtil.JRT_FS_JAR)) {
 			home = normalized.getParent().getParent();
 		} else {


### PR DESCRIPTION
## What it does

Avoid calls to `Path.toRealPath()` in `JRTUtil` which are expensive, especially under Windows since each element of the path is checked for the real name of its element. Just calling `Path.toAbsolutePath().normalize()` already covers most cases.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2393

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
