### PR TITLE
[sealed types] NPE on exhaustive pattern matching switch expressions with sealed interface

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SourceTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SourceTypeBinding.java
@@ -169,6 +169,7 @@ public SourceTypeBinding(SourceTypeBinding prototype) {
 
 	this.superclass = prototype.superclass;
 	this.superInterfaces = prototype.superInterfaces;
+	this.permittedTypes = prototype.permittedTypes;
 	this.fields = prototype.fields;
 	this.methods = prototype.methods;
 	this.memberTypes = prototype.memberTypes;
@@ -2610,6 +2611,8 @@ private MethodBinding checkRecordCanonicalConstructor(MethodBinding explicitCano
 
 @Override
 public ReferenceBinding[] permittedTypes() {
+	if (!isPrototype())
+		return this.permittedTypes = this.prototype.permittedTypes();
 	return this.permittedTypes;
 }
 

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullAnnotationTests21.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullAnnotationTests21.java
@@ -1101,4 +1101,36 @@ public class NullAnnotationTests21 extends AbstractNullAnnotationTest {
 		runner.classLibraries = this.LIBS;
 		runner.runConformTest();
 	}
+
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2521
+	// NPE on exhaustive pattern matching switch expressions with sealed interface
+	public void testIssue2521() {
+		Runner runner = new Runner();
+		runner.testFiles = new String[] {
+			"X.java",
+			"""
+			@org.eclipse.jdt.annotation.NonNullByDefault
+
+			public sealed interface X {
+
+				record Stuff() implements X {}
+
+				static Stuff match(X pm) {
+					return switch(pm) {
+						case Stuff s -> s;
+					 	//default -> new Stuff(); //... you should not need as we exhausted it but Eclipse NPE w/o a default.
+					};
+				}
+
+				public static void main(String[] args) {
+				    System.out.println(match(new Stuff()));
+				}
+			}
+			"""
+		};
+		runner.expectedOutputString =
+				"Stuff[]";
+		runner.classLibraries = this.LIBS;
+		runner.runConformTest();
+	}
 }


### PR DESCRIPTION


## What it does

Maintain correlation between a prototype and its annotated variant

* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2521


## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
