### PR TITLE
Add new API for supported/unsupported Java versions

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/impl/CompilerOptions.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/impl/CompilerOptions.java
@@ -35,6 +35,7 @@ import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.internal.compiler.Compiler;
@@ -258,6 +259,25 @@ public class CompilerOptions {
 	 * Note: Whenever a new version is added, make sure getLatestVersion()
 	 * is updated with it.
 	 */
+
+	/**
+	 * Unsupported JLS versions
+	 */
+	/*
+	 * Note: Whenever a new version is obsoleted, make sure getFirstVersion() is updated.
+	 */
+	public static Set<String> UNSUPPORTED_VERSIONS = Set.of(
+			VERSION_1_1,
+			VERSION_1_2,
+			VERSION_1_3,
+			VERSION_1_4,
+			VERSION_JSR14,
+			VERSION_CLDC1_1,
+			VERSION_1_5,
+			VERSION_1_6,
+			VERSION_1_7
+			);
+
 	public static final String ERROR = "error"; //$NON-NLS-1$
 	public static final String WARNING = "warning"; //$NON-NLS-1$
 	public static final String INFO = "info"; //$NON-NLS-1$
@@ -647,6 +667,18 @@ public class CompilerOptions {
 		this.parseLiteralExpressionsAsConstants = parseLiteralExpressionsAsConstants;
 	}
 
+	/**
+	 * Return the first (oldest) Java language version supported by the Eclipse compiler
+	 */
+	public static String getFirstSupportedJavaVersion() {
+		return VERSION_1_8;
+	}
+	/**
+	 * Return the first (oldest) Java language level supported by the Eclipse compiler
+	 */
+	public static long getFirstSupportedJdkLevel() {
+		return ClassFileConstants.JDK1_8;
+	}
 	/**
 	 * Return the latest Java language version supported by the Eclipse compiler
 	 */

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/core/JavaCore.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/core/JavaCore.java
@@ -3322,9 +3322,27 @@ public final class JavaCore extends Plugin {
 	 * @category OptionValue
 	 */
 	public static final String VERSION_CLDC_1_1 = "cldc1.1"; //$NON-NLS-1$
-	private static List<String> allVersions = Collections.unmodifiableList(Arrays.asList(VERSION_CLDC_1_1, VERSION_1_1, VERSION_1_2, VERSION_1_3, VERSION_1_4, VERSION_1_5,
+	private static final List<String> allVersions = Collections.unmodifiableList(Arrays.asList(VERSION_CLDC_1_1, VERSION_1_1, VERSION_1_2, VERSION_1_3, VERSION_1_4, VERSION_1_5,
 			VERSION_1_6, VERSION_1_7, VERSION_1_8, VERSION_9, VERSION_10, VERSION_11, VERSION_12, VERSION_13, VERSION_14, VERSION_15, VERSION_16, VERSION_17, VERSION_18,
 			VERSION_19, VERSION_20, VERSION_21, VERSION_22));
+
+	/**
+	 * Unordered set of all Java source versions <b>not supported</b> by compiler anymore.
+	 * The values are from {@link JavaCore}{@code #VERSION_*}.
+	 */
+	private static final Set<String> UNSUPPORTED_VERSIONS = CompilerOptions.UNSUPPORTED_VERSIONS;
+
+	/**
+	 * Ordered set (from oldest to latest) of all Java source versions <b>supported</b> by compiler.
+	 * The values are from {@link JavaCore}{@code #VERSION_*}.
+	 */
+	private static final List<String> SUPPORTED_VERSIONS;
+	static {
+		ArrayList<String> temp = new ArrayList<>();
+		temp.addAll(allVersions);
+		temp.removeAll(UNSUPPORTED_VERSIONS);
+		SUPPORTED_VERSIONS = Collections.unmodifiableList(temp);
+	}
 
 	/**
 	 * Returns all {@link JavaCore}{@code #VERSION_*} levels in the order of their
@@ -3335,6 +3353,22 @@ public final class JavaCore extends Plugin {
 	 */
 	public static List<String> getAllVersions() {
 		return allVersions;
+	}
+
+	/**
+	 * Returns all Java source versions fully supported by Eclipse compiler in the order of their introduction. For
+	 * example, {@link JavaCore#VERSION_1_8} appears before {@link JavaCore#VERSION_10}.
+	 * <p>
+	 * Note, some not included older or newer Java versions might be known by Eclipse compiler internally but not
+	 * exposed via this API because compiler does not support these anymore (or yet).
+	 *
+	 * @return all Java source versions fully supported by Eclipse compiler
+	 * @see #isJavaSourceVersionSupportedByCompiler(String)
+	 * @see #getFirstJavaSourceVersionSupportedByCompiler()
+	 * @since 3.39
+	 */
+	public static List<String> getAllJavaSourceVersionsSupportedByCompiler() {
+		return SUPPORTED_VERSIONS;
 	}
 
 	/**
@@ -3350,6 +3384,22 @@ public final class JavaCore extends Plugin {
 	 */
 	public static boolean isSupportedJavaVersion(String version) {
 		return CompilerOptions.versionToJdkLevel(version, false) > 0;
+	}
+
+	/**
+	 * Not all known Java versions are supported by Eclipse compiler. This method answers if the given Java source
+	 * version is fully supported.
+	 *
+	 * @return {@code true} if the given string represents Java language version is fully supported by Eclipse compiler
+	 * @see #getAllJavaSourceVersionsSupportedByCompiler()
+	 * @see #getFirstJavaSourceVersionSupportedByCompiler()
+	 * @since 3.39
+	 */
+	public static boolean isJavaSourceVersionSupportedByCompiler(String version) {
+		if(version == null || version.isBlank()) {
+			return false;
+		}
+		return SUPPORTED_VERSIONS.contains(version);
 	}
 
 	/**
@@ -6453,6 +6503,20 @@ public final class JavaCore extends Plugin {
 	public static String latestSupportedJavaVersion() {
 		return allVersions.get(allVersions.size() - 1);
 	}
+
+	/**
+	 * First (oldest) Java source version supported by the Eclipse compiler.
+	 * This is the first entry from {@link JavaCore#getAllJavaSourceVersionsSupportedByCompiler()}.
+	 *
+	 * @return first (oldest) Java source version supported by the Eclipse compiler
+	 * @see #getAllJavaSourceVersionsSupportedByCompiler()
+	 * @see #isJavaSourceVersionSupportedByCompiler(String)
+	 * @since 3.39
+	 */
+	public static String getFirstJavaSourceVersionSupportedByCompiler() {
+		return SUPPORTED_VERSIONS.get(0);
+	}
+
 	/**
 	 * Compares two given versions of the Java platform. The versions being compared must both be
 	 * one of the supported values mentioned in


### PR DESCRIPTION
- `List<String> getAllJavaProjectVersions()` - all Java versions that could be used for Java projects inside Eclipse. The difference to existing `getAllVersions()` API is that later one knows almost all Java versions ever released and might be used not only in JDT core but also in debugger/PDE area.
- `boolean isSupportedJavaProjectVersion(String version)` - differs from existing `isSupportedJavaVersion()` in the same way as explained above
- `String getFirstSupportedJavaVersion()` - similar to existing `latestSupportedJavaVersion()` and should return minimal "default" version supported by JDT.

API above will be used in JDT UI, Debug (PR's are following), and (most likely) PDE.

**Internal** API added in batch compiler `CompilerOptions`:
- `getFirstSupportedJavaVersion()`
- `getFirstSupportedJdkLevel()`

Bumped minor version segments on both core and compiler, even if compiler "only" provides internal API, it is more convenient to have them in-sync.

Related UI/Debugger changes that use new API are:

- https://github.com/eclipse-jdt/eclipse.jdt.debug/pull/452
- https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/1469

See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2536