### PR TITLE
Push array type and not component type onto operand stack on anewarray

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/CodeStream.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/CodeStream.java
@@ -407,7 +407,9 @@ public void anewarray(TypeBinding typeBinding) {
 	this.position++;
 	this.bCodeStream[this.classFileOffset++] = Opcodes.OPC_anewarray;
 	writeUnsignedShort(this.constantPool.literalIndexForType(typeBinding));
-	pushTypeBinding(1, typeBinding);
+
+	ClassScope scope = this.classFile.referenceBinding.scope;
+	pushTypeBinding(1, scope.createArrayType(typeBinding, 1));
 }
 
 public void areturn() {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchExpressionsYieldTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchExpressionsYieldTest.java
@@ -7837,4 +7837,35 @@ public class SwitchExpressionsYieldTest extends AbstractRegressionTest {
 				+ "Illegal enclosing instance specification for type X.Y\n"
 				+ "----------\n");
 	}
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2423
+	// [Switch-expression] Internal compiler error: java.lang.ClassCastException while compiling switch expression with exception handling
+	public void testIssue2423() {
+		if (this.complianceLevel < ClassFileConstants.JDK14)
+			return;
+		this.runConformTest(
+				new String[] {
+				"X.java",
+				"""
+				public class X {
+					static String getString(int i) {
+						System.out.println(switch (42) {
+						default -> {
+							try {
+								yield 42;
+							} finally {
+
+							}
+						}
+						});
+						return new String[] { "Hello", "World" }[i];
+					}
+					public static void main(String [] args) {
+						System.out.println(getString(0));
+					}
+				}
+				"""
+				},
+				"42\n"
+				+ "Hello");
+	}
 }


### PR DESCRIPTION


## What it does

* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2423

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
