### PR TITLE
Promote a tool name for the JavaCompiler

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/tool/EclipseCompiler.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/tool/EclipseCompiler.java
@@ -248,4 +248,9 @@ public class EclipseCompiler implements JavaCompiler {
 				null/* progress */).compile(arguments);
 		return succeed ? 0 : -1;
 	}
+
+	@Override
+	public String name() {
+		return "ecj"; //$NON-NLS-1$
+	}
 }


### PR DESCRIPTION
Currently there is no name for the ECJ Implementation of JavaCompiler. This sets the name so it is possible to identify the JavaCompiler as ECJ.
