### PR TITLE
[23] JEP 467 - Compiler changes for supporting markdown Javadoc comments

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/impl/JavaFeature.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/impl/JavaFeature.java
@@ -114,6 +114,10 @@ public enum JavaFeature {
 			Messages.bind(Messages.module_imports),
 			CharOperation.NO_CHAR_CHAR,
 			true),
+	MARKDOWN_COMMENTS(ClassFileConstants.JDK23,
+			Messages.bind(Messages.markdown_comments),
+			CharOperation.NO_CHAR_CHAR,
+			true),
     ;
 
 	final long compliance;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/AbstractCommentParser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/AbstractCommentParser.java
@@ -8,6 +8,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *******************************************************************************/
@@ -88,6 +92,7 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 	protected int[] lineEnds;
 
 	// Flags
+	protected boolean markdown = false;
 	protected boolean lineStarted = false;
 	protected boolean inlineTagStarted = false;
 	protected boolean inlineReturn= false;
@@ -187,10 +192,13 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 			}
 			int previousPosition = this.index;
 			char nextCharacter = 0;
+			this.markdown = this.source[this.javadocStart + 1] == '/';
 			if (realStart == this.javadocStart) {
-				nextCharacter = readChar(); // second '*'
-				while (peekChar() == '*') {
-					nextCharacter = readChar(); // read all contiguous '*'
+				nextCharacter = readChar(); // second '*' or '/'
+				if (!this.markdown) {
+					while (peekChar() == '*') {
+						nextCharacter = readChar(); // read all contiguous '*'
+					}
 				}
 				this.javadocTextStart = this.index;
 			}
@@ -236,6 +244,11 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 
 				// Consume rules depending on the read character
 				switch (nextCharacter) {
+					case '[':
+						if (this.markdown) {
+							parseMarkdownLinks();
+						}
+						break;
 					case '@' :
 						// Start tag parsing only if we are on line beginning or at inline tag beginning
 						// https://bugs.eclipse.org/bugs/show_bug.cgi?id=206345: ignore all tags when inside @literal or @code tags
@@ -398,25 +411,6 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 						// https://bugs.eclipse.org/bugs/show_bug.cgi?id=206345: do not update tag start position when ignoring tags
 						if (!considerTagAsPlainText) this.inlineTagStart = previousPosition;
 						break;
-					case '*' :
-						// Store the star position as text start while formatting
-						lastStarPosition = previousPosition;
-						if (previousChar != '*') {
-							this.starPosition = previousPosition;
-							if (isDomParser || isFormatterParser) {
-								if (lineHasStar) {
-									this.lineStarted = true;
-									if (this.textStart == -1) {
-										this.textStart = previousPosition;
-										if (this.index <= this.javadocTextEnd) textEndPosition = this.index;
-									}
-								}
-								if (!this.lineStarted) {
-									lineHasStar = true;
-								}
-							}
-						}
-						break;
 					case '\u000c' :	/* FORM FEED               */
 					case ' ' :			/* SPACE                   */
 					case '\t' :			/* HORIZONTAL TABULATION   */
@@ -429,8 +423,33 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 							textEndPosition = this.index;
 						}
 						break;
+					case '*' :
+						// Store the star position as text start while formatting
+						if (!this.markdown) {
+							lastStarPosition = previousPosition;
+							if (previousChar != '*') {
+								this.starPosition = previousPosition;
+								if (isDomParser || isFormatterParser) {
+									if (lineHasStar) {
+										this.lineStarted = true;
+										if (this.textStart == -1) {
+											this.textStart = previousPosition;
+											if (this.index <= this.javadocTextEnd) textEndPosition = this.index;
+										}
+									}
+									if (!this.lineStarted) {
+										lineHasStar = true;
+									}
+								}
+							}
+							break;
+						}
+						//$FALL-THROUGH$
 					case '/':
-						if (previousChar == '*') {
+						if (this.markdown) {
+							if (nextCharacter != '*') // fall-through
+								break;
+						} else if (previousChar == '*') {
 							// End of javadoc
 							break;
 						}
@@ -2957,6 +2976,10 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 	}
 
 	/*
+	 * Parse markdown links that are replacing @link and @linkplain
+	 */
+	protected abstract boolean parseMarkdownLinks() throws InvalidInputException;
+	/*
 	 * Parse tag declaration
 	 */
 	protected abstract boolean parseTag(int previousPosition) throws InvalidInputException;
@@ -3442,6 +3465,11 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 		// Whitespace or inline tag closing brace
 		char ch = peekChar();
 		switch (ch) {
+			case ']':
+				// TODO: Check if we need to exclude escaped ]
+				if (this.markdown)
+					return true;
+				break;
 			case '}':
 				return this.inlineTagStarted;
 			default:

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/AbstractCommentParser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/AbstractCommentParser.java
@@ -244,11 +244,6 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 
 				// Consume rules depending on the read character
 				switch (nextCharacter) {
-					case '[':
-						if (this.markdown) {
-							parseMarkdownLinks();
-						}
-						break;
 					case '@' :
 						// Start tag parsing only if we are on line beginning or at inline tag beginning
 						// https://bugs.eclipse.org/bugs/show_bug.cgi?id=206345: ignore all tags when inside @literal or @code tags
@@ -455,6 +450,10 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 						}
 						// $FALL-THROUGH$ - fall through default case
 					default :
+						if (this.markdown && nextCharacter == '[') {
+							if (parseMarkdownLinks())
+								break;
+						}
 						if (isFormatterParser && nextCharacter == '<') {
 							// html tags are meaningful for formatter parser
 							int initialIndex = this.index;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Scanner.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Scanner.java
@@ -571,6 +571,10 @@ protected final boolean scanForMarkdownBeginning() {
 	try {
 		int temp = this.currentPosition;
 		int count = 0;
+		// The scanner is already at \r, look for matching \n
+		if (this.currentCharacter == '\r' && this.source[temp] == '\n') {
+			temp++;
+		}
 		while(true) {
 			char c = this.source[temp++];
 			switch(c) {
@@ -580,7 +584,6 @@ protected final boolean scanForMarkdownBeginning() {
 						return true;
 					}
 					break;
-				case '\r' :
 				case '\n' :
 					return false;
 				default:
@@ -1953,6 +1956,9 @@ protected int getNextToken0() throws InvalidInputException {
 											pushLineSeparator();
 										}
 									}
+									if (!scanForMarkdownBeginning()) {
+										break;
+									}
 								}
 								isUnicode = false;
 								previous = this.currentPosition;
@@ -2846,6 +2852,9 @@ public final void jumpOverMethodBody() {
 										} else {
 											pushLineSeparator();
 										}
+									}
+									if (!scanForMarkdownBeginning()) {
+										break;
 									}
 								}
 								isUnicode = false;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/TerminalTokens.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/TerminalTokens.java
@@ -40,7 +40,8 @@ public interface TerminalTokens {
 							TokenNameCOMMENT_LINE = 1001,
 							TokenNameCOMMENT_BLOCK = 1002,
 							TokenNameCOMMENT_JAVADOC = 1003,
-							TokenNameSingleQuoteStringLiteral = 1004;
+							TokenNameSingleQuoteStringLiteral = 1004,
+							TokenNameCOMMENT_MARKDOWN = 1005;
 
 	static boolean isRestrictedKeyword(int tokenType) {
 		return switch (tokenType) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/util/Messages.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/util/Messages.java
@@ -133,6 +133,7 @@ public final class Messages {
 	public static String flexible_constructor_bodies;
 	public static String primitives_in_patterns;
 	public static String module_imports;
+	public static String markdown_comments;
 
 	static {
 		initializeMessages(BUNDLE_NAME, Messages.class);

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/parser/SelectionMarkdownTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/parser/SelectionMarkdownTest.java
@@ -1,0 +1,912 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.core.tests.compiler.parser;
+
+import java.util.Locale;
+import java.util.Map;
+
+import org.eclipse.jdt.core.tests.util.Util;
+import org.eclipse.jdt.internal.codeassist.select.SelectionJavadoc;
+import org.eclipse.jdt.internal.codeassist.select.SelectionParser;
+import org.eclipse.jdt.internal.compiler.ASTVisitor;
+import org.eclipse.jdt.internal.compiler.CompilationResult;
+import org.eclipse.jdt.internal.compiler.DefaultErrorHandlingPolicies;
+import org.eclipse.jdt.internal.compiler.ast.CompilationUnitDeclaration;
+import org.eclipse.jdt.internal.compiler.ast.ConstructorDeclaration;
+import org.eclipse.jdt.internal.compiler.ast.FieldDeclaration;
+import org.eclipse.jdt.internal.compiler.ast.MethodDeclaration;
+import org.eclipse.jdt.internal.compiler.ast.TypeDeclaration;
+import org.eclipse.jdt.internal.compiler.batch.CompilationUnit;
+import org.eclipse.jdt.internal.compiler.env.ICompilationUnit;
+import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
+import org.eclipse.jdt.internal.compiler.lookup.BlockScope;
+import org.eclipse.jdt.internal.compiler.lookup.ClassScope;
+import org.eclipse.jdt.internal.compiler.lookup.CompilationUnitScope;
+import org.eclipse.jdt.internal.compiler.lookup.MethodScope;
+import org.eclipse.jdt.internal.compiler.problem.DefaultProblemFactory;
+import org.eclipse.jdt.internal.compiler.problem.ProblemReporter;
+
+import junit.framework.Test;
+
+@SuppressWarnings({ "unchecked", "rawtypes" })
+public class SelectionMarkdownTest extends AbstractSelectionTest {
+
+	String source;
+	ICompilationUnit unit;
+	StringBuilder result;
+
+	public SelectionMarkdownTest(String testName) {
+		super(testName);
+	}
+
+	static {
+//		TESTS_NAMES = new String[] { "test07" };
+	}
+
+	public static Test suite() {
+		return buildMinimalComplianceTestSuite(SelectionMarkdownTest.class, F_23);
+	}
+
+	class JavadocSelectionVisitor extends ASTVisitor {
+
+		public boolean visit(ConstructorDeclaration constructor, ClassScope scope) {
+			if (constructor.javadoc != null) {
+				assertTrue("Invalid type for Javadoc on " + constructor, constructor.javadoc instanceof SelectionJavadoc);
+				SelectionMarkdownTest.this.result.append(constructor.javadoc.toString());
+			}
+			return super.visit(constructor, scope);
+		}
+
+		public boolean visit(FieldDeclaration field, MethodScope scope) {
+			if (field.javadoc != null) {
+				assertTrue("Invalid type for Javadoc on " + field, field.javadoc instanceof SelectionJavadoc);
+				SelectionMarkdownTest.this.result.append(field.javadoc.toString());
+			}
+			return super.visit(field, scope);
+		}
+
+		public boolean visit(MethodDeclaration method, ClassScope scope) {
+			if (method.javadoc != null) {
+				assertTrue("Invalid type for Javadoc on " + method, method.javadoc instanceof SelectionJavadoc);
+				SelectionMarkdownTest.this.result.append(method.javadoc.toString());
+			}
+			return super.visit(method, scope);
+		}
+
+		public boolean visit(TypeDeclaration type, BlockScope scope) {
+			if (type.javadoc != null) {
+				assertTrue("Invalid type for Javadoc on " + type, type.javadoc instanceof SelectionJavadoc);
+				SelectionMarkdownTest.this.result.append(type.javadoc.toString());
+			}
+			return super.visit(type, scope);
+		}
+
+		public boolean visit(TypeDeclaration type, ClassScope scope) {
+			if (type.javadoc != null) {
+				assertTrue("Invalid type for Javadoc on " + type, type.javadoc instanceof SelectionJavadoc);
+				SelectionMarkdownTest.this.result.append(type.javadoc.toString());
+			}
+			return super.visit(type, scope);
+		}
+
+		public boolean visit(TypeDeclaration type, CompilationUnitScope scope) {
+			if (type.javadoc != null) {
+				assertTrue("Invalid type for Javadoc on " + type, type.javadoc instanceof SelectionJavadoc);
+				SelectionMarkdownTest.this.result.append(type.javadoc.toString());
+			}
+			return super.visit(type, scope);
+		}
+	}
+
+	protected void assertValid(String expected) {
+		String actual = this.result.toString();
+		if (!actual.equals(expected)) {
+			System.out.println("Expected result for test "+testName()+":");
+			System.out.println(Util.displayString(actual, 3));
+			System.out.println("	source: [");
+			System.out.print(Util.indentString(this.source, 2));
+			System.out.println("]\n");
+			assertEquals("Invalid selection node", expected, actual);
+		}
+	}
+	@Override
+	protected void setUp() throws Exception {
+		super.setUp();
+		this.unit = null;
+	}
+
+	void setUnit(String name, String source) {
+		this.source = source;
+		this.unit = new CompilationUnit(source.toCharArray(), name, null);
+		this.result = new StringBuilder();
+	}
+
+	/*
+	 * Parse a method with selectionNode check
+	 */
+	protected CompilationResult  findJavadoc(String selection) {
+		return findJavadoc(selection, 1);
+	}
+
+	protected CompilationResult findJavadoc(String selection, int occurences) {
+
+		// Verify unit
+		assertNotNull("Missing compilation unit!", this.unit);
+
+		// Get selection start and end
+		int selectionStart = this.source.indexOf(selection);
+		int length = selection.length();
+		int selectionEnd = selectionStart + length - 1;
+		for (int i = 1; i < occurences; i++) {
+			selectionStart = this.source.indexOf(selection, selectionEnd);
+			selectionEnd = selectionStart + length - 1;
+		}
+
+		// Parse unit
+		CompilerOptions options = new CompilerOptions(getCompilerOptions());
+		SelectionParser parser = new SelectionParser(new ProblemReporter(DefaultErrorHandlingPolicies.proceedWithAllProblems(),
+			options,
+			new DefaultProblemFactory(Locale.getDefault())));
+		CompilationUnitDeclaration unitDecl = parser.dietParse(this.unit, new CompilationResult(this.unit, 0, 0, 0), selectionStart, selectionEnd);
+		parser.getMethodBodies(unitDecl);
+
+		// Visit compilation unit declaration to find javadoc
+		unitDecl.traverse(new JavadocSelectionVisitor(), unitDecl.scope);
+
+		// Return the unit declaration result
+		return unitDecl.compilationResult();
+	}
+
+	@Override
+	protected Map getCompilerOptions() {
+	    Map optionsMap = super.getCompilerOptions();
+		optionsMap.put(CompilerOptions.OPTION_DocCommentSupport, CompilerOptions.ENABLED);
+		optionsMap.put(CompilerOptions.OPTION_ReportInvalidJavadoc, CompilerOptions.WARNING);
+		optionsMap.put(CompilerOptions.OPTION_ReportInvalidJavadocTags, CompilerOptions.ENABLED);
+		optionsMap.put(CompilerOptions.OPTION_Compliance, CompilerOptions.VERSION_23);
+		optionsMap.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_23);
+		optionsMap.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.ENABLED);
+		optionsMap.put(CompilerOptions.OPTION_ReportPreviewFeatures, CompilerOptions.IGNORE);
+	    return optionsMap;
+    }
+
+	public void test01() {
+		setUnit("Test.java",
+			"public class Test {\n" +
+			"	 /// @see #foo() \n" +
+			"	void bar() {\n" +
+			"		foo();\n" +
+			"	}\n" +
+			"	void foo() {}\n" +
+			"}\n"
+		);
+		findJavadoc("foo");
+		assertValid("/**<SelectOnMethod:#foo()>*/\n");
+	}
+
+	public void test02() {
+		setUnit("Test.java",
+			"public class Test {\n" +
+			"	 /// {@link #foo() foo} \n" +
+			"	void bar() {\n" +
+			"		foo();\n" +
+			"	}\n" +
+			"	void foo() {}\n" +
+			"}\n"
+		);
+		findJavadoc("foo");
+		assertValid("/**<SelectOnMethod:#foo()>*/\n");
+	}
+
+	public void test03() {
+		setUnit("Test.java",
+			"public class Test {\n" +
+			"	 /// @see Test \n" +
+			"	void foo() {}\n" +
+			"}\n"
+		);
+		findJavadoc("Test", 2);
+		assertValid("/**<SelectOnType:Test>*/\n");
+	}
+
+	public void test04() {
+		setUnit("Test.java",
+			"public class Test {\n" +
+			"	 /// Javadoc {@link Test} \n" +
+			"	void foo() {}\n" +
+			"}\n"
+		);
+		findJavadoc("Test", 2);
+		assertValid("/**<SelectOnType:Test>*/\n");
+	}
+
+	public void test05() {
+		setUnit("Test.java",
+			"public class Test {\n" +
+			"	int field;\n" +
+			"	 /// @see #field \n" +
+			"	void foo() {}\n" +
+			"}\n"
+		);
+		findJavadoc("field", 2);
+		assertValid("/**<SelectOnField:#field>*/\n");
+	}
+
+	public void test06() {
+		setUnit("Test.java",
+			"public class Test {\n" +
+			"	int field;\n" +
+			"	 /// {@link #field}\n" +
+			"	void foo() {}\n" +
+			"}\n"
+		);
+		findJavadoc("field", 2);
+		assertValid("/**<SelectOnField:#field>*/\n");
+	}
+
+	public void test07() {
+		setUnit("Test.java",
+				"public class Test {\n" +
+				"	/// \n" +
+				"	/// @see Test#field\n" +
+				"	/// @see #foo(int, String)\n" +
+				"	/// @see Test#foo(int, String)\n" +
+				"	/// \n" +
+				"	void bar() {\n" +
+				"		foo(0, \"\");\n" +
+				"	}\n" +
+				"	int field;\n" +
+				"	void foo(int x, String s) {}\n" +
+				"}\n"
+			);
+		findJavadoc("foo");
+		findJavadoc("String");
+		findJavadoc("Test", 2);
+		findJavadoc("foo", 2);
+		findJavadoc("String", 2);
+		findJavadoc("Test", 3);
+		findJavadoc("field");
+		assertValid(
+			"/**<SelectOnMethod:#foo(int , String )>*/\n" +
+			"/**<SelectOnType:String>*/\n" +
+			"/**<SelectOnType:Test>*/\n" +
+			"/**<SelectOnMethod:Test#foo(int , String )>*/\n" +
+			"/**<SelectOnType:String>*/\n" +
+			"/**<SelectOnType:Test>*/\n" +
+			"/**<SelectOnField:Test#field>*/\n"
+			);
+	}
+
+	public void test08() {
+		setUnit("Test.java",
+			"public class Test {\n" +
+			"	 /// \n" +
+			"	 /// First {@link #foo(int, String)}\n" +
+			"	 /// Second {@link Test#foo(int, String) method foo}\n" +
+			"	 /// Third {@link Test#field field}\n" +
+			"	 /// \n" +
+			"	void bar() {\n" +
+			"		foo(0, \"\");\n" +
+			"	}\n" +
+			"	int field;\n" +
+			"	void foo(int x, String s) {}\n" +
+			"}\n"
+		);
+		findJavadoc("foo");
+		findJavadoc("String");
+		findJavadoc("Test", 2);
+		findJavadoc("foo", 2);
+		findJavadoc("String", 2);
+		findJavadoc("Test", 3);
+		findJavadoc("field");
+		assertValid(
+			"/**<SelectOnMethod:#foo(int , String )>*/\n" +
+			"/**<SelectOnType:String>*/\n" +
+			"/**<SelectOnType:Test>*/\n" +
+			"/**<SelectOnMethod:Test#foo(int , String )>*/\n" +
+			"/**<SelectOnType:String>*/\n" +
+			"/**<SelectOnType:Test>*/\n" +
+			"/**<SelectOnField:Test#field>*/\n"
+		);
+	}
+
+	public void test09() {
+		setUnit("test/junit/Test.java",
+			"package test.junit;\n" +
+			"public class Test {\n" +
+			"	 /// \n" +
+			"	 /// @see test.junit.Test\n" +
+			"	 /// @see test.junit.Test#field\n" +
+			"	 /// @see test.junit.Test#foo(Object[] array)\n" +
+			"	 /// \n" +
+			"	void bar() {\n" +
+			"		foo(null);\n" +
+			"	}\n" +
+			"	int field;\n" +
+			"	void foo(Object[] array) {}\n" +
+			"}\n"
+		);
+		findJavadoc("test", 2);
+		findJavadoc("junit", 2);
+		findJavadoc("Test", 2);
+		findJavadoc("test", 3);
+		findJavadoc("junit", 3);
+		findJavadoc("Test", 3);
+		findJavadoc("field");
+		findJavadoc("test", 4);
+		findJavadoc("junit", 4);
+		findJavadoc("Test", 4);
+		findJavadoc("foo");
+		findJavadoc("Object");
+		findJavadoc("array");
+		assertValid(
+			"/**<SelectOnType:test>*/\n" +
+			"/**<SelectOnType:test.junit>*/\n" +
+			"/**<SelectOnType:test.junit.Test>*/\n" +
+			"/**<SelectOnType:test>*/\n" +
+			"/**<SelectOnType:test.junit>*/\n" +
+			"/**<SelectOnType:test.junit.Test>*/\n" +
+			"/**<SelectOnField:test.junit.Test#field>*/\n" +
+			"/**<SelectOnType:test>*/\n" +
+			"/**<SelectOnType:test.junit>*/\n" +
+			"/**<SelectOnType:test.junit.Test>*/\n" +
+			"/**<SelectOnMethod:test.junit.Test#foo(Object[] array)>*/\n" +
+			"/**<SelectOnType:Object>*/\n" +
+			"/**\n" +
+			" */\n"
+		);
+	}
+
+	public void test10() {
+		setUnit("test/junit/Test.java",
+			"package test.junit;\n" +
+			"public class Test {\n" +
+			"	 /// Javadoc {@linkplain test.junit.Test}\n" +
+			"	 /// {@linkplain test.junit.Test#field field}\n" +
+			"	 /// last line {@linkplain test.junit.Test#foo(Object[] array) foo(Object[])}\n" +
+			"	 /// \n" +
+			"	void bar() {\n" +
+			"		foo(null);\n" +
+			"	}\n" +
+			"	int field;\n" +
+			"	void foo(Object[] array) {}\n" +
+			"}\n"
+		);
+		findJavadoc("test", 2);
+		findJavadoc("junit", 2);
+		findJavadoc("Test", 2);
+		findJavadoc("test", 3);
+		findJavadoc("junit", 3);
+		findJavadoc("Test", 3);
+		findJavadoc("field");
+		findJavadoc("test", 4);
+		findJavadoc("junit", 4);
+		findJavadoc("Test", 4);
+		findJavadoc("foo");
+		findJavadoc("Object");
+		findJavadoc("array");
+		assertValid(
+			"/**<SelectOnType:test>*/\n" +
+			"/**<SelectOnType:test.junit>*/\n" +
+			"/**<SelectOnType:test.junit.Test>*/\n" +
+			"/**<SelectOnType:test>*/\n" +
+			"/**<SelectOnType:test.junit>*/\n" +
+			"/**<SelectOnType:test.junit.Test>*/\n" +
+			"/**<SelectOnField:test.junit.Test#field>*/\n" +
+			"/**<SelectOnType:test>*/\n" +
+			"/**<SelectOnType:test.junit>*/\n" +
+			"/**<SelectOnType:test.junit.Test>*/\n" +
+			"/**<SelectOnMethod:test.junit.Test#foo(Object[] array)>*/\n" +
+			"/**<SelectOnType:Object>*/\n" +
+			"/**\n" +
+			" */\n"
+		);
+	}
+
+	public void test11() {
+		setUnit("Test.java",
+			"public class Test {\n" +
+			"	 /// \n" +
+			"	 /// @throws RuntimeException runtime exception\n" +
+			"	 /// @throws InterruptedException interrupted exception\n" +
+			"	 /// \n" +
+			"	void foo() {}\n" +
+			"}\n"
+		);
+		findJavadoc("RuntimeException");
+		findJavadoc("InterruptedException");
+		assertValid(
+			"/**<SelectOnType:RuntimeException>*/\n" +
+			"/**<SelectOnType:InterruptedException>*/\n"
+		);
+	}
+
+	public void test12() {
+		setUnit("Test.java",
+			"public class Test {\n" +
+			"	 /// \n" +
+			"	 /// @exception RuntimeException runtime exception\n" +
+			"	 /// @exception InterruptedException interrupted exception\n" +
+			"	 /// \n" +
+			"	void foo() {}\n" +
+			"}\n"
+		);
+		findJavadoc("RuntimeException");
+		findJavadoc("InterruptedException");
+		assertValid(
+			"/**<SelectOnType:RuntimeException>*/\n" +
+			"/**<SelectOnType:InterruptedException>*/\n"
+		);
+	}
+
+	public void test13() {
+		setUnit("Test.java",
+			"public class Test {\n" +
+			"	 /// \n" +
+			"	 /// @param xxx integer param\n" +
+			"	 /// @param str string param\n" +
+			"	 /// \n" +
+			"	void foo(int xxx, String str) {}\n" +
+			"}\n"
+		);
+		findJavadoc("xxx");
+		findJavadoc("str");
+		assertValid(
+			"/**<SelectOnLocalVariable:xxx>*/\n" +
+			"/**<SelectOnLocalVariable:str>*/\n"
+		);
+	}
+
+	public void test14() {
+		setUnit("Test.java",
+			"/// \n" +
+			"/// Javadoc of {@link Test}\n" +
+			"/// @see Field#foo\n" +
+			"/// \n" +
+			"public class Test {}\n" +
+			"/// \n" +
+			"/// Javadoc on {@link Field} to test selection in javadoc field references\n" +
+			"/// @see #foo\n" +
+			"/// \n" +
+			"class Field {\n" +
+			"	 /// \n" +
+			"	 /// Javadoc on {@link #foo} to test selection in javadoc field references\n" +
+			"	 /// @see #foo\n" +
+			"	 /// @see Field#foo\n" +
+			"	 /// \n" +
+			"	int foo;\n" +
+			"}\n"
+		);
+		findJavadoc("Field");
+		findJavadoc("foo");
+		findJavadoc("Field", 2);
+		findJavadoc("foo", 2);
+		findJavadoc("foo", 3);
+		findJavadoc("foo", 4);
+		findJavadoc("Field", 4);
+		findJavadoc("foo", 5);
+		assertValid(
+			"/**<SelectOnType:Field>*/\n" +
+			"/**<SelectOnField:Field#foo>*/\n" +
+			"/**<SelectOnType:Field>*/\n" +
+			"/**<SelectOnField:#foo>*/\n" +
+			"/**<SelectOnField:#foo>*/\n" +
+			"/**<SelectOnField:#foo>*/\n" +
+			"/**<SelectOnType:Field>*/\n" +
+			"/**<SelectOnField:Field#foo>*/\n"
+		);
+	}
+
+	public void test15() {
+		setUnit("Test.java",
+			"/// \n" +
+			"/// Javadoc of {@link Test}\n" +
+			"/// @see Method#foo(int, String)\n" +
+			"/// \n" +
+			"public class Test {}\n" +
+			"/// \n" +
+			"/// Javadoc on {@link Method} to test selection in javadoc method references\n" +
+			"/// @see #foo(int, String)\n" +
+			"/// \n" +
+			"class Method {\n" +
+			"	 /// \n" +
+			"	 /// Javadoc on {@link #foo(int,String)} to test selection in javadoc method references\n" +
+			"	 /// @see #foo(int, String)\n" +
+			"	 /// @see Method#foo(int, String)\n" +
+			"	 /// \n" +
+			"	void bar() {}\n" +
+			"	 /// \n" +
+			"	 /// Method with parameter and throws clause to test selection in javadoc\n" +
+			"	 /// @param xxx TODO\n" +
+			"	 /// @param str TODO\n" +
+			"	 /// @throws RuntimeException blabla\n" +
+			"	 /// @throws InterruptedException bloblo\n" +
+			"	 /// \n" +
+			"	void foo(int xxx, String str) throws RuntimeException, InterruptedException {}\n" +
+			"}\n"
+		);
+		findJavadoc("Method");
+		findJavadoc("foo");
+		findJavadoc("Method", 2);
+		findJavadoc("foo", 2);
+		findJavadoc("foo", 3);
+		findJavadoc("foo", 4);
+		findJavadoc("Method", 4);
+		findJavadoc("foo", 5);
+		findJavadoc("xxx");
+		findJavadoc("str");
+		findJavadoc("RuntimeException");
+		findJavadoc("InterruptedException");
+		assertValid(
+			"/**<SelectOnType:Method>*/\n" +
+			"/**<SelectOnMethod:Method#foo(int , String )>*/\n" +
+			"/**<SelectOnType:Method>*/\n" +
+			"/**<SelectOnMethod:#foo(int , String )>*/\n" +
+			"/**<SelectOnMethod:#foo(int , String )>*/\n" +
+			"/**<SelectOnMethod:#foo(int , String )>*/\n" +
+			"/**<SelectOnType:Method>*/\n" +
+			"/**<SelectOnMethod:Method#foo(int , String )>*/\n" +
+			"/**<SelectOnLocalVariable:xxx>*/\n" +
+			"/**<SelectOnLocalVariable:str>*/\n" +
+			"/**<SelectOnType:RuntimeException>*/\n" +
+			"/**<SelectOnType:InterruptedException>*/\n"
+		);
+	}
+
+	public void test16() {
+		setUnit("Test.java",
+			"/// \n" +
+			"/// Javadoc of {@link Test}\n" +
+			"/// @see Other\n" +
+			"/// \n" +
+			"public class Test {}\n" +
+			"/// \n" +
+			"/// Javadoc of {@link Other}\n" +
+			"/// @see Test\n" +
+			"// \n" +
+			"class Other {}\n"
+		);
+		findJavadoc("Test");
+		findJavadoc("Other");
+		findJavadoc("Test", 3);
+		findJavadoc("Other", 2);
+		assertValid(
+			"/**<SelectOnType:Test>*/\n" +
+			"/**<SelectOnType:Other>*/\n" +
+			"/**<SelectOnType:Test>*/\n" +
+			"/**<SelectOnType:Other>*/\n"
+		);
+	}
+
+	public void test17() {
+		setUnit("Test.java",
+			"/// \n" +
+			"/// @see Test.Field#foo\n" +
+			"/// \n" +
+			"public class Test {\n" +
+			"	 /// \n" +
+			"	 /// @see Field#foo\n" +
+			"	 /// \n" +
+			"	class Field {\n" +
+			"		/// \n" +
+			"		///  @see #foo\n" +
+			"		///  @see Field#foo\n" +
+			"		///  @see Test.Field#foo\n" +
+			"		/// \n" +
+			"		int foo;\n" +
+			"	}\n" +
+			"}\n"
+		);
+		findJavadoc("Test");
+		findJavadoc("Field");
+		findJavadoc("foo");
+		findJavadoc("Field", 2);
+		findJavadoc("foo", 2);
+		findJavadoc("foo", 3);
+		findJavadoc("Field", 4);
+		findJavadoc("foo", 4);
+		findJavadoc("Test", 3);
+		findJavadoc("Field", 5);
+		findJavadoc("foo", 5);
+		assertValid(
+			"/**<SelectOnType:Test>*/\n" +
+			"/**<SelectOnType:Test.Field>*/\n" +
+			"/**<SelectOnField:Test.Field#foo>*/\n" +
+			"/**<SelectOnType:Field>*/\n" +
+			"/**<SelectOnField:Field#foo>*/\n" +
+			"/**<SelectOnField:#foo>*/\n" +
+			"/**<SelectOnType:Field>*/\n" +
+			"/**<SelectOnField:Field#foo>*/\n" +
+			"/**<SelectOnType:Test>*/\n" +
+			"/**<SelectOnType:Test.Field>*/\n" +
+			"/**<SelectOnField:Test.Field#foo>*/\n"
+		);
+	}
+
+	public void test18() {
+		setUnit("Test.java",
+			"/// \n" +
+			"/// @see Test.Method#foo()\n" +
+			"/// \n" +
+			"public class Test {\n" +
+			"	 /// \n" +
+			"	 /// @see Method#foo()\n" +
+			"	 /// \n" +
+			"	class Method {\n" +
+			"		/// \n" +
+			"		/// @see #foo()\n" +
+			"		/// @see Method#foo()\n" +
+			"		/// @see Test.Method#foo()\n" +
+			"		/// \n" +
+			"		void foo() {}\n" +
+			"	}\n" +
+			"}"
+		);
+		findJavadoc("Test");
+		findJavadoc("Method");
+		findJavadoc("foo");
+		findJavadoc("Method", 2);
+		findJavadoc("foo", 2);
+		findJavadoc("foo", 3);
+		findJavadoc("Method", 4);
+		findJavadoc("foo", 4);
+		findJavadoc("Test", 3);
+		findJavadoc("Method", 5);
+		findJavadoc("foo", 5);
+		assertValid(
+			"/**<SelectOnType:Test>*/\n" +
+			"/**<SelectOnType:Test.Method>*/\n" +
+			"/**<SelectOnMethod:Test.Method#foo()>*/\n" +
+			"/**<SelectOnType:Method>*/\n" +
+			"/**<SelectOnMethod:Method#foo()>*/\n" +
+			"/**<SelectOnMethod:#foo()>*/\n" +
+			"/**<SelectOnType:Method>*/\n" +
+			"/**<SelectOnMethod:Method#foo()>*/\n" +
+			"/**<SelectOnType:Test>*/\n" +
+			"/**<SelectOnType:Test.Method>*/\n" +
+			"/**<SelectOnMethod:Test.Method#foo()>*/\n"
+		);
+	}
+
+	public void test19() {
+		setUnit("Test.java",
+			"/// \n" +
+			"/// @see Test.Other\n" +
+			"/// \n" +
+			"public class Test {\n" +
+			"	 /// \n" +
+			"	 /// @see Test\n" +
+			"	 /// @see Other\n" +
+			"	 /// @see Test.Other\n" +
+			"	 /// \n" +
+			"	class Other {}\n" +
+			"}"
+		);
+		findJavadoc("Test");
+		findJavadoc("Other");
+		findJavadoc("Test", 3);
+		findJavadoc("Other", 2);
+		findJavadoc("Test", 4);
+		findJavadoc("Other", 3);
+		assertValid(
+			"/**<SelectOnType:Test>*/\n" +
+			"/**<SelectOnType:Test.Other>*/\n" +
+			"/**<SelectOnType:Test>*/\n" +
+			"/**<SelectOnType:Other>*/\n" +
+			"/**<SelectOnType:Test>*/\n" +
+			"/**<SelectOnType:Test.Other>*/\n"
+		);
+	}
+
+	public void test20() {
+		setUnit("Test.java",
+			"public class Test {\n" +
+			"	void bar() {\n" +
+			"		/// \n" +
+			"		///  @see Field#foo\n" +
+			"		/// \n" +
+			"		class Field {\n" +
+			"			/// \n" +
+			"			///  @see #foo\n" +
+			"			///  @see Field#foo\n" +
+			"			/// \n" +
+			"			int foo;\n" +
+			"		}\n" +
+			"	}\n" +
+			"}\n"
+		);
+		findJavadoc("Field");
+		findJavadoc("foo");
+		findJavadoc("foo", 2);
+		findJavadoc("Field", 3);
+		findJavadoc("foo", 3);
+		assertValid(
+			"/**<SelectOnType:Field>*/\n" +
+			"/**<SelectOnField:Field#foo>*/\n" +
+			"/**<SelectOnField:#foo>*/\n" +
+			"/**<SelectOnType:Field>*/\n" +
+			"/**<SelectOnField:Field#foo>*/\n"
+		);
+	}
+
+	public void test21() {
+		setUnit("Test.java",
+			"public class Test {\n" +
+			"	void bar() {\n" +
+			"		/// \n" +
+			"		///  @see Method#foo()\n" +
+			"		/// \n" +
+			"		class Method {\n" +
+			"			/// \n" +
+			"			///  @see #foo()\n" +
+			"			///  @see Method#foo()\n" +
+			"			/// \n" +
+			"			void foo() {}\n" +
+			"		}\n" +
+			"	}\n" +
+			"}"
+		);
+		findJavadoc("Method");
+		findJavadoc("foo");
+		findJavadoc("foo", 2);
+		findJavadoc("Method", 3);
+		findJavadoc("foo", 3);
+		assertValid(
+			"/**<SelectOnType:Method>*/\n" +
+			"/**<SelectOnMethod:Method#foo()>*/\n" +
+			"/**<SelectOnMethod:#foo()>*/\n" +
+			"/**<SelectOnType:Method>*/\n" +
+			"/**<SelectOnMethod:Method#foo()>*/\n"
+		);
+	}
+
+	public void test22() {
+		setUnit("Test.java",
+			"public class Test {\n" +
+			"	void bar() {\n" +
+			"		/// \n" +
+			"		///  @see Test\n" +
+			"		///  @see Other\n" +
+			"		/// \n" +
+			"		class Other {}\n" +
+			"	}\n" +
+			"}"
+		);
+		findJavadoc("Test", 2);
+		findJavadoc("Other");
+		assertValid(
+			"/**<SelectOnType:Test>*/\n" +
+			"/**<SelectOnType:Other>*/\n"
+		);
+	}
+
+	public void test23() {
+		setUnit("Test.java",
+			"public class Test {\n" +
+			"	void bar() {\n" +
+			"		new Object() {\n" +
+			"			/// \n" +
+			"			///  @see Field#foo\n" +
+			"			/// \n" +
+			"			class Field {\n" +
+			"				/// \n" +
+			"				/// @see #foo\n" +
+			"				/// @see Field#foo\n" +
+			"				/// \n" +
+			"				int foo;\n" +
+			"			}\n" +
+			"		};\n" +
+			"	}\n" +
+			"}\n"
+		);
+		findJavadoc("Field");
+		findJavadoc("foo");
+		findJavadoc("foo", 2);
+		findJavadoc("Field", 3);
+		findJavadoc("foo", 3);
+		assertValid(
+			"/**<SelectOnType:Field>*/\n" +
+			"/**<SelectOnField:Field#foo>*/\n" +
+			"/**<SelectOnField:#foo>*/\n" +
+			"/**<SelectOnType:Field>*/\n" +
+			"/**<SelectOnField:Field#foo>*/\n"
+		);
+	}
+
+	public void test24() {
+		setUnit("Test.java",
+			"public class Test {\n" +
+			"	void bar() {\n" +
+			"		new Object() {\n" +
+			"			/// \n" +
+			"			///  @see Method#foo()\n" +
+			"			/// \n" +
+			"			class Method {\n" +
+			"				/// \n" +
+			"				/// @see #foo()\n" +
+			"				/// @see Method#foo()\n" +
+			"				/// \n" +
+			"				void foo() {}\n" +
+			"			}\n" +
+			"		};\n" +
+			"	}\n" +
+			"}"
+		);
+		findJavadoc("Method");
+		findJavadoc("foo");
+		findJavadoc("foo", 2);
+		findJavadoc("Method", 3);
+		findJavadoc("foo", 3);
+		assertValid(
+			"/**<SelectOnType:Method>*/\n" +
+			"/**<SelectOnMethod:Method#foo()>*/\n" +
+			"/**<SelectOnMethod:#foo()>*/\n" +
+			"/**<SelectOnType:Method>*/\n" +
+			"/**<SelectOnMethod:Method#foo()>*/\n"
+		);
+	}
+
+	public void test25() {
+		setUnit("Test.java",
+			"public class Test {\n" +
+			"	void bar() {\n" +
+			"		new Object() {\n" +
+			"			/// \n" +
+			"			///  @see Test\n" +
+			"			///  @see Other\n" +
+			"			/// \n" +
+			"			class Other {}\n" +
+			"		};\n" +
+			"	}\n" +
+			"}"
+		);
+		findJavadoc("Test", 2);
+		findJavadoc("Other");
+		assertValid(
+			"/**<SelectOnType:Test>*/\n" +
+			"/**<SelectOnType:Other>*/\n"
+		);
+	}
+
+	/**
+	 * bug 192449: [javadoc][assist] SelectionJavadocParser should not report problems
+	 * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=192449"
+	 */
+	public void test26() {
+		setUnit("Test.java",
+			"/// \n" +
+			"/// @see \n" +
+			"/// @throws noException\n" +
+			"/// @see Test\n" +
+			"/// @see Other\n" +
+			"/// \n" +
+			"public class Test {\n" +
+			"	 /// \n" +
+			"	 /// @see\n" +
+			"	 /// @param noParam\n" +
+			"	 /// @throws noException\n" +
+			"	 /// \n" +
+			"	void bar() {}\n" +
+			"}"
+		);
+
+		// parse and check results
+		CompilationResult compilationResult = findJavadoc("Other");
+		assertEquals("SelectionJavadocParser should not report errors", "", Util.getProblemLog(compilationResult, false, false));
+	}
+}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/parser/SelectionMarkdownTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/parser/SelectionMarkdownTest.java
@@ -578,7 +578,7 @@ public class SelectionMarkdownTest extends AbstractSelectionTest {
 			"/// \n" +
 			"/// Javadoc of {@link Other}\n" +
 			"/// @see Test\n" +
-			"// \n" +
+			"/// \n" +
 			"class Other {}\n"
 		);
 		findJavadoc("Test");

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/MarkdownCommentsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/MarkdownCommentsTest.java
@@ -1,0 +1,599 @@
+/*******************************************************************************
+ * Copyright (c) 2024 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.core.tests.compiler.regression;
+
+import java.util.Map;
+
+import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
+
+import junit.framework.Test;
+
+@SuppressWarnings({ "unchecked", "rawtypes" })
+public class MarkdownCommentsTest extends JavadocTest {
+
+	String docCommentSupport = CompilerOptions.ENABLED;
+	String reportInvalidJavadoc = CompilerOptions.ERROR;
+	String reportMissingJavadocDescription = CompilerOptions.ALL_STANDARD_TAGS;
+	String reportInvalidJavadocVisibility = CompilerOptions.PRIVATE;
+	String reportMissingJavadocTags = CompilerOptions.ERROR;
+	String reportMissingJavadocComments = null;
+	String reportMissingJavadocCommentsVisibility = null;
+	String reportDeprecation = CompilerOptions.ERROR;
+	String processAnnotations = null;
+	String reportJavadocDeprecation = null;
+
+	public MarkdownCommentsTest(String name) {
+		super(name);
+	}
+
+	// Use this static initializer to specify subset for tests
+	// All specified tests which does not belong to the class are skipped...
+	static {
+//		TESTS_NAMES = new String[] {"test018"};
+	}
+
+	public static Test suite() {
+		return buildMinimalComplianceTestSuite(MarkdownCommentsTest.class, F_23);
+	}
+
+	@Override
+	protected Map getCompilerOptions() {
+		Map options = super.getCompilerOptions();
+		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.ENABLED);
+		options.put(CompilerOptions.OPTION_DocCommentSupport, this.docCommentSupport);
+		options.put(CompilerOptions.OPTION_ReportInvalidJavadoc, this.reportInvalidJavadoc);
+		if (!CompilerOptions.IGNORE.equals(this.reportInvalidJavadoc)) {
+			options.put(CompilerOptions.OPTION_ReportInvalidJavadocTagsVisibility, this.reportInvalidJavadocVisibility);
+		}
+		if (this.reportJavadocDeprecation != null) {
+			options.put(CompilerOptions.OPTION_ReportInvalidJavadocTagsDeprecatedRef, this.reportJavadocDeprecation);
+		}
+		if (this.reportMissingJavadocComments != null) {
+			options.put(CompilerOptions.OPTION_ReportMissingJavadocComments, this.reportMissingJavadocComments);
+			options.put(CompilerOptions.OPTION_ReportMissingJavadocCommentsOverriding, CompilerOptions.ENABLED);
+			if (this.reportMissingJavadocCommentsVisibility != null) {
+				options.put(CompilerOptions.OPTION_ReportMissingJavadocCommentsVisibility,
+						this.reportMissingJavadocCommentsVisibility);
+			}
+		} else {
+			options.put(CompilerOptions.OPTION_ReportMissingJavadocComments, this.reportInvalidJavadoc);
+		}
+		if (this.reportMissingJavadocTags != null) {
+			options.put(CompilerOptions.OPTION_ReportMissingJavadocTags, this.reportMissingJavadocTags);
+			options.put(CompilerOptions.OPTION_ReportMissingJavadocTagsOverriding, CompilerOptions.ENABLED);
+		} else {
+			options.put(CompilerOptions.OPTION_ReportMissingJavadocTags, this.reportInvalidJavadoc);
+		}
+		if (this.reportMissingJavadocDescription != null) {
+			options.put(CompilerOptions.OPTION_ReportMissingJavadocTagDescription,
+					this.reportMissingJavadocDescription);
+		}
+		if (this.processAnnotations != null) {
+			options.put(CompilerOptions.OPTION_Process_Annotations, this.processAnnotations);
+		}
+		options.put(CompilerOptions.OPTION_ReportFieldHiding, CompilerOptions.IGNORE);
+		options.put(CompilerOptions.OPTION_ReportSyntheticAccessEmulation, CompilerOptions.IGNORE);
+		options.put(CompilerOptions.OPTION_ReportDeprecation, this.reportDeprecation);
+		options.put(CompilerOptions.OPTION_ReportUnusedImport, CompilerOptions.ERROR);
+		options.put(CompilerOptions.OPTION_ReportRawTypeReference, CompilerOptions.IGNORE);
+		options.put(CompilerOptions.OPTION_ReportUnusedPrivateMember, CompilerOptions.IGNORE);
+		return options;
+	}
+
+	@Override
+	protected void setUp() throws Exception {
+		super.setUp();
+		this.docCommentSupport = CompilerOptions.ENABLED;
+		this.reportInvalidJavadoc = CompilerOptions.ERROR;
+		this.reportInvalidJavadocVisibility = CompilerOptions.PRIVATE;
+		this.reportMissingJavadocTags = CompilerOptions.IGNORE;
+		this.reportMissingJavadocComments = CompilerOptions.IGNORE;
+		this.reportMissingJavadocCommentsVisibility = CompilerOptions.PUBLIC;
+		this.reportDeprecation = CompilerOptions.ERROR;
+		this.reportInvalidJavadoc = CompilerOptions.ERROR;
+	}
+
+	public void test001() {
+		this.runNegativeTest(new String[] { "X.java", """
+				public class X {
+					///
+					/// @param parameters array of String
+					///
+					public int sample(String[] params) {
+						return 42;
+					}
+				}
+				""", },
+
+				"----------\n" +
+				"1. ERROR in X.java (at line 3)\n" +
+				"	/// @param parameters array of String\n" +
+				"	           ^^^^^^^^^^\n" +
+				"Javadoc: Parameter parameters is not declared\n" +
+				"----------\n",
+				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
+	}
+	public void test002() {
+		this.runNegativeTest(new String[] { "X.java", """
+				public class X {
+					///
+					/// @param params
+					///
+					public void sample(String[] params) {
+						return 42;
+					}
+				}
+				""", },
+
+				"----------\n" +
+				"1. ERROR in X.java (at line 3)\n" +
+				"	/// @param params\n" +
+				"	           ^^^^^^\n" +
+				"Javadoc: Description expected after this reference\n" +
+				"----------\n" +
+				"2. ERROR in X.java (at line 6)\n" +
+				"	return 42;\n" +
+				"	^^^^^^^^^^\n" +
+				"Void methods cannot return a value\n" +
+				"----------\n",
+				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
+	}
+	public void test003() {
+		this.runNegativeTest(new String[] { "X.java", """
+				public class X {
+					///
+					/// @param params array of String
+					///
+					public void sample(String[] params) {
+						return 42;
+					}
+				}
+				""", },
+
+				"----------\n" +
+				"1. ERROR in X.java (at line 6)\n" +
+				"	return 42;\n" +
+				"	^^^^^^^^^^\n" +
+				"Void methods cannot return a value\n" +
+				"----------\n",
+				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
+	}
+	public void test004() {
+		this.runNegativeTest(new String[] { "X.java", """
+				public class X {
+					///
+					/// @see #method()
+					///
+					public void sample() {
+						return "";
+					}
+				}
+				""", },
+
+				"----------\n" +
+				"1. ERROR in X.java (at line 3)\n" +
+				"	/// @see #method()\n" +
+				"	          ^^^^^^\n" +
+				"Javadoc: The method method() is undefined for the type X\n" +
+				"----------\n" +
+				"2. ERROR in X.java (at line 6)\n" +
+				"	return \"\";\n" +
+				"	^^^^^^^^^^\n" +
+				"Void methods cannot return a value\n" +
+				"----------\n",
+				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
+	}
+	public void test005() {
+		this.runNegativeTest(new String[] { "X.java", """
+				public class X {
+					///
+					/// @see #method()
+					///
+					public void sample() {
+						return "";
+					}
+					protected void method() {}
+				}
+				""", },
+
+				"----------\n" +
+				"1. ERROR in X.java (at line 6)\n" +
+				"	return \"\";\n" +
+				"	^^^^^^^^^^\n" +
+				"Void methods cannot return a value\n" +
+				"----------\n",
+				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
+	}
+	public void test006() {
+		this.runConformTest(new String[] { "X.java",
+				"""
+				public class X {
+					/// @see #method()
+					public static void main(String[] arguments) {
+						System.out.println("Hello");
+					}
+					protected static void method() {}
+				}
+				""", },
+				"Hello",
+				getCompilerOptions(),
+				new String[]{"--enable-preview"}
+				);
+	}
+	public void test007() {
+		this.runNegativeTest(new String[] { "X.java",
+				"""
+				public class X {
+					///
+					/// @see #method()
+					public static void main(String[] arguments) {
+						System.out.println("Hello");
+					}
+				}
+				""", },
+				"----------\n" +
+				"1. ERROR in X.java (at line 3)\n" +
+				"	/// @see #method()\n" +
+				"	          ^^^^^^\n" +
+				"Javadoc: The method method() is undefined for the type X\n" +
+				"----------\n",
+				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
+	}
+	public void test008() {
+		this.runNegativeTest(new String[] { "X.java",
+				"""
+				public class X {
+					/// @see #method()
+					///
+					public static void main(String[] arguments) {
+						System.out.println("Hello");
+					}
+				}
+				""", },
+				"----------\n" +
+				"1. ERROR in X.java (at line 2)\n" +
+				"	/// @see #method()\n" +
+				"	          ^^^^^^\n" +
+				"Javadoc: The method method() is undefined for the type X\n" +
+				"----------\n",
+				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
+	}
+	public void test009() {
+		this.runNegativeTest(new String[] { "X.java",
+				"""
+				public class X {
+					//// @see #method()
+					////
+					public static void main(String[] arguments) {
+						System.out.println("Hello");
+					}
+				}
+				""", },
+				"----------\n" +
+				"1. ERROR in X.java (at line 2)\n" +
+				"	//// @see #method()\n" +
+				"	           ^^^^^^\n" +
+				"Javadoc: The method method() is undefined for the type X\n" +
+				"----------\n",
+				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
+	}
+	public void test010() {
+		String bkup = this.reportMissingJavadocTags;
+		try {
+			this.reportMissingJavadocTags = CompilerOptions.ERROR;
+			this.runNegativeTest(new String[] { "X.java",
+					"""
+					public class X {
+						/// Some text here without the necessary tags for main method
+						/// @param arguments array of strings
+
+						/// no tags here
+						public static void main(String[] arguments) {
+							System.out.println("Hello");
+						}
+					}
+					""", },
+					"----------\n" +
+					"1. ERROR in X.java (at line 6)\n" +
+					"	public static void main(String[] arguments) {\n" +
+					"	                                 ^^^^^^^^^\n" +
+					"Javadoc: Missing tag for parameter arguments\n" +
+					"----------\n",
+					JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
+		} finally {
+			this.reportMissingJavadocTags = bkup;
+		}
+	}
+	public void test011() {
+		String bkup = this.reportMissingJavadocTags;
+		try {
+			this.reportMissingJavadocTags = CompilerOptions.ERROR;
+			this.runNegativeTest(new String[] { "X.java",
+					"""
+					public class X {
+						/// Some text here without the necessary tags for main method
+						/// @param arguments array of strings
+						/// @return java.lang.Str
+
+						// This line will be ignored and the previous block will be considered as the Javadoc
+						public static void main(String[] arguments) {
+							System.out.println("Hello");
+						}
+					}
+					""", },
+					"----------\n" +
+					"1. ERROR in X.java (at line 4)\n" +
+					"	/// @return java.lang.Str\n" +
+					"	     ^^^^^^\n" +
+					"Javadoc: Unexpected tag\n" +
+					"----------\n",
+					JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
+		} finally {
+			this.reportMissingJavadocTags = bkup;
+		}
+	}
+	public void test012() {
+		String bkup = this.reportMissingJavadocTags;
+		try {
+			this.reportJavadocDeprecation = CompilerOptions.ERROR;
+			this.runNegativeTest(new String[] { "X.java",
+					"""
+					public class X {
+						/// Some text here without the necessary tags for main method
+						/// @param arguments
+
+						// This line will be ignored and the previous block will be considered as the Javadoc
+						public static void main(String[] arguments) {
+							System.out.println("Hello");
+						}
+					}
+					""", },
+					"----------\n" +
+					"1. ERROR in X.java (at line 3)\n" +
+					"	/// @param arguments\n" +
+					"	           ^^^^^^^^^\n" +
+					"Javadoc: Description expected after this reference\n" +
+					"----------\n",
+					JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
+		} finally {
+			this.reportMissingJavadocTags = bkup;
+		}
+	}
+	public void test013() {
+		String bkup = this.reportMissingJavadocTags;
+		try {
+			this.reportMissingJavadocTags = CompilerOptions.ERROR;
+			this.runNegativeTest(new String[] { "X.java",
+					"""
+					public class X {
+						/// Some text here without the necessary tags for main method
+						/// @param arguments array of strings
+
+						/**
+						 * This will be the effective javadoc and will be reported for missing tags
+						 */
+						public static void main(String[] arguments) {
+							System.out.println("Hello");
+						}
+					}
+					""", },
+					"----------\n" +
+					"1. ERROR in X.java (at line 8)\n" +
+					"	public static void main(String[] arguments) {\n" +
+					"	                                 ^^^^^^^^^\n" +
+					"Javadoc: Missing tag for parameter arguments\n" +
+					"----------\n",
+					JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
+		} finally {
+			this.reportMissingJavadocTags = bkup;
+		}
+	}
+	public void test014() {
+		String bkup = this.reportMissingJavadocTags;
+		try {
+			this.reportMissingJavadocTags = CompilerOptions.ERROR;
+			this.runNegativeTest(new String[] { "X.java",
+					"""
+					public class X {
+						/**
+						 * Some text here without the necessary tags for main method
+						 * @param arguments
+						 */
+
+						///
+						/// This will be the effective javadoc and will be reported for missing tags
+						///
+						public static void main(String[] arguments) {
+							System.out.println("Hello");
+						}
+					}
+					""", },
+					"----------\n" +
+					"1. ERROR in X.java (at line 10)\n" +
+					"	public static void main(String[] arguments) {\n" +
+					"	                                 ^^^^^^^^^\n" +
+					"Javadoc: Missing tag for parameter arguments\n" +
+					"----------\n",
+					JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
+		} finally {
+			this.reportMissingJavadocTags = bkup;
+		}
+	}
+	// Test mark down links inside []
+	public void test015() {
+		String bkup = this.reportMissingJavadocTags;
+		try {
+			this.reportMissingJavadocTags = CompilerOptions.ERROR;
+			this.runNegativeTest(new String[] { "X.java",
+					"""
+					public class X {
+						///
+						/// Reference to an invalid type [Strings]
+						///
+						public static void main() {
+							System.out.println("Hello");
+						}
+					}
+					""", },
+					"----------\n" +
+					"1. ERROR in X.java (at line 3)\n" +
+					"	/// Reference to an invalid type [Strings]\n" +
+					"	                                  ^^^^^^^\n" +
+					"Javadoc: Strings cannot be resolved to a type\n" +
+					"----------\n",
+					JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
+		} finally {
+			this.reportMissingJavadocTags = bkup;
+		}
+	}
+	public void test016() {
+		String bkup = this.reportMissingJavadocTags;
+		try {
+			this.reportMissingJavadocTags = CompilerOptions.ERROR;
+			this.runNegativeTest(new String[] { "X.java",
+					"""
+					public class X {
+						///
+						/// Reference to an invalid type [java.langs.Strings]
+						///
+						public static void main() {
+							System.out.println("Hello");
+						}
+					}
+					""", },
+					"----------\n" +
+					"1. ERROR in X.java (at line 3)\n" +
+					"	/// Reference to an invalid type [java.langs.Strings]\n" +
+					"	                                  ^^^^^^^^^^^^^^^^^^\n" +
+					"Javadoc: java.langs cannot be resolved to a type\n" +
+					"----------\n",
+					JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
+		} finally {
+			this.reportMissingJavadocTags = bkup;
+		}
+	}
+	public void test017() {
+		String bkup = this.reportMissingJavadocTags;
+		try {
+			this.reportMissingJavadocTags = CompilerOptions.ERROR;
+			this.runNegativeTest(new String[] { "X.java",
+					"""
+					public class X {
+						///
+						/// Reference to an invalid type [Strings] [java.langs.Strings]
+						///
+						public static void main() {
+							System.out.println("Hello");
+						}
+					}
+					""", },
+					"----------\n" +
+					"1. ERROR in X.java (at line 3)\n" +
+					"	/// Reference to an invalid type [Strings] [java.langs.Strings]\n" +
+					"	                                  ^^^^^^^\n" +
+					"Javadoc: Strings cannot be resolved to a type\n" +
+					"----------\n" +
+					"2. ERROR in X.java (at line 3)\n" +
+					"	/// Reference to an invalid type [Strings] [java.langs.Strings]\n" +
+					"	                                            ^^^^^^^^^^^^^^^^^^\n" +
+					"Javadoc: java.langs cannot be resolved to a type\n" +
+					"----------\n",
+					JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
+		} finally {
+			this.reportMissingJavadocTags = bkup;
+		}
+	}
+	public void test018() {
+		String bkup = this.reportMissingJavadocTags;
+		try {
+			this.reportMissingJavadocTags = CompilerOptions.ERROR;
+			this.runNegativeTest(new String[] { "X.java",
+					"""
+					public class X {
+						///
+						/// Reference to an invalid type [Strings][java.langs.Strings]
+						///
+						public static void main() {
+							System.out.println("Hello");
+						}
+					}
+					""", },
+					"----------\n" +
+					"1. ERROR in X.java (at line 3)\n" +
+					"	/// Reference to an invalid type [Strings][java.langs.Strings]\n" +
+					"	                                           ^^^^^^^^^^^^^^^^^^\n" +
+					"Javadoc: java.langs cannot be resolved to a type\n" +
+					"----------\n",
+					JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
+		} finally {
+			this.reportMissingJavadocTags = bkup;
+		}
+	}
+	public void test019() {
+		String bkup = this.reportMissingJavadocTags;
+		try {
+			this.reportMissingJavadocTags = CompilerOptions.IGNORE;
+			this.runNegativeTest(new String[] { "X.java",
+					"""
+					public class X {
+						///
+						/// Reference to an invalid method in a valid type [charArray()][java.lang.String#toCharArrays()]
+						///
+						public static void main(String[] args) {
+							System.out.println("Hello");
+						}
+					}
+					""", },
+					"----------\n" +
+					"1. ERROR in X.java (at line 3)\n" +
+					"	/// Reference to an invalid method in a valid type [charArray()][java.lang.String#toCharArrays()]\n" +
+					"	                                                                                  ^^^^^^^^^^^^\n" +
+					"Javadoc: The method toCharArrays() is undefined for the type String\n" +
+					"----------\n",
+					JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
+		} finally {
+			this.reportMissingJavadocTags = bkup;
+		}
+	}
+	public void test020() {
+		String bkup = this.reportMissingJavadocTags;
+		try {
+			this.reportMissingJavadocTags = CompilerOptions.IGNORE;
+			this.runNegativeTest(new String[] { "X.java",
+					"""
+					public class X {
+						///
+						/// Reference to an invalid method in a valid type [\\[\\]][java.lang.String#toCharArrays()]
+						///
+						public static void main(String[] args) {
+							System.out.println("Hello");
+						}
+					}
+					""", },
+					"----------\n" +
+					"1. ERROR in X.java (at line 3)\n" +
+					"	/// Reference to an invalid method in a valid type [\\[\\]][java.lang.String#toCharArrays()]\n" +
+					"	                                                                           ^^^^^^^^^^^^\n" +
+					"Javadoc: The method toCharArrays() is undefined for the type String\n" +
+					"----------\n",
+					JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
+		} finally {
+			this.reportMissingJavadocTags = bkup;
+		}
+	}
+}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TestAll.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TestAll.java
@@ -260,6 +260,7 @@ public static Test suite() {
 	 since_23.add(SuperAfterStatementsTest.class);
 	 since_23.add(ImplicitlyDeclaredClassesTest.class);
 	 since_23.add(PrimitiveInPatternsTest.class);
+	 since_23.add(MarkdownCommentsTest.class);
 
 	 // Build final test suite
 	TestSuite all = new TestSuite(TestAll.class.getName());

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/formatter/FormatterBugsTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/formatter/FormatterBugsTests.java
@@ -6112,9 +6112,9 @@ public void testBug311578a() throws JavaModelException {
 		"\n" +
 		"char                       x;\n" +
 		"\n" +
-		"////J-\n" +
+		"//J-\n" +
 		"int c      =  -     1  +    42;\n" +
-		"////J+\n" +
+		"//J+\n" +
 		"\n" +
 		"char                       y;\n" +
 		"\n" +
@@ -6143,9 +6143,9 @@ public void testBug311578a() throws JavaModelException {
 		"\n" +
 		"	char x;\n" +
 		"\n" +
-		"////J-\n" +
+		"//J-\n" +
 		"int c      =  -     1  +    42;\n" +
-		"////J+\n" +
+		"//J+\n" +
 		"\n" +
 		"	char y;\n" +
 		"\n" +
@@ -6180,9 +6180,9 @@ public void testBug311578b() throws JavaModelException {
 		"\n" +
 		"char                       x;\n" +
 		"\n" +
-		"////J-\n" +
+		"//J-\n" +
 		"int c      =  -     1  +    42;\n" +
-		"////J+\n" +
+		"//J+\n" +
 		"\n" +
 		"char                       y;\n" +
 		"\n" +
@@ -6211,9 +6211,9 @@ public void testBug311578b() throws JavaModelException {
 		"\n" +
 		"	char x;\n" +
 		"\n" +
-		"	//// J-\n" +
+		"	// J-\n" +
 		"	int c = -1 + 42;\n" +
-		"	//// J+\n" +
+		"	// J+\n" +
 		"\n" +
 		"	char y;\n" +
 		"\n" +
@@ -6248,9 +6248,9 @@ public void testBug311578c() throws JavaModelException {
 		"\n" +
 		"char                       x;\n" +
 		"\n" +
-		"////F--\n" +
+		"//F--\n" +
 		"int c      =  -     1  +    42;\n" +
-		"////F++\n" +
+		"//F++\n" +
 		"\n" +
 		"char                       y;\n" +
 		"\n" +
@@ -6279,9 +6279,9 @@ public void testBug311578c() throws JavaModelException {
 		"\n" +
 		"	char x;\n" +
 		"\n" +
-		"////F--\n" +
+		"//F--\n" +
 		"int c      =  -     1  +    42;\n" +
-		"////F++\n" +
+		"//F++\n" +
 		"\n" +
 		"	char y;\n" +
 		"\n" +
@@ -6318,9 +6318,9 @@ public void testBug311578d() throws JavaModelException {
 		"\n" +
 		"char                       x;\n" +
 		"\n" +
-		"////F--\n" +
+		"//F--\n" +
 		"int c      =  -     1  +    42;\n" +
-		"////F++\n" +
+		"//F++\n" +
 		"\n" +
 		"char                       y;\n" +
 		"\n" +
@@ -6355,9 +6355,9 @@ public void testBug311578d() throws JavaModelException {
 		"\n" +
 		"	char x;\n" +
 		"\n" +
-		"	//// F--\n" +
+		"	// F--\n" +
 		"	int c = -1 + 42;\n" +
-		"	//// F++\n" +
+		"	// F++\n" +
 		"\n" +
 		"	char y;\n" +
 		"\n" +

--- a/org.eclipse.jdt.core.tests.model/workspace/Formatter/test137/A_in.java
+++ b/org.eclipse.jdt.core.tests.model/workspace/Formatter/test137/A_in.java
@@ -116,7 +116,7 @@ public abstract class Type extends ASTNode {
 //	public IBinding resolvedType();
 }
 
-//// JSR-014
+// JSR-014
 //public class ParameterizedType extends Type {
 //	public ParameterizedType(AST ast) {
 //		super(ast);

--- a/org.eclipse.jdt.core.tests.model/workspace/Formatter/test137/A_out.java
+++ b/org.eclipse.jdt.core.tests.model/workspace/Formatter/test137/A_out.java
@@ -106,7 +106,7 @@ public abstract class Type extends ASTNode {
 	//	}
 	//	public IBinding resolvedType();
 }
-//// JSR-014
+// JSR-014
 //public class ParameterizedType extends Type {
 //	public ParameterizedType(AST ast) {
 //		super(ast);

--- a/org.eclipse.jdt.core/.settings/.api_filters
+++ b/org.eclipse.jdt.core/.settings/.api_filters
@@ -350,6 +350,11 @@
                 <message_argument value="TokenNameTextBlockTemplate"/>
             </message_arguments>
         </filter>
+        <filter id="1211105284">
+            <message_arguments>
+                <message_argument value="TokenNameCOMMENT_MARKDOWN"/>
+            </message_arguments>
+        </filter>
     </resource>
     <resource path="model/org/eclipse/jdt/core/util/ByteCodeVisitorAdapter.java" type="org.eclipse.jdt.core.util.ByteCodeVisitorAdapter">
         <filter id="576725006">

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/DocCommentParser.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/DocCommentParser.java
@@ -719,6 +719,12 @@ class DocCommentParser extends AbstractCommentParser {
 	}
 
 	@Override
+	protected boolean parseMarkdownLinks() {
+		// TODO Auto-generated method stub
+		return false;
+	}
+
+	@Override
 	protected boolean parseTag(int previousPosition) throws InvalidInputException {
 
 		// Read tag name

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/core/compiler/ITerminalSymbols.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/core/compiler/ITerminalSymbols.java
@@ -28,6 +28,7 @@ public interface ITerminalSymbols {
 	int TokenNameCOMMENT_LINE = 1001;
 	int TokenNameCOMMENT_BLOCK = 1002;
 	int TokenNameCOMMENT_JAVADOC = 1003;
+	int TokenNameCOMMENT_MARKDOWN = 1004;
 
 	/**
 	 * @deprecated With the introduction of "restricted keywords" in Java 9, classification of tokens

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/Member.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/Member.java
@@ -368,6 +368,7 @@ public ISourceRange getJavadocRange() throws JavaModelException {
 			int terminal= scanner.getNextToken();
 			loop: while (true) {
 				switch(terminal) {
+					case ITerminalSymbols.TokenNameCOMMENT_MARKDOWN :
 					case ITerminalSymbols.TokenNameCOMMENT_JAVADOC :
 						docOffset= scanner.getCurrentTokenStartPosition();
 						docEnd= scanner.getCurrentTokenEndPosition() + 1;

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/PublicScanner.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/PublicScanner.java
@@ -149,6 +149,7 @@ public class PublicScanner implements IScanner, ITerminalSymbols {
 			case TerminalTokens.TokenNameCOMMA : nextToken = ITerminalSymbols.TokenNameCOMMA; break;
 			case TerminalTokens.TokenNameCOMMENT_BLOCK : nextToken = ITerminalSymbols.TokenNameCOMMENT_BLOCK; break;
 			case TerminalTokens.TokenNameCOMMENT_JAVADOC : nextToken = ITerminalSymbols.TokenNameCOMMENT_JAVADOC; break;
+			case TerminalTokens.TokenNameCOMMENT_MARKDOWN : nextToken = ITerminalSymbols.TokenNameCOMMENT_MARKDOWN; break;
 			case TerminalTokens.TokenNameCOMMENT_LINE : nextToken = ITerminalSymbols.TokenNameCOMMENT_LINE; break;
 			case TerminalTokens.TokenNameCharacterLiteral : nextToken = ITerminalSymbols.TokenNameCharacterLiteral; break;
 			case TerminalTokens.TokenNameDIVIDE : nextToken = ITerminalSymbols.TokenNameDIVIDE; break;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
Compiler changes for supporting markdown Javadoc comments (https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2429)

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
