### PR TITLE
Bugfix for #2967: JavaModelTests logs "Failed to init Classpath".

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchBugsTests2.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchBugsTests2.java
@@ -2207,7 +2207,7 @@ public class JavaSearchBugsTests2 extends AbstractJavaSearchTests {
 				"  public void fooInt() {}\n" +
 				"}"
 			}, p.getProject().getLocation().append("lib478042.jar").toOSString(),
-				new String[] { p.getProject().getLocation().append("lib478042.jar").toOSString() },
+				new String[0],
 				CompilerOptions.getFirstSupportedJavaVersion());
 			refresh(p);
 
@@ -2241,7 +2241,7 @@ public class JavaSearchBugsTests2 extends AbstractJavaSearchTests {
 				"    }\n" +
 				"}\n"
 			}, p.getProject().getLocation().append("lib478042.jar").toOSString(),
-				new String[] { p.getProject().getLocation().append("lib478042.jar").toOSString() },
+				new String[0],
 				CompilerOptions.getFirstSupportedJavaVersion());
 			refresh(p);
 
@@ -2274,7 +2274,7 @@ public class JavaSearchBugsTests2 extends AbstractJavaSearchTests {
 				"    }\n" +
 				"}\n"
 			}, p.getProject().getLocation().append("lib478042.jar").toOSString(),
-				new String[] { p.getProject().getLocation().append("lib478042.jar").toOSString() },
+				new String[0],
 				CompilerOptions.getFirstSupportedJavaVersion());
 			refresh(p);
 
@@ -2537,7 +2537,7 @@ public class JavaSearchBugsTests2 extends AbstractJavaSearchTests {
 				"  public void fooInt() {}\n" +
 				"}"
 			}, p.getProject().getLocation().append("lib478042.jar").toOSString(),
-				new String[] { p.getProject().getLocation().append("lib478042.jar").toOSString() },
+				new String[0],
 				CompilerOptions.getFirstSupportedJavaVersion());
 			refresh(p);
 
@@ -2576,7 +2576,7 @@ public class JavaSearchBugsTests2 extends AbstractJavaSearchTests {
 				"    }\n" +
 				"}\n"
 			}, p.getProject().getLocation().append("lib478042.jar").toOSString(),
-				new String[] { p.getProject().getLocation().append("lib478042.jar").toOSString() },
+				new String[0],
 				CompilerOptions.getFirstSupportedJavaVersion());
 			refresh(p);
 
@@ -2614,7 +2614,7 @@ public class JavaSearchBugsTests2 extends AbstractJavaSearchTests {
 				"    }\n" +
 				"}\n"
 			}, p.getProject().getLocation().append("lib478042.jar").toOSString(),
-				new String[] { p.getProject().getLocation().append("lib478042.jar").toOSString() },
+				new String[0],
 				CompilerOptions.getFirstSupportedJavaVersion());
 			refresh(p);
 


### PR DESCRIPTION
## What it does
Fixes #2967 

## How to test
Run the test org.eclipse.jdt.core.tests.model.JavaSearchBugsTests2. The "Failed to init Classpath" error should not be logged.

## Root cause
There was some kind of "circular dependency". To create a JAR file named xyz.jar it is impossible to set up a classpath containing xyz.jar because does not exist yet.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
