### PR TITLE
Capture test cases from hohwille

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractRegressionTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractRegressionTest.java
@@ -837,6 +837,19 @@ protected static class JavacTestOptions {
 	Excuse excuseFor(JavacCompiler compiler) {
 		return null;
 	}
+	/** Difference were we're not sure which is correct, but want to be informed if either compiler changes. */
+	public static class DubiousOutcome extends Excuse {
+		DubiousOutcome(int mismatchType) {
+			super(mismatchType);
+		}
+		public static DubiousOutcome
+		EclipseErrorsJavacNone = RUN_JAVAC ?
+				new DubiousOutcome(MismatchType.EclipseErrorsJavacNone) : null,
+		JavacErrorsEclipseNone = RUN_JAVAC ?
+				new DubiousOutcome(MismatchType.JavacErrorsEclipseNone) : null,
+		JDK8319461 = RUN_JAVAC ? // https://bugs.openjdk.org/browse/JDK-8319461
+				new DubiousOutcome(MismatchType.JavacErrorsEclipseNone) : null;
+	}
 	public static class EclipseHasABug extends Excuse {
 		EclipseHasABug(int mismatchType) {
 			super(mismatchType);

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractRegressionTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractRegressionTest.java
@@ -508,17 +508,23 @@ static class JavacCompiler {
 			}
 		}
 		if (version == JavaCore.VERSION_17) {
-			if ("17-ea".equals(rawVersion)) {
-				return 0000;
-			}
-			if ("17".equals(rawVersion)) {
-				return 0000;
-			}
-			if ("17.0.1".equals(rawVersion)) {
-				return 0100;
-			}
-			if ("17.0.2".equals(rawVersion)) {
-				return 0200;
+			switch (rawVersion) {
+				case "17-ea":
+					return 0000;
+				case "17":
+					return 0000;
+				case "17.0.1":
+					return 0100;
+				case "17.0.2":
+					return 0200;
+				case "17.0.3":
+					return 0300;
+				case "17.0.4":
+					return 0400;
+				case "17.0.5":
+					return 0500;
+				case "17.0.6":
+					return 0600;
 			}
 		}
 		if (version == JavaCore.VERSION_18) {
@@ -561,6 +567,11 @@ static class JavacCompiler {
 			}
 			if ("20.0.2".equals(rawVersion)) {
 				return 0200;
+			}
+		}
+		if (version == JavaCore.VERSION_21) {
+			switch (rawVersion) {
+				case "21": return 0;
 			}
 		}
 		if (version == JavaCore.VERSION_22) {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/DubiousOutcomeTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/DubiousOutcomeTest.java
@@ -71,4 +71,174 @@ public class DubiousOutcomeTest extends AbstractRegressionTest {
 			"The method error(List<V>, T) in the type Outer is not applicable for the arguments (capture#1-of ? extends List<? extends Serializable>, String)\n" +
 			"----------\n");
 	}
+
+	public void testHohwille_20160104() {
+		// see https://github.com/m-m-m/util/issues/166#issuecomment-168652351
+		/* javac:
+		 	CombinedInterface.java:9: error: reference to setValue is ambiguous
+					setValue(Boolean.valueOf(value));
+					^
+			  both method setValue(Boolean) in TypedInterface and method setValue(V) in GenericInterface match
+			  where V is a type-variable:
+			    V extends Object declared in interface GenericInterface
+			1 error
+		 */
+		runConformTest(
+			new String[] {
+				"CombinedInterface.java",
+				"""
+				interface GenericInterface<V> {
+					void setValue(V value);
+				}
+				interface TypedInterface {
+					void setValue(Boolean value);
+				}
+				public interface CombinedInterface extends GenericInterface<Boolean>, TypedInterface {
+					default void set(boolean value) {
+						setValue(Boolean.valueOf(value));
+					}
+				}
+				"""
+			});
+	}
+
+	public void testHohwille_20180606() {
+		/* see https://github.com/m-m-m/util/issues/166#issuecomment-395133804
+		  javac:
+			GenericTest.java:3: error: type argument ? super B is not within bounds of type-variable B
+				private final GenericTest<? super A, ? super B> parent;
+				                                     ^
+			  where B,A are type-variables:
+			    B extends A declared in class GenericTest
+			    A extends Object declared in class GenericTest
+			GenericTest.java:5: error: type argument ? super B is not within bounds of type-variable B
+				public GenericTest(GenericTest<? super A, ? super B> parent) {
+				                                          ^
+			  where B,A are type-variables:
+			    B extends A declared in class GenericTest
+			    A extends Object declared in class GenericTest
+			2 errors
+		 */
+		runConformTest(
+			new String[] {
+				"GenericTest.java",
+				"""
+				public class GenericTest<A, B extends A> {
+
+					private final GenericTest<? super A, ? super B> parent;
+
+					public GenericTest(GenericTest<? super A, ? super B> parent) {
+						super();
+						this.parent = parent;
+					}
+				}
+				"""
+			});
+	}
+	public void testHohwille_20231104() {
+		/* see https://github.com/m-m-m/util/issues/166#issuecomment-1793234294
+		   and https://bugs.openjdk.org/browse/JDK-8319461
+		   My reduction
+		javac:
+			PropertyFactoryManager.java:15: error: incompatible types: inference variable P#1 has incompatible bounds
+					MyPropertyFactory factory = getRequiredFactory(propertyType, valueClass);
+					                                              ^
+			    equality constraints: P#2
+			    upper bounds: WritableProperty<V#1>,ReadableProperty<V#1>
+			  where P#1,V#1,P#2,V#2 are type-variables:
+			    P#1 extends ReadableProperty<V#1> declared in method <V#1,P#1>getRequiredFactory(Class<P#1>,Class<V#1>)
+			    V#1 extends Object declared in method <V#1,P#1>getRequiredFactory(Class<P#1>,Class<V#1>)
+			    P#2 extends ReadableProperty<V#2> declared in method <V#2,P#2>create(Class<P#2>,Class<V#2>)
+			    V#2 extends Object declared in method <V#2,P#2>create(Class<P#2>,Class<V#2>)
+			PropertyFactoryManager.java:21: error: incompatible types: inference variable P#1 has incompatible bounds
+					MyPropertyFactory factory = getRequiredFactory(propertyType, typeInfo.getValueClass());
+					                                              ^
+			    equality constraints: P#2
+			    upper bounds: WritableProperty<V#1>,ReadableProperty<V#1>
+			  where P#1,V#1,P#2,V#2 are type-variables:
+			    P#1 extends ReadableProperty<V#1> declared in method <V#1,P#1>getRequiredFactory(Class<P#1>,Class<V#1>)
+			    V#1 extends Object declared in method <V#1,P#1>getRequiredFactory(Class<P#1>,Class<V#1>)
+			    P#2 extends ReadableProperty<V#2> declared in method <V#2,P#2>create(Class<P#2>,PropertyTypeInfo<V#2>)
+			    V#2 extends Object declared in method <V#2,P#2>create(Class<P#2>,PropertyTypeInfo<V#2>)
+			2 errors
+		 */
+		runConformTest(
+			new String[] {
+				"PropertyFactoryManager.java",
+				"""
+				interface WritableObservableValue<V> { }
+				interface ReadableProperty<V> { }
+				interface WritableProperty<V> extends WritableObservableValue<V>, ReadableProperty<V> { }
+				interface PropertyTypeInfo<V> {
+					Class<V> getValueClass();
+				}
+				interface MyPropertyFactory<V, P extends WritableProperty<V>> {
+					<P2 extends ReadableProperty<V>> P2 create(PropertyTypeInfo<V> typeInfo);
+				}
+
+				public interface PropertyFactoryManager {
+					@SuppressWarnings({ "rawtypes" })
+					default <V, P extends ReadableProperty<V>> MyPropertyFactory create(Class<P> propertyType, Class<V> valueClass) {
+						// https://github.com/m-m-m/util/issues/166
+						MyPropertyFactory factory = getRequiredFactory(propertyType, valueClass);
+						return factory;
+					}
+					@SuppressWarnings({ "rawtypes", "unchecked" })
+					default <V, P extends ReadableProperty<V>> P create(Class<P> propertyType, PropertyTypeInfo<V> typeInfo) {
+						// https://github.com/m-m-m/util/issues/166
+						MyPropertyFactory factory = getRequiredFactory(propertyType, typeInfo.getValueClass());
+						return (P) factory.create(typeInfo);
+					}
+
+					default <V, P extends ReadableProperty<V>> MyPropertyFactory<V, ? extends P> getRequiredFactory(
+							Class<P> propertyType, Class<V> valueType) {
+						return null;
+					}
+				}
+				"""
+			});
+	}
+	public void testJDK8319461() {
+		/* Hohwille's reduction of the above
+			javac (the warning is irrelevant, could be easily avoided:
+			JDK8319461.java:3: warning: [rawtypes] found raw type: Factory
+					Factory factory = getFactory(propertyType, valueClass);
+					^
+			  missing type arguments for generic class Factory<V,P>
+			  where V,P are type-variables:
+			    V extends Object declared in interface Factory
+			    P extends WritableProperty<V> declared in interface Factory
+			JDK8319461.java:3: error: incompatible types: inference variable P#1 has incompatible bounds
+					Factory factory = getFactory(propertyType, valueClass);
+					                            ^
+			    equality constraints: P#2
+			    upper bounds: WritableProperty<V#1>,ReadableProperty<V#1>
+			  where P#1,V#1,P#2,V#2 are type-variables:
+			    P#1 extends ReadableProperty<V#1> declared in method <V#1,P#1>getFactory(Class<P#1>,Class<V#1>)
+			    V#1 extends Object declared in method <V#1,P#1>getFactory(Class<P#1>,Class<V#1>)
+			    P#2 extends ReadableProperty<V#2> declared in method <V#2,P#2>create(Class<P#2>,Class<V#2>,String)
+			    V#2 extends Object declared in method <V#2,P#2>create(Class<P#2>,Class<V#2>,String)
+			1 error
+			1 warning
+		 */
+		runConformTest(
+			new String[] {
+				"JDK8319461.java",
+				"""
+				public class JDK8319461 {
+					public <V, P extends ReadableProperty<V>> P create(Class<P> propertyType, Class<V> valueClass, String name) {
+						Factory factory = getFactory(propertyType, valueClass);
+						return null;
+					}
+					public <V, P extends ReadableProperty<V>> Factory<V, ? extends P> getFactory(Class<P> propertyType, Class<V> valueType) {
+						Factory<V, ? extends P> factory = null;
+						return factory;
+					}
+					public interface ReadableProperty<V> { }
+					public interface WritableProperty<V> extends ReadableProperty<V> { }
+					public interface Factory<V, P extends WritableProperty<V>> { }
+				}
+				"""
+			});
+	}
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/DubiousOutcomeTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/DubiousOutcomeTest.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.jdt.core.tests.compiler.regression;
 
+import org.eclipse.jdt.core.tests.compiler.regression.AbstractRegressionTest.JavacTestOptions.DubiousOutcome;
+
 import junit.framework.Test;
 
 /**
@@ -45,8 +47,8 @@ public class DubiousOutcomeTest extends AbstractRegressionTest {
 
 	public void testGH1591() {
 		// javac accepts
-		runNegativeTest(
-			new String[] {
+		Runner runner = new Runner();
+		runner.testFiles = new String[] {
 				"Outer.java",
 				"""
 				import java.io.Serializable;
@@ -63,13 +65,16 @@ public class DubiousOutcomeTest extends AbstractRegressionTest {
 
 					}
 				"""
-			},
+			};
+		runner.expectedCompilerLog =
 			"----------\n" +
 			"1. ERROR in Outer.java (at line 8)\n" +
 			"	error(supplier.get(), \"\");\n" +
 			"	^^^^^\n" +
 			"The method error(List<V>, T) in the type Outer is not applicable for the arguments (capture#1-of ? extends List<? extends Serializable>, String)\n" +
-			"----------\n");
+			"----------\n";
+		runner.javacTestOptions = DubiousOutcome.EclipseErrorsJavacNone;
+		runner.runNegativeTest();
 	}
 
 	public void testHohwille_20160104() {
@@ -83,8 +88,8 @@ public class DubiousOutcomeTest extends AbstractRegressionTest {
 			    V extends Object declared in interface GenericInterface
 			1 error
 		 */
-		runConformTest(
-			new String[] {
+		Runner runner = new Runner();
+		runner.testFiles = new String[] {
 				"CombinedInterface.java",
 				"""
 				interface GenericInterface<V> {
@@ -99,7 +104,9 @@ public class DubiousOutcomeTest extends AbstractRegressionTest {
 					}
 				}
 				"""
-			});
+			};
+		runner.javacTestOptions = DubiousOutcome.JavacErrorsEclipseNone;
+		runner.runConformTest();
 	}
 
 	public void testHohwille_20180606() {
@@ -119,8 +126,8 @@ public class DubiousOutcomeTest extends AbstractRegressionTest {
 			    A extends Object declared in class GenericTest
 			2 errors
 		 */
-		runConformTest(
-			new String[] {
+		Runner runner = new Runner();
+		runner.testFiles = new String[] {
 				"GenericTest.java",
 				"""
 				public class GenericTest<A, B extends A> {
@@ -133,7 +140,9 @@ public class DubiousOutcomeTest extends AbstractRegressionTest {
 					}
 				}
 				"""
-			});
+			};
+		runner.javacTestOptions = DubiousOutcome.JavacErrorsEclipseNone;
+		runner.runConformTest();
 	}
 	public void testHohwille_20231104() {
 		/* see https://github.com/m-m-m/util/issues/166#issuecomment-1793234294
@@ -162,8 +171,8 @@ public class DubiousOutcomeTest extends AbstractRegressionTest {
 			    V#2 extends Object declared in method <V#2,P#2>create(Class<P#2>,PropertyTypeInfo<V#2>)
 			2 errors
 		 */
-		runConformTest(
-			new String[] {
+		Runner runner = new Runner();
+		runner.testFiles = new String[] {
 				"PropertyFactoryManager.java",
 				"""
 				interface WritableObservableValue<V> { }
@@ -196,7 +205,9 @@ public class DubiousOutcomeTest extends AbstractRegressionTest {
 					}
 				}
 				"""
-			});
+			};
+		runner.javacTestOptions = DubiousOutcome.JDK8319461;
+		runner.runConformTest();
 	}
 	public void testJDK8319461() {
 		/* Hohwille's reduction of the above
@@ -221,8 +232,8 @@ public class DubiousOutcomeTest extends AbstractRegressionTest {
 			1 error
 			1 warning
 		 */
-		runConformTest(
-			new String[] {
+		Runner runner = new Runner();
+		runner.testFiles = new String[] {
 				"JDK8319461.java",
 				"""
 				public class JDK8319461 {
@@ -239,6 +250,8 @@ public class DubiousOutcomeTest extends AbstractRegressionTest {
 					public interface Factory<V, P extends WritableProperty<V>> { }
 				}
 				"""
-			});
+			};
+		runner.javacTestOptions = DubiousOutcome.JDK8319461;
+		runner.runConformTest();
 	}
 }


### PR DESCRIPTION
Tests extracted from https://github.com/m-m-m/util/issues/166

All of these tests pass with ecj and fail when invoked with
`-Drun.javac=enabled -Djdk.root=/home/java/jdk-22 -Dcompliance=22`
(insert your location of jdk-22, optionally select any other recent version).

I inserted tests into suite DubiousOutcomeTest, as the main purpose for now is to be informed when the outcome of any of these tests *change* during development, whereas the final call which outcome is correct/incorrect still needs to be made, since compilers do not agree.

