### PR TITLE
Don't use toOSString in JavaSearchScope.convertInternalToExternalPath()

### DIFF
--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/JavaSearchScope.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/JavaSearchScope.java
@@ -432,7 +432,7 @@ private String convertInternalToExternalPath(String given) {
 		if (targetResource != null) {
 			IPath targetLocation = targetResource.getLocation();
 			if (targetLocation != null) {
-				return targetLocation.toOSString();
+				return targetLocation.toString();
 			}
 		}
 	}


### PR DESCRIPTION
The usage of `IPath.toString()` and `toOSString()` seem to follow some surprising rules in `JavaSearchScope`.

In the case of `convertInternalToExternalPath()` we are supposed to use paths containing forward slash as that is what used in `JavaSearchScope.getPath()`.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2439