### PR TITLE
Ensure switch exhaustiveness with enum and 'case null' works OK

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchPatternTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchPatternTest.java
@@ -8051,4 +8051,48 @@ public class SwitchPatternTest extends AbstractRegressionTest9 {
 				"Start\n"
 				+ "Stop");
 	}
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2582
+	// Switch exhaustiveness error with enum and 'case null'
+	public void testIssue2582() {
+		runConformTest(
+				new String[] {
+					"X.java",
+					"""
+					enum Foo {
+					        FOO, BAR;
+					    }
+
+					public class X {
+					    public void dispatch(final Foo foo) {
+					        switch (foo)  {
+					            // forces JEP-441 exhaustiveness
+					            case null -> throw new NullPointerException("null foo");
+					            case FOO -> foo();
+					            case BAR -> bar();
+					        }
+					    }
+
+					    private void foo() {
+					    	System.out.println("Foo");
+					    }
+
+					    private void bar() {
+					    	System.out.println("Bar");
+					    }
+					    public static void main(String[] args) {
+					    	new X().dispatch(Foo.FOO);
+					    	new X().dispatch(Foo.BAR);
+					    	try {
+					    	new X().dispatch(null);
+					    	} catch (NullPointerException npe) {
+					    		System.out.println("Null");
+					    	}
+						}
+					}
+
+					"""
+				},
+				"Foo\nBar\n"
+				+ "Null");
+	}
 }


### PR DESCRIPTION


## What it does

* Regression test for https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2582

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
