### PR TITLE
[performance] share JRT entries across projects #2884

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JModPackageFragmentRoot.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JModPackageFragmentRoot.java
@@ -15,9 +15,7 @@ package org.eclipse.jdt.internal.core;
 
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.jdt.core.IClasspathAttribute;
-import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.internal.core.builder.ClasspathJMod;
-import org.eclipse.jdt.internal.core.util.HashtableOfArrayToObject;
 
 /**
  * A package fragment root that corresponds to a JMod file.
@@ -47,15 +45,10 @@ public class JModPackageFragmentRoot extends JarPackageFragmentRoot {
 	 */
 	@Override
 	public String getClassFilePath(String entryName) {
-		char[] name = CharOperation.append(ClasspathJMod.CLASSES_FOLDER, entryName.toCharArray());
-		return new String(name);
+		return ClasspathJMod.CLASSES_FOLDER + entryName;
 	}
 	@Override
-	protected void initRawPackageInfo(HashtableOfArrayToObject rawPackageInfo, String entryName, boolean isDirectory, String compliance) {
-		char[] name = entryName.toCharArray();
-		if (CharOperation.prefixEquals(ClasspathJMod.CLASSES_FOLDER, name)) {
-			name = CharOperation.subarray(name, ClasspathJMod.CLASSES_FOLDER.length, name.length);
-		}
-		super.initRawPackageInfo(rawPackageInfo, new String(name), isDirectory, compliance);
+	protected String getClassNameSubFolder() {
+		return ClasspathJMod.CLASSES_FOLDER;
 	}
 }

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JarPackageFragmentRoot.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JarPackageFragmentRoot.java
@@ -18,10 +18,13 @@ import java.io.InputStream;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.jar.Manifest;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipException;
@@ -41,9 +44,9 @@ import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jdt.internal.compiler.lookup.TypeConstants;
+import org.eclipse.jdt.internal.core.JarPackageFragmentRootInfo.PackageContent;
 import org.eclipse.jdt.internal.core.JavaModelManager.PerProjectInfo;
 import org.eclipse.jdt.internal.core.util.DeduplicationUtil;
-import org.eclipse.jdt.internal.core.util.HashtableOfArrayToObject;
 import org.eclipse.jdt.internal.core.util.Util;
 
 /**
@@ -56,10 +59,7 @@ import org.eclipse.jdt.internal.core.util.Util;
  * @see org.eclipse.jdt.core.IPackageFragmentRoot
  * @see org.eclipse.jdt.internal.core.JarPackageFragmentRootInfo
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class JarPackageFragmentRoot extends PackageFragmentRoot {
-
-	protected final static ArrayList EMPTY_LIST = new ArrayList();
 
 	/**
 	 * The path to the jar file
@@ -114,12 +114,12 @@ public class JarPackageFragmentRoot extends PackageFragmentRoot {
 	 */
 	@Override
 	protected boolean computeChildren(OpenableElementInfo info, IResource underlyingResource) throws JavaModelException {
-		final HashtableOfArrayToObject rawPackageInfo = new HashtableOfArrayToObject();
-		final Map<String, String> overridden = new HashMap<>();
+		Map<List<String>, PackageContent> rawPackageInfo= new HashMap<>();
+		Map<String, String> overridden = new HashMap<>();
 		IJavaElement[] children = NO_ELEMENTS;
 		try {
 			// always create the default package
-			rawPackageInfo.put(CharOperation.NO_STRINGS, new ArrayList[] { EMPTY_LIST, EMPTY_LIST });
+			rawPackageInfo.put(new ArrayList<>(), new PackageContent());
 
 			Object file = JavaModel.getTarget(this, true);
 			long classLevel = Util.getJdkLevel(file);
@@ -165,29 +165,26 @@ public class JarPackageFragmentRoot extends PackageFragmentRoot {
 							overridden.put(name, versionPath);
 						}
 					}
-					initRawPackageInfo(rawPackageInfo, name, member.isDirectory(), CompilerOptions.versionFromJdkLevel(classLevel));
+					initRawPackageInfo(rawPackageInfo, getClassNameSubFolder(), name, member.isDirectory(), CompilerOptions.versionFromJdkLevel(classLevel));
 				}
 			}  finally {
 				JavaModelManager.getJavaModelManager().closeZipFile(jar);
 			}
-			// loop through all of referenced packages, creating package fragments if necessary
-			// and cache the entry names in the rawPackageInfo table
-			children = new IJavaElement[rawPackageInfo.size()];
-			int index = 0;
-			for (Object[] o : rawPackageInfo.keyTable) {
-				String[] pkgName = (String[]) o;
-				if (pkgName == null) continue;
-				children[index++] = getPackageFragment(pkgName);
-			}
+			rawPackageInfo = unmodifiableCopy(rawPackageInfo);
+			children = createChildren(rawPackageInfo.keySet());
 		} catch (ZipException zipex) {
 			// malcious ZIP archive, leave the children empty
 			Util.log(zipex, "Invalid ZIP archive: " + toStringWithAncestors()); //$NON-NLS-1$
 			children = NO_ELEMENTS;
+			rawPackageInfo= Map.of();
+			overridden = Map.of();
 		} catch (CoreException e) {
 			if (e.getCause() instanceof ZipException zipex) {
 				// not a ZIP archive, leave the children empty
 				Util.log(zipex, "Invalid ZIP archive: " + toStringWithAncestors()); //$NON-NLS-1$
 				children = NO_ELEMENTS;
+				rawPackageInfo= Map.of();
+				overridden = Map.of();
 			} else if (e instanceof JavaModelException) {
 				throw (JavaModelException)e;
 			} else {
@@ -200,15 +197,16 @@ public class JarPackageFragmentRoot extends PackageFragmentRoot {
 		return true;
 	}
 
-	protected IJavaElement[] createChildren(final HashtableOfArrayToObject rawPackageInfo) {
-		IJavaElement[] children;
+	protected IJavaElement[] createChildren(Collection<List<String>> packagenames) {
+		// XXX sorting the children is unnecessary by contract - see org.eclipse.jdt.core.IParent#getChildren()
+		// but some tests like JavaProjectTests rely on a fixed child order
+		ArrayList<String[]> keys = new ArrayList<>(packagenames.stream().map(s->s.toArray(String[]::new)).toList() );
+		Collections.sort(keys, Arrays::compare);
+
+		IJavaElement[] children = new IJavaElement[packagenames.size()];
 		// loop through all of referenced packages, creating package fragments if necessary
-		// and cache the entry names in the rawPackageInfo table
-		children = new IJavaElement[rawPackageInfo.size()];
 		int index = 0;
-		for (Object[] o : rawPackageInfo.keyTable) {
-			String[] pkgName = (String[]) o;
-			if (pkgName == null) continue;
+		for (String[] pkgName : keys) {
 			children[index++] = getPackageFragment(pkgName);
 		}
 		return children;
@@ -352,56 +350,56 @@ public class JarPackageFragmentRoot extends PackageFragmentRoot {
 			return super.getUnderlyingResource();
 		}
 	}
-	protected void initRawPackageInfo(HashtableOfArrayToObject rawPackageInfo, String entryName, boolean isDirectory, String compliance) {
+
+	/** make sure all parent packages exit in rawPackageInfo and adds the given file to the given package
+	 * static implementation to make sure the result can be shared across instances */
+	static void initRawPackageInfo(Map<List<String>, PackageContent> rawPackageInfo, String classNameSubFolder,
+			String entryName, boolean isDirectory, String compliance) {
+		String className = entryToClassName(classNameSubFolder, entryName);
 		int lastSeparator;
 		if (isDirectory) {
-			if (entryName.charAt(entryName.length() - 1) == '/') {
-				lastSeparator = entryName.length() - 1;
+			if (className.charAt(className.length() - 1) == '/') {
+				lastSeparator = className.length() - 1;
 			} else {
-				lastSeparator = entryName.length();
+				lastSeparator = className.length();
 			}
 		} else {
-			lastSeparator = entryName.lastIndexOf('/');
+			lastSeparator = className.lastIndexOf('/');
 		}
-		String[] pkgName = Util.splitOn('/', entryName, 0, lastSeparator);
-		String[] existing = null;
-		int length = pkgName.length;
-		int existingLength = length;
-		while (existingLength >= 0) {
-			existing = (String[]) rawPackageInfo.getKey(pkgName, existingLength);
-			if (existing != null) break;
-			existingLength--;
+		ArrayList<String> pkgName = new ArrayList<>(Arrays.asList(Util.splitOn('/', className, 0, lastSeparator)));
+		PackageContent existing = null;
+		int length = pkgName.size();
+		int existingLength;
+		for (existingLength = length; existing == null; existingLength--) {
+			existing = rawPackageInfo.get(pkgName.subList(0, existingLength));
 		}
+		existingLength++;
 		for (int i = existingLength; i < length; i++) {
 			// sourceLevel must be null because we know nothing about it based on a jar file
-			if (Util.isValidFolderNameForPackage(pkgName[i], null, compliance)) {
-				System.arraycopy(existing, 0, existing = new String[i+1], 0, i);
-				existing[i] = DeduplicationUtil.intern(pkgName[i]);
-				rawPackageInfo.put(existing, new ArrayList[] { EMPTY_LIST, EMPTY_LIST });
+			if (Util.isValidFolderNameForPackage(pkgName.get(i), null, compliance)) {
+				List<String> path = pkgName.subList(0, i + 1);
+				existing = new PackageContent();
+				rawPackageInfo.put(path, existing);
 			} else {
 				// non-Java resource folder
 				if (!isDirectory) {
-					ArrayList[] children = (ArrayList[]) rawPackageInfo.get(existing);
-					if (children[1/*NON_JAVA*/] == EMPTY_LIST) children[1/*NON_JAVA*/] = new ArrayList();
-					children[1/*NON_JAVA*/].add(entryName);
+					existing.resources().add(className);
 				}
 				return;
 			}
 		}
-		if (isDirectory)
+		if (isDirectory) {
 			return;
-
-		// add classfile info amongst children
-		ArrayList[] children = (ArrayList[]) rawPackageInfo.get(pkgName);
-		if (org.eclipse.jdt.internal.compiler.util.Util.isClassFileName(entryName)) {
-			if (children[0/*JAVA*/] == EMPTY_LIST) children[0/*JAVA*/] = new ArrayList();
-			String nameWithoutExtension = entryName.substring(lastSeparator + 1, entryName.length() - 6);
-			children[0/*JAVA*/].add(nameWithoutExtension);
-		} else {
-			if (children[1/*NON_JAVA*/] == EMPTY_LIST) children[1/*NON_JAVA*/] = new ArrayList();
-			children[1/*NON_JAVA*/].add(entryName);
 		}
 
+		// add classfile info amongst children
+		PackageContent children = rawPackageInfo.get(pkgName);
+		if (org.eclipse.jdt.internal.compiler.util.Util.isClassFileName(className)) {
+			String nameWithoutExtension = className.substring(lastSeparator + 1, className.length() - 6);
+			children.javaClasses().add(nameWithoutExtension);
+		} else {
+			children.resources().add(className);
+		}
 	}
 	/**
 	 * @see IPackageFragmentRoot
@@ -475,6 +473,32 @@ public class JarPackageFragmentRoot extends PackageFragmentRoot {
 			JavaModelManager.getJavaModelManager().closeZipFile(jar);
 		}
 		return null;
+	}
+
+	/** overridden by JModPackageFragmentRoot */
+	protected String getClassNameSubFolder() {
+		return null;
+	}
+
+	static String entryToClassName(String classNameSubFolder, String entryName) {
+		if (classNameSubFolder != null && entryName.startsWith(classNameSubFolder)) {
+			return entryName.substring(classNameSubFolder.length());
+		} else {
+			return entryName;
+		}
+	}
+
+	/** creates a unmodifiable copy that is thread-safe and has it's Strings deduplicated **/
+	static Map<List<String>, PackageContent> unmodifiableCopy(Map<List<String>, PackageContent> rawPackageInfo) {
+		Map<List<String>, PackageContent> deduplicatedPackageInfo = new HashMap<>();
+
+		for (Entry<List<String>, PackageContent> e : rawPackageInfo.entrySet()) {
+			List<String> key = e.getKey();
+			PackageContent p = e.getValue();
+			PackageContent packageContent = new PackageContent(DeduplicationUtil.intern(p.javaClasses()), DeduplicationUtil.intern(p.resources()));
+			deduplicatedPackageInfo.put(DeduplicationUtil.intern(key), packageContent);
+		}
+		return Map.copyOf(deduplicatedPackageInfo);
 	}
 
 //	@Override

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JarPackageFragmentRootInfo.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JarPackageFragmentRootInfo.java
@@ -13,16 +13,25 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.core;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
-import org.eclipse.jdt.internal.core.util.HashtableOfArrayToObject;
 
 /**
  * The element info for <code>JarPackageFragmentRoot</code>s.
  */
 class JarPackageFragmentRootInfo extends PackageFragmentRootInfo {
-	// a map from package name (String[]) to a size-2 array of Array<String>, the first element being the .class file names, and the second element being the non-Java resource names
-	HashtableOfArrayToObject rawPackageInfo;
-	Map<String, String> overriddenClasses;
+	/** contains .class file names, and non-Java resource names of a package */
+	static record PackageContent(List<String> javaClasses, List<String> resources) {
+		PackageContent() {
+			this(new ArrayList<>(), new ArrayList<>());
+		}
+	}
 
+	/**
+	 * Cache for the the jar's entries names. A unmodifiable map from package name to PackageContent
+	 */
+	Map<List<String>, PackageContent> rawPackageInfo;
+	Map<String, String> overriddenClasses;
 }

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JrtPackageFragmentRoot.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JrtPackageFragmentRoot.java
@@ -13,12 +13,16 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.core;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
-import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.IPath;
@@ -28,12 +32,11 @@ import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaModelStatusConstants;
 import org.eclipse.jdt.core.IModuleDescription;
 import org.eclipse.jdt.core.JavaModelException;
-import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.internal.compiler.env.IModule;
 import org.eclipse.jdt.internal.compiler.env.IModulePathEntry;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jdt.internal.compiler.util.JRTUtil;
-import org.eclipse.jdt.internal.core.util.HashtableOfArrayToObject;
+import org.eclipse.jdt.internal.core.JarPackageFragmentRootInfo.PackageContent;
 import org.eclipse.jdt.internal.core.util.Util;
 
 /**
@@ -48,6 +51,14 @@ public class JrtPackageFragmentRoot extends JarPackageFragmentRoot implements IM
 
 	public static final ThreadLocal<Boolean> workingOnOldClasspath = new ThreadLocal<>();
 
+	record JrtModuleKey(File image, String moduleName, String classNameSubFolder) {/** nothing */}
+	/**
+	 * static cache for org.eclipse.jdt.internal.core.JarPackageFragmentRootInfo.rawPackageInfo across JarPackageFragmentRoot instances per java project
+	 *
+	 * @see org.eclipse.jdt.internal.core.JarPackageFragmentRootInfo#rawPackageInfo
+	 **/
+	private static final Map<JrtModuleKey, Map<List<String>, PackageContent>> childrenCache = new ConcurrentHashMap<>();
+
 	/**
 	 * Constructs a package fragment root which represents a module
 	 * contained in a JRT.
@@ -59,42 +70,52 @@ public class JrtPackageFragmentRoot extends JarPackageFragmentRoot implements IM
 
 	@Override
 	protected boolean computeChildren(OpenableElementInfo info, IResource underlyingResource) throws JavaModelException {
-		final HashtableOfArrayToObject rawPackageInfo = new HashtableOfArrayToObject();
-		final String compliance = CompilerOptions.VERSION_1_8; // TODO: Java 9 Revisit
-
-		// always create the default package
-		rawPackageInfo.put(CharOperation.NO_STRINGS, new ArrayList[] { EMPTY_LIST, EMPTY_LIST });
-
-		try {
-			org.eclipse.jdt.internal.compiler.util.JRTUtil.walkModuleImage(this.jarPath.toFile(),
-					new org.eclipse.jdt.internal.compiler.util.JRTUtil.JrtFileVisitor<Path>() {
-				@Override
-				public FileVisitResult visitPackage(Path dir, Path mod, BasicFileAttributes attrs) throws IOException {
-					initRawPackageInfo(rawPackageInfo, dir.toString(), true, compliance);
-					return FileVisitResult.CONTINUE;
-				}
-
-				@Override
-				public FileVisitResult visitFile(Path path, Path mod, BasicFileAttributes attrs) throws IOException {
-					initRawPackageInfo(rawPackageInfo, path.toString(), false, compliance);
-					return FileVisitResult.CONTINUE;
-				}
-
-				@Override
-				public FileVisitResult visitModule(Path path, String name) throws IOException {
-					if (!JrtPackageFragmentRoot.this.moduleName.equals(name)) {
-						return FileVisitResult.SKIP_SUBTREE;
-					}
-					return FileVisitResult.CONTINUE;
-				}
-			}, JRTUtil.NOTIFY_ALL);
-		} catch (IOException e) {
-			Util.log(e, "Error reading modules" + toStringWithAncestors()); //$NON-NLS-1$
-		}
-
-		info.setChildren(createChildren(rawPackageInfo));
+		JrtModuleKey key = new JrtModuleKey(this.jarPath.toFile(), this.moduleName, getClassNameSubFolder());
+		Map<List<String>, PackageContent> rawPackageInfo;
+		rawPackageInfo = childrenCache.computeIfAbsent(key, JrtPackageFragmentRoot::computeChildren);
+		info.setChildren(createChildren(rawPackageInfo.keySet()));
 		((JarPackageFragmentRootInfo) info).rawPackageInfo = rawPackageInfo;
 		return true;
+	}
+
+	/** static implementation to make sure the result can be shared across instances*/
+	private static Map<List<String>, PackageContent> computeChildren(JrtModuleKey key) {
+		Map<List<String>, PackageContent> rawPackageInfo= new HashMap<>();
+		File image= key.image();
+		String moduleName= key.moduleName();
+		String classNameSubFolder= key.classNameSubFolder();
+		String compliance = CompilerOptions.VERSION_1_8; // TODO: Java 9 Revisit
+		// always create the default package
+		rawPackageInfo.put(List.of(), new PackageContent());
+		try {
+			org.eclipse.jdt.internal.compiler.util.JRTUtil.walkModuleImage(image,
+					new org.eclipse.jdt.internal.compiler.util.JRTUtil.JrtFileVisitor<Path>() {
+						@Override
+						public FileVisitResult visitPackage(Path dir, Path mod, BasicFileAttributes attrs)
+								throws IOException {
+							initRawPackageInfo(rawPackageInfo, classNameSubFolder, dir.toString(), true, compliance);
+							return FileVisitResult.CONTINUE;
+						}
+
+						@Override
+						public FileVisitResult visitFile(Path path, Path mod, BasicFileAttributes attrs)
+								throws IOException {
+							initRawPackageInfo(rawPackageInfo, classNameSubFolder, path.toString(), false, compliance);
+							return FileVisitResult.CONTINUE;
+						}
+
+						@Override
+						public FileVisitResult visitModule(Path path, String name) throws IOException {
+							if (!moduleName.equals(name)) {
+								return FileVisitResult.SKIP_SUBTREE;
+							}
+							return FileVisitResult.CONTINUE;
+						}
+					}, JRTUtil.NOTIFY_ALL);
+		} catch (IOException e) {
+			Util.log(e, "Error reading modules" + image); //$NON-NLS-1$
+		}
+		return unmodifiableCopy(rawPackageInfo);
 	}
 	@Override
 	SourceMapper createSourceMapper(IPath sourcePath, IPath rootPath) throws JavaModelException {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/Openable.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/Openable.java
@@ -14,6 +14,7 @@
 package org.eclipse.jdt.internal.core;
 
 import java.util.Enumeration;
+import java.util.List;
 import java.util.Map;
 
 import org.eclipse.core.resources.*;
@@ -198,7 +199,7 @@ public boolean exists() {
 				} catch (JavaModelException e) {
 					return false;
 				}
-				return rootInfo.rawPackageInfo.containsKey(((PackageFragment) this).names);
+				return rootInfo.rawPackageInfo.containsKey(List.of(((PackageFragment) this).names));
 			}
 			break;
 		case IJavaElement.CLASS_FILE:

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/ClasspathJMod.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/ClasspathJMod.java
@@ -33,7 +33,7 @@ import org.eclipse.jdt.internal.compiler.util.SuffixConstants;
 public class ClasspathJMod extends ClasspathJar {
 
 	public static char[] CLASSES = "classes".toCharArray(); //$NON-NLS-1$
-	public static char[] CLASSES_FOLDER = "classes/".toCharArray(); //$NON-NLS-1$
+	public static final String CLASSES_FOLDER = "classes/"; //$NON-NLS-1$
 	private static int MODULE_DESCRIPTOR_NAME_LENGTH = IModule.MODULE_INFO_CLASS.length();
 
 	ClasspathJMod(String zipFilename, long lastModified, AccessRuleSet accessRuleSet, IPath externalAnnotationPath) {
@@ -43,7 +43,7 @@ public class ClasspathJMod extends ClasspathJar {
 	IModule initializeModule() {
 		IModule mod = null;
 		try (ZipFile file = new ZipFile(this.zipFilename)) {
-			String fileName = new String(CLASSES_FOLDER) + IModule.MODULE_INFO_CLASS;
+			String fileName = CLASSES_FOLDER + IModule.MODULE_INFO_CLASS;
 			ClassFileReader classfile = ClassFileReader.read(file, fileName);
 			if (classfile != null) {
 				mod = classfile.getModuleDeclaration();
@@ -62,7 +62,7 @@ public class ClasspathJMod extends ClasspathJar {
 			return null;
 
 		try {
-			qualifiedBinaryFileName = new String(CharOperation.append(CLASSES_FOLDER, qualifiedBinaryFileName.toCharArray()));
+			qualifiedBinaryFileName = CLASSES_FOLDER + qualifiedBinaryFileName;
 			IBinaryType reader = ClassFileReader.read(this.zipFile, qualifiedBinaryFileName);
 			if (reader != null) {
 				char[] modName = this.module == null ? null : this.module.name();

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/DeduplicationUtil.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/DeduplicationUtil.java
@@ -15,6 +15,9 @@
 
 package org.eclipse.jdt.internal.core.util;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.eclipse.jdt.internal.core.JavaElement;
 
 /** Utility to provide deduplication by best effort. **/
@@ -67,5 +70,28 @@ public final class DeduplicationUtil {
 			}
 			return a;
 		}
+	}
+
+	/** interns the elements and the list as whole **/
+	public static List<String> intern(List<String> a) {
+		if (a.size() == 0) {
+			return List.of();
+		}
+		synchronized (objectCache) {
+			Object existing = objectCache.get(a);
+			if (existing instanceof List l) {
+				@SuppressWarnings("unchecked")
+				List<String> existingList = l;
+				return existingList;
+			}
+		}
+
+		ArrayList<String> result= new ArrayList<>(a.size());
+		synchronized (stringSymbols) {
+			for (String s:a) {
+				result.add(s == null ? null :stringSymbols.add(s));
+			}
+		}
+		return internObject(List.copyOf(result));
 	}
 }


### PR DESCRIPTION
JarPackageFragmentRootInfo.rawPackageInfo hold a list of all files in the JRT but each projects gets its own JarPackageFragmentRootInfo. Calculate that files independent of the instance and reuse if for all projects. To safely share the result across threads an unmodifiable datastructure is used.

* use record instead of String[2] for classes vs resources
* reduce rawtypes, unchecked conversions
* avoid char[] to String conversions

tested by JavaProjectTests, AttachedJavadocTests

