### PR TITLE
performance: faster Java plugin shutdown

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelManager.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelManager.java
@@ -5576,6 +5576,7 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 
 		// wait for the initialization job to finish
 		try {
+			Job.getJobManager().wakeUp(JavaCore.PLUGIN_ID);
 			Job.getJobManager().join(JavaCore.PLUGIN_ID, null);
 		} catch (InterruptedException e) {
 			// ignore

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/processing/JobManager.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/processing/JobManager.java
@@ -595,6 +595,9 @@ public abstract class JobManager {
 		Thread thread = getProcessingThread();
 		try {
 			if (thread != null) { // see http://bugs.eclipse.org/bugs/show_bug.cgi?id=31858
+				synchronized (this.idleMonitor) {
+					this.idleMonitor.notifyAll(); // ensure its awake so it can be shutdown
+				}
 				synchronized (this) {
 					this.processingThread = null; // mark the job manager as shutting down so that the thread will stop by itself
 					notifyAll(); // ensure its awake so it can be shutdown


### PR DESCRIPTION
interrupts sleeping indexer

reproducable with ClasspathInitializerTests
14s->6s
