### PR TITLE
[23] Markdown doc comments with codeblock don't parse Javadoc tags afterwards

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/IMarkdownCommentHelper.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/IMarkdownCommentHelper.java
@@ -138,8 +138,8 @@ class MarkdownCommentHelper implements IMarkdownCommentHelper {
 		int required = this.insideFencedCodeBlock ? this.fenceLength : 3;
 		if (++this.fenceCharCount == required) {
 			this.insideFencedCodeBlock^=true;
+			this.fenceLength = this.fenceCharCount;
 		}
-		this.fenceLength = this.fenceCharCount;
 	}
 
 	@Override


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
Fixes #2980

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
