### PR TITLE
JDT Core throws NPE: Cannot invoke "AnnotationBinding.getAnnotationType()" because "annotationBinding" is null #2400

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
@@ -2025,6 +2025,8 @@ String deprecatedSinceValue(Supplier<AnnotationBinding[]> annotations) {
 		ReferenceContext contextSave = this.referenceContext;
 		try {
 			for (AnnotationBinding annotationBinding : annotations.get()) {
+				if (annotationBinding == null)
+					continue;
 				if (annotationBinding.getAnnotationType().id == TypeIds.T_JavaLangDeprecated) {
 					for (ElementValuePair elementValuePair : annotationBinding.getElementValuePairs()) {
 						if (CharOperation.equals(elementValuePair.getName(), TypeConstants.SINCE) && elementValuePair.value instanceof StringConstant)

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AnnotationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AnnotationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -12366,6 +12366,47 @@ public void testBugVisibility() {
 			"}",
 		},
 		"");
+}
+public void testIssue2400() {
+	if (this.complianceLevel < ClassFileConstants.JDK9) {
+		return;
+	}
+	Map customOptions = getCompilerOptions();
+	Object bkup = customOptions.get(CompilerOptions.OPTION_AnnotationBasedNullAnalysis);
+	customOptions.put(CompilerOptions.OPTION_AnnotationBasedNullAnalysis, CompilerOptions.ENABLED);
+	try {
+		runNegativeTest(
+			new String[] {
+				"TestClass.java",
+				"package test;\n"
+				+ "@com.Missing\n"
+				+ "@java.lang.Deprecated\n"
+				+ "public class TestClass {\n"
+				+ "}",
+				"com.java",
+				"package test;\n"
+				+ "public class com {\n"
+				+ "	test.TestClass value;"
+				+ "}",
+			},
+			"----------\n" +
+			"1. ERROR in TestClass.java (at line 2)\n" +
+			"	@com.Missing\n" +
+			"	 ^^^^^^^^^^^\n" +
+			"com.Missing cannot be resolved to a type\n" +
+			"----------\n" +
+			"----------\n" +
+			"1. WARNING in com.java (at line 3)\n" +
+			"	test.TestClass value;}\n" +
+			"	     ^^^^^^^^^\n" +
+			"The type TestClass is deprecated\n" +
+			"----------\n",
+			null,
+			true,
+			customOptions);
+	} finally {
+		customOptions.put(CompilerOptions.OPTION_AnnotationBasedNullAnalysis, bkup);
+	}
 }
 
 }


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2400

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
