### PR TITLE
Latest jarsign service produces CODESIGN.SF/RSA not ECLIPSE_.SF/RSA

### DIFF
--- a/org.eclipse.jdt.core/scripts/build.xml
+++ b/org.eclipse.jdt.core/scripts/build.xml
@@ -44,6 +44,8 @@
 				<exclude name="META-INF/eclipse.inf"/>
 				<exclude name="META-INF/ECLIPSE_.SF"/>
 				<exclude name="META-INF/ECLIPSE_.RSA"/>
+				<exclude name="META-INF/CODESIGN.SF"/>
+				<exclude name="META-INF/CODESIGN.RSA"/>
 			</fileset>
 		</zip>
 		<delete dir="${output}" />


### PR DESCRIPTION
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2193