### PR TITLE
[23] Code assist changes for markdown Javadoc comments

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/JavadocParser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/JavadocParser.java
@@ -601,22 +601,27 @@ public class JavadocParser extends AbstractCommentParser {
 						currentChar = readChar();
 						start = this.index;
 					} else {
-						int eofBkup = this.scanner.eofPosition;
-						this.scanner.eofPosition = this.index - 1;
-						this.scanner.resetTo(start, this.javadocEnd);
-						valid = parseReference(true);
-						this.scanner.eofPosition = eofBkup;
 						break loop;
 					}
 					break;
 				case '\r':
 				case '\n':
+					if ((this.kind & PARSER_KIND) == COMPLETION_PARSER) {
+						// TODO would like to trigger parseReference() with more tokens,
+						// but in "[some text][#theLink]" arbitrary chars are allowed which do not imply end of link identifier.
+						// To resolve this we would need to scan for detection of a second pair of brackets ...
+						break loop;
+					}
 					return false;
 				default:
 					break;
 			}
 			currentChar = readChar();
 		}
+		int eofBkup = this.scanner.eofPosition;
+		this.scanner.resetTo(start, Math.max(this.javadocEnd, this.index));
+		valid = parseReference(true);
+		this.scanner.eofPosition = eofBkup;
 		this.markdownHelper.resetLineStart();
 		return valid;
 	}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/parser/MarkdownCompletionParserTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/parser/MarkdownCompletionParserTest.java
@@ -765,5 +765,50 @@ public void test037() {
 	verifyCompletionOnJavadocTag("lin".toCharArray(), allTags, false);
 
 }
-
+public void testTypeLink() {
+	// create assist node for unfinished markdown link
+	String source = """
+		package javadoc;
+		///
+		/// see [Te
+		///
+		public class Test {}
+		""";
+	verifyCompletionInJavadoc(source, "[Te");
+	assertCompletionNodeResult(source, """
+			<CompletionOnJavadocSingleTypeReference:Te
+				infos:formal reference
+			>"""
+	);
+}
+public void testTypeLink_lastLine() {
+	// create assist node for unfinished markdown link at end of comment
+	String source = """
+		package javadoc;
+		///
+		/// see [Te
+		public class Test {}
+		""";
+	verifyCompletionInJavadoc(source, "[Te");
+	assertCompletionNodeResult(source, """
+			<CompletionOnJavadocSingleTypeReference:Te
+				infos:formal reference
+			>"""
+	);
+}
+public void testTypeLink_lastLine_emptyReference() {
+	// create assist node for unfinished markdown link at end of comment
+	String source = """
+		package javadoc;
+		///
+		/// see [
+		public class Test {}
+		""";
+	verifyCompletionInJavadoc(source, "[");
+	assertCompletionNodeResult(source, """
+			<CompletionOnJavadocSingleTypeReference:
+				infos:formal reference
+			>"""
+	);
+}
 }

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests23.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests23.java
@@ -320,4 +320,98 @@ public void test006() throws CoreException {
 		removeClasspathEntry(this.completion23Project, jarTwoPath);
 	}
 }
+
+public void testMarkdownTypeLink1() throws CoreException {
+	createFolder("/Completion23/src/javadoc");
+	this.workingCopies = new ICompilationUnit[1];
+	this.workingCopies[0] = getWorkingCopy("Completion23/src/javadoc/Test.java", """
+			package javadoc;
+			///
+			/// see [Te]
+			///
+			public class Test {}
+			""");
+	CompletionTestsRequestor2 requestor = new CompletionTestsRequestor2(true);
+	requestor.allowAllRequiredProposals();
+	String str = this.workingCopies[0].getSource();
+	String completeBehind = "[Te";
+	int cursorLocation = str.lastIndexOf(completeBehind) + completeBehind.length();
+	this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner);
+	assertResults(
+			"TemplateRuntime[TYPE_REF]{java.lang.runtime.TemplateRuntime, java.lang.runtime, Ljava.lang.runtime.TemplateRuntime;, null, null, "+(DEFAULT_RELEVANCE + R_JAVA_LIBRARY)+"}\n" +
+			"Test[TYPE_REF]{Test, javadoc, Ljavadoc.Test;, null, null, "+(DEFAULT_RELEVANCE + R_UNQUALIFIED)+"}",
+			requestor.getResults());
+}
+
+public void testMarkdownMethodLink1() throws CoreException {
+	createFolder("/Completion23/src/javadoc");
+	this.workingCopies = new ICompilationUnit[1];
+	this.workingCopies[0] = getWorkingCopy("Completion23/src/javadoc/Test.java", """
+			package javadoc;
+			///
+			/// see [#me] for details
+			public class Test {
+				void method() {}
+			}
+			""");
+	CompletionTestsRequestor2 requestor = new CompletionTestsRequestor2(true);
+	requestor.allowAllRequiredProposals();
+	String str = this.workingCopies[0].getSource();
+	String completeBehind = "[#me";
+	int cursorLocation = str.lastIndexOf(completeBehind) + completeBehind.length();
+	this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner);
+	assertResults(
+			"method[METHOD_REF]{method(), Ljavadoc.Test;, ()V, method, null, "+(DEFAULT_RELEVANCE + R_NON_STATIC)+"}",
+			requestor.getResults());
+}
+
+public void testMarkdownMethodLink2_qualified() throws CoreException {
+	// type-prefixed
+	// missing ']' at end of line
+	createFolder("/Completion23/src/javadoc");
+	this.workingCopies = new ICompilationUnit[1];
+	this.workingCopies[0] = getWorkingCopy("Completion23/src/javadoc/Test.java", """
+			package javadoc;
+			///
+			/// see [String#le
+			///
+			public class Test {
+				void method() {}
+			}
+			""");
+	CompletionTestsRequestor2 requestor = new CompletionTestsRequestor2(true);
+	requestor.allowAllRequiredProposals();
+	String str = this.workingCopies[0].getSource();
+	String completeBehind = "#le";
+	int cursorLocation = str.lastIndexOf(completeBehind) + completeBehind.length();
+	this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner);
+	assertResults(
+			"length[METHOD_REF]{length(), Ljava.lang.String;, ()I, length, null, "+(DEFAULT_RELEVANCE + R_NON_STATIC)+"}",
+			requestor.getResults());
+}
+
+public void testMarkdownMethodLink2_qualified2() throws CoreException {
+	// type-prefixed
+	// missing ']' at end of line
+	// link is on the last comment line
+	createFolder("/Completion23/src/javadoc");
+	this.workingCopies = new ICompilationUnit[1];
+	this.workingCopies[0] = getWorkingCopy("Completion23/src/javadoc/Test.java", """
+			package javadoc;
+			///
+			/// see [String#le
+			public class Test {
+				void method() {}
+			}
+			""");
+	CompletionTestsRequestor2 requestor = new CompletionTestsRequestor2(true);
+	requestor.allowAllRequiredProposals();
+	String str = this.workingCopies[0].getSource();
+	String completeBehind = "#le";
+	int cursorLocation = str.lastIndexOf(completeBehind) + completeBehind.length();
+	this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner);
+	assertResults(
+			"length[METHOD_REF]{length(), Ljava.lang.String;, ()I, length, null, "+(DEFAULT_RELEVANCE + R_NON_STATIC)+"}",
+			requestor.getResults());
+}
 }


### PR DESCRIPTION
test [] markdown link completion
ensure markdown links can be completed..
+ if ']' is still missing
+ on the last line of a comment
+ without any reference prefix

fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2744