### PR TITLE
ReadManager: reuse reader threads #1937

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/Compiler.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/Compiler.java
@@ -824,7 +824,7 @@ public class Compiler implements ITypeRequestor, ProblemSeverities {
 	 */
 	protected void internalBeginToCompile(ICompilationUnit[] sourceUnits, int maxUnits) {
 		abortIfPreviewNotAllowed(sourceUnits,maxUnits);
-		if (!this.useSingleThread && maxUnits >= ReadManager.THRESHOLD)
+		if (!this.useSingleThread)
 			this.parser.readManager = new ReadManager(sourceUnits, maxUnits);
 		try {
 			// Switch the current policy and compilation result for this unit to the requested one.


### PR DESCRIPTION
For easier monitoring.
https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1937

Also refactored the read-ahead-queue with java.util.concurrent, making the source smaller.
