### PR TITLE
Return a SortedSet in getAllJavaSourceVersionsSupportedByCompiler()

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/core/JavaCore.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/core/JavaCore.java
@@ -121,6 +121,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Hashtable;
@@ -128,6 +129,8 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.zip.ZipFile;
@@ -3336,12 +3339,19 @@ public final class JavaCore extends Plugin {
 	 * Ordered set (from oldest to latest) of all Java source versions <b>supported</b> by compiler.
 	 * The values are from {@link JavaCore}{@code #VERSION_*}.
 	 */
-	private static final List<String> SUPPORTED_VERSIONS;
+	private static final SortedSet<String> SUPPORTED_VERSIONS;
 	static {
-		ArrayList<String> temp = new ArrayList<>();
+		Comparator<String> byVersion = Comparator.comparingDouble((String v) -> {
+			try {
+				return Double.parseDouble(v);
+			} catch (RuntimeException e) {
+				return 0;
+			}
+		}).thenComparing(Comparator.naturalOrder());
+		SortedSet<String> temp = new TreeSet<>(byVersion);
 		temp.addAll(allVersions);
 		temp.removeAll(UNSUPPORTED_VERSIONS);
-		SUPPORTED_VERSIONS = Collections.unmodifiableList(temp);
+		SUPPORTED_VERSIONS = Collections.unmodifiableSortedSet(temp);
 	}
 
 	/**
@@ -3367,7 +3377,7 @@ public final class JavaCore extends Plugin {
 	 * @see #getFirstJavaSourceVersionSupportedByCompiler()
 	 * @since 3.39
 	 */
-	public static List<String> getAllJavaSourceVersionsSupportedByCompiler() {
+	public static SortedSet<String> getAllJavaSourceVersionsSupportedByCompiler() {
 		return SUPPORTED_VERSIONS;
 	}
 
@@ -6472,7 +6482,7 @@ public final class JavaCore extends Plugin {
 	 * @since 3.39
 	 */
 	public static String getFirstJavaSourceVersionSupportedByCompiler() {
-		return SUPPORTED_VERSIONS.get(0);
+		return SUPPORTED_VERSIONS.first();
 	}
 
 	/**


### PR DESCRIPTION
The list current returned by `JavaCore.getAllJavaSourceVersionsSupportedByCompiler()` is mainly/only used to either fetch the first or last element or test if a version-String is contained.

Especially for the last operation a Set is a better choice regarding runtime. A `SortedSet` additionally also offers the methods `first()`/`last()`, which are semantically more expressive than calling List.get(0)/List.get(List.size()-1).

Furthermore using a `SortedSet` would also better reflect the general semantic of the returned collection and element-access is usually not of interest. It would also reduce the number of methods provided by JavaCore and therefore make it's API smaller.

@iloveeclipse what do you think?

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
