### PR TITLE
[Switch-expressions] Internal inconsistency warning at compile time and verify error at runtime

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/CodeStream.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/CodeStream.java
@@ -1209,8 +1209,6 @@ private void adjustTypeBindingStackForDup2X2() {
 				this.operandStack.push(val1);
 			}
 		}
-		this.operandStack.push(val1);
-		this.operandStack.push(val1);
 	} else { // val1 category 1
 		TypeBinding val2 = this.operandStack.pop();
 		if (TypeIds.getCategory(val2.id) == 1) {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchExpressionsYieldTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchExpressionsYieldTest.java
@@ -7868,4 +7868,37 @@ public class SwitchExpressionsYieldTest extends AbstractRegressionTest {
 				"42\n"
 				+ "Hello");
 	}
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2447
+	// [Switch-expressions] Internal inconsistency warning at compile time and verify error at runtime
+	public void testIssue2447() {
+		if (this.complianceLevel < ClassFileConstants.JDK14)
+			return;
+		this.runConformTest(
+				new String[] {
+				"X.java",
+				"""
+				public class X {
+
+					static void foo(long l) {
+
+					}
+					public static void main(String[] args) {
+						long [] larray = { 10 };
+
+						foo(larray[0] = 10);
+						System.out.println(switch (42) {
+						default -> {
+							try {
+								yield 42;
+							} finally {
+
+							}
+						}
+						});
+					}
+				}
+				"""
+				},
+				"42");
+	}
 }


### PR DESCRIPTION
## What it does

* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2447

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
