### PR TITLE
Remove JavaCore.getFirstJavaSourceVersionSupportedByCompiler()

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/core/JavaCore.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/core/JavaCore.java
@@ -3374,7 +3374,6 @@ public final class JavaCore extends Plugin {
 	 *
 	 * @return all Java source versions fully supported by Eclipse compiler
 	 * @see #isJavaSourceVersionSupportedByCompiler(String)
-	 * @see #getFirstJavaSourceVersionSupportedByCompiler()
 	 * @since 3.39
 	 */
 	public static SortedSet<String> getAllJavaSourceVersionsSupportedByCompiler() {
@@ -3402,7 +3401,6 @@ public final class JavaCore extends Plugin {
 	 *
 	 * @return {@code true} if the given string represents Java language version is fully supported by Eclipse compiler
 	 * @see #getAllJavaSourceVersionsSupportedByCompiler()
-	 * @see #getFirstJavaSourceVersionSupportedByCompiler()
 	 * @since 3.39
 	 */
 	public static boolean isJavaSourceVersionSupportedByCompiler(String version) {
@@ -6470,19 +6468,6 @@ public final class JavaCore extends Plugin {
 	 */
 	public static String latestSupportedJavaVersion() {
 		return allVersions.get(allVersions.size() - 1);
-	}
-
-	/**
-	 * First (oldest) Java source version supported by the Eclipse compiler.
-	 * This is the first entry from {@link JavaCore#getAllJavaSourceVersionsSupportedByCompiler()}.
-	 *
-	 * @return first (oldest) Java source version supported by the Eclipse compiler
-	 * @see #getAllJavaSourceVersionsSupportedByCompiler()
-	 * @see #isJavaSourceVersionSupportedByCompiler(String)
-	 * @since 3.39
-	 */
-	public static String getFirstJavaSourceVersionSupportedByCompiler() {
-		return SUPPORTED_VERSIONS.first();
 	}
 
 	/**


### PR DESCRIPTION
## What it does

The recently added API method `JavaCore.getFirstJavaSourceVersionSupportedByCompiler()` can be replaced by
`JavaCore.getAllJavaSourceVersionsSupportedByCompiler().first()`
Follow-up on https://github.com/eclipse-jdt/eclipse.jdt.core/pull/2770 after all callers of the removed method have been replaced.


This should not be submitted before https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/1569.

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
