### PR TITLE
Fix typo in help for the batch compiler at --patch-module

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/messages.properties
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/messages.properties
@@ -242,7 +242,7 @@ misc.usage = {1} {2}\n\
 \                       resolved to be root modules\n\
 \    --limit-modules <module>(,<module>)*\n\
 \                       specify the observable module names\n\
-\    --patch-modules <module>=<directories separated by {0}>\n\
+\    --patch-module  <module>=<directories separated by {0}>\n\
 \                       specify source locations for patching the given module\n\
 \    --release <release> compile for a specific VM version\n\
 \ \n\

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/BatchCompilerTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/BatchCompilerTest.java
@@ -668,7 +668,7 @@ public void test012(){
         "                       resolved to be root modules\n" +
         "    --limit-modules <module>(,<module>)*\n" +
         "                       specify the observable module names\n" +
-        "    --patch-modules <module>=<directories separated by " + File.pathSeparator + ">\n" +
+        "    --patch-module  <module>=<directories separated by " + File.pathSeparator + ">\n" +
         "                       specify source locations for patching the given module\n" +
         "    --release <release> compile for a specific VM version\n" +
         " \n" +


### PR DESCRIPTION
The option is `--patch-module` not `--patch-modules`.