### PR TITLE
Remove obsoleted code in CompilerOptions

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ParameterizedQualifiedTypeReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ParameterizedQualifiedTypeReference.java
@@ -27,7 +27,6 @@ package org.eclipse.jdt.internal.compiler.ast;
 
 import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.internal.compiler.ASTVisitor;
-import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 import org.eclipse.jdt.internal.compiler.impl.Constant;
 import org.eclipse.jdt.internal.compiler.lookup.*;
 
@@ -317,14 +316,8 @@ public class ParameterizedQualifiedTypeReference extends ArrayQualifiedTypeRefer
 
 			    TypeVariableBinding[] typeVariables = currentOriginal.typeVariables();
 				if (typeVariables == Binding.NO_TYPE_VARIABLES) { // check generic
-					if (scope.compilerOptions().originalSourceLevel >= ClassFileConstants.JDK1_5) { // below 1.5, already reported as syntax error
-						scope.problemReporter().nonGenericTypeCannotBeParameterized(i, this, currentType, argTypes);
-						return null;
-					}
-					this.resolvedType =  (qualifyingType != null && qualifyingType.isParameterizedType())
-						? scope.environment().createParameterizedType(currentOriginal, null, qualifyingType)
-						: currentType;
-					return this.resolvedType;
+					scope.problemReporter().nonGenericTypeCannotBeParameterized(i, this, currentType, argTypes);
+					return null;
 				} else if (argLength != typeVariables.length) {
 					if (!isDiamond) { // check arity
 						scope.problemReporter().incorrectArityForParameterizedType(this, currentType, argTypes, i);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ParameterizedSingleTypeReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ParameterizedSingleTypeReference.java
@@ -27,7 +27,6 @@ package org.eclipse.jdt.internal.compiler.ast;
 
 import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.internal.compiler.ASTVisitor;
-import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 import org.eclipse.jdt.internal.compiler.impl.Constant;
 import org.eclipse.jdt.internal.compiler.lookup.*;
 
@@ -280,19 +279,10 @@ public class ParameterizedSingleTypeReference extends ArrayTypeReference {
 
 		TypeVariableBinding[] typeVariables = currentOriginal.typeVariables();
 		if (typeVariables == Binding.NO_TYPE_VARIABLES) { // non generic invoked with arguments
-			boolean isCompliant15 = scope.compilerOptions().originalSourceLevel >= ClassFileConstants.JDK1_5;
 			if ((currentOriginal.tagBits & TagBits.HasMissingType) == 0) {
-				if (isCompliant15) { // below 1.5, already reported as syntax error
-					this.resolvedType = currentType;
-					scope.problemReporter().nonGenericTypeCannotBeParameterized(0, this, currentType, argTypes);
-					return null;
-				}
-			}
-			// resilience do not rebuild a parameterized type unless compliance is allowing it
-			if (!isCompliant15) {
-				if (!this.resolvedType.isValidBinding())
-					return currentType;
-				return this.resolvedType = currentType;
+				this.resolvedType = currentType;
+				scope.problemReporter().nonGenericTypeCannotBeParameterized(0, this, currentType, argTypes);
+				return null;
 			}
 			// if missing generic type, and compliance >= 1.5, then will rebuild a parameterized binding
 		} else if (argLength != typeVariables.length) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/impl/CompilerOptions.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/impl/CompilerOptions.java
@@ -430,18 +430,8 @@ public class CompilerOptions {
 	public boolean generateGenericSignatureForLambdaExpressions;
 	/** Compliance level for the compiler, refers to a JDK version, e.g. {@link ClassFileConstants#JDK1_4} */
 	public long complianceLevel;
-	/** Original compliance level for the compiler, refers to a JDK version, e.g. {@link ClassFileConstants#JDK1_4},
-	 *  Usually same as the field complianceLevel, though the latter could deviate to create temporary sandbox
-	 *  modes during reconcile operations. See https://bugs.eclipse.org/bugs/show_bug.cgi?id=323633
-	 */
-	public long originalComplianceLevel;
 	/** Java source level, refers to a JDK version, e.g. {@link ClassFileConstants#JDK1_4} */
 	public long sourceLevel;
-	/** Original Java source level, refers to a JDK version, e.g. {@link ClassFileConstants#JDK1_4}
-	 *  Usually same as the field sourceLevel, though the latter could deviate to create temporary sandbox
-	 *  modes during reconcile operations. See https://bugs.eclipse.org/bugs/show_bug.cgi?id=323633
-	 * */
-	public long originalSourceLevel;
 	/** VM target level, refers to a JDK version, e.g. {@link ClassFileConstants#JDK1_4} */
 	public long targetJDK;
 	/** Source encoding format */
@@ -1575,8 +1565,8 @@ public class CompilerOptions {
 
 		// by default be compliant with first supported version
 		final long firstSupportedJdkLevel = getFirstSupportedJdkLevel();
-		this.complianceLevel = this.originalComplianceLevel = firstSupportedJdkLevel;
-		this.sourceLevel = this.originalSourceLevel = firstSupportedJdkLevel;
+		this.complianceLevel = firstSupportedJdkLevel;
+		this.sourceLevel = firstSupportedJdkLevel;
 		this.targetJDK = firstSupportedJdkLevel;
 
 		this.defaultEncoding = null; // will use the platform default encoding
@@ -1772,11 +1762,11 @@ public class CompilerOptions {
 		}
 		if ((optionValue = optionsMap.get(OPTION_Compliance)) != null) {
 			long level = versionToJdkLevel(optionValue);
-			if (level != 0) this.complianceLevel = this.originalComplianceLevel = level;
+			if (level != 0) this.complianceLevel = level;
 		}
 		if ((optionValue = optionsMap.get(OPTION_Source)) != null) {
 			long level = versionToJdkLevel(optionValue);
-			if (level != 0) this.sourceLevel = this.originalSourceLevel = level;
+			if (level != 0) this.sourceLevel = level;
 		}
 		if ((optionValue = optionsMap.get(OPTION_TargetPlatform)) != null) {
 			long level = versionToJdkLevel(optionValue);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BinaryTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BinaryTypeBinding.java
@@ -467,7 +467,7 @@ void cachePartsFrom(IBinaryType binaryType, boolean needFieldsAndMethods) {
 		}
 
 		CompilerOptions globalOptions = this.environment.globalOptions;
-		long sourceLevel = globalOptions.originalSourceLevel;
+		long sourceLevel = globalOptions.sourceLevel;
 		/* https://bugs.eclipse.org/bugs/show_bug.cgi?id=324850, even in a 1.4 project, we
 		   must internalize type variables and observe any parameterization of super class
 		   and/or super interfaces in order to be able to detect overriding in the presence

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/LookupEnvironment.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/LookupEnvironment.java
@@ -1679,7 +1679,7 @@ public boolean usesNullTypeAnnotations() {
 
 private void initializeUsesNullTypeAnnotation() {
 	this.globalOptions.useNullTypeAnnotations = Boolean.FALSE;
-	if (!this.globalOptions.isAnnotationBasedNullAnalysisEnabled || this.globalOptions.originalSourceLevel < ClassFileConstants.JDK1_8)
+	if (!this.globalOptions.isAnnotationBasedNullAnalysisEnabled)
 		return;
 	ReferenceBinding nullable;
 	ReferenceBinding nonNull;
@@ -1733,7 +1733,7 @@ public boolean usesOwningAnnotations() {
 
 private void initializeUsesOwningAnnotations() {
 	this.globalOptions.useOwningAnnotations = Boolean.FALSE;
-	if (!this.globalOptions.analyseResourceLeaks || this.globalOptions.originalSourceLevel < ClassFileConstants.JDK1_7)
+	if (!this.globalOptions.analyseResourceLeaks)
 		return;
 	ReferenceBinding owning;
 	ReferenceBinding notOwning;

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/compiler/parser/SourceTypeConverter.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/compiler/parser/SourceTypeConverter.java
@@ -141,7 +141,7 @@ public class SourceTypeConverter extends TypeConverter {
 		org.eclipse.jdt.core.ICompilationUnit cuHandle = topLevelTypeInfo.getHandle().getCompilationUnit();
 		this.cu = (ICompilationUnit) cuHandle;
 		final CompilationUnitElementInfo compilationUnitElementInfo = (CompilationUnitElementInfo) ((JavaElement) this.cu).getElementInfo();
-		if (this.has1_5Compliance &&
+		if (
 				(compilationUnitElementInfo.annotationNumber >= CompilationUnitElementInfo.ANNOTATION_THRESHOLD_FOR_DIET_PARSE ||
 				(compilationUnitElementInfo.hasFunctionalTypes && (this.flags & LOCAL_TYPE) != 0) ||
 				couldBeVarargs)) {
@@ -299,11 +299,9 @@ public class SourceTypeConverter extends TypeConverter {
 			field.type = createTypeReference(fieldInfo.getTypeName(), start, end);
 		}
 
-		// convert 1.5 specific constructs only if compliance is 1.5 or above
-		if (this.has1_5Compliance) {
-			/* convert annotations */
-			field.annotations = convertAnnotations(fieldHandle);
-		}
+		// convert 1.5 specific constructs
+		/* convert annotations */
+		field.annotations = convertAnnotations(fieldHandle);
 
 		/* conversion of field constant */
 		if ((this.flags & FIELD_INITIALIZATION) != 0) {
@@ -431,11 +429,9 @@ public class SourceTypeConverter extends TypeConverter {
 		method.declarationSourceStart = methodInfo.getDeclarationSourceStart();
 		method.declarationSourceEnd = methodInfo.getDeclarationSourceEnd();
 
-		// convert 1.5 specific constructs only if compliance is 1.5 or above
-		if (this.has1_5Compliance) {
-			/* convert annotations */
-			method.annotations = convertAnnotations(methodHandle);
-		}
+		// convert 1.5 specific constructs
+		/* convert annotations */
+		method.annotations = convertAnnotations(methodHandle);
 
 		/* convert arguments */
 		String[] argumentTypeSignatures = methodHandle.getParameterTypes();
@@ -457,11 +453,9 @@ public class SourceTypeConverter extends TypeConverter {
 						typeReference,
 						ClassFileConstants.AccDefault);
 				// do not care whether was final or not
-				// convert 1.5 specific constructs only if compliance is 1.5 or above
-				if (this.has1_5Compliance) {
-					/* convert annotations */
-					method.arguments[i].annotations = convertAnnotations(parameters[i]);
-				}
+				// convert 1.5 specific constructs
+				/* convert annotations */
+				method.arguments[i].annotations = convertAnnotations(parameters[i]);
 			}
 		}
 
@@ -546,11 +540,10 @@ public class SourceTypeConverter extends TypeConverter {
 		type.declarationSourceEnd = typeInfo.getDeclarationSourceEnd();
 		type.bodyEnd = type.declarationSourceEnd;
 
-		// convert 1.5 specific constructs only if compliance is 1.5 or above
-		if (this.has1_5Compliance) {
-			/* convert annotations */
-			type.annotations = convertAnnotations(typeHandle);
-		}
+		// convert 1.5 specific constructs
+		/* convert annotations */
+		type.annotations = convertAnnotations(typeHandle);
+
 		/* https://bugs.eclipse.org/bugs/show_bug.cgi?id=324850, even in a 1.4 project, we
 		   must internalize type variables and observe any parameterization of super class
 		   and/or super interfaces in order to be able to detect overriding in the presence

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/compiler/parser/TypeConverter.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/compiler/parser/TypeConverter.java
@@ -28,7 +28,6 @@ import org.eclipse.jdt.internal.compiler.ast.SingleTypeReference;
 import org.eclipse.jdt.internal.compiler.ast.TypeParameter;
 import org.eclipse.jdt.internal.compiler.ast.TypeReference;
 import org.eclipse.jdt.internal.compiler.ast.Wildcard;
-import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 import org.eclipse.jdt.internal.compiler.lookup.TypeBinding;
 import org.eclipse.jdt.internal.compiler.lookup.TypeConstants;
 import org.eclipse.jdt.internal.compiler.problem.ProblemReporter;
@@ -39,14 +38,11 @@ public abstract class TypeConverter {
 	int namePos;
 
 	protected ProblemReporter problemReporter;
-	protected boolean has1_5Compliance;
-	protected boolean has14_Compliance;
+
 	private final char memberTypeSeparator;
 
 	protected TypeConverter(ProblemReporter problemReporter, char memberTypeSeparator) {
 		this.problemReporter = problemReporter;
-		this.has1_5Compliance = problemReporter.options.originalComplianceLevel >= ClassFileConstants.JDK1_5;
-		this.has14_Compliance = problemReporter.options.originalComplianceLevel >= ClassFileConstants.JDK14;
 		this.memberTypeSeparator = memberTypeSeparator;
 	}
 
@@ -282,9 +278,7 @@ public abstract class TypeConverter {
 					break;
 				case Signature.C_GENERIC_START :
 					nameFragmentEnd = this.namePos-1;
-					// convert 1.5 specific constructs only if compliance is 1.5 or above
-					if (!this.has1_5Compliance)
-						break typeLoop;
+					// convert 1.5 specific constructs
 					if (fragments == null) fragments = new ArrayList(2);
 					addIdentifiers(typeSignature, nameFragmentStart, nameFragmentEnd + 1, identCount, fragments);
 					this.namePos++; // skip '<'
@@ -443,17 +437,17 @@ public abstract class TypeConverter {
 					   Because of the way type signatures are encoded, TypeConverter.decodeType(String, int, int, int) is immune
 					   to this problem. See https://bugs.eclipse.org/bugs/show_bug.cgi?id=325633
 					 */
-					if (this.has1_5Compliance || includeGenericsAnyway) {
+					if (includeGenericsAnyway) {
 						if (fragments == null) fragments = new ArrayList(2);
 					}
 					nameFragmentEnd = this.namePos-1;
-					if (this.has1_5Compliance || includeGenericsAnyway) {
+					if (includeGenericsAnyway) {
 						char[][] identifiers = CharOperation.splitOn('.', typeName, nameFragmentStart, this.namePos);
 						fragments.add(identifiers);
 					}
 					this.namePos++; // skip '<'
 					TypeReference[] arguments = decodeTypeArguments(typeName, length, start, end, includeGenericsAnyway); // positionned on '>' at end
-					if (this.has1_5Compliance || includeGenericsAnyway) {
+					if (includeGenericsAnyway) {
 						fragments.add(arguments);
 						identCount = 0;
 						nameFragmentStart = -1;

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/compiler/parser/TypeConverter.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/compiler/parser/TypeConverter.java
@@ -427,32 +427,22 @@ public abstract class TypeConverter {
 					identCount ++;
 					break;
 				case '<' :
-					/* We need to convert and preserve 1.5 specific constructs either if compliance is 1.5 or above,
-					   or the caller has explicitly requested generics to be included. The parameter includeGenericsAnyway
-					   should be used by the caller to signal that in the calling context generics information must be
-					   internalized even when the requesting project is 1.4. But in all cases, we must skip over them to
-					   see if there are any applicable type fragments after the type parameters: i.e we just aren't done
-					   having seen a '<' in 1.4 mode.
 
-					   Because of the way type signatures are encoded, TypeConverter.decodeType(String, int, int, int) is immune
-					   to this problem. See https://bugs.eclipse.org/bugs/show_bug.cgi?id=325633
-					 */
-					if (includeGenericsAnyway) {
-						if (fragments == null) fragments = new ArrayList(2);
-					}
+					if (fragments == null) fragments = new ArrayList(2);
+
 					nameFragmentEnd = this.namePos-1;
-					if (includeGenericsAnyway) {
-						char[][] identifiers = CharOperation.splitOn('.', typeName, nameFragmentStart, this.namePos);
-						fragments.add(identifiers);
-					}
+
+					char[][] identifiers = CharOperation.splitOn('.', typeName, nameFragmentStart, this.namePos);
+					fragments.add(identifiers);
+
 					this.namePos++; // skip '<'
 					TypeReference[] arguments = decodeTypeArguments(typeName, length, start, end, includeGenericsAnyway); // positionned on '>' at end
-					if (includeGenericsAnyway) {
-						fragments.add(arguments);
-						identCount = 0;
-						nameFragmentStart = -1;
-						nameFragmentEnd = -1;
-					}
+
+					fragments.add(arguments);
+					identCount = 0;
+					nameFragmentStart = -1;
+					nameFragmentEnd = -1;
+
 					// next increment will skip '>'
 					break;
 			}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/BinaryTypeConverter.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/BinaryTypeConverter.java
@@ -143,22 +143,20 @@ public class BinaryTypeConverter extends TypeConverter {
 
 		org.eclipse.jdt.internal.compiler.ast.TypeParameter[] typeParams = null;
 
-		// convert 1.5 specific constructs only if compliance is 1.5 or above
-		if (this.has1_5Compliance) {
-			/* convert type parameters */
-			ITypeParameter[] typeParameters = method.getTypeParameters();
-			if (typeParameters != null && typeParameters.length > 0) {
-				int parameterCount = typeParameters.length;
-				typeParams = new org.eclipse.jdt.internal.compiler.ast.TypeParameter[parameterCount];
-				for (int i = 0; i < parameterCount; i++) {
-					ITypeParameter typeParameter = typeParameters[i];
-					typeParams[i] =
-						createTypeParameter(
-								typeParameter.getElementName().toCharArray(),
-								stringArrayToCharArray(typeParameter.getBounds()),
-								0,
-								0);
-				}
+		// convert 1.5 specific constructs only
+		/* convert type parameters */
+		ITypeParameter[] typeParameters = method.getTypeParameters();
+		if (typeParameters != null && typeParameters.length > 0) {
+			int parameterCount = typeParameters.length;
+			typeParams = new org.eclipse.jdt.internal.compiler.ast.TypeParameter[parameterCount];
+			for (int i = 0; i < parameterCount; i++) {
+				ITypeParameter typeParameter = typeParameters[i];
+				typeParams[i] =
+					createTypeParameter(
+							typeParameter.getElementName().toCharArray(),
+							stringArrayToCharArray(typeParameter.getBounds()),
+							0,
+							0);
 			}
 		}
 
@@ -251,26 +249,24 @@ public class BinaryTypeConverter extends TypeConverter {
 			System.arraycopy(typeDeclaration.fields, 0, typeDeclaration.superInterfaces = new TypeReference[interfaceCount], 0, interfaceCount);
 		}
 
-		// convert 1.5 specific constructs only if compliance is 1.5 or above
-		if (this.has1_5Compliance) {
+		// convert 1.5 specific constructs
 
-			/* convert type parameters */
-			ITypeParameter[] typeParameters = type.getTypeParameters();
-			if (typeParameters != null && typeParameters.length > 0) {
-				int parameterCount = typeParameters.length;
-				org.eclipse.jdt.internal.compiler.ast.TypeParameter[] typeParams = new org.eclipse.jdt.internal.compiler.ast.TypeParameter[parameterCount];
-				for (int i = 0; i < parameterCount; i++) {
-					ITypeParameter typeParameter = typeParameters[i];
-					typeParams[i] =
-						createTypeParameter(
-								typeParameter.getElementName().toCharArray(),
-								stringArrayToCharArray(typeParameter.getBounds()),
-								0,
-								0);
-				}
-
-				typeDeclaration.typeParameters = typeParams;
+		/* convert type parameters */
+		ITypeParameter[] typeParameters = type.getTypeParameters();
+		if (typeParameters != null && typeParameters.length > 0) {
+			int parameterCount = typeParameters.length;
+			org.eclipse.jdt.internal.compiler.ast.TypeParameter[] typeParams = new org.eclipse.jdt.internal.compiler.ast.TypeParameter[parameterCount];
+			for (int i = 0; i < parameterCount; i++) {
+				ITypeParameter typeParameter = typeParameters[i];
+				typeParams[i] =
+					createTypeParameter(
+							typeParameter.getElementName().toCharArray(),
+							stringArrayToCharArray(typeParameter.getBounds()),
+							0,
+							0);
 			}
+
+			typeDeclaration.typeParameters = typeParams;
 		}
 
 		/* convert member types */


### PR DESCRIPTION
Found during the review of #2551

- CompilerOptions.originalComplianceLevel is obsoleted and can be removed + code in TypeConverter using it should be cleaned up.￼
- CompilerOptions.originalSourceLevel is obsoleted and can be removed + code in JDT that uses it should be cleaned up

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2760
