### PR TITLE
Prevent excessive creation of intermediate SplitPackageBinding instances

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/LookupEnvironment.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/LookupEnvironment.java
@@ -795,7 +795,7 @@ private PackageBinding computePackageFrom(char[][] constantPoolName, boolean isM
 			if (this.useModuleSystem) {
 				if (this.module.isUnnamed()) {
 					char[][] currentCompoundName = CharOperation.arrayConcat(parent.compoundName, constantPoolName[i]);
-					char[][] declaringModules = ((IModuleAwareNameEnvironment) this.nameEnvironment).getModulesDeclaringPackage(
+					char[][] declaringModules = ((IModuleAwareNameEnvironment) this.nameEnvironment).getUniqueModulesDeclaringPackage(
 							currentCompoundName, ModuleBinding.ANY);
 					List<PackageBinding> bindings = new ArrayList<>();
 					if (declaringModules != null) {
@@ -2403,7 +2403,7 @@ public Binding getInaccessibleBinding(char[][] compoundName, ModuleBinding clien
 		int length = compoundName.length;
 		for (int j=length; j>0; j--) {
 			char[][] candidateName = CharOperation.subarray(compoundName, 0, j);
-			char[][] moduleNames = moduleEnv.getModulesDeclaringPackage(candidateName, ModuleBinding.ANY);
+			char[][] moduleNames = moduleEnv.getUniqueModulesDeclaringPackage(candidateName, ModuleBinding.ANY);
 			if (moduleNames != null) {
 				// in some module a package named candidateName exists, verify observability & inaccessibility:
 				PackageBinding inaccessiblePackage = null;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/LookupEnvironment.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/LookupEnvironment.java
@@ -769,11 +769,14 @@ private PackageBinding computePackageFrom(char[][] constantPoolName, boolean isM
 			if (this.module.isUnnamed()) {
 				char[][] declaringModules = ((IModuleAwareNameEnvironment) this.nameEnvironment).getUniqueModulesDeclaringPackage(new char[][] {constantPoolName[0]}, ModuleBinding.ANY);
 				if (declaringModules != null) {
+					List<PackageBinding> bindings = new ArrayList<>();
 					for (char[] mod : declaringModules) {
 						ModuleBinding declaringModule = this.root.getModule(mod);
 						if (declaringModule != null)
-							packageBinding = SplitPackageBinding.combine(declaringModule.getTopLevelPackage(constantPoolName[0]), packageBinding, this.module);
+							bindings.add(declaringModule.getTopLevelPackage(constantPoolName[0]));
 					}
+					if (!bindings.isEmpty())
+						packageBinding = SplitPackageBinding.combineAll(bindings, this.module);
 				}
 			} else {
 				packageBinding = this.module.getTopLevelPackage(constantPoolName[0]);
@@ -794,12 +797,15 @@ private PackageBinding computePackageFrom(char[][] constantPoolName, boolean isM
 					char[][] currentCompoundName = CharOperation.arrayConcat(parent.compoundName, constantPoolName[i]);
 					char[][] declaringModules = ((IModuleAwareNameEnvironment) this.nameEnvironment).getModulesDeclaringPackage(
 							currentCompoundName, ModuleBinding.ANY);
+					List<PackageBinding> bindings = new ArrayList<>();
 					if (declaringModules != null) {
 						for (char[] mod : declaringModules) {
 							ModuleBinding declaringModule = this.root.getModule(mod);
 							if (declaringModule != null)
-								packageBinding = SplitPackageBinding.combine(declaringModule.getVisiblePackage(currentCompoundName), packageBinding, this.module);
+								bindings.add(declaringModule.getVisiblePackage(currentCompoundName));
 						}
+						if (!bindings.isEmpty())
+							packageBinding = SplitPackageBinding.combineAll(bindings, this.module);
 					}
 				} else {
 					packageBinding = this.module.getVisiblePackage(parent, constantPoolName[i]);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ModuleBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ModuleBinding.java
@@ -14,6 +14,7 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.compiler.lookup;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -595,13 +596,17 @@ public class ModuleBinding extends Binding implements IUpdatableModule {
 						}
 					} else {
 						// visible but foreign (when current is unnamed or auto):
+						List<PackageBinding> bindings = new ArrayList<>();
 						for (char[] declaringModuleName : declaringModuleNames) {
 							ModuleBinding declaringModule = this.environment.root.getModule(declaringModuleName);
 							if (declaringModule != null) {
 								PlainPackageBinding declaredPackage = declaringModule.getDeclaredPackage(fullFlatName);
-								binding = SplitPackageBinding.combine(declaredPackage, binding, this);
+								if (declaredPackage != null)
+									bindings.add(declaredPackage);
 							}
 						}
+						if (!bindings.isEmpty())
+							binding = SplitPackageBinding.combineAll(bindings, this);
 					}
 				}
 			}
@@ -664,11 +669,14 @@ public class ModuleBinding extends Binding implements IUpdatableModule {
 	}
 
 	PackageBinding combineWithPackagesFromOtherRelevantModules(PackageBinding currentBinding, char[][] compoundName, char[][] declaringModuleNames) {
-		for (ModuleBinding moduleBinding : otherRelevantModules(declaringModuleNames)) {
-			PlainPackageBinding nextBinding = moduleBinding.getDeclaredPackage(CharOperation.concatWith(compoundName, '.'));
-			currentBinding = SplitPackageBinding.combine(nextBinding, currentBinding, this);
-		}
-		return currentBinding;
+		char[] packageName = CharOperation.concatWith(compoundName, '.');
+		List<PackageBinding> bindings = otherRelevantModules(declaringModuleNames).stream()
+				.map(m -> m.getDeclaredPackage(packageName))
+				.collect(Collectors.toList());
+		if (bindings.isEmpty())
+			return currentBinding;
+		bindings.add(currentBinding);
+		return SplitPackageBinding.combineAll(bindings, this);
 	}
 
 	List<ModuleBinding> otherRelevantModules(char[][] declaringModuleNames) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/PlainPackageBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/PlainPackageBinding.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 GK Software SE, and others.
+ * Copyright (c) 2019, 2024 GK Software SE, and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -43,5 +43,11 @@ public class PlainPackageBinding extends PackageBinding {
 		if (this.enclosingModule == moduleBinding)
 			return this;
 		return null;
+	}
+
+	@Override
+	PackageBinding addPackage(PackageBinding element, ModuleBinding module) {
+		assert element instanceof PlainPackageBinding : "PlainPackageBinding cannot be parent of split " + element; //$NON-NLS-1$
+		return super.addPackage(element, module);
 	}
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SplitPackageBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SplitPackageBinding.java
@@ -81,6 +81,8 @@ public class SplitPackageBinding extends PackageBinding {
 							split.add(packageBinding);
 					}
 				}
+				if (split.incarnations.size() == 1) // we don't want singleton SplitPackageBinding
+					return split.incarnations.iterator().next(); // simply peel the only incarnation
 				return split;
 			}
 		}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SplitPackageBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SplitPackageBinding.java
@@ -13,15 +13,21 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.compiler.lookup;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
+import java.util.function.Consumer;
 
 import org.eclipse.jdt.core.compiler.CharOperation;
 
 public class SplitPackageBinding extends PackageBinding {
 	Set<ModuleBinding> declaringModules;
 	public Set<PlainPackageBinding> incarnations;
+
+	/** TEST ONLY */
+	public static Consumer<SplitPackageBinding> instanceListener;
 
 	/**
 	 * Combine two potential package bindings, answering either the better of those if the other has a problem,
@@ -51,6 +57,39 @@ public class SplitPackageBinding extends PackageBinding {
 		split.add(binding);
 		return split;
 	}
+	public static PackageBinding combineAll(List<PackageBinding> bindings, ModuleBinding primaryModule) {
+		// collect statistics per rank:
+		int[] numRanked = new int[RANK_VALID+1];
+		for (PackageBinding packageBinding : bindings) {
+			int rank = rank(packageBinding);
+			numRanked[rank]++;
+		}
+		SplitPackageBinding split = null;
+		for (int rank = 3; rank >= 0; rank--) {
+			int num = numRanked[rank];
+			if (num > 0) {
+				// rank is the best we have, so take all bindings at this rank:
+				for (PackageBinding packageBinding : bindings) {
+					if (rank(packageBinding) == rank) {
+						if (num == 1) {
+							return packageBinding;	// singleton doesn't need SplitPackageBinding
+						}
+						if (rank == 0) {
+							return null;			// only null, nothing to combine
+						}
+						// finally collect all relevant:
+						if (split == null)
+							split = new SplitPackageBinding(packageBinding, primaryModule);
+						else
+							split.add(packageBinding);
+					}
+				}
+				return split;
+			}
+		}
+		return null;
+	}
+	private static int RANK_VALID = 3;
 	private static int rank(PackageBinding candidate) {
 		if (candidate == null)
 			return 0;
@@ -58,7 +97,7 @@ public class SplitPackageBinding extends PackageBinding {
 			return 1;
 		if (!candidate.isValidBinding())
 			return 2;
-		return 3;
+		return RANK_VALID;
 	}
 
 	public SplitPackageBinding(PackageBinding initialBinding, ModuleBinding primaryModule) {
@@ -66,6 +105,10 @@ public class SplitPackageBinding extends PackageBinding {
 		this.declaringModules = new LinkedHashSet<>();
 		this.incarnations = new LinkedHashSet<>();
 		add(initialBinding);
+		// TEST hook:
+		if (instanceListener != null) {
+			instanceListener.accept(this);
+		}
 	}
 	public void add(PackageBinding packageBinding) {
 		if (packageBinding instanceof SplitPackageBinding) {
@@ -108,6 +151,7 @@ public class SplitPackageBinding extends PackageBinding {
 		ModuleBinding primaryModule = childPackage.enclosingModule;
 		// see if other incarnations contribute to the child package, too:
 		char[] flatName = CharOperation.concatWith(childPackage.compoundName, '.');
+		List<PackageBinding> bindings = new ArrayList<>();
 		for (PackageBinding incarnation :  this.incarnations) {
 			ModuleBinding moduleBinding = incarnation.enclosingModule;
 			if (moduleBinding == module)
@@ -115,9 +159,13 @@ public class SplitPackageBinding extends PackageBinding {
 			if (childPackage.isDeclaredIn(moduleBinding))
 				continue;
 			PlainPackageBinding next = moduleBinding.getDeclaredPackage(flatName);
-			childPackage = combine(next, childPackage, primaryModule);
+			if (next != null)
+				bindings.add(next);
 		}
-		return childPackage;
+		if (bindings.isEmpty())
+			return childPackage;
+		bindings.add(childPackage);
+		return combineAll(bindings, primaryModule);
 	}
 
 	@Override
@@ -131,13 +179,14 @@ public class SplitPackageBinding extends PackageBinding {
 		if (knownPackage != null)
 			return knownPackage;
 
-		PackageBinding candidate = null;
+		List<PackageBinding> bindings = new ArrayList<>();
 		for (PackageBinding incarnation : this.incarnations) {
 			PackageBinding package0 = incarnation.getPackage0(name);
 			if (package0 == null)
 				return null; // if any incarnation lacks cached info, a full findPackage will be necessary
-			candidate = combine(package0, candidate, this.enclosingModule);
+			bindings.add(package0);
 		}
+		PackageBinding candidate = combineAll(bindings, this.enclosingModule);
 		if (candidate != null)
 			this.knownPackages.put(name, candidate);
 
@@ -150,15 +199,15 @@ public class SplitPackageBinding extends PackageBinding {
 		if (knownPackage != null)
 			return knownPackage;
 
-		PackageBinding candidate = null;
+		List<PackageBinding> bindings = new ArrayList<>();
 		for (PackageBinding incarnation : this.incarnations) {
 			PackageBinding package0 = incarnation.getPackage0(name);
 			if (package0 == null)
 				continue;
-			candidate = combine(package0, candidate, this.enclosingModule);
+			bindings.add(package0);
 		}
 		// don't cache the result, maybe incomplete
-		return candidate;
+		return combineAll(bindings, this.enclosingModule);
 	}
 
 	@Override

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SplitPackageBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SplitPackageBinding.java
@@ -65,17 +65,14 @@ public class SplitPackageBinding extends PackageBinding {
 			numRanked[rank]++;
 		}
 		SplitPackageBinding split = null;
-		for (int rank = 3; rank >= 0; rank--) {
+		for (int rank = RANK_VALID; rank >= 0; rank--) {
 			int num = numRanked[rank];
 			if (num > 0) {
 				// rank is the best we have, so take all bindings at this rank:
 				for (PackageBinding packageBinding : bindings) {
 					if (rank(packageBinding) == rank) {
-						if (num == 1) {
-							return packageBinding;	// singleton doesn't need SplitPackageBinding
-						}
-						if (rank == 0) {
-							return null;			// only null, nothing to combine
+						if (num == 1 || rank != RANK_VALID) {
+							return packageBinding;	// singleton, problem & null don't need SplitPackageBinding
 						}
 						// finally collect all relevant:
 						if (split == null)


### PR DESCRIPTION
* don't call SPB.combine() in a tight loop, but use new combineAll()

fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2646
