### PR TITLE
Indexer performance: avoid java.io.File.getCanonicalPath

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/SearchParticipantTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/SearchParticipantTests.java
@@ -13,19 +13,28 @@
  *******************************************************************************/
 package org.eclipse.jdt.core.tests.model;
 
-import junit.framework.Test;
-
 import org.eclipse.core.resources.IResource;
-import org.eclipse.core.runtime.*;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.Path;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaModelException;
-import org.eclipse.jdt.core.search.*;
+import org.eclipse.jdt.core.search.IJavaSearchConstants;
+import org.eclipse.jdt.core.search.IJavaSearchScope;
+import org.eclipse.jdt.core.search.SearchDocument;
+import org.eclipse.jdt.core.search.SearchEngine;
+import org.eclipse.jdt.core.search.SearchParticipant;
+import org.eclipse.jdt.core.search.SearchPattern;
+import org.eclipse.jdt.core.search.SearchRequestor;
 import org.eclipse.jdt.core.tests.model.AbstractJavaSearchTests.JavaSearchResultCollector;
 import org.eclipse.jdt.core.tests.util.Util;
 import org.eclipse.jdt.internal.core.search.indexing.SourceIndexer;
 import org.eclipse.jdt.internal.core.search.processing.JobManager;
+
+import junit.framework.Test;
 
 /**
  * Tests the search participant supprt.
@@ -185,7 +194,8 @@ public class SearchParticipantTests extends ModifyingResourceTests implements IJ
 	}
 
 	IPath getIndexLocation() {
-		return new Path(getExternalPath() + "test.index");
+		// use a non-canonical path to show that path does not need to be canonical
+		return new Path(getExternalPath() + "/dummy/../test.index");
 	}
 
 	/*

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/index/FileIndexLocation.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/index/FileIndexLocation.java
@@ -24,18 +24,18 @@ import org.eclipse.core.runtime.Path;
 
 public class FileIndexLocation extends IndexLocation {
 	final File indexFile;
-	final String canonicalPath;
+	final Path indexPath;
 
 	public FileIndexLocation(File file) {
 		super(file);
 		this.indexFile = file;
-		this.canonicalPath = computeCanonicalFilePath(file);
+		this.indexPath = computeIndexPath(file);
 	}
 
 	public FileIndexLocation(URL url, File file) {
 		super(url);
 		this.indexFile = file;
-		this.canonicalPath = computeCanonicalFilePath(file);
+		this.indexPath = computeIndexPath(file);
 	}
 
 	public FileIndexLocation(File file, boolean participantIndex) {
@@ -84,18 +84,13 @@ public class FileIndexLocation extends IndexLocation {
 		return new FileInputStream(this.indexFile);
 	}
 
-	private static String computeCanonicalFilePath(File indexFile) {
-		try {
-			return indexFile.getCanonicalPath();
-		} catch (IOException e) {
-			// ignore
-		}
-		return null;
+	private static Path computeIndexPath(File indexFile) {
+		return new Path(indexFile.toString());
 	}
 
 	@Override
-	public String getCanonicalFilePath() {
-		return this.canonicalPath;
+	public Path getIndexPath() {
+		return this.indexPath;
 	}
 
 	@Override
@@ -115,10 +110,10 @@ public class FileIndexLocation extends IndexLocation {
 
 	@Override
 	public boolean startsWith(IPath path) {
-		if (this.canonicalPath==null) {
+		if (this.indexPath==null) {
 			return false;
 		}
-		return path.isPrefixOf(new Path(this.canonicalPath));
+		return path.isPrefixOf(this.indexPath);
 	}
 
 }

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/index/IndexLocation.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/index/IndexLocation.java
@@ -23,6 +23,7 @@ import java.net.URL;
 
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Path;
 import org.eclipse.jdt.internal.core.util.Util;
 
 /**
@@ -113,9 +114,9 @@ public abstract class IndexLocation {
 	public abstract String fileName();
 
 	/**
-	 * @return the canonical file path if the location is a file or null otherwise
+	 * @return the path if the location is a file or null otherwise
 	 */
-	public abstract String getCanonicalFilePath();
+	public abstract Path getIndexPath();
 
 	public abstract File getIndexFile();
 

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/index/JarIndexLocation.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/index/JarIndexLocation.java
@@ -105,7 +105,7 @@ public class JarIndexLocation extends IndexLocation {
 	}
 
 	@Override
-	public String getCanonicalFilePath() {
+	public Path getIndexPath() {
 		return null;
 	}
 

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/AddJarFileToIndex.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/AddJarFileToIndex.java
@@ -161,7 +161,6 @@ class AddJarFileToIndex extends BinaryContainer {
 					// external file -> it is ok to use toFile()
 					zip = new ZipFile(this.containerPath.toFile());
 					zipFilePath = (Path) this.containerPath;
-					// path is already canonical since coming from a library classpath entry
 				}
 
 				if (this.isCancelled) {
@@ -227,7 +226,7 @@ class AddJarFileToIndex extends BinaryContainer {
 				IPath indexPath = null;
 				IndexLocation indexLocation;
 				if ((indexLocation = index.getIndexLocation()) != null) {
-					indexPath = new Path(indexLocation.getCanonicalFilePath());
+					indexPath = indexLocation.getIndexPath();
 				}
 				boolean hasModuleInfoClass = false;
 				for (Enumeration<? extends ZipEntry> e = zip.entries(); e.hasMoreElements();) {

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/AddJrtToIndex.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/AddJrtToIndex.java
@@ -26,7 +26,6 @@ import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.jdt.core.search.IJavaSearchScope;
 import org.eclipse.jdt.core.search.SearchEngine;
 import org.eclipse.jdt.core.search.SearchParticipant;
@@ -126,7 +125,7 @@ public class AddJrtToIndex extends BinaryContainer {
 			this.participant = (participant != null) ? participant : SearchEngine.getDefaultSearchParticipant();
 			this.index = index;
 			IndexLocation indexLocation = index.getIndexLocation();
-			this.indexPath = indexLocation != null ? new Path(indexLocation.getCanonicalFilePath()) : null;
+			this.indexPath = indexLocation != null ? indexLocation.getIndexPath() : null;
 			this.container = container;
 			this.indexManager = indexManager;
 		}

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/IndexManager.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/IndexManager.java
@@ -441,7 +441,6 @@ public synchronized Index getIndex(IPath containerPath, boolean reuseExistingFil
  * Warning: Does not check whether index is consistent (not being used)
  */
 public synchronized Index getIndex(IPath containerPath, IndexLocation indexLocation, boolean reuseExistingFile, boolean createIfMissing) {
-	// Path is already canonical per construction
 	Index index = getIndex(indexLocation);
 	if (index == null) {
 		Object state = getIndexStates().get(indexLocation);
@@ -894,7 +893,6 @@ public synchronized Index recreateIndex(IPath containerPath) {
 	// only called to over write an existing cached index...
 	String containerPathString = containerPath.getDevice() == null ? containerPath.toString() : containerPath.toOSString();
 	try {
-		// Path is already canonical
 		IndexLocation indexLocation = computeIndexLocation(containerPath);
 		Index index = getIndex(indexLocation);
 		ReadWriteMonitor monitor = index == null ? null : index.monitor;
@@ -1098,7 +1096,6 @@ public synchronized boolean resetIndex(IPath containerPath) {
 	// only called to over write an existing cached index...
 	String containerPathString = containerPath.getDevice() == null ? containerPath.toString() : containerPath.toOSString();
 	try {
-		// Path is already canonical
 		IndexLocation indexLocation = computeIndexLocation(containerPath);
 		Index index = getIndex(indexLocation);
 		if (VERBOSE) {
@@ -1275,7 +1272,7 @@ public void scheduleDocumentIndexing(final SearchDocument searchDocument, IPath 
 			if (index == null) return true;
 			ReadWriteMonitor monitor = index.monitor;
 			if (monitor == null) return true; // index got deleted since acquired
-			final Path indexPath = new Path(indexLocation.getCanonicalFilePath());
+			final Path indexPath = indexLocation.getIndexPath();
 			try {
 				monitor.enterWrite(); // ask permission to write
 				indexDocument(searchDocument, searchParticipant, index, indexPath);


### PR DESCRIPTION
There seems to be no need of calculating the canonical filename. The methods of org.eclipse.jdt.core.search.SearchParticipant are either
 a) only called during junit test (SearchParticipantTests):
     * scheduleDocumentIndexing(),
     * removeIndex() or 
![image](https://github.com/eclipse-jdt/eclipse.jdt.core/assets/51790620/07c5510f-9f57-4d64-90c9-b241ba08aeca)
 b) the known implementations totally ignore the given indexName

The only tests that makes use of the indexname is SearchParticipantTests and even that works without getCanonicalPath() when using non canonical paths - that is demonstrated by this change by using a degenerated path.

Currently FileIndexLocation.computeCanonicalFilePath() is not known to be the main hotspot anywhere but for example during starting platform workspace it alone wastes 0.5 seconds on WIN OS.
![image](https://github.com/eclipse-jdt/eclipse.jdt.core/assets/51790620/aea44588-aa1d-4471-8d4a-98a4715ce639)


