### PR TITLE
Reintroduce old `CaseStatement` constructor

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/CaseStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/CaseStatement.java
@@ -54,6 +54,11 @@ public CaseStatement(Expression[] constantExpressions, int sourceStart, int sour
 	this.sourceEnd = sourceEnd;
 }
 
+@Deprecated
+public CaseStatement(int sourceEnd, int sourceStart, Expression[] constantExpressions) {
+	this(constantExpressions, sourceStart, sourceEnd);
+}
+
 /** Provide an under-the-hood view of label expressions, peeling away any abstractions that package many expressions as one
  *  @return flattened array of label expressions
  */


### PR DESCRIPTION
This should help support backwards compatibility for projects that extend the parser.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Reintroduce the old constructor for CaseStatement, which has as different parameter order, and mark it as deprecated.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See if this resolves https://github.com/projectlombok/lombok/issues/3648

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
