### PR TITLE
[sealed types] ECJ should not accept type annotations on permitted types

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
@@ -2705,7 +2705,7 @@ protected void consumeClassHeaderName1() {
 	consumeClassOrRecordHeaderName1(false);
 }
 protected void consumeClassHeaderPermittedSubclasses() {
-populatePermittedTypes();
+	populatePermittedTypes();
 }
 protected void consumeClassInstanceCreationExpression() {
 	// ClassInstanceCreationExpression ::= 'new' ClassType '(' ArgumentListopt ')' ClassBodyopt
@@ -4784,10 +4784,8 @@ private void populatePermittedTypes() {
 		typeDecl.permittedTypes = new TypeReference[length],
 		0,
 		length);
-	TypeReference[] permittedTypes = typeDecl.permittedTypes;
-	for (TypeReference typeReference : permittedTypes) {
-		typeDecl.bits |= (typeReference.bits & ASTNode.HasTypeAnnotations); // TODO: Confirm with spec
-//		typeReference.bits |= ASTNode.IsSuperType; // TODO: Check equivalent required
+	for (TypeReference typeReference : typeDecl.permittedTypes) {
+		rejectIllegalTypeAnnotations(typeReference);
 	}
 	typeDecl.bodyStart = typeDecl.permittedTypes[length-1].sourceEnd + 1;
 	this.listLength = 0; // reset after having read super-interfaces
@@ -6483,9 +6481,9 @@ private void rejectIllegalTypeAnnotations(TypeReference typeReference) {
 				problemReporter().misplacedTypeAnnotations(misplacedAnnotations[0], misplacedAnnotations[misplacedAnnotations.length - 1]);
 		}
 	}
-typeReference.annotations = null;
-typeReference.setAnnotationsOnDimensions(null);
-typeReference.bits &= ~ASTNode.HasTypeAnnotations;
+	typeReference.annotations = null;
+	typeReference.setAnnotationsOnDimensions(null);
+	typeReference.bits &= ~ASTNode.HasTypeAnnotations;
 }
 protected void consumeQualifiedSuperReceiver() {
 	// QualifiedSuperReceiver ::= Name '.' 'super'

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NegativeTypeAnnotationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NegativeTypeAnnotationTest.java
@@ -18,6 +18,7 @@ import java.util.Map;
 
 import org.eclipse.jdt.core.tests.compiler.regression.AbstractRegressionTest.JavacTestOptions.EclipseJustification;
 import org.eclipse.jdt.core.util.ClassFileBytesDisassembler;
+import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 
 import junit.framework.Test;
@@ -4492,5 +4493,36 @@ public class NegativeTypeAnnotationTest extends AbstractRegressionTest {
 				"	             ^^^^^^^^^^^^^^^\n" +
 				"Annotation types that do not specify explicit target element types cannot be applied here\n" +
 				"----------\n");
+	}
+
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2554
+	// [sealed types] ECJ should not accept type annotations on permitted types
+	public void testIssue2554() throws Exception {
+		if (this.complianceLevel < ClassFileConstants.JDK17)
+			return;
+		this.runNegativeTest(
+				new String[] {
+					"X.java",
+					"""
+					import java.lang.annotation.ElementType;
+					import java.lang.annotation.Target;
+
+					@Target(ElementType.TYPE_USE)
+					@interface T {
+					}
+					public sealed interface X permits @T A {
+						public static void main(String[] args) {
+							System.out.println();
+						}
+					}
+					final class A implements X {}
+					""",
+				},
+				"----------\n"
+				+ "1. ERROR in X.java (at line 7)\n"
+				+ "	public sealed interface X permits @T A {\n"
+				+ "	                                  ^^\n"
+				+ "Syntax error, type annotations are illegal here\n"
+				+ "----------\n");
 	}
 }


### PR DESCRIPTION
## What it does

* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2554

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
