### PR TITLE
Add module-info.java to eclipse null annotations

### DIFF
--- a/org.eclipse.jdt.annotation/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.annotation/META-INF/MANIFEST.MF
@@ -7,4 +7,3 @@ Bundle-Version: 2.3.0.qualifier
 Export-Package: org.eclipse.jdt.annotation
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Vendor: %providerName
-Automatic-Module-Name: org.eclipse.jdt.annotation

--- a/org.eclipse.jdt.annotation/pom.xml
+++ b/org.eclipse.jdt.annotation/pom.xml
@@ -33,7 +33,31 @@
               <args>${project.build.sourceEncoding}</args>
             </compilerArgs>
 		  </configuration>
-		</plugin>
+    </plugin>
+    <plugin>
+      <groupId>org.moditect</groupId>
+      <artifactId>moditect-maven-plugin</artifactId>
+      <version>1.0.0.Final</version>
+      <executions>
+        <execution>
+            <id>add-module-infos</id>
+            <phase>package</phase>
+            <goals>
+                <goal>add-module-info</goal>
+            </goals>
+            <configuration>
+                <jvmVersion>11</jvmVersion>
+                <module>
+                  <moduleInfoSource>
+                    module org.eclipse.jdt.annotation {
+                      exports org.eclipse.jdt.annotation;
+                    }
+                  </moduleInfoSource>
+                </module>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
   	</plugins>
   </build>
 </project>


### PR DESCRIPTION
This change just adds a module-info.java

## What it does

See #2538 . It adds a module-info.java to the eclipse annotations jar.

## How to test

Create a jlink bundled application that uses `org.eclipse.jdt.annotation` module.

## Author checklist

The following is not really applicable.

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
