### PR TITLE
fix formatting setting in eclipse profile, here space before assignment

### DIFF
--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/DefaultCodeFormatterOptions.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/DefaultCodeFormatterOptions.java
@@ -3377,6 +3377,8 @@ public class DefaultCodeFormatterOptions {
 		setJavaConventionsSettings();
 		this.tab_char = TAB;
 		this.tab_size = 4;
+		// overwrite, eclipse jdt settings require no space before assignment
+		this.insert_space_before_assignment_operator = false;
 	}
 
 	public void setJavaConventionsSettings() {


### PR DESCRIPTION
As described in https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1609 eclipse is violating the default jdt code conventions expected from contributors.

## What it does
This changes the eclipse default formatter profile in a way that "space before assignment" is not set.

## How to test
create a new java project, create a java file with an assignment. Run the formatter on the file.

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
