### PR TITLE
Incorrect startPosition of a SingleVariableDeclaration in the catch block

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter18Test.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter18Test.java
@@ -5483,4 +5483,36 @@ public void testLambdaParameterSourcePosition() throws JavaModelException {
 	assertEquals(1, variableElement.getSourceRange().getLength());
 }
 
+public void testSVDStartPositionIssue() throws JavaModelException {
+	String contents = """
+				public class X {
+					public static void example() {
+						try {
+							System.out.println("try");
+						}
+						/** */
+						catch (RuntimeException e) {
+							System.out.println("catch");
+						}
+					}
+				}
+			""";
+	this.workingCopy = getWorkingCopy("/Converter22/src/xyz/X.java", true/*resolve*/);
+	CompilationUnit cu = (CompilationUnit) buildAST(contents, this.workingCopy);
+	TypeDeclaration typedeclaration = (TypeDeclaration) getASTNode(cu, 0);
+	MethodDeclaration methodDeclaration = (MethodDeclaration) typedeclaration.bodyDeclarations().get(0);
+	Block block = methodDeclaration.getBody();
+	List<ASTNode> statements = block.statements();
+	TryStatement tryStatement = (TryStatement) statements.get(0);
+	List<ASTNode> catchClauseList = tryStatement.catchClauses();
+	CatchClause catchClause = (CatchClause) catchClauseList.get(0);
+	SingleVariableDeclaration svd = catchClause.getException();
+
+	assertEquals("Not a Single Variable Declaration", ASTNode.SINGLE_VARIABLE_DECLARATION, svd.getNodeType());
+	assertEquals("Not a Simple Type", ASTNode.SIMPLE_TYPE, svd.getType().getNodeType());
+	assertEquals("Not a Simple Name", ASTNode.SIMPLE_NAME, svd.getName().getNodeType());
+	assertEquals("Single Variable Declaration length is not correct", svd.getLength(), 18);
+	assertEquals("Single Variable Declaration startPosition is not correct", svd.getStartPosition(), 116);
+}
+
 }

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/CommentRecorderParser.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/CommentRecorderParser.java
@@ -203,6 +203,11 @@ public class CommentRecorderParser extends Parser {
 		return position;
 	}
 
+	@Override
+	protected void consumeExitTryBlock() {
+		flushCommentsDefinedPriorTo(this.scanner.currentPosition);
+	}
+
 	protected int getCommentPtr() {
 		int lastComment = this.scanner.commentPtr;
 		if (lastComment == -1 && this.currentElement != null) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2564

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
