### PR TITLE
[Switch-expressions] java.lang.VerifyError: Bad type on operand stack

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/CodeStream.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/CodeStream.java
@@ -6031,7 +6031,7 @@ public void ldc2_w(long constant) {
 
 public void ldcForIndex(int index) {
 	this.stackDepth++;
-	this.operandStack.push(TypeBinding.INT);
+	this.operandStack.push(ConstantPool.JavaLangStringConstantPoolName);
 	if (this.stackDepth > this.stackMax) {
 		this.stackMax = this.stackDepth;
 	}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchExpressionsYieldTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchExpressionsYieldTest.java
@@ -7971,4 +7971,34 @@ public class SwitchExpressionsYieldTest extends AbstractRegressionTest {
 				},
 				"double\n42");
 	}
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2455
+	// [Switch-expressions] java.lang.VerifyError: Bad type on operand stack
+	public void testIssue2455() {
+		if (this.complianceLevel < ClassFileConstants.JDK14)
+			return;
+		this.runConformTest(
+				new String[] {
+				"X.java",
+				"""
+				public class X {
+					static void foo(String s, int i) {
+						System.out.println("String = " + s + " int = " + i);
+					}
+					public static void main(String[] args) {
+
+						foo("Hello", switch (42) {
+						default -> {
+							try {
+								yield 42;
+							} finally {
+
+							}
+						}
+						});
+					}
+				}
+				"""
+				},
+				"String = Hello int = 42");
+	}
 }


### PR DESCRIPTION
## What it does

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2455

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
