### PR TITLE
Get rid of the unused bit field org.eclipse.jdt.internal.compiler.ast.ASTNode.IsSuperType

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ASTNode.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ASTNode.java
@@ -287,7 +287,6 @@ public abstract class ASTNode implements TypeConstants, TypeIds {
 	public static final int IsThenStatementUnreachable = Bit9; // as computed by control flow analysis or null analysis
 
 	// for type reference
-	public static final int IsSuperType = Bit5;
 	public static final int IsVarArgs = Bit15;
 	public static final int IgnoreRawTypeCheck = Bit31;
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
@@ -2597,7 +2597,6 @@ protected void consumeClassHeaderExtends() {
 	TypeDeclaration typeDecl = (TypeDeclaration) this.astStack[this.astPtr];
 	typeDecl.bits |= (superClass.bits & ASTNode.HasTypeAnnotations);
 	typeDecl.superclass = superClass;
-	superClass.bits |= ASTNode.IsSuperType;
 	typeDecl.bodyStart = typeDecl.superclass.sourceEnd + 1;
 	// recovery
 	if (this.currentElement != null){
@@ -2621,7 +2620,6 @@ protected void consumeClassHeaderImplements() {
 	for (TypeReference superinterface : superinterfaces) {
 		TypeReference typeReference = superinterface;
 		typeDecl.bits |= (typeReference.bits & ASTNode.HasTypeAnnotations);
-		typeReference.bits |= ASTNode.IsSuperType;
 	}
 	typeDecl.bodyStart = typeDecl.superInterfaces[length-1].sourceEnd + 1;
 	this.listLength = 0; // reset after having read super-interfaces
@@ -4695,7 +4693,6 @@ protected void consumeInterfaceHeaderExtends() {
 	for (TypeReference superinterface : superinterfaces) {
 		TypeReference typeReference = superinterface;
 		typeDecl.bits |= (typeReference.bits & ASTNode.HasTypeAnnotations);
-		typeReference.bits |= ASTNode.IsSuperType;
 	}
 	typeDecl.bodyStart = typeDecl.superInterfaces[length-1].sourceEnd + 1;
 	this.listLength = 0; // reset after having read super-interfaces
@@ -10282,7 +10279,6 @@ protected void consumeTypeParameter1WithExtends() {
 	TypeParameter typeParameter = (TypeParameter) this.genericsStack[this.genericsPtr];
 	typeParameter.declarationSourceEnd = superType.sourceEnd;
 	typeParameter.type = superType;
-	superType.bits |= ASTNode.IsSuperType;
 	typeParameter.bits |= (superType.bits & ASTNode.HasTypeAnnotations);
 	this.genericsStack[this.genericsPtr] = typeParameter;
 }
@@ -10297,11 +10293,9 @@ protected void consumeTypeParameter1WithExtendsAndBounds() {
 	typeParameter.declarationSourceEnd = bounds[additionalBoundsLength - 1].sourceEnd;
 	typeParameter.type = superType;
 	typeParameter.bits |= (superType.bits & ASTNode.HasTypeAnnotations);
-	superType.bits |= ASTNode.IsSuperType;
 	typeParameter.bounds = bounds;
 	for (TypeReference bound2 : bounds) {
 		TypeReference bound = bound2;
-		bound.bits |= ASTNode.IsSuperType;
 		typeParameter.bits |= (bound.bits & ASTNode.HasTypeAnnotations);
 	}
 }
@@ -10367,7 +10361,6 @@ protected void consumeTypeParameterWithExtends() {
 	typeParameter.declarationSourceEnd = superType.sourceEnd;
 	typeParameter.type = superType;
 	typeParameter.bits |= (superType.bits & ASTNode.HasTypeAnnotations);
-	superType.bits |= ASTNode.IsSuperType;
 }
 protected void consumeTypeParameterWithExtendsAndBounds() {
 	//TypeParameter ::= TypeParameterHeader 'extends' ReferenceType AdditionalBoundList
@@ -10379,12 +10372,10 @@ protected void consumeTypeParameterWithExtendsAndBounds() {
 	TypeParameter typeParameter = (TypeParameter) this.genericsStack[this.genericsPtr];
 	typeParameter.type = superType;
 	typeParameter.bits |= (superType.bits & ASTNode.HasTypeAnnotations);
-	superType.bits |= ASTNode.IsSuperType;
 	typeParameter.bounds = bounds;
 	typeParameter.declarationSourceEnd = bounds[additionalBoundsLength - 1].sourceEnd;
 	for (TypeReference bound2 : bounds) {
 		TypeReference bound = bound2;
-		bound.bits |= ASTNode.IsSuperType;
 		typeParameter.bits |= (bound.bits & ASTNode.HasTypeAnnotations);
 	}
 }
@@ -10764,7 +10755,6 @@ protected void consumeRecordDeclaration() {
 	long[] poss = new long[sources.length];
 	Arrays.fill(poss, 0);
 	TypeReference superClass = new QualifiedTypeReference(sources, poss);
-	superClass.bits |= ASTNode.IsSuperType;
 	typeDecl.superclass = superClass;
 	typeDecl.declarationSourceEnd = flushCommentsDefinedPriorTo(this.endStatementPosition);
 }

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionParser.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionParser.java
@@ -2397,10 +2397,8 @@ private void classHeaderExtendsOrImplements(boolean isInterface, boolean isRecor
 							this.identifierPositionStack[ptr], keywords);
 					if (isInterface) {
 						type.superInterfaces = new TypeReference[] { completionOnKeyword };
-						type.superInterfaces[0].bits |= ASTNode.IsSuperType;
 					} else {
 						type.superclass = completionOnKeyword;
-						type.superclass.bits |= ASTNode.IsSuperType;
 					}
 					this.assistNode = completionOnKeyword;
 					this.lastCheckPoint = completionOnKeyword.sourceEnd + 1;
@@ -2728,7 +2726,6 @@ protected void consumeClassHeaderExtends() {
 						this.identifierPositionStack[ptr],
 						keywords);
 					type.superclass = completionOnKeyword;
-					type.superclass.bits |= ASTNode.IsSuperType;
 					this.assistNode = completionOnKeyword;
 					this.lastCheckPoint = completionOnKeyword.sourceEnd + 1;
 				}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/compiler/parser/SourceTypeConverter.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/compiler/parser/SourceTypeConverter.java
@@ -569,7 +569,6 @@ public class SourceTypeConverter extends TypeConverter {
 		/* set superclass and superinterfaces */
 		if (typeInfo.getSuperclassName() != null) {
 			type.superclass = createTypeReference(typeInfo.getSuperclassName(), start, end, true /* include generics */);
-			type.superclass.bits |= ASTNode.IsSuperType;
 		}
 		char[][] interfaceNames = typeInfo.getInterfaceNames();
 		int interfaceCount = interfaceNames == null ? 0 : interfaceNames.length;
@@ -577,7 +576,6 @@ public class SourceTypeConverter extends TypeConverter {
 			type.superInterfaces = new TypeReference[interfaceCount];
 			for (int i = 0; i < interfaceCount; i++) {
 				type.superInterfaces[i] = createTypeReference(interfaceNames[i], start, end, true /* include generics */);
-				type.superInterfaces[i].bits |= ASTNode.IsSuperType;
 			}
 		}
 		char[][] permittedSubtypeNames = typeInfo.getPermittedSubtypeNames();

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/compiler/parser/TypeConverter.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/compiler/parser/TypeConverter.java
@@ -98,7 +98,6 @@ public abstract class TypeConverter {
 					parameter.bounds = new TypeReference[length-1];
 					for (int i = 1; i < length; i++) {
 						TypeReference bound = createTypeReference(typeParameterBounds[i], start, end);
-						bound.bits |= ASTNode.IsSuperType;
 						parameter.bounds[i-1] = bound;
 					}
 				}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/BinaryTypeConverter.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/BinaryTypeConverter.java
@@ -234,7 +234,6 @@ public class BinaryTypeConverter extends TypeConverter {
 			TypeReference typeReference = createTypeReference(type.getSuperclassTypeSignature());
 			if (typeReference != null) {
 				typeDeclaration.superclass = typeReference;
-				typeDeclaration.superclass.bits |= ASTNode.IsSuperType;
 			}
 		}
 
@@ -245,8 +244,7 @@ public class BinaryTypeConverter extends TypeConverter {
 		for (int i = 0; i < interfaceCount; i++) {
 			TypeReference typeReference = createTypeReference(interfaceTypes[i]);
 			if (typeReference != null) {
-				typeDeclaration.superInterfaces[count] = typeReference;
-				typeDeclaration.superInterfaces[count++].bits |= ASTNode.IsSuperType;
+				typeDeclaration.superInterfaces[count++] = typeReference;
 			}
 		}
 		if (count != interfaceCount) {


### PR DESCRIPTION

## What it does

Garbage collect unused name and its pointless references

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
