### PR TITLE
ECJ fails: Problem detected during type inference: Unknown error at invocation of getReadOnly(P)

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BoundSet.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BoundSet.java
@@ -966,7 +966,7 @@ class BoundSet {
 
 		List<Pair<TypeBinding>> superPairs = allSuperPairsWithCommonGenericType(s_cap, t_cap);
 		if (superPairs.isEmpty())
-			return null;
+			return Collections.emptyList();
 		List<ConstraintTypeFormula> result = new ArrayList<>();
 		for (Pair<TypeBinding> pair : superPairs) {
 			// future JLS should apply upwards projection according to https://mail.openjdk.org/pipermail/compiler-dev/2024-May/026579.html

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BoundSet.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BoundSet.java
@@ -22,6 +22,7 @@ import static java.util.stream.Collectors.toMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -33,6 +34,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import org.eclipse.jdt.internal.compiler.ast.Wildcard;
+import org.eclipse.jdt.internal.compiler.util.Tuples.Pair;
 
 /**
  * Implementation of 18.1.3 in JLS8.
@@ -624,9 +626,8 @@ class BoundSet {
 							}
 						}
 					}
-					ConstraintFormula[] typeArgumentConstraints = deriveTypeArgumentConstraints ? deriveTypeArgumentConstraints(bound1, bound2) : null;
-					if (typeArgumentConstraints != null) {
-						for (ConstraintFormula typeArgumentConstraint : typeArgumentConstraints) {
+					if (deriveTypeArgumentConstraints) {
+						for (ConstraintTypeFormula typeArgumentConstraint : deriveTypeArgumentConstraints(bound1, bound2, context)) {
 							if (!reduceOneConstraint(context, typeArgumentConstraint))
 								return false;
 						}
@@ -949,28 +950,42 @@ class BoundSet {
 		return ConstraintTypeFormula.create(left, right, boundRight.relation, isAnyLeftSoft||boundRight.isSoft);
 	}
 
-	private ConstraintTypeFormula[] deriveTypeArgumentConstraints(TypeBound boundS, TypeBound boundT) {
+	private List<ConstraintTypeFormula> deriveTypeArgumentConstraints(TypeBound boundS, TypeBound boundT, InferenceContext18 context) {
 		/* From 18.4:
 		 *  If two bounds have the form α <: S and α <: T, and if for some generic class or interface, G,
 		 *  there exists a supertype (4.10) of S of the form G<S1, ..., Sn> and a supertype of T of the form G<T1, ..., Tn>,
 		 *  then for all i, 1 ≤ i ≤ n, if Si and Ti are types (not wildcards), the constraint ⟨Si = Ti⟩ is implied.
 		 */
 		// callers must ensure both relations are <: and both lefts are equal
-		TypeBinding[] supers = superTypesWithCommonGenericType(boundS.right, boundT.right);
-		if (supers != null)
-			return typeArgumentEqualityConstraints(supers[0], supers[1], boundS.isSoft || boundT.isSoft);
-		return null;
+
+		// §4.10.2 requires the use of capture to find supertypes:
+		int sourceStart = context.currentInvocation.sourceStart();
+		int sourceEnd = context.currentInvocation.sourceEnd();
+		TypeBinding s_cap = boundS.right.capture(context.scope, sourceStart, sourceEnd);
+		TypeBinding t_cap = boundT.right.capture(context.scope, sourceStart, sourceEnd);
+
+		List<Pair<TypeBinding>> superPairs = allSuperPairsWithCommonGenericType(s_cap, t_cap);
+		if (superPairs.isEmpty())
+			return null;
+		List<ConstraintTypeFormula> result = new ArrayList<>();
+		for (Pair<TypeBinding> pair : superPairs) {
+			// future JLS should apply upwards projection according to https://mail.openjdk.org/pipermail/compiler-dev/2024-May/026579.html
+			TypeBinding g_s = pair.left().upwardsProjection(context.scope);
+			TypeBinding g_t = pair.right().upwardsProjection(context.scope);
+			result.addAll(typeArgumentEqualityConstraints(g_s, g_t, boundS.isSoft || boundT.isSoft));
+		}
+		return result;
 	}
 
-	private ConstraintTypeFormula[] typeArgumentEqualityConstraints(TypeBinding s, TypeBinding t, boolean isSoft) {
-		if (s == null || s.kind() != Binding.PARAMETERIZED_TYPE || t == null || t.kind() != Binding.PARAMETERIZED_TYPE)
-			return null;
-		if (TypeBinding.equalsEquals(s, t)) // don't create useless constraints
-			return null;
-		TypeBinding[] sis = s.typeArguments();
-		TypeBinding[] tis = t.typeArguments();
+	private List<ConstraintTypeFormula> typeArgumentEqualityConstraints(TypeBinding g_s, TypeBinding g_t, boolean isSoft) {
+		if (g_s == null || g_s.kind() != Binding.PARAMETERIZED_TYPE || g_t == null || g_t.kind() != Binding.PARAMETERIZED_TYPE)
+			return Collections.emptyList();
+		if (TypeBinding.equalsEquals(g_s, g_t)) // don't create useless constraints
+			return Collections.emptyList();
+		TypeBinding[] sis = g_s.typeArguments();
+		TypeBinding[] tis = g_t.typeArguments();
 		if (sis == null || tis == null || sis.length != tis.length)
-			return null;
+			return Collections.emptyList();
 		List<ConstraintTypeFormula> result = new ArrayList<>();
 		for (int i = 0; i < sis.length; i++) {
 			TypeBinding si = sis[i];
@@ -979,9 +994,7 @@ class BoundSet {
 				continue;
 			result.add(ConstraintTypeFormula.create(si, ti, ReductionResult.SAME, isSoft));
 		}
-		if (result.size() > 0)
-			return result.toArray(new ConstraintTypeFormula[result.size()]);
-		return null;
+		return result;
 	}
 
 	/**
@@ -1208,14 +1221,14 @@ class BoundSet {
 				TypeBinding s1 = superBounds.get(i).right;
 				for (int j=i+1; j<len; j++) {
 					TypeBinding s2 = superBounds.get(j).right;
-					TypeBinding[] supers = superTypesWithCommonGenericType(s1, s2);
-					if (supers != null) {
+					List<Pair<TypeBinding>> pairs = allSuperPairsWithCommonGenericType(s1, s2);
+					for (Pair<TypeBinding> pair : pairs) {
 						/* HashMap<K#8,V#9> and HashMap<K#8,ArrayList<T>> with an instantiation for V9 = ArrayList<T> already in the
 						   bound set should not be seen as two different parameterizations of the same generic class or interface.
 						   See https://bugs.eclipse.org/bugs/show_bug.cgi?id=432626 for a test that triggers this condition.
 						   See https://bugs.openjdk.java.net/browse/JDK-8056092: recommendation is to check for proper types.
 						*/
-						if (supers[0].isProperType(true) && supers[1].isProperType(true) && !TypeBinding.equalsEquals(supers[0], supers[1]))
+						if (pair.left().isProperType(true) && pair.right().isProperType(true) && !TypeBinding.equalsEquals(pair.left(), pair.right()))
 							return true;
 					}
 				}
@@ -1261,28 +1274,25 @@ class BoundSet {
 		return false;
 	}
 
-	protected TypeBinding[] superTypesWithCommonGenericType(TypeBinding s, TypeBinding t) {
+	protected List<Pair<TypeBinding>> allSuperPairsWithCommonGenericType(TypeBinding s, TypeBinding t) {
 		if (s == null || s.id == TypeIds.T_JavaLangObject || t == null || t.id == TypeIds.T_JavaLangObject)
-			return null;
+			return Collections.emptyList();
+		List<Pair<TypeBinding>> result = new ArrayList<>();
 		if (TypeBinding.equalsEquals(s.original(), t.original())) {
-			return new TypeBinding[] { s, t };
+			result.add(new Pair<>(s, t));
 		}
 		TypeBinding tSuper = t.findSuperTypeOriginatingFrom(s);
 		if (tSuper != null) {
-			return new TypeBinding[] {s, tSuper};
+			result.add(new Pair<>(s, tSuper));
 		}
-		TypeBinding[] result = superTypesWithCommonGenericType(s.superclass(), t);
-		if (result != null)
-			return result;
+		result.addAll(allSuperPairsWithCommonGenericType(s.superclass(), t));
 		ReferenceBinding[] superInterfaces = s.superInterfaces();
 		if (superInterfaces != null) {
 			for (ReferenceBinding superInterface : superInterfaces) {
-				result = superTypesWithCommonGenericType(superInterface, t);
-				if (result != null)
-					return result;
+				result.addAll(allSuperPairsWithCommonGenericType(superInterface, t));
 			}
 		}
-		return null;
+		return result;
 	}
 
 	public TypeBinding getEquivalentOuterVariable(InferenceVariable variable, InferenceVariable[] outerVariables) {
@@ -1304,14 +1314,17 @@ class BoundSet {
 		}
 		return null;
 	}
-	public TypeBinding[] condition18_5_5_item_4(
+	public TypeBinding condition18_5_5_item_4(
 			ReferenceBinding rAlpha,
 			InferenceVariable[] alpha,
 			TypeBinding tPrime, InferenceContext18 ctx18) {
-		/* If T' is a parameterization of a generic class G, and there exists a supertype
-		 *  of R<α1, ..., αn> that is also a parameterization of G, let R' be that supertype.
-		 */
-		return tPrime.isParameterizedType() ?
-				superTypesWithCommonGenericType(rAlpha, tPrime) : null;
+		if (tPrime.isParameterizedType()) {
+			/* If T' is a parameterization of a generic class G, and there exists a supertype
+			 *  of R<α1, ..., αn> that is also a parameterization of G, let R' be that supertype.
+			 */
+			return rAlpha.findSuperTypeOriginatingFrom(tPrime);
+		} else {
+			return null;
+		}
 	}
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
@@ -2064,27 +2064,17 @@ public class InferenceContext18 {
 			return false;
 		ReferenceBinding rAlpha = this.environment.createParameterizedType(
 				(ReferenceBinding) typeBinding.original(), alphas, typeBinding.enclosingType(), typeBinding.getTypeAnnotations());
-		TypeBinding[] rPrimes = this.currentBounds.condition18_5_5_item_4(rAlpha, alphas, tPrime, this);
-		if (rPrimes != null) {
-			// TODO:
+		TypeBinding rPrime = this.currentBounds.condition18_5_5_item_4(rAlpha, alphas, tPrime, this);
+		if (rPrime != null) {
 			/* The constraint formula ‹T' = R'› is reduced (18.2) and the resulting bounds are
-			 * incorporated into B1 to produce a new bound set, B2.
-			 * TODO: refactor the method below into two? - instead of creating array - here reusing. */
-			for (TypeBinding rPrime : rPrimes) {
-				if (!rPrime.isParameterizedType()) continue;
-				try {
-					if (!reduceAndIncorporate(ConstraintTypeFormula.create(tPrime, rPrime, ReductionResult.SAME))) {
-						 /* If B2 contains the bound false, inference fails. */
-						return false;
-					}
-				} catch (InferenceFailureException e) {
+			 * incorporated into B1 to produce a new bound set, B2. */
+			try {
+				if (!reduceAndIncorporate(ConstraintTypeFormula.create(tPrime, rPrime, ReductionResult.SAME))) {
+					 /* If B2 contains the bound false, inference fails. */
 					return false;
 				}
-//				if (rPrime.typeArguments().length == 0) continue; // TODO: should we?
-//				if (!reduceWithEqualityConstraints(new TypeBinding[] {tPrime}, new TypeBinding[] {rPrime})) {
-//					 /* If B2 contains the bound false, inference fails. */
-//					return false;
-//				}
+			} catch (InferenceFailureException e) {
+				return false;
 			}
 		} /* else part: Otherwise, B2 is the same as B1.*/
 		return true;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/IntersectionTypeBinding18.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/IntersectionTypeBinding18.java
@@ -357,7 +357,10 @@ public class IntersectionTypeBinding18 extends ReferenceBinding {
 	public ReferenceBinding downwardsProjection(Scope scope, TypeBinding[] mentionedTypeVariables) {
 		ReferenceBinding[] projectedTypes = new ReferenceBinding[this.intersectingTypes.length];
 		for (int i = 0; i < this.intersectingTypes.length; ++i) {
-			projectedTypes[i] = this.intersectingTypes[i].downwardsProjection(scope, mentionedTypeVariables);
+			ReferenceBinding projected = this.intersectingTypes[i].downwardsProjection(scope, mentionedTypeVariables);
+			if (projected == null)
+				return null;
+			projectedTypes[i] = projected;
 		}
 		return (ReferenceBinding) scope.environment().createIntersectionType18(projectedTypes);
 	}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/LookupEnvironment.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/LookupEnvironment.java
@@ -48,6 +48,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.internal.compiler.ClassFile;
@@ -1468,8 +1469,8 @@ public WildcardBinding createWildcard(ReferenceBinding genericType, int rank, Ty
 	return this.typeSystem.getWildcard(genericType, rank, bound, otherBounds, boundKind);
 }
 
-public CaptureBinding createCapturedWildcard(WildcardBinding wildcard, ReferenceBinding contextType, int start, int end, ASTNode cud, int id) {
-	return this.typeSystem.getCapturedWildcard(wildcard, contextType, start, end, cud, id);
+public CaptureBinding createCapturedWildcard(WildcardBinding wildcard, ReferenceBinding contextType, int start, int end, ASTNode cud, Supplier<Integer> idSupplier) {
+	return this.typeSystem.getCapturedWildcard(wildcard, contextType, start, end, cud, idSupplier);
 }
 
 public WildcardBinding createWildcard(ReferenceBinding genericType, int rank, TypeBinding bound, TypeBinding[] otherBounds, int boundKind, AnnotationBinding [] annotations) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedTypeBinding.java
@@ -197,7 +197,7 @@ public class ParameterizedTypeBinding extends ReferenceBinding implements Substi
 				if (wildcard.boundKind == Wildcard.SUPER && wildcard.bound.id == TypeIds.T_JavaLangObject)
 					capturedArguments[i] = wildcard.bound;
 				else if (needUniqueCapture)
-					capturedArguments[i] = this.environment.createCapturedWildcard(wildcard, contextType, start, end, cud, compilationUnitScope.nextCaptureID());
+					capturedArguments[i] = this.environment.createCapturedWildcard(wildcard, contextType, start, end, cud, compilationUnitScope::nextCaptureID);
 				else
 					capturedArguments[i] = new CaptureBinding(wildcard, contextType, start, end, cud, compilationUnitScope.nextCaptureID());
 			} else {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Scope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Scope.java
@@ -4696,7 +4696,7 @@ public abstract class Scope {
 						} else {
 							expressions = ((ReferenceExpression)invocationSite).createPseudoExpressions(argumentTypes);
 						}
-						InferenceContext18 ic18 = new InferenceContext18(this, expressions, null, null);
+						InferenceContext18 ic18 = new InferenceContext18(this, expressions, invocationSite, null);
 						if (!ic18.isMoreSpecificThan(mbj, mbk, levelj == VARARGS_COMPATIBLE, levelk == VARARGS_COMPATIBLE)) {
 							continue nextJ;
 						}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeBinding.java
@@ -308,17 +308,29 @@ public TypeBinding erasure() {
 /**
  * Perform an upwards type projection as per JLS 4.10.5
  * @param scope Relevant scope for evaluating type projection
- * @param mentionedTypeVariables Filter for mentioned type variabled
- * @return Upwards type projection of 'this', or null if downwards projection is undefined
+ * @param mentionedTypeVariables Filter for mentioned type variables
+ * @return Upwards type projection of 'this', or null if upwards projection is undefined
 */
 public TypeBinding upwardsProjection(Scope scope, TypeBinding[] mentionedTypeVariables) {
+	return this;
+}
+/**
+ * Perform an upwards type projection as per JLS 4.10.5
+ * @param scope Relevant scope for evaluating type projection
+ * @return Upwards type projection of 'this', or null if upwards projection is undefined
+*/
+public TypeBinding upwardsProjection(Scope scope) {
+	TypeBinding[] mentionedTypeVariables= syntheticTypeVariablesMentioned();
+	if (mentionedTypeVariables != null && mentionedTypeVariables.length > 0) {
+		return upwardsProjection(scope, mentionedTypeVariables);
+	}
 	return this;
 }
 
 /**
  * Perform a downwards type projection as per JLS 4.10.5
  * @param scope Relevant scope for evaluating type projection
- * @param mentionedTypeVariables Filter for mentioned type variabled
+ * @param mentionedTypeVariables Filter for mentioned type variables
  * @return Downwards type projection of 'this', or null if downwards projection is undefined
 */
 public TypeBinding downwardsProjection(Scope scope, TypeBinding[] mentionedTypeVariables) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeSystem.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeSystem.java
@@ -21,6 +21,7 @@ package org.eclipse.jdt.internal.compiler.lookup;
 
 import java.util.HashMap;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 import org.eclipse.jdt.internal.compiler.ast.ASTNode;
 import org.eclipse.jdt.internal.compiler.util.SimpleLookupTable;
@@ -453,7 +454,7 @@ public class TypeSystem {
 	}
 
 	// No need for an override in ATS, since interning is position specific and either the wildcard there is annotated or not.
-	public final CaptureBinding getCapturedWildcard(WildcardBinding wildcard, ReferenceBinding contextType, int start, int end, ASTNode cud, int id) {
+	public final CaptureBinding getCapturedWildcard(WildcardBinding wildcard, ReferenceBinding contextType, int start, int end, ASTNode cud, Supplier<Integer> idSupplier) {
 
 		WildcardBinding unannotatedWildcard = (WildcardBinding) getUnannotatedType(wildcard);
 		TypeBinding[] derivedTypes = this.types[unannotatedWildcard.id];  // by construction, cachedInfo != null now.
@@ -490,7 +491,7 @@ public class TypeSystem {
 			System.arraycopy(derivedTypes, 0, derivedTypes = new TypeBinding[length * 2], 0, length);
 			this.types[unannotatedWildcard.id] = derivedTypes;
 		}
-		return (CaptureBinding) (derivedTypes[i] = new CaptureBinding(wildcard, contextType, start, end, cud, id));
+		return (CaptureBinding) (derivedTypes[i] = new CaptureBinding(wildcard, contextType, start, end, cud, idSupplier.get()));
 		// the above constructor already registers the capture, don't repeat that here
 	}
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/util/Tuples.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/util/Tuples.java
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (c) 2024 GK Software SE, and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Stephan Herrmann - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.internal.compiler.util;
+
+public interface Tuples {
+
+	record Pair<T> (T left, T right) {}
+
+}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest.java
@@ -4985,7 +4985,7 @@ public void testBug434044_comment36() {
 		"1. ERROR in EclipseJava8Generics.java (at line 28)\n" +
 		"	final Object propertyValue = typedProperty.getBar().doFoo(null);\n" +
 		"	                                                    ^^^^^\n" +
-		"The method doFoo(String) is ambiguous for the type capture#2-of ? extends EclipseJava8Generics.AbstractFoo<?>\n" +
+		"The method doFoo(String) is ambiguous for the type capture#3-of ? extends EclipseJava8Generics.AbstractFoo<?>\n" +
 		"----------\n");
 }
 public void testBug434793() {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NegativeLambdaExpressionsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NegativeLambdaExpressionsTest.java
@@ -8612,7 +8612,7 @@ public void test428177() {
 		"5. ERROR in X.java (at line 38)\n" +
 		"	return stream.collect(Collectors.toList()); // NO ERROR\n" +
 		"	       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
-		"Type mismatch: cannot convert from List<capture#17-of ? extends String> to Stream<String>\n" +
+		"Type mismatch: cannot convert from List<capture#16-of ? extends String> to Stream<String>\n" +
 		"----------\n");
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=428795, - [1.8]Internal compiler error: java.lang.NullPointerException at org.eclipse.jdt.internal.compiler.ast.MessageSend.analyseCode


### PR DESCRIPTION
fix for #2413 considering this advice:
* by Maurizio Cimadamore: inspect all pairs of matching supertypes
  * see https://mail.openjdk.org/pipermail/compiler-dev/2024-May/026578.html
* by Dan Smith: super type computation should use capture then upwards projection
  *  see https://mail.openjdk.org/pipermail/compiler-dev/2024-May/026579.html

additionally
+ avoid incrementing captureId when capture is reused not created
+ account for nullability of downwardsProjection (ITB18)
+ follow-up cleaning of IC18.findRPrimeAndResultingBounds()
+ avoid some array<->list conversions


