### PR TITLE
EvaluationContextWrapperTest cleanup

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/eval/EvaluationContextWrapperTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/eval/EvaluationContextWrapperTest.java
@@ -13,11 +13,11 @@
  *******************************************************************************/
 package org.eclipse.jdt.core.tests.eval;
 
-import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
 import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -91,7 +91,7 @@ public class EvaluationContextWrapperTest extends EvaluationTest {
 		super.tearDown();
 	}
 
-	public void testBug573589_StaticImport() throws JavaModelException, InstallException {
+	public void testBug573589_StaticImport() throws Exception {
 		try {
 			StringBuilder source = new StringBuilder();
 			source.append("import static java.lang.Math.max;\n");
@@ -116,7 +116,7 @@ public class EvaluationContextWrapperTest extends EvaluationTest {
 		}
 	}
 
-	public void testBug573589_StaticImport_AttachedSource() throws JavaModelException, InstallException {
+	public void testBug573589_StaticImport_AttachedSource() throws Exception {
 		try {
 			StringBuilder source = new StringBuilder();
 			source.append("import static java.lang.Math.max;\n");
@@ -142,11 +142,11 @@ public class EvaluationContextWrapperTest extends EvaluationTest {
 		}
 	}
 
-	private void compileAndDeploy15(String source, String className) {
+	private void compileAndDeploy15(String source, String className) throws Exception {
 		compileAndDeploy15(source, className, "");
 	}
 
-	private Map<String, String> compileAndDeploy15(String source, String className, String locationPrefix) {
+	private Map<String, String> compileAndDeploy15(String source, String className, String locationPrefix) throws Exception {
 		resetEnv(); // needed to reinitialize the caches
 		String srcDir = this.project.getProject().getLocation().toFile().getAbsolutePath() + File.separator + SOURCE_DIRECTORY.concat(locationPrefix);
 		String binDir = this.project.getProject().getLocation().toFile().getAbsolutePath() + File.separator + BIN_DIR.concat(locationPrefix);
@@ -156,22 +156,11 @@ public class EvaluationContextWrapperTest extends EvaluationTest {
 
 		File directory = new File(srcDir);
 		if (!directory.exists()) {
-			if (!directory.mkdir()) {
-				System.out.println("Could not create " + srcDir);
-				return result;
-			}
+			Files.createDirectories(directory.toPath());
 		}
 
 		String fileName = srcDir + File.separator + className + ".java";
-		try {
-			BufferedWriter writer = new BufferedWriter(new FileWriter(fileName));
-			writer.write(source);
-			writer.flush();
-			writer.close();
-		} catch(IOException e) {
-			e.printStackTrace();
-			return result;
-		}
+		Files.write(Paths.get(fileName), source.getBytes());
 		StringBuilder buffer = new StringBuilder();
 		buffer
 			.append("\"")
@@ -182,16 +171,19 @@ public class EvaluationContextWrapperTest extends EvaluationTest {
 			.append(Util.getJavaClassLibsAsString())
 			.append(srcDir)
 			.append("\"");
-		BatchCompiler.compile(buffer.toString(), new PrintWriter(System.out), new PrintWriter(System.err), null/*progress*/);
+		StringWriter out = new StringWriter();
+		StringWriter err = new StringWriter();
+		PrintWriter errWriter = new PrintWriter(out);
+		PrintWriter outWriter = new PrintWriter(err);
+		boolean compiled = BatchCompiler.compile(buffer.toString(), outWriter, errWriter, null/*progress*/);
+		if (!compiled) {
+			fail("Failed to compile '" + className + "', system error: '" + err.toString() + "', system out: '" + out.toString()+ "'");
+		}
 		return result;
 	}
 
-	private void refreshProject() {
-		try {
-			this.project.getProject().refreshLocal(IResource.DEPTH_INFINITE, null);
-		} catch (CoreException e1) {
-			e1.printStackTrace();
-		}
+	private void refreshProject() throws Exception {
+		this.project.getProject().refreshLocal(IResource.DEPTH_INFINITE, null);
 	}
 
 	private void removeTempClass(String className) {
@@ -261,10 +253,7 @@ public class EvaluationContextWrapperTest extends EvaluationTest {
 		IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
 		IProject proj = root.getProject(name);
 		if (proj.exists()) {
-        	try {
-        		proj.delete(true, true, null);
-        	}
-        	catch(Exception e) {}
+			proj.delete(true, true, null);
         }
 		proj = root.getProject(name);
 		proj.create(null);
@@ -300,31 +289,19 @@ public class EvaluationContextWrapperTest extends EvaluationTest {
         return jproject;
 	}
 
-	private void addSourceContainer(IJavaProject prj, String name) {
+	private void addSourceContainer(IJavaProject prj, String name) throws Exception {
 		IFolder folder = prj.getProject().getFolder(name);
 		if(!folder.exists()) {
-			try {
-				folder.create(false, true, null);
-			} catch (CoreException e) {
-				throw new AssertionError(e);
-			}
+			folder.create(false, true, null);
 		}
 		IClasspathEntry entry = JavaCore.newSourceEntry(prj.getPackageFragmentRoot(folder).getPath());
-		try {
-			prj.setRawClasspath(addToClasspath(prj.getRawClasspath(), entry), null);
-		} catch (JavaModelException e) {
-			throw new AssertionError(e);
-		}
+		prj.setRawClasspath(addToClasspath(prj.getRawClasspath(), entry), null);
 	}
 
-	private void addLibrary(IJavaProject prj, String path, String sourcePath) {
+	private void addLibrary(IJavaProject prj, String path, String sourcePath) throws Exception {
 		IClasspathEntry entry = JavaCore.newLibraryEntry(new Path(path), Optional.ofNullable(sourcePath).map(Path::new).orElse(null),
 				Optional.ofNullable(sourcePath).map(p -> new Path(path)).orElse(null));
-		try {
-			prj.setRawClasspath(addToClasspath(prj.getRawClasspath(), entry), null);
-		} catch (JavaModelException e) {
-			throw new AssertionError(e);
-		}
+		prj.setRawClasspath(addToClasspath(prj.getRawClasspath(), entry), null);
 	}
 
 	private static IClasspathEntry[] addToClasspath(IClasspathEntry[] original, IClasspathEntry add) {


### PR DESCRIPTION
- don't hide exceptions
- use nio to properly report failures
- record and print compiler output on fail

See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2998
