### PR TITLE
cache JrtFileSystem in ClasspathJrt.jrtFileSystem #2815

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/ClasspathJep247.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/ClasspathJep247.java
@@ -261,7 +261,7 @@ public class ClasspathJep247 extends ClasspathJrt {
 		}
 		if (moduleName == null) {
 			// Delegate to the boss, even if it means inaccurate error reporting at times
-			List<String> mods = JRTUtil.getModulesDeclaringPackage(this.file, qualifiedPackageName, moduleName);
+			List<String> mods = JRTUtil.getModulesDeclaringPackage(this.jrtFileSystem, qualifiedPackageName, moduleName);
 			return CharOperation.toCharArrays(mods);
 		}
 		return singletonModuleNameIf(this.packageCache.contains(qualifiedPackageName));

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/ClasspathJep247Jdk12.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/ClasspathJep247Jdk12.java
@@ -264,7 +264,7 @@ public class ClasspathJep247Jdk12 extends ClasspathJep247 {
 	public synchronized char[][] getModulesDeclaringPackage(String qualifiedPackageName, String moduleName) {
 		if (this.jdklevel >= ClassFileConstants.JDK9) {
 			// Delegate to the boss, even if it means inaccurate error reporting at times
-			List<String> mods = JRTUtil.getModulesDeclaringPackage(this.file, qualifiedPackageName, moduleName);
+			List<String> mods = JRTUtil.getModulesDeclaringPackage(this.jrtFileSystem, qualifiedPackageName, moduleName);
 			return CharOperation.toCharArrays(mods);
 		}
 		if (this.packageCache == null) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/ClasspathJrt.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/ClasspathJrt.java
@@ -43,10 +43,12 @@ import org.eclipse.jdt.internal.compiler.env.NameEnvironmentAnswer;
 import org.eclipse.jdt.internal.compiler.lookup.BinaryTypeBinding.ExternalAnnotationStatus;
 import org.eclipse.jdt.internal.compiler.util.CtSym;
 import org.eclipse.jdt.internal.compiler.util.JRTUtil;
+import org.eclipse.jdt.internal.compiler.util.JrtFileSystem;
 
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class ClasspathJrt extends ClasspathLocation implements IMultiModuleEntry {
 	public final File file;
+	protected final JrtFileSystem jrtFileSystem;
 	protected ZipFile annotationZipFile;
 	protected final boolean closeZipFileAtEnd;
 	protected static final Map<String, Map<String,IModule>> ModulesCache = new ConcurrentHashMap<>();
@@ -57,6 +59,11 @@ public class ClasspathJrt extends ClasspathLocation implements IMultiModuleEntry
 			AccessRuleSet accessRuleSet, String destinationPath) {
 		super(accessRuleSet, destinationPath);
 		this.file = file;
+		try {
+			this.jrtFileSystem= JRTUtil.getJrtSystem(file, null);
+		} catch (IOException e) {
+			throw new IllegalStateException("Failed to init packages for " + file, e); //$NON-NLS-1$
+		}
 		this.closeZipFileAtEnd = closeZipFileAtEnd;
 		this.moduleNamesCache = new HashSet<>();
 	}
@@ -67,12 +74,12 @@ public class ClasspathJrt extends ClasspathLocation implements IMultiModuleEntry
 	}
 	@Override
 	public char[][] getModulesDeclaringPackage(String qualifiedPackageName, String moduleName) {
-		List<String> modules = JRTUtil.getModulesDeclaringPackage(this.file, qualifiedPackageName, moduleName);
+		List<String> modules = JRTUtil.getModulesDeclaringPackage(this.jrtFileSystem, qualifiedPackageName, moduleName);
 		return CharOperation.toCharArrays(modules);
 	}
 	@Override
 	public boolean hasCompilationUnit(String qualifiedPackageName, String moduleName) {
-		return JRTUtil.hasCompilationUnit(this.file, qualifiedPackageName, moduleName);
+		return JRTUtil.hasCompilationUnit(this.jrtFileSystem, qualifiedPackageName, moduleName);
 	}
 	@Override
 	public NameEnvironmentAnswer findClass(char[] typeName, String qualifiedPackageName, String moduleName, String qualifiedBinaryFileName) {
@@ -84,7 +91,7 @@ public class ClasspathJrt extends ClasspathLocation implements IMultiModuleEntry
 			return null; // most common case
 
 		try {
-			IBinaryType reader = ClassFileReader.readFromModule(this.file, moduleName, qualifiedBinaryFileName, this.moduleNamesCache::contains);
+			IBinaryType reader = JRTUtil.getClassfile(this.jrtFileSystem, qualifiedBinaryFileName, moduleName, this.moduleNamesCache::contains);
 
 			if (reader != null) {
 				reader = maybeDecorateForExternalAnnotations(qualifiedBinaryFileName, reader);
@@ -135,7 +142,7 @@ public class ClasspathJrt extends ClasspathLocation implements IMultiModuleEntry
 		final ArrayList answers = new ArrayList();
 
 		try {
-			JRTUtil.walkModuleImage(this.file, new JRTUtil.JrtFileVisitor<java.nio.file.Path>() {
+			JRTUtil.walkModuleImage(this.jrtFileSystem, new JRTUtil.JrtFileVisitor<java.nio.file.Path>() {
 
 				@Override
 				public FileVisitResult visitPackage(java.nio.file.Path dir, java.nio.file.Path modPath, BasicFileAttributes attrs) throws IOException {
@@ -209,7 +216,7 @@ public class ClasspathJrt extends ClasspathLocation implements IMultiModuleEntry
 		Map<String, IModule> cache = ModulesCache.computeIfAbsent(this.file.getPath(), key -> {
 			HashMap<String,IModule> newCache = new HashMap<>();
 			try {
-				org.eclipse.jdt.internal.compiler.util.JRTUtil.walkModuleImage(this.file,
+				org.eclipse.jdt.internal.compiler.util.JRTUtil.walkModuleImage(this.jrtFileSystem,
 						new org.eclipse.jdt.internal.compiler.util.JRTUtil.JrtFileVisitor<Path>() {
 
 					@Override
@@ -227,7 +234,7 @@ public class ClasspathJrt extends ClasspathLocation implements IMultiModuleEntry
 					@Override
 					public FileVisitResult visitModule(Path p, String name) throws IOException {
 						try {
-							ClasspathJrt.this.acceptModule(JRTUtil.getClassfile(ClasspathJrt.this.file, IModule.MODULE_INFO_CLASS, name), newCache);
+							ClasspathJrt.this.acceptModule(ClasspathJrt.this.jrtFileSystem.getClassfile(IModule.MODULE_INFO_CLASS, name), newCache);
 						} catch (ClassFormatException e) {
 							throw new IOException(e);
 						}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/tool/EclipseCompilerImpl.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/tool/EclipseCompilerImpl.java
@@ -540,7 +540,7 @@ public class EclipseCompilerImpl extends Main {
 										EclipseFileManager efm = (EclipseFileManager) standardJavaFileManager;
 										@SuppressWarnings("resource") // XXX EclipseFileManager should close jrtfs but it looks like standardJavaFileManager is never closed
 										// Was leaking new JrtFileSystem(classpathJrt.file):
-										JrtFileSystem jrtfs = efm.getJrtFileSystem(classpathJrt.file);
+										JrtFileSystem jrtfs = efm.getJrtFileSystem(classpathJrt.file); // XXX use classpathJrt.jrtFileSystem??
 										efm.locationHandler.newSystemLocation(StandardLocation.SYSTEM_MODULES, jrtfs);
 									} catch (IOException e) {
 										String error = "Failed to create JRTFS from " + classpathJrt.file; //$NON-NLS-1$

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/util/JRTUtil.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/util/JRTUtil.java
@@ -14,7 +14,6 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.compiler.util;
 
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -22,7 +21,6 @@ import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.net.URI;
 import java.nio.channels.ClosedByInterruptException;
-import java.nio.file.DirectoryStream;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystemAlreadyExistsException;
 import java.nio.file.FileSystemNotFoundException;
@@ -34,15 +32,11 @@ import java.nio.file.Path;
 import java.nio.file.ProviderNotFoundException;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
-import java.util.stream.Stream;
 
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFormatException;
@@ -236,16 +230,11 @@ public class JRTUtil {
 	 * @param visitor an instance of JrtFileVisitor to be notified of the entries in the JRT image.
 	 * @param notify flag indicating the notifications the client is interested in.
 	 */
-	public static void walkModuleImage(File image, final JRTUtil.JrtFileVisitor<Path> visitor, int notify) throws IOException {
-		JrtFileSystem system = getJrtSystem(image, null);
-		if (system == null) {
-			return;
-		}
-		system.walkModuleImage(visitor, notify);
+	public static void walkModuleImage(File image, JRTUtil.JrtFileVisitor<Path> visitor, int notify) throws IOException {
+		walkModuleImage(getJrtSystem(image, null), visitor, notify);
 	}
 
-	public static void walkModuleImage(File image, String release, final JRTUtil.JrtFileVisitor<Path> visitor, int notify) throws IOException {
-		JrtFileSystem system = getJrtSystem(image, release);
+	public static void walkModuleImage(JrtFileSystem system, JRTUtil.JrtFileVisitor<Path> visitor, int notify) throws IOException {
 		if (system == null) {
 			return;
 		}
@@ -263,8 +252,13 @@ public class JRTUtil {
 	public static byte[] getClassfileContent(File jrt, String fileName, String module) throws IOException {
 		JrtFileSystem system = getJrtSystem(jrt, null);
 		if (system == null) {
-			throw new FileNotFoundException(String.valueOf(jrt));
+			throw new FileNotFoundException(String.valueOf(system));
 		}
+		return getClassfileContent(system,fileName, module);
+	}
+
+	public static byte[] getClassfileContent(JrtFileSystem system, String fileName, String module)
+			throws FileNotFoundException, IOException {
 		return system.getClassfileContent(fileName, module);
 	}
 
@@ -277,15 +271,24 @@ public class JRTUtil {
 	}
 
 	public static ClassFileReader getClassfile(File jrt, String fileName, String module, Predicate<String> moduleNameFilter) throws IOException, ClassFormatException {
-		JrtFileSystem system = getJrtSystem(jrt, null);
-		if (system == null) {
+		JrtFileSystem jrtSystem = getJrtSystem(jrt, null);
+		if (jrtSystem == null) {
 			throw new FileNotFoundException(String.valueOf(jrt));
 		}
+		return getClassfile(jrtSystem, fileName, module, moduleNameFilter);
+	}
+
+	public static ClassFileReader getClassfile(JrtFileSystem system, String fileName, String module,
+			Predicate<String> moduleNameFilter)
+			throws FileNotFoundException, IOException, ClassFormatException {
 		return system.getClassfile(fileName, module, moduleNameFilter);
 	}
 
 	public static List<String> getModulesDeclaringPackage(File jrt, String qName, String moduleName) {
-		JrtFileSystem system = getJrtSystem(jrt);
+		return getModulesDeclaringPackage(getJrtSystem(jrt), qName, moduleName);
+	}
+
+	public static List<String> getModulesDeclaringPackage(JrtFileSystem system, String qName, String moduleName) {
 		if (system == null) {
 			return List.of();
 		}
@@ -294,6 +297,10 @@ public class JRTUtil {
 
 	public static boolean hasCompilationUnit(File jrt, String qualifiedPackageName, String moduleName) {
 		JrtFileSystem system = getJrtSystem(jrt);
+		return hasCompilationUnit(system, qualifiedPackageName, moduleName);
+	}
+
+	public static boolean hasCompilationUnit(JrtFileSystem system, String qualifiedPackageName, String moduleName) {
 		if (system == null) {
 			return false;
 		}
@@ -481,305 +488,5 @@ class Jdk {
 			ver = ver.replace("\"", "");  //$NON-NLS-1$//$NON-NLS-2$
 		}
 		return ver;
-	}
-}
-
-class JrtFileSystem {
-
-	private final Map<String, String> packageToModule = new HashMap<>();
-
-	private final Map<String, List<String>> packageToModules = new HashMap<>();
-
-	FileSystem fs;
-	final Path modRoot;
-	final Jdk jdk;
-	final String release;
-
-	public static JrtFileSystem getNewJrtFileSystem(Jdk jdk, String release) throws IOException {
-		if (release == null || jdk.sameRelease(release)) {
-			return new JrtFileSystem(jdk, null);
-		} else {
-			return new JrtFileSystemWithOlderRelease(jdk, release);
-		}
-	}
-
-	/**
-	 * The jrt file system is based on the location of the JRE home whose libraries
-	 * need to be loaded.
-	 */
-	JrtFileSystem(Jdk jdkHome, String release) throws IOException {
-		this.jdk = jdkHome;
-		this.release = release;
-		JRTUtil.MODULE_TO_LOAD = System.getProperty("modules.to.load"); //$NON-NLS-1$
-		this.fs = JRTUtil.getJrtFileSystem(this.jdk.path);
-		this.modRoot = this.fs.getPath(JRTUtil.MODULES_SUBDIR);
-		// Set up the root directory where modules are located
-		walkJrtForModules();
-	}
-
-	public List<String> getModulesDeclaringPackage(String qualifiedPackageName, String moduleName) {
-		qualifiedPackageName = qualifiedPackageName.replace('.', '/');
-		String module = this.packageToModule.get(qualifiedPackageName);
-		if (moduleName == null) {
-			// wildcard search:
-			if (module == null)
-				return null;
-			if (module == JRTUtil.MULTIPLE)
-				return this.packageToModules.get(qualifiedPackageName);
-			return Collections.singletonList(module);
-		}
-		if (module != null) {
-			// specific search:
-			if (module == JRTUtil.MULTIPLE) {
-				List<String> list = this.packageToModules.get(qualifiedPackageName);
-				if (list.contains(moduleName))
-					return Collections.singletonList(moduleName);
-			} else {
-				if (module.equals(moduleName))
-					return Collections.singletonList(moduleName);
-			}
-		}
-		return null;
-	}
-
-	public String[] getModules(String fileName) {
-		int idx = fileName.lastIndexOf('/');
-		String pack = null;
-		if (idx != -1) {
-			pack = fileName.substring(0, idx);
-		} else {
-			pack = JRTUtil.DEFAULT_PACKAGE;
-		}
-		String module = this.packageToModule.get(pack);
-		if (module != null) {
-			if (module == JRTUtil.MULTIPLE) {
-				List<String> list = this.packageToModules.get(pack);
-				return list.toArray(new String[0]);
-			} else {
-				return new String[]{module};
-			}
-		}
-		return JRTUtil.DEFAULT_MODULE;
-	}
-
-	public boolean hasClassFile(String qualifiedPackageName, String module) {
-		if (module == null)
-			return false;
-		// easy checks first:
-		String knownModule = this.packageToModule.get(qualifiedPackageName);
-		if (knownModule == null || (knownModule != JRTUtil.MULTIPLE && !knownModule.equals(module)))
-			return false;
-		Path packagePath = this.fs.getPath(JRTUtil.MODULES_SUBDIR, module, qualifiedPackageName);
-		if (!Files.exists(packagePath))
-			return false;
-		// iterate files:
-		try {
-			try (Stream<Path> list = Files.list(packagePath)) {
-				return list.anyMatch(filePath -> filePath.toString().endsWith(SuffixConstants.SUFFIX_STRING_class)
-						|| filePath.toString().endsWith(SuffixConstants.SUFFIX_STRING_CLASS));
-			}
-		} catch (IOException e) {
-			return false;
-		}
-	}
-
-	public InputStream getContentFromJrt(String fileName, String module) throws IOException {
-		if (module != null) {
-			byte[] fileBytes = getFileBytes(fileName, module);
-			if(fileBytes == null) {
-				return null;
-			}
-			return new ByteArrayInputStream(fileBytes);
-		}
-		String[] modules = getModules(fileName);
-		for (String mod : modules) {
-			byte[] fileBytes = getFileBytes(fileName, mod);
-			if(fileBytes != null) {
-				return new ByteArrayInputStream(fileBytes);
-			}
-		}
-		return null;
-	}
-
-	private ClassFileReader getClassfile(String fileName, Predicate<String> moduleNameFilter) throws IOException, ClassFormatException {
-		String[] modules = getModules(fileName);
-		for (String mod : modules) {
-			if (moduleNameFilter != null && !moduleNameFilter.test(mod)) {
-				continue;
-			}
-			ClassFileReader reader = getClassfileFromModule(fileName, mod);
-			if (reader != null) {
-				return reader;
-			}
-		}
-		return null;
-	}
-
-	byte[] getClassfileContent(String fileName, String module) throws IOException {
-		byte[] content = null;
-		if (module != null) {
-			content = getFileBytes(fileName, module);
-		} else {
-			String[] modules = getModules(fileName);
-			for (String mod : modules) {
-				content = getFileBytes(fileName, mod);
-				if (content != null) {
-					break;
-				}
-			}
-		}
-		return content;
-	}
-
-	private byte[] getFileBytes(String fileName, String module) throws IOException {
-		Path path = this.fs.getPath(JRTUtil.MODULES_SUBDIR, module, fileName);
-		if(JRTUtil.DISABLE_CACHE) {
-			return JRTUtil.safeReadBytes(path);
-		} else {
-			return JRTUtil.classCache.getClassBytes(this.jdk, path);
-		}
-	}
-
-	ClassFileReader getClassfileFromModule(String fileName, String module) throws IOException, ClassFormatException {
-		Path path = this.fs.getPath(JRTUtil.MODULES_SUBDIR, module, fileName);
-		byte[] content = null;
-		if(JRTUtil.DISABLE_CACHE) {
-			content = JRTUtil.safeReadBytes(path);
-		} else {
-			content = JRTUtil.classCache.getClassBytes(this.jdk, path);
-		}
-		if (content != null) {
-			ClassFileReader reader = new ClassFileReader(path.toUri(), content, fileName.toCharArray());
-			reader.moduleName = module.toCharArray();
-			return reader;
-		} else {
-			return null;
-		}
-	}
-	public ClassFileReader getClassfile(String fileName, String module, Predicate<String> moduleNameFilter) throws IOException, ClassFormatException {
-		ClassFileReader reader = null;
-		if (module == null) {
-			reader = getClassfile(fileName, moduleNameFilter);
-		} else {
-			reader = getClassfileFromModule(fileName, module);
-		}
-		return reader;
-	}
-
-	public ClassFileReader getClassfile(String fileName, String module) throws IOException, ClassFormatException {
-		if (module == null) {
-			return getClassfile(fileName, (Predicate<String>)null);
-		} else {
-			return getClassfileFromModule(fileName, module);
-		}
-	}
-
-	void walkJrtForModules() throws IOException {
-		Iterable<Path> roots = this.fs.getRootDirectories();
-		for (Path path : roots) {
-			try (DirectoryStream<Path> stream = Files.newDirectoryStream(path)) {
-				for (final Path subdir: stream) {
-					if (!subdir.toString().equals(JRTUtil.MODULES_SUBDIR)) {
-						Files.walkFileTree(subdir, new SimpleFileVisitor<>() {
-							@Override
-							public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-								// e.g. /modules/java.base
-								Path relative = subdir.relativize(file);
-								cachePackage(relative.getParent().toString(), relative.getFileName().toString());
-								return FileVisitResult.CONTINUE;
-							}
-						});
-					}
-			    }
-			} catch (Exception e) {
-				throw new IOException(e.getMessage(), e);
-			}
-		}
-	}
-
-	void walkModuleImage(final JRTUtil.JrtFileVisitor<Path> visitor, final int notify) throws IOException {
-		Files.walkFileTree(this.modRoot, new SimpleFileVisitor<>() {
-			@Override
-			public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
-				int count = dir.getNameCount();
-				if (count == 1) return FileVisitResult.CONTINUE;
-				if (count == 2) {
-					// e.g. /modules/java.base
-					Path mod = dir.getName(1);
-					if ((JRTUtil.MODULE_TO_LOAD != null && JRTUtil.MODULE_TO_LOAD.length() > 0 &&
-							JRTUtil.MODULE_TO_LOAD.indexOf(mod.toString()) == -1)) {
-						return FileVisitResult.SKIP_SUBTREE;
-					}
-					return ((notify & JRTUtil.NOTIFY_MODULES) == 0) ?
-							FileVisitResult.CONTINUE : visitor.visitModule(dir, JRTUtil.sanitizedFileName(mod));
-				}
-				if ((notify & JRTUtil.NOTIFY_PACKAGES) == 0) {
-					// We are dealing with a module or not client is not interested in packages
-					return FileVisitResult.CONTINUE;
-				}
-				return visitor.visitPackage(dir.subpath(2, count), dir.getName(1), attrs);
-			}
-
-			@Override
-			public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-				if ((notify & JRTUtil.NOTIFY_FILES) == 0)
-					return FileVisitResult.CONTINUE;
-				int count = file.getNameCount();
-				// This happens when a file in a default package is present. E.g. /modules/some.module/file.name
-				if (count == 3) {
-					cachePackage(JRTUtil.DEFAULT_PACKAGE, file.getName(1).toString());
-				}
-				return visitor.visitFile(file.subpath(2, count), file.getName(1), attrs);
-			}
-		});
-	}
-
-	synchronized void cachePackage(String packageName, String module) {
-		packageName = packageName.replace('.', '/');
-		String currentModule = this.packageToModule.get(packageName);
-		if (currentModule == null) {
-			// Nothing found? Cache and return
-			this.packageToModule.put(packageName.intern(), module.intern());
-			return;
-		}
-		if(currentModule.equals(module)) {
-			// Same module found? Just return
-			return;
-		}
-
-		// We observe an additional module containing package
-		if (currentModule == JRTUtil.MULTIPLE) {
-			// We have already a list => update it
-			List<String> list = this.packageToModules.get(packageName);
-			if (!list.contains(module)) {
-				if (JRTUtil.JAVA_BASE.equals(module)) {
-					list.add(0, JRTUtil.JAVA_BASE);
-				} else {
-					list.add(module.intern());
-				}
-			}
-		} else {
-			// We found a second module => create a list
-			List<String> list = new ArrayList<>();
-			// Just do this as comparator might be overkill
-			if (JRTUtil.JAVA_BASE == currentModule || JRTUtil.JAVA_BASE.equals(currentModule)) {
-				list.add(currentModule.intern());
-				list.add(module.intern());
-			} else {
-				list.add(module.intern());
-				list.add(currentModule.intern());
-			}
-			packageName = packageName.intern();
-			this.packageToModules.put(packageName, list);
-			this.packageToModule.put(packageName, JRTUtil.MULTIPLE);
-		}
-	}
-
-	/**
-	 * @return JDK release string (something like <code>1.8.0_05<code>) read from the "release" file from JDK home
-	 *         directory
-	 */
-	public String getJdkRelease() {
-		return this.jdk.release;
 	}
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/util/JrtFileSystem.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/util/JrtFileSystem.java
@@ -1,0 +1,335 @@
+/*******************************************************************************
+ * Copyright (c) 2015, 2024 IBM Corporation.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.internal.compiler.util;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.DirectoryStream;
+import java.nio.file.FileSystem;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader;
+import org.eclipse.jdt.internal.compiler.classfmt.ClassFormatException;
+
+public class JrtFileSystem {
+
+	private final Map<String, String> packageToModule = new HashMap<>();
+
+	private final Map<String, List<String>> packageToModules = new HashMap<>();
+
+	FileSystem fs;
+	final Path modRoot;
+	final Jdk jdk;
+	final String release;
+
+	public static JrtFileSystem getNewJrtFileSystem(Jdk jdk, String release) throws IOException {
+		if (release == null || jdk.sameRelease(release)) {
+			return new JrtFileSystem(jdk, null);
+		} else {
+			return new JrtFileSystemWithOlderRelease(jdk, release);
+		}
+	}
+
+	/**
+	 * The jrt file system is based on the location of the JRE home whose libraries
+	 * need to be loaded.
+	 */
+	JrtFileSystem(Jdk jdkHome, String release) throws IOException {
+		this.jdk = jdkHome;
+		this.release = release;
+		JRTUtil.MODULE_TO_LOAD = System.getProperty("modules.to.load"); //$NON-NLS-1$
+		this.fs = JRTUtil.getJrtFileSystem(this.jdk.path);
+		this.modRoot = this.fs.getPath(JRTUtil.MODULES_SUBDIR);
+		// Set up the root directory where modules are located
+		walkJrtForModules();
+	}
+
+	public List<String> getModulesDeclaringPackage(String qualifiedPackageName, String moduleName) {
+		qualifiedPackageName = qualifiedPackageName.replace('.', '/');
+		String module = this.packageToModule.get(qualifiedPackageName);
+		if (moduleName == null) {
+			// wildcard search:
+			if (module == null)
+				return null;
+			if (module == JRTUtil.MULTIPLE)
+				return this.packageToModules.get(qualifiedPackageName);
+			return Collections.singletonList(module);
+		}
+		if (module != null) {
+			// specific search:
+			if (module == JRTUtil.MULTIPLE) {
+				List<String> list = this.packageToModules.get(qualifiedPackageName);
+				if (list.contains(moduleName))
+					return Collections.singletonList(moduleName);
+			} else {
+				if (module.equals(moduleName))
+					return Collections.singletonList(moduleName);
+			}
+		}
+		return null;
+	}
+
+	public String[] getModules(String fileName) {
+		int idx = fileName.lastIndexOf('/');
+		String pack = null;
+		if (idx != -1) {
+			pack = fileName.substring(0, idx);
+		} else {
+			pack = JRTUtil.DEFAULT_PACKAGE;
+		}
+		String module = this.packageToModule.get(pack);
+		if (module != null) {
+			if (module == JRTUtil.MULTIPLE) {
+				List<String> list = this.packageToModules.get(pack);
+				return list.toArray(new String[0]);
+			} else {
+				return new String[]{module};
+			}
+		}
+		return JRTUtil.DEFAULT_MODULE;
+	}
+
+	public boolean hasClassFile(String qualifiedPackageName, String module) {
+		if (module == null)
+			return false;
+		// easy checks first:
+		String knownModule = this.packageToModule.get(qualifiedPackageName);
+		if (knownModule == null || (knownModule != JRTUtil.MULTIPLE && !knownModule.equals(module)))
+			return false;
+		Path packagePath = this.fs.getPath(JRTUtil.MODULES_SUBDIR, module, qualifiedPackageName);
+		if (!Files.exists(packagePath))
+			return false;
+		// iterate files:
+		try {
+			try (Stream<Path> list = Files.list(packagePath)) {
+				return list.anyMatch(filePath -> filePath.toString().endsWith(SuffixConstants.SUFFIX_STRING_class)
+						|| filePath.toString().endsWith(SuffixConstants.SUFFIX_STRING_CLASS));
+			}
+		} catch (IOException e) {
+			return false;
+		}
+	}
+
+	public InputStream getContentFromJrt(String fileName, String module) throws IOException {
+		if (module != null) {
+			byte[] fileBytes = getFileBytes(fileName, module);
+			if(fileBytes == null) {
+				return null;
+			}
+			return new ByteArrayInputStream(fileBytes);
+		}
+		String[] modules = getModules(fileName);
+		for (String mod : modules) {
+			byte[] fileBytes = getFileBytes(fileName, mod);
+			if(fileBytes != null) {
+				return new ByteArrayInputStream(fileBytes);
+			}
+		}
+		return null;
+	}
+
+	private ClassFileReader getClassfile(String fileName, Predicate<String> moduleNameFilter) throws IOException, ClassFormatException {
+		String[] modules = getModules(fileName);
+		for (String mod : modules) {
+			if (moduleNameFilter != null && !moduleNameFilter.test(mod)) {
+				continue;
+			}
+			ClassFileReader reader = getClassfileFromModule(fileName, mod);
+			if (reader != null) {
+				return reader;
+			}
+		}
+		return null;
+	}
+
+	byte[] getClassfileContent(String fileName, String module) throws IOException {
+		byte[] content = null;
+		if (module != null) {
+			content = getFileBytes(fileName, module);
+		} else {
+			String[] modules = getModules(fileName);
+			for (String mod : modules) {
+				content = getFileBytes(fileName, mod);
+				if (content != null) {
+					break;
+				}
+			}
+		}
+		return content;
+	}
+
+	private byte[] getFileBytes(String fileName, String module) throws IOException {
+		Path path = this.fs.getPath(JRTUtil.MODULES_SUBDIR, module, fileName);
+		if(JRTUtil.DISABLE_CACHE) {
+			return JRTUtil.safeReadBytes(path);
+		} else {
+			return JRTUtil.classCache.getClassBytes(this.jdk, path);
+		}
+	}
+
+	ClassFileReader getClassfileFromModule(String fileName, String module) throws IOException, ClassFormatException {
+		Path path = this.fs.getPath(JRTUtil.MODULES_SUBDIR, module, fileName);
+		byte[] content = null;
+		if(JRTUtil.DISABLE_CACHE) {
+			content = JRTUtil.safeReadBytes(path);
+		} else {
+			content = JRTUtil.classCache.getClassBytes(this.jdk, path);
+		}
+		if (content != null) {
+			ClassFileReader reader = new ClassFileReader(path.toUri(), content, fileName.toCharArray());
+			reader.moduleName = module.toCharArray();
+			return reader;
+		} else {
+			return null;
+		}
+	}
+	public ClassFileReader getClassfile(String fileName, String module, Predicate<String> moduleNameFilter) throws IOException, ClassFormatException {
+		ClassFileReader reader = null;
+		if (module == null) {
+			reader = getClassfile(fileName, moduleNameFilter);
+		} else {
+			reader = getClassfileFromModule(fileName, module);
+		}
+		return reader;
+	}
+
+	public ClassFileReader getClassfile(String fileName, String module) throws IOException, ClassFormatException {
+		if (module == null) {
+			return getClassfile(fileName, (Predicate<String>)null);
+		} else {
+			return getClassfileFromModule(fileName, module);
+		}
+	}
+
+	void walkJrtForModules() throws IOException {
+		Iterable<Path> roots = this.fs.getRootDirectories();
+		for (Path path : roots) {
+			try (DirectoryStream<Path> stream = Files.newDirectoryStream(path)) {
+				for (final Path subdir: stream) {
+					if (!subdir.toString().equals(JRTUtil.MODULES_SUBDIR)) {
+						Files.walkFileTree(subdir, new SimpleFileVisitor<>() {
+							@Override
+							public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+								// e.g. /modules/java.base
+								Path relative = subdir.relativize(file);
+								cachePackage(relative.getParent().toString(), relative.getFileName().toString());
+								return FileVisitResult.CONTINUE;
+							}
+						});
+					}
+			    }
+			} catch (Exception e) {
+				throw new IOException(e.getMessage(), e);
+			}
+		}
+	}
+
+	void walkModuleImage(final JRTUtil.JrtFileVisitor<Path> visitor, final int notify) throws IOException {
+		Files.walkFileTree(this.modRoot, new SimpleFileVisitor<>() {
+			@Override
+			public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+				int count = dir.getNameCount();
+				if (count == 1) return FileVisitResult.CONTINUE;
+				if (count == 2) {
+					// e.g. /modules/java.base
+					Path mod = dir.getName(1);
+					if ((JRTUtil.MODULE_TO_LOAD != null && JRTUtil.MODULE_TO_LOAD.length() > 0 &&
+							JRTUtil.MODULE_TO_LOAD.indexOf(mod.toString()) == -1)) {
+						return FileVisitResult.SKIP_SUBTREE;
+					}
+					return ((notify & JRTUtil.NOTIFY_MODULES) == 0) ?
+							FileVisitResult.CONTINUE : visitor.visitModule(dir, JRTUtil.sanitizedFileName(mod));
+				}
+				if ((notify & JRTUtil.NOTIFY_PACKAGES) == 0) {
+					// We are dealing with a module or not client is not interested in packages
+					return FileVisitResult.CONTINUE;
+				}
+				return visitor.visitPackage(dir.subpath(2, count), dir.getName(1), attrs);
+			}
+
+			@Override
+			public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+				if ((notify & JRTUtil.NOTIFY_FILES) == 0)
+					return FileVisitResult.CONTINUE;
+				int count = file.getNameCount();
+				// This happens when a file in a default package is present. E.g. /modules/some.module/file.name
+				if (count == 3) {
+					cachePackage(JRTUtil.DEFAULT_PACKAGE, file.getName(1).toString());
+				}
+				return visitor.visitFile(file.subpath(2, count), file.getName(1), attrs);
+			}
+		});
+	}
+
+	synchronized void cachePackage(String packageName, String module) {
+		packageName = packageName.replace('.', '/');
+		String currentModule = this.packageToModule.get(packageName);
+		if (currentModule == null) {
+			// Nothing found? Cache and return
+			this.packageToModule.put(packageName.intern(), module.intern());
+			return;
+		}
+		if(currentModule.equals(module)) {
+			// Same module found? Just return
+			return;
+		}
+
+		// We observe an additional module containing package
+		if (currentModule == JRTUtil.MULTIPLE) {
+			// We have already a list => update it
+			List<String> list = this.packageToModules.get(packageName);
+			if (!list.contains(module)) {
+				if (JRTUtil.JAVA_BASE.equals(module)) {
+					list.add(0, JRTUtil.JAVA_BASE);
+				} else {
+					list.add(module.intern());
+				}
+			}
+		} else {
+			// We found a second module => create a list
+			List<String> list = new ArrayList<>();
+			// Just do this as comparator might be overkill
+			if (JRTUtil.JAVA_BASE == currentModule || JRTUtil.JAVA_BASE.equals(currentModule)) {
+				list.add(currentModule.intern());
+				list.add(module.intern());
+			} else {
+				list.add(module.intern());
+				list.add(currentModule.intern());
+			}
+			packageName = packageName.intern();
+			this.packageToModules.put(packageName, list);
+			this.packageToModule.put(packageName, JRTUtil.MULTIPLE);
+		}
+	}
+
+	/**
+	 * @return JDK release string (something like <code>1.8.0_05<code>) read from the "release" file from JDK home
+	 *         directory
+	 */
+	public String getJdkRelease() {
+		return this.jdk.release;
+	}
+}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JarEntryFile.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JarEntryFile.java
@@ -53,8 +53,8 @@ public class JarEntryFile  extends JarEntryResource {
 		if (Util.isJrt(root.getPath().toOSString())) {
 			try {
 				Object target = JavaModel.getTarget(root, false);
-				if (target != null && target instanceof File) {
-					return JRTUtil.getContentFromJrt((File) target, getEntryName(), root.getElementName());
+				if (target instanceof File file) {
+					return JRTUtil.getContentFromJrt(file, getEntryName(), root.getElementName());
 				}
 			} catch (IOException e) {
 				throw new JavaModelException(e, IJavaModelStatusConstants.IO_EXCEPTION);

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaProject.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaProject.java
@@ -878,10 +878,10 @@ public class JavaProject
 
 	/** Helper for computing the transitive closure of a set of modules. */
 	private static class ModuleLookup {
-		File jrtFile;
-		Map<String, JrtPackageFragmentRoot> modNames2Roots = new HashMap<>();
-		Map<String, IModule> modules = new HashMap<>();
-		Set<IModule> resultModuleSet = new HashSet<>();
+		private final File jrtFile;
+		private final Map<String, JrtPackageFragmentRoot> modNames2Roots = new HashMap<>();
+		private final Map<String, IModule> modules = new HashMap<>();
+		private final Set<IModule> resultModuleSet = new HashSet<>();
 
 		public ModuleLookup(File jrtFile) {
 			this.jrtFile = jrtFile;

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/ClasspathJrtWithReleaseOption.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/ClasspathJrtWithReleaseOption.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.core.builder;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileSystem;
 import java.nio.file.FileVisitResult;
@@ -39,45 +40,71 @@ import org.eclipse.jdt.internal.compiler.env.IModule;
 import org.eclipse.jdt.internal.compiler.env.NameEnvironmentAnswer;
 import org.eclipse.jdt.internal.compiler.util.CtSym;
 import org.eclipse.jdt.internal.compiler.util.JRTUtil;
+import org.eclipse.jdt.internal.compiler.util.JrtFileSystem;
 import org.eclipse.jdt.internal.compiler.util.SimpleSet;
 import org.eclipse.jdt.internal.compiler.util.SuffixConstants;
 import org.eclipse.jdt.internal.core.util.Util;
 
 public class ClasspathJrtWithReleaseOption extends ClasspathJrt {
 
-	static String MODULE_INFO = "module-info.sig"; //$NON-NLS-1$
+	private static final String MODULE_INFO = "module-info.sig"; //$NON-NLS-1$
 
 	final String release;
-	String releaseCode;
+	private final String releaseCode;
 	/**
 	 * Null for releases without ct.sym file or for releases matching current one
 	 */
 	private FileSystem fs;
-	protected Path releasePath;
-	protected Path modulePath;
-	private String modPathString;
-	CtSym ctSym;
-
+	private final Path releasePath;
+	private final String modPathString;
+	private CtSym ctSym;
+	private final JrtFileSystem jrtFileSystemForRelease;
 
 
 	public ClasspathJrtWithReleaseOption(String zipFilename, AccessRuleSet accessRuleSet, IPath externalAnnotationPath,
 			String release) throws CoreException {
-		super();
+		super(zipFilename);
 		if (release == null || release.equals("")) { //$NON-NLS-1$
 			throw new IllegalArgumentException("--release argument can not be null"); //$NON-NLS-1$
 		}
-		setZipFile(zipFilename);
 		this.accessRuleSet = accessRuleSet;
 		if (externalAnnotationPath != null) {
 			this.externalAnnotationPath = externalAnnotationPath.toString();
 		}
 		this.release = getReleaseOptionFromCompliance(release);
+		JrtFileSystem systemForRelease = null;
+		try {
+			systemForRelease = JRTUtil.getJrtSystem(new File(zipFilename), this.release);
+		} catch (IOException e) {
+			Util.log(e, "Failed to init packages for " + zipFilename); //$NON-NLS-1$
+		}
+		this.jrtFileSystemForRelease = systemForRelease;
 		try {
 			this.ctSym = JRTUtil.getCtSym(Path.of(this.zipFilename).getParent().getParent());
 		} catch (IOException e) {
 			throw new CoreException(Status.error("Failed to init ct.sym for " + this.zipFilename, e)); //$NON-NLS-1$
 		}
-		initialize();
+
+		/**
+		 * Set up the paths where modules and regular classes need to be read. We need to deal with two different kind of
+		 * formats of cy.sym, see {@link CtSym} javadoc.
+		 *
+		 * @see CtSym
+		 */
+		this.releaseCode = CtSym.getReleaseCode(this.release);
+		this.fs = this.ctSym.getFs();
+		this.releasePath = this.ctSym.getRoot();
+		Path modPath = this.fs.getPath(this.releaseCode + (this.ctSym.isJRE12Plus() ? "" : "-modules")); //$NON-NLS-1$ //$NON-NLS-2$
+		this.modPathString = !Files.exists(modPath) ? null: (this.zipFilename + "|"+ modPath.toString()); //$NON-NLS-1$
+
+		if (!Files.exists(this.releasePath.resolve(this.releaseCode))) {
+			Exception e = new IllegalArgumentException("release " + this.release + " is not found in the system"); //$NON-NLS-1$//$NON-NLS-2$
+			throw new CoreException(Status.error(e.getMessage(), e));
+		}
+		if (Files.exists(this.fs.getPath(this.releaseCode, "system-modules"))) { //$NON-NLS-1$
+			this.fs = null;  // Fallback to default version, all classes are on jrt fs, not here.
+		}
+
 		loadModules();
 	}
 	/*
@@ -100,31 +127,6 @@ public class ClasspathJrtWithReleaseOption extends ClasspathJrt {
 		}
 	}
 
-	/**
-	 * Set up the paths where modules and regular classes need to be read. We need to deal with two different kind of
-	 * formats of cy.sym, see {@link CtSym} javadoc.
-	 *
-	 * @see CtSym
-	 */
-	protected void initialize() throws CoreException {
-		this.releaseCode = CtSym.getReleaseCode(this.release);
-		this.fs = this.ctSym.getFs();
-		this.releasePath = this.ctSym.getRoot();
-		Path modPath = this.fs.getPath(this.releaseCode + (this.ctSym.isJRE12Plus() ? "" : "-modules")); //$NON-NLS-1$ //$NON-NLS-2$
-		if (Files.exists(modPath)) {
-			this.modulePath = modPath;
-			this.modPathString = this.zipFilename + "|"+ modPath.toString(); //$NON-NLS-1$
-		}
-
-		if (!Files.exists(this.releasePath.resolve(this.releaseCode))) {
-			Exception e = new IllegalArgumentException("release " + this.release + " is not found in the system"); //$NON-NLS-1$//$NON-NLS-2$
-			throw new CoreException(Status.error(e.getMessage(), e));
-		}
-		if (Files.exists(this.fs.getPath(this.releaseCode, "system-modules"))) { //$NON-NLS-1$
-			this.fs = null;  // Fallback to default version, all classes are on jrt fs, not here.
-		}
-	}
-
 	Map<String, SimpleSet> findPackagesInModules() {
 		// In JDK 11 and before, classes are not listed under their respective modules
 		// Hence, we simply go to the default module system for package-module mapping
@@ -137,7 +139,7 @@ public class ClasspathJrtWithReleaseOption extends ClasspathJrt {
 		Map<String, SimpleSet> cache = PackageCache.computeIfAbsent(this.modPathString, key -> {
 			final Map<String, SimpleSet> packagesInModule = new HashMap<>();
 			try {
-				JRTUtil.walkModuleImage(this.jrtFile, this.release, new JrtPackageVisitor(packagesInModule), JRTUtil.NOTIFY_PACKAGES | JRTUtil.NOTIFY_MODULES);
+				JRTUtil.walkModuleImage(this.jrtFileSystemForRelease, new JrtPackageVisitor(packagesInModule), JRTUtil.NOTIFY_PACKAGES | JRTUtil.NOTIFY_MODULES);
 			} catch (IOException e) {
 				Util.log(e, "Failed to init packages for " + this.modPathString); //$NON-NLS-1$
 			}
@@ -223,15 +225,19 @@ public class ClasspathJrtWithReleaseOption extends ClasspathJrt {
 				}
 			} else {
 				// Read the file in a "classic" way from the JDK itself
-				reader = ClassFileReader.readFromModule(this.jrtFile, moduleName, qualifiedBinaryFileName,
-						moduleNameFilter);
+				if (this.jrtFileSystem == null) {
+					return null;
+				}
+				reader = JRTUtil.getClassfile(this.jrtFileSystem, qualifiedBinaryFileName, moduleName, moduleNameFilter);
 			}
-			if (reader != null)
-				return createAnswer(fileNameWithoutExtension, reader, reader.getModule());
+			if (reader == null) {
+				return null;
+			}
+			return createAnswer(fileNameWithoutExtension, reader, reader.getModule());
 		} catch (ClassFormatException | IOException e) {
 			// treat as if class file is missing
+			return null;
 		}
-		return null;
 	}
 
 	@Override


### PR DESCRIPTION
to avoid ephemeral memory allocations

https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2815
