### PR TITLE
Provide ability to track dependencies during batch compilation (#2529)

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/Main.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/Main.java
@@ -27,8 +27,10 @@
  *								Bug 408815 - [batch][null] Add CLI option for COMPILER_PB_SYNTACTIC_NULL_ANALYSIS_FOR_FIELDS
  *     Jesper S Moller   - Contributions for
  *								bug 407297 - [1.8][compiler] Control generation of parameter names by option
- *    Mat Booth - Contribution for bug 405176
- *    Frits Jalvingh - fix for bug 533830.
+ *     Mat Booth - Contribution for bug 405176
+ *     Frits Jalvingh - fix for bug 533830.
+ *     Salesforce - Contribution for
+ *								https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2529
  *******************************************************************************/
 package org.eclipse.jdt.internal.compiler.batch;
 
@@ -3889,7 +3891,7 @@ protected void handleWarningToken(String token, boolean isEnabling) {
 protected void handleErrorToken(String token, boolean isEnabling) {
 	handleErrorOrWarningToken(token, isEnabling, ProblemSeverities.Error);
 }
-private void setSeverity(String compilerOptions, int severity, boolean isEnabling) {
+protected void setSeverity(String compilerOptions, int severity, boolean isEnabling) {
 	if (isEnabling) {
 		switch(severity) {
 			case ProblemSeverities.Error :

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NameEnvironmentAnswerListenerTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NameEnvironmentAnswerListenerTest.java
@@ -1,0 +1,175 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Salesforce and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Salesforce - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.core.tests.compiler.regression;
+
+import static java.util.stream.Collectors.joining;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.tests.util.Util;
+import org.eclipse.jdt.internal.compiler.batch.FileSystem;
+import org.eclipse.jdt.internal.compiler.batch.Main;
+import org.eclipse.jdt.internal.compiler.env.NameEnvironmentAnswer;
+import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
+import org.eclipse.jdt.internal.compiler.problem.ProblemSeverities;
+import org.junit.Assert;
+
+public class NameEnvironmentAnswerListenerTest extends AbstractComparableTest {
+
+	public NameEnvironmentAnswerListenerTest(String name) {
+		super(name);
+	}
+
+	/**
+	 * Extension of ECJ Batch compiler to allow pre-configuration as well as registration of listener.
+	 * <p>
+	 * This is modeled after real-world use in Bazel ECJ Toolchain.
+	 * </p>
+	 * @see <a href="https://github.com/salesforce/bazel-jdt-java-toolchain/blob/04c27501b9623300ff38f500cd53af8ce0a11835/compiler/src/main/buildjar/com/google/devtools/build/buildjar/javac/BlazeEcjMain.java#L98">BlazeEcjMain.java</a>
+	 */
+	static class EclipseBatchCompiler extends Main {
+
+		Set<String> answeredFileNames = new LinkedHashSet<>();
+
+		public EclipseBatchCompiler(PrintWriter errAndOutWriter) {
+			super(errAndOutWriter, errAndOutWriter, false /* systemExitWhenFinished */, null /* customDefaultOptions */,
+					null /* compilationProgress */);
+
+			setSeverity(CompilerOptions.OPTION_ReportForbiddenReference, ProblemSeverities.Error, true);
+			setSeverity(CompilerOptions.OPTION_ReportDiscouragedReference, ProblemSeverities.Error, true);
+		}
+
+		@Override
+		public FileSystem getLibraryAccess() {
+			// we use this to collect information about all used dependencies during
+			// compilation
+			FileSystem nameEnvironment = super.getLibraryAccess();
+			nameEnvironment.setNameEnvironmentAnswerListener(this::recordNameEnvironmentAnswer);
+			return nameEnvironment;
+		}
+
+		protected void recordNameEnvironmentAnswer(NameEnvironmentAnswer answer) {
+			Assert.assertNotNull("don't call without answer", answer);
+
+			char[] fileName = null;
+			if(answer.getBinaryType() != null) {
+				URI uri = answer.getBinaryType().getURI();
+				this.answeredFileNames.add(uri.toString());
+				return;
+			} else if(answer.getCompilationUnit() != null) {
+				fileName = answer.getCompilationUnit().getFileName();
+			} else if(answer.getSourceTypes() != null && answer.getSourceTypes().length > 0) {
+				fileName = answer.getSourceTypes()[0].getFileName(); // the first type is guaranteed to be the requested type
+			} else if(answer.getResolvedBinding() != null) {
+				fileName = answer.getResolvedBinding().getFileName();
+			}
+			if (fileName != null) this.answeredFileNames.add(new String(fileName));
+		}
+	}
+
+	public void testNameEnvironmentAnswerListener() throws IOException {
+		String path = LIB_DIR;
+		if(!path.endsWith(File.separator)) {
+			path += File.separator;
+		}
+		String libPath = path + "lib.jar";
+		Util.createJar(
+				new String[] {
+						"p/Color.java",
+						"package p;\n" +
+						"public enum Color {\n" +
+						"	R, Y;\n" +
+						"	public static Color getColor() {\n" +
+						"		return R;\n" +
+						"	}\n" +
+						"}",
+					},
+				libPath, JavaCore.VERSION_17);
+
+		String unusedLibPath = path + "lib_unused.jar";
+		Util.createJar(
+				new String[] {
+						"p2/Color.java",
+						"package p2;\n" +
+						"public enum Color {\n" +
+						"	R, Y;\n" +
+						"	public static Color getColor() {\n" +
+						"		return R;\n" +
+						"	}\n" +
+						"}",
+					},
+				unusedLibPath, JavaCore.VERSION_17);
+
+		String srcDir =  path + "src";
+		String[] pathsAndContents =
+				new String[] {
+					"s/X.java",
+					"package s;\n" +
+					"import p.Color;\n" +
+					"public class X {\n" +
+					"	public static final Color MY = Color.R;\n" +
+					"}"
+				};
+		Util.createSourceDir(pathsAndContents, srcDir);
+
+		List<String> classpath = new ArrayList<>(Arrays.asList(getDefaultClassPaths()));
+		classpath.add(libPath);
+		classpath.add(unusedLibPath);
+
+		File outputDirectory = new File(Util.getOutputDirectory());
+		if (!outputDirectory.isDirectory()) {
+			outputDirectory.mkdirs();
+		}
+
+		List<String> ecjArguments = new ArrayList<>();
+
+		ecjArguments.add("-classpath");
+		ecjArguments.add(classpath.stream()
+				.map(jar -> jar.equals(unusedLibPath) ? String.format("%s[-**/*]", jar) : jar)
+				.collect(joining(File.pathSeparator)));
+
+
+		ecjArguments.add("-d");
+		ecjArguments.add(outputDirectory.getAbsolutePath());
+
+		ecjArguments.add("--release");
+		ecjArguments.add("17");
+
+		ecjArguments.add(srcDir+ File.separator + "s"+ File.separator + "X.java");
+
+		EclipseBatchCompiler compiler;
+		File logFile = new File(outputDirectory, "compile.log");
+		try(PrintWriter log = new PrintWriter(new FileOutputStream(logFile))) {
+			compiler = new EclipseBatchCompiler(log);
+			boolean compileOK;
+			compileOK = compiler.compile(ecjArguments.toArray(new String[ecjArguments.size()]));
+			if(!compileOK) {
+				String logOutputString = Util.fileContent(logFile.getAbsolutePath());
+				Assert.fail("Compile failed, output: '" + logOutputString + "'");
+			}
+		}
+		Assert.assertTrue("must reference p.Color", compiler.answeredFileNames.stream().anyMatch(s -> s.contains(libPath)));
+		Assert.assertFalse("must not reference p2.Color", compiler.answeredFileNames.stream().anyMatch(s -> s.contains(unusedLibPath)));
+	}
+}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TestAll.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TestAll.java
@@ -94,6 +94,7 @@ public static Test suite() {
 	standardTests.add(InitializationTests.class);
 	standardTests.add(ResourceLeakTests.class);
 	standardTests.add(PackageBindingTest.class);
+	standardTests.add(NameEnvironmentAnswerListenerTest.class);
 
 	// add all javadoc tests
 	for (int i=0, l=JavadocTest.ALL_CLASSES.size(); i<l; i++) {


### PR DESCRIPTION
Added callback to track FileSystem.findType() results during compilation. The callback (if set by clients) will see all types requested by the compiler during compilation, so it will be able to track used/unused compilation dependencies (important for example for bazel Java toolchain).

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2529

PS
This is what https://github.com/eclipse-jdt/eclipse.jdt.core/pull/2530 was supposed to be but due the troubles with the original PR branch setup we were unable to complete PR with proper set of changes.