### PR TITLE
Empty stack error compiling project with broken classpath

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchExpressionsYieldTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchExpressionsYieldTest.java
@@ -8001,4 +8001,33 @@ public class SwitchExpressionsYieldTest extends AbstractRegressionTest {
 				},
 				"String = Hello int = 42");
 	}
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2485
+	// Empty stack error compiling project with broken classpath
+	public void testIssue2485() {
+		if (this.complianceLevel < ClassFileConstants.JDK14)
+			return;
+		this.runConformTest(
+				new String[] {
+				"X.java",
+				"""
+				public class X {
+				    public static int convertOpcode(int from, int to) {
+				        return switch (from) {
+				            case 42 ->
+			                    switch (to) {
+			                        case 42 -> 42;
+			                        default -> throw new UnsupportedOperationException();
+			                    };
+				            default -> throw new UnsupportedOperationException();
+				        };
+				    }
+				    public static void main(String [] args) {
+				        System.out.println("With 42 & 42 = " + convertOpcode(42, 42));
+			        }
+				}
+				"""
+				},
+				"With 42 & 42 = 42");
+	}
+
 }


### PR DESCRIPTION
## What it does

Fix failure of operand stack management code in handling chained `goto`s

* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2485

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
