### PR TITLE
Refactor `ASTRequestor` to reduce the access it has to the compiler

### DIFF
--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ASTRequestor.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ASTRequestor.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.jdt.core.dom;
 
+import java.util.function.Function;
+
 import org.eclipse.jdt.core.ICompilationUnit;
 
 /**
@@ -36,12 +38,14 @@ import org.eclipse.jdt.core.ICompilationUnit;
 public abstract class ASTRequestor {
 
 	/**
-	 * The compilation unit resolver used to resolve bindings, or
-	 * <code>null</code> if none. Note that this field is non-null
+	 * The function used to resolve additional bindings,
+	 * or <code>null</code> if none.
+	 * The function accepts the binding key and returns the corresponding <code>IBinding</code>.
+	 * Note that this field is non-null
 	 * only within the dynamic scope of a call to
 	 * <code>ASTParser.createASTs</code>.
 	 */
-	CompilationUnitResolver compilationUnitResolver = null;
+	Function<String, IBinding> additionalBindingResolver = null;
 
 	/**
 	 * Creates a new instance.
@@ -111,8 +115,8 @@ public abstract class ASTRequestor {
 		IBinding[] result = new IBinding[length];
 		for (int i = 0; i < length; i++) {
 			result[i] = null;
-			if (this.compilationUnitResolver != null) {
-				result[i] = this.compilationUnitResolver.createBinding(bindingKeys[i]);
+			if (this.additionalBindingResolver != null) {
+				result[i] = this.additionalBindingResolver.apply(bindingKeys[i]);
 			}
 		}
 		return result;

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/CompilationUnitResolver.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/CompilationUnitResolver.java
@@ -964,7 +964,7 @@ class CompilationUnitResolver extends Compiler {
 			int flags) {
 
 		// temporarily connect ourselves to the ASTResolver - must disconnect when done
-		astRequestor.compilationUnitResolver = this;
+		astRequestor.additionalBindingResolver = this::createBinding;
 		this.bindingTables = new DefaultBindingResolver.BindingTables();
 		CompilationUnitDeclaration unit = null;
 		try {
@@ -1067,7 +1067,7 @@ class CompilationUnitResolver extends Compiler {
 			throw e; // rethrow
 		} finally {
 			// disconnect ourselves from ast requestor
-			astRequestor.compilationUnitResolver = null;
+			astRequestor.additionalBindingResolver = null;
 		}
 	}
 


### PR DESCRIPTION
## What it does
This reduces the access that `ASTRequestor` has to the `CompilationUnitResolver` to just the method it needs, `createBinding`.

This also makes it possible to use an alternate additional binding resolver instead of hardcoding the one implemented by `CompilationUnitResolver`.

## How to test
Run the AST Converter test suite (I'm sure this feature is used elsewhere, but this is the only place that I know uses it for sure).

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
