### PR TITLE
 [23] Formatter support for markdown doc comments

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Javadoc.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Javadoc.java
@@ -42,6 +42,7 @@ public class Javadoc extends ASTNode {
 	// bug https://bugs.eclipse.org/bugs/show_bug.cgi?id=153399
 	// Store value tag positions
 	public long valuePositions = -1;
+	public boolean isMarkdown;
 
 	public Javadoc(int sourceStart, int sourceEnd) {
 		this.sourceStart = sourceStart;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/JavadocParser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/JavadocParser.java
@@ -97,6 +97,7 @@ public class JavadocParser extends AbstractCommentParser {
 		this.javadocStart = this.sourceParser.scanner.commentStarts[commentPtr];
 		this.javadocEnd = this.sourceParser.scanner.commentStops[commentPtr]-1;
 		this.firstTagPosition = this.sourceParser.scanner.commentTagStarts[commentPtr];
+		this.markdown = this.sourceParser.scanner.commentIsMarkdown[commentPtr];
 		this.validValuePositions = -1;
 		this.invalidValuePositions = -1;
 		this.tagWaitingForDescription = NO_TAG_VALUE;
@@ -104,11 +105,13 @@ public class JavadocParser extends AbstractCommentParser {
 		// Init javadoc if necessary
 		if (this.checkDocComment) {
 			this.docComment = new Javadoc(this.javadocStart, this.javadocEnd);
+			this.docComment.isMarkdown = this.markdown;
 		} else if (this.setJavadocPositions) {
 			// https://bugs.eclipse.org/bugs/show_bug.cgi?id=189459
 			// if annotation processors are there, javadoc object is required but
 			// they need not be resolved
 			this.docComment = new Javadoc(this.javadocStart, this.javadocEnd);
+			this.docComment.isMarkdown = this.markdown;
 			this.docComment.bits &= ~ASTNode.ResolveJavadoc;
 		} else {
 			this.docComment = null;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
@@ -11499,22 +11499,14 @@ public int flushCommentsDefinedPriorTo(int position) {
 			break;
 		// move valid comment infos, overriding obsolete comment infos
 		case 2:
-			this.scanner.commentStarts[0] = this.scanner.commentStarts[index+1];
-			this.scanner.commentStops[0] = this.scanner.commentStops[index+1];
-			this.scanner.commentTagStarts[0] = this.scanner.commentTagStarts[index+1];
-			this.scanner.commentStarts[1] = this.scanner.commentStarts[index+2];
-			this.scanner.commentStops[1] = this.scanner.commentStops[index+2];
-			this.scanner.commentTagStarts[1] = this.scanner.commentTagStarts[index+2];
+			this.scanner.copyCommentInfo(0, index+1);
+			this.scanner.copyCommentInfo(1, index+2);
 			break;
 		case 1:
-			this.scanner.commentStarts[0] = this.scanner.commentStarts[index+1];
-			this.scanner.commentStops[0] = this.scanner.commentStops[index+1];
-			this.scanner.commentTagStarts[0] = this.scanner.commentTagStarts[index+1];
+			this.scanner.copyCommentInfo(0, index+1);
 			break;
 		default:
-			System.arraycopy(this.scanner.commentStarts, index + 1, this.scanner.commentStarts, 0, validCount);
-			System.arraycopy(this.scanner.commentStops, index + 1, this.scanner.commentStops, 0, validCount);
-			System.arraycopy(this.scanner.commentTagStarts, index + 1, this.scanner.commentTagStarts, 0, validCount);
+			this.scanner.copyAllCommentInfo(index+1, 0, validCount);
 	}
 	this.scanner.commentPtr = validCount - 1;
 	return position;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Scanner.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Scanner.java
@@ -92,6 +92,7 @@ public class Scanner implements TerminalTokens {
 	public final static int COMMENT_ARRAYS_SIZE = 30;
 	public int[] commentStops = new int[COMMENT_ARRAYS_SIZE];
 	public int[] commentStarts = new int[COMMENT_ARRAYS_SIZE];
+	public boolean[] commentIsMarkdown = new boolean[COMMENT_ARRAYS_SIZE];
 	public int[] commentTagStarts = new int[COMMENT_ARRAYS_SIZE];
 	public int commentPtr = -1; // no comment test with commentPtr value -1
 	public int lastCommentLinePosition = -1;
@@ -3215,6 +3216,7 @@ public void recordComment(int token) {
 	// compute position
 	int commentStart = this.startPosition;
 	int stopPosition = this.currentPosition;
+	boolean isMarkdown = false;
 	switch (token) {
 		case TokenNameCOMMENT_LINE:
 			// both positions are negative
@@ -3226,6 +3228,7 @@ public void recordComment(int token) {
 			stopPosition = -this.currentPosition;
 			break;
 		case TokenNameCOMMENT_MARKDOWN:
+			isMarkdown = true;
 			break;
 	}
 
@@ -3233,12 +3236,11 @@ public void recordComment(int token) {
 	int length = this.commentStops.length;
 	if (++this.commentPtr >=  length) {
 		int newLength = length + COMMENT_ARRAYS_SIZE*10;
-		System.arraycopy(this.commentStops, 0, this.commentStops = new int[newLength], 0, length);
-		System.arraycopy(this.commentStarts, 0, this.commentStarts = new int[newLength], 0, length);
-		System.arraycopy(this.commentTagStarts, 0, this.commentTagStarts = new int[newLength], 0, length);
+		growCommentInfoArrays(length, newLength);
 	}
 	this.commentStops[this.commentPtr] = stopPosition;
 	this.commentStarts[this.commentPtr] = commentStart;
+	this.commentIsMarkdown[this.commentPtr] = isMarkdown;
 }
 
 /**
@@ -5938,6 +5940,25 @@ public static InvalidInputException invalidInput() {
 	return new InvalidInputException();
 }
 
+public void copyCommentInfo(int to, int from) {
+	this.commentStarts[to] = this.commentStarts[from];
+	this.commentStops[to] = this.commentStops[from];
+	this.commentTagStarts[to] = this.commentTagStarts[from];
+	this.commentIsMarkdown[to] = this.commentIsMarkdown[from];
+}
 
+public void copyAllCommentInfo(int from, int to, int length) {
+	System.arraycopy(this.commentStarts, from, this.commentStarts, to, length);
+	System.arraycopy(this.commentStops, from, this.commentStops, to, length);
+	System.arraycopy(this.commentTagStarts, from, this.commentTagStarts, to, length);
+	System.arraycopy(this.commentIsMarkdown, from, this.commentIsMarkdown, 0, length);
+}
+
+protected void growCommentInfoArrays(int length, int newLength) {
+	System.arraycopy(this.commentStops, 0, this.commentStops = new int[newLength], 0, length);
+	System.arraycopy(this.commentStarts, 0, this.commentStarts = new int[newLength], 0, length);
+	System.arraycopy(this.commentIsMarkdown, 0, this.commentIsMarkdown = new boolean[newLength], 0, length);
+	System.arraycopy(this.commentTagStarts, 0, this.commentTagStarts = new int[newLength], 0, length);
+}
 
 }

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterMarkdownTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterMarkdownTest.java
@@ -3327,6 +3327,7 @@ public class ASTConverterMarkdownTest extends ConverterTestSetup {
 				Comment comment = (Comment) unitComments.get(0);
 				assertEquals("Comment should be javadoc", comment.getNodeType(), ASTNode.JAVADOC);
 				Javadoc docComment = (Javadoc) comment;
+				assertTrue(this.prefix+"should be markdown", docComment.isMarkdown());
 				assertEquals(this.prefix+"Wrong number of tags", 1, docComment.tags().size());
 
 				TagElement tagElement = (TagElement) docComment.tags().get(0);

--- a/org.eclipse.jdt.core/.settings/.api_filters
+++ b/org.eclipse.jdt.core/.settings/.api_filters
@@ -205,6 +205,14 @@
             </message_arguments>
         </filter>
     </resource>
+    <resource path="dom/org/eclipse/jdt/core/dom/Javadoc.java" type="org.eclipse.jdt.core.dom.Javadoc">
+        <filter comment="Evolution: add property for markdown javadoc" id="336658481">
+            <message_arguments>
+                <message_argument value="org.eclipse.jdt.core.dom.Javadoc"/>
+                <message_argument value="MARKDOWN_PROPERTY"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="dom/org/eclipse/jdt/core/dom/MemberRef.java" type="org.eclipse.jdt.core.dom.MemberRef">
         <filter id="576725006">
             <message_arguments>

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionJavadocParser.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionJavadocParser.java
@@ -112,6 +112,7 @@ public class CompletionJavadocParser extends JavadocParser {
 	@Override
 	protected boolean commentParse() {
 		this.docComment = new CompletionJavadoc(this.javadocStart, this.javadocEnd);
+		this.docComment.isMarkdown = this.markdown;
 		this.firstTagPosition = 1; // bug 429340: completion parser needs to parse the whole comment
 		return super.commentParse();
 	}

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionJavadocParser.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionJavadocParser.java
@@ -65,6 +65,7 @@ public class SelectionJavadocParser extends JavadocParser {
 	@Override
 	protected boolean commentParse() {
 		this.docComment = new SelectionJavadoc(this.javadocStart, this.javadocEnd);
+		this.docComment.isMarkdown = this.markdown;
 		return super.commentParse();
 	}
 

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/DocCommentParser.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/DocCommentParser.java
@@ -80,6 +80,9 @@ class DocCommentParser extends AbstractCommentParser {
 			commentParse();
 		}
 		this.docComment.setSourceRange(start, length);
+		if (this.ast.apiLevel >= AST.JLS23_INTERNAL) {
+			this.docComment.setMarkdown(this.markdown);
+		}
 		if (this.ast.apiLevel == AST.JLS2_INTERNAL) {
 			setComment(start, length);  // backward compatibility
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ImportDeclaration.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ImportDeclaration.java
@@ -181,6 +181,7 @@ public class ImportDeclaration extends ASTNode {
 	 * @exception UnsupportedOperationException if this operation is used in
 	 * an AST below JLS23
 	 * @since 3.39
+	 * @noreference preview feature
 	 */
 	public List modifiers() {
 		if (this.ast.apiLevel < AST.JLS23_INTERNAL)
@@ -202,6 +203,7 @@ public class ImportDeclaration extends ASTNode {
 	 * @return the bit-wise "or" of <code>Modifier</code> constants
 	 * @see Modifier
 	 * @since 3.39
+	 * @noreference preview feature
 	 */
 	public int getModifiers() {
 		if (this.modifiers == null) {

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/Javadoc.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/Javadoc.java
@@ -49,6 +49,13 @@ public class Javadoc extends Comment {
 	public static final ChildListPropertyDescriptor TAGS_PROPERTY =
 		new ChildListPropertyDescriptor(Javadoc.class, "tags", TagElement.class, CYCLE_RISK); //$NON-NLS-1$
 
+	/**
+	 * The "markdown" structural property of this node type (type: {@link Boolean}) (added in JLS23 API).
+	 * @since 3.39
+	 * @noreference This field belongs to a preview feature and is not intended to be referenced by clients
+	 */
+	public static final SimplePropertyDescriptor MARKDOWN_PROPERTY =
+		new SimplePropertyDescriptor(Javadoc.class, "static", boolean.class, MANDATORY); //$NON-NLS-1$
 
 	/**
 	 * A list of property descriptors (element type:
@@ -66,6 +73,14 @@ public class Javadoc extends Comment {
 	 */
 	private static final List PROPERTY_DESCRIPTORS_3_0;
 
+	/**
+	 * A list of property descriptors (element type:
+	 * {@link StructuralPropertyDescriptor}),
+	 * or null if uninitialized.
+	 * @since 3.39
+	 */
+	private static final List PROPERTY_DESCRIPTORS_23;
+
 	static {
 		List properyList = new ArrayList(3);
 		createPropertyList(Javadoc.class, properyList);
@@ -77,6 +92,12 @@ public class Javadoc extends Comment {
 		createPropertyList(Javadoc.class, properyList);
 		addProperty(TAGS_PROPERTY, properyList);
 		PROPERTY_DESCRIPTORS_3_0 = reapPropertyList(properyList);
+
+		properyList = new ArrayList(3);
+		createPropertyList(Javadoc.class, properyList);
+		addProperty(TAGS_PROPERTY, properyList);
+		addProperty(MARKDOWN_PROPERTY, properyList);
+		PROPERTY_DESCRIPTORS_23 = reapPropertyList(properyList);
 	}
 
 	/**
@@ -92,8 +113,10 @@ public class Javadoc extends Comment {
 	public static List propertyDescriptors(int apiLevel) {
 		if (apiLevel == AST.JLS2_INTERNAL) {
 			return PROPERTY_DESCRIPTORS_2_0;
-		} else {
+		} else if (apiLevel < AST.JLS23_INTERNAL) {
 			return PROPERTY_DESCRIPTORS_3_0;
+		} else {
+			return PROPERTY_DESCRIPTORS_23;
 		}
 	}
 
@@ -119,6 +142,8 @@ public class Javadoc extends Comment {
 	 */
 	private final ASTNode.NodeList tags =
 		new ASTNode.NodeList(TAGS_PROPERTY);
+
+	private boolean isMarkdown;
 
 	/**
 	 * Creates a new AST node for a doc comment owned by the given AST.
@@ -153,6 +178,20 @@ public class Javadoc extends Comment {
 		}
 		// allow default implementation to flag the error
 		return super.internalGetSetObjectProperty(property, get, value);
+	}
+
+	@Override
+	boolean internalGetSetBooleanProperty(SimplePropertyDescriptor property, boolean get, boolean value) {
+		if (property == MARKDOWN_PROPERTY) {
+			if (get) {
+				return isMarkdown();
+			} else {
+				setMarkdown(value);
+				return false;
+			}
+		}
+		// allow default implementation to flag the error
+		return super.internalGetSetBooleanProperty(property, get, value);
 	}
 
 	@Override
@@ -289,9 +328,39 @@ public class Javadoc extends Comment {
 		return this.tags;
 	}
 
+	/**
+	 * Returns whether this javadoc is a markdown comment (added in JLS23 API).
+	 *
+	 * @return <code>true</code> if this is a markdown comment,
+	 *    and <code>false</code> if this is a traditional javadoc comment.
+	 * @since 3.39
+	 */
+	public boolean isMarkdown() {
+		if (this.ast.apiLevel < AST.JLS23_INTERNAL) {
+			throw new UnsupportedOperationException("Operation not supported in AST below JLS23"); //$NON-NLS-1$
+		}
+		return this.isMarkdown;
+	}
+
+	/**
+	 * Sets whether this javadoc is a markdown comment (added in JLS23 API).
+	 *
+	 * @param isMarkdown <code>true</code> if this is a markdown comment,
+	 *    and <code>false</code> if this is a traditional javadoc comment.
+	 * @since 3.39
+	 */
+	public void setMarkdown(boolean isMarkdown) {
+		if (this.ast.apiLevel < AST.JLS23_INTERNAL) {
+			throw new UnsupportedOperationException("Operation not supported in AST below JLS23"); //$NON-NLS-1$
+		}
+		preValueChange(MARKDOWN_PROPERTY);
+		this.isMarkdown = isMarkdown;
+		postValueChange(MARKDOWN_PROPERTY);
+	}
+
 	@Override
 	int memSize() {
-		int size = super.memSize() + 2 * 4;
+		int size = super.memSize() + 3 * 4;
 		if (this.comment != MINIMAL_DOC_COMMENT) {
 			// anything other than the default string takes space
 			size += stringSize(this.comment);

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/Javadoc.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/Javadoc.java
@@ -334,6 +334,7 @@ public class Javadoc extends Comment {
 	 * @return <code>true</code> if this is a markdown comment,
 	 *    and <code>false</code> if this is a traditional javadoc comment.
 	 * @since 3.39
+	 * @noreference preview feature
 	 */
 	public boolean isMarkdown() {
 		if (this.ast.apiLevel < AST.JLS23_INTERNAL) {
@@ -348,6 +349,7 @@ public class Javadoc extends Comment {
 	 * @param isMarkdown <code>true</code> if this is a markdown comment,
 	 *    and <code>false</code> if this is a traditional javadoc comment.
 	 * @since 3.39
+	 * @noreference preview feature
 	 */
 	public void setMarkdown(boolean isMarkdown) {
 		if (this.ast.apiLevel < AST.JLS23_INTERNAL) {

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/Modifier.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/Modifier.java
@@ -807,6 +807,7 @@ public final class Modifier extends ASTNode implements IExtendedModifier {
 	 *
 	 * @return true if the receiver is the module modifier, false otherwise
 	 * @since 3.39
+	 * @noreference preview feature
 	 */
 	public static boolean isModule(int flags) {
 		return (flags & Modifier.MODULE) != 0;

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/TextEditsBuilder.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/TextEditsBuilder.java
@@ -16,6 +16,7 @@ package org.eclipse.jdt.internal.formatter;
 import static org.eclipse.jdt.internal.compiler.parser.TerminalTokens.TokenNameCOMMENT_LINE;
 import static org.eclipse.jdt.internal.compiler.parser.TerminalTokens.TokenNameCOMMENT_BLOCK;
 import static org.eclipse.jdt.internal.compiler.parser.TerminalTokens.TokenNameCOMMENT_JAVADOC;
+import static org.eclipse.jdt.internal.compiler.parser.TerminalTokens.TokenNameCOMMENT_MARKDOWN;
 import static org.eclipse.jdt.internal.compiler.parser.TerminalTokens.TokenNameNotAToken;
 import static org.eclipse.jdt.internal.compiler.parser.TerminalTokens.TokenNameStringLiteral;
 import static org.eclipse.jdt.internal.compiler.parser.TerminalTokens.TokenNameTextBlock;
@@ -120,6 +121,12 @@ public class TextEditsBuilder extends TokenTraverser {
 	protected boolean token(Token token, int index) {
 
 		bufferWhitespaceBefore(token, index);
+
+		if (token.tokenType == TokenNameCOMMENT_MARKDOWN) {
+			flushBuffer(token.originalStart);
+			this.counter = token.originalEnd + 1;
+			return true; // don't touch markdown format for now.
+		}
 
 		List<Token> structure = token.getInternalStructure();
 		if (token.tokenType == TokenNameCOMMENT_LINE) {

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/Token.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/Token.java
@@ -17,6 +17,7 @@ package org.eclipse.jdt.internal.formatter;
 import static org.eclipse.jdt.internal.compiler.parser.TerminalTokens.TokenNameCOMMENT_BLOCK;
 import static org.eclipse.jdt.internal.compiler.parser.TerminalTokens.TokenNameCOMMENT_JAVADOC;
 import static org.eclipse.jdt.internal.compiler.parser.TerminalTokens.TokenNameCOMMENT_LINE;
+import static org.eclipse.jdt.internal.compiler.parser.TerminalTokens.TokenNameCOMMENT_MARKDOWN;
 
 import java.util.List;
 
@@ -142,7 +143,7 @@ public class Token {
 	public static Token fromCurrent(Scanner scanner, int currentToken) {
 		int start = scanner.getCurrentTokenStartPosition();
 		int end = scanner.getCurrentTokenEndPosition();
-		if (currentToken == TokenNameCOMMENT_LINE) {
+		if (currentToken == TokenNameCOMMENT_LINE || currentToken == TokenNameCOMMENT_MARKDOWN) {
 			// don't include line separator, but set break-after
 			while (end > start) {
 				char c = scanner.source[end];

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/CommentRecorderParser.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/CommentRecorderParser.java
@@ -182,22 +182,14 @@ public class CommentRecorderParser extends Parser {
 				break;
 			// move valid comment infos, overriding obsolete comment infos
 			case 2:
-				this.scanner.commentStarts[0] = this.scanner.commentStarts[index+1];
-				this.scanner.commentStops[0] = this.scanner.commentStops[index+1];
-				this.scanner.commentTagStarts[0] = this.scanner.commentTagStarts[index+1];
-				this.scanner.commentStarts[1] = this.scanner.commentStarts[index+2];
-				this.scanner.commentStops[1] = this.scanner.commentStops[index+2];
-				this.scanner.commentTagStarts[1] = this.scanner.commentTagStarts[index+2];
+				this.scanner.copyCommentInfo(0, index+1);
+				this.scanner.copyCommentInfo(1, index+2);
 				break;
 			case 1:
-				this.scanner.commentStarts[0] = this.scanner.commentStarts[index+1];
-				this.scanner.commentStops[0] = this.scanner.commentStops[index+1];
-				this.scanner.commentTagStarts[0] = this.scanner.commentTagStarts[index+1];
+				this.scanner.copyCommentInfo(0, index+1);
 				break;
 			default:
-				System.arraycopy(this.scanner.commentStarts, index + 1, this.scanner.commentStarts, 0, validCount);
-				System.arraycopy(this.scanner.commentStops, index + 1, this.scanner.commentStops, 0, validCount);
-				System.arraycopy(this.scanner.commentTagStarts, index + 1, this.scanner.commentTagStarts, 0, validCount);
+				this.scanner.copyAllCommentInfo(index + 1, 0, validCount);
 		}
 		this.scanner.commentPtr = validCount - 1;
 		return position;
@@ -316,6 +308,7 @@ public class CommentRecorderParser extends Parser {
 		Arrays.fill(this.commentStops, 0);
 		Arrays.fill(this.scanner.commentStops, 0);
 		Arrays.fill(this.scanner.commentStarts, 0);
+		Arrays.fill(this.scanner.commentIsMarkdown, false);
 		Arrays.fill(this.scanner.commentTagStarts, 0);
 		this.scanner.commentPtr = -1; // no comment test with commentPtr value -1
 		this.scanner.lastCommentLinePosition = -1;


### PR DESCRIPTION
Minimal fix for https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2851

Restore ability to format Java in file with markdown comments:
+ avoid AssertionError in TokenManager.firstIndexIn
  - visit(Javadoc) needs to look for TokenNameCOMMENT_MARKDOWN specifically
+ fix infinite loop in tokenizeMultilineComment()
  - detect markdown comment
  - search for '/' not '*'
  - token should not include the final '\n'

Leave markdown comments unchanged by formatting for now


Includes a draft addition to support `Javadoc.isMarkdown()` in DOM AST.