### PR TITLE
wait for build after refresh. Fix #2998

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/eval/EvaluationContextWrapperTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/eval/EvaluationContextWrapperTest.java
@@ -182,6 +182,7 @@ public class EvaluationContextWrapperTest extends EvaluationTest {
 
 	private void refreshProject() throws Exception {
 		this.project.getProject().refreshLocal(IResource.DEPTH_INFINITE, null);
+		waitForAutoBuild(); // wait for builds to complete.
 	}
 
 	private void removeTempClass(String className) {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/eval/EvaluationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/eval/EvaluationTest.java
@@ -20,6 +20,13 @@ import java.util.Arrays;
 import java.util.Map;
 import junit.framework.Test;
 import junit.framework.TestSuite;
+
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.OperationCanceledException;
+import org.eclipse.core.runtime.jobs.ISchedulingRule;
+import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jdt.core.compiler.CategorizedProblem;
 import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.core.tests.junit.extension.StopableTestCase;
@@ -40,6 +47,7 @@ import org.eclipse.jdt.internal.compiler.env.INameEnvironment;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jdt.internal.compiler.problem.DefaultProblem;
 import org.eclipse.jdt.internal.compiler.problem.DefaultProblemFactory;
+import org.eclipse.jdt.internal.core.JavaModelManager;
 import org.eclipse.jdt.internal.eval.EvaluationContext;
 import org.eclipse.jdt.internal.eval.EvaluationResult;
 import org.eclipse.jdt.internal.eval.GlobalVariable;
@@ -568,5 +576,41 @@ public class EvaluationTest extends AbstractCompilerTest implements StopableTest
 			} catch (TargetException e) {
 			}
 		}
+	}
+
+	public void waitForAutoBuild() {
+		if (isWorkspaceRuleAlreadyInUse(getWorkspaceRoot())) {
+			// Don't wait holding workspace lock on FAMILY_AUTO_BUILD, because
+			// we might deadlock with AutoBuildOffJob
+			System.out.println("\n\nAborted waitForAutoBuild() because running with the workspace rule\n\n");
+			return;
+		}
+		boolean wasInterrupted = false;
+		do {
+			try {
+				Job.getJobManager().wakeUp(ResourcesPlugin.FAMILY_AUTO_BUILD);
+				Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_BUILD, null);
+				JavaModelManager.getIndexManager().waitForIndex(isIndexDisabledForTest(), null);
+				wasInterrupted = false;
+			} catch (OperationCanceledException e) {
+				e.printStackTrace();
+			} catch (InterruptedException e) {
+				wasInterrupted = true;
+			}
+		} while (wasInterrupted);
+	}
+
+	private static boolean isWorkspaceRuleAlreadyInUse(ISchedulingRule rule) {
+		ISchedulingRule currentJobRule = Job.getJobManager().currentRule();
+		boolean workspaceRuleActive = currentJobRule != null && rule.contains(currentJobRule);
+		return workspaceRuleActive;
+	}
+
+	private IWorkspaceRoot getWorkspaceRoot() {
+		return getWorkspace().getRoot();
+	}
+
+	private IWorkspace getWorkspace() {
+		return ResourcesPlugin.getWorkspace();
 	}
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
Wait for builds after refreshing the project.

## How to test
EvaluationContextWrapperTest should not fail on builds

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
