### PR TITLE
Fix ClasspathMultiReleaseJar using the wrong path when finding classes

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/ClasspathMultiReleaseJar.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/ClasspathMultiReleaseJar.java
@@ -130,7 +130,7 @@ public class ClasspathMultiReleaseJar extends ClasspathJar {
 		for (String path : supportedVersions(this.zipFile)) {
 			String s = null;
 			try {
-				s = META_INF_VERSIONS + path + "/" + binaryFileName;  //$NON-NLS-1$
+				s = path + "/" + qualifiedBinaryFileName;  //$NON-NLS-1$
 				ZipEntry entry = this.zipFile.getEntry(s);
 				if (entry == null)
 					continue;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
This is a simple bug fix for https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2682, and just changes the initialization line.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
You'll need a multi-release jar file, which contains classes with different public API compared to an older version. The simplest is likely a class annotated with `@Deprecated(forRemoval = true)` in jdk 11, but just `@Deprecated` in jdk 8.

**I'm still working on creating a simple reproduction test for this**, as it was much simpler to test this in a debugger with an existing local library. *This is why this is just a draft PR.*

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
