### PR TITLE
Add optimistic locking to OpenableElementInfo add/delete/set operations

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ClasspathTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ClasspathTests.java
@@ -5782,6 +5782,13 @@ public void testUnknownElements1() throws CoreException {
 		classpath[1] = src1;
 		project.setRawClasspath(classpath, null);
 
+		try {
+			Thread.sleep(500);
+		} catch (InterruptedException e) {
+			e.printStackTrace();
+		}
+		waitForManualRefresh();
+
 		// check that .classpath has correct content
 		String contents = new String (org.eclipse.jdt.internal.core.util.Util.getResourceContentsAsCharArray(getFile("/P/.classpath")));
 		assertSourceEquals(

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaProjectTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaProjectTests.java
@@ -2486,8 +2486,12 @@ public void testBug148859() throws CoreException {
 				}
 			},
 			null);
+		try {
+			Thread.sleep(500);
+		} catch (InterruptedException e) {
+			e.printStackTrace();
+		}
 		waitForManualRefresh();
-		waitForAutoBuild();
 		IPackageFragmentRoot root = getPackageFragmentRoot("P", "");
 		assertElementsEqual(
 			"Unexpected children size in 'P' default source folder",

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelManager.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelManager.java
@@ -1357,34 +1357,31 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 
 		static final IJavaModelStatus NEED_RESOLUTION = new JavaModelStatus();
 
-		public IProject project;
-		public Object savedState;
-		public boolean triedRead;
-		public IClasspathEntry[] rawClasspath;
-		public IClasspathEntry[] referencedEntries;
-		public IJavaModelStatus rawClasspathStatus;
-		public int rawTimeStamp = 0;
-		public boolean writtingRawClasspath = false;
-		public IClasspathEntry[] resolvedClasspath;
-		public IJavaModelStatus unresolvedEntryStatus;
-		public Map<IPath, IClasspathEntry> rootPathToRawEntries; // reverse map from a package fragment root's path to the raw entry
-		public Map<IPath, IClasspathEntry> rootPathToResolvedEntries; // map from a package fragment root's path to the resolved entry
-		public IPath outputLocation;
-		public Map<IPath, ObjectVector> jrtRoots; // A map between a JRT file system (as a string) and the package fragment roots found in it.
+		public final IProject project;
+		public volatile Object savedState;
+		public volatile boolean triedRead;
+		public volatile IClasspathEntry[] rawClasspath;
+		public volatile IClasspathEntry[] referencedEntries;
+		public volatile IJavaModelStatus rawClasspathStatus;
+		public volatile int rawTimeStamp;
+		public volatile boolean writtingRawClasspath;
+		public volatile IClasspathEntry[] resolvedClasspath;
+		public volatile IJavaModelStatus unresolvedEntryStatus;
+		public volatile Map<IPath, IClasspathEntry> rootPathToRawEntries; // reverse map from a package fragment root's path to the raw entry
+		private Map<IPath, IClasspathEntry> rootPathToResolvedEntries; // map from a package fragment root's path to the resolved entry
+		public volatile IPath outputLocation;
+		public volatile Map<IPath, ObjectVector> jrtRoots; // A map between a JRT file system (as a string) and the package fragment roots found in it.
 
-		public IEclipsePreferences preferences;
-		public Hashtable<String, String> options;
+		public volatile IEclipsePreferences preferences;
+		public volatile Hashtable<String, String> options;
 
 		private final SecondaryTypes secondaryTypes;
 
 		// NB: PackageFragment#getAttachedJavadoc uses this map differently
 		// and stores String data, not JavadocContents as values
-		public LRUCache<IJavaElement, Object> javadocCache;
+		public volatile LRUCache<IJavaElement, Object> javadocCache;
 
 		public PerProjectInfo(IProject project) {
-
-			this.triedRead = false;
-			this.savedState = null;
 			this.project = project;
 			this.javadocCache = new LRUCache<>(JAVADOC_CACHE_INITIAL_SIZE);
 			this.secondaryTypes = new SecondaryTypes();
@@ -1394,6 +1391,14 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 			if (this.unresolvedEntryStatus == NEED_RESOLUTION)
 				return null;
 			return this.resolvedClasspath;
+		}
+
+		public synchronized Map<IPath, IClasspathEntry> getRootPathToResolvedEntries() {
+			Map<IPath, IClasspathEntry> entries = this.rootPathToResolvedEntries;
+			if (entries == null) {
+				return Map.of();
+			}
+			return entries;
 		}
 
 		public void forgetExternalTimestampsAndIndexes() {
@@ -1453,16 +1458,18 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 			}
 			ClasspathChange classpathChange = addClasspathChange ? addClasspathChange() : null;
 
-			if (referencedEntries != null)	this.referencedEntries = referencedEntries;
-			if (this.referencedEntries == null) this.referencedEntries = ClasspathEntry.NO_ENTRIES;
-			this.rawClasspath = newRawClasspath;
-			this.outputLocation = newOutputLocation;
-			this.rawClasspathStatus = newRawClasspathStatus;
-			this.resolvedClasspath = newResolvedClasspath;
-			this.rootPathToRawEntries = newRootPathToRawEntries;
-			this.rootPathToResolvedEntries = newRootPathToResolvedEntries;
-			this.unresolvedEntryStatus = newUnresolvedEntryStatus;
-			this.javadocCache = new LRUCache<>(JAVADOC_CACHE_INITIAL_SIZE);
+			synchronized (this) {
+				if (referencedEntries != null)	this.referencedEntries = referencedEntries;
+				if (this.referencedEntries == null) this.referencedEntries = ClasspathEntry.NO_ENTRIES;
+				this.rawClasspath = newRawClasspath;
+				this.outputLocation = newOutputLocation;
+				this.rawClasspathStatus = newRawClasspathStatus;
+				this.resolvedClasspath = newResolvedClasspath;
+				this.rootPathToRawEntries = newRootPathToRawEntries;
+				this.rootPathToResolvedEntries = newRootPathToResolvedEntries;
+				this.unresolvedEntryStatus = newUnresolvedEntryStatus;
+				this.javadocCache = new LRUCache<>(JAVADOC_CACHE_INITIAL_SIZE);
+			}
 
 			return classpathChange;
 		}
@@ -2229,7 +2236,8 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 				continue;
 
 			IClasspathEntry persistedEntry = null;
-			if ((persistedEntry = perProjectInfo.rootPathToResolvedEntries.get(referencedEntries[index].getPath())) != null) {
+			Map<IPath, IClasspathEntry> rootPathToResolvedEntries = perProjectInfo.getRootPathToResolvedEntries();
+			if ((persistedEntry = rootPathToResolvedEntries.get(referencedEntries[index].getPath())) != null) {
 				// TODO: reconsider this - may want to copy the values instead of reference assignment?
 				referencedEntries[index] = persistedEntry;
 			}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelManager.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelManager.java
@@ -464,7 +464,7 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 
 		@Override
 		public boolean belongsTo(Object family) {
-			return ResourcesPlugin.FAMILY_MANUAL_REFRESH == family;
+			return ResourcesPlugin.FAMILY_MANUAL_REFRESH == family || JavaModelManager.class == family;
 		}
 	}
 

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaProject.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaProject.java
@@ -1801,15 +1801,14 @@ public class JavaProject
 	public IClasspathEntry getClasspathEntryFor(IPath path) throws JavaModelException {
 		getResolvedClasspath(); // force resolution
 		PerProjectInfo perProjectInfo = getPerProjectInfo();
-		if (perProjectInfo == null)
+		if (perProjectInfo == null) {
 			return null;
-		Map rootPathToResolvedEntries = perProjectInfo.rootPathToResolvedEntries;
-		if (rootPathToResolvedEntries == null)
-			return null;
-		IClasspathEntry classpathEntry = (IClasspathEntry) rootPathToResolvedEntries.get(path);
+		}
+		Map<IPath, IClasspathEntry> rootPathToResolvedEntries = perProjectInfo.getRootPathToResolvedEntries();
+		IClasspathEntry classpathEntry = rootPathToResolvedEntries.get(path);
 		if (classpathEntry == null) {
 			path = getProject().getWorkspace().getRoot().getLocation().append(path);
-			classpathEntry = (IClasspathEntry) rootPathToResolvedEntries.get(path);
+			classpathEntry = rootPathToResolvedEntries.get(path);
 		}
 		return classpathEntry;
 	}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/PackageFragmentRoot.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/PackageFragmentRoot.java
@@ -625,10 +625,8 @@ public IClasspathEntry getResolvedClasspathEntry() throws JavaModelException {
 	IClasspathEntry resolvedEntry = null;
 	JavaProject project = getJavaProject();
 	project.getResolvedClasspath(); // force the resolved entry cache to be populated
-	Map rootPathToResolvedEntries = project.getPerProjectInfo().rootPathToResolvedEntries;
-	if (rootPathToResolvedEntries != null) {
-		resolvedEntry = (IClasspathEntry) rootPathToResolvedEntries.get(getPath());
-	}
+	Map<IPath, IClasspathEntry> rootPathToResolvedEntries = project.getPerProjectInfo().getRootPathToResolvedEntries();
+	resolvedEntry = rootPathToResolvedEntries.get(getPath());
 	if (resolvedEntry == null) {
 		throw new JavaModelException(new JavaModelStatus(IJavaModelStatusConstants.ELEMENT_NOT_ON_CLASSPATH, this));
 	}


### PR DESCRIPTION
I have an impression that JavaModel.getJavaProjects() that uses OpenableElementInfo to maintain children may sometimes return stale data because OpenableElementInfo is not synchronized and probably could be accessed from different threads (the volatile children field indicates that the original authors assumed multi-threaded access to that data).

This could explain why we sometimes see absolutely fully unexpected test failures related to the Java projects state.

See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2716