### PR TITLE
Statements before super feature misssing name and proper validation

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ConstructorDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ConstructorDeclaration.java
@@ -686,13 +686,8 @@ public void resolveStatements() {
 }
 
 private void partitionConstructorStatements() {
-
-
-	if (!(JavaFeature.STATEMENTS_BEFORE_SUPER.isSupported(
-			this.scope.compilerOptions().sourceLevel,
-			this.scope.compilerOptions().enablePreviewFeatures)))
-		return;
-
+	if (this.scope.compilerOptions().sourceLevel < ClassFileConstants.JDK22)
+			return;
 	if (!this.constructorCall.isImplicitSuper()) {
 		this.postPrologueConstructorCall = this.constructorCall;
 		this.postPrologueConstructorCall.firstStatement = true;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/messages.properties
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/messages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2000, 2023 IBM Corporation and others.
+# Copyright (c) 2000, 2024 IBM Corporation and others.
 #
 # This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License 2.0
@@ -77,3 +77,4 @@ record_patterns = Record Pattern
 unnamed_patterns_and_vars = Unnamed Patterns and Variables
 implicit_classes_and_instance_main_methods = Implicitly Declared Classes and Instance Main Methods
 string_templates = String Template
+statements_before_super = Statements Before Super

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericTypeTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericTypeTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -39060,6 +39060,9 @@ public void test1119() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=166963
 public void test1120() {
+	String msg = (this.complianceLevel < ClassFileConstants.JDK22) ?
+						"Constructor call must be the first statement in a constructor\n" :
+							"Statements Before Super is a preview feature and disabled by default. Use --enable-preview to enable\n";
 	this.runNegativeTest(
 		new String[] {
 			"X.java",
@@ -39076,7 +39079,7 @@ public void test1120() {
 		"1. ERROR in X.java (at line 4)\n" +
 		"	this(zork);\n" +
 		"	^^^^^^^^^^^\n" +
-		"Constructor call must be the first statement in a constructor\n" +
+		msg +
 		"----------\n" +
 		"2. ERROR in X.java (at line 4)\n" +
 		"	this(zork);\n" +


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
A proper name is missing for the "statements before super" Java feature. Any error reporting will fail with exception due to missing name. Also, the validation + reporting code was shadowed by a preceding check rendering it useless.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
