### PR TITLE
[Formatter][Unnamed patterns/variables] leading space added to conditional statements following an unnamed variable

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/formatter/FormatterRegressionTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/formatter/FormatterRegressionTests.java
@@ -16396,4 +16396,72 @@ public void testGH1473c() throws JavaModelException {
 	String input = getCompilationUnit("Formatter", "", "testGH1473", "in.java").getSource();
 	formatSource(input, getCompilationUnit("Formatter", "", "testGH1473", "C_out.java").getSource());
 }
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3070
+// [Formatter] leading space added to conditional statements following an unnamed variable
+public void testIssue3070() {
+	setComplianceLevel(CompilerOptions.VERSION_23);
+	String source =
+		"""
+		class Example {
+			private void foo() {
+				var a = false;
+
+				try {
+				} catch (Exception _) { // <- the unnamed variable triggers the issue
+				}
+
+				if (a) { // <- no leading space before the variable name
+				}
+			}
+		}
+		""";
+	formatSource(source,
+		"""
+		class Example {
+			private void foo() {
+				var a = false;
+
+				try {
+				} catch (Exception _) { // <- the unnamed variable triggers the issue
+				}
+
+				if (a) { // <- no leading space before the variable name
+				}
+			}
+		}
+		""");
+}
+public void testIssue3070_2() {
+	setComplianceLevel(CompilerOptions.VERSION_23);
+	String source =
+		"""
+		class Example {
+			private void foo() {
+				var a = false;
+
+				try {
+				} catch (Exception e) { // <- the unnamed variable triggers the issue
+				}
+
+				if (a) { // <- no leading space before the variable name
+				}
+			}
+		}
+		""";
+	formatSource(source,
+		"""
+		class Example {
+			private void foo() {
+				var a = false;
+
+				try {
+				} catch (Exception e) { // <- the unnamed variable triggers the issue
+				}
+
+				if (a) { // <- no leading space before the variable name
+				}
+			}
+		}
+		""");
+}
 }

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/TokenManager.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/TokenManager.java
@@ -19,6 +19,7 @@ import static org.eclipse.jdt.internal.compiler.parser.TerminalTokens.TokenNameI
 import static org.eclipse.jdt.internal.compiler.parser.TerminalTokens.TokenNameNotAToken;
 import static org.eclipse.jdt.internal.compiler.parser.TerminalTokens.TokenNameStringLiteral;
 import static org.eclipse.jdt.internal.compiler.parser.TerminalTokens.TokenNameTextBlock;
+import static org.eclipse.jdt.internal.compiler.parser.TerminalTokens.TokenNameUNDERSCORE;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -174,6 +175,9 @@ public class TokenManager implements Iterable<Token> {
 			if (TerminalTokens.isRestrictedKeyword(tokenType) && t.tokenType == TokenNameIdentifier) {
 				if (tokenType == TerminalTokens.getRestrictedKeyword(toString(t)))
 					break;
+			}
+			if (t.tokenType == TokenNameUNDERSCORE && tokenType == TokenNameIdentifier) {
+				break;
 			}
 			index += forward ? 1 : -1;
 		}


### PR DESCRIPTION

## What it does

* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3070


## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
