### PR TITLE
re-introduced ClassFileReader.read(InputStream, String)

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/ClassFileReader.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/ClassFileReader.java
@@ -118,6 +118,16 @@ public static ClassFileReader read(File file, boolean fullyInitialize) throws Cl
 	return classFileReader;
 }
 
+/**
+ * <strong>PROVISIONAL</strong>: This has been re-introduced not to break Xtext (see
+ * <a href="https://github.com/eclipse/xtext/issues/3089">https://github.com/eclipse/xtext/issues/3089</a>).
+ *
+ * @author Lorenzo Bettini
+ */
+public static ClassFileReader read(InputStream stream, String fileName) throws ClassFormatException, IOException {
+	return read(Util.getInputStreamAsByteArray(stream), fileName);
+}
+
 public static ClassFileReader read(byte[] classFileBytes, String fileName) throws ClassFormatException, IOException {
 	return read(classFileBytes, fileName, false);
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TestAll.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TestAll.java
@@ -95,6 +95,7 @@ public static Test suite() {
 	standardTests.add(ResourceLeakTests.class);
 	standardTests.add(PackageBindingTest.class);
 	standardTests.add(NameEnvironmentAnswerListenerTest.class);
+	standardTests.add(XtextDependencies.class);
 
 	// add all javadoc tests
 	for (int i=0, l=JavadocTest.ALL_CLASSES.size(); i<l; i++) {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/XtextDependencies.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/XtextDependencies.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Lorenzo Bettini and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Lorenzo Bettini - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.core.tests.compiler.regression;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader;
+import org.eclipse.jdt.internal.compiler.classfmt.ClassFormatException;
+
+/**
+ * Only to keep track of internal API used by Xtext.
+ */
+public class XtextDependencies {
+
+	public ClassFileReader ClassFileReader_read_InputStream() throws ClassFormatException, IOException {
+		return ClassFileReader.read((InputStream) null, (String) null);
+	}
+}


### PR DESCRIPTION
To avoid breaking Xtext.

The signature was changed in
https://github.com/eclipse-jdt/eclipse.jdt.core/pull/2555

## What it does
This re-introduced `org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader.read(InputStream, String)`, which was changed into `org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader.read(byte[], String)` in https://github.com/eclipse-jdt/eclipse.jdt.core/pull/2555, breaking Xtext (https://github.com/eclipse/xtext/issues/3089).