### PR TITLE
ArrayStoreException in SelectionParser.buildMoreCompletionContext

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ResolveTests12To15.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ResolveTests12To15.java
@@ -1702,4 +1702,35 @@ public void testGH1568_5() throws JavaModelException {
 		elements
 	);
 }
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2443
+// ArrayStoreException in SelectionParser.buildMoreCompletionContext
+public void testGH2443() throws JavaModelException {
+	this.wc = getWorkingCopy("/Resolve15/src/X.java",
+					"""
+					 public class X {
+
+						public static void main(String[] args) {
+
+							for (String sourcePath : args) {
+								new X() {
+									public void foo(String file) {
+										file.hashCode();
+									}
+
+								};
+							}
+						}
+					}
+					""");
+	String str = this.wc.getSource();
+	String selection = "file";
+	int start = str.lastIndexOf(selection);
+	int length = selection.length();
+	IJavaElement[] elements = this.wc.codeSelect(start, length);
+	assertElementsEqual(
+		"Unexpected elements",
+		"file [in foo(String) [in <anonymous #1> [in main(String[]) [in X [in [Working copy] X.java [in <default> [in src [in Resolve15]]]]]]]]",
+		elements
+	);
+}
 }

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionParser.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionParser.java
@@ -1929,6 +1929,7 @@ protected boolean restartRecovery() {
 			case K_INSIDE_EXPRESSION_SWITCH:
 			case K_INSIDE_IF:
 			case K_INSIDE_WHILE:
+			case K_INSIDE_FOR_EACH:
 				deferRestartOnLocalType = true;
 				break;
 			case K_TYPE_DELIMITER:


### PR DESCRIPTION

## What it does

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2443

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
