### PR TITLE
Avoid read source twice during compile #2691

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/Compiler.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/Compiler.java
@@ -844,11 +844,7 @@ public class Compiler implements ITypeRequestor, ProblemSeverities {
 					CompilationUnitDeclaration parsedUnit;
 					unitResult = new CompilationResult(sourceUnits[i], i, maxUnits, this.options.maxProblemsPerUnit);
 					long parseStart = System.currentTimeMillis();
-					if (this.totalUnits < this.parseThreshold) {
-						parsedUnit = this.parser.parse(sourceUnits[i], unitResult);
-					} else {
-						parsedUnit = this.parser.dietParse(sourceUnits[i], unitResult);
-					}
+					parsedUnit = this.parser.parse(sourceUnits[i], unitResult);
 					long resolveStart = System.currentTimeMillis();
 					this.stats.parseTime += resolveStart - parseStart;
 					// initial type binding creation


### PR DESCRIPTION
Use parse() instead of dietParse() to avoid parse during Parser.getMethodBodies()

https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2691
