### PR TITLE
Force signing of split package bundles to use new certificate

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/forceQualifierUpdate.txt
+++ b/org.eclipse.jdt.core.compiler.batch/forceQualifierUpdate.txt
@@ -2,3 +2,4 @@ Comparator errors in I20230607-0720
 Comparator errors in I20230906-0400
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1388
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1759
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044

--- a/org.eclipse.jdt.core/forceQualifierUpdate.txt
+++ b/org.eclipse.jdt.core/forceQualifierUpdate.txt
@@ -14,3 +14,4 @@ https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/11
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1659
 https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1781
 https://github.com/eclipse-jdt/eclipse.jdt.core/pull/2341
+https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044


### PR DESCRIPTION
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2044