### PR TITLE
Fix various failures recently introduced at levels 1.5-

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/CodeStream.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/CodeStream.java
@@ -7641,6 +7641,12 @@ protected void writeWidePosition(BranchLabel label) {
 	}
 }
 private TypeBinding retrieveLocalType(int currentPC, int resolvedPosition) {
+
+	if ((this.generateAttributes & (ClassFileConstants.ATTR_VARS
+			| ClassFileConstants.ATTR_STACK_MAP_TABLE
+			| ClassFileConstants.ATTR_STACK_MAP)) == 0)
+		return null; // can't retrieve what we didn't record.
+
 	for (int i = this.allLocalsCounter  - 1 ; i >= 0; i--) {
 		LocalVariableBinding localVariable = this.locals[i];
 		if (localVariable == null) continue;
@@ -7660,6 +7666,7 @@ private TypeBinding retrieveLocalType(int currentPC, int resolvedPosition) {
 			}
 		}
 	}
+
 	if (this.methodDeclaration != null) {
 		ReferenceBinding declaringClass = this.methodDeclaration.binding.declaringClass;
 		if (resolvedPosition == 0 && !this.methodDeclaration.isStatic()) {


### PR DESCRIPTION

## What it does

At 1.5-, as we are not simulating the VM stack, we don't need toretrieve types of locals referenced by the bytecode instruction. As a matter of we cannot, because we don't record them in the first place.

Fixes the failures reported at https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2234#issuecomment-2100383962

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2234

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
