### PR TITLE
[23] JEP 455 - Exhaustiveness of Switch #2869

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/core/compiler/IProblem.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/core/compiler/IProblem.java
@@ -2690,4 +2690,10 @@ void setSourceStart(int sourceStart);
 	 */
 	int WrongCaseType =  PreviewRelated + 2100;
 
+	/**
+	 * @since 3.39
+	 * @noreference preview feature
+	 */
+	int IncompatibleCaseType =  PreviewRelated + 2101;
+
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ClassFile.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ClassFile.java
@@ -4019,7 +4019,7 @@ public class ClassFile implements TypeConstants, TypeIds {
 		for (CaseStatement.ResolvedCase c : constants) {
 			if (c.isPattern()) {
 				int typeOrDynIndex;
-				if ((switchStatement.switchBits & SwitchStatement.Primitive) != 0) {
+				if (c.e.resolvedType.isPrimitiveType()) {
 					// Dynamic for Class.getPrimitiveClass(Z) or such
 					typeOrDynIndex = this.constantPool.literalIndexForDynamic(c.primitivesBootstrapIdx,
 							c.t.signature(),

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/CaseStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/CaseStatement.java
@@ -302,7 +302,7 @@ public Constant resolveConstantExpression(BlockScope scope,
 			throw new AssertionError("Unexpected control flow"); //$NON-NLS-1$
 		} else if (expression instanceof NullLiteral) {
 			if (!caseType.isCompatibleWith(switchType, scope)) {
-				scope.problemReporter().typeMismatchError(TypeBinding.NULL, switchType, expression, null);
+				scope.problemReporter().caseConstantIncompatible(TypeBinding.NULL, switchType, expression);
 			}
 			switchStatement.switchBits |= SwitchStatement.NullCase;
 			return IntConstant.fromValue(-1);
@@ -311,7 +311,7 @@ public Constant resolveConstantExpression(BlockScope scope,
 		} else {
 			if (switchStatement.isNonTraditional) {
 				if (switchType.isBaseType() && !expression.isConstantValueOfTypeAssignableToType(caseType, switchType)) {
-					scope.problemReporter().typeMismatchError(caseType, switchType, expression, null);
+					scope.problemReporter().caseConstantIncompatible(caseType, switchType, expression);
 					return Constant.NotAConstant;
 				}
 			}
@@ -354,7 +354,7 @@ public Constant resolveConstantExpression(BlockScope scope,
 		// constantExpression.computeConversion(scope, caseType, switchExpressionType); - do not report boxing/unboxing conversion
 		return expression.constant;
 	}
-	scope.problemReporter().typeMismatchError(expression.resolvedType, switchType, expression, switchStatement.expression);
+	scope.problemReporter().caseConstantIncompatible(expression.resolvedType, switchType, expression);
 	return Constant.NotAConstant;
 }
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/CaseStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/CaseStatement.java
@@ -215,7 +215,8 @@ public ResolvedCase[] resolveCase(BlockScope scope, TypeBinding switchExpression
 			continue; // already processed
 		}
 		e.setExpressionContext(ExpressionContext.TESTING_CONTEXT);
-		e.setExpectedType(switchExpressionType);
+		if (e instanceof Pattern p)
+			p.setOuterExpressionType(switchExpressionType);
 
 		TypeBinding	caseType = e.resolveType(scope);
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/EitherOrMultiPattern.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/EitherOrMultiPattern.java
@@ -21,6 +21,7 @@ import org.eclipse.jdt.internal.compiler.flow.FlowContext;
 import org.eclipse.jdt.internal.compiler.flow.FlowInfo;
 import org.eclipse.jdt.internal.compiler.lookup.BlockScope;
 import org.eclipse.jdt.internal.compiler.lookup.LocalVariableBinding;
+import org.eclipse.jdt.internal.compiler.lookup.Scope;
 import org.eclipse.jdt.internal.compiler.lookup.TypeBinding;
 
 public class EitherOrMultiPattern extends Pattern {
@@ -109,11 +110,11 @@ public class EitherOrMultiPattern extends Pattern {
 	}
 
 	@Override
-	public boolean coversType(TypeBinding type) {
+	public boolean coversType(TypeBinding type, Scope scope) {
 		if (!isUnguarded())
 			return false;
 		for (Pattern p : this.patterns) {
-			if (p.coversType(type))
+			if (p.coversType(type, scope))
 				return true;
 		}
 		return false;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Expression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Expression.java
@@ -685,6 +685,9 @@ public boolean checkUnsafeCast(Scope scope, TypeBinding castType, TypeBinding ex
 /**
  * Base types need that the widening is explicitly done by the compiler using some bytecode like i2f.
  * Also check unsafe type operations.
+ * @param scope a scope
+ * @param runtimeType this is the type <strong>required</strong> at runtime
+ * @param compileTimeType this is what the compiler knows about the provided value
  */
 public void computeConversion(Scope scope, TypeBinding runtimeType, TypeBinding compileTimeType) {
 	if (runtimeType == null || compileTimeType == null)

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/GuardedPattern.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/GuardedPattern.java
@@ -21,6 +21,7 @@ import org.eclipse.jdt.internal.compiler.flow.FlowInfo;
 import org.eclipse.jdt.internal.compiler.impl.Constant;
 import org.eclipse.jdt.internal.compiler.lookup.BlockScope;
 import org.eclipse.jdt.internal.compiler.lookup.LocalVariableBinding;
+import org.eclipse.jdt.internal.compiler.lookup.Scope;
 import org.eclipse.jdt.internal.compiler.lookup.TypeBinding;
 import org.eclipse.jdt.internal.compiler.lookup.TypeIds;
 
@@ -64,8 +65,8 @@ public class GuardedPattern extends Pattern {
 	}
 
 	@Override
-	public boolean isUnconditional(TypeBinding t) {
-		return isUnguarded() && this.primaryPattern.isUnconditional(t);
+	public boolean isUnconditional(TypeBinding t, Scope scope) {
+		return isUnguarded() && this.primaryPattern.isUnconditional(t, scope);
 	}
 
 	@Override
@@ -80,8 +81,8 @@ public class GuardedPattern extends Pattern {
 	}
 
 	@Override
-	public boolean coversType(TypeBinding type) {
-		return isUnguarded() && this.primaryPattern.coversType(type);
+	public boolean coversType(TypeBinding type, Scope scope) {
+		return isUnguarded() && this.primaryPattern.coversType(type, scope);
 	}
 
 	@Override

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/InstanceOfExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/InstanceOfExpression.java
@@ -371,17 +371,10 @@ private void checkForPrimitives(BlockScope scope, TypeBinding checkedType, TypeB
 }
 
 private void checkRefForPrimitivesAndAddSecretVariable(BlockScope scope, TypeBinding checkedType, TypeBinding expressionType) {
-	if (!(JavaFeature.PRIMITIVES_IN_PATTERNS.isSupported(
-			scope.compilerOptions().sourceLevel,
-			scope.compilerOptions().enablePreviewFeatures)))
+	if (!JavaFeature.PRIMITIVES_IN_PATTERNS.isSupported(scope.compilerOptions()))
 		return;
 	PrimitiveConversionRoute route = Pattern.findPrimitiveConversionRoute(checkedType, expressionType, scope);
 	this.testContextRecord = new TestContextRecord(checkedType, expressionType, route);
-	if (route == PrimitiveConversionRoute.UNBOXING_CONVERSION
-			|| route == PrimitiveConversionRoute.UNBOXING_AND_WIDENING_PRIMITIVE_CONVERSION
-		) {
-		addSecretExpressionValue(scope, expressionType);
-	}
 }
 
 private void addSecretExpressionValue(BlockScope scope, TypeBinding expressionType) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/InstanceOfExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/InstanceOfExpression.java
@@ -240,7 +240,10 @@ private void generateTypeCheck(BlockScope scope, CodeStream codeStream, BranchLa
 			break;
 //			TODO:	case WIDENING_REFERENCE_AND_UNBOXING_COVERSION:
 //			TODO:	case WIDENING_REFERENCE_AND_UNBOXING_COVERSION_AND_WIDENING_PRIMITIVE_CONVERSION:
-//			TODO:	case NARROWING_AND_UNBOXING_CONVERSION:
+		case NARROWING_AND_UNBOXING_CONVERSION:
+			TypeBinding boxType = scope.environment().computeBoxingType(this.type.resolvedType);
+			codeStream.instance_of(this.type, boxType);
+			break;
 		case UNBOXING_CONVERSION:
 		case UNBOXING_AND_WIDENING_PRIMITIVE_CONVERSION:
 			codeStream.ifnull(internalFalseLabel);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/InstanceOfExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/InstanceOfExpression.java
@@ -300,7 +300,7 @@ public TypeBinding resolveType(BlockScope scope) {
 	TypeBinding expressionType = this.expression.resolveType(scope);
 	if (this.pattern != null) {
 		this.pattern.setExpressionContext(ExpressionContext.TESTING_CONTEXT);
-		this.pattern.setExpectedType(this.expression.resolvedType);
+		this.pattern.setOuterExpressionType(this.expression.resolvedType);
 		this.pattern.resolveType(scope);
 
 		addSecretExpressionValue(scope, expressionType);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Pattern.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Pattern.java
@@ -58,7 +58,7 @@ public abstract class Pattern extends Expression {
 	}
 
 	protected TypeBinding outerExpressionType; // the expression type of the enclosing instanceof, switch or outer record pattern
-	
+
 	record TestContextRecord(TypeBinding left, TypeBinding right, PrimitiveConversionRoute route) {}
 
 	public Pattern getEnclosingPattern() {
@@ -247,6 +247,10 @@ public abstract class Pattern extends Expression {
 					return PrimitiveConversionRoute.WIDENING_REFERENCE_AND_UNBOXING_COVERSION;
 				if (BaseTypeBinding.isWidening(destinationType.id, exprPrimId))
 					return PrimitiveConversionRoute.WIDENING_REFERENCE_AND_UNBOXING_COVERSION_AND_WIDENING_PRIMITIVE_CONVERSION;
+			} else if (destinationIsBaseType) {
+				TypeBinding boxedDestinationType = scope.environment().computeBoxingType(destinationType);
+				if (boxedDestinationType.isCompatibleWith(expressionType))
+					return PrimitiveConversionRoute.NARROWING_AND_UNBOXING_CONVERSION;
 			}
 		}
 		return PrimitiveConversionRoute.NO_CONVERSION_ROUTE;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Pattern.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Pattern.java
@@ -93,6 +93,8 @@ public abstract class Pattern extends Expression {
 					return true;
 				case WIDENING_PRIMITIVE_CONVERSION:
 					return BaseTypeBinding.isExactWidening(this.resolvedType.id, type.id);
+				case WIDENING_AND_NARROWING_PRIMITIVE_CONVERSION:
+					return false; // char->byte
 				/* §14.11.1.1 "CE contains a type pattern with a primitive type P,
 				 * 		 	and T is the wrapper class for the primitive type W,
 				 *			and the conversion from type W to type P is unconditionally exact (5.7.2). */
@@ -214,12 +216,12 @@ public abstract class Pattern extends Expression {
 			if (TypeBinding.equalsEquals(destinationType, expressionType)) {
 				return PrimitiveConversionRoute.IDENTITY_CONVERSION;
 			}
+			if (BaseTypeBinding.isWideningAndNarrowing(destinationType.id, expressionType.id))
+				return PrimitiveConversionRoute.WIDENING_AND_NARROWING_PRIMITIVE_CONVERSION;
 			if (BaseTypeBinding.isWidening(destinationType.id, expressionType.id))
 				return PrimitiveConversionRoute.WIDENING_PRIMITIVE_CONVERSION;
 			if (BaseTypeBinding.isNarrowing(destinationType.id, expressionType.id))
 				return PrimitiveConversionRoute.NARROWING_PRIMITVE_CONVERSION;
-			if (BaseTypeBinding.isWideningAndNarrowing(destinationType.id, expressionType.id))
-				return PrimitiveConversionRoute.WIDENING_AND_NARROWING_PRIMITIVE_CONVERSION;
 		} else {
 			if (expressionIsBaseType) {
 				if (expressionType instanceof NullTypeBinding

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/RecordPattern.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/RecordPattern.java
@@ -98,16 +98,6 @@ public class RecordPattern extends Pattern {
 	}
 
 	@Override
-	public void setExpectedType(TypeBinding expectedType) {
-		this.expectedType = expectedType;
-	}
-
-	@Override
-	public TypeBinding expectedType() {
-		return this.expectedType;
-	}
-
-	@Override
 	public TypeBinding resolveType(BlockScope scope) {
 
 		this.constant = Constant.NotAConstant;
@@ -127,9 +117,8 @@ public class RecordPattern extends Pattern {
 		}
 
 		if (this.resolvedType.isRawType()) {
-			TypeBinding expressionType = expectedType();
-			if (expressionType instanceof ReferenceBinding) {
-				ReferenceBinding binding = inferRecordParameterization(scope, (ReferenceBinding) expressionType);
+			if (this.outerExpressionType instanceof ReferenceBinding) {
+				ReferenceBinding binding = inferRecordParameterization(scope, (ReferenceBinding) this.outerExpressionType);
 				if (binding == null || !binding.isValidBinding()) {
 					scope.problemReporter().cannotInferRecordPatternTypes(this);
 				    return this.resolvedType = null;
@@ -143,7 +132,7 @@ public class RecordPattern extends Pattern {
 			Pattern p = this.patterns[i];
 			p.resolveTypeWithBindings(bindings, scope);
 			bindings = LocalVariableBinding.merge(bindings, p.bindingsWhenTrue());
-			p.setExpectedType(this.resolvedType.components()[i].type);
+			p.setOuterExpressionType(this.resolvedType.components()[i].type);
 		}
 
 		if (this.resolvedType == null || !this.resolvedType.isValidBinding()) {
@@ -161,9 +150,9 @@ public class RecordPattern extends Pattern {
 						tp.local.binding.type = componentBinding.type;
 				}
 			}
-			TypeBinding expressionType = componentBinding.type;
-			if (p1.isApplicable(expressionType, scope)) {
-				p1.isTotalTypeNode = p1.coversType(componentBinding.type, scope);
+			TypeBinding componentType = componentBinding.type;
+			if (p1.isApplicable(componentType, scope)) {
+				p1.isTotalTypeNode = p1.coversType(componentType, scope);
 				MethodBinding[] methods = this.resolvedType.getMethods(componentBinding.name);
 				if (methods != null && methods.length > 0) {
 					p1.accessorMethod = methods[0];

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/RecordPattern.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/RecordPattern.java
@@ -29,6 +29,7 @@ import org.eclipse.jdt.internal.compiler.lookup.LocalVariableBinding;
 import org.eclipse.jdt.internal.compiler.lookup.MethodBinding;
 import org.eclipse.jdt.internal.compiler.lookup.RecordComponentBinding;
 import org.eclipse.jdt.internal.compiler.lookup.ReferenceBinding;
+import org.eclipse.jdt.internal.compiler.lookup.Scope;
 import org.eclipse.jdt.internal.compiler.lookup.TypeBinding;
 
 public class RecordPattern extends Pattern {
@@ -72,7 +73,7 @@ public class RecordPattern extends Pattern {
 	}
 
 	@Override
-	public boolean coversType(TypeBinding t) {
+	public boolean coversType(TypeBinding t, Scope scope) {
 
 		if (!isUnguarded())
 			return false;
@@ -89,7 +90,7 @@ public class RecordPattern extends Pattern {
 		for (int i = 0; i < components.length; i++) {
 			Pattern p = this.patterns[i];
 			RecordComponentBinding componentBinding = components[i];
-			if (!p.coversType(componentBinding.type)) {
+			if (!p.coversType(componentBinding.type, scope)) {
 				return false;
 			}
 		}
@@ -149,7 +150,7 @@ public class RecordPattern extends Pattern {
 			return this.resolvedType;
 		}
 
-		this.isTotalTypeNode = super.coversType(this.resolvedType);
+		this.isTotalTypeNode = super.coversType(this.resolvedType, scope);
 		RecordComponentBinding[] components = this.resolvedType.capture(scope, this.sourceStart, this.sourceEnd).components();
 		for (int i = 0; i < components.length; i++) {
 			Pattern p1 = this.patterns[i];
@@ -162,7 +163,7 @@ public class RecordPattern extends Pattern {
 			}
 			TypeBinding expressionType = componentBinding.type;
 			if (p1.isApplicable(expressionType, scope)) {
-				p1.isTotalTypeNode = p1.coversType(componentBinding.type);
+				p1.isTotalTypeNode = p1.coversType(componentBinding.type, scope);
 				MethodBinding[] methods = this.resolvedType.getMethods(componentBinding.name);
 				if (methods != null && methods.length > 0) {
 					p1.accessorMethod = methods[0];
@@ -189,7 +190,7 @@ public class RecordPattern extends Pattern {
 	}
 
 	@Override
-	public boolean isUnconditional(TypeBinding t) {
+	public boolean isUnconditional(TypeBinding t, Scope scope) {
 		return false;
 	}
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
@@ -1013,7 +1013,7 @@ public class SwitchStatement extends Expression {
 	}
 	private void generateTypeSwitchPatternPrologue(CodeStream codeStream, int invokeDynamicNumber) {
 		TypeBinding exprType = this.expression.resolvedType;
-		char[] signature =typeSwitchSignature(exprType);
+		char[] signature = typeSwitchSignature(exprType);
 		int argsSize = TypeIds.getCategory(exprType.id) + 1; // Object | PRIM, restartIndex (PRIM = Z|S|I..)
 		codeStream.invokeDynamic(invokeDynamicNumber,
 				argsSize,
@@ -1026,10 +1026,14 @@ public class SwitchStatement extends Expression {
 		char[] arg1 = switch (exprType.id) {
 			case TypeIds.T_JavaLangLong, TypeIds.T_JavaLangFloat, TypeIds.T_JavaLangDouble, TypeIds.T_JavaLangBoolean ->
 				exprType.signature();
-			default ->
-				exprType.isPrimitiveType()
-					? exprType.signature()
-					: "Ljava/lang/Object;".toCharArray(); //$NON-NLS-1$
+			default -> {
+				if (exprType.id > TypeIds.T_LastWellKnownTypeId && exprType.erasure().isBoxedPrimitiveType())
+					yield exprType.erasure().signature(); // <T extends Integer> / <? extends Short> ...
+				else
+					yield exprType.isPrimitiveType()
+						? exprType.signature()
+						: "Ljava/lang/Object;".toCharArray(); //$NON-NLS-1$
+			}
 		};
 		return CharOperation.concat("(".toCharArray(), arg1, "I)I".toCharArray()); //$NON-NLS-1$ //$NON-NLS-2$
 	}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypePattern.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypePattern.java
@@ -138,13 +138,8 @@ public class TypePattern extends Pattern {
 				codeStream.generateImplicitConversion(this.implicitConversion);
 				break;
 			case BOXING_CONVERSION:
+			case BOXING_CONVERSION_AND_WIDENING_REFERENCE_CONVERSION: // widening needs no conversion :)
 				codeStream.generateBoxingConversion(provided.id);
-				break;
-			case BOXING_CONVERSION_AND_WIDENING_REFERENCE_CONVERSION:
-				int providedId = provided.id;
-				codeStream.generateBoxingConversion(providedId);
-				TypeBinding unboxedType = scope.environment().computeBoxingType(TypeBinding.wellKnownBaseType(providedId));
-				this.computeConversion(scope, lhs, unboxedType);
 				break;
 			case WIDENING_REFERENCE_AND_UNBOXING_COVERSION:
 				codeStream.generateUnboxingConversion(expected.id);
@@ -155,7 +150,11 @@ public class TypePattern extends Pattern {
 				this.computeConversion(scope, TypeBinding.wellKnownBaseType(rhsUnboxed), expected);
 				codeStream.generateImplicitConversion(this.implicitConversion);
 				break;
-//				TODO:	case NARROWING_AND_UNBOXING_CONVERSION:
+			case NARROWING_AND_UNBOXING_CONVERSION:
+				TypeBinding boxType = scope.environment().computeBoxingType(expected);
+				codeStream.checkcast(boxType);
+				codeStream.generateUnboxingConversion(expected.id);
+				break;
 			case UNBOXING_CONVERSION:
 				codeStream.generateUnboxingConversion(expected.id);
 				break;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypePattern.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypePattern.java
@@ -124,9 +124,9 @@ public class TypePattern extends Pattern {
 
 	@Override
 	public void generateTestingConversion(BlockScope scope, CodeStream codeStream) {
-		TypeBinding rhs = this.expectedType;
-		TypeBinding lhs = this.resolvedType;
-		PrimitiveConversionRoute route = Pattern.findPrimitiveConversionRoute(lhs, rhs, scope);
+		TypeBinding provided = this.outerExpressionType;
+		TypeBinding expected = this.resolvedType;
+		PrimitiveConversionRoute route = Pattern.findPrimitiveConversionRoute(expected, provided, scope);
 		switch (route) {
 			case IDENTITY_CONVERSION:
 				// Do nothing
@@ -134,33 +134,33 @@ public class TypePattern extends Pattern {
 			case WIDENING_PRIMITIVE_CONVERSION:
 			case NARROWING_PRIMITVE_CONVERSION:
 			case WIDENING_AND_NARROWING_PRIMITIVE_CONVERSION:
-				this.computeConversion(scope, lhs, rhs);
+				this.computeConversion(scope, expected, provided);
 				codeStream.generateImplicitConversion(this.implicitConversion);
 				break;
 			case BOXING_CONVERSION:
-				codeStream.generateBoxingConversion(rhs.id);
+				codeStream.generateBoxingConversion(provided.id);
 				break;
 			case BOXING_CONVERSION_AND_WIDENING_REFERENCE_CONVERSION:
-				int rightId = rhs.id;
-				codeStream.generateBoxingConversion(rightId);
-				TypeBinding unboxedType = scope.environment().computeBoxingType(TypeBinding.wellKnownBaseType(rightId));
+				int providedId = provided.id;
+				codeStream.generateBoxingConversion(providedId);
+				TypeBinding unboxedType = scope.environment().computeBoxingType(TypeBinding.wellKnownBaseType(providedId));
 				this.computeConversion(scope, lhs, unboxedType);
 				break;
 			case WIDENING_REFERENCE_AND_UNBOXING_COVERSION:
-				codeStream.generateUnboxingConversion(lhs.id);
+				codeStream.generateUnboxingConversion(expected.id);
 				break;
 			case WIDENING_REFERENCE_AND_UNBOXING_COVERSION_AND_WIDENING_PRIMITIVE_CONVERSION:
-				int rhsUnboxed = TypeIds.box2primitive(rhs.superclass().id);
+				int rhsUnboxed = TypeIds.box2primitive(provided.superclass().id);
 				codeStream.generateUnboxingConversion(rhsUnboxed);
-				this.computeConversion(scope, TypeBinding.wellKnownBaseType(rhsUnboxed), lhs);
+				this.computeConversion(scope, TypeBinding.wellKnownBaseType(rhsUnboxed), expected);
 				codeStream.generateImplicitConversion(this.implicitConversion);
 				break;
 //				TODO:	case NARROWING_AND_UNBOXING_CONVERSION:
 			case UNBOXING_CONVERSION:
-				codeStream.generateUnboxingConversion(lhs.id);
+				codeStream.generateUnboxingConversion(expected.id);
 				break;
 			case UNBOXING_AND_WIDENING_PRIMITIVE_CONVERSION:
-				this.computeConversion(scope, lhs, rhs);
+				this.computeConversion(scope, expected, provided);
 				codeStream.generateImplicitConversion(this.implicitConversion);
 				break;
 			case NO_CONVERSION_ROUTE:

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BaseTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BaseTypeBinding.java
@@ -160,6 +160,7 @@ public class BaseTypeBinding extends TypeBinding {
 				case TypeIds.Short2Long:
 				case TypeIds.Short2Float:
 				case TypeIds.Short2Double:
+				case TypeIds.Char2Int:
 				case TypeIds.Char2Long:
 				case TypeIds.Char2Float:
 				case TypeIds.Char2Double:

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeIds.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeIds.java
@@ -297,4 +297,18 @@ public interface TypeIds {
 	public static int getCategory(int typeId) {
 		return typeId == TypeIds.T_double || typeId == TypeIds.T_long ? 2 : 1;
 	}
+
+	public static int box2primitive(int id) {
+		return switch (id) {
+			case T_JavaLangBoolean -> T_boolean;
+			case T_JavaLangByte -> T_byte;
+			case T_JavaLangCharacter -> T_char;
+			case T_JavaLangShort -> T_short;
+			case T_JavaLangInteger -> T_int;
+			case T_JavaLangLong -> T_long;
+			case T_JavaLangFloat -> T_float;
+			case T_JavaLangDouble -> T_double;
+			default -> -1;
+		};
+	}
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
@@ -1668,6 +1668,14 @@ public void caseExpressionWrongType(Expression expression, TypeBinding switchBin
 		expression.sourceStart,
 		expression.sourceEnd);
 }
+public void caseConstantIncompatible(TypeBinding resolvedType, TypeBinding switchType, Expression expression) {
+	this.handle(
+			IProblem.IncompatibleCaseType,
+			new String[] {String.valueOf(resolvedType.readableName()), String.valueOf(switchType.readableName())},
+			new String[] {String.valueOf(resolvedType.shortReadableName()), String.valueOf(switchType.shortReadableName())},
+			expression.sourceStart,
+			expression.sourceEnd);
+}
 public void classExtendFinalClass(SourceTypeBinding type, TypeReference superclass, TypeBinding superTypeBinding) {
 	String name = new String(type.sourceName());
 	String superTypeFullName = new String(superTypeBinding.readableName());

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/messages.properties
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/messages.properties
@@ -1195,6 +1195,7 @@
 
 # JEP 455 Primitive Types in Patterns, instanceof, and switch (Preview)
 2100 = Case constants in a switch on ''{0}'' must have type ''{1}''
+2101 = Case constant of type {0} is incompatible with switch selector type {1}
 
 ### ELABORATIONS
 ## Access restrictions

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AssignmentTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AssignmentTest.java
@@ -2090,7 +2090,7 @@ public void test068() {
 			"6. ERROR in X.java (at line 9)\n" +
 			"	case \'a\' :   // case statement\n" +
 			"	     ^^^\n" +
-			"Type mismatch: cannot convert from char to Integer\n" +
+			"Case constant of type char is incompatible with switch selector type Integer\n" +
 			"----------\n");
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=480989

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AutoBoxingTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AutoBoxingTest.java
@@ -4956,7 +4956,7 @@ public void test165() {
 		"4. ERROR in X.java (at line 8)\n" +
 		"	case s:\n" +
 		"	     ^\n" +
-		"Type mismatch: cannot convert from short to Integer\n" +
+		"Case constant of type short is incompatible with switch selector type Integer\n" +
 		"----------\n" +
 		"5. WARNING in X.java (at line 12)\n" +
 		"	Integer i2 = 10 ;\n" +
@@ -4976,7 +4976,7 @@ public void test165() {
 		"8. ERROR in X.java (at line 17)\n" +
 		"	case b:\n" +
 		"	     ^\n" +
-		"Type mismatch: cannot convert from byte to Integer\n" +
+		"Case constant of type byte is incompatible with switch selector type Integer\n" +
 		"----------\n" +
 		"9. WARNING in X.java (at line 21)\n" +
 		"	Integer i3 = 10 ;\n" +
@@ -4996,7 +4996,7 @@ public void test165() {
 		"12. ERROR in X.java (at line 26)\n" +
 		"	case c:\n" +
 		"	     ^\n" +
-		"Type mismatch: cannot convert from char to Integer\n" +
+		"Case constant of type char is incompatible with switch selector type Integer\n" +
 		"----------\n");
 }
 
@@ -5245,7 +5245,7 @@ public void test169() {
 			"7. ERROR in X.java (at line 7)\n" +
 			"	case 1:\n" +
 			"	     ^\n" +
-			"Type mismatch: cannot convert from int to T\n" +
+			"Case constant of type int is incompatible with switch selector type T\n" +
 			"----------\n" +
 			"8. WARNING in X.java (at line 12)\n" +
 			"	t = 5;\n" +
@@ -5287,7 +5287,7 @@ public void test169() {
 			"6. ERROR in X.java (at line 7)\n" +
 			"	case 1:\n" +
 			"	     ^\n" +
-			"Type mismatch: cannot convert from int to T\n" +
+			"Case constant of type int is incompatible with switch selector type T\n" +
 			"----------\n" +
 			"7. WARNING in X.java (at line 12)\n" +
 			"	t = 5;\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/CompilerInvocationTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/CompilerInvocationTests.java
@@ -615,6 +615,7 @@ public void test011_problem_categories() {
 		expectedProblemAttributes.put("ImportInternalNameProvided", DEPRECATED);
 		expectedProblemAttributes.put("ImportNotFound", new ProblemAttributes(CategorizedProblem.CAT_IMPORT));
 		expectedProblemAttributes.put("ImportNotVisible", DEPRECATED);
+		expectedProblemAttributes.put("IncompatibleCaseType", new ProblemAttributes(CategorizedProblem.CAT_PREVIEW_RELATED));
 		expectedProblemAttributes.put("IncompatibleExceptionInInheritedMethodThrowsClause", new ProblemAttributes(CategorizedProblem.CAT_MEMBER));
 		expectedProblemAttributes.put("IncompatibleExceptionInThrowsClause", new ProblemAttributes(CategorizedProblem.CAT_MEMBER));
 		expectedProblemAttributes.put("IncompatibleExceptionInThrowsClauseForNonInheritedInterfaceMethod", new ProblemAttributes(CategorizedProblem.CAT_NAME_SHADOWING_CONFLICT));
@@ -1744,6 +1745,7 @@ public void test012_compiler_problems_tuning() {
 		expectedProblemAttributes.put("ImportInternalNameProvided", SKIP);
 		expectedProblemAttributes.put("ImportNotFound", SKIP);
 		expectedProblemAttributes.put("ImportNotVisible", SKIP);
+		expectedProblemAttributes.put("IncompatibleCaseType", SKIP);
 		expectedProblemAttributes.put("IncompatibleExceptionInInheritedMethodThrowsClause", SKIP);
 		expectedProblemAttributes.put("IncompatibleExceptionInThrowsClause", SKIP);
 		expectedProblemAttributes.put("IncompatibleExceptionInThrowsClauseForNonInheritedInterfaceMethod", new ProblemAttributes(JavaCore.COMPILER_PB_INCOMPATIBLE_NON_INHERITED_INTERFACE_METHOD));

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PatternMatching16Test.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PatternMatching16Test.java
@@ -198,17 +198,24 @@ public class PatternMatching16Test extends AbstractRegressionTest {
 	}
 	public void test003a() {
 		Map<String, String> options = getCompilerOptions(true);
-		runNegativeTest(
+		String[] testFiles =
 				new String[] {
 						"X3.java",
 						"@SuppressWarnings(\"preview\")\n" +
 						"public class X3 {\n" +
 						"  public void foo(Number num) {\n" +
 						"		if (num instanceof int) {\n" +
+						"			System.out.print(\"int\");\n" +
 						"		}\n " +
 						"	}\n" +
+						"	public static void main(String... args) {\n" +
+						"		new X3().foo(3);" +
+						"	}\n" +
 						"}\n",
-				},
+				};
+		if (this.complianceLevel < ClassFileConstants.JDK23) {
+			runNegativeTest(
+				testFiles,
 				"----------\n" +
 				"1. ERROR in X3.java (at line 4)\n" +
 				"	if (num instanceof int) {\n" +
@@ -219,6 +226,9 @@ public class PatternMatching16Test extends AbstractRegressionTest {
 				null,
 				true,
 				options);
+		} else {
+			runConformTest(testFiles, "int", options, new String[] {"--enable-preview"}, JavacTestOptions.DEFAULT);
+		}
 	}
 	public void test004() {
 		Map<String, String> options = getCompilerOptions(true);

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PrimitiveInPatternsTestSH.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PrimitiveInPatternsTestSH.java
@@ -1423,6 +1423,193 @@ public class PrimitiveInPatternsTestSH extends AbstractRegressionTest9 {
 			----------
 			""");
 	}
+	public void testBooleanSwitchExhaustive_OK() {
+		runConformTest(new String[] {
+				"X.java",
+				"""
+				public class X {
+					static int m1(boolean b) {
+						return switch (b) {
+							case true -> 1;
+							case false -> 0;
+						};
+					}
+					public static void main(String... args) {
+						System.out.print(m1(true));
+						System.out.print(m1(false));
+					}
+				}
+				"""
+			},
+			"10");
+	}
+	public void testBooleanSwitchExhaustive_NOK() {
+		runNegativeTest(new String[] {
+				"X.java",
+				"""
+				public class X {
+					static int m1(boolean b) {
+						return switch (b) {
+							case true -> 1;
+						};
+					}
+				}
+				"""
+			},
+			"""
+			----------
+			1. ERROR in X.java (at line 3)
+				return switch (b) {
+				               ^
+			A switch expression should have a default case
+			----------
+			""");
+	}
+
+	// exhaustiveness with identity conversion is already cover testNarrowingInSwitchFrom()
+
+	public void testShortSwitchExhaustive_int_Number_Comparable() {
+		runConformTest(new String[] {
+				"X.java",
+				"""
+				public class X {
+					static int m1(short s) {
+						return switch (s) {
+							case 1 -> 0;
+							case int v -> v*2;
+						};
+					}
+					static int m2(short s) {
+						return switch (s) {
+							case 1 -> 0;
+							case Number v -> v.intValue()*2;
+						};
+					}
+					static int m3(short s) {
+						return switch (s) {
+							case 1 -> 0;
+							case Comparable<?> v -> humbug(v);
+						};
+					}
+					static int humbug(Comparable<?> v) {
+						return 8;
+					}
+					public static void main(String... args) {
+						System.out.print(m1((short) 1));
+						System.out.print(m1((short) 4));
+						System.out.print(m2((short) 1));
+						System.out.print(m2((short) 4));
+						System.out.print(m3((short) 1));
+						System.out.print(m3((short) 4));
+					}
+				}
+				"""
+			},
+			"080808");
+	}
+
+	public void testIntSwitchExhaustive_NOK() {
+		runNegativeTest(new String[] {
+				"X.java",
+				"""
+				public class X {
+					static float m1(Integer i) {
+						return switch(i) {
+							case 1 -> 1.0f;
+							case float f -> f;
+						};
+					}
+					static float m2(int i) {
+						return switch(i) {
+							case 1 -> 1;
+							case float f -> f;
+						};
+					}
+				}
+				"""
+			},
+			"""
+			----------
+			1. ERROR in X.java (at line 3)
+				return switch(i) {
+				              ^
+			A switch expression should have a default case
+			----------
+			2. ERROR in X.java (at line 9)
+				return switch(i) {
+				              ^
+			A switch expression should have a default case
+			----------
+			""");
+	}
+
+	public void testIntSwitchExhaustive_OK() {
+		runConformTest(new String[] {
+				"X.java",
+				"""
+				public class X {
+					static double m1(Integer i) {
+						return switch(i) {
+							case 1 -> 1.0f;
+							case double d -> d;
+						};
+					}
+					static double m2(int i) {
+						return switch(i) {
+							case 1 -> 1;
+							case double d -> d;
+						};
+					}
+					public static void main(String... args) {
+						System.out.print(m1(1));
+						System.out.print('|');
+						System.out.print(m1(3));
+						System.out.print('|');
+						System.out.print(m2(1));
+						System.out.print('|');
+						System.out.print(m2(3));
+					}
+				}
+				"""
+			},
+			"1.0|3.0|1.0|3.0");
+	}
+
+	public void testLongSwitchExhaustive_NOK() {
+		runNegativeTest(new String[] {
+				"X.java",
+				"""
+				public class X {
+					static float m1(Long l) {
+						return switch(l) {
+							case 1L -> 1.0f;
+							case float f -> f;
+						};
+					}
+					static double m2(long l) {
+						return switch(l) {
+							case 1L -> 1.0d;
+							case double d -> d;
+						};
+					}
+				}
+				"""
+			},
+			"""
+			----------
+			1. ERROR in X.java (at line 3)
+				return switch(l) {
+				              ^
+			A switch expression should have a default case
+			----------
+			2. ERROR in X.java (at line 9)
+				return switch(l) {
+				              ^
+			A switch expression should have a default case
+			----------
+			""");
+	}
+
 	// test from spec
 	public void _testSpec001() {
 		runConformTest(new String[] {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PrimitiveInPatternsTestSH.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PrimitiveInPatternsTestSH.java
@@ -1165,6 +1165,117 @@ public class PrimitiveInPatternsTestSH extends AbstractRegressionTest9 {
 				"false|false|49|-1|1|-|49|-1|49|-1|49|-1|49.0|-1.0|49.0|-1.0|");
 	}
 
+	public void testPrimitivePatternInSwitch_narrowConst_NOK() {
+		StringBuilder methods = new StringBuilder();
+		StringBuilder calls = new StringBuilder();
+		String methodTmpl =
+				"""
+					public static PRIM switchPRIM(Object in) {
+						return switch (in) {
+							case MAX -> NEGVAL;
+							default -> MAX;
+						};
+					}
+				""";
+		String callTmpl =
+				"""
+						BOX vBOX = VAL;
+						System.out.print(X.switchPRIM(vBOX));
+						System.out.print('|');
+						vBOX = MAX;
+						System.out.print(X.switchPRIM(vBOX));
+						System.out.print('|');
+				""";
+		// for all primitive types:
+		for (int i = 0; i < PRIMITIVES.length; i++) {
+			methods.append(fillIn(methodTmpl, i));
+			calls.append(fillIn(callTmpl, i));
+		}
+		StringBuilder classX = new StringBuilder("public class X {\n");
+		classX.append(methods.toString());
+		classX.append("public static void main(String[] args) {\n");
+		classX.append(calls);
+		classX.append("}}\n");
+		runNegativeTest(new String[] { "X.java", classX.toString() },
+				"""
+				----------
+				1. ERROR in X.java (at line 4)
+					case true -> false;
+					     ^^^^
+				Case constant of type boolean is incompatible with switch selector type Object
+				----------
+				2. ERROR in X.java (at line 10)
+					case Byte.MAX_VALUE -> -1;
+					     ^^^^^^^^^^^^^^
+				Case constant of type byte is incompatible with switch selector type Object
+				----------
+				3. ERROR in X.java (at line 16)
+					case 'z' -> '-';
+					     ^^^
+				Case constant of type char is incompatible with switch selector type Object
+				----------
+				4. ERROR in X.java (at line 22)
+					case Short.MAX_VALUE -> -1;
+					     ^^^^^^^^^^^^^^^
+				Case constant of type short is incompatible with switch selector type Object
+				----------
+				5. ERROR in X.java (at line 28)
+					case Integer.MAX_VALUE -> -1;
+					     ^^^^^^^^^^^^^^^^^
+				Case constant of type int is incompatible with switch selector type Object
+				----------
+				6. ERROR in X.java (at line 34)
+					case Long.MAX_VALUE -> -1L;
+					     ^^^^^^^^^^^^^^
+				Case constant of type long is incompatible with switch selector type Object
+				----------
+				7. ERROR in X.java (at line 40)
+					case Float.MAX_VALUE -> -1.0f;
+					     ^^^^^^^^^^^^^^^
+				Case constant of type float is incompatible with switch selector type Object
+				----------
+				8. ERROR in X.java (at line 46)
+					case Double.MAX_VALUE -> -1.0d;
+					     ^^^^^^^^^^^^^^^^
+				Case constant of type double is incompatible with switch selector type Object
+				----------
+				""");
+	}
+
+	public void testPrimitivePatternInSwitch_narrowUnbox() {
+		StringBuilder methods = new StringBuilder();
+		StringBuilder calls = new StringBuilder();
+		String methodTmpl =
+				"""
+					public static PRIM switchPRIM(Object in) {
+						return switch (in) {
+							case PRIM v -> v;
+							default -> NEGVAL;
+						};
+					}
+				""";
+		String callTmpl =
+				"""
+						BOX vBOX = VAL;
+						System.out.print(X.switchPRIM(vBOX));
+						System.out.print('|');
+						System.out.print(X.switchPRIM(new Object()));
+						System.out.print('|');
+				""";
+		// for all primitive types:
+		for (int i = 0; i < PRIMITIVES.length; i++) {
+			methods.append(fillIn(methodTmpl, i));
+			calls.append(fillIn(callTmpl, i));
+		}
+		StringBuilder classX = new StringBuilder("public class X {\n");
+		classX.append(methods.toString());
+		classX.append("public static void main(String[] args) {\n");
+		classX.append(calls);
+		classX.append("}}\n");
+		runConformTest(new String[] { "X.java", classX.toString() },
+				"true|false|49|-1|1|-|49|-1|49|-1|49|-1|49.0|-1.0|49.0|-1.0|");
+	}
+
 	private void testPrimitivePatternInSwitch_from_unboxAndNarrow_NOK(String from, int idx, String expectedError) {
 		assert from.equals(BOXES[idx]) : "mismatching from vs idx";
 		StringBuilder methods = new StringBuilder();

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchExpressionsYieldTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchExpressionsYieldTest.java
@@ -204,7 +204,7 @@ public class SwitchExpressionsYieldTest extends AbstractRegressionTest {
 			"1. ERROR in X.java (at line 12)\n" +
 			"	case \"hello\" -> throw new java.io.IOException(\"hello\");\n" +
 			"	     ^^^^^^^\n" +
-			"Type mismatch: cannot convert from String to int\n" +
+			"Case constant of type String is incompatible with switch selector type int\n" +
 			"----------\n");
 	}
 	public void testBug544073_005() {
@@ -273,7 +273,7 @@ public class SwitchExpressionsYieldTest extends AbstractRegressionTest {
 			"2. ERROR in X.java (at line 13)\n" +
 			"	case \"hello\" -> throw new IOException(\"hello\");\n" +
 			"	     ^^^^^^^\n" +
-			"Type mismatch: cannot convert from String to int\n" +
+			"Case constant of type String is incompatible with switch selector type int\n" +
 			"----------\n");
 	}
 	/*
@@ -929,7 +929,7 @@ public class SwitchExpressionsYieldTest extends AbstractRegressionTest {
 				"1. ERROR in X.java (at line 9)\n" +
 				"	case \"2\": \n" +
 				"	     ^^^\n" +
-				"Type mismatch: cannot convert from String to int\n" +
+				"Case constant of type String is incompatible with switch selector type int\n" +
 				"----------\n";
 		this.runNegativeTest(
 				testFiles,
@@ -7677,7 +7677,7 @@ public class SwitchExpressionsYieldTest extends AbstractRegressionTest {
 						+ "1. ERROR in X.java (at line 8)\n"
 						+ "	case 1.0 -> System.out.println(d);\n"
 						+ "	     ^^^\n"
-						+ "Type mismatch: cannot convert from double to void\n"
+						+ "Case constant of type double is incompatible with switch selector type void\n"
 						+ "----------\n");
 	}
 	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2382
@@ -7801,7 +7801,7 @@ public class SwitchExpressionsYieldTest extends AbstractRegressionTest {
 						"2. ERROR in X.java (at line 8)\n" +
 						"	case null -> System.out.println(d);\n" +
 						"	     ^^^^\n" +
-						"Type mismatch: cannot convert from null to void\n" +
+						"Case constant of type null is incompatible with switch selector type void\n" +
 						"----------\n");
 	}
 	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2387

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchPatternTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchPatternTest.java
@@ -442,7 +442,7 @@ public class SwitchPatternTest extends AbstractRegressionTest9 {
 			"1. ERROR in X.java (at line 4)\n" +
 			"	case null, default : System.out.println(\"Default\");\n" +
 			"	     ^^^^\n" +
-			"Type mismatch: cannot convert from null to int\n" +
+			"Case constant of type null is incompatible with switch selector type int\n" +
 			"----------\n" +
 			"2. ERROR in X.java (at line 5)\n" +
 			"	default : System.out.println(\"Object\");\n" +
@@ -551,7 +551,7 @@ public class SwitchPatternTest extends AbstractRegressionTest9 {
 			"1. ERROR in X.java (at line 4)\n" +
 			"	case 1: System.out.println(\"Integer\"); break;\n" +
 			"	     ^\n" +
-			"Type mismatch: cannot convert from int to Object\n" +
+			"Case constant of type int is incompatible with switch selector type Object\n" +
 			"----------\n" +
 			"2. ERROR in X.java (at line 10)\n" +
 			"	Zork();\n" +
@@ -873,7 +873,7 @@ public class SwitchPatternTest extends AbstractRegressionTest9 {
 				"1. ERROR in X.java (at line 8)\n" +
 				"	case null:\n" +
 				"	     ^^^^\n" +
-				"Type mismatch: cannot convert from null to int\n" +
+				"Case constant of type null is incompatible with switch selector type int\n" +
 				"----------\n");
 	}
 	public void testBug574538_01() {
@@ -1654,17 +1654,17 @@ public class SwitchPatternTest extends AbstractRegressionTest9 {
 			"2. ERROR in X.java (at line 5)\n" +
 			"	case null  -> System.out.println(\"null\");\n" +
 			"	     ^^^^\n" +
-			"Type mismatch: cannot convert from null to int\n" +
+			"Case constant of type null is incompatible with switch selector type int\n" +
 			"----------\n" +
 			"3. ERROR in X.java (at line 11)\n" +
 			"	case \"F\"  :\n" +
 			"	     ^^^\n" +
-			"Type mismatch: cannot convert from String to Object\n" +
+			"Case constant of type String is incompatible with switch selector type Object\n" +
 			"----------\n" +
 			"4. ERROR in X.java (at line 13)\n" +
 			"	case 2 :\n" +
 			"	     ^\n" +
-			"Type mismatch: cannot convert from int to Object\n" +
+			"Case constant of type int is incompatible with switch selector type Object\n" +
 			"----------\n");
 	}
 	public void testBug574559_001() {
@@ -3573,7 +3573,7 @@ public class SwitchPatternTest extends AbstractRegressionTest9 {
 				"2. ERROR in X.java (at line 4)\n" +
 				"	case Integer j, \"\":\n" +
 				"	                ^^\n" +
-				"Type mismatch: cannot convert from String to Number\n" +
+				"Case constant of type String is incompatible with switch selector type Number\n" +
 				"----------\n");
 	}
 	public void testBug575047_08() {
@@ -4009,12 +4009,12 @@ public class SwitchPatternTest extends AbstractRegressionTest9 {
 				"2. ERROR in X.java (at line 4)\n" +
 				"	case Integer i2, 4.5:\n" +
 				"	                 ^^^\n" +
-				"Type mismatch: cannot convert from double to Number\n" +
+				"Case constant of type double is incompatible with switch selector type Number\n" +
 				"----------\n" +
 				"3. ERROR in X.java (at line 5)\n" +
 				"	case 4.3: System.out.println();\n" +
 				"	     ^^^\n" +
-				"Type mismatch: cannot convert from double to Number\n" +
+				"Case constant of type double is incompatible with switch selector type Number\n" +
 				"----------\n");
 	}
 	public void testBug575686_1() {
@@ -6309,7 +6309,7 @@ public class SwitchPatternTest extends AbstractRegressionTest9 {
 				"1. ERROR in X.java (at line 10)\n" +
 				"	case E.A1 -> {\n" +
 				"	     ^^^^\n" +
-				"Type mismatch: cannot convert from E to E.InnerE\n" +
+				"Case constant of type E is incompatible with switch selector type E.InnerE\n" +
 				"----------\n");
 	}
 	public void testIssue1250_4() {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchTest.java
@@ -285,7 +285,7 @@ public void test010() {
 			"2. ERROR in X.java (at line 5)\n" +
 			"	case 0 : \n" +
 			"	     ^\n" +
-			"Type mismatch: cannot convert from int to X\n" +
+			"Case constant of type int is incompatible with switch selector type X\n" +
 			"----------\n" +
 			"3. ERROR in X.java (at line 6)\n" +
 			"	Zork z;\n" +
@@ -934,42 +934,42 @@ public void testCaseTypeMismatch() {
 		"1. ERROR in X.java (at line 4)\n" +
 		"	case 123: break;\n" +
 		"	     ^^^\n" +
-		"Type mismatch: cannot convert from int to String\n" +
+		"Case constant of type int is incompatible with switch selector type String\n" +
 		"----------\n" +
 		"2. ERROR in X.java (at line 5)\n" +
 		"	case (byte) 1: break;\n" +
 		"	     ^^^^^^^^\n" +
-		"Type mismatch: cannot convert from byte to String\n" +
+		"Case constant of type byte is incompatible with switch selector type String\n" +
 		"----------\n" +
 		"3. ERROR in X.java (at line 6)\n" +
 		"	case (char) 2: break;\n" +
 		"	     ^^^^^^^^\n" +
-		"Type mismatch: cannot convert from char to String\n" +
+		"Case constant of type char is incompatible with switch selector type String\n" +
 		"----------\n" +
 		"4. ERROR in X.java (at line 7)\n" +
 		"	case (short)3: break;\n" +
 		"	     ^^^^^^^^\n" +
-		"Type mismatch: cannot convert from short to String\n" +
+		"Case constant of type short is incompatible with switch selector type String\n" +
 		"----------\n" +
 		"5. ERROR in X.java (at line 8)\n" +
 		"	case (int) 4: break;\n" +
 		"	     ^^^^^^^\n" +
-		"Type mismatch: cannot convert from int to String\n" +
+		"Case constant of type int is incompatible with switch selector type String\n" +
 		"----------\n" +
 		"6. ERROR in X.java (at line 9)\n" +
 		"	case (long) 5: break;\n" +
 		"	     ^^^^^^^^\n" +
-		"Type mismatch: cannot convert from long to String\n" +
+		"Case constant of type long is incompatible with switch selector type String\n" +
 		"----------\n" +
 		"7. ERROR in X.java (at line 10)\n" +
 		"	case (float) 6: break;\n" +
 		"	     ^^^^^^^^^\n" +
-		"Type mismatch: cannot convert from float to String\n" +
+		"Case constant of type float is incompatible with switch selector type String\n" +
 		"----------\n" +
 		"8. ERROR in X.java (at line 11)\n" +
 		"	case (double) 7: break;\n" +
 		"	     ^^^^^^^^^^\n" +
-		"Type mismatch: cannot convert from double to String\n" +
+		"Case constant of type double is incompatible with switch selector type String\n" +
 		"----------\n" +
 		"9. ERROR in X.java (at line 12)\n" +
 		"	case (boolean) 8: break;\n" +
@@ -979,9 +979,9 @@ public void testCaseTypeMismatch() {
 		"10. ERROR in X.java (at line 12)\n" +
 		"	case (boolean) 8: break;\n" +
 		"	     ^^^^^^^^^^^\n" +
-		"Type mismatch: cannot convert from boolean to String\n" +
+		"Case constant of type boolean is incompatible with switch selector type String\n" +
 		"----------\n";
-		String oldMessage =
+	String oldMessage =
 			"----------\n" +
 			"1. ERROR in X.java (at line 3)\n" +
 			"	switch(args[0]) {\n" +
@@ -1024,7 +1024,7 @@ public void testCaseTypeMismatch2() {
 		"1. ERROR in X.java (at line 7)\n" +
 		"	case Days.Sunday: break;\n" +
 		"	     ^^^^^^^^^^^\n" +
-		"Type mismatch: cannot convert from Days to String\n" +
+		"Case constant of type Days is incompatible with switch selector type String\n" +
 		"----------\n";
 		String oldMessage =
 			"----------\n" +
@@ -1059,17 +1059,17 @@ public void testCaseTypeMismatch3() {
 		"1. ERROR in X.java (at line 7)\n" +
 		"	case \"0\": break;\n" +
 		"	     ^^^\n" +
-		"Type mismatch: cannot convert from String to int\n" +
+		"Case constant of type String is incompatible with switch selector type int\n" +
 		"----------\n" +
 		"2. ERROR in X.java (at line 10)\n" +
 		"	case \"Sunday\": break;\n" +
 		"	     ^^^^^^^^\n" +
-		"Type mismatch: cannot convert from String to Days\n" +
+		"Case constant of type String is incompatible with switch selector type Days\n" +
 		"----------\n" +
 		"3. ERROR in X.java (at line 13)\n" +
 		"	case \"0\": break;\n" +
 		"	     ^^^\n" +
-		"Type mismatch: cannot convert from String to Integer\n" +
+		"Case constant of type String is incompatible with switch selector type Integer\n" +
 		"----------\n";
 
 		this.runNegativeTest(new String[] {


### PR DESCRIPTION
+ true + false = exhaustive over boolean :)
+ leverage PrimitiveConversionRoute for Pattern.coversType()
+ fine-tune combinations of primitive and boxing types
+ fix one omission in BaseTypeBinding.isExactWidening()
+ code gen to respect exhaustiveness of switch over primitives
+ fix code gen for bootstrap in the case of boxing+widening conversion
+ simplify condition for generating a throwing default

fixes #2869

