### PR TITLE
[23] DOM support for JEP 476: Module Import Declarations (Preview)

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ImportReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ImportReference.java
@@ -33,6 +33,7 @@ public class ImportReference extends ASTNode {
 	public int declarationSourceStart;
 	public int declarationSourceEnd;
 	public int modifiers; // 1.5 addition for static imports
+	public int modifiersSourceStart;
 	public Annotation[] annotations;
 	// star end position
 	public int trailingStarPosition;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
@@ -8894,7 +8894,13 @@ protected void consumeSingleModifierImportDeclarationName(int modifier) {
 	pushOnAstStack(impt = new ImportReference(tokens, positions, false, modifier));
 
 	this.modifiers = ClassFileConstants.AccDefault;
-	this.modifiersSourceStart = -1; // <-- see comment into modifiersFlag(int)
+	// 'module' stores position on stack, 'static' sets modifiersSourceStart:
+	if (modifier == ClassFileConstants.AccModule) {
+		impt.modifiersSourceStart = this.intStack[this.intPtr--];
+	} else { // static
+		impt.modifiersSourceStart = this.modifiersSourceStart;
+	}
+	this.modifiersSourceStart = -1; // see checkAndSetModifiers()
 
 	if (this.currentToken == TokenNameSEMICOLON){
 		impt.declarationSourceEnd = this.scanner.currentPosition - 1;
@@ -9334,6 +9340,7 @@ protected void consumeStaticImportOnDemandDeclarationName() {
 	// star end position
 	impt.trailingStarPosition = this.intStack[this.intPtr--];
 	this.modifiers = ClassFileConstants.AccDefault;
+	impt.modifiersSourceStart = this.modifiersSourceStart;
 	this.modifiersSourceStart = -1; // <-- see comment into modifiersFlag(int)
 
 	if (this.currentToken == TokenNameSEMICOLON){

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter_23Test.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter_23Test.java
@@ -1,0 +1,112 @@
+/*******************************************************************************
+ * Copyright (c) 2024 GK Software SE and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
+ * Contributors:
+ *     Stephan Herrmann - Initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.core.tests.dom;
+
+import java.util.List;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTNode;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.ImportDeclaration;
+import org.eclipse.jdt.core.dom.Modifier;
+
+import junit.framework.Test;
+
+public class ASTConverter_23Test extends ConverterTestSetup {
+
+	ICompilationUnit workingCopy;
+
+	public void setUpSuite() throws Exception {
+		super.setUpSuite();
+		this.ast = AST.newAST(getAST23(), false);
+		this.currentProject = getJavaProject("Converter_23");
+		this.currentProject.setOption(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_23);
+		this.currentProject.setOption(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_23);
+		this.currentProject.setOption(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, JavaCore.VERSION_23);
+		this.currentProject.setOption(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, JavaCore.ENABLED);
+		this.currentProject.setOption(JavaCore.COMPILER_PB_REPORT_PREVIEW_FEATURES, JavaCore.IGNORE);
+	}
+
+	public ASTConverter_23Test(String name) {
+		super(name);
+	}
+
+	public static Test suite() {
+		return buildModelTestSuite(ASTConverter_23Test.class);
+	}
+
+	static int getAST23() {
+		return AST.JLS23;
+	}
+	protected void tearDown() throws Exception {
+		super.tearDown();
+		if (this.workingCopy != null) {
+			this.workingCopy.discardWorkingCopy();
+			this.workingCopy = null;
+		}
+	}
+
+
+	public void test001() throws CoreException {
+		String contents = """
+				package p;
+				import module java.base;
+				import static java.lang.System.out;
+				class X {
+					void m() {
+						out.println(Map.class.toString());
+					}
+				}
+				""";
+		this.workingCopy = getWorkingCopy("/Converter_23/src/p/X.java", true/*resolve*/);
+		ASTNode node = buildAST(
+			contents,
+			this.workingCopy);
+		assertEquals("Not a compilation unit", ASTNode.COMPILATION_UNIT, node.getNodeType());
+		CompilationUnit compilationUnit = (CompilationUnit) node;
+		assertProblemsSize(compilationUnit, 0);
+		List<ImportDeclaration> imports = compilationUnit.imports();
+		assertEquals("Incorrect no of imports", 2, imports.size());
+
+		{
+			ImportDeclaration imp = imports.get(0);
+			assertEquals("Incorrect modifier bits", Modifier.MODULE, imp.getModifiers());
+			assertEquals("Incorrect no of modifiers", 1, imp.modifiers().size());
+			Modifier mod = (Modifier) imp.modifiers().get(0);
+			assertEquals("Incorrect modifier", "module", mod.getKeyword().toString());
+			assertEquals("Incorrect modifier", Modifier.ModifierKeyword.MODULE_KEYWORD, mod.getKeyword());
+			assertEquals("Incorrect position", 18, mod.getStartPosition());
+			assertEquals("Incorrect content", "module", contents.substring(mod.getStartPosition(), mod.getStartPosition()+6));
+			assertEquals("Incorrect name", "java.base", imp.getName().toString());
+		}
+		{
+			ImportDeclaration imp = imports.get(1);
+			assertEquals("Incorrect modifier bits", Modifier.STATIC, imp.getModifiers());
+			assertEquals("Incorrect no of modifiers", 1, imp.modifiers().size());
+			Modifier mod = (Modifier) imp.modifiers().get(0);
+			assertEquals("Incorrect modifier", "static", mod.getKeyword().toString());
+			assertEquals("Incorrect modifier", Modifier.ModifierKeyword.STATIC_KEYWORD, mod.getKeyword());
+			assertEquals("Incorrect position", 43, mod.getStartPosition());
+			assertEquals("Incorrect content", "static", contents.substring(mod.getStartPosition(), mod.getStartPosition()+6));
+			assertEquals("Incorrect name", "java.lang.System.out", imp.getName().toString());
+		}
+	}
+}

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/RunConverterTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/RunConverterTests.java
@@ -58,6 +58,7 @@ public static Class[] getAllTestClasses() {
 		ASTConverter_15Test.class,
 		ASTConverter_16Test.class,
 		ASTConverter_17Test.class,
+		ASTConverter_23Test.class,
 		ASTConverter_GuardedPattern_Test.class,
 		ASTConverter_RecordPattern_Test.class,
 		ASTConverterSuperAfterStatements.class,

--- a/org.eclipse.jdt.core.tests.model/workspace/Converter_23/.classpath
+++ b/org.eclipse.jdt.core.tests.model/workspace/Converter_23/.classpath
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="var" path="CONVERTER_JCL_21_LIB" sourcepath="CONVERTER_JCL_21_SRC" rootpath="CONVERTER_JCL_SRCROOT"/>
+	<classpathentry kind="var" path="CONVERTER_JCL_22_LIB" sourcepath="CONVERTER_JCL_22_SRC" rootpath="CONVERTER_JCL_SRCROOT">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/org.eclipse.jdt.core/.settings/.api_filters
+++ b/org.eclipse.jdt.core/.settings/.api_filters
@@ -192,6 +192,12 @@
         </filter>
     </resource>
     <resource path="dom/org/eclipse/jdt/core/dom/ImportDeclaration.java" type="org.eclipse.jdt.core.dom.ImportDeclaration">
+        <filter comment="Evolution to support module imports" id="336658481">
+            <message_arguments>
+                <message_argument value="org.eclipse.jdt.core.dom.ImportDeclaration"/>
+                <message_argument value="MODIFIERS_PROPERTY"/>
+            </message_arguments>
+        </filter>
         <filter id="576778288">
             <message_arguments>
                 <message_argument value="ASTNode"/>
@@ -248,6 +254,14 @@
             <message_arguments>
                 <message_argument value="IExtendedModifier"/>
                 <message_argument value="Modifier"/>
+            </message_arguments>
+        </filter>
+    </resource>
+    <resource path="dom/org/eclipse/jdt/core/dom/Modifier.java" type="org.eclipse.jdt.core.dom.Modifier$ModifierKeyword">
+        <filter comment="Evolution to support module imports" id="336658481">
+            <message_arguments>
+                <message_argument value="org.eclipse.jdt.core.dom.Modifier.ModifierKeyword"/>
+                <message_argument value="MODULE_KEYWORD"/>
             </message_arguments>
         </filter>
     </resource>

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/AST.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/AST.java
@@ -2499,6 +2499,9 @@ public final class AST {
 		if (Modifier.isNonSealed(flags)) {
 			result.add(newModifier(Modifier.ModifierKeyword.NON_SEALED_KEYWORD));
 		}
+		if (Modifier.isModule(flags)) {
+			result.add(newModifier(Modifier.ModifierKeyword.MODULE_KEYWORD));
+		}
 		return result;
 	}
 

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ASTMatcher.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ASTMatcher.java
@@ -1129,7 +1129,11 @@ public class ASTMatcher {
 			return false;
 		}
 		ImportDeclaration o = (ImportDeclaration) other;
-		if (node.getAST().apiLevel >= AST.JLS3_INTERNAL) {
+		if (node.getAST().apiLevel >= AST.JLS23_INTERNAL) {
+			if (!safeSubtreeListMatch(node.modifiers(), o.modifiers())) {
+				return false;
+			}
+		} else if (node.getAST().apiLevel >= AST.JLS3_INTERNAL) {
 			if (node.isStatic() != o.isStatic()) {
 				return false;
 			}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ImportDeclaration.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ImportDeclaration.java
@@ -52,6 +52,14 @@ public class ImportDeclaration extends ASTNode {
 		new SimplePropertyDescriptor(ImportDeclaration.class, "static", boolean.class, MANDATORY); //$NON-NLS-1$
 
 	/**
+	 * The "modifiers" structural property of this node type (element type: {@link IExtendedModifier}) (added in JLS23 API).
+	 * @since 3.39
+	 * @noreference preview feature
+	 */
+	public static final ChildListPropertyDescriptor MODIFIERS_PROPERTY =
+			new ChildListPropertyDescriptor(ImportDeclaration.class, "modifiers", IExtendedModifier.class, CYCLE_RISK); //$NON-NLS-1$
+
+	/**
 	 * A list of property descriptors (element type:
 	 * {@link StructuralPropertyDescriptor}),
 	 * or null if uninitialized.
@@ -67,6 +75,14 @@ public class ImportDeclaration extends ASTNode {
 	 */
 	private static final List PROPERTY_DESCRIPTORS_3_0;
 
+	/**
+	 * A list of property descriptors (element type:
+	 * {@link StructuralPropertyDescriptor}),
+	 * or null if uninitialized.
+	 * @since 3.39
+	 */
+	private static final List PROPERTY_DESCRIPTORS_23;
+
 	static {
 		List properyList = new ArrayList(3);
 		createPropertyList(ImportDeclaration.class, properyList);
@@ -80,6 +96,14 @@ public class ImportDeclaration extends ASTNode {
 		addProperty(NAME_PROPERTY, properyList);
 		addProperty(ON_DEMAND_PROPERTY, properyList);
 		PROPERTY_DESCRIPTORS_3_0 = reapPropertyList(properyList);
+
+		properyList = new ArrayList(5);
+		createPropertyList(ImportDeclaration.class, properyList);
+		addProperty(STATIC_PROPERTY, properyList);
+		addProperty(MODIFIERS_PROPERTY, properyList);
+		addProperty(NAME_PROPERTY, properyList);
+		addProperty(ON_DEMAND_PROPERTY, properyList);
+		PROPERTY_DESCRIPTORS_23 = reapPropertyList(properyList);
 	}
 
 	/**
@@ -94,10 +118,12 @@ public class ImportDeclaration extends ASTNode {
 	 * @since 3.0
 	 */
 	public static List propertyDescriptors(int apiLevel) {
-		if (apiLevel == AST.JLS2_INTERNAL) {
-			return PROPERTY_DESCRIPTORS_2_0;
-		} else {
+		if (apiLevel >= AST.JLS23_INTERNAL) {
+			return PROPERTY_DESCRIPTORS_23;
+		} else if (apiLevel >= AST.JLS3_INTERNAL) {
 			return PROPERTY_DESCRIPTORS_3_0;
+		} else {
+			return PROPERTY_DESCRIPTORS_2_0;
 		}
 	}
 
@@ -120,6 +146,14 @@ public class ImportDeclaration extends ASTNode {
 	private boolean isStatic = false;
 
 	/**
+	 * The extended modifiers (element type: {@link IExtendedModifier}).
+	 * Added in JLS23; defaults to an empty list
+	 * (see constructor).
+	 * @since 3.39
+	 */
+	private ASTNode.NodeList modifiers = null;
+
+	/**
 	 * Creates a new AST node for an import declaration owned by the
 	 * given AST. The import declaration initially is a regular (non-static)
 	 * single type import for an unspecified, but legal, Java type name.
@@ -133,6 +167,55 @@ public class ImportDeclaration extends ASTNode {
 	 */
 	ImportDeclaration(AST ast) {
 		super(ast);
+		if (ast.apiLevel >= AST.JLS23_INTERNAL) {
+			this.modifiers = new ASTNode.NodeList(MODIFIERS_PROPERTY);
+		}
+	}
+
+	/**
+	 * Returns the live ordered list of modifiers of this declaration (added in JLS23 API).
+	 *
+	 * @return the live list of modifiers (element type: {@link IExtendedModifier})
+	 * @exception UnsupportedOperationException if this operation is used in
+	 * an AST below JLS23
+	 * @since 3.39
+	 */
+	public List modifiers() {
+		if (this.ast.apiLevel < AST.JLS23_INTERNAL)
+			throw new UnsupportedOperationException("Operation not supported in AST below JLS23"); //$NON-NLS-1$
+		return this.modifiers;
+	}
+
+	/**
+	 * Returns the modifiers explicitly specified on this declaration.
+	 * <p>
+	 * This method is a convenience method that computes these flags based on availability:
+	 * </p>
+	 * <ul>
+	 * <li>At JLS23 it is computed from from {@link #modifiers()}.</li>
+	 * <li>At JLS3 only the information from {@link #isStatic()} is available.</li>
+	 * <li>At lower JLS {@code 0} is constantly returned.
+	 * </ul>
+	 *
+	 * @return the bit-wise "or" of <code>Modifier</code> constants
+	 * @see Modifier
+	 * @since 3.39
+	 */
+	public int getModifiers() {
+		int computedmodifierFlags = this.isStatic ? Modifier.STATIC : Modifier.NONE;
+		if (this.modifiers == null) {
+			// JLS3 behavior (for JLS2 this is constantly 0)
+			return computedmodifierFlags;
+		}
+		// JLS23 behavior - convenience method
+		// performance could be improved by caching computed flags
+		// but this would require tracking changes to this.modifiers
+		for (Object x : modifiers()) {
+			if (x instanceof Modifier modifier) {
+				computedmodifierFlags |= modifier.getKeyword().toFlagValue();
+			}
+		}
+		return computedmodifierFlags;
 	}
 
 	@Override
@@ -177,10 +260,20 @@ public class ImportDeclaration extends ASTNode {
 	}
 
 	@Override
+	final List internalGetChildListProperty(ChildListPropertyDescriptor property) {
+		if (property == MODIFIERS_PROPERTY) {
+			return modifiers();
+		}
+		// allow default implementation to flag the error
+		return super.internalGetChildListProperty(property);
+	}
+
+	@Override
 	final int getNodeType0() {
 		return IMPORT_DECLARATION;
 	}
 
+	@SuppressWarnings("unchecked")
 	@Override
 	ASTNode clone0(AST target) {
 		ImportDeclaration result = new ImportDeclaration(target);
@@ -188,6 +281,9 @@ public class ImportDeclaration extends ASTNode {
 		result.setOnDemand(isOnDemand());
 		if (this.ast.apiLevel >= AST.JLS3_INTERNAL) {
 			result.setStatic(isStatic());
+		}
+		if (this.ast.apiLevel >= AST.JLS23_INTERNAL) {
+			result.modifiers().addAll(ASTNode.copySubtrees(target, modifiers()));
 		}
 		result.setName((Name) getName().clone(target));
 		return result;
@@ -204,6 +300,9 @@ public class ImportDeclaration extends ASTNode {
 		boolean visitChildren = visitor.visit(this);
 		if (visitChildren) {
 			acceptChild(visitor, getName());
+			if (this.ast.apiLevel >= AST.JLS23_INTERNAL) {
+				acceptChildren(visitor, this.modifiers);
+			}
 		}
 		visitor.endVisit(this);
 	}
@@ -296,6 +395,15 @@ public class ImportDeclaration extends ASTNode {
 	 * @since 3.1
 	 */
 	public boolean isStatic() {
+		if (this.modifiers != null) {
+			// JLS23 behavior: extract from the list of Modifier
+			for (Object x : modifiers()) {
+				if (x instanceof Modifier modifier && modifier.isStatic()) {
+					return true;
+				}
+			}
+			return false;
+		}
 		unsupportedIn2();
 		return this.isStatic;
 	}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/Modifier.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/Modifier.java
@@ -120,6 +120,12 @@ public final class Modifier extends ASTNode implements IExtendedModifier {
 		 */
 		public static final ModifierKeyword NON_SEALED_KEYWORD = new ModifierKeyword("non-sealed", NON_SEALED);//$NON-NLS-1$
 
+		/**
+		 * @since 3.39
+		 * @noreference preview feature
+		 */
+		public static final ModifierKeyword MODULE_KEYWORD = new ModifierKeyword("module", MODULE);//$NON-NLS-1$
+
 		static {
 			KEYWORDS = new HashMap(20);
 			ModifierKeyword[] ops = {
@@ -136,7 +142,8 @@ public final class Modifier extends ASTNode implements IExtendedModifier {
 					STRICTFP_KEYWORD,
 					DEFAULT_KEYWORD,
 					SEALED_KEYWORD,
-					NON_SEALED_KEYWORD
+					NON_SEALED_KEYWORD,
+					MODULE_KEYWORD
 				};
 			for (ModifierKeyword op : ops) {
 				KEYWORDS.put(op.toString(), op);
@@ -348,6 +355,13 @@ public final class Modifier extends ASTNode implements IExtendedModifier {
 	 * @noreference preview feature
 	 */
 	public static final int WHEN = 0x2000;
+	/**
+	 * "module" modifier constant (bit mask).
+	 * Applicable only to imports.
+	 * @since 3.39
+	 * @noreference preview feature
+	 */
+	public static final int MODULE = 0x8000;
 
 	/**
 	 * "default" modifier constant (bit mask) (added in JLS8 API).
@@ -786,6 +800,16 @@ public final class Modifier extends ASTNode implements IExtendedModifier {
 	 */
 	public boolean isNonSealed() {
 		return this.modifierKeyword == ModifierKeyword.NON_SEALED_KEYWORD;
+	}
+
+	/**
+	 * Answer true if the receiver is the module modifier, false otherwise.
+	 *
+	 * @return true if the receiver is the module modifier, false otherwise
+	 * @since 3.39
+	 */
+	public static boolean isModule(int flags) {
+		return (flags & Modifier.MODULE) != 0;
 	}
 
 	@Override

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/NaiveASTFlattener.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/NaiveASTFlattener.java
@@ -96,6 +96,13 @@ public class NaiveASTFlattener extends ASTVisitor {
 	private static final int JLS21 = AST.JLS21;
 
 	/**
+	 * Internal synonym for {@link AST#JLS23}. Use to alleviate
+	 * deprecation warnings.
+	 * @deprecated
+	 */
+	private static final int JLS23 = AST.JLS23;
+
+	/**
 	 * The string buffer into which the serialized representation of the AST is
 	 * written.
 	 */
@@ -845,7 +852,11 @@ public class NaiveASTFlattener extends ASTVisitor {
 	public boolean visit(ImportDeclaration node) {
 		printIndent();
 		this.buffer.append("import ");//$NON-NLS-1$
-		if (node.getAST().apiLevel() >= JLS3) {
+		if (node.getAST().apiLevel() >= JLS23) {
+			if (node.modifiers().size() == 1) {
+				this.buffer.append(((Modifier) node.modifiers().get(0)).getKeyword().toString()).append(' ');
+			}
+		} else if (node.getAST().apiLevel() >= JLS3) {
 			if (node.isStatic()) {
 				this.buffer.append("static ");//$NON-NLS-1$
 			}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/ASTRewriteFlattener.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/ASTRewriteFlattener.java
@@ -98,6 +98,9 @@ public class ASTRewriteFlattener extends ASTVisitor {
 	/** @deprecated using deprecated code */
 	private static final int JLS14_INTERNAL = AST.JLS14;
 
+	/** @deprecated using deprecated code */
+	private static final int JLS23_INTERNAL = AST.JLS23;
+
 	public static String asString(ASTNode node, RewriteEventStore store) {
 		ASTRewriteFlattener flattener= new ASTRewriteFlattener(store);
 		node.accept(flattener);
@@ -603,7 +606,12 @@ public class ASTRewriteFlattener extends ASTVisitor {
 	@Override
 	public boolean visit(ImportDeclaration node) {
 		this.result.append("import "); //$NON-NLS-1$
-		if (node.getAST().apiLevel() >= JLS3_INTERNAL) {
+		if (node.getAST().apiLevel() >= JLS23_INTERNAL) {
+			List<Modifier> modifiers = node.modifiers();
+			for (Modifier modifier : modifiers) {
+				this.result.append(modifier.getKeyword().toString()).append(' ');
+			}
+		} else if (node.getAST().apiLevel() >= JLS3_INTERNAL) {
 			if (getBooleanAttribute(node, ImportDeclaration.STATIC_PROPERTY)) {
 				this.result.append("static ");//$NON-NLS-1$
 			}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/compiler/SourceElementParser.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/compiler/SourceElementParser.java
@@ -617,42 +617,9 @@ protected void consumeSingleMemberAnnotation(boolean isTypeAnnotation) {
 @Override
 protected void consumeSingleStaticImportDeclarationName() {
 	// SingleTypeImportDeclarationName ::= 'import' 'static' Name
-	ImportReference impt;
-	int length;
-	char[][] tokens = new char[length = this.identifierLengthStack[this.identifierLengthPtr--]][];
-	this.identifierPtr -= length;
-	long[] positions = new long[length];
-	System.arraycopy(this.identifierStack, this.identifierPtr + 1, tokens, 0, length);
-	System.arraycopy(this.identifierPositionStack, this.identifierPtr + 1, positions, 0, length);
-	pushOnAstStack(impt = newImportReference(tokens, positions, false, ClassFileConstants.AccStatic));
+	super.consumeSingleStaticImportDeclarationName();
 
-	this.modifiers = ClassFileConstants.AccDefault;
-	this.modifiersSourceStart = -1; // <-- see comment into modifiersFlag(int)
-
-	if (this.currentToken == TokenNameSEMICOLON){
-		impt.declarationSourceEnd = this.scanner.currentPosition - 1;
-	} else {
-		impt.declarationSourceEnd = impt.sourceEnd;
-	}
-	impt.declarationEnd = impt.declarationSourceEnd;
-	//this.endPosition is just before the ;
-	impt.declarationSourceStart = this.intStack[this.intPtr--];
-
-	if(!this.statementRecoveryActivated &&
-			this.options.sourceLevel < ClassFileConstants.JDK1_5 &&
-			this.lastErrorEndPositionBeforeRecovery < this.scanner.currentPosition) {
-		impt.modifiers = ClassFileConstants.AccDefault; // convert the static import reference to a non-static importe reference
-		problemReporter().invalidUsageOfStaticImports(impt);
-	}
-
-	// recovery
-	if (this.currentElement != null){
-		this.lastCheckPoint = impt.declarationSourceEnd+1;
-		this.currentElement = this.currentElement.add(impt, 0);
-		this.lastIgnoredToken = -1;
-		this.restartRecovery = true; // used to avoid branching back into the regular automaton
-	}
-	if (this.reportReferenceInfo) {
+	if (this.reportReferenceInfo && this.astStack[this.astPtr] instanceof ImportReference impt) {
 		// Name for static import is TypeName '.' Identifier
 		// => accept unknown ref on identifier
 		int tokensLength = impt.tokens.length-1;
@@ -714,44 +681,8 @@ protected void consumeStaticImportOnDemandDeclarationName() {
 	/* push an ImportRef build from the last name
 	stored in the identifier stack. */
 
-	ImportReference impt;
-	int length;
-	char[][] tokens = new char[length = this.identifierLengthStack[this.identifierLengthPtr--]][];
-	this.identifierPtr -= length;
-	long[] positions = new long[length];
-	System.arraycopy(this.identifierStack, this.identifierPtr + 1, tokens, 0, length);
-	System.arraycopy(this.identifierPositionStack, this.identifierPtr + 1, positions, 0, length);
-	pushOnAstStack(impt = new ImportReference(tokens, positions, true, ClassFileConstants.AccStatic));
-
-	// star end position
-	impt.trailingStarPosition = this.intStack[this.intPtr--];
-	this.modifiers = ClassFileConstants.AccDefault;
-	this.modifiersSourceStart = -1; // <-- see comment into modifiersFlag(int)
-
-	if (this.currentToken == TokenNameSEMICOLON){
-		impt.declarationSourceEnd = this.scanner.currentPosition - 1;
-	} else {
-		impt.declarationSourceEnd = impt.sourceEnd;
-	}
-	impt.declarationEnd = impt.declarationSourceEnd;
-	//this.endPosition is just before the ;
-	impt.declarationSourceStart = this.intStack[this.intPtr--];
-
-	if(!this.statementRecoveryActivated &&
-			this.options.sourceLevel < ClassFileConstants.JDK1_5 &&
-			this.lastErrorEndPositionBeforeRecovery < this.scanner.currentPosition) {
-		impt.modifiers = ClassFileConstants.AccDefault; // convert the static import reference to a non-static importe reference
-		problemReporter().invalidUsageOfStaticImports(impt);
-	}
-
-	// recovery
-	if (this.currentElement != null){
-		this.lastCheckPoint = impt.declarationSourceEnd+1;
-		this.currentElement = this.currentElement.add(impt, 0);
-		this.lastIgnoredToken = -1;
-		this.restartRecovery = true; // used to avoid branching back into the regular automaton
-	}
-	if (this.reportReferenceInfo) {
+	super.consumeStaticImportOnDemandDeclarationName();
+	if (this.reportReferenceInfo && this.astStack[this.astPtr] instanceof ImportReference impt) {
 		this.requestor.acceptTypeReference(impt.tokens, impt.sourceStart, impt.sourceEnd);
 	}
 }


### PR DESCRIPTION
+ parser to record modifier start position of imports
+ avoid code duplication in SourceElementParser
+ new list ImportDeclaration.modifiers()
  + at 23 even 'static' is represented in that list
+ existing accessors may scan that list if present

fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2834
