### PR TITLE
Fixed apt test failing with Java 1.8 compilation settings

### DIFF
--- a/org.eclipse.jdt.apt.tests/src/org/eclipse/jdt/apt/tests/MixedModeTesting.java
+++ b/org.eclipse.jdt.apt.tests/src/org/eclipse/jdt/apt/tests/MixedModeTesting.java
@@ -180,11 +180,11 @@ public class MixedModeTesting extends APTTestBase{
 
 		// drop something to possibily fire off an incremental build
 		String codeB = "package p1;\n"
-			+ "public class B {}\n";
+			+ "public class X {}\n";
 
-		env.addClass( srcRoot, "p1", "B", codeB );
+		env.addClass( srcRoot, "p1", "X", codeB );
 		fullBuild( project.getFullPath() );
 		expectingNoProblems();
-		expectingMarkers(new String[]{"Called the third time."});
+		expectingMarkers(new String[]{"Called the third time.", "Called the third time."});
 	}
 }


### PR DESCRIPTION
There are few interesting observations:

1) The test fail didn't show up in jenkins. I can't see why. 
2) The test fails now because an unexpected execution from BatchGenProcessor happens, which wasn't there before. 
3) The MixedModeTesting.testAPTRoundingInMixedMode1() was added before BatchGenProcessor was added, and never run into the BatchGenProcessor code, it only used BatchGen1AnnotationProcessor. Now both processors are active, resulting in a duplicated output.
4) Both processors are active now because we enable annotation processing by default with 1.8 level projects (and required an explicit option for 1.4).

For now I've simply updated test expectation.

See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2536
