### PR TITLE
JDT Core throws NullPointerException: Cannot read field "declaringClass" because "enumConstructor" is null #2398

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ExplicitConstructorCall.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ExplicitConstructorCall.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -348,7 +348,10 @@ public class ExplicitConstructorCall extends Statement implements Invocation {
 			}
 			if (receiverType != null) {
 				// prevent (explicit) super constructor invocation from within enum
-				if (this.accessMode == ExplicitConstructorCall.Super && receiverType.erasure().id == TypeIds.T_JavaLangEnum) {
+				MethodBinding mBinding = methodScope.referenceMethod().binding;
+ 				if (this.accessMode == ExplicitConstructorCall.Super &&
+ 						(mBinding != null && (mBinding.tagBits & TagBits.HasMissingType) == 0)
+						&& receiverType.erasure().id == TypeIds.T_JavaLangEnum) {
 					scope.problemReporter().cannotInvokeSuperConstructorInEnum(this, methodScope.referenceMethod().binding);
 				}
 				// qualification should be from the type of the enclosingType

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/EnumTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/EnumTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -7297,5 +7297,35 @@ public void testBug388314() throws Exception {
 	if (index == -1) {
 		assertEquals("Wrong contents", expectedOutput, actualOutput);
 	}
+}
+public void testGHIssue2398() {
+	if (this.complianceLevel < ClassFileConstants.JDK1_8)
+		return;
+	this.runNegativeTest(new String[] {
+			"com/test/X.java",
+			"""
+			package com.test;
+			public class X {
+				public static void main(String[] args) {
+					System.out.println("Success");
+				}
+				enum Inner extends com.test.Option {
+					private String s;
+					Inner(com.test.Option.Missing v) {
+						super();
+					}
+				}
+			}"""},
+			"----------\n" +
+			"1. ERROR in com\\test\\X.java (at line 6)\n" +
+			"	enum Inner extends com.test.Option {\n" +
+			"	^^^^\n" +
+			"Syntax error on token \"enum\", class expected\n" +
+			"----------\n" +
+			"2. ERROR in com\\test\\X.java (at line 8)\n" +
+			"	Inner(com.test.Option.Missing v) {\n" +
+			"	      ^^^^^^^^^^^^^^^\n" +
+			"com.test.Option cannot be resolved to a type\n" +
+			"----------\n");
 }
 }


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
Fixes #2398 

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
