### PR TITLE
Stop passing -Xnoagent in Java 22+

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/runtime/StandardVMLauncher.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/runtime/StandardVMLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -126,7 +126,7 @@ public String[] getCommandLine() {
 	// debug mode
 	if (this.debugPort != -1) {
 		addXdebug(commandLine);
-		commandLine.add("-Xnoagent");
+		addXnoagent(commandLine);
 		// commandLine.add("-Djava.compiler=NONE");
 		commandLine.add(
 			"-Xrunjdwp:transport=dt_socket,address=" +
@@ -199,6 +199,14 @@ private void addXdebug(List<String> commandLine, long vmVersion) {
 		commandLine.add("-Xdebug");
 	}
 }
+
+private void addXnoagent(List<String> commandLine) {
+    long vmVersion = Util.getMajorMinorVMVersion();
+    if (vmVersion != -1 && vmVersion < ClassFileConstants.JDK22) {
+        commandLine.add("-Xnoagent");
+    }
+}
+
 /**
  * Sets the name of the batch file used to launch the VM.
  * When this option is set, the launcher writes the command line to the given batch file,


### PR DESCRIPTION
## What it does
Fixes deprecation warnings "Option -Xnoagent was deprecated in JDK 22 and will likely be removed in a future release." in tests output on Java 22+ as can be seen at https://download.eclipse.org/eclipse/downloads/drops4/I20240718-2200/testresults/ep433I-unit-cen64-gtk3-java22_linux.gtk.x86_64_22/org.eclipse.jdt.core.tests.eval.TestAll.txt

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
