### PR TITLE
[23] exhaustiveness signalling difference between javac and ecj

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/.settings/.api_filters
+++ b/org.eclipse.jdt.core.compiler.batch/.settings/.api_filters
@@ -23,6 +23,12 @@
                 <message_argument value="DisallowedStatementInPrologue"/>
             </message_arguments>
         </filter>
+        <filter comment="this preview constant (marked @noreference) is unnecesary" id="405864542">
+            <message_arguments>
+                <message_argument value="org.eclipse.jdt.core.compiler.IProblem"/>
+                <message_argument value="DuplicateTotalPattern"/>
+            </message_arguments>
+        </filter>
         <filter comment="renamed constant for JEP 482" id="405864542">
             <message_arguments>
                 <message_argument value="org.eclipse.jdt.core.compiler.IProblem"/>

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/core/compiler/IProblem.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/core/compiler/IProblem.java
@@ -2537,9 +2537,6 @@ void setSourceStart(int sourceStart);
 	/** @since 3.28
 	 * @noreference preview feature error */
 	int EnhancedSwitchMissingDefault = PreviewRelated + 1908;
-	/** @since 3.28
-	 * @noreference preview feature error */
-	int DuplicateTotalPattern = PreviewRelated + 1909;
 
 	 /** @since 3.34
 	 * @noreference preview feature error */

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/CaseStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/CaseStatement.java
@@ -403,7 +403,6 @@ private Constant resolveCasePattern(BlockScope scope, TypeBinding caseType, Type
 				switchStatement.switchBits |= SwitchStatement.TotalPattern;
 				if (switchStatement.defaultCase != null && !(e instanceof RecordPattern))
 					scope.problemReporter().illegalTotalPatternWithDefault(this);
-				switchStatement.totalPattern = e;
 			}
 			e.isTotalTypeNode = true;
 			if (switchStatement.nullCase == null)

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/GuardedPattern.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/GuardedPattern.java
@@ -65,11 +65,6 @@ public class GuardedPattern extends Pattern {
 	}
 
 	@Override
-	public boolean isUnconditional(TypeBinding t, Scope scope) {
-		return isUnguarded() && this.primaryPattern.isUnconditional(t, scope);
-	}
-
-	@Override
 	public boolean isUnguarded() {
 		Constant cst = this.condition.optimizedBooleanConstant();
 		return cst != null && cst != Constant.NotAConstant && cst.booleanValue() == true;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Pattern.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Pattern.java
@@ -117,7 +117,7 @@ public abstract class Pattern extends Expression {
 	}
 
 	public boolean isUnconditional(TypeBinding t, Scope scope) {
-		return isUnguarded() && coversType(t, scope);
+		return false;
 	}
 
 	public abstract void generateCode(BlockScope currentScope, CodeStream codeStream, BranchLabel patternMatchLabel, BranchLabel matchFailLabel);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/RecordPattern.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/RecordPattern.java
@@ -180,11 +180,6 @@ public class RecordPattern extends Pattern {
 	}
 
 	@Override
-	public boolean isUnconditional(TypeBinding t, Scope scope) {
-		return false;
-	}
-
-	@Override
 	public boolean dominates(Pattern p) {
 		/* 14.30.3: A record pattern with type R and pattern list L dominates another record pattern
 		   with type S and pattern list M if (i) R and S name the same record class, and (ii)

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
@@ -1187,6 +1187,7 @@ public class SwitchStatement extends Expression {
 				LocalVariableBinding[] patternVariables = NO_VARIABLES;
 				boolean caseNullDefaultFound = false;
 				boolean defaultFound = false;
+				Pattern aTotalPattern = null;
 				for (int i = 0; i < length; i++) {
 					ResolvedCase[] constantsList;
 					final Statement statement = this.statements[i];
@@ -1197,6 +1198,8 @@ public class SwitchStatement extends Expression {
 						constantsList = caseStmt.resolveCase(this.scope, expressionType, this);
 						patternVariables = statement.bindingsWhenTrue();
 						for (ResolvedCase c : constantsList) {
+							if (c.e instanceof Pattern p && p.isTotalTypeNode && p.isUnguarded)
+								aTotalPattern = p;
 							Constant con = c.c;
 							if (con == Constant.NotAConstant)
 								continue;
@@ -1271,6 +1274,9 @@ public class SwitchStatement extends Expression {
 						statement.resolveWithBindings(patternVariables, this.scope);
 						patternVariables = LocalVariableBinding.merge(patternVariables, statement.bindingsWhenComplete());
 					}
+				}
+				if (!defaultFound && aTotalPattern != null) {
+					this.totalPattern = aTotalPattern;
 				}
 				if (expressionType != null
 						&& (expressionType.id == TypeIds.T_boolean || expressionType.id == TypeIds.T_JavaLangBoolean)

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
@@ -1192,8 +1192,7 @@ public class SwitchStatement extends Expression {
 					ResolvedCase[] constantsList;
 					final Statement statement = this.statements[i];
 					if (statement instanceof CaseStatement caseStmt) {
-						caseNullDefaultFound = caseNullDefaultFound ? caseNullDefaultFound
-								: isCaseStmtNullDefault(caseStmt);
+						caseNullDefaultFound |= isCaseStmtNullDefault(caseStmt);
 						defaultFound |= caseStmt.constantExpressions == Expression.NO_EXPRESSIONS;
 						constantsList = caseStmt.resolveCase(this.scope, expressionType, this);
 						patternVariables = statement.bindingsWhenTrue();

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
@@ -12597,14 +12597,6 @@ public void enhancedSwitchMissingDefaultCase(ASTNode element) {
 			element.sourceStart,
 			element.sourceEnd);
 }
-public void duplicateTotalPattern(ASTNode element) {
-	this.handle(
-			IProblem.DuplicateTotalPattern,
-			NoArgument,
-			NoArgument,
-			element.sourceStart,
-			element.sourceEnd);
-}
 public void unexpectedTypeinSwitchPattern(TypeBinding type, ASTNode element) {
 	this.handle(
 			IProblem.UnexpectedTypeinSwitchPattern,

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/messages.properties
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/messages.properties
@@ -1156,7 +1156,7 @@
 1906 = This case label is dominated by one of the preceding case labels
 1907 = Switch case cannot have both unconditional pattern and default label
 1908 = An enhanced switch statement should be exhaustive; a default label expected
-1909 = The switch statement cannot have more than one unconditional pattern
+# 1909 removed
 1910 = Unnecessary 'null' pattern, the switch selector expression cannot be null
 1911 = Unexpected type {0}, expected class or array type
 1920 = A null case label has to be either the only expression in a case label or the first expression followed only by a default

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/CompilerInvocationTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/CompilerInvocationTests.java
@@ -1340,7 +1340,6 @@ public void test011_problem_categories() {
 	    expectedProblemAttributes.put("PatternDominated", new ProblemAttributes(true));
 	    expectedProblemAttributes.put("IllegalTotalPatternWithDefault", new ProblemAttributes(true));
 	    expectedProblemAttributes.put("EnhancedSwitchMissingDefault", new ProblemAttributes(true));
-	    expectedProblemAttributes.put("DuplicateTotalPattern", new ProblemAttributes(true));
 	    expectedProblemAttributes.put("UnexpectedTypeinSwitchPattern", new ProblemAttributes(true));
 	    expectedProblemAttributes.put("UnexpectedTypeinRecordPattern", new ProblemAttributes(true));
 	    expectedProblemAttributes.put("RecordPatternMismatch", new ProblemAttributes(true));
@@ -2474,7 +2473,6 @@ public void test012_compiler_problems_tuning() {
 	    expectedProblemAttributes.put("PatternDominated", SKIP);
 	    expectedProblemAttributes.put("IllegalTotalPatternWithDefault", SKIP);
 	    expectedProblemAttributes.put("EnhancedSwitchMissingDefault", SKIP);
-	    expectedProblemAttributes.put("DuplicateTotalPattern", SKIP);
 	    expectedProblemAttributes.put("UnexpectedTypeinSwitchPattern", SKIP);
 	    expectedProblemAttributes.put("UnexpectedTypeinRecordPattern", SKIP);
 	    expectedProblemAttributes.put("RecordPatternMismatch", SKIP);

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PrimitiveInPatternsTestSH.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PrimitiveInPatternsTestSH.java
@@ -2221,6 +2221,7 @@ public class PrimitiveInPatternsTestSH extends AbstractRegressionTest9 {
 	}
 
 	public void testCoversTypePlusDefault() {
+		// case int i "covers" type Integer but is not unconditional
 		runConformTest(new String[] {
 				"X.java",
 				"""
@@ -2241,6 +2242,72 @@ public class PrimitiveInPatternsTestSH extends AbstractRegressionTest9 {
 				},
 				"true");
 	}
+
+	public void testUnconditionPlusDefault() {
+		// case int i "covers" type int and is unconditional
+		// various combinations of dominance with/without default
+		runNegativeTest(new String[] {
+				"X.java",
+				"""
+				public class X  {
+					int foo1(int myInt) {
+						return switch (myInt) {
+							case int i  -> i;
+							default -> 0; // conflict with preceding total pattern (unguarded and unconditional)
+						};
+					}
+					int foo2(int myInt) {
+						return switch (myInt) { // swapped order of cases
+							default -> 0;
+							case int i  -> i; // conflict with preceding default
+						};
+					}
+					int foo3(int myInt) {
+						return switch (myInt) {
+							default -> 0;
+							case int i  -> i; // conflict with preceding default
+							case short s -> s; // additionally dominated by int i
+						};
+					}
+					int foo4(int myInt) {
+						return switch (myInt) {
+							case int i  -> i;
+							case short s -> s; // dominated by int i
+						};
+					}
+				}
+				"""
+				},
+				"""
+				----------
+				1. ERROR in X.java (at line 5)
+					default -> 0; // conflict with preceding total pattern (unguarded and unconditional)
+					^^^^^^^
+				Switch case cannot have both unconditional pattern and default label
+				----------
+				2. ERROR in X.java (at line 11)
+					case int i  -> i; // conflict with preceding default
+					     ^^^^^
+				This case label is dominated by one of the preceding case labels
+				----------
+				3. ERROR in X.java (at line 17)
+					case int i  -> i; // conflict with preceding default
+					     ^^^^^
+				This case label is dominated by one of the preceding case labels
+				----------
+				4. ERROR in X.java (at line 18)
+					case short s -> s; // additionally dominated by int i
+					     ^^^^^^^
+				This case label is dominated by one of the preceding case labels
+				----------
+				5. ERROR in X.java (at line 24)
+					case short s -> s; // dominated by int i
+					     ^^^^^^^
+				This case label is dominated by one of the preceding case labels
+				----------
+				""");
+	}
+
 	// test from spec
 	public void _testSpec001() {
 		runConformTest(new String[] {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PrimitiveInPatternsTestSH.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PrimitiveInPatternsTestSH.java
@@ -2220,6 +2220,27 @@ public class PrimitiveInPatternsTestSH extends AbstractRegressionTest9 {
 
 	}
 
+	public void testCoversTypePlusDefault() {
+		runConformTest(new String[] {
+				"X.java",
+				"""
+				public class X  {
+					public static int foo(Integer myInt) {
+						return switch (myInt) {
+							case int i  -> i;
+							default -> 0;
+						};
+					}
+
+					public static void main(String argv[]) {
+						Integer i = 100;
+						System.out.println(X.foo(i) == i);
+					}
+				}
+				"""
+				},
+				"true");
+	}
 	// test from spec
 	public void _testSpec001() {
 		runConformTest(new String[] {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordPatternTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordPatternTest.java
@@ -367,12 +367,6 @@ public class RecordPatternTest extends AbstractRegressionTest9 {
 				"	case Rectangle(ColoredPoint(Point(int x, int y), Color c),\n" +
 				"				ColoredPoint(Point(int x1, int y1), Color c1)) -> {\n" +
 				"	     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
-				"The switch statement cannot have more than one unconditional pattern\n" +
-				"----------\n" +
-				"2. ERROR in X.java (at line 7)\n" +
-				"	case Rectangle(ColoredPoint(Point(int x, int y), Color c),\n" +
-				"				ColoredPoint(Point(int x1, int y1), Color c1)) -> {\n" +
-				"	     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
 				"This case label is dominated by one of the preceding case labels\n" +
 				"----------\n");
 	}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchPatternTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchPatternTest.java
@@ -2876,11 +2876,6 @@ public class SwitchPatternTest extends AbstractRegressionTest9 {
 			"----------\n" +
 			"1. ERROR in X.java (at line 5)\n" +
 			"	case Integer i1 -> 0;\n" +
-			"	^^^^^^^^^^^^^^^\n" +
-			"Switch case cannot have both unconditional pattern and default label\n" +
-			"----------\n" +
-			"2. ERROR in X.java (at line 5)\n" +
-			"	case Integer i1 -> 0;\n" +
 			"	     ^^^^^^^^^^\n" +
 			"This case label is dominated by one of the preceding case labels\n" +
 			"----------\n");
@@ -3537,11 +3532,6 @@ public class SwitchPatternTest extends AbstractRegressionTest9 {
 				},
 				"----------\n" +
 				"1. ERROR in X.java (at line 6)\n" +
-				"	case String s -> -1;\n" +
-				"	     ^^^^^^^^\n" +
-				"The switch statement cannot have more than one unconditional pattern\n" +
-				"----------\n" +
-				"2. ERROR in X.java (at line 6)\n" +
 				"	case String s -> -1;\n" +
 				"	     ^^^^^^^^\n" +
 				"This case label is dominated by one of the preceding case labels\n" +
@@ -5751,11 +5741,6 @@ public class SwitchPatternTest extends AbstractRegressionTest9 {
 				"1. ERROR in X.java (at line 7)\n" +
 				"	case Integer i ->                     // Error - dominated case label\n" +
 				"	     ^^^^^^^^^\n" +
-				"The switch statement cannot have more than one unconditional pattern\n" +
-				"----------\n" +
-				"2. ERROR in X.java (at line 7)\n" +
-				"	case Integer i ->                     // Error - dominated case label\n" +
-				"	     ^^^^^^^^^\n" +
 				"This case label is dominated by one of the preceding case labels\n" +
 				"----------\n");
 	}
@@ -5777,11 +5762,6 @@ public class SwitchPatternTest extends AbstractRegressionTest9 {
 				},
 				"----------\n" +
 				"1. ERROR in X.java (at line 7)\n" +
-				"	case Integer i when true ->                     // Error - dominated case label\n" +
-				"	     ^^^^^^^^^\n" +
-				"The switch statement cannot have more than one unconditional pattern\n" +
-				"----------\n" +
-				"2. ERROR in X.java (at line 7)\n" +
 				"	case Integer i when true ->                     // Error - dominated case label\n" +
 				"	     ^^^^^^^^^\n" +
 				"This case label is dominated by one of the preceding case labels\n" +


### PR DESCRIPTION
+ precise implementation of TypePattern.isUnconditional()
  - remove implementations in parent / sibling classes
+ defer setting SwitchStatement.totalPattern until we know if a default case is present (otherwise we would generated inconsistent code for default).

+ clarify that flagDuplicateDefault() flags only conditionally,
  renamed to checkDuplicateDefault()
  - inside this method clarify that only one error is reported per loc.
+ remove all conflict reporting from CaseStatement.resolveCasePattern
  - will be done within SwitchStatement.resolve() anyway
+ remove IProblem.DuplicateTotalPattern and related code
  - all errors reported here coincided with a dominance error
+ adjust tests: no longer expect secondary errors

fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2915

