### PR TITLE
dom: fix ASTNode MT issues

### DIFF
--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ASTNode.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ASTNode.java
@@ -2880,15 +2880,20 @@ public abstract class ASTNode {
 	/**
      * Begin lazy initialization of this node.
      * Here is the code pattern found in all AST
-     * node subclasses:
+     * node subclasses. For thread safety it uses a "double-checked locking idiom":
+     *
      * <pre>
-     * if (this.foo == null) {
-	 *    // lazy init must be thread-safe for readers
+     * private volatile ASTNode node; // has to be declared volatile and ASTNode has to be threadsafe!
+     * ...
+     * if (this.node == null) {
      *    synchronized (this) {
-     *       if (this.foo == null) {
+     *       if (this.node == null) { // double check
      *          preLazyInit();
-     *          this.foo = ...; // code to create new node
-     *          postLazyInit(this.foo, FOO_PROPERTY);
+     *          ASTNode node = ...; // code to create new node
+     *          node.xyz = ...; // initialize all fields
+     *          // Finally write the full initialized field:
+     *          this.node = postLazyInit(node, FOO_PROPERTY);
+     *          // Do not modify node after writing it to this.node!
      *       }
      *    }
      * }
@@ -2905,19 +2910,18 @@ public abstract class ASTNode {
 	/**
      * End lazy initialization of this node.
      *
-	 * @param newChild the new child of this node, or <code>null</code> if
-	 *   there is no replacement child
+	 * @param newChild the new child of this node
 	 * @param property the property descriptor of this node describing
      * the relationship between node and child
-     * @since 3.0
      */
-	final void postLazyInit(ASTNode newChild, ChildPropertyDescriptor property) {
+	final <T extends ASTNode> T postLazyInit(T newChild, ChildPropertyDescriptor property) {
 		// IMPORTANT: this method is called by readers
 		// ASTNode.this is locked at this point
 		// newChild is brand new (so no chance of concurrent access)
 		newChild.setParent(this, property);
 		// turn events back on (they were turned off in corresponding preLazyInit)
 		this.ast.reenableEvents();
+		return newChild;
 	}
 
 	/**

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/AbstractTypeDeclaration.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/AbstractTypeDeclaration.java
@@ -130,8 +130,7 @@ public abstract class AbstractTypeDeclaration extends BodyDeclaration {
 			synchronized (this) {
 				if (this.typeName == null) {
 					preLazyInit();
-					this.typeName = new SimpleName(this.ast);
-					postLazyInit(this.typeName, internalNameProperty());
+					this.typeName = postLazyInit(new SimpleName(this.ast), internalNameProperty());
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/Annotation.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/Annotation.java
@@ -100,8 +100,7 @@ public abstract class Annotation extends Expression implements IExtendedModifier
 			synchronized (this) {
 				if (this.typeName == null) {
 					preLazyInit();
-					this.typeName = new SimpleName(this.ast);
-					postLazyInit(this.typeName, internalTypeNameProperty());
+					this.typeName = postLazyInit(new SimpleName(this.ast), internalTypeNameProperty());
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/AnnotationTypeMemberDeclaration.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/AnnotationTypeMemberDeclaration.java
@@ -256,8 +256,7 @@ public class AnnotationTypeMemberDeclaration extends BodyDeclaration {
 			synchronized (this) {
 				if (this.memberType == null) {
 					preLazyInit();
-					this.memberType = this.ast.newPrimitiveType(PrimitiveType.INT);
-					postLazyInit(this.memberType, TYPE_PROPERTY);
+					this.memberType = postLazyInit(this.ast.newPrimitiveType(PrimitiveType.INT), TYPE_PROPERTY);
 				}
 			}
 		}
@@ -296,8 +295,7 @@ public class AnnotationTypeMemberDeclaration extends BodyDeclaration {
 			synchronized (this) {
 				if (this.memberName == null) {
 					preLazyInit();
-					this.memberName = new SimpleName(this.ast);
-					postLazyInit(this.memberName, NAME_PROPERTY);
+					this.memberName = postLazyInit(new SimpleName(this.ast), NAME_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ArrayAccess.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ArrayAccess.java
@@ -170,8 +170,7 @@ public class ArrayAccess extends Expression {
 			synchronized (this) {
 				if (this.arrayExpression == null) {
 					preLazyInit();
-					this.arrayExpression = new SimpleName(this.ast);
-					postLazyInit(this.arrayExpression, ARRAY_PROPERTY);
+					this.arrayExpression = postLazyInit(new SimpleName(this.ast), ARRAY_PROPERTY);
 				}
 			}
 		}
@@ -212,8 +211,7 @@ public class ArrayAccess extends Expression {
 			synchronized (this) {
 				if (this.indexExpression == null) {
 					preLazyInit();
-					this.indexExpression = new SimpleName(this.ast);
-					postLazyInit(this.indexExpression, INDEX_PROPERTY);
+					this.indexExpression = postLazyInit(new SimpleName(this.ast), INDEX_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ArrayCreation.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ArrayCreation.java
@@ -206,9 +206,8 @@ public class ArrayCreation extends Expression {
 			synchronized (this) {
 				if (this.arrayType == null) {
 					preLazyInit();
-					this.arrayType = this.ast.newArrayType(
-							this.ast.newPrimitiveType(PrimitiveType.INT));
-					postLazyInit(this.arrayType, TYPE_PROPERTY);
+					this.arrayType = postLazyInit(this.ast.newArrayType(this.ast.newPrimitiveType(PrimitiveType.INT)),
+							TYPE_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ArrayType.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ArrayType.java
@@ -272,8 +272,7 @@ public class ArrayType extends Type {
 			synchronized (this) {
 				if (this.type == null) {
 					preLazyInit();
-					this.type = new SimpleType(this.ast);
-					postLazyInit(this.type, property);
+					this.type = postLazyInit(new SimpleType(this.ast), property);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/AssertStatement.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/AssertStatement.java
@@ -172,8 +172,7 @@ public class AssertStatement extends Statement {
 			synchronized (this) {
 				if (this.expression == null) {
 					preLazyInit();
-					this.expression = new SimpleName(this.ast);
-					postLazyInit(this.expression, EXPRESSION_PROPERTY);
+					this.expression = postLazyInit(new SimpleName(this.ast), EXPRESSION_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/Assignment.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/Assignment.java
@@ -340,8 +340,7 @@ public class Assignment extends Expression {
 			synchronized (this) {
 				if (this.leftHandSide == null) {
 					preLazyInit();
-					this.leftHandSide= new SimpleName(this.ast);
-					postLazyInit(this.leftHandSide, LEFT_HAND_SIDE_PROPERTY);
+					this.leftHandSide = postLazyInit(new SimpleName(this.ast), LEFT_HAND_SIDE_PROPERTY);
 				}
 			}
 		}
@@ -381,8 +380,7 @@ public class Assignment extends Expression {
 			synchronized (this) {
 				if (this.rightHandSide == null) {
 					preLazyInit();
-					this.rightHandSide= new SimpleName(this.ast);
-					postLazyInit(this.rightHandSide, RIGHT_HAND_SIDE_PROPERTY);
+					this.rightHandSide = postLazyInit(new SimpleName(this.ast), RIGHT_HAND_SIDE_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/CastExpression.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/CastExpression.java
@@ -168,8 +168,7 @@ public class CastExpression extends Expression {
 			synchronized (this) {
 				if (this.type == null) {
 					preLazyInit();
-					this.type = this.ast.newPrimitiveType(PrimitiveType.INT);
-					postLazyInit(this.type, TYPE_PROPERTY);
+					this.type = postLazyInit(this.ast.newPrimitiveType(PrimitiveType.INT), TYPE_PROPERTY);
 				}
 			}
 		}
@@ -207,8 +206,7 @@ public class CastExpression extends Expression {
 			synchronized (this) {
 				if (this.expression == null) {
 					preLazyInit();
-					this.expression = new SimpleName(this.ast);
-					postLazyInit(this.expression, EXPRESSION_PROPERTY);
+					this.expression = postLazyInit(new SimpleName(this.ast), EXPRESSION_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/CatchClause.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/CatchClause.java
@@ -171,8 +171,7 @@ public class CatchClause extends ASTNode {
 			synchronized (this) {
 				if (this.exceptionDecl == null) {
 					preLazyInit();
-					this.exceptionDecl = new SingleVariableDeclaration(this.ast);
-					postLazyInit(this.exceptionDecl, EXCEPTION_PROPERTY);
+					this.exceptionDecl = postLazyInit(new SingleVariableDeclaration(this.ast), EXCEPTION_PROPERTY);
 				}
 			}
 		}
@@ -211,8 +210,7 @@ public class CatchClause extends ASTNode {
 			synchronized (this) {
 				if (this.body == null) {
 					preLazyInit();
-					this.body = new Block(this.ast);
-					postLazyInit(this.body, BODY_PROPERTY);
+					this.body = postLazyInit(new Block(this.ast), BODY_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ClassInstanceCreation.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ClassInstanceCreation.java
@@ -383,8 +383,7 @@ public class ClassInstanceCreation extends Expression {
 			synchronized (this) {
 				if (this.typeName == null) {
 					preLazyInit();
-					this.typeName = new SimpleName(this.ast);
-					postLazyInit(this.typeName, NAME_PROPERTY);
+					this.typeName = postLazyInit(new SimpleName(this.ast), NAME_PROPERTY);
 				}
 			}
 		}
@@ -443,8 +442,7 @@ public class ClassInstanceCreation extends Expression {
 			synchronized (this) {
 				if (this.type == null) {
 					preLazyInit();
-					this.type = new SimpleType(this.ast);
-					postLazyInit(this.type, TYPE_PROPERTY);
+					this.type = postLazyInit(new SimpleType(this.ast), TYPE_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ConditionalExpression.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ConditionalExpression.java
@@ -196,8 +196,7 @@ public class ConditionalExpression extends Expression {
 			synchronized (this) {
 				if (this.conditionExpression == null) {
 					preLazyInit();
-					this.conditionExpression = new SimpleName(this.ast);
-					postLazyInit(this.conditionExpression, EXPRESSION_PROPERTY);
+					this.conditionExpression = postLazyInit(new SimpleName(this.ast), EXPRESSION_PROPERTY);
 				}
 			}
 		}
@@ -236,8 +235,7 @@ public class ConditionalExpression extends Expression {
 			synchronized (this) {
 				if (this.thenExpression == null) {
 					preLazyInit();
-					this.thenExpression = new SimpleName(this.ast);
-					postLazyInit(this.thenExpression, THEN_EXPRESSION_PROPERTY);
+					this.thenExpression = postLazyInit(new SimpleName(this.ast), THEN_EXPRESSION_PROPERTY);
 				}
 			}
 		}
@@ -276,8 +274,7 @@ public class ConditionalExpression extends Expression {
 			synchronized (this) {
 				if (this.elseExpression == null) {
 					preLazyInit();
-					this.elseExpression = new SimpleName(this.ast);
-					postLazyInit(this.elseExpression, ELSE_EXPRESSION_PROPERTY);
+					this.elseExpression = postLazyInit(new SimpleName(this.ast), ELSE_EXPRESSION_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/CreationReference.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/CreationReference.java
@@ -167,8 +167,7 @@ public class CreationReference extends MethodReference {
 			synchronized (this) {
 				if (this.type == null) {
 					preLazyInit();
-					this.type = new SimpleType(this.ast);
-					postLazyInit(this.type, TYPE_PROPERTY);
+					this.type = postLazyInit(new SimpleType(this.ast), TYPE_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/DoStatement.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/DoStatement.java
@@ -172,9 +172,8 @@ public class DoStatement extends Statement {
 				b = this.body;
 				if (b == null) {
 					preLazyInit();
-					b = new Block(this.ast);
+					b = postLazyInit(new Block(this.ast), BODY_PROPERTY);
 					this.body = b;
-					postLazyInit(b, BODY_PROPERTY);
 				}
 			}
 		}
@@ -221,8 +220,7 @@ public class DoStatement extends Statement {
             synchronized (this) {
                 if (this.expression == null) {
                     preLazyInit();
-                    this.expression = new SimpleName(this.ast);
-                    postLazyInit(this.expression, EXPRESSION_PROPERTY);
+                    this.expression = postLazyInit(new SimpleName(this.ast), EXPRESSION_PROPERTY);
                 }
             }
         }

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/EnhancedForStatement.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/EnhancedForStatement.java
@@ -194,8 +194,7 @@ public class EnhancedForStatement extends Statement {
 			synchronized (this) {
 				if (this.parameter == null) {
 					preLazyInit();
-					this.parameter = this.ast.newSingleVariableDeclaration();
-					postLazyInit(this.parameter, PARAMETER_PROPERTY);
+					this.parameter = postLazyInit(this.ast.newSingleVariableDeclaration(), PARAMETER_PROPERTY);
 				}
 			}
 		}
@@ -233,8 +232,7 @@ public class EnhancedForStatement extends Statement {
 			synchronized (this) {
 				if (this.expression == null) {
 					preLazyInit();
-					this.expression = new SimpleName(this.ast);
-					postLazyInit(this.expression, EXPRESSION_PROPERTY);
+					this.expression = postLazyInit(new SimpleName(this.ast), EXPRESSION_PROPERTY);
 				}
 			}
 		}
@@ -273,8 +271,7 @@ public class EnhancedForStatement extends Statement {
 			synchronized (this) {
 				if (this.body == null) {
 					preLazyInit();
-					this.body = new Block(this.ast);
-					postLazyInit(this.body, BODY_PROPERTY);
+					this.body = postLazyInit(new Block(this.ast), BODY_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/EnumConstantDeclaration.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/EnumConstantDeclaration.java
@@ -257,8 +257,7 @@ public class EnumConstantDeclaration extends BodyDeclaration {
 			synchronized (this) {
 				if (this.constantName == null) {
 					preLazyInit();
-					this.constantName = new SimpleName(this.ast);
-					postLazyInit(this.constantName, NAME_PROPERTY);
+					this.constantName = postLazyInit(new SimpleName(this.ast), NAME_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ExpressionMethodReference.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ExpressionMethodReference.java
@@ -191,8 +191,7 @@ public class ExpressionMethodReference extends MethodReference {
 			synchronized (this) {
 				if (this.expression == null) {
 					preLazyInit();
-					this.expression = new SimpleName(this.ast);
-					postLazyInit(this.expression, EXPRESSION_PROPERTY);
+					this.expression = postLazyInit(new SimpleName(this.ast), EXPRESSION_PROPERTY);
 				}
 			}
 		}
@@ -242,8 +241,7 @@ public class ExpressionMethodReference extends MethodReference {
 			synchronized (this) {
 				if (this.methodName == null) {
 					preLazyInit();
-					this.methodName = new SimpleName(this.ast);
-					postLazyInit(this.methodName, NAME_PROPERTY);
+					this.methodName = postLazyInit(new SimpleName(this.ast), NAME_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ExpressionStatement.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ExpressionStatement.java
@@ -149,8 +149,7 @@ public class ExpressionStatement extends Statement {
 			synchronized (this) {
 				if (this.expression == null) {
 					preLazyInit();
-					this.expression = new MethodInvocation(this.ast);
-					postLazyInit(this.expression, EXPRESSION_PROPERTY);
+					this.expression = postLazyInit(new MethodInvocation(this.ast), EXPRESSION_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/FieldAccess.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/FieldAccess.java
@@ -200,8 +200,7 @@ public class FieldAccess extends Expression {
 			synchronized (this) {
 				if (this.expression == null) {
 					preLazyInit();
-					this.expression = new SimpleName(this.ast);
-					postLazyInit(this.expression, EXPRESSION_PROPERTY);
+					this.expression = postLazyInit(new SimpleName(this.ast), EXPRESSION_PROPERTY);
 				}
 			}
 		}
@@ -240,8 +239,7 @@ public class FieldAccess extends Expression {
 			synchronized (this) {
 				if (this.fieldName == null) {
 					preLazyInit();
-					this.fieldName = new SimpleName(this.ast);
-					postLazyInit(this.fieldName, NAME_PROPERTY);
+					this.fieldName = postLazyInit(new SimpleName(this.ast), NAME_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/FieldDeclaration.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/FieldDeclaration.java
@@ -291,8 +291,7 @@ public class FieldDeclaration extends BodyDeclaration {
 			synchronized (this) {
 				if (this.baseType == null) {
 					preLazyInit();
-					this.baseType = this.ast.newPrimitiveType(PrimitiveType.INT);
-					postLazyInit(this.baseType, TYPE_PROPERTY);
+					this.baseType = postLazyInit(this.ast.newPrimitiveType(PrimitiveType.INT), TYPE_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ForStatement.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ForStatement.java
@@ -292,8 +292,7 @@ public class ForStatement extends Statement {
 			synchronized (this) {
 				if (this.body == null) {
 					preLazyInit();
-					this.body = new Block(this.ast);
-					postLazyInit(this.body, BODY_PROPERTY);
+					this.body = postLazyInit(new Block(this.ast), BODY_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/GuardedPattern.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/GuardedPattern.java
@@ -205,8 +205,7 @@ public class GuardedPattern extends Pattern{
 			synchronized (this) {
 				if (this.conditionalExpression == null) {
 					preLazyInit();
-					this.conditionalExpression = this.ast.newNullLiteral();
-					postLazyInit(this.pattern, EXPRESSION_PROPERTY);
+					this.conditionalExpression = postLazyInit(this.ast.newNullLiteral(), EXPRESSION_PROPERTY);
 				}
 			}
 		}
@@ -229,8 +228,7 @@ public class GuardedPattern extends Pattern{
 			synchronized (this) {
 				if (this.pattern == null) {
 					preLazyInit();
-					this.pattern = this.ast.newNullPattern();
-					postLazyInit(this.pattern, PATTERN_PROPERTY);
+					this.pattern = postLazyInit(this.ast.newNullPattern(), PATTERN_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/IfStatement.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/IfStatement.java
@@ -196,8 +196,7 @@ public class IfStatement extends Statement {
 			synchronized (this) {
 				if (this.expression == null) {
 					preLazyInit();
-					this.expression = new SimpleName(this.ast);
-					postLazyInit(this.expression, EXPRESSION_PROPERTY);
+					this.expression = postLazyInit(new SimpleName(this.ast), EXPRESSION_PROPERTY);
 				}
 			}
 		}
@@ -236,8 +235,7 @@ public class IfStatement extends Statement {
 			synchronized (this) {
 				if (this.thenStatement == null) {
 					preLazyInit();
-					this.thenStatement = new Block(this.ast);
-					postLazyInit(this.thenStatement, THEN_STATEMENT_PROPERTY);
+					this.thenStatement = postLazyInit(new Block(this.ast), THEN_STATEMENT_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ImplicitTypeDeclaration.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ImplicitTypeDeclaration.java
@@ -182,9 +182,9 @@ public class ImplicitTypeDeclaration extends AbstractTypeDeclaration {
 			synchronized (this) {
 				if (this.typeName == null) {
 					preLazyInit();
-					this.typeName = new EmptyName(this.ast);
-					this.typeName.setSourceRange(this.getStartPosition(), 0);
-					postLazyInit(this.typeName, NAME_PROPERTY);
+					EmptyName e= new EmptyName(this.ast);
+					e.setSourceRange(this.getStartPosition(), 0);
+					this.typeName =postLazyInit(e, NAME_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ImportDeclaration.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ImportDeclaration.java
@@ -226,9 +226,9 @@ public class ImportDeclaration extends ASTNode {
 			synchronized (this) {
 				if (this.importName == null) {
 					preLazyInit();
-					this.importName =this.ast.newQualifiedName(
-							new SimpleName(this.ast), new SimpleName(this.ast));
-					postLazyInit(this.importName, NAME_PROPERTY);
+					this.importName = postLazyInit(
+							this.ast.newQualifiedName(new SimpleName(this.ast), new SimpleName(this.ast)),
+							NAME_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/InfixExpression.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/InfixExpression.java
@@ -398,8 +398,7 @@ public class InfixExpression extends Expression {
 			synchronized (this) {
 				if (this.leftOperand == null) {
 					preLazyInit();
-					this.leftOperand= new SimpleName(this.ast);
-					postLazyInit(this.leftOperand, LEFT_OPERAND_PROPERTY);
+					this.leftOperand = postLazyInit(new SimpleName(this.ast), LEFT_OPERAND_PROPERTY);
 				}
 			}
 		}
@@ -438,8 +437,7 @@ public class InfixExpression extends Expression {
 			synchronized (this) {
 				if (this.rightOperand  == null) {
 					preLazyInit();
-					this.rightOperand= new SimpleName(this.ast);
-					postLazyInit(this.rightOperand, RIGHT_OPERAND_PROPERTY);
+					this.rightOperand = postLazyInit(new SimpleName(this.ast), RIGHT_OPERAND_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/Initializer.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/Initializer.java
@@ -249,8 +249,7 @@ public class Initializer extends BodyDeclaration {
 			synchronized (this) {
 				if (this.body == null) {
 					preLazyInit();
-					this.body= new Block(this.ast);
-					postLazyInit(this.body, BODY_PROPERTY);
+					this.body = postLazyInit(new Block(this.ast), BODY_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/InstanceofExpression.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/InstanceofExpression.java
@@ -166,8 +166,7 @@ public class InstanceofExpression extends Expression {
 			synchronized (this) {
 				if (this.leftOperand == null) {
 					preLazyInit();
-					this.leftOperand= new SimpleName(this.ast);
-					postLazyInit(this.leftOperand, LEFT_OPERAND_PROPERTY);
+					this.leftOperand = postLazyInit(new SimpleName(this.ast), LEFT_OPERAND_PROPERTY);
 				}
 			}
 		}
@@ -206,8 +205,7 @@ public class InstanceofExpression extends Expression {
 			synchronized (this) {
 				if (this.rightOperand == null) {
 					preLazyInit();
-					this.rightOperand= new SimpleType(this.ast);
-					postLazyInit(this.rightOperand, RIGHT_OPERAND_PROPERTY);
+					this.rightOperand = postLazyInit(new SimpleType(this.ast), RIGHT_OPERAND_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/LabeledStatement.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/LabeledStatement.java
@@ -172,8 +172,7 @@ public class LabeledStatement extends Statement {
 			synchronized (this) {
 				if (this.labelName == null) {
 					preLazyInit();
-					this.labelName= new SimpleName(this.ast);
-					postLazyInit(this.labelName, LABEL_PROPERTY);
+					this.labelName= postLazyInit(new SimpleName(this.ast), LABEL_PROPERTY);
 				}
 			}
 		}
@@ -211,8 +210,7 @@ public class LabeledStatement extends Statement {
 			synchronized (this) {
 				if (this.body == null) {
 					preLazyInit();
-					this.body= new EmptyStatement(this.ast);
-					postLazyInit(this.body, BODY_PROPERTY);
+					this.body = postLazyInit(new EmptyStatement(this.ast), BODY_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/LambdaExpression.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/LambdaExpression.java
@@ -259,8 +259,7 @@ public class LambdaExpression extends Expression {
 			synchronized (this) {
 				if (this.body == null) {
 					preLazyInit();
-					this.body = new Block(this.ast);
-					postLazyInit(this.body, BODY_PROPERTY);
+					this.body = postLazyInit(new Block(this.ast), BODY_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/MemberRef.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/MemberRef.java
@@ -200,8 +200,7 @@ public class MemberRef extends ASTNode implements IDocElement {
 			synchronized (this) {
 				if (this.memberName == null) {
 					preLazyInit();
-					this.memberName = new SimpleName(this.ast);
-					postLazyInit(this.memberName, NAME_PROPERTY);
+					this.memberName = postLazyInit(new SimpleName(this.ast), NAME_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/MemberValuePair.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/MemberValuePair.java
@@ -170,8 +170,7 @@ public class MemberValuePair extends ASTNode {
 			synchronized (this) {
 				if (this.name == null) {
 					preLazyInit();
-					this.name = new SimpleName(this.ast);
-					postLazyInit(this.name, NAME_PROPERTY);
+					this.name = postLazyInit(new SimpleName(this.ast), NAME_PROPERTY);
 				}
 			}
 		}
@@ -224,8 +223,7 @@ public class MemberValuePair extends ASTNode {
 			synchronized (this) {
 				if (this.value == null) {
 					preLazyInit();
-					this.value= new SimpleName(this.ast);
-					postLazyInit(this.value, VALUE_PROPERTY);
+					this.value = postLazyInit(new SimpleName(this.ast), VALUE_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/MethodDeclaration.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/MethodDeclaration.java
@@ -352,13 +352,13 @@ public class MethodDeclaration extends BodyDeclaration {
 	 * JLS3 and later: lazily initialized; defaults to void; null allowed.
 	 * Note that this field is ignored for constructor declarations.
 	 */
-	private Type returnType = null;
+	private volatile Type returnType = null;
 
 	/**
 	 * Indicated whether the return type has been initialized.
 	 * @since 3.1
 	 */
-	private boolean returnType2Initialized = false;
+	private volatile boolean returnType2Initialized = false;
 
 	/**
 	 * The type paramters (element type: {@link TypeParameter}).
@@ -762,8 +762,7 @@ public class MethodDeclaration extends BodyDeclaration {
 			synchronized (this) {
 				if (this.methodName == null) {
 					preLazyInit();
-					this.methodName = new SimpleName(this.ast);
-					postLazyInit(this.methodName, NAME_PROPERTY);
+					this.methodName = postLazyInit(new SimpleName(this.ast), NAME_PROPERTY);
 				}
 			}
 		}
@@ -973,8 +972,7 @@ public class MethodDeclaration extends BodyDeclaration {
 			synchronized (this) {
 				if (this.returnType == null) {
 					preLazyInit();
-					this.returnType = this.ast.newPrimitiveType(PrimitiveType.VOID);
-					postLazyInit(this.returnType, RETURN_TYPE_PROPERTY);
+					this.returnType = postLazyInit(this.ast.newPrimitiveType(PrimitiveType.VOID), RETURN_TYPE_PROPERTY);
 				}
 			}
 		}
@@ -1046,9 +1044,8 @@ public class MethodDeclaration extends BodyDeclaration {
 			synchronized (this) {
 				if (this.returnType == null && !this.returnType2Initialized) {
 					preLazyInit();
-					this.returnType = this.ast.newPrimitiveType(PrimitiveType.VOID);
+					this.returnType = postLazyInit(this.ast.newPrimitiveType(PrimitiveType.VOID), RETURN_TYPE2_PROPERTY);
 					this.returnType2Initialized = true;
-					postLazyInit(this.returnType, RETURN_TYPE2_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/MethodInvocation.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/MethodInvocation.java
@@ -303,8 +303,7 @@ public class MethodInvocation extends Expression {
 			synchronized (this) {
 				if (this.methodName == null) {
 					preLazyInit();
-					this.methodName = new SimpleName(this.ast);
-					postLazyInit(this.methodName, NAME_PROPERTY);
+					this.methodName = postLazyInit(new SimpleName(this.ast), NAME_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/MethodRef.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/MethodRef.java
@@ -230,8 +230,7 @@ public class MethodRef extends ASTNode implements IDocElement {
 			synchronized (this) {
 				if (this.methodName == null) {
 					preLazyInit();
-					this.methodName = new SimpleName(this.ast);
-					postLazyInit(this.methodName, NAME_PROPERTY);
+					this.methodName = postLazyInit(new SimpleName(this.ast), NAME_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/MethodRefParameter.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/MethodRefParameter.java
@@ -228,8 +228,7 @@ public class MethodRefParameter extends ASTNode {
 			synchronized (this) {
 				if (this.type == null) {
 					preLazyInit();
-					this.type = this.ast.newPrimitiveType(PrimitiveType.INT);
-					postLazyInit(this.type, TYPE_PROPERTY);
+					this.type = postLazyInit(this.ast.newPrimitiveType(PrimitiveType.INT), TYPE_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ModuleDeclaration.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ModuleDeclaration.java
@@ -286,9 +286,9 @@ public class ModuleDeclaration extends ASTNode {
 			synchronized (this) {
 				if (this.name == null) {
 					preLazyInit();
-					this.name =this.ast.newQualifiedName(
-							new SimpleName(this.ast), new SimpleName(this.ast));
-					postLazyInit(this.name, NAME_PROPERTY);
+					this.name = postLazyInit(
+							this.ast.newQualifiedName(new SimpleName(this.ast), new SimpleName(this.ast)),
+							NAME_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ModulePackageAccess.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ModulePackageAccess.java
@@ -136,10 +136,9 @@ public abstract class ModulePackageAccess extends ModuleDirective {
 			synchronized (this) {
 				if (this.name == null) {
 					preLazyInit();
-					this.name =this.ast.newQualifiedName(
-							new SimpleName(this.ast), new SimpleName(this.ast));
-					ChildPropertyDescriptor p = internalNameProperty();
-					postLazyInit(this.name, p);
+					this.name = postLazyInit(
+							this.ast.newQualifiedName(new SimpleName(this.ast), new SimpleName(this.ast)),
+							internalNameProperty());
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ModuleQualifiedName.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ModuleQualifiedName.java
@@ -171,8 +171,7 @@ public class ModuleQualifiedName extends Name {
 			synchronized (this) {
 				if (this.moduleQualifier == null) {
 					preLazyInit();
-					this.moduleQualifier = new SimpleName(this.ast);
-					postLazyInit(this.moduleQualifier, MODULE_QUALIFIER_PROPERTY);
+					this.moduleQualifier = postLazyInit(new SimpleName(this.ast), MODULE_QUALIFIER_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/NameQualifiedType.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/NameQualifiedType.java
@@ -201,8 +201,7 @@ public class NameQualifiedType extends AnnotatableType {
 			synchronized (this) {
 				if (this.qualifier == null) {
 					preLazyInit();
-					this.qualifier = new SimpleName(this.ast);
-					postLazyInit(this.qualifier, QUALIFIER_PROPERTY);
+					this.qualifier = postLazyInit(new SimpleName(this.ast), QUALIFIER_PROPERTY);
 				}
 			}
 		}
@@ -240,8 +239,7 @@ public class NameQualifiedType extends AnnotatableType {
 			synchronized (this) {
 				if (this.name == null) {
 					preLazyInit();
-					this.name = new SimpleName(this.ast);
-					postLazyInit(this.name, NAME_PROPERTY);
+					this.name = postLazyInit(new SimpleName(this.ast), NAME_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/PackageDeclaration.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/PackageDeclaration.java
@@ -281,8 +281,7 @@ public class PackageDeclaration extends ASTNode {
 			synchronized (this) {
 				if (this.packageName == null) {
 					preLazyInit();
-					this.packageName = new SimpleName(this.ast);
-					postLazyInit(this.packageName, NAME_PROPERTY);
+					this.packageName = postLazyInit(new SimpleName(this.ast), NAME_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ParameterizedType.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ParameterizedType.java
@@ -178,8 +178,7 @@ public class ParameterizedType extends Type {
 			synchronized (this) {
 				if (this.type == null) {
 					preLazyInit();
-					this.type = new SimpleType(this.ast);
-					postLazyInit(this.type, TYPE_PROPERTY);
+					this.type = postLazyInit(new SimpleType(this.ast), TYPE_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ParenthesizedExpression.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ParenthesizedExpression.java
@@ -144,8 +144,7 @@ public class ParenthesizedExpression extends Expression {
 			synchronized (this) {
 				if (this.expression == null) {
 					preLazyInit();
-					this.expression = new SimpleName(this.ast);
-					postLazyInit(this.expression, EXPRESSION_PROPERTY);
+					this.expression = postLazyInit(new SimpleName(this.ast), EXPRESSION_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/PatternInstanceofExpression.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/PatternInstanceofExpression.java
@@ -234,8 +234,7 @@ public class PatternInstanceofExpression extends Expression {
 			synchronized (this) {
 				if (this.leftOperand == null) {
 					preLazyInit();
-					this.leftOperand= new SimpleName(this.ast);
-					postLazyInit(this.leftOperand, LEFT_OPERAND_PROPERTY);
+					this.leftOperand = postLazyInit(new SimpleName(this.ast), LEFT_OPERAND_PROPERTY);
 				}
 			}
 		}
@@ -277,8 +276,7 @@ public class PatternInstanceofExpression extends Expression {
 			synchronized (this) {
 				if (this.rightOperand == null) {
 					preLazyInit();
-					this.rightOperand= new SingleVariableDeclaration(this.ast);
-					postLazyInit(this.rightOperand, RIGHT_OPERAND_PROPERTY);
+					this.rightOperand = postLazyInit(new SingleVariableDeclaration(this.ast), RIGHT_OPERAND_PROPERTY);
 				}
 			}
 		}
@@ -297,8 +295,7 @@ public class PatternInstanceofExpression extends Expression {
 			synchronized (this) {
 				if (this.pattern == null) {
 					preLazyInit();
-					this.pattern = new TypePattern(this.ast);
-					postLazyInit(this.pattern, PATTERN_PROPERTY);
+					this.pattern = postLazyInit(new TypePattern(this.ast), PATTERN_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/PostfixExpression.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/PostfixExpression.java
@@ -273,8 +273,7 @@ public class PostfixExpression extends Expression {
 			synchronized (this) {
 				if (this.operand == null) {
 					preLazyInit();
-					this.operand= new SimpleName(this.ast);
-					postLazyInit(this.operand, OPERAND_PROPERTY);
+					this.operand = postLazyInit(new SimpleName(this.ast), OPERAND_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/PrefixExpression.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/PrefixExpression.java
@@ -290,8 +290,7 @@ public class PrefixExpression extends Expression {
 			synchronized (this) {
 				if (this.operand == null) {
 					preLazyInit();
-					this.operand= new SimpleName(this.ast);
-					postLazyInit(this.operand, OPERAND_PROPERTY);
+					this.operand = postLazyInit(new SimpleName(this.ast), OPERAND_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ProvidesDirective.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ProvidesDirective.java
@@ -172,9 +172,8 @@ public class ProvidesDirective extends ModuleDirective {
 			synchronized (this) {
 				if (this.name == null) {
 					preLazyInit();
-					this.name = this.ast.newQualifiedName(
-							new SimpleName(this.ast), new SimpleName(this.ast));
-					postLazyInit(this.name, NAME_PROPERTY);
+					this.name = postLazyInit(this.ast.newQualifiedName(
+							new SimpleName(this.ast), new SimpleName(this.ast)), NAME_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/QualifiedName.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/QualifiedName.java
@@ -176,8 +176,7 @@ public class QualifiedName extends Name {
 			synchronized (this) {
 				if (this.qualifier == null) {
 					preLazyInit();
-					this.qualifier = new SimpleName(this.ast);
-					postLazyInit(this.qualifier, QUALIFIER_PROPERTY);
+					this.qualifier = postLazyInit(new SimpleName(this.ast), QUALIFIER_PROPERTY);
 				}
 			}
 		}
@@ -216,8 +215,7 @@ public class QualifiedName extends Name {
 			synchronized (this) {
 				if (this.name == null) {
 					preLazyInit();
-					this.name = new SimpleName(this.ast);
-					postLazyInit(this.name, NAME_PROPERTY);
+					this.name = postLazyInit(new SimpleName(this.ast), NAME_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/QualifiedType.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/QualifiedType.java
@@ -264,8 +264,7 @@ public class QualifiedType extends AnnotatableType {
 			synchronized (this) {
 				if (this.qualifier == null) {
 					preLazyInit();
-					this.qualifier = new SimpleType(this.ast);
-					postLazyInit(this.qualifier, QUALIFIER_PROPERTY);
+					this.qualifier = postLazyInit(new SimpleType(this.ast), QUALIFIER_PROPERTY);
 				}
 			}
 		}
@@ -303,8 +302,7 @@ public class QualifiedType extends AnnotatableType {
 			synchronized (this) {
 				if (this.name == null) {
 					preLazyInit();
-					this.name = new SimpleName(this.ast);
-					postLazyInit(this.name, NAME_PROPERTY);
+					this.name = postLazyInit(new SimpleName(this.ast), NAME_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/RecordPattern.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/RecordPattern.java
@@ -189,8 +189,8 @@ public class RecordPattern extends Pattern {
 			synchronized (this) {
 				if (this.patternType == null) {
 					preLazyInit();
-					this.patternType= this.ast.newPrimitiveType(PrimitiveType.INT);
-					postLazyInit(this.patternType, PATTERN_TYPE_PROPERTY);
+					this.patternType = postLazyInit(this.ast.newPrimitiveType(PrimitiveType.INT),
+							PATTERN_TYPE_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/RequiresDirective.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/RequiresDirective.java
@@ -204,9 +204,9 @@ public class RequiresDirective extends ModuleDirective {
 			synchronized (this) {
 				if (this.name == null) {
 					preLazyInit();
-					this.name =this.ast.newQualifiedName(
-							new SimpleName(this.ast), new SimpleName(this.ast));
-					postLazyInit(this.name, NAME_PROPERTY);
+					this.name = postLazyInit(
+							this.ast.newQualifiedName(new SimpleName(this.ast), new SimpleName(this.ast)),
+							NAME_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/SimpleType.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/SimpleType.java
@@ -208,8 +208,7 @@ public class SimpleType extends AnnotatableType {
 			synchronized (this) {
 				if (this.typeName == null) {
 					preLazyInit();
-					this.typeName = new SimpleName(this.ast);
-					postLazyInit(this.typeName, NAME_PROPERTY);
+					this.typeName = postLazyInit(new SimpleName(this.ast), NAME_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/SingleMemberAnnotation.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/SingleMemberAnnotation.java
@@ -168,8 +168,7 @@ public final class SingleMemberAnnotation extends Annotation {
 			synchronized (this) {
 				if (this.value == null) {
 					preLazyInit();
-					this.value = new SimpleName(this.ast);
-					postLazyInit(this.value, VALUE_PROPERTY);
+					this.value = postLazyInit(new SimpleName(this.ast), VALUE_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/SingleVariableDeclaration.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/SingleVariableDeclaration.java
@@ -504,8 +504,7 @@ public class SingleVariableDeclaration extends VariableDeclaration {
 			synchronized (this) {
 				if (this.type == null) {
 					preLazyInit();
-					this.type = this.ast.newPrimitiveType(PrimitiveType.INT);
-					postLazyInit(this.type, TYPE_PROPERTY);
+					this.type = postLazyInit(this.ast.newPrimitiveType(PrimitiveType.INT), TYPE_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/StringTemplateComponent.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/StringTemplateComponent.java
@@ -149,8 +149,7 @@ public class StringTemplateComponent extends Expression {
 			synchronized (this) {
 				if (this.expression == null) {
 					preLazyInit();
-					this.expression = new SimpleName(this.ast);
-					postLazyInit(this.expression, EMBEDDED_EXPRESSION_PROPERTY);
+					this.expression = postLazyInit(new SimpleName(this.ast), EMBEDDED_EXPRESSION_PROPERTY);
 				}
 			}
 		}
@@ -181,8 +180,7 @@ public class StringTemplateComponent extends Expression {
 			synchronized (this) {
 				if (this.fragment == null) {
 					preLazyInit();
-					this.fragment = new StringFragment(this.ast);
-					postLazyInit(this.fragment, STRING_FRAGMENT_PROPERTY);
+					this.fragment = postLazyInit(new StringFragment(this.ast), STRING_FRAGMENT_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/StringTemplateExpression.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/StringTemplateExpression.java
@@ -120,8 +120,7 @@ public class StringTemplateExpression extends Expression {
 			synchronized (this) {
 				if (this.processor == null) {
 					preLazyInit();
-					this.processor = new SimpleName(this.ast);
-					postLazyInit(this.processor, TEMPLATE_PROCESSOR);
+					this.processor = postLazyInit(new SimpleName(this.ast), TEMPLATE_PROCESSOR);
 				}
 			}
 		}
@@ -152,8 +151,7 @@ public class StringTemplateExpression extends Expression {
 			synchronized (this) {
 				if (this.firstFragment == null) {
 					preLazyInit();
-					this.firstFragment = new StringFragment(this.ast);
-					postLazyInit(this.firstFragment, FIRST_STRING_FRAGMENT);
+					this.firstFragment = postLazyInit(new StringFragment(this.ast), FIRST_STRING_FRAGMENT);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/SuperFieldAccess.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/SuperFieldAccess.java
@@ -203,8 +203,7 @@ public class SuperFieldAccess extends Expression {
 			synchronized (this) {
 				if (this.fieldName == null) {
 					preLazyInit();
-					this.fieldName = new SimpleName(this.ast);
-					postLazyInit(this.fieldName, NAME_PROPERTY);
+					this.fieldName = postLazyInit(new SimpleName(this.ast), NAME_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/SuperMethodInvocation.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/SuperMethodInvocation.java
@@ -301,8 +301,7 @@ public class SuperMethodInvocation extends Expression {
 			synchronized (this) {
 				if (this.methodName == null) {
 					preLazyInit();
-					this.methodName = new SimpleName(this.ast);
-					postLazyInit(this.methodName, NAME_PROPERTY);
+					this.methodName = postLazyInit(new SimpleName(this.ast), NAME_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/SuperMethodReference.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/SuperMethodReference.java
@@ -229,8 +229,7 @@ public class SuperMethodReference extends MethodReference {
 			synchronized (this) {
 				if (this.methodName == null) {
 					preLazyInit();
-					this.methodName = new SimpleName(this.ast);
-					postLazyInit(this.methodName, NAME_PROPERTY);
+					this.methodName = postLazyInit(new SimpleName(this.ast), NAME_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/SwitchCase.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/SwitchCase.java
@@ -233,9 +233,8 @@ public class SwitchCase extends Statement {
 			synchronized (this) {
 				if (!this.expressionInitialized) {
 					preLazyInit();
-					this.optionalExpression = new SimpleName(this.ast);
+					this.optionalExpression = postLazyInit(new SimpleName(this.ast), EXPRESSION_PROPERTY);
 					this.expressionInitialized = true;
-					postLazyInit(this.optionalExpression, EXPRESSION_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/SwitchExpression.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/SwitchExpression.java
@@ -179,8 +179,7 @@ public class SwitchExpression extends Expression {
 			synchronized (this) {
 				if (this.expression == null) {
 					preLazyInit();
-					this.expression = new SimpleName(this.ast);
-					postLazyInit(this.expression, EXPRESSION_PROPERTY);
+					this.expression = postLazyInit(new SimpleName(this.ast), EXPRESSION_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/SwitchStatement.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/SwitchStatement.java
@@ -178,8 +178,7 @@ public class SwitchStatement extends Statement {
 			synchronized (this) {
 				if (this.expression == null) {
 					preLazyInit();
-					this.expression = new SimpleName(this.ast);
-					postLazyInit(this.expression, EXPRESSION_PROPERTY);
+					this.expression = postLazyInit(new SimpleName(this.ast), EXPRESSION_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/SynchronizedStatement.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/SynchronizedStatement.java
@@ -79,12 +79,12 @@ public class SynchronizedStatement extends Statement {
 	 * The expression; lazily initialized; defaults to an unspecified, but
 	 * legal, expression.
 	 */
-	private Expression expression = null;
+	private volatile Expression expression;
 
 	/**
 	 * The body; lazily initialized; defaults to an empty block.
 	 */
-	private Block body = null;
+	private volatile Block body;
 
 	/**
 	 * Creates a new unparented synchronized statement node owned by the given
@@ -170,8 +170,7 @@ public class SynchronizedStatement extends Statement {
 			synchronized (this) {
 				if (this.expression == null) {
 					preLazyInit();
-					this.expression = new SimpleName(this.ast);
-					postLazyInit(this.expression, EXPRESSION_PROPERTY);
+					this.expression = postLazyInit(new SimpleName(this.ast), EXPRESSION_PROPERTY);
 				}
 			}
 		}
@@ -210,8 +209,7 @@ public class SynchronizedStatement extends Statement {
 			synchronized (this) {
 				if (this.body == null) {
 					preLazyInit();
-					this.body = new Block(this.ast);
-					postLazyInit(this.body, BODY_PROPERTY);
+					this.body = postLazyInit(new Block(this.ast), BODY_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ThrowStatement.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ThrowStatement.java
@@ -146,8 +146,7 @@ public class ThrowStatement extends Statement {
 			synchronized (this) {
 				if (this.expression == null) {
 					preLazyInit();
-					this.expression = new SimpleName(this.ast);
-					postLazyInit(this.expression, EXPRESSION_PROPERTY);
+					this.expression = postLazyInit(new SimpleName(this.ast), EXPRESSION_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/TryStatement.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/TryStatement.java
@@ -289,8 +289,7 @@ public class TryStatement extends Statement {
 			synchronized (this) {
 				if (this.body == null) {
 					preLazyInit();
-					this.body = new Block(this.ast);
-					postLazyInit(this.body, BODY_PROPERTY);
+					this.body = postLazyInit(new Block(this.ast), BODY_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/TypeDeclarationStatement.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/TypeDeclarationStatement.java
@@ -214,8 +214,7 @@ public class TypeDeclarationStatement extends Statement {
 			synchronized (this) {
 				if (this.typeDecl == null) {
 					preLazyInit();
-					this.typeDecl = new TypeDeclaration(this.ast);
-					postLazyInit(this.typeDecl, typeDeclProperty());
+					this.typeDecl = postLazyInit(new TypeDeclaration(this.ast), typeDeclProperty());
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/TypeLiteral.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/TypeLiteral.java
@@ -143,8 +143,7 @@ public class TypeLiteral extends Expression {
 			synchronized (this) {
 				if (this.type == null) {
 					preLazyInit();
-					this.type = this.ast.newPrimitiveType(PrimitiveType.INT);
-					postLazyInit(this.type, TYPE_PROPERTY);
+					this.type = postLazyInit(this.ast.newPrimitiveType(PrimitiveType.INT), TYPE_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/TypeMethodReference.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/TypeMethodReference.java
@@ -189,8 +189,7 @@ public class TypeMethodReference extends MethodReference {
 			synchronized (this) {
 				if (this.type == null) {
 					preLazyInit();
-					this.type = new SimpleType(this.ast);
-					postLazyInit(this.type, TYPE_PROPERTY);
+					this.type = postLazyInit(new SimpleType(this.ast), TYPE_PROPERTY);
 				}
 			}
 		}
@@ -239,8 +238,7 @@ public class TypeMethodReference extends MethodReference {
 			synchronized (this) {
 				if (this.methodName == null) {
 					preLazyInit();
-					this.methodName = new SimpleName(this.ast);
-					postLazyInit(this.methodName, NAME_PROPERTY);
+					this.methodName = postLazyInit(new SimpleName(this.ast), NAME_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/TypeParameter.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/TypeParameter.java
@@ -219,8 +219,7 @@ public class TypeParameter extends ASTNode {
 			synchronized (this) {
 				if (this.typeVariableName == null) {
 					preLazyInit();
-					this.typeVariableName = new SimpleName(this.ast);
-					postLazyInit(this.typeVariableName, NAME_PROPERTY);
+					this.typeVariableName = postLazyInit(new SimpleName(this.ast), NAME_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/TypePattern.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/TypePattern.java
@@ -158,8 +158,8 @@ public class TypePattern extends Pattern {
 			synchronized (this) {
 				if (this.patternVariable == null) {
 					preLazyInit();
-					this.patternVariable= new SingleVariableDeclaration(this.ast);
-					postLazyInit(this.patternVariable, PATTERN_VARIABLE_PROPERTY);
+					this.patternVariable = postLazyInit(new SingleVariableDeclaration(this.ast),
+							PATTERN_VARIABLE_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/UsesDirective.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/UsesDirective.java
@@ -146,9 +146,9 @@ public class UsesDirective extends ModuleDirective {
 			synchronized (this) {
 				if (this.name == null) {
 					preLazyInit();
-					this.name = this.ast.newQualifiedName(
-							new SimpleName(this.ast), new SimpleName(this.ast));
-					postLazyInit(this.name, NAME_PROPERTY);
+					this.name = postLazyInit(
+							this.ast.newQualifiedName(new SimpleName(this.ast), new SimpleName(this.ast)),
+							NAME_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/VariableDeclaration.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/VariableDeclaration.java
@@ -213,8 +213,7 @@ public abstract class VariableDeclaration extends ASTNode {
 			synchronized (this) {
 				if (this.variableName == null) {
 					preLazyInit();
-					this.variableName = new SimpleName(this.ast);
-					postLazyInit(this.variableName, internalNameProperty());
+					this.variableName = postLazyInit(new SimpleName(this.ast), internalNameProperty());
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/VariableDeclarationExpression.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/VariableDeclarationExpression.java
@@ -349,8 +349,7 @@ public class VariableDeclarationExpression extends Expression {
 			synchronized (this) {
 				if (this.baseType == null) {
 					preLazyInit();
-					this.baseType = this.ast.newPrimitiveType(PrimitiveType.INT);
-					postLazyInit(this.baseType, TYPE_PROPERTY);
+					this.baseType = postLazyInit(this.ast.newPrimitiveType(PrimitiveType.INT), TYPE_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/VariableDeclarationStatement.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/VariableDeclarationStatement.java
@@ -352,8 +352,7 @@ public class VariableDeclarationStatement extends Statement {
 			synchronized (this) {
 				if (this.baseType == null) {
 					preLazyInit();
-					this.baseType = this.ast.newPrimitiveType(PrimitiveType.INT);
-					postLazyInit(this.baseType, TYPE_PROPERTY);
+					this.baseType = postLazyInit(this.ast.newPrimitiveType(PrimitiveType.INT), TYPE_PROPERTY);
 				}
 			}
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/WhileStatement.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/WhileStatement.java
@@ -171,8 +171,7 @@ public class WhileStatement extends Statement {
 			synchronized (this) {
 				if (this.expression == null) {
 					preLazyInit();
-					this.expression = new SimpleName(this.ast);
-					postLazyInit(this.expression, EXPRESSION_PROPERTY);
+					this.expression = postLazyInit(new SimpleName(this.ast), EXPRESSION_PROPERTY);
 				}
 			}
 		}
@@ -211,8 +210,7 @@ public class WhileStatement extends Statement {
 			synchronized (this) {
 				if (this.body == null) {
 					preLazyInit();
-					this.body = new Block(this.ast);
-					postLazyInit(this.body, BODY_PROPERTY);
+					this.body = postLazyInit(new Block(this.ast), BODY_PROPERTY);
 				}
 			}
 		}


### PR DESCRIPTION
Static code analysis complains that newChild.setParent had modified fields after initialize. fixes:

* 'Remove this dangerous instance of double-checked locking'
* 'Fully initialize ... before assigning it.'
* atomic increment
* wrong fieldname in GuardedPattern.getExpression()

found by: SonarLint
