### PR TITLE
[23] default imports between explicit/implicit classes are in conflict

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/CompilationUnitScope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/CompilationUnitScope.java
@@ -764,9 +764,6 @@ private MethodBinding findStaticMethod(ReferenceBinding currentType, char[] sele
 	return null;
 }
 ImportBinding[] getDefaultImports() {
-	// initialize the default imports if necessary... share the default java.lang.* import
-	if (this.environment.root.defaultImports != null) return this.environment.root.defaultImports;
-
 	if (JavaFeature.IMPLICIT_CLASSES_AND_INSTANCE_MAIN_METHODS.isSupported(this.environment.globalOptions) &&
 			this.referenceContext.isSimpleCompilationUnit()) {
 		ModuleBinding module = this.environment.getModule(CharOperation.concatWith(TypeConstants.JAVA_BASE, '.'));
@@ -774,8 +771,12 @@ ImportBinding[] getDefaultImports() {
 			ImportBinding javaBase = new ImportBinding(TypeConstants.JAVA_BASE, true, module, null);
 			// No need for the java.lang.* as module java.base covers it
 			return new ImportBinding[] {javaBase};
+			// this module import is not cached, there shouldn't be many files needing it.
 		}
 	}
+	// initialize the default imports if necessary... share the default java.lang.* import
+	if (this.environment.root.defaultImports != null) return this.environment.root.defaultImports;
+
 	Binding importBinding = this.environment.getTopLevelPackage(TypeConstants.JAVA);
 	if (importBinding != null)
 		importBinding = ((PackageBinding) importBinding).getTypeOrPackage(TypeConstants.JAVA_LANG[1], module(), false);

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/parser/ImplicitlyDeclaredClassesTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/parser/ImplicitlyDeclaredClassesTest.java
@@ -315,4 +315,35 @@ public class ImplicitlyDeclaredClassesTest extends AbstractRegressionTest9 {
 						}"""},
 					"true");
 	}
+	@Test
+	public void testImplicitImport() {
+		// the explicit class must be given first to trigger https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2952
+		// the test is made as negative because we can't execute the second class
+		// and we are not interested in executing the first, which cannot see the second
+		runNegativeTest(
+				new String[] {
+					"b/B.java",
+					"""
+					package b;
+					import java.util.Collection;
+					public class B {
+						public static void print(Collection<?> col) {
+							System.out.print(col.size());
+						}
+						Zork zork;
+					}
+					""",
+					"X.java",
+					"""
+					void main() {
+						b.B.print(Collections.emptySet());
+					}"""
+				},
+				"----------\n" +
+				"1. ERROR in b\\B.java (at line 7)\n" +
+				"	Zork zork;\n" +
+				"	^^^^\n" +
+				"Zork cannot be resolved to a type\n" +
+				"----------\n");
+	}
 }


### PR DESCRIPTION
don't use the cached default `import java.lang.*` in implicitly declared classes.

fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2952
