### PR TITLE
False positive warning "Potential resource leak" inside "try with resources"

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/FakedTrackingVariable.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/FakedTrackingVariable.java
@@ -556,11 +556,15 @@ public class FakedTrackingVariable extends LocalDeclaration {
 		if (binding.isStatic())
 			return false;
 		ReferenceBinding declaringClass = binding.declaringClass;
-		if (declaringClass.equals(binding.returnType)) {
-			for (char[][] compoundName : TypeConstants.FLUENT_RESOURCE_CLASSES) {
-				if (CharOperation.equals(compoundName, declaringClass.compoundName))
-					return true;
+		while (declaringClass != null) {
+			if (declaringClass.equals(binding.returnType)) {
+				for (char[][] compoundName : TypeConstants.FLUENT_RESOURCE_CLASSES) {
+					if (CharOperation.equals(compoundName, declaringClass.compoundName))
+						return true;
+				}
+				return false;
 			}
+			declaringClass = declaringClass.superclass();
 		}
 		return false;
 	}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/BatchCompilerTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/BatchCompilerTest.java
@@ -8357,7 +8357,7 @@ public void test230_sourcepath_vs_classpath() throws IOException, InterruptedExc
 			"}\n",
 		},
 		"\"" + OUTPUT_DIR + File.separator + "src1" + File.separator + "X.java\"" /* commandLine */
-		+ " -verbose -proc:none -d \"" + OUTPUT_DIR + File.separator + "bin1" + "\"",
+		+ " -verbose -warn:-resource -proc:none -d \"" + OUTPUT_DIR + File.separator + "bin1" + "\"",
 		"[parsing    ---OUTPUT_DIR_PLACEHOLDER---/src1/X.java - #1/1]\n" + /* expectedOutOutputString */
 		"[reading    java/lang/Object.class]\n" +
 		"[analyzing  ---OUTPUT_DIR_PLACEHOLDER---/src1/X.java - #1/1]\n" +
@@ -8393,7 +8393,7 @@ public void test230_sourcepath_vs_classpath() throws IOException, InterruptedExc
 		},
 		"\"" + OUTPUT_DIR +  File.separator + "Y.java\""
 		+ " -classpath \"" + OUTPUT_DIR + File.separator + "bin1" + "\""
-		+ " -verbose -proc:none -d \"" + OUTPUT_DIR + "\"",
+		+ " -verbose -warn:-resource -proc:none -d \"" + OUTPUT_DIR + "\"",
 		"[parsing    ---OUTPUT_DIR_PLACEHOLDER---/Y.java - #1/1]\n" +
 		"[reading    java/lang/Object.class]\n" +
 		"[analyzing  ---OUTPUT_DIR_PLACEHOLDER---/Y.java - #1/1]\n" +
@@ -8415,7 +8415,8 @@ public void test230_sourcepath_vs_classpath() throws IOException, InterruptedExc
 	String commonOptions =
 		" -classpath \"" + OUTPUT_DIR + File.separator + "bin1" + "\""
 		+ " -sourcepath \"" + OUTPUT_DIR + File.separator + "src2" + "\""
-		+ " -d \"" + OUTPUT_DIR + File.separator + "bin2" + "\"";
+		+ " -d \"" + OUTPUT_DIR + File.separator + "bin2" + "\""
+		+ " -warn:-resource";
 	String setting= System.getProperty("jdt.compiler.useSingleThread");
 	try {
 		System.setProperty("jdt.compiler.useSingleThread", "true");

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ResourceLeakTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ResourceLeakTests.java
@@ -7269,4 +7269,26 @@ public void testGH2129() {
 		"",
 		options);
 }
+public void testGH2642() {
+	Map options = getCompilerOptions();
+	options.put(CompilerOptions.OPTION_ReportPotentiallyUnclosedCloseable, CompilerOptions.ERROR);
+	options.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
+	options.put(CompilerOptions.OPTION_ReportExplicitlyClosedAutoCloseable, CompilerOptions.ERROR);
+	runLeakTest(
+		new String[] {
+			"DemoNonCloseableWarning.java",
+			"""
+			import java.io.FileWriter;
+			public class DemoNonCloseableWarning {
+			    public static void main(String[] args) throws Exception {
+			        try (FileWriter writer = new FileWriter("/dev/null")) {
+			            writer.append("\\n");
+			        }
+			    }
+			}
+			"""
+		},
+		"",
+		options);
+}
 }


### PR DESCRIPTION
Traverse supers to detect fluent methods

Test:
+ fine tune test230_sourcepath_vs_classpath to avoid superclass loading

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2642

