### PR TITLE
Create warning when parsing targets too new Java versions

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/core/compiler/IProblem.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/core/compiler/IProblem.java
@@ -2231,6 +2231,8 @@ void setSourceStart(int sourceStart);
 	int PreviewAPIUsed = Compliance + 1108;
 	/** @since 3.39*/
 	int JavaVersionNotSupported = Compliance + 1109;
+	/** @since 3.40*/
+	int JavaVersionTooRecent = Compliance + 1110;
 
 	/** @since 3.13 */
 	int UnlikelyCollectionMethodArgumentType = 1200;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/impl/CompilerOptions.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/impl/CompilerOptions.java
@@ -433,6 +433,14 @@ public class CompilerOptions {
 	public long complianceLevel;
 	/** Java source level, refers to a JDK version, e.g. {@link ClassFileConstants#JDK1_4} */
 	public long sourceLevel;
+	/**
+	 * Initially requested source version, not necessarily consistent with {@link #sourceLevel} as
+	 * sourceLevel forcibly contain a version that is compatible with ECJ.
+	 * <p>Consumers are free to use {@code sourceLevel} or this
+	 * {@code requestedSourceVersion} value to decide of their behavior.</p>
+	 * <p>May be {@code null}.</p>
+	 */
+	public String requestedSourceVersion;
 	/** VM target level, refers to a JDK version, e.g. {@link ClassFileConstants#JDK1_4} */
 	public long targetJDK;
 	/** Source encoding format */
@@ -1769,7 +1777,7 @@ public class CompilerOptions {
 			long level = versionToJdkLevel(optionValue);
 			if (level != 0) this.complianceLevel = level;
 		}
-		if ((optionValue = optionsMap.get(OPTION_Source)) != null) {
+		if ((this.requestedSourceVersion = optionValue = optionsMap.get(OPTION_Source)) != null) {
 			long level = versionToJdkLevel(optionValue);
 			if (level != 0) this.sourceLevel = level;
 		}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
@@ -37,6 +37,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.Runtime.Version;
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -12832,6 +12833,21 @@ public CompilationUnitDeclaration parse(
 					this.problemReporter,
 					compilationResult,
 					0);
+
+		var problemReporterContext = this.problemReporter.referenceContext;
+		this.problemReporter.referenceContext = this.referenceContext;
+		if (this.problemReporter != null && this.options != null && this.options.requestedSourceVersion != null && !this.options.requestedSourceVersion.isBlank()) {
+			try {
+				var requestedVersion = Version.parse(this.options.requestedSourceVersion);
+				var latestVersion = Version.parse(CompilerOptions.getLatestVersion());
+				if (requestedVersion.compareTo(latestVersion) > 0) {
+					this.problemReporter.tooRecentJavaVersion(requestedVersion.toString(), latestVersion.toString());
+				}
+			} catch (Exception ex) {
+				this.problemReporter.abortDueToInternalError(ex.getMessage());
+			}
+		}
+		this.problemReporter.referenceContext = problemReporterContext;
 
 		/* scanners initialization */
 		char[] contents;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
@@ -826,6 +826,16 @@ public void abortDueToNotSupportedJavaVersion(String notSupportedVersion, String
 			0,
 			0);
 }
+public void tooRecentJavaVersion(String notSupportedVersion, String firstSupportedVersion) {
+	String[] args = new String[] {notSupportedVersion, firstSupportedVersion};
+	this.handle(
+			IProblem.JavaVersionTooRecent,
+			args,
+			args,
+			ProblemSeverities.Warning,
+			0,
+			0);
+}
 public void abstractMethodCannotBeOverridden(SourceTypeBinding type, MethodBinding concreteMethod) {
 
 	this.handle(

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/messages.properties
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/messages.properties
@@ -908,6 +908,7 @@
 1107 = The Java feature ''{0}'' is only available with source level {1} and above
 1108 = You are using an API that is part of a preview feature and may be removed in future
 1109 = Compiling for Java version ''{0}'' is no longer supported. Minimal supported version is ''{1}''
+1110 = Compiling for Java version ''{0}'' is not supported yet. Using ''{1}'' instead
 # more programming problems:
 1200 = Unlikely argument type {0} for {1} on a {2}
 1201 = Unlikely argument type for equals(): {0} seems to be unrelated to {2}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/CompilerInvocationTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/CompilerInvocationTests.java
@@ -65,6 +65,7 @@ import org.eclipse.jdt.core.compiler.CategorizedProblem;
 import org.eclipse.jdt.core.compiler.IProblem;
 import org.eclipse.jdt.internal.compiler.CompilationResult;
 import org.eclipse.jdt.internal.compiler.ICompilerRequestor;
+import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jdt.internal.compiler.impl.IrritantSet;
 import org.eclipse.jdt.internal.compiler.problem.DefaultProblemFactory;
@@ -1247,6 +1248,7 @@ public void test011_problem_categories() {
 	    expectedProblemAttributes.put("FeatureNotSupported", new ProblemAttributes(CategorizedProblem.CAT_COMPLIANCE));
 	    expectedProblemAttributes.put("PreviewAPIUsed", new ProblemAttributes(CategorizedProblem.CAT_COMPLIANCE));
 	    expectedProblemAttributes.put("JavaVersionNotSupported", new ProblemAttributes(CategorizedProblem.CAT_COMPLIANCE));
+	    expectedProblemAttributes.put("JavaVersionTooRecent", new ProblemAttributes(CategorizedProblem.CAT_COMPLIANCE));
 	    expectedProblemAttributes.put("SwitchExpressionsYieldIncompatibleResultExpressionTypes", new ProblemAttributes(CategorizedProblem.CAT_TYPE));
 	    expectedProblemAttributes.put("SwitchExpressionsYieldEmptySwitchBlock", new ProblemAttributes(CategorizedProblem.CAT_SYNTAX));
 	    expectedProblemAttributes.put("SwitchExpressionsYieldNoResultExpression", new ProblemAttributes(CategorizedProblem.CAT_INTERNAL));
@@ -2381,6 +2383,7 @@ public void test012_compiler_problems_tuning() {
 	    expectedProblemAttributes.put("FeatureNotSupported", SKIP);
 	    expectedProblemAttributes.put("PreviewAPIUsed", SKIP);
 	    expectedProblemAttributes.put("JavaVersionNotSupported", SKIP);
+	    expectedProblemAttributes.put("JavaVersionTooRecent", SKIP);
 	    expectedProblemAttributes.put("SwitchExpressionsYieldIncompatibleResultExpressionTypes", SKIP);
 	    expectedProblemAttributes.put("SwitchExpressionsYieldEmptySwitchBlock", SKIP);
 	    expectedProblemAttributes.put("SwitchExpressionsYieldNoResultExpression", SKIP);
@@ -2581,5 +2584,25 @@ public void test012_compiler_problems_tuning() {
 				return true;
 		}
 		return false;
+	}
+
+	public void testTooNewJavaVersionRequested() {
+		Map<String, String> options = new HashMap<>(JavaCore.getDefaultOptions());
+		String latestJavaVersionSupportedByECJ = CompilerOptions.versionFromJdkLevel(ClassFileConstants.getLatestJDKLevel());
+		String message = """
+			----------
+			1. WARNING in A.java (at line 1)
+				class A{}
+				^
+			Compiling for Java version 'XXX0' is not supported yet. Using 'XXX' instead
+			----------
+			""".replaceAll("XXX", latestJavaVersionSupportedByECJ);
+		options.put(CompilerOptions.OPTION_Source, latestJavaVersionSupportedByECJ + "0");
+		runNegativeTest(new String[] {"A.java", "class A{}"},
+				message,
+				null,
+				false,
+				null,
+				options);
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3018

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does

Create a warning when options specify a new Java source version

## How to test

* Create a basic Java Project and a basic Java file in it
* Verify there is no error
* Edit the .settings/org.eclipse.jdt.core.prefs, set the value of `org.eclipse.jdt.core.compiler.compliance` to `24` (basically last version support by ECJ + 1).
* Reopen the file, edit => a warning is now shown "Java language version '24' is not supported, using version '23' instead"


## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
