### PR TITLE
Fix BatchCompilerTest - ZipFile "used by another process" on win #2766

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/util/Util.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/util/Util.java
@@ -1306,12 +1306,17 @@ private static boolean waitUntilFileDeleted(File file) {
         System.out.print("	- wait for ("+DELETE_MAX_WAIT+"ms max): ");
     }
     int count = 0;
-    int delay = 10; // ms
+    int delay = 1; // ms
     int maxRetry = DELETE_MAX_WAIT / delay;
     int time = 0;
     while (count < maxRetry) {
         try {
             count++;
+
+            // manually trigger GC to invoke Cleaner for ZipFile that is forgotten to be closed
+            // see https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2766
+            System.gc(); // workaround
+
             Thread.sleep(delay);
             time += delay;
             if (time > DELETE_MAX_TIME) DELETE_MAX_TIME = time;


### PR DESCRIPTION
https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2766

Works around error in JDK which forgets to close Jar when System.getSecurityManager()==null

As workaround trigger a GC to make a associated Cleaner Run for the ZipFile no longer referenced.

- [X] I have thoroughly tested my changes
