### PR TITLE
ClassCastException with array as wildcard generic parameter

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/CaptureBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/CaptureBinding.java
@@ -284,7 +284,7 @@ public class CaptureBinding extends TypeVariableBinding {
 		}
 	}
 	@Override
-	public ReferenceBinding upwardsProjection(Scope scope, TypeBinding[] mentionedTypeVariables) {
+	public TypeBinding upwardsProjection(Scope scope, TypeBinding[] mentionedTypeVariables) {
 		if (enterRecursiveProjectionFunction()) {
 			try {
 				for (TypeBinding mentionedTypeVariable : mentionedTypeVariables) {
@@ -292,7 +292,7 @@ public class CaptureBinding extends TypeVariableBinding {
 						TypeBinding upperBoundForProjection = this.upperBoundForProjection();
 						if (upperBoundForProjection == null)
 							upperBoundForProjection = scope.getJavaLangObject();
-						return ((ReferenceBinding)upperBoundForProjection).upwardsProjection(scope, mentionedTypeVariables);
+						return upperBoundForProjection.upwardsProjection(scope, mentionedTypeVariables);
 					}
 				}
 				return this;
@@ -535,13 +535,13 @@ public class CaptureBinding extends TypeVariableBinding {
 	}
 
 	@Override
-	public ReferenceBinding downwardsProjection(Scope scope, TypeBinding[] mentionedTypeVariables) {
-		ReferenceBinding result = null;
+	public TypeBinding downwardsProjection(Scope scope, TypeBinding[] mentionedTypeVariables) {
+		TypeBinding result = null;
 		if (enterRecursiveProjectionFunction()) {
 			for (TypeBinding mentionedTypeVariable : mentionedTypeVariables) {
 				if (TypeBinding.equalsEquals(this, mentionedTypeVariable)) {
 					if (this.lowerBound != null) {
-						result = (ReferenceBinding) this.lowerBound.downwardsProjection(scope, mentionedTypeVariables);
+						result = this.lowerBound.downwardsProjection(scope, mentionedTypeVariables);
 					}
 					break;
 				}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/IntersectionTypeBinding18.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/IntersectionTypeBinding18.java
@@ -348,7 +348,11 @@ public class IntersectionTypeBinding18 extends ReferenceBinding {
 	public ReferenceBinding upwardsProjection(Scope scope, TypeBinding[] mentionedTypeVariables) {
 		ReferenceBinding[] projectedTypes = new ReferenceBinding[this.intersectingTypes.length];
 		for (int i = 0; i < this.intersectingTypes.length; ++i) {
-			projectedTypes[i] =  this.intersectingTypes[i].upwardsProjection(scope, mentionedTypeVariables);
+			TypeBinding projected = this.intersectingTypes[i].upwardsProjection(scope, mentionedTypeVariables);
+			if (projected instanceof ReferenceBinding refBinding)
+				projectedTypes[i] =  refBinding;
+			else
+				return null;
 		}
 		return (ReferenceBinding) scope.environment().createIntersectionType18(projectedTypes);
 	}
@@ -357,10 +361,11 @@ public class IntersectionTypeBinding18 extends ReferenceBinding {
 	public ReferenceBinding downwardsProjection(Scope scope, TypeBinding[] mentionedTypeVariables) {
 		ReferenceBinding[] projectedTypes = new ReferenceBinding[this.intersectingTypes.length];
 		for (int i = 0; i < this.intersectingTypes.length; ++i) {
-			ReferenceBinding projected = this.intersectingTypes[i].downwardsProjection(scope, mentionedTypeVariables);
-			if (projected == null)
+			TypeBinding projected = this.intersectingTypes[i].downwardsProjection(scope, mentionedTypeVariables);
+			if (projected instanceof ReferenceBinding refBind)
+				projectedTypes[i] = refBind;
+			else
 				return null;
-			projectedTypes[i] = projected;
 		}
 		return (ReferenceBinding) scope.environment().createIntersectionType18(projectedTypes);
 	}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
@@ -2050,7 +2050,8 @@ public char[] sourceName() {
  * @return Upwards type projection of 'this', or null if downwards projection is undefined
 */
 @Override
-public ReferenceBinding upwardsProjection(Scope scope, TypeBinding[] mentionedTypeVariables) {
+public TypeBinding upwardsProjection(Scope scope, TypeBinding[] mentionedTypeVariables) {
+	// Note: return type remains as TypeBinding, because subclass CaptureBinding may return an ArrayBinding :(
 	return this;
 }
 
@@ -2061,7 +2062,8 @@ public ReferenceBinding upwardsProjection(Scope scope, TypeBinding[] mentionedTy
  * @return Downwards type projection of 'this', or null if downwards projection is undefined
 */
 @Override
-public ReferenceBinding downwardsProjection(Scope scope, TypeBinding[] mentionedTypeVariables) {
+public TypeBinding downwardsProjection(Scope scope, TypeBinding[] mentionedTypeVariables) {
+	// Note: return type remains as TypeBinding, because subclass CaptureBinding may return an ArrayBinding :(
 	return this;
 }
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeVariableBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeVariableBinding.java
@@ -1205,12 +1205,12 @@ public class TypeVariableBinding extends ReferenceBinding {
 	}
 
 	@Override
-	public ReferenceBinding upwardsProjection(Scope scope, TypeBinding[] mentionedTypeVariables) {
+	public TypeBinding upwardsProjection(Scope scope, TypeBinding[] mentionedTypeVariables) {
 		return this;
 	}
 
 	@Override
-	public ReferenceBinding downwardsProjection(Scope scope, TypeBinding[] mentionedTypeVariables) {
+	public TypeBinding downwardsProjection(Scope scope, TypeBinding[] mentionedTypeVariables) {
 		return this;
 	}
 

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
@@ -1007,6 +1007,26 @@ public void testGH1560_2() {
 		+ "----------\n",
 		null, true, options);
 }
+public void testGH2817() {
+	Runner runner = new Runner();
+	runner.testFiles = new String[] {
+			"Test.java",
+			"""
+			class A<T> {}
+			class B<T> {}
+
+			public interface Test {
+			    <T> void use(T t, B<? super T> b);
+			    <T> B<A<? super T>> create();
+
+			    default void test() {
+			        use(new A<Object[]>(), create());
+			    }
+			}
+			"""
+		};
+	runner.runConformTest();
+}
 public static Class<GenericsRegressionTest_9> testClass() {
 	return GenericsRegressionTest_9.class;
 }


### PR DESCRIPTION
avoid the bogus cast

fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2817
