### PR TITLE
Replace "UTF8" with StandardCharsets.UTF_8

### DIFF
--- a/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/util/FileSystemUtil.java
+++ b/org.eclipse.jdt.apt.core/src/org/eclipse/jdt/apt/core/internal/util/FileSystemUtil.java
@@ -179,7 +179,7 @@ public final class FileSystemUtil
      * The file will be created if it does not already exist.
      */
     public static void writeStringToFile(File file, String contents) throws IOException {
-    	byte[] data = contents.getBytes("UTF8"); //$NON-NLS-1$
+    	byte[] data = contents.getBytes(StandardCharsets.UTF_8);
     	OutputStream out = new BufferedOutputStream(new FileOutputStream(file));
     	try {
     		for (byte b : data) {

--- a/org.eclipse.jdt.core.tests.builder/src/org/eclipse/jdt/core/tests/builder/TestingEnvironment.java
+++ b/org.eclipse.jdt.core.tests.builder/src/org/eclipse/jdt/core/tests/builder/TestingEnvironment.java
@@ -27,6 +27,7 @@ import org.eclipse.jdt.internal.core.JavaModelManager;
 import org.eclipse.jdt.internal.core.JavaProject;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 public class TestingEnvironment {
@@ -89,12 +90,7 @@ public class TestingEnvironment {
 	public IPath addClass(IPath packagePath, String className, String contents) {
 		checkAssertion("a workspace must be open", this.isOpen); //$NON-NLS-1$
 		IPath classPath = packagePath.append(className + ".java"); //$NON-NLS-1$
-		try {
-			createFile(classPath, contents.getBytes("UTF8")); //$NON-NLS-1$
-		} catch (UnsupportedEncodingException e) {
-			e.printStackTrace();
-			checkAssertion("e1", false); //$NON-NLS-1$
-		}
+		createFile(classPath, contents.getBytes(StandardCharsets.UTF_8));
 		return classPath;
 	}
 
@@ -370,12 +366,7 @@ public void addLibrary(IPath projectPath, IPath libraryPath, IPath sourceAttachm
 	public IPath addFile(IPath root, String fileName, String contents){
 		checkAssertion("a workspace must be open", this.isOpen); //$NON-NLS-1$
 		IPath filePath = root.append(fileName);
-		try {
-			createFile(filePath, contents.getBytes("UTF8")); //$NON-NLS-1$
-		} catch (UnsupportedEncodingException e) {
-			e.printStackTrace();
-			checkAssertion("e1", false); //$NON-NLS-1$
-		}
+		createFile(filePath, contents.getBytes(StandardCharsets.UTF_8));
 		return filePath;
 	}
 


### PR DESCRIPTION
Avoids NON-NLS and possible UnsupportedEncodingException
