### PR TITLE
[23] markdown javadoc should detect code regions

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/AbstractCommentParser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/AbstractCommentParser.java
@@ -421,7 +421,7 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 							}
 						} else if (this.lineStarted && isDomParser) {
 							textEndPosition = this.index;
-						} else if (this.markdownHelper.recordSignificantLeadingSpace()) {
+						} else if (!this.lineStarted && this.markdownHelper.recordSignificantLeadingSpace()) {
 							if (this.textStart == -1)
 								this.textStart = this.index; // first relevant whitespace is start of text
 						}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/IMarkdownCommentHelper.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/IMarkdownCommentHelper.java
@@ -108,8 +108,10 @@ class MarkdownCommentHelper implements IMarkdownCommentHelper {
 	@Override
 	public void recordSlash(int nextIndex) {
 		if (this.slashCount < 3) {
-			if (++this.slashCount == 3)
+			if (++this.slashCount == 3) {
 				this.markdownLineStart = nextIndex;
+				this.leadingSpaces = 0;
+			}
 		}
 	}
 
@@ -136,7 +138,7 @@ class MarkdownCommentHelper implements IMarkdownCommentHelper {
 
 	@Override
 	public boolean isInCodeBlock() {
-		return this.insideFence || this.leadingSpaces > this.commonIndent;
+		return this.insideFence || (this.leadingSpaces - this.commonIndent >= 4);
 	}
 
 	@Override

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/IMarkdownCommentHelper.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/IMarkdownCommentHelper.java
@@ -1,0 +1,163 @@
+/*******************************************************************************
+ * Copyright (c) 2024 GK Software SE and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
+ * Contributors:
+ *     Stephan Herrmann - Initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.internal.compiler.parser;
+
+/**
+ * Companion class for AbstractCommentParser to decide significance of whitespace
+ * within a markdown comment,
+ * and to detect code blocks (either by indentation or fenced with {@code ```}).
+ */
+public interface IMarkdownCommentHelper {
+
+	void recordSlash(int nextIndex);
+
+	void recordBackTick(boolean lineStarted);
+
+	/**
+	 * When at the beginning of a comment line, record that a whitespace was seen.
+	 * @return {@code true} if this whitespace is significant,
+	 *  i.e., beyond the common indent of all lines of this commonmark comment.
+	 */
+	boolean recordSignificantLeadingSpace();
+
+	boolean isInCodeBlock();
+
+	/** Retrieve the start of the current text, possibly including significant leading whitespace. */
+	int getTextStart(int textStart);
+
+	/** Call me when we are past the first element of a line. */
+	void resetLineStart();
+
+	void resetAtLineEnd();
+
+
+	static IMarkdownCommentHelper create(AbstractCommentParser parser) {
+		boolean markdown = parser.source[parser.javadocStart + 1] == '/';
+		if (markdown) {
+			int lineStart = parser.javadocStart + 3;
+			int commonIndent = parser.peekMarkdownCommonIndent(lineStart);
+			return new MarkdownCommentHelper(lineStart, commonIndent);
+		} else {
+			return new NullMarkdownHelper();
+		}
+	}
+
+}
+
+class NullMarkdownHelper implements IMarkdownCommentHelper {
+	public NullMarkdownHelper() {
+	}
+	@Override
+	public void recordSlash(int nextIndex) {
+		// nop
+	}
+	@Override
+	public void recordBackTick(boolean lineStarted) {
+		// nop
+	}
+	@Override
+	public boolean recordSignificantLeadingSpace() {
+		return false;
+	}
+	@Override
+	public boolean isInCodeBlock() {
+		return false;
+	}
+	@Override
+	public int getTextStart(int textStart) {
+		return textStart;
+	}
+	@Override
+	public void resetLineStart() {
+		// nop
+	}
+	@Override
+	public void resetAtLineEnd() {
+		// nop
+	}
+}
+class MarkdownCommentHelper implements IMarkdownCommentHelper {
+
+	int commonIndent;
+	int slashCount = 0;
+	int leadingSpaces = 0;
+	int markdownLineStart = -1;
+	int backTickCount = 0;
+	boolean insideFence = false;
+
+	public MarkdownCommentHelper(int lineStart, int commonIndent) {
+		this.markdownLineStart = lineStart;
+		this.commonIndent = commonIndent;
+	}
+
+	@Override
+	public void recordSlash(int nextIndex) {
+		if (this.slashCount < 3) {
+			if (++this.slashCount == 3)
+				this.markdownLineStart = nextIndex;
+		}
+	}
+
+	@Override
+	public void recordBackTick(boolean lineStarted) {
+		if (this.backTickCount < 3) {
+			if (this.backTickCount == 0 && lineStarted) {
+				return;
+			}
+			if (++this.backTickCount == 3) {
+				this.insideFence^=true;
+			}
+		}
+	}
+
+	@Override
+	public boolean recordSignificantLeadingSpace() {
+		if (this.markdownLineStart != -1) {
+			if (++this.leadingSpaces > this.commonIndent)
+				return true;
+		}
+		return false;
+	}
+
+	@Override
+	public boolean isInCodeBlock() {
+		return this.insideFence || this.leadingSpaces > this.commonIndent;
+	}
+
+	@Override
+	public int getTextStart(int textStart) {
+		if (this.markdownLineStart > -1) {
+			return this.markdownLineStart + this.commonIndent;
+		}
+		return textStart;
+	}
+
+	@Override
+	public void resetLineStart() {
+		this.markdownLineStart = -1;
+	}
+
+	@Override
+	public void resetAtLineEnd() {
+		this.slashCount = 0;
+		this.leadingSpaces = 0;
+		this.markdownLineStart = -1;
+		this.backTickCount = 0;
+		// do not reset `insideFence`
+	}
+}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/JavadocParser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/JavadocParser.java
@@ -359,6 +359,7 @@ public class JavadocParser extends AbstractCommentParser {
 	@Override
 	protected void createTag() {
 		this.tagValue = TAG_OTHERS_VALUE;
+		this.markdownHelper.resetLineStart();
 	}
 
 	@Override
@@ -616,10 +617,12 @@ public class JavadocParser extends AbstractCommentParser {
 			}
 			currentChar = readChar();
 		}
+		this.markdownHelper.resetLineStart();
 		return valid;
 	}
 	@Override
 	protected boolean parseTag(int previousPosition) throws InvalidInputException {
+		this.markdownHelper.resetLineStart();
 
 		// Complain when tag is missing a description
 		// Note that if the parse of an inline tag has already started, consider it

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/parser/RunCompletionParserTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/parser/RunCompletionParserTests.java
@@ -97,6 +97,39 @@ public class RunCompletionParserTests extends junit.framework.TestCase {
 			TestCase.RUN_ONLY_ID = null;
 			all.addTest(AbstractCompilerTest.buildComplianceTestSuite(ClassFileConstants.JDK10, tests_10));
 		}
+		if ((possibleComplianceLevels & AbstractCompilerTest.F_11) != 0) {
+			ArrayList tests_11 = (ArrayList)testClasses.clone();
+			tests_11.addAll(TEST_CLASSES_1_5);
+			// Reset forgotten subsets tests
+			TestCase.TESTS_PREFIX = null;
+			TestCase.TESTS_NAMES = null;
+			TestCase.TESTS_NUMBERS= null;
+			TestCase.TESTS_RANGE = null;
+			TestCase.RUN_ONLY_ID = null;
+			all.addTest(AbstractCompilerTest.buildComplianceTestSuite(ClassFileConstants.JDK11, tests_11));
+		}
+		if ((possibleComplianceLevels & AbstractCompilerTest.F_17) != 0) {
+			ArrayList tests_17 = (ArrayList)testClasses.clone();
+			tests_17.addAll(TEST_CLASSES_1_5);
+			// Reset forgotten subsets tests
+			TestCase.TESTS_PREFIX = null;
+			TestCase.TESTS_NAMES = null;
+			TestCase.TESTS_NUMBERS= null;
+			TestCase.TESTS_RANGE = null;
+			TestCase.RUN_ONLY_ID = null;
+			all.addTest(AbstractCompilerTest.buildComplianceTestSuite(ClassFileConstants.JDK17, tests_17));
+		}
+		if ((possibleComplianceLevels & AbstractCompilerTest.F_21) != 0) {
+			ArrayList tests_21 = (ArrayList)testClasses.clone();
+			tests_21.addAll(TEST_CLASSES_1_5);
+			// Reset forgotten subsets tests
+			TestCase.TESTS_PREFIX = null;
+			TestCase.TESTS_NAMES = null;
+			TestCase.TESTS_NUMBERS= null;
+			TestCase.TESTS_RANGE = null;
+			TestCase.RUN_ONLY_ID = null;
+			all.addTest(AbstractCompilerTest.buildComplianceTestSuite(ClassFileConstants.JDK21, tests_21));
+		}
 		if ((possibleComplianceLevels & AbstractCompilerTest.F_23) != 0) {
 			ArrayList tests_23 = (ArrayList)testClasses.clone();
 			tests_23.addAll(TEST_CLASSES_23);
@@ -106,7 +139,7 @@ public class RunCompletionParserTests extends junit.framework.TestCase {
 			TestCase.TESTS_NUMBERS= null;
 			TestCase.TESTS_RANGE = null;
 			TestCase.RUN_ONLY_ID = null;
-			all.addTest(AbstractCompilerTest.buildComplianceTestSuite(ClassFileConstants.JDK10, tests_23));
+			all.addTest(AbstractCompilerTest.buildComplianceTestSuite(ClassFileConstants.JDK23, tests_23));
 		}
 		return all;
 	}

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterMarkdownTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterMarkdownTest.java
@@ -808,14 +808,12 @@ public class ASTConverterMarkdownTest extends ConverterTestSetup {
 							}
 						} else {
 							int start = tagStart;
-							boolean newLine = false;
-							while (source[start+1] == '/' || Character.isWhitespace(source[start+1])) {
-								start++; // purge non-stored characters
-								if (source[tagStart] == '\r' || source[tagStart] == '\n') {
-									newLine = true;
+							if (source[tagStart] == '\r' || source[tagStart] == '\n') {
+								while (source[start] == '/' || Character.isWhitespace(source[start])) {
+									start++; // purge non-stored characters
 								}
+								tagStart = start;
 							}
-							if (newLine) tagStart = start;
 						}
 					}
 					tagStart = getLinkTagStartPosition(tagName, source, tagStart);

--- a/org.eclipse.jdt.core.tests.model/workspace/Converter_23/src/markdown/testBug228648/A.java
+++ b/org.eclipse.jdt.core.tests.model/workspace/Converter_23/src/markdown/testBug228648/A.java
@@ -1,8 +1,10 @@
-package javadoc.testBug228648;
-import javadoc.testBug228648.B.Inner;
+package markdown.testBug228648;
+import markdown.testBug228648.B.Inner;
 ///
-/// #foo(Inner)}
-/// #foo2(B)}
+/// [#foo(Inner)]
+/// [#foo2(B)]
+/// see {@link #foo(Inner)}
+/// or {@link #foo2(B)}
 ///
 public class A {
     public void foo(Inner inner) {

--- a/org.eclipse.jdt.core.tests.model/workspace/Converter_23/src/markdown/testBug228648/B.java
+++ b/org.eclipse.jdt.core.tests.model/workspace/Converter_23/src/markdown/testBug228648/B.java
@@ -1,4 +1,4 @@
-package javadoc.testBug228648;
+package markdown.testBug228648;
 public class B {
         class Inner {   
         }

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/DocCommentParser.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/DocCommentParser.java
@@ -259,6 +259,7 @@ class DocCommentParser extends AbstractCommentParser {
 		}
 		tagElement.setSourceRange(start, this.tagSourceEnd-start+1);
 		this.scanner.resetTo(position, this.javadocEnd);
+		this.markdownHelper.resetLineStart();
 	}
 
 	@Override
@@ -773,6 +774,7 @@ class DocCommentParser extends AbstractCommentParser {
 							// If last fragment is a tag, then use it as previous tag
 							ASTNode lastFragment = (ASTNode) fragments.get(size-1);
 							if (lastFragment.getNodeType() == ASTNode.TAG_ELEMENT) {
+								lastFragment.setSourceRange(lastFragment.getStartPosition(), this.index - previousPosition);
 								previousTag = (TagElement) lastFragment;
 							}
 						}
@@ -797,6 +799,7 @@ class DocCommentParser extends AbstractCommentParser {
 			}
 			currentChar = readChar();
 		}
+		this.markdownHelper.resetLineStart();
 		return valid;
 	}
 
@@ -1047,6 +1050,7 @@ class DocCommentParser extends AbstractCommentParser {
 				break;
 		}
 		this.textStart = this.index;
+		this.markdownHelper.resetLineStart();
 		return valid;
 	}
 
@@ -1127,6 +1131,7 @@ class DocCommentParser extends AbstractCommentParser {
 
 	@Override
 	protected void pushText(int start, int end) {
+		start = this.markdownHelper.getTextStart(start);
 
 		// Create text element
 		TextElement text = this.ast.newTextElement();
@@ -1168,6 +1173,7 @@ class DocCommentParser extends AbstractCommentParser {
 		previousTag.fragments().add(text);
 		previousTag.setSourceRange(previousStart, end-previousStart);
 		this.textStart = -1;
+		this.markdownHelper.resetLineStart();
 	}
 
 	@Override

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/DocCommentParser.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/DocCommentParser.java
@@ -805,6 +805,7 @@ class DocCommentParser extends AbstractCommentParser {
 
 	@Override
 	protected boolean parseTag(int previousPosition) throws InvalidInputException {
+		this.markdownHelper.resetLineStart();
 
 		// Read tag name
 		int currentPosition = this.index;
@@ -1050,7 +1051,6 @@ class DocCommentParser extends AbstractCommentParser {
 				break;
 		}
 		this.textStart = this.index;
-		this.markdownHelper.resetLineStart();
 		return valid;
 	}
 
@@ -1173,7 +1173,6 @@ class DocCommentParser extends AbstractCommentParser {
 		previousTag.fragments().add(text);
 		previousTag.setSourceRange(previousStart, end-previousStart);
 		this.textStart = -1;
-		this.markdownHelper.resetLineStart();
 	}
 
 	@Override


### PR DESCRIPTION
+ finetune parsing start of line by new companion IMarkdownCommentHelper
  + detect excess slashes after '///'
  + determine minimum amount of whitespace per markdown comment
  + preserve additional whitespace at beginning of line

Also:
+ avoid showing closing ']' of links
+ resolve one warning (redundant null check)
+ fix and extend compliance settings in RunCompletionParserTests
+ fix & extend test source in ../Converter_23/src/markdown/testBug228648

fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2808