### PR TITLE
prevent raw type warnings in tests

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/util/TestVerifier.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/util/TestVerifier.java
@@ -136,7 +136,7 @@ private void compileVerifyTests(String verifierDir) {
 	}
 	String fileName = dir + File.separator + simpleName + ".java";
 	Util.writeToFile(getVerifyTestsCode(), fileName);
-	BatchCompiler.compile("\"" + fileName + "\" -d \"" + verifierDir + "\" -warn:-resource -classpath \"" + Util.getJavaClassLibsAsString() + "\"", new PrintWriter(System.out), new PrintWriter(System.err), null/*progress*/);
+	BatchCompiler.compile("\"" + fileName + "\" -d \"" + verifierDir + "\" -warn:-resource -warn:-raw -warn:-unsafe -classpath \"" + Util.getJavaClassLibsAsString() + "\"", new PrintWriter(System.out), new PrintWriter(System.err), null/*progress*/);
 }
 public void execute(String className, String[] classpaths) {
 	setOutputBuffer(new StringBuilder());


### PR DESCRIPTION
## What it does
I removed the raw type warnings from the tests. Currently hundreds of times the following is written to console:
```
----------
1. WARNING in /tmp/comptest/run.1722929041244/verifier/org/eclipse/jdt/core/tests/util/VerifyTests.java (at line 57)
     Class testClass = urlClassLoader.loadClass(className);
     ^^^^^
Class is a raw type. References to generic type Class<T> should be parameterized
----------
2. WARNING in /tmp/comptest/run.1722929041244/verifier/org/eclipse/jdt/core/tests/util/VerifyTests.java (at line 60)
     Method main = testClass.getMethod("main", new Class[] {String[].class});
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Type safety: The method getMethod(String, Class...) belongs to the raw type Class. References to generic type Class<T> should be parameterized
----------
2 problems (2 warnings)
```
I added `-warn:-raw -warn:-unsafe` to the compiler options for `compileVerifyTests` to prevent this.

One thing I noticed. The code causing this is explicate marked to be compatible with Java 5 language level. If I see it correctly the minimum Java language level is currently 8 for tests. The better solution would be to make the code Java 8 compatible and remove the Java 5 filtering.


## How to test
Check the console, no such warnings anymore.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
