### PR TITLE
[performance] BatchImageBuilder: write .class files in batches

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ICompilerRequestor.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ICompilerRequestor.java
@@ -22,4 +22,26 @@ public interface ICompilerRequestor {
 	 * Accept a compilation result.
 	 */
 	public void acceptResult(CompilationResult result);
+
+	/**
+	 * Optionally called to start multiple {@link #acceptResult(CompilationResult)}
+	 */
+	public default void startBatch() {
+		//nothing
+	}
+
+	/**
+	 * Optionally called after some {@link #acceptResult(CompilationResult)} to signal a good point in time
+	 */
+	public default void flushBatch() {
+		//nothing
+	}
+
+	/**
+	 * if {@link #startBatch} was called then endBatch is called to finalize possibly multiple
+	 * {@link #acceptResult(CompilationResult)}
+	 */
+	public default void endBatch() {
+		// nothing
+	}
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ProcessTaskManager.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ProcessTaskManager.java
@@ -14,30 +14,34 @@
 
 package org.eclipse.jdt.internal.compiler;
 
-import java.util.concurrent.ExecutionException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 import org.eclipse.jdt.internal.compiler.ast.CompilationUnitDeclaration;
 import org.eclipse.jdt.internal.compiler.problem.AbortCompilation;
 import org.eclipse.jdt.internal.compiler.util.Messages;
 
-public class ProcessTaskManager {
+public class ProcessTaskManager implements AutoCloseable {
 
 	private final Compiler compiler;
 	private final int startingIndex;
-	private volatile Future<?> processingTask; // synchronized write, volatile read
-	CompilationUnitDeclaration unitToProcess;
-	private Throwable caughtException;
+	private volatile boolean processing;
+	private final Future<?> processingTask; // synchronized write, volatile read
+	/** synchronized access **/
+	private CompilationUnitDeclaration unitWithError;
 
-	// queue
-	volatile int currentIndex, availableIndex, size, sleepCount;
-	private final CompilationUnitDeclaration[] units;
+	/** contains CompilationUnitDeclaration or something else as stop signal **/
+	private final BlockingQueue<Object> units;
 
-	public static final int PROCESSED_QUEUE_SIZE = 100;
+	private static final int PROCESSED_QUEUE_SIZE = 100;
+	private static final Object STOP_SIGNAL = new Object();
 
 	/** Normally a single thread is created an reused on subsequent builds **/
 	private static final ExecutorService executor = Executors.newCachedThreadPool(r -> {
@@ -46,159 +50,128 @@ public class ProcessTaskManager {
 		return t;
 	});
 
-public ProcessTaskManager(Compiler compiler, int startingIndex) {
-	this.compiler = compiler;
-	this.startingIndex = startingIndex;
+	public ProcessTaskManager(Compiler compiler, int startingIndex) {
+		this.compiler = compiler;
+		this.startingIndex = startingIndex;
 
-	this.currentIndex = 0;
-	this.availableIndex = 0;
-	this.size = PROCESSED_QUEUE_SIZE;
-	this.sleepCount = 0; // 0 is no one, +1 is the processing thread & -1 is the writing/main thread
-	this.units = new CompilationUnitDeclaration[this.size];
-
-	synchronized (this) {
-		this.processingTask = executor.submit(this::compile);
+		this.units = new ArrayBlockingQueue<>(PROCESSED_QUEUE_SIZE);
+		this.processing = true;
+		this.processingTask = executor.submit(this::processing);
 	}
-}
 
 // add unit to the queue - wait if no space is available
-private synchronized void addNextUnit(CompilationUnitDeclaration newElement) {
-	while (this.units[this.availableIndex] != null) {
-		//System.out.print('a');
-		//if (this.sleepCount < 0) throw new IllegalStateException(Integer.valueOf(this.sleepCount).toString());
-		this.sleepCount = 1;
+	private void addNextUnit(Object newElement) {
 		try {
-			wait(250);
-		} catch (InterruptedException ignore) {
-			// ignore
+			this.units.put(newElement);
+		} catch (InterruptedException interrupt) {
+			throw new RuntimeException(interrupt);
 		}
-		this.sleepCount = 0;
 	}
 
-	this.units[this.availableIndex++] = newElement;
-	if (this.availableIndex >= this.size)
-		this.availableIndex = 0;
-	if (this.sleepCount <= -1)
-		notify(); // wake up writing thread to accept next unit - could be the last one - must avoid deadlock
-}
+	private Object lastSignal;
 
-public CompilationUnitDeclaration removeNextUnit() throws Error {
-	CompilationUnitDeclaration next = null;
-	boolean yield = false;
-	synchronized (this) {
-		next = this.units[this.currentIndex];
-		if (next == null || this.caughtException != null) {
-			do {
-				if (this.processingTask == null) {
-					if (this.caughtException != null) {
-						// rethrow the caught exception from the processingThread in the main compiler thread
-						if (this.caughtException instanceof Error)
-							throw (Error) this.caughtException;
-						throw (RuntimeException) this.caughtException;
+	/** blocks until at least one CompilationUnitDeclaration can be returned or empty when no more elements can be expected **/
+	public Collection<CompilationUnitDeclaration> removeNextUnits() throws Error, AbortCompilation {
+		List<CompilationUnitDeclaration> elements = new ArrayList<>();
+		do {
+			Object next = this.lastSignal;
+			this.lastSignal = null;
+			try {
+				// wait until at least 1 element is available:
+				if (next == null) {
+					next = this.units.take();
+				}
+				while (next instanceof CompilationUnitDeclaration cu) {
+					elements.add(cu);
+					// optionally read more elements if already available:
+					next = this.units.poll();
+				}
+				if (!elements.isEmpty()) {
+					if (next != null) {
+						// defer any stop signal until all CompilationUnitDeclaration read
+						this.lastSignal = next;
 					}
-					return null;
+					return elements;
 				}
-				//System.out.print('r');
-				//if (this.sleepCount > 0) throw new IllegalStateException(Integer.valueOf(this.sleepCount).toString());
-				this.sleepCount = -1;
-				try {
-					wait(100);
-				} catch (InterruptedException ignore) {
-					// ignore
-				}
-				this.sleepCount = 0;
-				next = this.units[this.currentIndex];
-			} while (next == null);
-		}
-
-		this.units[this.currentIndex++] = null;
-		if (this.currentIndex >= this.size)
-			this.currentIndex = 0;
-		if (this.sleepCount >= 1 && ++this.sleepCount > 4) {
-			notify(); // wake up processing thread to add next unit but only after removing some elements first
-			yield = this.sleepCount > 8;
-		}
+			} catch (InterruptedException interrupt) {
+				throw new AbortCompilation(true/* silent */, new RuntimeException(interrupt));
+			}
+			if (next instanceof Error error) {
+				throw error;
+			}
+			if (next instanceof RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			if (next == STOP_SIGNAL) {
+				return Collections.emptyList();
+			}
+			throw new IllegalStateException("Received unexpected element to process: " + String.valueOf(next)); //$NON-NLS-1$
+		} while (true);
 	}
-	if (yield)
-		Thread.yield();
-	return next;
-}
 
-private void compile() {
-	int unitIndex = this.startingIndex;
-	synchronized (this) { // wait until processingTask is assigned
-		@SuppressWarnings("unused")
-		Future<?> p = this.processingTask;
-	}
-	boolean noAnnotations = this.compiler.annotationProcessorManager == null;
-	while (this.processingTask != null) {
-		this.unitToProcess = null;
-		int index = -1;
-		boolean cleanup = noAnnotations || this.compiler.shouldCleanup(unitIndex);
+	private void processing() {
 		try {
-			synchronized (this) {
-				if (this.processingTask == null) return;
+			int unitIndex = this.startingIndex;
+			boolean noAnnotations = this.compiler.annotationProcessorManager == null;
+			while (this.processing) {
+				int index = unitIndex++;
+				boolean cleanup = noAnnotations || this.compiler.shouldCleanup(index);
+				CompilationUnitDeclaration unitToProcess = this.compiler.getUnitToProcess(index);
+				try {
+					if (unitToProcess == null) {
+						break;
+					}
+					if (unitToProcess.compilationResult.hasBeenAccepted) {
+						continue;
+					}
 
-				this.unitToProcess = this.compiler.getUnitToProcess(unitIndex);
-				if (this.unitToProcess == null) {
-					this.processingTask = null;
+					try {
+						this.compiler.reportProgress(Messages.bind(Messages.compilation_processing,
+								new String(unitToProcess.getFileName())));
+						if (this.compiler.options.verbose)
+							this.compiler.out.println(Messages.bind(Messages.compilation_process,
+									new String[] { String.valueOf(index + 1), String.valueOf(this.compiler.totalUnits),
+											new String(unitToProcess.getFileName()) }));
+						try {
+							this.compiler.process(unitToProcess, index);
+						} catch (AbortCompilation abortCompilation) {
+							throw abortCompilation;
+						} catch (Error | RuntimeException uncheckedThrowable) {
+							throw new RuntimeException(
+									"Internal Error compiling " + new String(unitToProcess.getFileName()), //$NON-NLS-1$
+									uncheckedThrowable);
+						}
+					} finally {
+						// cleanup compilation unit result, but only if not annotation processed.
+						if (cleanup) {
+							unitToProcess.cleanUp();
+						}
+					}
+
+					addNextUnit(unitToProcess);
+				} catch (Error | RuntimeException uncheckedThrowable) {
+					this.units.clear(); // make sure there is room for a premature stop signal
+					synchronized (this) {
+						this.unitWithError = unitToProcess;
+					}
+					addNextUnit(uncheckedThrowable);
 					return;
 				}
-				index = unitIndex++;
-				if (this.unitToProcess.compilationResult.hasBeenAccepted)
-					continue;
 			}
-
-			try {
-				this.compiler.reportProgress(Messages.bind(Messages.compilation_processing, new String(this.unitToProcess.getFileName())));
-				if (this.compiler.options.verbose)
-					this.compiler.out.println(
-						Messages.bind(Messages.compilation_process,
-						new String[] {
-							String.valueOf(index + 1),
-							String.valueOf(this.compiler.totalUnits),
-							new String(this.unitToProcess.getFileName())
-						}));
-				try {
-					this.compiler.process(this.unitToProcess, index);
-				} catch (AbortCompilation keptCancelation) {
-					throw keptCancelation;
-				} catch (Error | RuntimeException e) {
-					throw new RuntimeException("Internal Error compiling " + new String(this.unitToProcess.getFileName()), e); //$NON-NLS-1$
-				}
-			} finally {
-				// cleanup compilation unit result, but only if not annotation processed.
-				if (this.unitToProcess != null && cleanup)
-					this.unitToProcess.cleanUp();
-			}
-
-			addNextUnit(this.unitToProcess);
-		} catch (Error | RuntimeException e) {
-			synchronized (this) {
-				this.processingTask = null;
-				this.caughtException = e;
-			}
-			return;
+		} finally {
+			addNextUnit(STOP_SIGNAL);
 		}
 	}
-}
-
-public void shutdown() {
-	try {
-		Future<?> t = null;
-		synchronized (this) {
-			t = this.processingTask;
-			if (t != null) {
-				// stop processing on error:
-				this.processingTask = null;
-				notifyAll();
-			}
-		}
-		if (t != null) {
-			t.get(250, TimeUnit.MILLISECONDS); // do not wait forever
-		}
-	} catch (InterruptedException | ExecutionException | TimeoutException ignored) {
-		// ignore
+	synchronized CompilationUnitDeclaration getUnitWithError(){
+		return this.unitWithError;
 	}
-}
+
+	@Override
+	public void close() {
+		// On exceptional handling (error/cancel) the processingTask could be still running.
+		// stop it:
+		this.processing = false;
+		this.units.clear(); // no longer needed and allows addNextUnit() to progress if blocked
+		this.processingTask.cancel(true); // interrupt whatever else the task is doing
+	}
 }

--- a/org.eclipse.jdt.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core/META-INF/MANIFEST.MF
@@ -42,7 +42,7 @@ Export-Package: org.eclipse.jdt.core,
  org.eclipse.jdt.internal.formatter;x-friends:="org.eclipse.jdt.core.tests.model, org.eclipse.jdt.core.tests.compiler, org.eclipse.jdt.core.tests.builder, org.eclipse.jdt.core.tests.performance, org.eclipse.jdt.ui.tests, org.eclipse.jdt.ui.tests",
  org.eclipse.jdt.internal.formatter.linewrap;x-friends:="org.eclipse.jdt.core.tests.model, org.eclipse.jdt.core.tests.compiler, org.eclipse.jdt.core.tests.builder, org.eclipse.jdt.core.tests.performance, org.eclipse.jdt.ui.tests",
  org.eclipse.jdt.internal.formatter.old;x-friends:="org.eclipse.jdt.core.tests.model, org.eclipse.jdt.core.tests.compiler, org.eclipse.jdt.core.tests.builder, org.eclipse.jdt.core.tests.performance, org.eclipse.jdt.ui.tests"
-Require-Bundle: org.eclipse.core.resources;bundle-version="[3.21.0,4.0.0)",
+Require-Bundle: org.eclipse.core.resources;bundle-version="[3.22.0,4.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
  org.eclipse.core.filesystem;bundle-version="[1.11.0,2.0.0)",
  org.eclipse.text;bundle-version="[3.6.0,4.0.0)",

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/AbstractImageBuilder.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/AbstractImageBuilder.java
@@ -159,9 +159,7 @@ public void acceptResult(CompilationResult result) {
 		ArrayList duplicateTypeNames = null;
 		ArrayList definedTypeNames = new ArrayList(length);
 		ArrayList<CompilationParticipantResult> postProcessingResults = new ArrayList<>();
-		for (int i = 0; i < length; i++) {
-			ClassFile classFile = classFiles[i];
-
+		for (ClassFile classFile : classFiles) {
 			char[][] compoundName = classFile.getCompoundName();
 			char[] typeName = compoundName[compoundName.length - 1];
 			boolean isNestedType = classFile.isNestedType;
@@ -1004,10 +1002,6 @@ protected char[] writeClassFile(ClassFile classFile, SourceFile compilationUnit,
 	return filePath.lastSegment().toCharArray();
 }
 
-protected void writeClassFileContents(ClassFile classFile, IFile file, String qualifiedFileName, boolean isTopLevelType, SourceFile compilationUnit) throws CoreException {
-	if (JavaBuilder.DEBUG) {
-		trace("Writing changed class file " + file.getName());//$NON-NLS-1$
-	}
-	file.write(classFile.getBytes(), true, true, false, null);
-}
+abstract protected void writeClassFileContents(ClassFile classFile, IFile file, String qualifiedFileName, boolean isTopLevelType, SourceFile compilationUnit) throws CoreException;
+
 }


### PR DESCRIPTION
ProcessTaskManager
* use java.util.concurrent for queue
* signal Cancel/Exception/Stop via the queue
* implements AutoCloseable for try-with-resource
* drain as much Elements as possible from the queue

Improves the performance of "Clean all projects"

For example building platform workspace on Windows AbstractImageBuilder.compile(): 120 sec -> 91 sec

With this change the Compiler is actually waiting for parsing most time and not for the write to FileSystem anymore.
