### PR TITLE
when readManager used in getMethodBodies()?

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
@@ -11691,6 +11691,9 @@ public void getMethodBodies(CompilationUnitDeclaration unit) {
 
 	//real parse of the method....
 	CompilationResult compilationResult = unit.compilationResult;
+	if (this.readManager != null) {
+		throw new IllegalStateException("readManager used in getMethodBodies()"); //$NON-NLS-1$
+	}
 	char[] contents = this.readManager != null
 		? this.readManager.getContents(compilationResult.compilationUnit)
 		: compilationResult.compilationUnit.getContents();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
