### PR TITLE
[23] ECJ Crashes with CCE #2782

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ExplicitConstructorCall.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ExplicitConstructorCall.java
@@ -323,11 +323,11 @@ public class ExplicitConstructorCall extends Statement implements Invocation {
 					return;
 			}
 			boolean hasError = false;
-			ConstructorDeclaration constructorDeclaration = (ConstructorDeclaration) methodDeclaration;
 			if (methodDeclaration == null || !methodDeclaration.isConstructor()) {
 				hasError = true;
 			} else {
 				// is it the first constructor call?
+				ConstructorDeclaration constructorDeclaration = (ConstructorDeclaration) methodDeclaration;
 				ExplicitConstructorCall constructorCall = constructorDeclaration.constructorCall;
 				if (constructorCall == null) {
 					constructorCall = constructorDeclaration.getLateConstructorCall(); // JEP 482
@@ -339,7 +339,7 @@ public class ExplicitConstructorCall extends Statement implements Invocation {
 			if (hasError) {
 				if (!(methodDeclaration instanceof CompactConstructorDeclaration)) {// already flagged for CCD
 					if (JavaFeature.FLEXIBLE_CONSTRUCTOR_BODIES.isSupported(scope.compilerOptions())) {
-						boolean isTopLevel = Arrays.stream(constructorDeclaration.statements).anyMatch(this::equals);
+						boolean isTopLevel = Arrays.stream(methodDeclaration.statements).anyMatch(this::equals);
 						if (isTopLevel)
 							scope.problemReporter().duplicateExplicitConstructorCall(this);
 						else // otherwise it's illegally nested in some control structure:

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ReconcilerTests21.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ReconcilerTests21.java
@@ -18,6 +18,7 @@ package org.eclipse.jdt.core.tests.model;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IncrementalProjectBuilder;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IProblemRequestor;
@@ -243,4 +244,45 @@ public void testIssue1998() throws Exception {
 		deleteProject(p);
 	}
 }
+public void testGH2782() throws CoreException {
+	IJavaProject p = createJava21Project("p");
+	try {
+		createFolder("p/src/test");
+		createFile("p/src/test/StringVar2.java",
+				"""
+				package test;
+                public class StringVar2 {
+                  public void test () {
+                    "foo".
+                    if (true);
+                  }
+                }
+				""");
+		p.getProject().build(IncrementalProjectBuilder.FULL_BUILD, null);
+		IMarker[] markers = p.getProject().findMarkers(null, true, IResource.DEPTH_INFINITE);
+		assertMarkers("markers in p",
+				"""
+				Constructor call must be the first statement in a constructor
+				Syntax error on token "if", super expected""",
+				markers);
+
+		ICompilationUnit unit = getCompilationUnit("p/src/test/StringVar2.java");
+		this.problemRequestor.initialize(unit.getSource().toCharArray());
+		this.workingCopy = getCompilationUnit("p/src/test/StringVar2.java").getWorkingCopy(this.wcOwner, null);
+		assertProblems("Expecting no problems",
+				"""
+				----------
+				1. ERROR in /p/src/test/StringVar2.java (at line 5)
+					if (true);
+					^^
+				Syntax error on token "if", super expected
+				----------
+				""",
+				this.problemRequestor);
+		this.workingCopy.discardWorkingCopy();
+	} finally {
+		deleteProject(p);
+	}
+}
+
 }

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ReconcilerTests21.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ReconcilerTests21.java
@@ -260,6 +260,7 @@ public void testGH2782() throws CoreException {
 				""");
 		p.getProject().build(IncrementalProjectBuilder.FULL_BUILD, null);
 		IMarker[] markers = p.getProject().findMarkers(null, true, IResource.DEPTH_INFINITE);
+		sortMarkers(markers);
 		assertMarkers("markers in p",
 				"""
 				Constructor call must be the first statement in a constructor


### PR DESCRIPTION
+ do expect ExplicitConstructorCall even in regular method

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2782
