### PR TITLE
NON-NLS tag ignored for specific method references targeting a string literal

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ReferenceExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ReferenceExpression.java
@@ -125,7 +125,7 @@ public class ReferenceExpression extends FunctionalExpression implements IPolyEx
 		char [] source = new char [this.sourceEnd+1];
 		System.arraycopy(this.text, 0, source, this.sourceStart, this.sourceEnd - this.sourceStart + 1);
 		parser.scanner = this.scanner;
-		ReferenceExpression copy =  (ReferenceExpression) parser.parseExpression(source, this.sourceStart, this.sourceEnd - this.sourceStart + 1,
+		ReferenceExpression copy =  (ReferenceExpression) parser.parseReferenceExpression(source, this.sourceStart, this.sourceEnd - this.sourceStart + 1,
 										this.enclosingScope.referenceCompilationUnit(), false /* record line separators */);
 		copy.original = this;
 		copy.sourceStart = this.sourceStart;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
@@ -932,7 +932,7 @@ private boolean haltOnSyntaxError = false;
 private boolean tolerateDefaultClassMethods = false;
 private boolean processingLambdaParameterList = false;
 private boolean expectTypeAnnotation = false;
-private boolean reparsingLambdaExpression = false;
+private boolean reparsingFunctionalExpression = false;
 
 private Map<TypeDeclaration, Integer[]> recordNestedMethodLevels;
 private Map<Integer, Boolean> recordPatternSwitches;
@@ -9406,7 +9406,7 @@ private void consumeTextBlock() {
 private TextBlock createTextBlock(char[] allchars, int start, int end) {
 	TextBlock textBlock;
 	if (this.recordStringLiterals &&
-			!this.reparsingLambdaExpression &&
+			!this.reparsingFunctionalExpression &&
 			this.checkExternalizeStrings &&
 			this.lastPosistion < this.scanner.currentPosition &&
 			!this.statementRecoveryActivated) {
@@ -9873,7 +9873,7 @@ protected void consumeToken(int type) {
 		case TokenNameStringLiteral :
 			StringLiteral stringLiteral;
 			if (this.recordStringLiterals &&
-					!this.reparsingLambdaExpression &&
+					!this.reparsingFunctionalExpression &&
 					this.checkExternalizeStrings &&
 					this.lastPosistion < this.scanner.currentPosition &&
 					!this.statementRecoveryActivated) {
@@ -13133,7 +13133,7 @@ private ASTNode[] parseBodyDeclarations(char[] source, int offset, int length, C
 
 public Expression parseLambdaExpression(char[] source, int offset, int length, CompilationUnitDeclaration unit, boolean recordLineSeparators) {
 	this.haltOnSyntaxError = true; // unexposed/unshared object, no threading concerns.
-	this.reparsingLambdaExpression = true;
+	this.reparsingFunctionalExpression = true;
 	return parseExpression(source, offset, length, unit, recordLineSeparators);
 }
 
@@ -13159,6 +13159,10 @@ public char[][] parsePackageDeclaration(char[] source, CompilationResult result)
 
 	return this.compilationUnit.currentPackage == null ? null : this.compilationUnit.currentPackage.getImportName();
 
+}
+public Expression parseReferenceExpression(char[] source, int offset, int length, CompilationUnitDeclaration unit, boolean recordLineSeparators) {
+	this.reparsingFunctionalExpression = true;
+	return parseExpression(source, offset, length, unit, recordLineSeparators);
 }
 public Expression parseExpression(char[] source, int offset, int length, CompilationUnitDeclaration unit, boolean recordLineSeparators) {
 

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ExternalizeStringLiteralsTest_1_5.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ExternalizeStringLiteralsTest_1_5.java
@@ -270,6 +270,39 @@ public void test007() {
 		true,
 		customOptions);
 }
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3025
+// NON-NLS tag ignored for specific method references targeting a string literal
+public void testIssue3025() {
+	Map customOptions = getCompilerOptions();
+	customOptions.put(CompilerOptions.OPTION_ReportNonExternalizedStringLiteral, CompilerOptions.ERROR);
+	this.runNegativeTest(
+		new String[] {
+			"X.java",
+			"""
+			import java.util.List;
+			import java.util.function.Predicate;
+
+			public class X {
+				public static void main(String[] args) {
+					List<String> list = List.<String>of();
+					list.removeIf("."::equals); //$NON-NLS-1$
+					list.removeIf(e -> "..".equals(e)); //$NON-NLS-1$
+					list.removeIf((Predicate<String>) "..."::equals); //$NON-NLS-1$
+					System.out.println("....");
+				}
+			}
+			""",
+		},
+		"----------\n" +
+		"1. ERROR in X.java (at line 10)\n" +
+		"	System.out.println(\"....\");\n" +
+		"	                   ^^^^^^\n" +
+		"Non-externalized string literal; it should be followed by //$NON-NLS-<n>$\n" +
+		"----------\n",
+		null,
+		true,
+		customOptions);
+}
 public static Class testClass() {
 	return ExternalizeStringLiteralsTest_1_5.class;
 }


### PR DESCRIPTION


## What it does
* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3025

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
