### PR TITLE
[Switch][Record Patterns] Unchecked conversion error missing from ECJ

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/CaseStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/CaseStatement.java
@@ -384,7 +384,7 @@ private Constant resolveCasePattern(BlockScope scope, TypeBinding caseType, Type
 			if (expressionType != TypeBinding.NULL && !(e instanceof RecordPattern)) {
 				boolean isLegal = e.checkCastTypesCompatibility(scope, type, expressionType, e, false);
 				if (!isLegal || (e.bits & ASTNode.UnsafeCast) != 0) {
-					scope.problemReporter().unsafeCastInInstanceof(e, type, expressionType);
+					scope.problemReporter().unsafeCastInTestingContext(e, type, expressionType);
 				}
 			}
 		} else if (type.isValidBinding()) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/CaseStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/CaseStatement.java
@@ -384,12 +384,6 @@ private Constant resolveCasePattern(BlockScope scope, TypeBinding caseType, Type
 			if (!e.isApplicable(switchExpressionType, scope, e)) {
 				return Constant.NotAConstant;
 			}
-			if (expressionType != TypeBinding.NULL && !(e instanceof RecordPattern)) {
-				boolean isLegal = e.checkCastTypesCompatibility(scope, type, expressionType, e, false);
-				if (!isLegal || (e.bits & ASTNode.UnsafeCast) != 0) {
-					scope.problemReporter().unsafeCastInTestingContext(e, type, expressionType);
-				}
-			}
 		} else if (type.isValidBinding()) {
 			// if not a valid binding, an error has already been reported for unresolved type
 			if (Pattern.findPrimitiveConversionRoute(type, expressionType, scope) == PrimitiveConversionRoute.NO_CONVERSION_ROUTE) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/CaseStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/CaseStatement.java
@@ -381,6 +381,9 @@ private Constant resolveCasePattern(BlockScope scope, TypeBinding caseType, Type
 		// The following code is copied from InstanceOfExpression#resolve()
 		// But there are enough differences to warrant a copy
 		if (!type.isReifiable()) {
+			if (!e.isApplicable(switchExpressionType, scope, e)) {
+				return Constant.NotAConstant;
+			}
 			if (expressionType != TypeBinding.NULL && !(e instanceof RecordPattern)) {
 				boolean isLegal = e.checkCastTypesCompatibility(scope, type, expressionType, e, false);
 				if (!isLegal || (e.bits & ASTNode.UnsafeCast) != 0) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/EitherOrMultiPattern.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/EitherOrMultiPattern.java
@@ -55,6 +55,13 @@ public class EitherOrMultiPattern extends Pattern {
 	}
 
 	@Override
+	public void setOuterExpressionType(TypeBinding expressionType) {
+		super.setOuterExpressionType(expressionType);
+		for (int i = 0; i < this.patternsCount; i++)
+			this.patterns[i].setOuterExpressionType(expressionType);
+	}
+
+	@Override
 	public TypeBinding resolveType(BlockScope scope) {
 		boolean hasError = false;
 		for (int i = 0; i < this.patternsCount; i++) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/GuardedPattern.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/GuardedPattern.java
@@ -77,6 +77,12 @@ public class GuardedPattern extends Pattern {
 	}
 
 	@Override
+	public void setOuterExpressionType(TypeBinding expressionType) {
+		super.setOuterExpressionType(expressionType);
+		this.primaryPattern.setOuterExpressionType(expressionType);
+	}
+
+	@Override
 	public boolean coversType(TypeBinding type, Scope scope) {
 		return isUnguarded() && this.primaryPattern.coversType(type, scope);
 	}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/GuardedPattern.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/GuardedPattern.java
@@ -130,7 +130,7 @@ public class GuardedPattern extends Pattern {
 	}
 
 	@Override
-	protected boolean isApplicable(TypeBinding other, BlockScope scope) {
-		return this.primaryPattern.isApplicable(other, scope);
+	protected boolean isApplicable(TypeBinding expressionType, BlockScope scope, ASTNode location) {
+		return this.primaryPattern.isApplicable(expressionType, scope, location);
 	}
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/InstanceOfExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/InstanceOfExpression.java
@@ -289,7 +289,7 @@ public TypeBinding resolveType(BlockScope scope) {
 			if (expressionType != TypeBinding.NULL) {
 				boolean isLegal = checkCastTypesCompatibility(scope, checkedType, expressionType, this.expression, true);
 				if (!isLegal || (this.bits & ASTNode.UnsafeCast) != 0) {
-					scope.problemReporter().unsafeCastInInstanceof(this.expression, checkedType, expressionType);
+					scope.problemReporter().unsafeCastInTestingContext(this.expression, checkedType, expressionType);
 				} else  {
 					checkRefForPrimitivesAndAddSecretVariable(scope, checkedType, expressionType);
 				}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/InstanceOfExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/InstanceOfExpression.java
@@ -277,6 +277,9 @@ public TypeBinding resolveType(BlockScope scope) {
 	if (expressionType == null || checkedType == null)
 		return null;
 
+	if (this.pattern instanceof RecordPattern) // subsequent tests are not relevant for RecordPatterns
+		return this.resolvedType = TypeBinding.BOOLEAN;
+
 	if (!checkedType.isReifiable()) {
 		CompilerOptions options = scope.compilerOptions();
 		// Report same as before for older compliances

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Pattern.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Pattern.java
@@ -165,7 +165,7 @@ public abstract class Pattern extends Expression {
 				applicable = false;
 			}
 			if ((this.bits & ASTNode.UnsafeCast) != 0) {
-				scope.problemReporter().unsafeCastInInstanceof(this, this.outerExpressionType, patternType);
+				scope.problemReporter().unsafeCastInTestingContext(this, patternType, this.outerExpressionType);
 			}
 		}
 		return applicable;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Pattern.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Pattern.java
@@ -139,36 +139,39 @@ public abstract class Pattern extends Expression {
 	}
 
 	// 14.30.3 Properties of Patterns: A pattern p is said to be applicable at a type T if ...
-	protected boolean isApplicable(TypeBinding other, BlockScope scope) {
-		TypeBinding patternType = this.resolvedType;
-		if (patternType == null) // ill resolved pattern
-			return false;
+	protected boolean isApplicable(TypeBinding expressionType, BlockScope scope, ASTNode location) {
+		if (expressionType == TypeBinding.NULL)
+			return true;
+		TypeReference typeRef = getType();
+		if (typeRef == null)
+			return true; // nothing to be checked for wildcard '_'
+		TypeBinding patternType = typeRef.resolvedType;
+		if (patternType == null || !patternType.isValidBinding() || !expressionType.isValidBinding())
+			return false; // problem already reported
+
 		// 14.30.3 Properties of Patterns doesn't allow boxing nor unboxing, primitive widening/narrowing (< JLS23)
-		if (patternType.isBaseType() != other.isBaseType() && !JavaFeature.PRIMITIVES_IN_PATTERNS.isSupported(scope.compilerOptions())) {
-			scope.problemReporter().incompatiblePatternType(this, other, patternType);
+		if (patternType.isBaseType() != expressionType.isBaseType() && !JavaFeature.PRIMITIVES_IN_PATTERNS.isSupported(scope.compilerOptions())) {
+			scope.problemReporter().notCompatibleTypesError(location, expressionType, patternType);
 			return false;
 		}
-		boolean applicable = true;
 		if (patternType.isBaseType()) {
 			PrimitiveConversionRoute route = Pattern.findPrimitiveConversionRoute(this.resolvedType, this.outerExpressionType, scope);
-			if (!TypeBinding.equalsEquals(other, patternType)
+			if (!TypeBinding.equalsEquals(expressionType, patternType)
 					&& route == PrimitiveConversionRoute.NO_CONVERSION_ROUTE) {
-				scope.problemReporter().incompatiblePatternType(this, other, patternType);
+				scope.problemReporter().notCompatibleTypesError(location, expressionType, patternType);
 				return false;
 			}
 		} else {
-			if (!checkCastTypesCompatibility(scope, patternType, other, null, true)) {
-				if (this.enclosingPattern != null) {
-					scope.problemReporter().incompatiblePatternType(this, other, patternType);
-					return false;
-				}
-				applicable = false;
+			if (!checkCastTypesCompatibility(scope, patternType, expressionType, null, true)) {
+				scope.problemReporter().notCompatibleTypesError(location, expressionType, patternType);
+				return false;
 			}
 			if ((this.bits & ASTNode.UnsafeCast) != 0) {
-				scope.problemReporter().unsafeCastInTestingContext(this, patternType, this.outerExpressionType);
+				scope.problemReporter().unsafeCastInTestingContext(location, patternType, this.outerExpressionType);
+				return false;
 			}
 		}
-		return applicable;
+		return true;
 	}
 
 	public abstract boolean dominates(Pattern p);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Pattern.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Pattern.java
@@ -148,6 +148,7 @@ public abstract class Pattern extends Expression {
 			scope.problemReporter().incompatiblePatternType(this, other, patternType);
 			return false;
 		}
+		boolean applicable = true;
 		if (patternType.isBaseType()) {
 			PrimitiveConversionRoute route = Pattern.findPrimitiveConversionRoute(this.resolvedType, this.outerExpressionType, scope);
 			if (!TypeBinding.equalsEquals(other, patternType)
@@ -155,11 +156,19 @@ public abstract class Pattern extends Expression {
 				scope.problemReporter().incompatiblePatternType(this, other, patternType);
 				return false;
 			}
-		} else if (!checkCastTypesCompatibility(scope, other, patternType, null, true)) {
-			scope.problemReporter().incompatiblePatternType(this, other, patternType);
-			return false;
+		} else {
+			if (!checkCastTypesCompatibility(scope, patternType, other, null, true)) {
+				if (this.enclosingPattern != null) {
+					scope.problemReporter().incompatiblePatternType(this, other, patternType);
+					return false;
+				}
+				applicable = false;
+			}
+			if ((this.bits & ASTNode.UnsafeCast) != 0) {
+				scope.problemReporter().unsafeCastInInstanceof(this, this.outerExpressionType, patternType);
+			}
 		}
-		return true;
+		return applicable;
 	}
 
 	public abstract boolean dominates(Pattern p);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/RecordPattern.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/RecordPattern.java
@@ -117,18 +117,14 @@ public class RecordPattern extends Pattern {
 			return this.resolvedType = null;
 		}
 
-		if (this.outerExpressionType instanceof ReferenceBinding) {
-			if (this.resolvedType.isRawType()) {
+		if (this.resolvedType.isRawType()) {
+			if (this.outerExpressionType instanceof ReferenceBinding) {
 				ReferenceBinding binding = inferRecordParameterization(scope, (ReferenceBinding) this.outerExpressionType);
 				if (binding == null || !binding.isValidBinding()) {
 					scope.problemReporter().cannotInferRecordPatternTypes(this);
 				    return this.resolvedType = null;
 				}
 				this.resolvedType = binding.capture(scope, this.sourceStart, this.sourceEnd);
-			} else {
-				if (!this.isApplicable(this.outerExpressionType, scope)) {
-					scope.problemReporter().typeMismatchError(this.outerExpressionType, this.resolvedType, this, null);
-				}
 			}
 		}
 
@@ -156,7 +152,7 @@ public class RecordPattern extends Pattern {
 				}
 			}
 			TypeBinding componentType = componentBinding.type;
-			if (p1.isApplicable(componentType, scope)) {
+			if (p1.isApplicable(componentType, scope, p1)) {
 				p1.isTotalTypeNode = p1.coversType(componentType, scope);
 				MethodBinding[] methods = this.resolvedType.getMethods(componentBinding.name);
 				if (methods != null && methods.length > 0) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/RecordPattern.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/RecordPattern.java
@@ -117,14 +117,18 @@ public class RecordPattern extends Pattern {
 			return this.resolvedType = null;
 		}
 
-		if (this.resolvedType.isRawType()) {
-			if (this.outerExpressionType instanceof ReferenceBinding) {
+		if (this.outerExpressionType instanceof ReferenceBinding) {
+			if (this.resolvedType.isRawType()) {
 				ReferenceBinding binding = inferRecordParameterization(scope, (ReferenceBinding) this.outerExpressionType);
 				if (binding == null || !binding.isValidBinding()) {
 					scope.problemReporter().cannotInferRecordPatternTypes(this);
 				    return this.resolvedType = null;
 				}
 				this.resolvedType = binding.capture(scope, this.sourceStart, this.sourceEnd);
+			} else {
+				if (!this.isApplicable(this.outerExpressionType, scope)) {
+					scope.problemReporter().typeMismatchError(this.outerExpressionType, this.resolvedType, this, null);
+				}
 			}
 		}
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
@@ -7303,7 +7303,7 @@ public void noSuchEnclosingInstance(TypeBinding targetType, ASTNode location, bo
 		location.sourceStart,
 		location instanceof LambdaExpression ? ((LambdaExpression)location).diagnosticsSourceEnd() : location.sourceEnd);
 }
-public void notCompatibleTypesError(EqualExpression expression, TypeBinding leftType, TypeBinding rightType) {
+public void notCompatibleTypesError(ASTNode location, TypeBinding leftType, TypeBinding rightType) {
 	String leftName = new String(leftType.readableName());
 	String rightName = new String(rightType.readableName());
 	String leftShortName = new String(leftType.shortReadableName());
@@ -7312,28 +7312,18 @@ public void notCompatibleTypesError(EqualExpression expression, TypeBinding left
 		leftShortName = leftName;
 		rightShortName = rightName;
 	}
-	this.handle(
-		IProblem.IncompatibleTypesInEqualityOperator,
-		new String[] {leftName, rightName },
-		new String[] {leftShortName, rightShortName },
-		expression.sourceStart,
-		expression.sourceEnd);
-}
-public void notCompatibleTypesError(Expression expression, TypeBinding leftType, TypeBinding rightType) {
-	String leftName = new String(leftType.readableName());
-	String rightName = new String(rightType.readableName());
-	String leftShortName = new String(leftType.shortReadableName());
-	String rightShortName = new String(rightType.shortReadableName());
-	if (leftShortName.equals(rightShortName)){
-		leftShortName = leftName;
-		rightShortName = rightName;
+	int problemId = IProblem.IncompatibleTypesInEqualityOperator; // name is misleading, also used for instanceof patterns
+	if (location instanceof Pattern p && p.getEnclosingPattern() instanceof RecordPattern) {
+		problemId = IProblem.PatternTypeMismatch;
+	} else if (location instanceof InstanceOfExpression) {
+		problemId = IProblem.IncompatibleTypesInConditionalOperator;
 	}
 	this.handle(
-		IProblem.IncompatibleTypesInConditionalOperator,
+		problemId,
 		new String[] {leftName, rightName },
 		new String[] {leftShortName, rightShortName },
-		expression.sourceStart,
-		expression.sourceEnd);
+		location.sourceStart,
+		location.sourceEnd);
 }
 public void notCompatibleTypesErrorInForeach(Expression expression, TypeBinding leftType, TypeBinding rightType) {
 	String leftName = new String(leftType.readableName());
@@ -8538,7 +8528,7 @@ public void typeCastError(CastExpression expression, TypeBinding leftType, TypeB
 		expression.sourceStart,
 		expression.sourceEnd);
 }
-public void unsafeCastInTestingContext(Expression expression, TypeBinding castType, TypeBinding expressionType) {
+public void unsafeCastInTestingContext(ASTNode location, TypeBinding castType, TypeBinding expressionType) {
 	String castName = new String(castType.readableName());
 	String exprName = new String(expressionType.readableName());
 	String castShortName = new String(castType.shortReadableName());
@@ -8551,8 +8541,8 @@ public void unsafeCastInTestingContext(Expression expression, TypeBinding castTy
 		IProblem.UnsafeCast,
 		new String[] { exprName, castName },
 		new String[] { exprShortName, castShortName },
-		expression.sourceStart,
-		expression.sourceEnd);
+		location.sourceStart,
+		location.sourceEnd);
 }
 public void typeCollidesWithEnclosingType(TypeDeclaration typeDecl) {
 	String[] arguments = new String[] {new String(typeDecl.name)};
@@ -12401,14 +12391,6 @@ public void recordPatternSignatureMismatch(TypeBinding type, ASTNode element) {
 			IProblem.RecordPatternMismatch,
 			new String[] {new String(type.readableName())},
 			new String[] {new String(type.shortReadableName())},
-			element.sourceStart,
-			element.sourceEnd);
-}
-public void incompatiblePatternType(ASTNode element, TypeBinding type, TypeBinding expected) {
-	this.handle(
-			IProblem.PatternTypeMismatch,
-			new String[] {new String(type.readableName()), new String(expected.readableName())},
-			new String[] {new String(type.shortReadableName()), new String(expected.readableName())},
 			element.sourceStart,
 			element.sourceEnd);
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
@@ -8538,19 +8538,19 @@ public void typeCastError(CastExpression expression, TypeBinding leftType, TypeB
 		expression.sourceStart,
 		expression.sourceEnd);
 }
-public void unsafeCastInInstanceof(Expression expression, TypeBinding leftType, TypeBinding rightType) {
-	String leftName = new String(leftType.readableName());
-	String rightName = new String(rightType.readableName());
-	String leftShortName = new String(leftType.shortReadableName());
-	String rightShortName = new String(rightType.shortReadableName());
-	if (leftShortName.equals(rightShortName)){
-		leftShortName = leftName;
-		rightShortName = rightName;
+public void unsafeCastInTestingContext(Expression expression, TypeBinding castType, TypeBinding expressionType) {
+	String castName = new String(castType.readableName());
+	String exprName = new String(expressionType.readableName());
+	String castShortName = new String(castType.shortReadableName());
+	String exprShortName = new String(expressionType.shortReadableName());
+	if (castShortName.equals(exprShortName)){
+		castShortName = castName;
+		exprShortName = exprName;
 	}
 	this.handle(
 		IProblem.UnsafeCast,
-		new String[] { rightName, leftName },
-		new String[] { rightShortName, leftShortName },
+		new String[] { exprName, castName },
+		new String[] { exprShortName, castShortName },
 		expression.sourceStart,
 		expression.sourceEnd);
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
@@ -7312,7 +7312,7 @@ public void notCompatibleTypesError(ASTNode location, TypeBinding leftType, Type
 		leftShortName = leftName;
 		rightShortName = rightName;
 	}
-	int problemId = IProblem.IncompatibleTypesInEqualityOperator; // name is misleading, also used for instanceof patterns
+	int problemId = IProblem.IncompatibleTypesInEqualityOperator;
 	if (location instanceof Pattern p && p.getEnclosingPattern() instanceof RecordPattern) {
 		problemId = IProblem.PatternTypeMismatch;
 	} else if (location instanceof InstanceOfExpression) {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/InstanceofPrimaryPatternTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/InstanceofPrimaryPatternTest.java
@@ -646,4 +646,28 @@ public class InstanceofPrimaryPatternTest extends AbstractRegressionTest {
 			+ "A pattern variable with the same name is already defined in the statement\n"
 			+ "----------\n");
 	}
+
+	public void testGH3074() {
+		runNegativeTest(
+			new String[] {
+				"Example.java",
+				"""
+				class Example<T> {
+					private void foo(String x) {
+						if (x instanceof Example<String> es) {
+
+						}
+					}
+				}
+				"""
+			},
+			"""
+			----------
+			1. ERROR in Example.java (at line 3)
+				if (x instanceof Example<String> es) {
+				    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+			Incompatible conditional operand types String and Example<String>
+			----------
+			""");
+	}
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PatternMatching16Test.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PatternMatching16Test.java
@@ -2401,7 +2401,7 @@ public class PatternMatching16Test extends AbstractRegressionTest {
 				"----------\n" +
 				"1. ERROR in X.java (at line 4)\n" +
 				"	if (obj instanceof T t) {\n" +
-				"	    ^^^\n" +
+				"	    ^^^^^^^^^^^^^^^^^^\n" +
 				"Type Object cannot be safely cast to T\n" +
 				"----------\n",
 				"X.java:4: error: Object cannot be safely cast to T\n" +
@@ -2460,7 +2460,7 @@ public class PatternMatching16Test extends AbstractRegressionTest {
 				"----------\n" +
 				"1. ERROR in X.java (at line 4)\n" +
 				"	if (obj instanceof X<String> p) {\n" +
-				"	    ^^^\n" +
+				"	    ^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
 				"Type X<capture#1-of ?> cannot be safely cast to X<String>\n" +
 				"----------\n",
 				"",

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PrimitiveInPatternsTestSH.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PrimitiveInPatternsTestSH.java
@@ -2302,6 +2302,28 @@ public class PrimitiveInPatternsTestSH extends AbstractRegressionTest9 {
 				""");
 	}
 
+	public void testIncompatiblePrimitiveInInstanceof() {
+		runNegativeTest(new String[] {
+				"X.java",
+				"""
+				public class X  {
+					void foo() {
+						if (this instanceof int i)
+							return;
+					}
+				}
+				"""
+				},
+				"""
+				----------
+				1. ERROR in X.java (at line 3)
+					if (this instanceof int i)
+					    ^^^^^^^^^^^^^^^^^^^^^
+				Incompatible conditional operand types X and int
+				----------
+				""");
+	}
+
 	// test from spec
 	public void _testSpec001() {
 		runConformTest(new String[] {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordPatternTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordPatternTest.java
@@ -1568,8 +1568,8 @@ public class RecordPatternTest extends AbstractRegressionTest9 {
 				"----------\n" +
 				"1. ERROR in X.java (at line 4)\n" +
 				"	if (objectBox instanceof Box<String>(String s)) {\n" +
-				"	    ^^^^^^^^^\n" +
-				"Type Box<Object> cannot be safely cast to Box<String>\n" +
+				"	                         ^^^^^^^^^^^^^^^^^^^^^\n" +
+				"Type mismatch: cannot convert from Box<Object> to Box<String>\n" +
 				"----------\n");
 	}
 	public void test48() {
@@ -2008,8 +2008,8 @@ public class RecordPatternTest extends AbstractRegressionTest9 {
 				"----------\n" +
 				"1. ERROR in X.java (at line 10)\n" +
 				"	if (p instanceof R<>(String a)) {\n" +
-				"	    ^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
-				"Incompatible conditional operand types R<capture#1-of ? extends I> and R\n" +
+				"	                 ^^^^^^^^^^^^^\n" +
+				"Type mismatch: cannot convert from R<capture#1-of ? extends I> to R\n" +
 				"----------\n");
 	}
 	public void testIssue900_1() {
@@ -4685,5 +4685,55 @@ public class RecordPatternTest extends AbstractRegressionTest9 {
 				"	                                      ^^\n" +
 				"Syntax error on tokens, delete these tokens\n" +
 				"----------\n");
+	}
+
+	public void testIssue3066() {
+		runNegativeTest(new String[] {
+				"X.java",
+				"""
+				public record X<T>(int x) {
+					public static void main(String[] args) {
+						Object o = new Object();
+						switch (o) {
+						case X<String>(int x):
+						default:
+						}
+					}
+				}
+				"""
+			},
+			"""
+			----------
+			1. ERROR in X.java (at line 5)
+				case X<String>(int x):
+				     ^^^^^^^^^^^^^^^^
+			Type X<String> cannot be safely cast to Object
+			----------
+			""");
+	}
+
+	public void testIssue3066_notApplicable() {
+		runNegativeTest(new String[] {
+				"X.java",
+				"""
+				public record X(int x) {
+					public static void main(String[] args) {
+						java.io.Serializable o = "";
+						switch (o) {
+						case X(int x):
+						default:
+						}
+					}
+				}
+				"""
+			},
+			"""
+			----------
+			1. ERROR in X.java (at line 5)
+				case X(int x):
+				     ^^^^^^^^
+			Type mismatch: cannot convert from Serializable to X
+			----------
+			""");
 	}
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordPatternTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordPatternTest.java
@@ -4707,7 +4707,7 @@ public class RecordPatternTest extends AbstractRegressionTest9 {
 			1. ERROR in X.java (at line 5)
 				case X<String>(int x):
 				     ^^^^^^^^^^^^^^^^
-			Type X<String> cannot be safely cast to Object
+			Type Object cannot be safely cast to X<String>
 			----------
 			""");
 	}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordPatternTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordPatternTest.java
@@ -299,12 +299,12 @@ public class RecordPatternTest extends AbstractRegressionTest9 {
 				"1. ERROR in X.java (at line 3)\n" +
 				"	if (r instanceof Rectangle(ColoredPoint(Point(String o1, String o2), Color c),\n" +
 				"	                                              ^^^^^^^^^\n" +
-				"Record component with type int is not compatible with type java.lang.String\n" +
+				"Record component with type int is not compatible with type String\n" +
 				"----------\n" +
 				"2. ERROR in X.java (at line 3)\n" +
 				"	if (r instanceof Rectangle(ColoredPoint(Point(String o1, String o2), Color c),\n" +
 				"	                                                         ^^^^^^^^^\n" +
-				"Record component with type int is not compatible with type java.lang.String\n" +
+				"Record component with type int is not compatible with type String\n" +
 				"----------\n");
 	}
 	// Test that pattern types that don't match record component's types are reported
@@ -1568,8 +1568,8 @@ public class RecordPatternTest extends AbstractRegressionTest9 {
 				"----------\n" +
 				"1. ERROR in X.java (at line 4)\n" +
 				"	if (objectBox instanceof Box<String>(String s)) {\n" +
-				"	                         ^^^^^^^^^^^^^^^^^^^^^\n" +
-				"Type mismatch: cannot convert from Box<Object> to Box<String>\n" +
+				"	    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
+				"Incompatible conditional operand types Box<Object> and Box<String>\n" +
 				"----------\n");
 	}
 	public void test48() {
@@ -1958,7 +1958,7 @@ public class RecordPatternTest extends AbstractRegressionTest9 {
 				"1. ERROR in X.java (at line 7)\n" +
 				"	if (p instanceof R(String a)) {\n" +
 				"	                   ^^^^^^^^\n" +
-				"Record component with type capture#2-of ? extends I is not compatible with type java.lang.String\n" +
+				"Record component with type capture#2-of ? extends I is not compatible with type String\n" +
 				"----------\n");
 	}
 	public void testRecordPatternTypeInference_010() {
@@ -2008,8 +2008,8 @@ public class RecordPatternTest extends AbstractRegressionTest9 {
 				"----------\n" +
 				"1. ERROR in X.java (at line 10)\n" +
 				"	if (p instanceof R<>(String a)) {\n" +
-				"	                 ^^^^^^^^^^^^^\n" +
-				"Type mismatch: cannot convert from R<capture#1-of ? extends I> to R\n" +
+				"	    ^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
+				"Incompatible conditional operand types R<capture#1-of ? extends I> and R\n" +
 				"----------\n");
 	}
 	public void testIssue900_1() {
@@ -2505,7 +2505,7 @@ public class RecordPatternTest extends AbstractRegressionTest9 {
 			"2. ERROR in X.java (at line 6)\n" +
 			"	case Record<String>(Object o, StringBuilder s) -> {break;}\n" +
 			"	                              ^^^^^^^^^^^^^^^\n" +
-			"Record component with type String is not compatible with type java.lang.StringBuilder\n" +
+			"Record component with type String is not compatible with type StringBuilder\n" +
 			"----------\n");
 	}
 	public void testIssue1224_5() {
@@ -4401,7 +4401,7 @@ public class RecordPatternTest extends AbstractRegressionTest9 {
 				"2. ERROR in X.java (at line 10)\n" +
 				"	if (o instanceof R2(Short d)) {\n" +
 				"	                    ^^^^^^^\n" +
-				"Record component with type short is not compatible with type java.lang.Short\n" +
+				"Record component with type short is not compatible with type Short\n" +
 				"----------\n" +
 				"3. ERROR in X.java (at line 13)\n" +
 				"	if (o instanceof R2(int d)) {\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordPatternTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordPatternTest.java
@@ -1558,7 +1558,7 @@ public class RecordPatternTest extends AbstractRegressionTest9 {
 				+ "public class X {\n"
 				+ "  static void printGenericBoxString1(Box<Object> objectBox) {\n"
 				+ "    if (objectBox instanceof Box<String>(String s)) {\n"
-				+ "      System.out.println(s); // this one should report an unsafe cast error\n"
+				+ "      System.out.println(s);\n"
 				+ "    }\n"
 				+ "  }\n"
 				+ "  public static void main(String[] args) {}\n"

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchPatternTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchPatternTest.java
@@ -2650,11 +2650,6 @@ public class SwitchPatternTest extends AbstractRegressionTest9 {
 				"	case List<String> s: \n" +
 				"	     ^^^^^^^^^^^^^^\n" +
 				"Type Object cannot be safely cast to List<String>\n" +
-				"----------\n" +
-				"3. ERROR in X.java (at line 9)\n" +
-				"	case List<String> s: \n" +
-				"	     ^^^^^^^^^^^^^^\n" +
-				"This case label is dominated by one of the preceding case labels\n" +
 				"----------\n");
 	}
 	public void testBug573921_8() {
@@ -7335,11 +7330,6 @@ public class SwitchPatternTest extends AbstractRegressionTest9 {
 				+ "	case WrapperRec(ExhaustiveSwitch.Data data) when data.name.isEmpty() -> { }\n"
 				+ "	                ^^^^^^^^^^^^^^^^\n"
 				+ "ExhaustiveSwitch cannot be resolved to a type\n"
-				+ "----------\n"
-				+ "4. ERROR in X.java (at line 12)\n"
-				+ "	case WrapperRec(ExhaustiveSwitch.Data data) when data.name.isEmpty() -> { }\n"
-				+ "	                ^^^^^^^^^^^^^^^^^^^^^^^^^^\n"
-				+ "Record component with type Data is not compatible with type ExhaustiveSwitch.Data\n"
 				+ "----------\n");
 	}
 	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1955


### PR DESCRIPTION
+ try to balance responsibility about type checking between
  - Pattern.isApplicable() - don't yet report in nested position
  - RecordPattern.resolveType() - failed to check isApplicable()
  - InstanceOfExpression.resolveType() - avoid pattern-agnostic checks

+ added the 1st(!) test for inapplicable record pattern in switch

fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3066
fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3074