### PR TITLE
CCE while typing try-with-resources

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/core/compiler/IProblem.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/core/compiler/IProblem.java
@@ -2070,6 +2070,8 @@ void setSourceStart(int sourceStart);
 	int OverrideAddingReturnOwning = Internal + 1267;
 	/** @since 3.38 */
 	int StaticResourceField = Internal + 1268;
+	/** @since 3.38 */
+	int ResourceIsNotAValue = Internal + 1269;
 
 	// terminally
 	/** @since 3.14 */

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TryStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TryStatement.java
@@ -1159,15 +1159,19 @@ public void resolve(BlockScope upperScope) {
 			}
 		} else { // expression
 			Expression node = (Expression) this.resources[i];
-			TypeBinding resourceType = node.resolvedType;
-			if (resourceType instanceof ReferenceBinding) {
-				if (resourceType.findSuperTypeOriginatingFrom(TypeIds.T_JavaLangAutoCloseable, false /*AutoCloseable is not a class*/) == null && resourceType.isValidBinding()) {
+			if (node instanceof NameReference && (node.bits & Binding.VARIABLE) == 0) {
+				upperScope.problemReporter().resourceNotAValue((NameReference) node);
+			} else {
+				TypeBinding resourceType = node.resolvedType;
+				if (resourceType instanceof ReferenceBinding) {
+					if (resourceType.findSuperTypeOriginatingFrom(TypeIds.T_JavaLangAutoCloseable, false /*AutoCloseable is not a class*/) == null && resourceType.isValidBinding()) {
+						upperScope.problemReporter().resourceHasToImplementAutoCloseable(resourceType, node);
+						((Expression) this.resources[i]).resolvedType = new ProblemReferenceBinding(CharOperation.splitOn('.', resourceType.shortReadableName()), null, ProblemReasons.InvalidTypeForAutoManagedResource);
+					}
+				} else if (resourceType != null) { // https://bugs.eclipse.org/bugs/show_bug.cgi?id=349862, avoid secondary error in problematic null case
 					upperScope.problemReporter().resourceHasToImplementAutoCloseable(resourceType, node);
 					((Expression) this.resources[i]).resolvedType = new ProblemReferenceBinding(CharOperation.splitOn('.', resourceType.shortReadableName()), null, ProblemReasons.InvalidTypeForAutoManagedResource);
 				}
-			} else if (resourceType != null) { // https://bugs.eclipse.org/bugs/show_bug.cgi?id=349862, avoid secondary error in problematic null case
-				upperScope.problemReporter().resourceHasToImplementAutoCloseable(resourceType, node);
-				((Expression) this.resources[i]).resolvedType = new ProblemReferenceBinding(CharOperation.splitOn('.', resourceType.shortReadableName()), null, ProblemReasons.InvalidTypeForAutoManagedResource);
 			}
 		}
 	}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
@@ -8109,6 +8109,15 @@ public void resourceHasToImplementAutoCloseable(TypeBinding binding, ASTNode ref
 			reference.sourceStart,
 			reference.sourceEnd);
 }
+public void resourceNotAValue(NameReference node) {
+	String[] arguments = { node.toString() };
+	this.handle(
+			IProblem.ResourceIsNotAValue,
+			arguments,
+			arguments,
+			node.sourceStart,
+			node.sourceEnd);
+}
 private int retrieveClosingAngleBracketPosition(int start) {
 	if (this.referenceContext == null) return start;
 	CompilationResult compilationResult = this.referenceContext.compilationResult();

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/messages.properties
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/messages.properties
@@ -921,6 +921,7 @@
 1266 = Unsafe redefinition, super method tagged this parameter as ''@{0}''
 1267 = Unsafe redefinition, super method is not tagged as ''@{0}''
 1268 = It is not recommended to hold a resource in a static field
+1269 = {0} cannot be resolved to a variable
 
 # Java9 - Module declaration related
 1300 = {0} cannot be resolved to a module

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/CompilerInvocationTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/CompilerInvocationTests.java
@@ -1017,6 +1017,7 @@ public void test011_problem_categories() {
 		expectedProblemAttributes.put("RepeatableAnnotationWithRepeatingContainerAnnotation", new ProblemAttributes(CategorizedProblem.CAT_TYPE));
 		expectedProblemAttributes.put("RepeatedAnnotationWithContainerAnnotation", new ProblemAttributes(CategorizedProblem.CAT_TYPE));
 		expectedProblemAttributes.put("ResourceHasToImplementAutoCloseable", new ProblemAttributes(CategorizedProblem.CAT_TYPE));
+		expectedProblemAttributes.put("ResourceIsNotAValue", new ProblemAttributes(CategorizedProblem.CAT_INTERNAL));
 		expectedProblemAttributes.put("ReturnTypeAmbiguous", DEPRECATED);
 		expectedProblemAttributes.put("ReturnTypeCannotBeVoidArray", DEPRECATED);
 		expectedProblemAttributes.put("ReturnTypeInheritedNameHidesEnclosingName", DEPRECATED);
@@ -2137,6 +2138,7 @@ public void test012_compiler_problems_tuning() {
 		expectedProblemAttributes.put("RequiredNonNullButProvidedUnknown", new ProblemAttributes(JavaCore.COMPILER_PB_NULL_UNCHECKED_CONVERSION));
 		expectedProblemAttributes.put("RequiredNonNullButProvidedSpecdNullable", new ProblemAttributes(JavaCore.COMPILER_PB_NULL_SPECIFICATION_VIOLATION));
 		expectedProblemAttributes.put("ResourceHasToImplementAutoCloseable", SKIP);
+		expectedProblemAttributes.put("ResourceIsNotAValue", SKIP);
 		expectedProblemAttributes.put("ReturnTypeAmbiguous", SKIP);
 		expectedProblemAttributes.put("ReturnTypeCannotBeVoidArray", SKIP);
 		expectedProblemAttributes.put("ReturnTypeInheritedNameHidesEnclosingName", SKIP);

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TryStatement9Test.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TryStatement9Test.java
@@ -740,6 +740,32 @@ public void testBug577128_1() {
 		"close() call\n" +
 		"close() call");
 }
+public void testGH1825() {
+	runNegativeTest(
+		new String[] {
+			"X.java",
+			"""
+			import java.io.*;
+			class X {
+				protected X read() throws IOException {
+					InputStream is = null;
+
+					try (InputStream ){
+					}
+					return null;
+				}
+			}
+			"""
+		},
+		"""
+		----------
+		1. ERROR in X.java (at line 6)
+			try (InputStream ){
+			     ^^^^^^^^^^^
+		InputStream cannot be resolved to a variable
+		----------
+		""");
+}
 
 public static Class testClass() {
 	return TryStatement9Test.class;


### PR DESCRIPTION
fixes #1825

Detect the error, preventing generateCode() which is doomed to explode
