### PR TITLE
Mark `ImplicitTypeDeclaration` with `@noreference`

### DIFF
--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ImplicitTypeDeclaration.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ImplicitTypeDeclaration.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 /**
  * @since 3.38
+ * @noreference
  */
 public class ImplicitTypeDeclaration extends AbstractTypeDeclaration {
 


### PR DESCRIPTION
## What it does
Mark `ImplicitTypeDeclaration` with the `@noreference` JavaDoc tag, since it's an API introduced by a preview feature

See https://github.com/eclipse-jdt/eclipse.jdt.core/pull/2483#issuecomment-2128276430

## How to test
This doesn't change any behaviour.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
