### PR TITLE
Remove redundant super interfaces

### DIFF
--- a/org.eclipse.jdt.apt.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.apt.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.apt.core; singleton:=true
-Bundle-Version: 3.8.400.qualifier
+Bundle-Version: 3.8.500.qualifier
 Bundle-Localization: plugin
 Export-Package: com.sun.mirror.apt,
  com.sun.mirror.declaration,

--- a/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/declaration/MemberDeclarationImpl.java
+++ b/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/declaration/MemberDeclarationImpl.java
@@ -25,7 +25,7 @@ import com.sun.mirror.declaration.MemberDeclaration;
 import com.sun.mirror.util.DeclarationVisitor;
 import com.sun.mirror.util.SourcePosition;
 
-public abstract class MemberDeclarationImpl extends DeclarationImpl implements MemberDeclaration, EclipseMirrorObject
+public abstract class MemberDeclarationImpl extends DeclarationImpl implements MemberDeclaration
 {
     MemberDeclarationImpl(final IBinding binding, BaseProcessorEnv env)
     {

--- a/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/declaration/TypeDeclarationImpl.java
+++ b/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/declaration/TypeDeclarationImpl.java
@@ -40,12 +40,11 @@ import com.sun.mirror.declaration.TypeDeclaration;
 import com.sun.mirror.declaration.TypeParameterDeclaration;
 import com.sun.mirror.type.DeclaredType;
 import com.sun.mirror.type.InterfaceType;
-import com.sun.mirror.type.ReferenceType;
 import com.sun.mirror.type.TypeMirror;
 import com.sun.mirror.util.DeclarationVisitor;
 
 public abstract class TypeDeclarationImpl extends MemberDeclarationImpl
-	implements TypeDeclaration, DeclaredType, ReferenceType, EclipseMirrorType
+	implements TypeDeclaration, DeclaredType, EclipseMirrorType
 {
 	// jdt core compiler add a field to a type with the following name when there is a hierachy problem with the type.
 	private static final String HAS_INCONSISTENT_TYPE_HIERACHY = "has inconsistent hierarchy"; //$NON-NLS-1$

--- a/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/env/MessagerImpl.java
+++ b/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/env/MessagerImpl.java
@@ -14,17 +14,16 @@
 
 package org.eclipse.jdt.apt.core.internal.env;
 
-import com.sun.mirror.apt.Messager;
-import com.sun.mirror.util.SourcePosition;
-
 import org.eclipse.core.resources.IFile;
 import org.eclipse.jdt.apt.core.internal.util.SourcePositionImpl;
 import org.eclipse.jdt.apt.core.util.EclipseMessager;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 
+import com.sun.mirror.util.SourcePosition;
 
-public class MessagerImpl implements Messager, EclipseMessager
+
+public class MessagerImpl implements EclipseMessager
 {
 	public static enum Severity {
 		ERROR,

--- a/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/env/ReconcileEnv.java
+++ b/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/env/ReconcileEnv.java
@@ -15,7 +15,6 @@ package org.eclipse.jdt.apt.core.internal.env;
 
 
 import org.eclipse.core.resources.IFile;
-import org.eclipse.jdt.apt.core.env.EclipseAnnotationProcessorEnvironment;
 import org.eclipse.jdt.apt.core.env.Phase;
 import org.eclipse.jdt.apt.core.internal.AptPlugin;
 import org.eclipse.jdt.apt.core.internal.env.MessagerImpl.Severity;
@@ -29,7 +28,7 @@ import org.eclipse.jdt.core.dom.IBinding;
 
 import com.sun.mirror.apt.Filer;
 
-public class ReconcileEnv extends AbstractCompilationEnv implements EclipseAnnotationProcessorEnvironment{
+public class ReconcileEnv extends AbstractCompilationEnv{
 
 	/** The compilation unit being reconciled */
 	private final ICompilationUnit _workingCopy;

--- a/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/type/ErrorType.java
+++ b/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/type/ErrorType.java
@@ -14,6 +14,13 @@
 
 package org.eclipse.jdt.apt.core.internal.type;
 
+import java.util.Collection;
+import java.util.Collections;
+
+import org.eclipse.jdt.apt.core.internal.declaration.EclipseMirrorType;
+import org.eclipse.jdt.apt.core.internal.env.BaseProcessorEnv;
+import org.eclipse.jdt.core.dom.ITypeBinding;
+
 import com.sun.mirror.declaration.AnnotationTypeDeclaration;
 import com.sun.mirror.declaration.ClassDeclaration;
 import com.sun.mirror.declaration.InterfaceDeclaration;
@@ -23,21 +30,13 @@ import com.sun.mirror.type.ArrayType;
 import com.sun.mirror.type.ClassType;
 import com.sun.mirror.type.DeclaredType;
 import com.sun.mirror.type.InterfaceType;
-import com.sun.mirror.type.ReferenceType;
 import com.sun.mirror.type.TypeMirror;
 import com.sun.mirror.util.TypeVisitor;
-
-import java.util.Collection;
-import java.util.Collections;
-
-import org.eclipse.jdt.apt.core.internal.declaration.EclipseMirrorType;
-import org.eclipse.jdt.apt.core.internal.env.BaseProcessorEnv;
-import org.eclipse.jdt.core.dom.ITypeBinding;
 
 /**
  * This is the error type marker
  */
-public abstract class ErrorType implements DeclaredType, ReferenceType, EclipseMirrorType
+public abstract class ErrorType implements DeclaredType, EclipseMirrorType
 {
     final String _name;
 


### PR DESCRIPTION
## What it does
Remove redundant super interfaces that just create warnings in the workspace.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
