### PR TITLE
Compiler has trouble parsing multipattern case label expressions.

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchPatternTest21.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchPatternTest21.java
@@ -836,4 +836,126 @@ public class SwitchPatternTest21 extends AbstractBatchCompilerTest {
 						""", },
 				"success");
 	}
+
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2070
+	// [Switch] Compiler is unable to parse a particular multicase construct
+	public void testIssue2070() {
+		runConformTest(
+				new String[] {
+						"X.java",
+						"""
+						public class X {
+						    public boolean foo(Object o) {
+						    	return switch (o) {
+						    	case Integer _, Integer[] _ -> true;
+						    		default -> false;
+						    	};
+						    }
+						    public static void main(String argv[]) {
+						    	System.out.println(new X().foo(new Object()));
+						    }
+						}
+						"""
+				},
+			"false");
+	}
+
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2956
+	// Unnamed patterns inside of multi case patterns fail to parse
+	public void testIssue2956() {
+		runConformTest(
+				new String[] {
+						"Main.java",
+						"""
+						public class Main {
+						    public sealed interface MyType {
+						        record A() implements MyType {
+						        }
+
+						        record B(int value) implements MyType {
+						        }
+
+						        record C() implements MyType {
+						        }
+						    }
+
+						    public static void main(String[] args) {
+						        MyType myType = new MyType.A();
+						        switch (myType) {
+						            case MyType.A(), MyType.B(_) -> { System.out.println("A or B");}
+						            case MyType.C() -> {}
+						        }
+						    }
+						}
+						"""
+				},
+			"A or B");
+	}
+
+
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2956
+	// Unnamed patterns inside of multi case patterns fail to parse
+	public void testIssue2956_2() {
+		runConformTest(
+				new String[] {
+						"Main.java",
+						"""
+						public class Main {
+						    public sealed interface MyType {
+						        record A() implements MyType {
+						        }
+
+						        record B(int value) implements MyType {
+						        }
+
+						        record C() implements MyType {
+						        }
+						    }
+
+						    public static void main(String[] args) {
+						        MyType myType = new MyType.A();
+						        switch (myType) {
+						            case MyType.A()  ->  { System.out.println("A");}
+						            case MyType.B(_) ->  { System.out.println("B");}
+						            case MyType.C()  ->  { System.out.println("C");}
+						        }
+						    }
+						}
+						"""
+				},
+			"A");
+	}
+
+
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2956
+	// Unnamed patterns inside of multi case patterns fail to parse
+	public void testIssue2956_3() {
+		runConformTest(
+				new String[] {
+						"Main.java",
+						"""
+						public class Main {
+						    public sealed interface MyType {
+						        record A() implements MyType {
+						        }
+
+						        record B(int value) implements MyType {
+						        }
+
+						        record C() implements MyType {
+						        }
+						    }
+
+						    public static void main(String[] args) {
+						        MyType myType = new MyType.A();
+						        switch (myType) {
+						            case MyType.B(_), MyType.A()  -> { System.out.println("A or B");}
+						            case MyType.C() -> {}
+						        }
+						    }
+						}
+						"""
+				},
+			"A or B");
+	}
 }


### PR DESCRIPTION
## What it does

* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2956
* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2070

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
