### PR TITLE
Bug 466406 - [compile] valid final variable causes eclipse compilation error when set via multiple catch blocks

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TryStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TryStatement.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -204,9 +204,10 @@ public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext, Fl
 			int catchCount;
 			this.catchExits = new boolean[catchCount = this.catchBlocks.length];
 			this.catchExitInitStateIndexes = new int[catchCount];
+			FlowInfo incoming = tryInfo.copy();
 			for (int i = 0; i < catchCount; i++) {
 				// keep track of the inits that could potentially have led to this exception handler (for final assignments diagnosis)
-				FlowInfo catchInfo = prepareCatchInfo(flowInfo, handlingContext, tryInfo, i);
+				FlowInfo catchInfo = prepareCatchInfo(flowInfo, handlingContext, incoming, i);
 				flowContext.conditionalLevel++;
 				catchInfo =
 					this.catchBlocks[i].analyseCode(
@@ -332,9 +333,10 @@ public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext, Fl
 			int catchCount;
 			this.catchExits = new boolean[catchCount = this.catchBlocks.length];
 			this.catchExitInitStateIndexes = new int[catchCount];
+			FlowInfo incoming = tryInfo.copy();
 			for (int i = 0; i < catchCount; i++) {
 				// keep track of the inits that could potentially have led to this exception handler (for final assignments diagnosis)
-				FlowInfo catchInfo = prepareCatchInfo(flowInfo, handlingContext, tryInfo, i);
+				FlowInfo catchInfo = prepareCatchInfo(flowInfo, handlingContext, incoming, i);
 				insideSubContext.conditionalLevel = 1;
 				catchInfo =
 					this.catchBlocks[i].analyseCode(

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TryStatementTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TryStatementTest.java
@@ -6264,6 +6264,65 @@ public void testBug387612c() {
 		false/*shouldFlush*/);
 }
 
+public void testGH2726() {
+	Runner runner = new Runner();
+	runner.testFiles = new String[] {
+			"ExceptionTest.java",
+			"""
+			public class ExceptionTest {
+
+				public void doStuff() throws Exception {
+				}
+
+				public void test() {
+					final Exception ex;
+					try {
+						doStuff();
+						return;
+					} catch (NullPointerException e) {
+						ex = e;
+					} catch (Exception e) {
+						// compile error here, only in the IDE
+						ex = e;
+					}
+					ex.printStackTrace();
+				 }
+			}
+			"""
+		};
+	runner.runConformTest();
+}
+public void testGH2726b() {
+	Runner runner = new Runner();
+	runner.testFiles = new String[] {
+			"ExceptionTest.java",
+			"""
+			public class ExceptionTest {
+
+				public void doStuff() throws Exception {
+				}
+
+				public void test() {
+					final Exception ex;
+					try {
+						doStuff();
+						return;
+					} catch (NullPointerException e) {
+						ex = e;
+					} catch (Exception e) {
+						// compile error here, only in the IDE
+						ex = e;
+					} finally {
+						System.out.print(1); // non-empty finally block causes other code branch to be used
+					}
+					ex.printStackTrace();
+				 }
+			}
+			"""
+		};
+	runner.runConformTest();
+}
+
 public static Class testClass() {
 	return TryStatementTest.class;
 }


### PR DESCRIPTION
avoid spilling flow info from one catch block to the next via accumulated updates in `tryInfo`.

fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2726

