### PR TITLE
classfmt: fix "Implicit narrowing conversion" warnings

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/ClassFileStruct.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/ClassFileStruct.java
@@ -54,9 +54,17 @@ public int u2At(int relativeOffset) {
 	int position = relativeOffset + this.structOffset;
 	return ((this.reference[position++] & 0xFF) << 8) | (this.reference[position] & 0xFF);
 }
-public long u4At(int relativeOffset) {
+
+/**
+ * Returns an 32 bit integer created of 4 bytes. The return value should be treated as an <strong>unsigned</strong> integer! i.e. if the caller does math with
+ * the result he should use the unsigned methods from Integer like {@link java.lang.Integer#toUnsignedLong(int)} or
+ * {@link java.lang.Integer#compareUnsigned(int, int)}. Note that addition with the + operator is safe to use.
+ * @param relativeOffset unsigned integer
+ * @return unsigned integer
+ */
+public int u4At(int relativeOffset) {
 	int position = relativeOffset + this.structOffset;
-	return (((this.reference[position++] & 0xFFL) << 24) | ((this.reference[position++] & 0xFF) << 16) | ((this.reference[position++] & 0xFF) << 8) | (this.reference[position] & 0xFF));
+	return (((this.reference[position++] & 0xFF) << 24) | ((this.reference[position++] & 0xFF) << 16) | ((this.reference[position++] & 0xFF) << 8) | (this.reference[position] & 0xFF));
 }
 public char[] utf8At(int relativeOffset, int bytesAvailable) {
 	int length = bytesAvailable;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/MethodInfo.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/MethodInfo.java
@@ -482,7 +482,7 @@ private synchronized void readCodeAttribute() {
 }
 private void decodeCodeAttribute(int offset) {
 	int readOffset = offset + 10;
-	int codeLength = (int) u4At(readOffset);
+	int codeLength = u4At(readOffset);
 	readOffset += (4 + codeLength);
 	int exceptionTableLength = u2At(readOffset);
 	readOffset += 2;

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/ClassFileAttribute.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/ClassFileAttribute.java
@@ -24,7 +24,8 @@ import org.eclipse.jdt.core.util.IConstantPoolEntry;
  */
 public class ClassFileAttribute extends ClassFileStruct implements IClassFileAttribute {
 	public static final IClassFileAttribute[] NO_ATTRIBUTES = new IClassFileAttribute[0];
-	private final long attributeLength;
+	/** unsigned integer **/
+	private final int attributeLength;
 	private final int attributeNameIndex;
 	private final char[] attributeName;
 
@@ -56,7 +57,7 @@ public class ClassFileAttribute extends ClassFileStruct implements IClassFileAtt
 	 */
 	@Override
 	public long getAttributeLength() {
-		return this.attributeLength;
+		return Integer.toUnsignedLong(this.attributeLength);
 	}
 
 }

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/ClassFileReader.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/ClassFileReader.java
@@ -85,7 +85,7 @@ public class ClassFileReader extends ClassFileStruct implements IClassFileReader
 		int constantPoolCount;
 		int[] constantPoolOffsets;
 		try {
-			this.magicNumber = (int) u4At(classFileBytes, 0, 0);
+			this.magicNumber = u4At(classFileBytes, 0, 0);
 			if (this.magicNumber != 0xCAFEBABE) {
 				throw new ClassFormatException(ClassFormatException.INVALID_MAGIC_NUMBER);
 			}
@@ -237,7 +237,7 @@ public class ClassFileReader extends ClassFileStruct implements IClassFileReader
 						readOffset += 8;
 						if (attributeCountForField != 0) {
 							for (int j = 0; j < attributeCountForField; j++) {
-								int attributeLength = (int) u4At(classFileBytes, 2, readOffset);
+								int attributeLength = u4At(classFileBytes, 2, readOffset);
 								readOffset += (6 + attributeLength);
 							}
 						}
@@ -263,7 +263,7 @@ public class ClassFileReader extends ClassFileStruct implements IClassFileReader
 						readOffset += 8;
 						if (attributeCountForMethod != 0) {
 							for (int j = 0; j < attributeCountForMethod; j++) {
-								int attributeLength = (int) u4At(classFileBytes, 2, readOffset);
+								int attributeLength = u4At(classFileBytes, 2, readOffset);
 								readOffset += (6 + attributeLength);
 							}
 						}
@@ -323,7 +323,7 @@ public class ClassFileReader extends ClassFileStruct implements IClassFileReader
 						} else {
 							this.attributes[attributesIndex++] = new ClassFileAttribute(classFileBytes, this.constantPool, readOffset);
 						}
-						long tmp = u4At(classFileBytes, readOffset + 2, 0);
+						int tmp = u4At(classFileBytes, readOffset + 2, 0);
 						readOffset += (6 + tmp);
 					}
 				} else {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/ClassFileStruct.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/ClassFileStruct.java
@@ -58,10 +58,20 @@ public abstract class ClassFileStruct {
 		int position = relativeOffset + structOffset;
 		return ((reference[position++] & 0xFF) << 8) + (reference[position] & 0xFF);
 	}
-	protected long u4At(byte[] reference, int relativeOffset, int structOffset) {
+
+	/**
+	 * Returns an 32 bit integer created of 4 bytes. The return value should be treated as an <strong>unsigned</strong> integer! i.e. if the caller does math with
+	 * the result he should use the unsigned methods from Integer like {@link java.lang.Integer#toUnsignedLong(int)} or
+	 * {@link java.lang.Integer#compareUnsigned(int, int)}. Note that addition with the + operator is safe to use.
+	 * @param reference byte array
+	 * @param relativeOffset unsigned integer
+	 * @param structOffset unsigned integer
+	 * @return unsigned integer
+	 */
+	protected int u4At(byte[] reference, int relativeOffset, int structOffset) {
 		int position = relativeOffset + structOffset;
 		return (
-			((reference[position++] & 0xFFL) << 24)
+			((reference[position++] & 0xFF) << 24)
 				+ ((reference[position++] & 0xFF) << 16)
 				+ ((reference[position++] & 0xFF) << 8)
 				+ (reference[position] & 0xFF));

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/CodeAttribute.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/CodeAttribute.java
@@ -37,7 +37,9 @@ public class CodeAttribute extends ClassFileAttribute implements ICodeAttribute 
 	private final int attributesCount;
 	private byte[] bytecodes;
 	private final byte[] classFileBytes;
-	private final long codeLength;
+	/** unsigned integer */
+	private final int codeLength;
+	/** unsigned integer */
 	private final int codeOffset;
 	private final IConstantPool constantPool;
 	private IExceptionTableEntry[] exceptionTableEntries;
@@ -55,7 +57,7 @@ public class CodeAttribute extends ClassFileAttribute implements ICodeAttribute 
 		this.maxLocals = u2At(classFileBytes, 8, offset);
 		this.codeLength = u4At(classFileBytes, 10, offset);
 		this.codeOffset = offset + 14;
-		int readOffset = (int) (14 + this.codeLength);
+		int readOffset = 14 + this.codeLength;
 		this.exceptionTableLength = u2At(classFileBytes, readOffset, offset);
 		readOffset += 2;
 		this.exceptionTableEntries = NO_EXCEPTION_TABLE;
@@ -123,7 +125,7 @@ public class CodeAttribute extends ClassFileAttribute implements ICodeAttribute 
 	@Override
 	public byte[] getBytecodes() {
 		if (this.bytecodes == null) {
-			System.arraycopy(this.classFileBytes, this.codeOffset, (this.bytecodes = new byte[(int) this.codeLength]), 0, (int) this.codeLength);
+			System.arraycopy(this.classFileBytes, this.codeOffset, (this.bytecodes = new byte[this.codeLength]), 0, this.codeLength);
 		}
 		return this.bytecodes;
 	}
@@ -133,7 +135,7 @@ public class CodeAttribute extends ClassFileAttribute implements ICodeAttribute 
 	 */
 	@Override
 	public long getCodeLength() {
-		return this.codeLength;
+		return Integer.toUnsignedLong(this.codeLength);
 	}
 
 	/**
@@ -944,7 +946,7 @@ public class CodeAttribute extends ClassFileAttribute implements ICodeAttribute 
 					}
 					defaultOffset = i4At(this.classFileBytes, 0, pc);
 					pc += 4;
-					int npairs = (int) u4At(this.classFileBytes, 0, pc);
+					int npairs = u4At(this.classFileBytes, 0, pc);
 					int[][] offset_pairs = new int[npairs][2];
 					pc += 4;
 					for (int i = 0; i < npairs; i++) {
@@ -1185,7 +1187,7 @@ public class CodeAttribute extends ClassFileAttribute implements ICodeAttribute 
 				default:
 					throw new ClassFormatException(ClassFormatException.INVALID_BYTECODE);
 			}
-			if (pc >= (this.codeLength + this.codeOffset)) {
+			if (Integer.compareUnsigned(pc, this.codeLength + this.codeOffset) >= 0) {
 				break;
 			}
 		}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/StackMapAttribute.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/StackMapAttribute.java
@@ -56,7 +56,7 @@ public class StackMapAttribute
 		} else {
 			this.frames = NO_FRAMES;
 		}
-		final int byteLength = (int) u4At(classFileBytes, 2, offset);
+		final int byteLength = u4At(classFileBytes, 2, offset);
 
 		if (length != 0) {
 			System.arraycopy(classFileBytes, offset + 6, this.bytes = new byte[byteLength], 0, byteLength);

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/StackMapTableAttribute.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/StackMapTableAttribute.java
@@ -56,7 +56,7 @@ public class StackMapTableAttribute
 		} else {
 			this.frames = NO_FRAMES;
 		}
-		final int byteLength = (int) u4At(classFileBytes, 2, offset);
+		final int byteLength = u4At(classFileBytes, 2, offset);
 
 		if (length != 0) {
 			System.arraycopy(classFileBytes, offset + 6, this.bytes = new byte[byteLength], 0, byteLength);


### PR DESCRIPTION
ClassFileStruct.u4At(int) is supposed to return an unsigned integer. The return value is currently always used as primitive integer (signed) to compute readOffset inside the class file (which will then passed as argument to the method again). So any negative value would trigger an ArrayIndexOutOfBoundsException when used as index into the byte array.

The intermediate usage of primitive long did not help and only triggered warnings at the call sites.

https://github.com/eclipse-jdt/eclipse.jdt.core/security/code-scanning/18 ff
