### PR TITLE
SwitchPatternTests failing in I-builds

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/CaseStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/CaseStatement.java
@@ -391,6 +391,8 @@ private Constant resolveCasePattern(BlockScope scope, TypeBinding caseType, Type
 					scope.problemReporter().typeMismatchError(expressionType, type, e, null);
 					return Constant.NotAConstant;
 				}
+			} else {
+				this.swich.isPrimitiveSwitch = true;
 			}
 		}
 		if (e.coversType(expressionType, scope)) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
@@ -1023,7 +1023,9 @@ public class SwitchStatement extends Expression {
 		char[] arg1 = switch (exprType.id) {
 			case TypeIds.T_JavaLangLong, TypeIds.T_JavaLangFloat, TypeIds.T_JavaLangDouble, TypeIds.T_JavaLangBoolean,
 				TypeIds.T_JavaLangByte, TypeIds.T_JavaLangShort, TypeIds.T_JavaLangInteger, TypeIds.T_JavaLangCharacter->
-				exprType.signature();
+				this.isPrimitiveSwitch
+				? exprType.signature()
+				: "Ljava/lang/Object;".toCharArray(); //$NON-NLS-1$
 			default -> {
 				if (exprType.id > TypeIds.T_LastWellKnownTypeId && exprType.erasure().isBoxedPrimitiveType())
 					yield exprType.erasure().signature(); // <T extends Integer> / <? extends Short> ...


### PR DESCRIPTION
fixes issue #2982


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
fixes issue #2982 
<!-- Include relevant issues and describe how they are addressed. -->
The return value of the CallSite [used by invokedynamic of typeSwitch] has changed in Java 23 - we need to check that if its a primitive enabled switch pattern (meaning that its 23 + preview then use the new signature else old]


## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

run 
org.eclipse.jdt.core.tests.compiler.regression.SwitchPatternTest testBug574525_03 - at level 21 and 22 with a 21 and 22 jre respectively.
-- | --


<br class="Apple-interchange-newline">

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
