### PR TITLE
use StandardCharsets instead of charset lookup from String

### DIFF
--- a/org.eclipse.jdt.apt.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.apt.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.apt.core; singleton:=true
-Bundle-Version: 3.8.400.qualifier
+Bundle-Version: 3.8.500.qualifier
 Bundle-Localization: plugin
 Export-Package: com.sun.mirror.apt,
  com.sun.mirror.declaration,

--- a/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/JarFactoryContainer.java
+++ b/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/JarFactoryContainer.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.jar.JarEntry;
@@ -105,7 +106,7 @@ public abstract class JarFactoryContainer extends FactoryContainer
     protected static void readServiceProvider(InputStream is, String serviceName, Map<String, String> classNames) throws IOException {
     	BufferedReader rd = null;
     	try {
-	        rd = new BufferedReader(new InputStreamReader(is, "UTF-8")); //$NON-NLS-1$
+	        rd = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
 	        for (String line = rd.readLine(); line != null; line = rd.readLine()) {
 	            // hack off any comments
 	            int iComment = line.indexOf('#');

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/Bug376673Test.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/Bug376673Test.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.jdt.core.tests.model;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -59,7 +60,7 @@ public class Bug376673Test extends ModifyingResourceTests {
 					"	public p\uD842\uDF9F.i\uD842\uDF9F.Test test;",
 					"}",
 			};
-			IFile file = createFile("/P/src/pkg/UseJarClass.java", String.join(System.lineSeparator(), classFileContent), "UTF-8");
+			IFile file = createFile("/P/src/pkg/UseJarClass.java", String.join(System.lineSeparator(), classFileContent), StandardCharsets.UTF_8);
 			file.setCharset("UTF-8", null);
 			refresh(p);
 			waitForAutoBuild();

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchBugsTests2.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchBugsTests2.java
@@ -21,7 +21,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -708,12 +707,8 @@ public class JavaSearchBugsTests2 extends AbstractJavaSearchTests {
 			String content = "package pkg;\n" +
 					"class \uD842\uDF9F1 {}\n";
 			createFolder("/P/pkg");
-			try {
-				IFile file = createFile("/P/pkg/\uD842\uDF9F1.java", content, "UTF-8");
-				file.setCharset("UTF-8", null);
-			} catch (UnsupportedEncodingException e) {
-				System.out.println("unsupported encoding");
-			}
+			IFile file = createFile("/P/pkg/\uD842\uDF9F1.java", content, StandardCharsets.UTF_8);
+			file.setCharset("UTF-8", null);
 			waitUntilIndexesReady();
 			IJavaSearchScope scope = SearchEngine. createJavaSearchScope(
 					new IJavaElement[] { project }, IJavaSearchScope.SOURCES);
@@ -735,12 +730,8 @@ public class JavaSearchBugsTests2 extends AbstractJavaSearchTests {
 					"	public void \uD842\uDF9Fm() {}\n" +
 					"}\n";
 			createFolder("/P/pkg");
-			try {
-				IFile file = createFile("/P/pkg/\uD842\uDF9F1.java", content, "UTF-8");
-				file.setCharset("UTF-8", null);
-			} catch (UnsupportedEncodingException e) {
-				System.out.println("unsupported encoding");
-			}
+			IFile file = createFile("/P/pkg/\uD842\uDF9F1.java", content, StandardCharsets.UTF_8);
+			file.setCharset("UTF-8", null);
 			waitUntilIndexesReady();
 			IJavaSearchScope scope = SearchEngine. createJavaSearchScope(
 					new IJavaElement[] { project }, IJavaSearchScope.SOURCES);
@@ -762,12 +753,8 @@ public class JavaSearchBugsTests2 extends AbstractJavaSearchTests {
 					"	public \uD842\uDF9F1() {}\n" +
 					"}\n";
 			createFolder("/P/pkg");
-			try {
-				IFile file = createFile("/P/pkg/\uD842\uDF9F1.java", content, "UTF-8");
-				file.setCharset("UTF-8", null);
-			} catch (UnsupportedEncodingException e) {
-				System.out.println("unsupported encoding");
-			}
+			IFile file = createFile("/P/pkg/\uD842\uDF9F1.java", content, StandardCharsets.UTF_8);
+			file.setCharset("UTF-8", null);
 			waitUntilIndexesReady();
 			IJavaSearchScope scope = SearchEngine. createJavaSearchScope(
 					new IJavaElement[] { project }, IJavaSearchScope.SOURCES);
@@ -789,12 +776,8 @@ public class JavaSearchBugsTests2 extends AbstractJavaSearchTests {
 					"	public int \uD842\uDF9Ff;\n" +
 					"}\n";
 			createFolder("/P/pkg");
-			try {
-				IFile file = createFile("/P/pkg/\uD842\uDF9F1.java", content, "UTF-8");
-				file.setCharset("UTF-8", null);
-			} catch (UnsupportedEncodingException e) {
-				System.out.println("unsupported encoding");
-			}
+			IFile file = createFile("/P/pkg/\uD842\uDF9F1.java", content, StandardCharsets.UTF_8);
+			file.setCharset("UTF-8", null);
 			waitUntilIndexesReady();
 			IJavaSearchScope scope = SearchEngine. createJavaSearchScope(
 					new IJavaElement[] { project }, IJavaSearchScope.SOURCES);

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ModifyingResourceTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ModifyingResourceTests.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
 import java.util.StringTokenizer;
 
 import org.eclipse.core.resources.IFile;
@@ -200,6 +201,9 @@ protected IFile createFile(String path, byte[] content) throws CoreException {
 @Override
 protected IFile createFile(String path, String content) throws CoreException {
 	return createFile(path, content.getBytes());
+}
+protected IFile createFile(String path, String content, Charset charsetName) throws CoreException {
+	return createFile(path, content.getBytes(charsetName));
 }
 protected IFile createFile(String path, String content, String charsetName) throws CoreException, UnsupportedEncodingException {
 	return createFile(path, content.getBytes(charsetName));

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/core/util/ExternalAnnotationUtil.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/core/util/ExternalAnnotationUtil.java
@@ -17,7 +17,7 @@ import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
@@ -716,18 +716,13 @@ public final class ExternalAnnotationUtil {
 		String line;
 		while ((line = tailReader.readLine()) != null)
 			head.append(line).append('\n');
-		ByteArrayInputStream newContent = new ByteArrayInputStream(head.toString().getBytes("UTF-8")); //$NON-NLS-1$
+		ByteArrayInputStream newContent = new ByteArrayInputStream(head.toString().getBytes(StandardCharsets.UTF_8));
 		annotationFile.setContents(newContent, IResource.KEEP_HISTORY, monitor);
 	}
 
 	private static void createNewFile(IFile file, String newContent, IProgressMonitor monitor) throws CoreException {
 		ensureExists(file.getParent(), monitor);
-
-		try {
-			file.create(new ByteArrayInputStream(newContent.getBytes("UTF-8")), false, monitor); //$NON-NLS-1$
-		} catch (UnsupportedEncodingException e) {
-			throw new CoreException(new Status(IStatus.ERROR, JavaCore.PLUGIN_ID, e.getMessage(), e));
-		}
+		file.create(new ByteArrayInputStream(newContent.getBytes(StandardCharsets.UTF_8)), false, monitor);
 	}
 
 	private static void ensureExists(IContainer container, IProgressMonitor monitor) throws CoreException {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
I used `java.nio.charset.StandardCharsets.UTF_8` instead of lookup from string. This prevents the unneeded lookup. In additation no `UnsupportedEncodingException` could be thrown.

## How to test
This doesn't change any behavior.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
