### PR TITLE
EmptyStackException when invoking a static method on a null literal in a ternary operator

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ConditionalExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ConditionalExpression.java
@@ -331,10 +331,12 @@ public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext,
 				// End of if statement
 				endifLabel.place();
 			}
-			if (this.valueIfFalse.resolvedType == TypeBinding.NULL) {
-				if (!this.resolvedType.isBaseType()) {
-					codeStream.operandStack.pop(TypeBinding.NULL);
-					codeStream.operandStack.push(this.resolvedType);
+			if (valueRequired) {
+				if (this.valueIfFalse.resolvedType == TypeBinding.NULL) {
+					if (!this.resolvedType.isBaseType()) {
+						codeStream.operandStack.pop(TypeBinding.NULL);
+						codeStream.operandStack.push(this.resolvedType);
+					}
 				}
 			}
 		}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ConditionalExpressionTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ConditionalExpressionTest.java
@@ -657,4 +657,92 @@ public class ConditionalExpressionTest extends AbstractRegressionTest {
 				},
 				"42");
 	}
+
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3042
+	// java.util.EmptyStackException: null when invoking a static method on a null string literal in a ternary operator
+	public void testIssue3042() {
+		if (this.complianceLevel < ClassFileConstants.JDK14)
+			return;
+		this.runConformTest(
+				new String[] {
+						"X.java",
+						"""
+						public class X {
+
+							static void parseFailure(X o) {
+								(o != null ? o : null).bar();
+							}
+
+							static void bar() {
+								System.out.println("Bar!");
+							}
+
+							public static void main(String[] args) {
+								parseFailure(new X());
+								parseFailure(null);
+							}
+						}
+						"""
+				},
+				"Bar!\nBar!");
+	}
+
+	public void testIssue3042_2() {
+		if (this.complianceLevel < ClassFileConstants.JDK14)
+			return;
+		this.runConformTest(
+				new String[] {
+						"X.java",
+						"""
+						public class X {
+
+							void parseFailure(X o) {
+								(o != null ? o : null).bar();
+							}
+
+							void bar() {
+								System.out.println("Bar!");
+							}
+
+							public static void main(String[] args) {
+								new X().parseFailure(new X());
+								try {
+									new X().parseFailure(null);
+								} catch (NullPointerException npe) {
+									System.out.println("NPE!");
+								}
+							}
+						}
+						"""
+				},
+				"Bar!\nNPE!");
+	}
+
+	public void testIssue3042_3() {
+		if (this.complianceLevel < ClassFileConstants.JDK14)
+			return;
+		this.runConformTest(
+				new String[] {
+						"X.java",
+						"""
+						public class X {
+
+							void parseSuccess(X o) {
+								(o == null ? null : o).bar();
+								((X) null).bar();
+							}
+
+							static void bar() {
+								System.out.println("Bar!");
+							}
+
+							public static void main(String[] args) {
+								new X().parseSuccess(new X());
+								new X().parseSuccess(null);
+							}
+						}
+						"""
+				},
+				"Bar!\nBar!\nBar!\nBar!");
+	}
 }


### PR DESCRIPTION

## What it does

* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3042

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
