### PR TITLE
An extension point allowing third parties to override source to dom tree implementations

### DIFF
--- a/org.eclipse.jdt.core.tests.model/plugin.xml
+++ b/org.eclipse.jdt.core.tests.model/plugin.xml
@@ -92,5 +92,12 @@
         </run>
      </filesystem>
   </extension>
+  <extension
+        point="org.eclipse.jdt.core.compilationUnitResolver">
+     <resolver
+           class="org.eclipse.jdt.core.tests.dom.CompilationUnitResolverDiscoveryTest$TEST_RESOLVER"
+           id="org.eclipse.jdt.core.tests.model.resolver1">
+     </resolver>
+  </extension>
 	
 </plugin>

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/CompilationUnitResolverDiscoveryTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/CompilationUnitResolverDiscoveryTest.java
@@ -1,0 +1,184 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat Inc and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.core.tests.dom;
+
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.WorkingCopyOwner;
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.ASTRequestor;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.FileASTRequestor;
+import org.eclipse.jdt.core.dom.IMethodBinding;
+import org.eclipse.jdt.core.dom.MethodDeclaration;
+import org.eclipse.jdt.core.dom.PackageDeclaration;
+import org.eclipse.jdt.internal.compiler.batch.FileSystem.Classpath;
+import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
+import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
+import org.eclipse.jdt.internal.core.dom.ICompilationUnitResolver;
+
+import junit.framework.Test;
+
+public class CompilationUnitResolverDiscoveryTest extends ConverterTestSetup {
+
+	ICompilationUnit workingCopy;
+
+	@Override
+	public void setUpSuite() throws Exception {
+		super.setUpSuite();
+		this.ast = AST.newAST(AST.getJLSLatest(), false);
+	}
+
+	public CompilationUnitResolverDiscoveryTest(String name) {
+		super(name);
+	}
+
+	public static Test suite() {
+		String javaVersion = System.getProperty("java.version");
+		int index = -1;
+		if ( (index = javaVersion.indexOf('-')) != -1) {
+			javaVersion = javaVersion.substring(0, index);
+		} else {
+			if (javaVersion.length() > 3) {
+				javaVersion = javaVersion.substring(0, 3);
+			}
+		}
+		long jdkLevel = CompilerOptions.versionToJdkLevel(javaVersion);
+		if (jdkLevel >= ClassFileConstants.JDK9) {
+			isJRE9 = true;
+		}
+		return buildModelTestSuite(CompilationUnitResolverDiscoveryTest.class);
+	}
+
+	@Override
+	protected void tearDown() throws Exception {
+		super.tearDown();
+		if (this.workingCopy != null) {
+			this.workingCopy.discardWorkingCopy();
+			this.workingCopy = null;
+		}
+	}
+
+	public void testCompilationUnitResolverNoSysprop() throws JavaModelException {
+		String SELECTED_SYSPROP = "ICompilationUnitResolver";
+		String original = System.getProperty(SELECTED_SYSPROP);
+		try {
+			System.clearProperty(SELECTED_SYSPROP);
+			ICompilationUnit sourceUnit = getCompilationUnit("Converter9" , "src", "testBug497719_001", "X.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+			ASTNode result = runConversion(this.ast.apiLevel(), sourceUnit, true, true);
+			assertTrue("Not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT);
+			CompilationUnit compilationUnit = (CompilationUnit) result;
+			ASTNode node = getASTNode(compilationUnit, 0, 0);
+			assertEquals("Not a compilation unit", ASTNode.METHOD_DECLARATION, node.getNodeType());
+			MethodDeclaration methodDeclaration = (MethodDeclaration) node;
+			IMethodBinding mb = methodDeclaration.resolveBinding();
+			assertEquals(mb.getClass().getName(), "org.eclipse.jdt.core.dom.MethodBinding");
+		} finally {
+			System.setProperty(SELECTED_SYSPROP, original);
+		}
+	}
+
+	public void testCompilationUnitResolverInvalidSysprop() throws JavaModelException {
+		String SELECTED_SYSPROP = "ICompilationUnitResolver";
+		String original = System.getProperty(SELECTED_SYSPROP);
+		try {
+			System.setProperty(SELECTED_SYSPROP, "doesNotExist");
+			ICompilationUnit sourceUnit = getCompilationUnit("Converter9" , "src", "testBug497719_001", "X.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+			ASTNode result = runConversion(this.ast.apiLevel(), sourceUnit, true, true);
+			assertTrue("Not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT);
+			CompilationUnit compilationUnit = (CompilationUnit) result;
+			ASTNode node = getASTNode(compilationUnit, 0, 0);
+			assertEquals("Not a compilation unit", ASTNode.METHOD_DECLARATION, node.getNodeType());
+			MethodDeclaration methodDeclaration = (MethodDeclaration) node;
+			IMethodBinding mb = methodDeclaration.resolveBinding();
+			assertEquals(mb.getClass().getName(), "org.eclipse.jdt.core.dom.MethodBinding");
+		} finally {
+			System.setProperty(SELECTED_SYSPROP, original);
+		}
+	}
+
+	public void testCompilationUnitResolverValidSysprop() throws JavaModelException {
+		String SELECTED_SYSPROP = "ICompilationUnitResolver";
+		String original = System.getProperty(SELECTED_SYSPROP);
+		try {
+			System.setProperty(SELECTED_SYSPROP, "org.eclipse.jdt.core.tests.model.resolver1");
+			ICompilationUnit sourceUnit = getCompilationUnit("Converter9" , "src", "testBug497719_001", "X.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+			ASTNode result = runConversion(this.ast.apiLevel(), sourceUnit, true, true);
+			assertTrue("Not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT);
+			CompilationUnit compilationUnit = (CompilationUnit) result;
+			PackageDeclaration pd = compilationUnit.getPackage();
+			assertNotNull(pd);
+			String pdName = pd.getName().toString();
+			assertEquals(pdName, "compilationUnitResolverDiscoveryTest");
+		} finally {
+			System.setProperty(SELECTED_SYSPROP, original);
+		}
+	}
+
+
+	/*
+	 * Custom made interface that implements exactly to the test
+	 */
+	public static final class TEST_RESOLVER implements ICompilationUnitResolver {
+		@Override
+		public CompilationUnit toCompilationUnit(org.eclipse.jdt.internal.compiler.env.ICompilationUnit sourceUnit,
+				boolean initialNeedsToResolveBinding, IJavaProject project, List<Classpath> classpaths,
+				int focalPosition, int apiLevel, Map<String, String> compilerOptions,
+				WorkingCopyOwner parsedUnitWorkingCopyOwner, WorkingCopyOwner typeRootWorkingCopyOwner, int flags,
+				IProgressMonitor monitor) {
+			// Return a mostly-invalid hard-coded dom tree for the purpose of this test
+			AST ast = AST.newAST(apiLevel, JavaCore.ENABLED.equals(compilerOptions.get(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES)));
+			CompilationUnit res = ast.newCompilationUnit();
+			PackageDeclaration pack = ast.newPackageDeclaration();
+			pack.setName(ast.newSimpleName("compilationUnitResolverDiscoveryTest"));
+			res.setPackage(pack);
+			return res;
+		}
+
+		@Override
+		public void resolve(String[] sourceFilePaths, String[] encodings, String[] bindingKeys,
+				FileASTRequestor requestor, int apiLevel, Map<String, String> compilerOptions,
+				List<Classpath> classpathList, int flags, IProgressMonitor monitor) {
+		}
+
+		@Override
+		public void parse(ICompilationUnit[] compilationUnits, ASTRequestor requestor, int apiLevel,
+				Map<String, String> compilerOptions, int flags, IProgressMonitor monitor) {
+			// TODO Auto-generated method stub
+
+		}
+
+		@Override
+		public void parse(String[] sourceFilePaths, String[] encodings, FileASTRequestor requestor, int apiLevel,
+				Map<String, String> compilerOptions, int flags, IProgressMonitor monitor) {
+			// TODO Auto-generated method stub
+
+		}
+
+		@Override
+		public void resolve(ICompilationUnit[] compilationUnits, String[] bindingKeys, ASTRequestor requestor,
+				int apiLevel, Map<String, String> compilerOptions, IJavaProject project,
+				WorkingCopyOwner workingCopyOwner, int flags, IProgressMonitor monitor) {
+			// TODO Auto-generated method stub
+
+		}
+	}
+}

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/CompilationUnitResolverDiscoveryTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/CompilationUnitResolverDiscoveryTest.java
@@ -9,7 +9,7 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
+ *     Red Hat Inc - initial API and implementation
  *******************************************************************************/
 package org.eclipse.jdt.core.tests.dom;
 
@@ -162,23 +162,20 @@ public class CompilationUnitResolverDiscoveryTest extends ConverterTestSetup {
 		@Override
 		public void parse(ICompilationUnit[] compilationUnits, ASTRequestor requestor, int apiLevel,
 				Map<String, String> compilerOptions, int flags, IProgressMonitor monitor) {
-			// TODO Auto-generated method stub
-
+			// irrelevant for test
 		}
 
 		@Override
 		public void parse(String[] sourceFilePaths, String[] encodings, FileASTRequestor requestor, int apiLevel,
 				Map<String, String> compilerOptions, int flags, IProgressMonitor monitor) {
-			// TODO Auto-generated method stub
-
+			// irrelevant for test
 		}
 
 		@Override
 		public void resolve(ICompilationUnit[] compilationUnits, String[] bindingKeys, ASTRequestor requestor,
 				int apiLevel, Map<String, String> compilerOptions, IJavaProject project,
 				WorkingCopyOwner workingCopyOwner, int flags, IProgressMonitor monitor) {
-			// TODO Auto-generated method stub
-
+			// irrelevant for test
 		}
 	}
 }

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/CompilationUnitResolverDiscoveryTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/CompilationUnitResolverDiscoveryTest.java
@@ -92,7 +92,11 @@ public class CompilationUnitResolverDiscoveryTest extends ConverterTestSetup {
 			IMethodBinding mb = methodDeclaration.resolveBinding();
 			assertEquals(mb.getClass().getName(), "org.eclipse.jdt.core.dom.MethodBinding");
 		} finally {
-			System.setProperty(SELECTED_SYSPROP, original);
+			if (original == null) {
+				System.clearProperty(SELECTED_SYSPROP);
+			} else {
+				System.setProperty(SELECTED_SYSPROP, original);
+			}
 		}
 	}
 
@@ -111,7 +115,11 @@ public class CompilationUnitResolverDiscoveryTest extends ConverterTestSetup {
 			IMethodBinding mb = methodDeclaration.resolveBinding();
 			assertEquals(mb.getClass().getName(), "org.eclipse.jdt.core.dom.MethodBinding");
 		} finally {
-			System.setProperty(SELECTED_SYSPROP, original);
+			if (original == null) {
+				System.clearProperty(SELECTED_SYSPROP);
+			} else {
+				System.setProperty(SELECTED_SYSPROP, original);
+			}
 		}
 	}
 
@@ -129,7 +137,11 @@ public class CompilationUnitResolverDiscoveryTest extends ConverterTestSetup {
 			String pdName = pd.getName().toString();
 			assertEquals(pdName, "compilationUnitResolverDiscoveryTest");
 		} finally {
-			System.setProperty(SELECTED_SYSPROP, original);
+			if (original == null) {
+				System.clearProperty(SELECTED_SYSPROP);
+			} else {
+				System.setProperty(SELECTED_SYSPROP, original);
+			}
 		}
 	}
 

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/RunConverterTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/RunConverterTests.java
@@ -16,9 +16,11 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
+
+import org.eclipse.jdt.core.tests.junit.extension.TestCase;
+
 import junit.framework.Test;
 import junit.framework.TestSuite;
-import org.eclipse.jdt.core.tests.junit.extension.TestCase;
 
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class RunConverterTests extends junit.framework.TestCase {
@@ -61,6 +63,7 @@ public static Class[] getAllTestClasses() {
 		ASTConverterStringTemplateTest.class,
 		ASTConverterSuperAfterStatements.class,
 		ASTConverterEitherOrMultiPatternTest.class,
+		CompilationUnitResolverDiscoveryTest.class
 	};
 }
 public static Test suite() {

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ASTParser.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ASTParser.java
@@ -48,6 +48,7 @@ import org.eclipse.jdt.internal.core.ClassFileWorkingCopy;
 import org.eclipse.jdt.internal.core.DefaultWorkingCopyOwner;
 import org.eclipse.jdt.internal.core.JavaModelManager;
 import org.eclipse.jdt.internal.core.PackageFragment;
+import org.eclipse.jdt.internal.core.dom.ICompilationUnitResolver;
 import org.eclipse.jdt.internal.core.dom.util.DOMASTUtil;
 import org.eclipse.jdt.internal.core.util.CodeSnippetParsingUtil;
 import org.eclipse.jdt.internal.core.util.RecordedParsingInformation;

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ASTParser.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ASTParser.java
@@ -974,14 +974,14 @@ public class ASTParser {
 			initializeDefaults();
 		}
 	}
-    @SuppressWarnings("unchecked")
-    private static <T> T[] safeCopyOf(T[] original) {
-        return original == null ? null : Arrays.copyOf(original, original.length);
-    }
 
-    private static <K,V> Map<K,V> safeUnmodifiableMap(Map<? extends K, ? extends V> m) {
-    	return m == null ? null : Collections.unmodifiableMap(m);
-    }
+	private static <T> T[] safeCopyOf(T[] original) {
+		return original == null ? null : Arrays.copyOf(original, original.length);
+	}
+
+	private static <K,V> Map<K,V> safeUnmodifiableMap(Map<? extends K, ? extends V> m) {
+		return m == null ? null : Collections.unmodifiableMap(m);
+	}
 
 	/**
 	 * Creates ASTs for a batch of compilation units.
@@ -1260,9 +1260,9 @@ public class ASTParser {
 						}
 					}
 
-					CompilationUnit result2 = this.unitResolver.toCompilationUnit(sourceUnit, needToResolveBindings, this.project, getClasspath(), useSearcher ? this.focalPointPosition : -1, this.apiLevel, safeUnmodifiableMap(this.compilerOptions), this.workingCopyOwner, wcOwner, flags, monitor);
-					result2.setTypeRoot(this.typeRoot);
-					return result2;
+					CompilationUnit result = this.unitResolver.toCompilationUnit(sourceUnit, needToResolveBindings, this.project, getClasspath(), useSearcher ? this.focalPointPosition : -1, this.apiLevel, safeUnmodifiableMap(this.compilerOptions), this.workingCopyOwner, wcOwner, flags, monitor);
+					result.setTypeRoot(this.typeRoot);
+					return result;
 				} finally {
 					// unitResolver should already handle this.
 					// Leaving this finally in place to avoid changing indentation

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ASTParser.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ASTParser.java
@@ -17,6 +17,8 @@ package org.eclipse.jdt.core.dom;
 
 import java.io.PrintWriter;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -963,9 +965,9 @@ public class ASTParser {
 				if ((this.bits & CompilationUnitResolver.BINDING_RECOVERY) != 0) {
 					flags |= ICompilationUnit.ENABLE_BINDINGS_RECOVERY;
 				}
-				this.unitResolver.resolve(compilationUnits, bindingKeys, requestor, this.apiLevel, this.compilerOptions, this.project, this.workingCopyOwner, flags, monitor);
+				this.unitResolver.resolve(Arrays.copyOf(compilationUnits, compilationUnits.length), Arrays.copyOf(bindingKeys, bindingKeys.length), requestor, this.apiLevel, Collections.unmodifiableMap(this.compilerOptions), this.project, this.workingCopyOwner, flags, monitor);
 			} else {
-				this.unitResolver.parse(compilationUnits, requestor, this.apiLevel, this.compilerOptions, flags, monitor);
+				this.unitResolver.parse(Arrays.copyOf(compilationUnits, compilationUnits.length), requestor, this.apiLevel, Collections.unmodifiableMap(this.compilerOptions), flags, monitor);
 			}
 		} finally {
 			// reset to defaults to allow reuse (and avoid leaking)
@@ -1058,9 +1060,9 @@ public class ASTParser {
 				if ((this.bits & CompilationUnitResolver.BINDING_RECOVERY) != 0) {
 					flags |= ICompilationUnit.ENABLE_BINDINGS_RECOVERY;
 				}
-				this.unitResolver.resolve(sourceFilePaths, encodings, bindingKeys, requestor, this.apiLevel, this.compilerOptions, getClasspath(), flags, monitor);
+				this.unitResolver.resolve(Arrays.copyOf(sourceFilePaths, sourceFilePaths.length), Arrays.copyOf(encodings, encodings.length), Arrays.copyOf(bindingKeys, bindingKeys.length), requestor, this.apiLevel, Collections.unmodifiableMap(this.compilerOptions), getClasspath(), flags, monitor);
 			} else {
-				this.unitResolver.parse(sourceFilePaths, encodings, requestor, this.apiLevel, this.compilerOptions, flags, monitor);
+				this.unitResolver.parse(Arrays.copyOf(sourceFilePaths, sourceFilePaths.length), Arrays.copyOf(encodings, encodings.length), requestor, this.apiLevel, Collections.unmodifiableMap(this.compilerOptions), flags, monitor);
 			}
 		} finally {
 			// reset to defaults to allow reuse (and avoid leaking)
@@ -1250,7 +1252,7 @@ public class ASTParser {
 						}
 					}
 
-					CompilationUnit result2 = this.unitResolver.toCompilationUnit(sourceUnit, needToResolveBindings, this.project, getClasspath(), useSearcher ? this.focalPointPosition : -1, this.apiLevel, this.compilerOptions, this.workingCopyOwner, wcOwner, flags, monitor);
+					CompilationUnit result2 = this.unitResolver.toCompilationUnit(sourceUnit, needToResolveBindings, this.project, getClasspath(), useSearcher ? this.focalPointPosition : -1, this.apiLevel, Collections.unmodifiableMap(this.compilerOptions), this.workingCopyOwner, wcOwner, flags, monitor);
 					result2.setTypeRoot(this.typeRoot);
 					return result2;
 				} finally {

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ASTParser.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ASTParser.java
@@ -965,15 +965,23 @@ public class ASTParser {
 				if ((this.bits & CompilationUnitResolver.BINDING_RECOVERY) != 0) {
 					flags |= ICompilationUnit.ENABLE_BINDINGS_RECOVERY;
 				}
-				this.unitResolver.resolve(Arrays.copyOf(compilationUnits, compilationUnits.length), Arrays.copyOf(bindingKeys, bindingKeys.length), requestor, this.apiLevel, Collections.unmodifiableMap(this.compilerOptions), this.project, this.workingCopyOwner, flags, monitor);
+				this.unitResolver.resolve(safeCopyOf(compilationUnits), safeCopyOf(bindingKeys), requestor, this.apiLevel, safeUnmodifiableMap(this.compilerOptions), this.project, this.workingCopyOwner, flags, monitor);
 			} else {
-				this.unitResolver.parse(Arrays.copyOf(compilationUnits, compilationUnits.length), requestor, this.apiLevel, Collections.unmodifiableMap(this.compilerOptions), flags, monitor);
+				this.unitResolver.parse(safeCopyOf(compilationUnits), requestor, this.apiLevel, safeUnmodifiableMap(this.compilerOptions), flags, monitor);
 			}
 		} finally {
 			// reset to defaults to allow reuse (and avoid leaking)
 			initializeDefaults();
 		}
 	}
+    @SuppressWarnings("unchecked")
+    private static <T> T[] safeCopyOf(T[] original) {
+        return original == null ? null : Arrays.copyOf(original, original.length);
+    }
+
+    private static <K,V> Map<K,V> safeUnmodifiableMap(Map<? extends K, ? extends V> m) {
+    	return m == null ? null : Collections.unmodifiableMap(m);
+    }
 
 	/**
 	 * Creates ASTs for a batch of compilation units.
@@ -1060,9 +1068,9 @@ public class ASTParser {
 				if ((this.bits & CompilationUnitResolver.BINDING_RECOVERY) != 0) {
 					flags |= ICompilationUnit.ENABLE_BINDINGS_RECOVERY;
 				}
-				this.unitResolver.resolve(Arrays.copyOf(sourceFilePaths, sourceFilePaths.length), Arrays.copyOf(encodings, encodings.length), Arrays.copyOf(bindingKeys, bindingKeys.length), requestor, this.apiLevel, Collections.unmodifiableMap(this.compilerOptions), getClasspath(), flags, monitor);
+				this.unitResolver.resolve(safeCopyOf(sourceFilePaths), safeCopyOf(encodings), safeCopyOf(bindingKeys), requestor, this.apiLevel, safeUnmodifiableMap(this.compilerOptions), getClasspath(), flags, monitor);
 			} else {
-				this.unitResolver.parse(Arrays.copyOf(sourceFilePaths, sourceFilePaths.length), Arrays.copyOf(encodings, encodings.length), requestor, this.apiLevel, Collections.unmodifiableMap(this.compilerOptions), flags, monitor);
+				this.unitResolver.parse(safeCopyOf(sourceFilePaths), safeCopyOf(encodings), requestor, this.apiLevel, safeUnmodifiableMap(this.compilerOptions), flags, monitor);
 			}
 		} finally {
 			// reset to defaults to allow reuse (and avoid leaking)
@@ -1252,7 +1260,7 @@ public class ASTParser {
 						}
 					}
 
-					CompilationUnit result2 = this.unitResolver.toCompilationUnit(sourceUnit, needToResolveBindings, this.project, getClasspath(), useSearcher ? this.focalPointPosition : -1, this.apiLevel, Collections.unmodifiableMap(this.compilerOptions), this.workingCopyOwner, wcOwner, flags, monitor);
+					CompilationUnit result2 = this.unitResolver.toCompilationUnit(sourceUnit, needToResolveBindings, this.project, getClasspath(), useSearcher ? this.focalPointPosition : -1, this.apiLevel, safeUnmodifiableMap(this.compilerOptions), this.workingCopyOwner, wcOwner, flags, monitor);
 					result2.setTypeRoot(this.typeRoot);
 					return result2;
 				} finally {

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/CompilationUnitResolver.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/CompilationUnitResolver.java
@@ -76,6 +76,7 @@ import org.eclipse.jdt.internal.core.LocalVariable;
 import org.eclipse.jdt.internal.core.NameLookup;
 import org.eclipse.jdt.internal.core.SourceRefElement;
 import org.eclipse.jdt.internal.core.SourceTypeElementInfo;
+import org.eclipse.jdt.internal.core.dom.ICompilationUnitResolver;
 import org.eclipse.jdt.internal.core.util.BindingKeyResolver;
 import org.eclipse.jdt.internal.core.util.CommentRecorderParser;
 import org.eclipse.jdt.internal.core.util.DOMFinder;

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/CompilationUnitResolver.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/CompilationUnitResolver.java
@@ -82,6 +82,45 @@ import org.eclipse.jdt.internal.core.util.DOMFinder;
 
 @SuppressWarnings({ "rawtypes", "unchecked" })
 class CompilationUnitResolver extends Compiler {
+
+	private static final class ECJCompilationUnitResolver implements ICompilationUnitResolver {
+
+		@Override
+		public void resolve(String[] sourceFilePaths, String[] encodings, String[] bindingKeys,
+				FileASTRequestor requestor, int apiLevel, Map<String, String> compilerOptions, List<Classpath> classpath,
+				int flags, IProgressMonitor monitor) {
+			CompilationUnitResolver.resolve(sourceFilePaths, encodings, bindingKeys, requestor, apiLevel, compilerOptions, classpath, flags, monitor);
+		}
+
+		@Override
+		public void parse(ICompilationUnit[] compilationUnits, ASTRequestor requestor, int apiLevel,
+				Map<String, String> compilerOptions, int flags, IProgressMonitor monitor) {
+			CompilationUnitResolver.parse(compilationUnits, requestor, apiLevel, compilerOptions, flags, monitor);
+		}
+
+		@Override
+		public void parse(String[] sourceFilePaths, String[] encodings, FileASTRequestor requestor, int apiLevel,
+				Map<String, String> compilerOptions, int flags, IProgressMonitor monitor) {
+			CompilationUnitResolver.parse(sourceFilePaths, encodings, requestor, apiLevel, compilerOptions, flags, monitor);
+		}
+
+		@Override
+		public void resolve(ICompilationUnit[] compilationUnits, String[] bindingKeys, ASTRequestor requestor,
+				int apiLevel, Map<String, String> compilerOptions, IJavaProject project,
+				WorkingCopyOwner workingCopyOwner, int flags, IProgressMonitor monitor) {
+			CompilationUnitResolver.resolve(compilationUnits, bindingKeys, requestor, apiLevel, compilerOptions, project, workingCopyOwner, flags, monitor);
+		}
+
+		@Override
+		public CompilationUnit toCompilationUnit(org.eclipse.jdt.internal.compiler.env.ICompilationUnit sourceUnit, final boolean initialNeedsToResolveBinding, IJavaProject project, List<Classpath> classpaths, int focalPosition,
+			int apiLevel, Map<String, String> compilerOptions, WorkingCopyOwner parsedUnitWorkingCopyOwner, WorkingCopyOwner typeRootWorkingCopyOwner, int flags, IProgressMonitor monitor) {
+			return CompilationUnitResolver.toCompilationUnit(sourceUnit, initialNeedsToResolveBinding, project,
+					classpaths, focalPosition == -1 ? null : new NodeSearcher(focalPosition), apiLevel, compilerOptions, parsedUnitWorkingCopyOwner, typeRootWorkingCopyOwner, flags, monitor);
+		}
+	}
+
+	public static final ECJCompilationUnitResolver FACADE = new ECJCompilationUnitResolver();
+
 	public static final int RESOLVE_BINDING = 0x1;
 	public static final int PARTIAL = 0x2;
 	public static final int STATEMENT_RECOVERY = 0x4;
@@ -1406,6 +1445,62 @@ class CompilationUnitResolver extends Compiler {
 			verifyMethods,
 			analyzeCode,
 			generateCode);
+	}
+
+	public static CompilationUnit toCompilationUnit(org.eclipse.jdt.internal.compiler.env.ICompilationUnit sourceUnit, final boolean initialNeedsToResolveBinding, IJavaProject project, List<Classpath> classpaths, NodeSearcher nodeSearcher,
+			int apiLevel, Map<String, String> compilerOptions, WorkingCopyOwner parsedUnitWorkingCopyOwner, WorkingCopyOwner typeRootWorkingCopyOwner, int flags, IProgressMonitor monitor) {
+		// this -> astParser, pass as args
+		CompilationUnitDeclaration compilationUnitDeclaration = null;
+		boolean needsToResolveBindingsState = initialNeedsToResolveBinding;
+		try {
+			if (initialNeedsToResolveBinding) {
+				try {
+					// parse and resolve
+					compilationUnitDeclaration =
+						CompilationUnitResolver.resolve(
+							sourceUnit,
+							project,
+							classpaths,
+							nodeSearcher,
+							compilerOptions,
+							parsedUnitWorkingCopyOwner,
+							flags,
+							monitor);
+				} catch (JavaModelException e) {
+					flags &= ~ICompilationUnit.ENABLE_BINDINGS_RECOVERY;
+					compilationUnitDeclaration = CompilationUnitResolver.parse(
+							sourceUnit,
+							nodeSearcher,
+							compilerOptions,
+							flags);
+					needsToResolveBindingsState = false;
+				}
+			} else {
+				compilationUnitDeclaration = CompilationUnitResolver.parse(
+						sourceUnit,
+						nodeSearcher,
+						compilerOptions,
+						flags,
+						project);
+				needsToResolveBindingsState = false;
+			}
+			return CompilationUnitResolver.convert(
+				compilationUnitDeclaration,
+				sourceUnit.getContents(),
+				apiLevel,
+				compilerOptions,
+				needsToResolveBindingsState,
+				typeRootWorkingCopyOwner,
+				needsToResolveBindingsState ? new DefaultBindingResolver.BindingTables() : null,
+				flags,
+				monitor,
+				project != null,
+				project);
+		} finally {
+			if (compilationUnitDeclaration != null && initialNeedsToResolveBinding) {
+				compilationUnitDeclaration.cleanUp();
+			}
+		}
 	}
 
 	private void worked(int work) {

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/CompilationUnitResolver.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/CompilationUnitResolver.java
@@ -122,7 +122,7 @@ class CompilationUnitResolver extends Compiler {
 
 	private static ECJCompilationUnitResolver FACADE;
 	public static synchronized ICompilationUnitResolver getInstance() {
-		if( FACADE == null ) {
+		if (FACADE == null) {
 			FACADE = new ECJCompilationUnitResolver();
 		}
 		return FACADE;

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/CompilationUnitResolver.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/CompilationUnitResolver.java
@@ -120,7 +120,14 @@ class CompilationUnitResolver extends Compiler {
 		}
 	}
 
-	public static final ECJCompilationUnitResolver FACADE = new ECJCompilationUnitResolver();
+	private static ECJCompilationUnitResolver FACADE;
+	public static synchronized ICompilationUnitResolver getInstance() {
+		if( FACADE == null ) {
+			FACADE = new ECJCompilationUnitResolver();
+		}
+		return FACADE;
+	}
+
 
 	public static final int RESOLVE_BINDING = 0x1;
 	public static final int PARTIAL = 0x2;

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/CompilationUnitResolverDiscovery.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/CompilationUnitResolverDiscovery.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package org.eclipse.jdt.core.dom;
 
+import java.util.Objects;
+
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IExtension;
@@ -24,36 +26,57 @@ class CompilationUnitResolverDiscovery {
 	private static final String COMPILATION_UNIT_RESOLVER_EXTPOINT_ID = "compilationUnitResolver" ; //$NON-NLS-1$
 	private static boolean ERROR_LOGGED = false;
 
+	private static String lastId;
+	private static IConfigurationElement lastExtension;
 
 	static ICompilationUnitResolver getInstance() {
-		String compilationUnitResolverId = System.getProperty(SELECTED_SYSPROP);
+		String id = System.getProperty(SELECTED_SYSPROP);
+		IConfigurationElement configElement = getConfigurationElement(id);
+		lastId = id;
+		lastExtension = configElement;
+		if (configElement != null) {
+			try {
+				// We do prefer creating a new instance on each call, as it can allow the extension
+				// to store some state more easily than by using a singleton.
+				Object executableExtension = configElement.createExecutableExtension("class"); //$NON-NLS-1$
+				if (executableExtension instanceof ICompilationUnitResolver icur) {
+					return icur;
+				}
+			} catch (CoreException e) {
+				if (!setErrorLogged()) {
+					ILog.get().error("Could not instantiate ICompilationUnitResolver: '" + id + "' with class: " + configElement.getAttribute("class"), e); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+				}
+			}
+		}
+		return CompilationUnitResolver.getInstance();
+	}
+
+	/**
+	 *
+	 * @param id
+	 * @return The extension element with the given id or <code>null</null> if not found
+	 */
+	private static IConfigurationElement getConfigurationElement(String id) {
+		if (id == null || id.isBlank()) {
+			return null;
+		}
+		if (lastExtension != null && Objects.equals(id, lastId)) {
+			return lastExtension;
+		}
 		IExtensionPoint extension = Platform.getExtensionRegistry().getExtensionPoint(JavaCore.PLUGIN_ID, COMPILATION_UNIT_RESOLVER_EXTPOINT_ID);
-		if (extension != null && compilationUnitResolverId != null && !compilationUnitResolverId.isEmpty()) {
+		if (extension != null) {
 			IExtension[] extensions = extension.getExtensions();
 			for (IExtension ext : extensions) {
 				IConfigurationElement[] configElements = ext.getConfigurationElements();
 				for (final IConfigurationElement configElement : configElements) {
 					String elementId = configElement.getAttribute("id"); //$NON-NLS-1$
-					if (compilationUnitResolverId.equals(elementId)) {
-						String elementName =configElement.getName();
-						if (!("resolver".equals(elementName))) { //$NON-NLS-1$
-							continue;
-						}
-						try {
-							Object executableExtension = configElement.createExecutableExtension("class"); //$NON-NLS-1$
-							if (executableExtension instanceof ICompilationUnitResolver icur) {
-								return icur;
-							}
-						} catch (CoreException e) {
-							if (!setErrorLogged()) {
-								ILog.get().error("Could not instantiate ICompilationUnitResolver: '" + elementId + "' with class: " + configElement.getAttribute("class"), e); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-							}
-						}
+					if (id.equals(elementId) && "resolver".equals(configElement.getName())) { //$NON-NLS-1$
+						return configElement;
 					}
 				}
 			}
 		}
-		return CompilationUnitResolver.getInstance();
+		return null;
 	}
 
 	/**

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/CompilationUnitResolverDiscovery.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/CompilationUnitResolverDiscovery.java
@@ -45,16 +45,26 @@ class CompilationUnitResolverDiscovery {
 								return icur;
 							}
 						} catch (CoreException e) {
-							if( !ERROR_LOGGED) {
+							if( !setErrorLogged()) {
 								ILog.get().error("Could not instantiate ICompilationUnitResolver: '" + elementId + "' with class: " + configElement.getAttribute("class"), e); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-								ERROR_LOGGED = true;
 							}
 						}
 					}
 				}
 			}
 		}
-		return CompilationUnitResolver.FACADE;
+		return CompilationUnitResolver.getInstance();
 	}
 
+	/*
+	 * Set the ERROR_LOGGED field to true.
+	 * Return the previous value of ERROR_LOGGED.
+	 */
+	private static synchronized boolean setErrorLogged() {
+		boolean prev = ERROR_LOGGED;
+		if( !ERROR_LOGGED) {
+			ERROR_LOGGED = true;
+		}
+		return prev;
+	}
 }

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/CompilationUnitResolverDiscovery.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/CompilationUnitResolverDiscovery.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jdt.core.dom;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.IExtension;
+import org.eclipse.core.runtime.IExtensionPoint;
+import org.eclipse.core.runtime.ILog;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.jdt.core.JavaCore;
+
+class CompilationUnitResolverDiscovery {
+	private static final String COMPILATION_UNIT_RESOLVER_EXTPOINT_ID = "compilationUnitResolver" ; //$NON-NLS-1$
+	private static boolean ERROR_LOGGED = false;
+
+
+	static ICompilationUnitResolver getInstance() {
+		String compilationUnitResolverId = System.getProperty(ICompilationUnitResolver.class.getSimpleName());
+		IExtensionPoint extension = Platform.getExtensionRegistry().getExtensionPoint(JavaCore.PLUGIN_ID, COMPILATION_UNIT_RESOLVER_EXTPOINT_ID);
+		if (extension != null && compilationUnitResolverId != null && !compilationUnitResolverId.isEmpty()) {
+			IExtension[] extensions = extension.getExtensions();
+			for (IExtension ext : extensions) {
+				IConfigurationElement[] configElements = ext.getConfigurationElements();
+				for (final IConfigurationElement configElement : configElements) {
+					String elementId = configElement.getAttribute("id"); //$NON-NLS-1$
+					if( compilationUnitResolverId.equals(elementId)) {
+						String elementName =configElement.getName();
+						if (!("resolver".equals(elementName))) { //$NON-NLS-1$
+							continue;
+						}
+						try {
+							Object executableExtension = configElement.createExecutableExtension("class"); //$NON-NLS-1$
+							if( executableExtension instanceof ICompilationUnitResolver icur) {
+								return icur;
+							}
+						} catch (CoreException e) {
+							if( !ERROR_LOGGED) {
+								ILog.get().error("Could not instantiate ICompilationUnitResolver: '" + elementId + "' with class: " + configElement.getAttribute("class"), e); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+								ERROR_LOGGED = true;
+							}
+						}
+					}
+				}
+			}
+		}
+		return CompilationUnitResolver.FACADE;
+	}
+
+}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/CompilationUnitResolverDiscovery.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/CompilationUnitResolverDiscovery.java
@@ -34,18 +34,18 @@ class CompilationUnitResolverDiscovery {
 				IConfigurationElement[] configElements = ext.getConfigurationElements();
 				for (final IConfigurationElement configElement : configElements) {
 					String elementId = configElement.getAttribute("id"); //$NON-NLS-1$
-					if( compilationUnitResolverId.equals(elementId)) {
+					if (compilationUnitResolverId.equals(elementId)) {
 						String elementName =configElement.getName();
 						if (!("resolver".equals(elementName))) { //$NON-NLS-1$
 							continue;
 						}
 						try {
 							Object executableExtension = configElement.createExecutableExtension("class"); //$NON-NLS-1$
-							if( executableExtension instanceof ICompilationUnitResolver icur) {
+							if (executableExtension instanceof ICompilationUnitResolver icur) {
 								return icur;
 							}
 						} catch (CoreException e) {
-							if( !setErrorLogged()) {
+							if (!setErrorLogged()) {
 								ILog.get().error("Could not instantiate ICompilationUnitResolver: '" + elementId + "' with class: " + configElement.getAttribute("class"), e); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 							}
 						}
@@ -56,15 +56,13 @@ class CompilationUnitResolverDiscovery {
 		return CompilationUnitResolver.getInstance();
 	}
 
-	/*
-	 * Set the ERROR_LOGGED field to true.
-	 * Return the previous value of ERROR_LOGGED.
+	/**
+	 * Set the ERROR_LOGGED field to <code>true</code>.
+	 * @return the previous value of ERROR_LOGGED.
 	 */
 	private static synchronized boolean setErrorLogged() {
 		boolean prev = ERROR_LOGGED;
-		if( !ERROR_LOGGED) {
-			ERROR_LOGGED = true;
-		}
+		ERROR_LOGGED = true;
 		return prev;
 	}
 }

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/CompilationUnitResolverDiscovery.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/CompilationUnitResolverDiscovery.java
@@ -17,14 +17,16 @@ import org.eclipse.core.runtime.IExtensionPoint;
 import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.internal.core.dom.ICompilationUnitResolver;
 
 class CompilationUnitResolverDiscovery {
+	private static final String SELECTED_SYSPROP = "ICompilationUnitResolver"; //$NON-NLS-1$
 	private static final String COMPILATION_UNIT_RESOLVER_EXTPOINT_ID = "compilationUnitResolver" ; //$NON-NLS-1$
 	private static boolean ERROR_LOGGED = false;
 
 
 	static ICompilationUnitResolver getInstance() {
-		String compilationUnitResolverId = System.getProperty(ICompilationUnitResolver.class.getSimpleName());
+		String compilationUnitResolverId = System.getProperty(SELECTED_SYSPROP);
 		IExtensionPoint extension = Platform.getExtensionRegistry().getExtensionPoint(JavaCore.PLUGIN_ID, COMPILATION_UNIT_RESOLVER_EXTPOINT_ID);
 		if (extension != null && compilationUnitResolverId != null && !compilationUnitResolverId.isEmpty()) {
 			IExtension[] extensions = extension.getExtensions();

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ICompilationUnitResolver.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ICompilationUnitResolver.java
@@ -1,0 +1,108 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jdt.core.dom;
+
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.WorkingCopyOwner;
+import org.eclipse.jdt.internal.compiler.batch.FileSystem.Classpath;
+
+/**
+ * This interface is used to resolve a jdt dom tree from source files.
+ * It is contributed via the compilationUnitResolver extension point.
+ *
+ * @since 3.38
+ */
+interface ICompilationUnitResolver {
+	/**
+	 * Resolve the given source paths with the following options.
+	 *
+	 * @param sourceFilePaths the compilation units to create ASTs for
+	 * @param encodings the given encoding for the source units
+	 * @param bindingKeys the binding keys to create bindings for
+	 * @param requestor the AST requestor that collects abstract syntax trees and bindings
+	 * @param apiLevel Level of AST API desired.
+	 * @param compilerOptions Compiler options. Defaults to JavaCore.getOptions().
+	 * @param classpathList A list of classpaths to use during this operation
+	 * @param flags Flags to to be used during this operation
+	 * @param monitor A progress monitor
+	 */
+	void resolve(String[] sourceFilePaths, String[] encodings, String[] bindingKeys, FileASTRequestor requestor,
+			int apiLevel, Map<String, String> compilerOptions, List<Classpath> classpathList, int flags,
+			IProgressMonitor monitor);
+
+	/**
+	 * Parse the given source paths with the following options.
+	 *
+	 * @param compilationUnits the compilation units to create ASTs for
+	 * @param requestor the AST requestor that collects abstract syntax trees and bindings
+	 * @param apiLevel Level of AST API desired.
+	 * @param compilerOptions Compiler options. Defaults to JavaCore.getOptions().
+	 * @param flags Flags to to be used during this operation
+	 * @param monitor A progress monitor
+	 */
+	void parse(ICompilationUnit[] compilationUnits, ASTRequestor requestor, int apiLevel,
+			Map<String, String> compilerOptions, int flags, IProgressMonitor monitor);
+
+	/**
+	 *
+	 * @param sourceFilePaths the compilation units to create ASTs for
+	 * @param encodings the given encoding for the source units
+	 * @param requestor the AST requester that collects abstract syntax trees and bindings
+	 * @param apiLevel Level of AST API desired.
+	 * @param compilerOptions Compiler options. Defaults to JavaCore.getOptions().
+	 * @param flags Flags to to be used during this operation
+	 * @param monitor A progress monitor
+	 */
+	void parse(String[] sourceFilePaths, String[] encodings, FileASTRequestor requestor, int apiLevel,
+			Map<String, String> compilerOptions, int flags, IProgressMonitor monitor);
+
+	/**
+	 *
+	 * @param compilationUnits the compilation units to create ASTs for
+	 * @param bindingKeys the binding keys to create bindings for
+	 * @param requestor the AST requester that collects abstract syntax trees and bindings
+	 * @param apiLevel Level of AST API desired.
+	 * @param compilerOptions Compiler options. Defaults to JavaCore.getOptions().
+	 * @param project The project providing the context of the resolution
+	 * @param workingCopyOwner  The owner of the working copy
+	 * @param flags Flags to to be used during this operation
+	 * @param monitor A progress monitor
+	 */
+	void resolve(ICompilationUnit[] compilationUnits, String[] bindingKeys, ASTRequestor requestor, int apiLevel,
+			Map<String, String> compilerOptions, IJavaProject project, WorkingCopyOwner workingCopyOwner, int flags,
+			IProgressMonitor monitor);
+
+
+
+	/**
+	 * Convert the given source unit into a CompilationUnit using the following options.
+	 *
+	 * @param sourceUnit A source unit
+	 * @param initialNeedsToResolveBinding Initial guess as to whether we need to resolve bindings
+	 * @param project The project providing the context of the conversion
+	 * @param classpaths A list of classpaths to use during this operation
+	 * @param focalPosition a position to focus on, or -1 if N/A
+	 * @param apiLevel Level of AST API desired.
+	 * @param compilerOptions Compiler options. Defaults to JavaCore.getOptions().
+	 * @param parsedUnitWorkingCopyOwner The working copy owner of the unit
+	 * @param typeRootWorkingCopyOwner The working copy owner of the type
+	 * @param flags Flags to to be used during this operation
+	 * @param monitor A progress monitor
+	 * @return A CompilationUnit
+	 */
+	CompilationUnit toCompilationUnit(org.eclipse.jdt.internal.compiler.env.ICompilationUnit sourceUnit, final boolean initialNeedsToResolveBinding, IJavaProject project, List<Classpath> classpaths, int focalPosition,
+			int apiLevel, Map<String, String> compilerOptions, WorkingCopyOwner parsedUnitWorkingCopyOwner, WorkingCopyOwner typeRootWorkingCopyOwner, int flags, IProgressMonitor monitor);
+}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/ICompilationUnitResolver.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/ICompilationUnitResolver.java
@@ -8,7 +8,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *******************************************************************************/
-package org.eclipse.jdt.core.dom;
+package org.eclipse.jdt.internal.core.dom;
 
 import java.util.List;
 import java.util.Map;
@@ -17,15 +17,20 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.WorkingCopyOwner;
+import org.eclipse.jdt.core.dom.ASTRequestor;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.FileASTRequestor;
 import org.eclipse.jdt.internal.compiler.batch.FileSystem.Classpath;
 
 /**
  * This interface is used to resolve a jdt dom tree from source files.
- * It is contributed via the compilationUnitResolver extension point.
+ * It is contributed to via the compilationUnitResolver extension point.
+ * This interface is currently internal only, and is not considered API.
+ * This interface may be modified, changed, or removed at any time.
  *
  * @since 3.38
  */
-interface ICompilationUnitResolver {
+public interface ICompilationUnitResolver {
 	/**
 	 * Resolve the given source paths with the following options.
 	 *

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/ICompilationUnitResolver.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/ICompilationUnitResolver.java
@@ -35,6 +35,9 @@ import org.eclipse.jdt.internal.compiler.batch.FileSystem.Classpath;
 * consulting with the Red Hat team.
 * </p>
 *
+* See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2641 for discussion on possible
+* changes to this interface
+*
 * @since 3.38
  */
 public interface ICompilationUnitResolver {

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/ICompilationUnitResolver.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/ICompilationUnitResolver.java
@@ -42,7 +42,7 @@ import org.eclipse.jdt.internal.compiler.batch.FileSystem.Classpath;
  */
 public interface ICompilationUnitResolver {
 	/**
-	 * Resolve the given source paths with the following options.
+	 * Parse the ASTs and resolve the bindings for the given source files using the following options.
 	 *
 	 * @param sourceFilePaths the compilation units to create ASTs for
 	 * @param encodings the given encoding for the source units
@@ -59,7 +59,7 @@ public interface ICompilationUnitResolver {
 			IProgressMonitor monitor);
 
 	/**
-	 * Parse the given source paths with the following options.
+	 * Parse the ASTs for the given source units using the following options.
 	 *
 	 * @param compilationUnits the compilation units to create ASTs for
 	 * @param requestor the AST requestor that collects abstract syntax trees and bindings
@@ -72,6 +72,7 @@ public interface ICompilationUnitResolver {
 			Map<String, String> compilerOptions, int flags, IProgressMonitor monitor);
 
 	/**
+	 * Parse the given source paths with the following options.
 	 *
 	 * @param sourceFilePaths the compilation units to create ASTs for
 	 * @param encodings the given encoding for the source units
@@ -85,6 +86,7 @@ public interface ICompilationUnitResolver {
 			Map<String, String> compilerOptions, int flags, IProgressMonitor monitor);
 
 	/**
+	 * Parse and resolve bindings for the given compilation units with the following options.
 	 *
 	 * @param compilationUnits the compilation units to create ASTs for
 	 * @param bindingKeys the binding keys to create bindings for

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/ICompilationUnitResolver.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/ICompilationUnitResolver.java
@@ -37,9 +37,7 @@ import org.eclipse.jdt.internal.compiler.batch.FileSystem.Classpath;
 *
 * See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2641 for discussion on possible
 * changes to this interface
-*
-* @since 3.38
- */
+*/
 public interface ICompilationUnitResolver {
 	/**
 	 * Parse the ASTs and resolve the bindings for the given source files using the following options.

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/ICompilationUnitResolver.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/ICompilationUnitResolver.java
@@ -28,7 +28,14 @@ import org.eclipse.jdt.internal.compiler.batch.FileSystem.Classpath;
  * This interface is currently internal only, and is not considered API.
  * This interface may be modified, changed, or removed at any time.
  *
- * @since 3.38
+* <p>
+* <strong>EXPERIMENTAL</strong>. This class or interface has been added as
+* part of a work in progress. There is no guarantee that this API will
+* work or that it will remain the same. Please do not use this API without
+* consulting with the Red Hat team.
+* </p>
+*
+* @since 3.38
  */
 public interface ICompilationUnitResolver {
 	/**

--- a/org.eclipse.jdt.core/plugin.properties
+++ b/org.eclipse.jdt.core/plugin.properties
@@ -23,6 +23,7 @@ classpathVariableInitializersName=Classpath Variable Initializers
 classpathContainerInitializersName=Classpath Container Initializers
 codeFormattersName=Source Code Formatters
 compilationParticipantsName=Compilation Participants
+compilationUnitResolverName=Compilation Unit Resolver
 annotationProcessorManagerName=Java 6 Annotation Processor Manager
 javaTaskName=Java Task
 javaPropertiesName=Java Properties File

--- a/org.eclipse.jdt.core/plugin.xml
+++ b/org.eclipse.jdt.core/plugin.xml
@@ -64,6 +64,14 @@
 	schema="schema/compilationParticipant.exsd"/>
 
 <!-- =================================================================================== -->
+<!-- Extension Point: Compilation Unit Resolver                                            -->
+<!-- =================================================================================== -->
+
+<extension-point name="%compilationUnitResolverName" 
+	id="compilationUnitResolver"
+	schema="schema/compilationUnitResolver.exsd"/>
+
+<!-- =================================================================================== -->
 <!-- Extension Point: Java 6 Annotation Processor Manager                                -->
 <!-- =================================================================================== -->
 

--- a/org.eclipse.jdt.core/schema/compilationUnitResolver.exsd
+++ b/org.eclipse.jdt.core/schema/compilationUnitResolver.exsd
@@ -1,0 +1,121 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Schema file written by PDE -->
+<schema targetNamespace="org.eclipse.jdt.core" xmlns="http://www.w3.org/2001/XMLSchema">
+<annotation>
+      <appInfo>
+         <meta.schema plugin="org.eclipse.jdt.core" id="compilationUnitResolver" name="Compilation Unit Resolver"/>
+      </appInfo>
+      <documentation>
+         This extension point provides the ability to override the default behavior of converting source files into the JDT DOM tree. Only one extension will be used, and only when the system property `ICompilationUnitResolver` is set to the id of that extension. This extension point is not intended to be implemented by clients.
+      </documentation>
+   </annotation>
+
+   <element name="extension">
+      <annotation>
+         <appInfo>
+            <meta.element />
+         </appInfo>
+      </annotation>
+      <complexType>
+         <sequence>
+            <element ref="resolver" minOccurs="0" maxOccurs="1"/>
+         </sequence>
+         <attribute name="point" type="string" use="required">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="id" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string">
+            <annotation>
+               <documentation>
+                  
+               </documentation>
+               <appInfo>
+                  <meta.attribute translatable="true"/>
+               </appInfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="resolver">
+      <annotation>
+         <documentation>
+            Definition of a compilation unit resolver.
+         </documentation>
+      </annotation>
+      <complexType>
+         <attribute name="class" type="string" use="required">
+            <annotation>
+               <documentation>
+                  The class that implements this compilation unit resolver. This class must implement the  &lt;code&gt;org.eclipse.jdt.core.dom.ICompilationUnitResolver&lt;/code&gt; interface with a public 0-arg constructor.
+               </documentation>
+               <appInfo>
+                  <meta.attribute kind="java" basedOn=":org.eclipse.jdt.core.dom.ICompilationUnitResolver"/>
+               </appInfo>
+            </annotation>
+         </attribute>
+         <attribute name="id" type="string" use="required">
+            <annotation>
+               <documentation>
+                  A unique identifier for this resolver.
+               </documentation>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="since"/>
+      </appInfo>
+      <documentation>
+         3.38
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="examples"/>
+      </appInfo>
+      <documentation>
+         Example of a declaration of a &lt;code&gt;compilationUnitResolver&lt;/code&gt;:  &lt;pre&gt;                                                                       
+&lt;extension
+      point=&quot;org.eclipse.jdt.core.compilationParticipant&quot;&gt;
+   &lt;resolver
+         class=&quot;org.eclipse.jdt.core.CompilationUnitResolver1&quot;
+         id=&quot;org.eclipse.jdt.core.MyCustomResolver&quot;&gt;
+   &lt;/resolver&gt;
+&lt;/extension&gt;
+&lt;/pre&gt;
+      </documentation>
+   </annotation>
+
+
+
+   <annotation>
+      <appInfo>
+         <meta.section type="copyright"/>
+      </appInfo>
+      <documentation>
+         Copyright (c) 2024 Red Hat, Inc. and others.&lt;br&gt;
+
+This program and the accompanying materials
+are made available under the terms of the Eclipse Public License 2.0
+which accompanies this distribution, and is available at 
+&lt;a href=&quot;https://www.eclipse.org/legal/epl-2.0&quot;&gt;https://www.eclipse.org/legal/epl-v20.html&lt;/a&gt;/
+
+SPDX-License-Identifier: EPL-2.0
+      </documentation>
+   </annotation>
+
+</schema>

--- a/org.eclipse.jdt.core/schema/compilationUnitResolver.exsd
+++ b/org.eclipse.jdt.core/schema/compilationUnitResolver.exsd
@@ -6,7 +6,7 @@
          <meta.schema plugin="org.eclipse.jdt.core" id="compilationUnitResolver" name="Compilation Unit Resolver"/>
       </appInfo>
       <documentation>
-         This extension point provides the ability to override the default behavior of converting source files into the JDT DOM tree. Only one extension will be used, and only when the system property `ICompilationUnitResolver` is set to the id of that extension. This extension point is not intended to be implemented by clients.
+         This extension point provides the ability to override the default behavior of converting source files into the JDT DOM tree. The resolver will be instantiated on-demand based on the value of the system property `ICompilationUnitResolver`, which must be set to the id of an implementing extension. This extension point is not intended to be implemented by clients. This extension point is not considered API. This extension point may be modified or removed at any moment. 
       </documentation>
    </annotation>
 

--- a/org.eclipse.jdt.core/schema/compilationUnitResolver.exsd
+++ b/org.eclipse.jdt.core/schema/compilationUnitResolver.exsd
@@ -57,7 +57,7 @@
          <attribute name="class" type="string" use="required">
             <annotation>
                <documentation>
-                  The class that implements this compilation unit resolver. This class must implement the  &lt;code&gt;org.eclipse.jdt.core.dom.ICompilationUnitResolver&lt;/code&gt; interface with a public 0-arg constructor.
+                  The class that implements this compilation unit resolver. This class must implement the  &lt;code&gt;org.eclipse.jdt.internal.core.dom.ICompilationUnitResolver&lt;/code&gt; interface with a public 0-arg constructor.
                </documentation>
                <appInfo>
                   <meta.attribute kind="java" basedOn=":org.eclipse.jdt.core.dom.ICompilationUnitResolver"/>


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

This extension point would allow third party products to override the conversion between java source files and the JDT dom tree with a custom implementation. In order to prevent rogue extenders from simply breaking people's installations, a system property selecting the preferred ICompilationUnitResolver must be set, as well. 

As consumers of JDT become more diverse and also have been operating in environments not previously expected, being able to properly define the borders and interactions between and among the various parts of JDT becomes important. As resources to maintain various parts of the codebase become scarce, allowing the community to experiment with potentially more efficient solutions also becomes important. 

Ensuring that the community can contribute to a common codebase for the vast majority of the shared work is critical to providing that community  the cohesion, common goals, and shared visions that maintains a project. And allowing different elements of the community the freedom, via extension points or otherwise, to investigate alternatives to parts of the current codebase will serve to keep the project growing long term. 

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Other than exposing an extension point, this change does not significantly change any behavior. To test, one could attempt to make a plugin using this extension point and verifying that the various interface methods are called in a runtime workbench. I am not familiar with how the jdt.core project prefers to automatically test extension points, especially ones that require a sysprop to also be set. 

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
