### PR TITLE
[performance] Avoid reading SourceFile twice

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/env/ICompilationUnit.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/env/ICompilationUnit.java
@@ -37,6 +37,11 @@ public interface ICompilationUnit extends IDependent {
  * CharOperation.NO_CHAR being the candidate of choice.
  */
 char[] getContents();
+
+/** if {@link #getContents()} keeps a cached copy that cache can be released with this method **/
+default void releaseContent() {
+	// nothing
+}
 /**
  * Answer the name of the top level public type.
  * For example, {Hashtable}.

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
@@ -11693,6 +11693,7 @@ public void getMethodBodies(CompilationUnitDeclaration unit) {
 	char[] contents = this.readManager != null
 		? this.readManager.getContents(compilationResult.compilationUnit)
 		: compilationResult.compilationUnit.getContents();
+	compilationResult.compilationUnit.releaseContent();
 	this.scanner.setSource(contents, compilationResult);
 
 	if (this.javadocParser != null && this.javadocParser.checkDocComment) {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/ResourceCompilationUnit.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/ResourceCompilationUnit.java
@@ -67,6 +67,11 @@ public class ResourceCompilationUnit implements ICompilationUnit {
 	}
 
 	@Override
+	public void releaseContent() {
+		this.contentRef = null;
+	}
+
+	@Override
 	public char[] getFileName() {
 		return this.fileName;
 	}


### PR DESCRIPTION
During compile parsing happens in two stages:
1. diet parse (any blocks like method bodies are skipped)
2. parse bodies Both phases did read the source .java file from file system. With this change the file contents is kept until no longer needed. It is cached in a SoftReference to avoid OutOfMemoryError.

https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2691
