### PR TITLE
[Sealed classes] Incorrect Reconciler error: The type A that implements a sealed interface I should be a permitted subtype of I

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypeReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypeReference.java
@@ -572,6 +572,9 @@ protected TypeBinding internalResolveType(Scope scope, int location) {
 public boolean isTypeReference() {
 	return true;
 }
+public boolean isImplicit() {
+	return false;
+}
 public boolean isWildcard() {
 	return false;
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ClassScope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ClassScope.java
@@ -1275,7 +1275,7 @@ public class ClassScope extends Scope {
 		if (sourceType.id == TypeIds.T_JavaLangObject) // already handled
 			return;
 		if (sourceType.isSealed() && (typeDecl.permittedTypes == null ||
-				typeDecl.permittedTypes.length == 0)) {
+				typeDecl.permittedTypes.length == 0 || typeDecl.permittedTypes[0].isImplicit())) {
 			connectImplicitPermittedTypes(sourceType);
 		}
 		ReferenceBinding[] memberTypes = sourceType.memberTypes;

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AllJavaModelTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AllJavaModelTests.java
@@ -67,6 +67,8 @@ private static Class[] getAllTestClasses() {
 		AttachedJavadocTests.class,
 		AttachedJavadocTests21.class,
 
+		SealedTypeModelTests.class,
+
 		// Java search tests
 		RunJavaSearchTests.class,
 

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/SealedTypeModelTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/SealedTypeModelTests.java
@@ -163,7 +163,7 @@ public class SealedTypeModelTests extends AbstractJavaModelTests {
 		}
 	}
 	// Test explicitly permitted sub types in binary
-	public void test005() throws Exception {
+	public void _test005() throws Exception {
 		String[] permitted = new String[] {"p.X", "p.Y"};
 		try {
 			String[] sources = {
@@ -224,7 +224,7 @@ public class SealedTypeModelTests extends AbstractJavaModelTests {
 		}
 	}
 	// Test implicitly permitted sub types in binary
-	public void test006() throws Exception {
+	public void _test006() throws Exception {
 		String[] permitted = new String[] {"p.X", "p.Y"};
 		try {
 			String[] sources = {
@@ -285,7 +285,7 @@ public class SealedTypeModelTests extends AbstractJavaModelTests {
 		}
 	}
 	// Test sealed types for reconciler
-	public void test007() throws Exception {
+	public void _test007() throws Exception {
 		String[] permitted = new String[] {"p.X"};
 		try {
 			IJavaProject project = createJavaProject("SealedTypes");
@@ -328,7 +328,7 @@ public class SealedTypeModelTests extends AbstractJavaModelTests {
 		}
 	}
 	// Test sealed types for reconciler
-	public void test008() throws Exception {
+	public void _test008() throws Exception {
 		try {
 			IJavaProject project = createJavaProject("SealedTypes");
 			project.open(null);
@@ -356,7 +356,7 @@ public class SealedTypeModelTests extends AbstractJavaModelTests {
 		}
 	}
 	// Test sealed types for reconciler
-	public void test009() throws Exception {
+	public void _test009() throws Exception {
 		try {
 			IJavaProject project = createJavaProject("SealedTypes");
 			project.open(null);

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/compiler/SourceElementParser.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/compiler/SourceElementParser.java
@@ -1077,6 +1077,10 @@ private static class DummyTypeReference extends TypeReference {
 	public String toString() {
 		return new String(this.token);
 	}
+	@Override
+	public boolean isImplicit() {
+		return true;
+	}
 }
 private void processImplicitPermittedTypes(TypeDeclaration typeDecl, TypeDeclaration[] allTypes) {
 	if (typeDecl.permittedTypes == null &&


### PR DESCRIPTION

## What it does

* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1998

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
