### PR TITLE
Avoid read source twice during compile #2691

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,6 @@ pipeline {
 					# via configuration/argLine property in pom.xml
 					# export MAVEN_OPTS="-Xmx2G"
 					
-					mvn clean install -f org.eclipse.jdt.core.compiler.batch -DlocalEcjVersion=99.99 -Dmaven.repo.local=$WORKSPACE/.m2/repository -DcompilerBaselineMode=disable -DcompilerBaselineReplace=none
 					
 					mvn -U clean verify --batch-mode --fail-at-end -Dmaven.repo.local=$WORKSPACE/.m2/repository \
 						-Ptest-on-javase-22 -Pbree-libs -Papi-check -Pjavadoc -Pp2-repo \
@@ -39,7 +38,6 @@ pipeline {
 						-DDetectVMInstallationsJob.disabled=true \
 						-Dtycho.apitools.debug \
 						-Dtycho.debug.artifactcomparator \
-						-Dcbi-ecj-version=99.99
 					"""
 			}
 			post {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/AbstractImageBuilder.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/AbstractImageBuilder.java
@@ -411,6 +411,7 @@ protected void compile(SourceFile[] units, SourceFile[] additionalUnits, boolean
 	this.notifier.checkCancel();
 	try {
 		this.inCompiler = true;
+		this.compiler.parseThreshold = Integer.MAX_VALUE; // fully parse to avoid second read of source
 		this.compiler.compile(units);
 	} catch (AbortCompilation ignored) {
 		// ignore the AbortCompilcation coming from BuildNotifier.checkCancelWithinCompiler()


### PR DESCRIPTION
Use parse() instead of dietParse() to avoid parse during Parser.getMethodBodies()

https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2691
