### PR TITLE
Don't run tests for stable features with enable-preview

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.tests.compiler/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.core.tests.compiler;singleton:=true
-Bundle-Version: 3.13.400.qualifier
+Bundle-Version: 3.13.500.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jdt.core.tests.compiler,

--- a/org.eclipse.jdt.core.tests.compiler/pom.xml
+++ b/org.eclipse.jdt.core.tests.compiler/pom.xml
@@ -19,7 +19,7 @@
     <relativePath>../tests-pom/</relativePath>
   </parent>
   <artifactId>org.eclipse.jdt.core.tests.compiler</artifactId>
-  <version>3.13.400-SNAPSHOT</version>
+  <version>3.13.500-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchPatternTest21.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchPatternTest21.java
@@ -2,14 +2,11 @@ package org.eclipse.jdt.core.tests.compiler.regression;
 
 import java.util.Map;
 
-import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 
 import junit.framework.Test;
 
 public class SwitchPatternTest21 extends AbstractBatchCompilerTest {
-
-	private static String[] JAVAC_OPTIONS = new String[] { "--enable-preview" };
 
 	static {
 		//	TESTS_NAMES = new String [] { "testNaming" };
@@ -26,14 +23,11 @@ public class SwitchPatternTest21 extends AbstractBatchCompilerTest {
 	@Override
 	protected Map<String, String> getCompilerOptions() {
 		CompilerOptions compilerOptions = new CompilerOptions(super.getCompilerOptions());
-		if (compilerOptions.sourceLevel == ClassFileConstants.JDK22) {
-			compilerOptions.enablePreviewFeatures = true;
-		}
 		return compilerOptions.getMap();
 	}
 
 	public void runConformTest(String[] files, String expectedOutput) {
-		super.runConformTest(files, expectedOutput, null, JAVAC_OPTIONS);
+		super.runConformTest(files, expectedOutput, null, null);
 	}
 
 	@Override

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TestAll.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TestAll.java
@@ -247,7 +247,7 @@ public static Test suite() {
 	 ArrayList since_22 = new ArrayList();
 //	 since_22.add(SuperAfterStatementsTest.class);
 	 since_22.add(UnnamedPatternsAndVariablesTest.class);
-	 since_22.add(UseOfUnderscoreWithPreviewTest.class);
+	 since_22.add(UseOfUnderscoreJava22Test.class);
 	 since_22.add(SuperAfterStatementsTest.class);
 	 since_22.add(StringTemplateTest.class);
 	 since_22.add(SwitchPatternTest21.class);

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/UnnamedPatternsAndVariablesTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/UnnamedPatternsAndVariablesTest.java
@@ -15,14 +15,11 @@ import java.util.Map;
 
 import org.eclipse.jdt.core.util.ClassFileBytesDisassembler;
 import org.eclipse.jdt.core.util.ClassFormatException;
-import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 
 import junit.framework.Test;
 
 public class UnnamedPatternsAndVariablesTest extends AbstractBatchCompilerTest {
-
-	private static String[] JAVAC_OPTIONS = new String[] { "--enable-preview" };
 
 	public static Test suite() {
 		return buildMinimalComplianceTestSuite(UnnamedPatternsAndVariablesTest.class, F_22);
@@ -39,16 +36,13 @@ public class UnnamedPatternsAndVariablesTest extends AbstractBatchCompilerTest {
 	@Override
 	protected Map<String, String> getCompilerOptions() {
 		CompilerOptions compilerOptions = new CompilerOptions(super.getCompilerOptions());
-		if (compilerOptions.sourceLevel == ClassFileConstants.JDK22) {
-			compilerOptions.enablePreviewFeatures = true;
-		}
 		return compilerOptions.getMap();
 	}
 
 	public void runConformTest(String[] files, String expectedOutput) {
 		if(!isJRE22Plus)
 			return;
-		super.runConformTest(files, expectedOutput, null, JAVAC_OPTIONS);
+		super.runConformTest(files, expectedOutput, null, null);
 	}
 
 	public void testAllSnippetsFromUnnamedVariablesAndPatternsProposal() {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/UseOfUnderscoreJava22Test.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/UseOfUnderscoreJava22Test.java
@@ -12,27 +12,23 @@ package org.eclipse.jdt.core.tests.compiler.regression;
 
 import java.util.Map;
 
-import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 
 import junit.framework.Test;
 
-public class UseOfUnderscoreWithPreviewTest extends AbstractBatchCompilerTest {
+public class UseOfUnderscoreJava22Test extends AbstractBatchCompilerTest {
 
 	public static Test suite() {
-		return buildMinimalComplianceTestSuite(UseOfUnderscoreWithPreviewTest.class, F_22);
+		return buildMinimalComplianceTestSuite(UseOfUnderscoreJava22Test.class, F_22);
 	}
 
-	public UseOfUnderscoreWithPreviewTest(String name) {
+	public UseOfUnderscoreJava22Test(String name) {
 		super(name);
 	}
 
 	@Override
 	protected Map<String, String> getCompilerOptions() {
 		CompilerOptions compilerOptions = new CompilerOptions(super.getCompilerOptions());
-		if (compilerOptions.sourceLevel == ClassFileConstants.JDK22) {
-			compilerOptions.enablePreviewFeatures = true;
-		}
 		return compilerOptions.getMap();
 	}
 


### PR DESCRIPTION
## What it does
Tests for https://openjdk.org/jeps/441 and https://openjdk.org/jeps/456 without --enable-preview as these are stable features.

## How to test
Tests succeed.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
