### PR TITLE
[Sealed types][selection] Can't navigate in files in 2nd level child

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/Java21ElementTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/Java21ElementTests.java
@@ -14,6 +14,7 @@
 package org.eclipse.jdt.core.tests.model;
 
 import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.tests.util.AbstractCompilerTest;
@@ -365,6 +366,27 @@ public class Java21ElementTests extends AbstractJavaModelTests {
 
 		ICompilationUnit unit = getCompilationUnit("/Java21Elements/src/Test.java");
 		assertFalse(unit.getTypes()[0].getMethods()[0].isMainMethodCandidate());
+	}
+
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2574
+	// [Sealed types][selection] Can't navigate in files in 2nd level child
+	public void testIssue2574() throws Exception {
+
+		this.project.open(null);
+
+		createFile("/Java21Elements/src/Top.java", "public sealed interface Top permits Middle {}\n");
+		createFile("/Java21Elements/src/Middle.java", "public sealed interface Middle extends Top permits Down {}\n");
+		createFile("/Java21Elements/src/Down.java", "public record Down(String foo) implements Middle {}\n");
+		createFile("/Java21Elements/src/String.java", "public class String {}\n");
+
+		ICompilationUnit unit = getCompilationUnit("/Java21Elements/src/Down.java");
+		int start = unit.getWorkingCopy(null).getSource().lastIndexOf("String");
+		IJavaElement[] elements = unit.codeSelect(start, 6);
+		assertElementsEqual(
+				"Unexpected elements",
+				"String [in String.java [in <default> [in src [in Java21Elements]]]]",
+				elements
+			);
 	}
 
 }


### PR DESCRIPTION

## What it does

* Regression test for https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2574

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
