### PR TITLE
[Sealed types + switch expression] Internal inconsistency warning at compile time and verify error at runtime

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeVariableBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeVariableBinding.java
@@ -731,6 +731,20 @@ public class TypeVariableBinding extends ReferenceBinding {
 	    return true;
 	}
 
+	@Override
+	public boolean isSealed() {
+		if (this.superclass != null && this.superclass.isSealed())
+			return true;
+
+		if (this.superInterfaces != null && this.superInterfaces != Binding.NO_SUPERINTERFACES) {
+		    for (int i = 0, length = this.superInterfaces.length; i < length; i++) {
+		        if (this.superInterfaces[i].isSealed())
+		        	return true;
+		    }
+		}
+		return false;
+	}
+
 //	/**
 //	 * Returns the original type variable for a given variable.
 //	 * Only different from receiver for type variables of generic methods of parameterized types

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
@@ -1345,7 +1345,6 @@ public void operandStackSizeInappropriate(ASTNode location) {
 		ProblemSeverities.Warning,
 		location.sourceStart,
 		location.sourceEnd);
-	throw new AssertionError("Anomalous/Inconsistent operand stack!"); //$NON-NLS-1$
 }
 public void bytecodeExceeds64KLimit(LambdaExpression location) {
 	bytecodeExceeds64KLimit(location.binding, location.sourceStart, location.diagnosticsSourceEnd());

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchPatternTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchPatternTest.java
@@ -8273,4 +8273,34 @@ public class SwitchPatternTest extends AbstractRegressionTest9 {
 				"----------\n";
 		runner.runNegativeTest();
 	}
+
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2714
+	// [Sealed types + switch expression] Internal inconsistency warning at compile time and verify error at runtime
+	public void testIssue2714() {
+		runConformTest(
+				new String[] {
+						"X.java",
+						"""
+						public interface X {
+
+						  static <T extends AbstractSealedClass> Integer get(T object) {
+						    return switch (object) {
+						      case ClassB ignored -> 42;
+						    };
+						  }
+
+						  public abstract sealed class AbstractSealedClass permits ClassB {
+						  }
+
+						  public final class ClassB extends AbstractSealedClass {
+						  }
+
+						  public static void main(String[] args) {
+						   System.out.println(get(new ClassB()));
+						  }
+						}
+						"""
+				},
+				"42");
+	}
 }


### PR DESCRIPTION

## What it does

* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2714

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
