### PR TITLE
[23] Folding a markdown region hides the first line of subsequent Java

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/ClassFileReader.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/ClassFileReader.java
@@ -122,7 +122,6 @@ public static ClassFileReader read(File file, boolean fullyInitialize) throws Cl
  * <strong>PROVISIONAL</strong>: This has been re-introduced not to break Xtext (see
  * <a href="https://github.com/eclipse/xtext/issues/3089">https://github.com/eclipse/xtext/issues/3089</a>).
  *
- * @author Lorenzo Bettini
  */
 public static ClassFileReader read(InputStream stream, String fileName) throws ClassFormatException, IOException {
 	return read(Util.getInputStreamAsByteArray(stream), fileName);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/impl/JavaFeature.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/impl/JavaFeature.java
@@ -94,7 +94,7 @@ public enum JavaFeature {
 	 * <dt>Individual exceptions from old rules
 	 * <dd><ul><li>MethodScope.findField()<li>Scope.getBinding(char[], int, InvocationSite, boolean)</ul>
 	 * <dt>Main code gen change in TypeDeclaration.manageEnclosingInstanceAccessIfNecessary()
-	 * <dd>Only if feature is actually supported, we will generate special synthetid args & fields<br>
+	 * <dd>Only if feature is actually supported, we will generate special synthetid args &amp; fields<br>
 	 * Uses some feature-specific help from BlockScope.getEmulationPath()
 	 * </dl>
 	 */

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Scanner.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Scanner.java
@@ -1947,6 +1947,7 @@ protected int getNextToken0() throws InvalidInputException {
 										}
 									}
 									if (!lineBeginsWithMarkdown()) {
+										this.currentPosition--;
 										break;
 									}
 								}
@@ -1980,6 +1981,7 @@ protected int getNextToken0() throws InvalidInputException {
 											}
 										}
 										if (!lineBeginsWithMarkdown()) {
+											this.currentPosition--;
 											break;
 										}
 									}
@@ -2844,6 +2846,7 @@ public final void jumpOverMethodBody() {
 										}
 									}
 									if (!lineBeginsWithMarkdown()) {
+										this.currentPosition--;
 										break;
 									}
 								}
@@ -2877,6 +2880,7 @@ public final void jumpOverMethodBody() {
 											}
 										}
 										if (!lineBeginsWithMarkdown()) {
+											this.currentPosition--;
 											break;
 										}
 									}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/MarkdownCommentsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/MarkdownCommentsTest.java
@@ -350,7 +350,7 @@ public class MarkdownCommentsTest extends JavadocTest {
 					"""
 					public class X {
 						/// Some text here without the necessary tags for main method
-						/// @param arguments
+						/// @param arguments\s 
 
 						// This line will be ignored and the previous block will be considered as the Javadoc
 						public static void main(String[] arguments) {
@@ -360,7 +360,7 @@ public class MarkdownCommentsTest extends JavadocTest {
 					""", },
 					"----------\n" +
 					"1. WARNING in X.java (at line 3)\n" +
-					"	/// @param arguments\n" +
+					"	/// @param arguments \n" +
 					"	           ^^^^^^^^^\n" +
 					"Javadoc: Description expected after this reference\n" +
 					"----------\n");


### PR DESCRIPTION
code

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1615

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
