### PR TITLE
[23] Type compatibility error in primitive type pattern #2891

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/IGenerateTypeCheck.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/IGenerateTypeCheck.java
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ * Copyright (c) 2024 GK Software SE and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
+ * Contributors:
+ *     Stephan Herrmann - Initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.internal.compiler.ast;
+
+import org.eclipse.jdt.internal.compiler.ast.Pattern.PrimitiveConversionRoute;
+import org.eclipse.jdt.internal.compiler.codegen.BranchLabel;
+import org.eclipse.jdt.internal.compiler.codegen.CodeStream;
+import org.eclipse.jdt.internal.compiler.lookup.BaseTypeBinding;
+import org.eclipse.jdt.internal.compiler.lookup.BlockScope;
+import org.eclipse.jdt.internal.compiler.lookup.TypeBinding;
+
+/**
+ * A mixin for nodes that may generate a runtime type check based on a {@link PrimitiveConversionRoute}
+ */
+interface IGenerateTypeCheck {
+
+	default void generateTypeCheck(TypeBinding providedType, TypeReference expectedTypeRef, BlockScope scope, CodeStream codeStream, BranchLabel falseLabel, PrimitiveConversionRoute route) {
+		switch (route) {
+			case IDENTITY_CONVERSION -> {
+				consumeProvidedValue(providedType, codeStream);
+				codeStream.iconst_1();
+				setPatternIsTotalType();
+			}
+			case WIDENING_PRIMITIVE_CONVERSION,
+			NARROWING_PRIMITVE_CONVERSION,
+			WIDENING_AND_NARROWING_PRIMITIVE_CONVERSION -> {
+				generateExactConversions(providedType, expectedTypeRef.resolvedType, scope, codeStream);
+				setPatternIsTotalType();
+			}
+			case BOXING_CONVERSION,
+			BOXING_CONVERSION_AND_WIDENING_REFERENCE_CONVERSION -> {
+				consumeProvidedValue(providedType, codeStream);
+				codeStream.iconst_1();
+				setPatternIsTotalType();
+			}
+			case WIDENING_REFERENCE_AND_UNBOXING_COVERSION,
+			WIDENING_REFERENCE_AND_UNBOXING_COVERSION_AND_WIDENING_PRIMITIVE_CONVERSION -> {
+				codeStream.ifnull(falseLabel);
+				codeStream.iconst_1();
+				setPatternIsTotalType();
+			}
+			case NARROWING_AND_UNBOXING_CONVERSION -> {
+				TypeBinding boxType = scope.environment().computeBoxingType(expectedTypeRef.resolvedType);
+				codeStream.instance_of(expectedTypeRef, boxType);
+			}
+			case UNBOXING_CONVERSION,
+			UNBOXING_AND_WIDENING_PRIMITIVE_CONVERSION -> {
+				codeStream.ifnull(falseLabel);
+				codeStream.iconst_1();
+				setPatternIsTotalType();
+			}
+			case NO_CONVERSION_ROUTE -> {
+				codeStream.instance_of(expectedTypeRef, expectedTypeRef.resolvedType);
+				break;
+			}
+			default -> {
+				throw new IllegalArgumentException("Unexpected conversion route "+route); //$NON-NLS-1$
+			}
+		}
+	}
+
+	/* Overridden in InstanceOfExpression */
+	default void consumeProvidedValue(TypeBinding provided, CodeStream codeStream) {
+		codeStream.pop(provided);
+	}
+
+	void setPatternIsTotalType();
+
+	default void generateExactConversions(TypeBinding provided, TypeBinding expected, BlockScope scope, CodeStream codeStream) {
+		if (BaseTypeBinding.isExactWidening(expected.id, provided.id)) {
+			consumeProvidedValue(provided, codeStream);
+			codeStream.iconst_1();
+		} else {
+			codeStream.invokeExactConversionsSupport(BaseTypeBinding.getRightToLeft(expected.id, provided.id));
+		}
+	}
+}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Pattern.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Pattern.java
@@ -144,8 +144,8 @@ public abstract class Pattern extends Expression {
 		TypeBinding patternType = this.resolvedType;
 		if (patternType == null) // ill resolved pattern
 			return false;
-		// 14.30.3 Properties of Patterns doesn't allow boxing nor unboxing, primitive widening/narrowing.
-		if (patternType.isBaseType() != other.isBaseType()) {
+		// 14.30.3 Properties of Patterns doesn't allow boxing nor unboxing, primitive widening/narrowing (< JLS23)
+		if (patternType.isBaseType() != other.isBaseType() && !JavaFeature.PRIMITIVES_IN_PATTERNS.isSupported(scope.compilerOptions())) {
 			scope.problemReporter().incompatiblePatternType(this, other, patternType);
 			return false;
 		}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypePattern.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypePattern.java
@@ -35,7 +35,7 @@ import org.eclipse.jdt.internal.compiler.lookup.TypeBinding;
 import org.eclipse.jdt.internal.compiler.lookup.TypeIds;
 import org.eclipse.jdt.internal.compiler.lookup.TypeVariableBinding;
 
-public class TypePattern extends Pattern {
+public class TypePattern extends Pattern implements IGenerateTypeCheck {
 
 	public LocalDeclaration local;
 
@@ -120,6 +120,16 @@ public class TypePattern extends Pattern {
 			}
 			this.local.generateCode(currentScope, codeStream);
 		}
+	}
+
+	public void generateTypeCheck(BlockScope scope, CodeStream codeStream, BranchLabel internalFalseLabel) {
+		generateTypeCheck(this.outerExpressionType, getType(), scope, codeStream, internalFalseLabel,
+				Pattern.findPrimitiveConversionRoute(this.resolvedType, this.accessorMethod.returnType, scope));
+	}
+
+	@Override
+	public void setPatternIsTotalType() {
+		this.isTotalTypeNode = true;
 	}
 
 	@Override

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/CodeStream.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/CodeStream.java
@@ -1088,6 +1088,12 @@ public void dsub() {
 	this.bCodeStream[this.classFileOffset++] = Opcodes.OPC_dsub;
 }
 
+public void dup(TypeBinding type) {
+	if (TypeIds.getCategory(type.id) == 2)
+		dup2();
+	else
+		dup();
+}
 public void dup() {
 	this.countLabels = 0;
 	this.stackDepth++;
@@ -4498,7 +4504,7 @@ public void instance_of(TypeReference typeReference, TypeBinding typeBinding) {
 	this.position++;
 	this.bCodeStream[this.classFileOffset++] = Opcodes.OPC_instanceof;
 	writeUnsignedShort(this.constantPool.literalIndexForType(typeBinding));
-	this.operandStack.pop(OperandCategory.ONE);
+	this.operandStack.pop(TypeIds.getCategory(typeBinding.id));
 	this.operandStack.push(TypeBinding.INT);
 }
 
@@ -6875,6 +6881,13 @@ public void optimizeBranch(int oldPosition, BranchLabel lbl) {
 			}
 		}
 	}
+}
+
+public void pop(TypeBinding type) {
+	if (TypeIds.getCategory(type.id) == 2)
+		pop2();
+	else
+		pop();
 }
 
 public void pop() {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PrimitiveInPatternsTestSH.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PrimitiveInPatternsTestSH.java
@@ -2074,6 +2074,94 @@ public class PrimitiveInPatternsTestSH extends AbstractRegressionTest9 {
 			""");
 	}
 
+	public void testPrimitiveRecordComponent_narrow() {
+		runConformTest(new String[] {
+				"X.java",
+				"""
+				record RforRecord(long x) {}
+				public class X  {
+					public void foo() {
+						if (new RforRecord(0L) instanceof RforRecord(int y)) {
+							System.out.print("Yay");
+						}
+						if (new RforRecord(5000000000L) instanceof RforRecord(int y)) {
+							System.out.print("Nay");
+						} else {
+							System.out.print("!");
+						}
+					}
+					public static void main(String... args) {
+						new X().foo();
+					}
+				}
+				"""},
+				"Yay!");
+	}
+
+	public void testPrimitiveRecordComponent_unbox() {
+		runConformTest(new String[] {
+				"X.java",
+				"""
+				record RforRecord(Long x) {}
+				public class X  {
+					public void foo() {
+						if (new RforRecord(0L) instanceof RforRecord(long y)) {
+							System.out.print("Yay");
+						}
+					}
+					public static void main(String... args) {
+						new X().foo();
+					}
+				}
+				"""},
+				"Yay");
+	}
+
+	public void testPrimitiveRecordComponent_unboxAndWiden() {
+		runConformTest(new String[] {
+				"X.java",
+				"""
+				record RforRecord(Integer x) {}
+				public class X  {
+					public void foo() {
+						if (new RforRecord(0) instanceof RforRecord(long y)) {
+							System.out.print("Yay");
+						}
+					}
+					public static void main(String... args) {
+						new X().foo();
+					}
+				}
+				"""},
+				"Yay");
+	}
+
+	public void testPrimitiveRecordComponent_narrowingAndUnboxing_nested() {
+		runConformTest(new String[] {
+				"X.java",
+				"""
+				record Rec1(Rec2 r) {}
+				record Rec2(Number x) {}
+				public class X  {
+					public void foo() {
+						if (new Rec1(new Rec2(Integer.valueOf(1))) instanceof Rec1(Rec2(int y))) {
+							System.out.print("Yay"+y);
+						}
+						if (new Rec1(new Rec2(Short.valueOf((short)1))) instanceof Rec1(Rec2(int y))) {
+							System.out.print("Nay");
+						} else {
+							System.out.print("!");
+						}
+					}
+					public static void main(String... args) {
+						new X().foo();
+					}
+				}
+				"""},
+				"Yay1!");
+
+	}
+
 	// test from spec
 	public void _testSpec001() {
 		runConformTest(new String[] {


### PR DESCRIPTION
code gen for matching with primitive type pattern nested in record patt.
+ more locations to handle 1 or 2 byte pops, dups ... (generically)
+ extract IGenerateTypeCheck f. InstanceOfExpression.generateTypeCheck()
+ TypePattern to implement IGenerateTypeCheck, too.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2891