### PR TITLE
Resolve errors in run.javac mode

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractRegressionTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractRegressionTest.java
@@ -1169,7 +1169,7 @@ protected static class JavacTestOptions {
 			JavacBug8204534 = RUN_JAVAC ? // https://bugs.openjdk.java.net/browse/JDK-8204534
 				new JavacHasABug(MismatchType.EclipseErrorsJavacNone, ClassFileConstants.JDK11, 0000) : null,
 			JavacBug8207032 = RUN_JAVAC ? // https://bugs.openjdk.java.net/browse/JDK-8207032
-				new JavacHasABug(MismatchType.EclipseErrorsJavacNone) : null,
+				new JavacHasABug(MismatchType.EclipseErrorsJavacNone, ClassFileConstants.JDK11, 0000) : null,
 			JavacBug8044196 = RUN_JAVAC ? // likely https://bugs.openjdk.java.net/browse/JDK-8044196, intermittently masked by https://bugs.openjdk.java.net/browse/JDK-8029161
 				new JavacHasABug(MismatchType.EclipseErrorsJavacNone, ClassFileConstants.JDK9, 0000, true) : null,
 			JavacBug6337964 = RUN_JAVAC ? // https://bugs.eclipse.org/bugs/show_bug.cgi?id=112433
@@ -1184,7 +1184,10 @@ protected static class JavacTestOptions {
 					new JavacBug8226510(" --release 12 --enable-preview -Xlint:-preview") : null,
 		    JavacBug8299416 = RUN_JAVAC ? // https://bugs.openjdk.java.net/browse/JDK-8299416
 					new JavacBugExtraJavacOptionsPlusMismatch(" --release 20 --enable-preview -Xlint:-preview",
-							MismatchType.EclipseErrorsJavacNone| MismatchType.EclipseErrorsJavacWarnings) : null;
+							MismatchType.EclipseErrorsJavacNone| MismatchType.EclipseErrorsJavacWarnings) : null,
+		    JavacBug8336255 = RUN_JAVAC ? // https://bugs.openjdk.org/browse/JDK-8336255
+					new JavacBugExtraJavacOptionsPlusMismatch(" --release 23 --enable-preview -Xlint:-preview",
+							MismatchType.JavacErrorsEclipseNone) : null;
 
 		// bugs that have been fixed but that we've not identified
 		public static JavacHasABug

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ModuleCompilationTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ModuleCompilationTests.java
@@ -771,7 +771,7 @@ public class ModuleCompilationTests extends AbstractModuleCompilationTest {
 				"The type p.X is not accessible\n" +
 				"----------\n" +
 				"1 problem (1 error)\n",
-				"cannot be resolved",
+				"does not read it",
 				OUTPUT_DIR + File.separator + out,
 				JavacTestOptions.JavacHasABug.JavacBug8207032);
 	}
@@ -1274,7 +1274,7 @@ public class ModuleCompilationTests extends AbstractModuleCompilationTest {
 				buffer,
 				"",
 				"option -bootclasspath not supported at compliance level 9 and above\n",
-				"not allowed"); // when specifying -bootclasspath javac answers: "option --boot-class-path not allowed with target 1.9" (two bugs)
+				"option --boot-class-path cannot be used together with --release"); // error message has changed between versions, name of option plus reason for illegality can be questioned
 	}
 	public void test025() {
 		File outputDirectory = new File(OUTPUT_DIR);
@@ -5426,7 +5426,7 @@ public void testBug521362_emptyFile() {
 				"The import x.y.z cannot be resolved\n" +
 				"----------\n" +
 				"3 problems (3 errors)\n",
-				"package conflict");
+				"reads package x.y.z from both");
 	}
 	public void testBug522472d() {
 		File outputDirectory = new File(OUTPUT_DIR);
@@ -5502,7 +5502,7 @@ public void testBug521362_emptyFile() {
 				"The package x.y.z is accessible from more than one module: mod.one, mod.one.a\n" +
 				"----------\n" +
 				"3 problems (3 errors)\n",
-				"conflict");
+				"reads package x.y.z from both");
 	}
 	public void testIssue2357_001() throws Exception {
 		File outputDirectory = new File(OUTPUT_DIR);

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordPatternTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordPatternTest.java
@@ -4422,7 +4422,9 @@ public class RecordPatternTest extends AbstractRegressionTest9 {
 	public void testIssue1999() {
 		Map<String, String> options = getCompilerOptions();
 		options.put(CompilerOptions.OPTION_ReportUnnecessaryTypeCheck, CompilerOptions.ERROR);
-		runNegativeTest(new String[] {
+		runNegativeTest(
+				true,
+				new String[] {
 				"X.java",
 				"""
 				interface I {
@@ -4454,13 +4456,15 @@ public class RecordPatternTest extends AbstractRegressionTest9 {
 				}
 				"""
 				},
+				null,
+				options,
 				"----------\n" +
 				"1. ERROR in X.java (at line 18)\n" +
 				"	if (a instanceof A) {} // warn here\n" +
 				"	    ^^^^^^^^^^^^^^\n" +
 				"The expression of type A is already an instance of type A\n" +
 				"----------\n",
-				null, true, options);
+				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2007
 	public void testIssue2007() {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SuperAfterStatementsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SuperAfterStatementsTest.java
@@ -2018,6 +2018,7 @@ public class SuperAfterStatementsTest extends AbstractRegressionTest9 {
 			}
 			"""};
 		runner.expectedOutputString = "f3f1";
+		runner.javacTestOptions = JavacTestOptions.JavacHasABug.JavacBug8336255;
 		runner.runConformTest();
 	}
 	public void testComplexNesting_NOK() {


### PR DESCRIPTION
+ SuperAfterStatementsTest: new excuse JavacBug8207032
+ MarkdownCommentsTest
  - pass suitable arguments to javac and java
  - initialize reporting options only in one place (setUp())
  - remove unrelated errors for better comparison
  - fine tune problem severities for better comparison with javac
+ ModuleCompilationTests
  - adjust to current error messages from javac
+ RecordPatternTest: 1 EclipseWarningConfiguredAsError

See a related summary in https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2212#issuecomment-2323293285