### PR TITLE
remove recursion from VMInputStream

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/runtime/VMInputStream.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/runtime/VMInputStream.java
@@ -57,14 +57,16 @@ public boolean markSupported() {
 }
 @Override
 public int read() throws IOException {
-	try {
-		return this.input.read();
-	} catch (IOException e) {
-		if (isRunning()) {
-			return read();
-		}
-		throw e;
+	while (true) {
+		try {
+			return this.input.read();
+		} catch (IOException e) {
+            if (!isRunning()) {
+                throw e;
+            }
+        }
 	}
+
 }
 @Override
 public int read(byte b[]) throws IOException {


### PR DESCRIPTION
## What it does
Currently `VMInputStream` uses recursion to retry reads in the `int read()` method. I replaced the recursive call with a while loop. This removes unnecessary overhead while running tests.

## How to test
This doesn't change any behavior.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
