### PR TITLE
[23] Parsing details for markdown comments #2824

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/AbstractCommentParser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/AbstractCommentParser.java
@@ -246,6 +246,9 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 					consumeToken();
 				}
 
+				if (this.markdown && !Character.isWhitespace(nextCharacter) && nextCharacter != '/' && nextCharacter != '`') {
+					this.markdownHelper.recordText();
+				}
 				// Consume rules depending on the read character
 				switch (nextCharacter) {
 					case '@' :

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/AbstractCommentParser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/AbstractCommentParser.java
@@ -472,8 +472,8 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 									this.textStart = this.index;
 									break;
 								}
-							} else if (nextCharacter == '`') {
-								this.markdownHelper.recordBackTick(this.lineStarted);
+							} else if (nextCharacter == '`' || nextCharacter == '~') {
+								this.markdownHelper.recordFenceChar(previousChar, nextCharacter, this.lineStarted);
 							}
 						}
 						if (isFormatterParser && nextCharacter == '<') {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/MarkdownCommentsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/MarkdownCommentsTest.java
@@ -301,6 +301,7 @@ public class MarkdownCommentsTest extends JavadocTest {
 					public class X {
 						/// Some text here without the necessary tags for main method
 						/// @param arguments array of strings
+						/// @return java.lang.Str -- should not raise an error
 
 						/// no tags here
 						public static void main(String[] arguments) {
@@ -309,7 +310,7 @@ public class MarkdownCommentsTest extends JavadocTest {
 					}
 					""", },
 					"----------\n" +
-					"1. ERROR in X.java (at line 6)\n" +
+					"1. ERROR in X.java (at line 7)\n" +
 					"	public static void main(String[] arguments) {\n" +
 					"	                                 ^^^^^^^^^\n" +
 					"Javadoc: Missing tag for parameter arguments\n" +
@@ -590,6 +591,34 @@ public class MarkdownCommentsTest extends JavadocTest {
 					"	/// Reference to an invalid method in a valid type [\\[\\]][java.lang.String#toCharArrays()]\n" +
 					"	                                                                           ^^^^^^^^^^^^\n" +
 					"Javadoc: The method toCharArrays() is undefined for the type String\n" +
+					"----------\n",
+					JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
+		} finally {
+			this.reportMissingJavadocTags = bkup;
+		}
+	}
+	public void test021() {
+		// arrays in method reference lack escaping.
+		// TODO specific error message?
+		String bkup = this.reportMissingJavadocTags;
+		try {
+			this.reportMissingJavadocTags = CompilerOptions.IGNORE;
+			this.runNegativeTest(new String[] { "X.java",
+					"""
+					///
+					/// Reference to method with array parameter: [#main(String[])]
+					///
+					public class X {
+						public static void main(String[] args) {
+							System.out.println("Hello");
+						}
+					}
+					""", },
+					"----------\n" +
+					"1. ERROR in X.java (at line 2)\n" +
+					"	/// Reference to method with array parameter: [#main(String[])]\n" +
+					"	                                                    ^^^^^^^^\n" +
+					"Javadoc: Invalid parameters declaration\n" +
 					"----------\n",
 					JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 		} finally {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterMarkdownTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterMarkdownTest.java
@@ -3368,4 +3368,154 @@ public class ASTConverterMarkdownTest extends ConverterTestSetup {
 			}
 		}
 	}
+
+	public void testGH2808_codeAfterPara() throws JavaModelException {
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy("/Converter_23/src/markdown/gh2808/CodeAfterPara.java",
+				"""
+				package markdown.gh2808;
+
+				public class CodeAfterPara {
+					/// Plain Text
+					///     @Override public void four() // four significant spaces but no blank line
+					void noBlankLine() { }
+
+					/// Plain Text
+					///  \s
+					///     @Override public void four() // four significant spaces after blank line
+					void withBlankLine() { }
+				}
+				"""
+		);
+		CompilationUnit compilUnit = (CompilationUnit) runConversion(this.workingCopies[0], true);
+		if (this.docCommentSupport.equals(JavaCore.ENABLED)) {
+			List unitComments = compilUnit.getCommentList();
+			assertEquals("Wrong number of comments", 2, unitComments.size());
+
+			{ // comments on noBlankLine()
+				Comment comment = (Comment) unitComments.get(0);
+				assertEquals("Comment should be javadoc", comment.getNodeType(), ASTNode.JAVADOC);
+				List tagList = ((Javadoc) comment).tags();
+
+				String[] tags = {
+						null,
+						"@Override" // parsed as tag, due to lack of blank line
+					};
+				String[][] lines = {
+						{"Plain Text"},
+						{" public void four() // four significant spaces but no blank line"}
+					};
+				assertTagsAndTexts(tagList, tags, lines);
+			}
+
+			{ // comments on withBlankLine()
+				Comment comment = (Comment) unitComments.get(1);
+				assertEquals("Comment should be javadoc", comment.getNodeType(), ASTNode.JAVADOC);
+				String[] tags = {
+						null
+					};
+				String[][] lines = {
+						{ // one TagElement with 2 TextElements
+							"Plain Text",
+							"    @Override public void four() // four significant spaces after blank line"
+						}
+					};
+				assertTagsAndTexts(((Javadoc) comment).tags(), tags, lines);
+
+			}
+		}
+	}
+
+	public void testGH2808_terminatingAnIndentedCodeBlock() throws JavaModelException {
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy("/Converter_23/src/markdown/gh2808/BlockEnding.java",
+				"""
+				package markdown.gh2808;
+
+				public class BlockEnding {
+					/// Plain Text
+					///
+					///     @Override public void four()
+					///     ```
+					///     /// doc
+					///     /// ```
+					///     /// @Override Nested Code
+					///     /// ```
+					///     ```
+					void indentedWithFence() { }
+
+					/// Plain Text
+					///
+					///     @Override public void four()
+					/// Plain again
+					void paraAfterCode() { }
+				}
+				"""
+		);
+		CompilationUnit compilUnit = (CompilationUnit) runConversion(this.workingCopies[0], true);
+		if (this.docCommentSupport.equals(JavaCore.ENABLED)) {
+			List unitComments = compilUnit.getCommentList();
+			assertEquals("Wrong number of comments", 2, unitComments.size());
+
+			{ // comments on indentedWithFence(): fence does not terminate indented code block, even nested doc comment is give verbatim
+				Comment comment = (Comment) unitComments.get(0);
+				assertEquals("Comment should be javadoc", comment.getNodeType(), ASTNode.JAVADOC);
+				List tagList = ((Javadoc) comment).tags();
+
+				String[] tags = {
+						null
+					};
+				String[][] lines = {
+						{ // one TagElement with many TextElements
+							"Plain Text",
+							"    @Override public void four()",
+							"    ```",
+							"    /// doc",
+							"    /// ```",
+							"    /// @Override Nested Code",
+							"    /// ```",
+							"    ```"
+						}
+					};
+				assertTagsAndTexts(tagList, tags, lines);
+			}
+
+			{ // comments on paraAfterCode() (requires jdt.ui to see what is rendered as code)
+				Comment comment = (Comment) unitComments.get(1);
+				assertEquals("Comment should be javadoc", comment.getNodeType(), ASTNode.JAVADOC);
+				String[] tags = {
+						null
+					};
+				String[][] lines = {
+						{
+							"Plain Text",
+							"    @Override public void four()",
+							"Plain again"
+						}
+					};
+				assertTagsAndTexts(((Javadoc) comment).tags(), tags, lines);
+			}
+		}
+	}
+
+	protected void assertTagsAndTexts(List<ASTNode> tagList, String[] tags, String[][] liness) {
+		assertEquals(this.prefix+"Wrong number of tags", tags.length, tagList.size());
+
+		for (int i = 0; i < liness.length; i++) {
+			ASTNode tagNode = tagList.get(i);
+			String tag = tags[i];
+			assertEquals(this.prefix+"Invalid type for fragment ["+tagNode+"]", ASTNode.TAG_ELEMENT, tagNode.getNodeType());
+			TagElement tagElement = (TagElement) tagNode;
+			assertEquals(this.prefix+"Invalid tag", tag, tagElement.getTagName());
+			List<? extends ASTNode> fragments = tagElement.fragments();
+			String[] lines = liness[i];
+			assertEquals(this.prefix+"Wrong number of fragments", lines.length, fragments.size());
+			for (int j = 0; j < lines.length; j++) {
+				ASTNode fragment = fragments.get(j);
+				String line = lines[j];
+				assertEquals(this.prefix+"Invalid type for fragment ["+fragment+"]", ASTNode.TEXT_ELEMENT, fragment.getNodeType());
+				assertEquals(this.prefix+"Wrong text content", line, ((TextElement) fragment).getText());
+			}
+		}
+	}
 }


### PR DESCRIPTION
+ codeblock cannot interrupt a paragraph
+ separate handling of code blocks indented vs fenced
  + fence does not terminate indented code block
  + handle various forms of fences:
    + \`  vs. ~
    + different fence lengths
    + no mixed fences
    + fences inside fenced region
+ handle (and require) escaping of `[` `]` inside references (method arguments)

fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2824