### PR TITLE
Fix NullPointerException in JavaModel#isJmod because Path#fromOSSString can return null

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModel.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModel.java
@@ -402,7 +402,10 @@ public static boolean isJimage(File file) {
 }
 public static boolean isJmod(File file) {
 	IPath path = Path.fromOSString(file.getPath());
-	return SuffixConstants.EXTENSION_jmod.equalsIgnoreCase(path.getFileExtension());
+	if (path != null && SuffixConstants.EXTENSION_jmod.equalsIgnoreCase(path.getFileExtension())) {
+		return true;
+	}
+	return false;
 }
 
 /**


### PR DESCRIPTION
## What it does
- Checking for null when calling Path#fromOOSString

## How to test
- Problem when the resource is a zip ending with *.iar

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
