### PR TITLE
[Switch][Sealed types] Bad static analysis with the old switch syntax + an exhautive pattern matching on a sealed type throws a MatchException

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
@@ -886,7 +886,6 @@ public class SwitchStatement extends Expression {
 				if (this.preSwitchInitStateIndex != -1) {
 					codeStream.removeNotDefinitelyAssignedVariables(currentScope, this.preSwitchInitStateIndex);
 				}
-				defaultLabel.place();
 				/* a default case is not needed for an exhaustive switch expression
 				 * we need to handle the default case to throw an error in order to make the stack map consistent.
 				 * All cases will return a value on the stack except the missing default case.
@@ -895,9 +894,10 @@ public class SwitchStatement extends Expression {
 				CompilerOptions compilerOptions = this.scope != null ? this.scope.compilerOptions() : null;
 				if (compilerOptions.complianceLevel >= ClassFileConstants.JDK19) {
 					// since 19 we have MatchException for this
-					if (codeStream.lastAbruptCompletion != codeStream.position) {
+					if (this.statements.length > 0 && this.statements[this.statements.length - 1].canCompleteNormally()) {
 						codeStream.goto_(this.breakLabel); // hop, skip and jump over match exception throw.
 					}
+					defaultLabel.place();
 					codeStream.newJavaLangMatchException();
 					codeStream.dup();
 					codeStream.aconst_null();
@@ -906,6 +906,7 @@ public class SwitchStatement extends Expression {
 					codeStream.athrow();
 				} else {
 					// old style using IncompatibleClassChangeError:
+					defaultLabel.place();
 					codeStream.newJavaLangIncompatibleClassChangeError();
 					codeStream.dup();
 					codeStream.invokeJavaLangIncompatibleClassChangeErrorDefaultConstructor();

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypeDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypeDeclaration.java
@@ -109,7 +109,7 @@ public class TypeDeclaration extends Statement implements ProblemSeverities, Ref
 	public int nRecordComponents;
 	public static Set<String> disallowedComponentNames;
 
-	// 15 Sealed Type preview support
+	// 17 Sealed Type support
 	public TypeReference[] permittedTypes;
 
 	// TEST ONLY: disable one fix here to challenge another related fix (in TypeSystem):

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchPatternTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchPatternTest.java
@@ -9072,4 +9072,160 @@ public class SwitchPatternTest extends AbstractRegressionTest9 {
 				"I.K.E\n" +
 				"I.K.F");
 	}
+
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3096
+	// [Switch][Sealed types] Bad static analysis with the old switch syntax + an exhautive pattern matching on a sealed type throws a MatchException
+	public void testIssue3096() {
+		runConformTest(
+				new String[] {
+						"X.java",
+						"""
+						public sealed interface X permits X.R {
+							record R(String s) implements X {
+							}
+
+							public static void add(X x) {
+								switch (x) {
+								case R r:
+									if (r.s == null) {
+										throw new NullPointerException();
+									}
+								}
+							}
+
+							public static void main(String[] args) {
+								add(new R("bar"));
+							}
+						}
+						"""
+				},
+				"");
+	}
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3096
+	// [Switch][Sealed types] Bad static analysis with the old switch syntax + an exhautive pattern matching on a sealed type throws a MatchException
+	public void testIssue3096_2() {
+		runConformTest(
+				new String[] {
+						"X.java",
+						"""
+						public sealed interface X permits X.R {
+							record R(String s) implements X {
+							}
+
+							public static void add(X x) {
+								switch (x) {
+								case R r:
+									if (r.s == null) {
+										throw new NullPointerException();
+									}
+									break;
+								}
+							}
+
+							public static void main(String[] args) {
+								add(new R("bar"));
+							}
+						}
+						"""
+				},
+				"");
+	}
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3096
+	// [Switch][Sealed types] Bad static analysis with the old switch syntax + an exhautive pattern matching on a sealed type throws a MatchException
+	public void testIssue3096_3() {
+		runConformTest(
+				new String[] {
+						"X.java",
+						"""
+						public sealed interface X permits X.R {
+							record R(String s) implements X {
+							}
+
+							public static void add(X x) {
+								switch (x) {
+								case R r:
+									if (r.s == null) {
+										throw new NullPointerException();
+									}
+									System.out.println("R");
+								}
+							}
+
+							public static void main(String[] args) {
+								add(new R("bar"));
+							}
+						}
+						"""
+				},
+				"R");
+	}
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3096
+	// [Switch][Sealed types] Bad static analysis with the old switch syntax + an exhautive pattern matching on a sealed type throws a MatchException
+	public void testIssue3096_4() {
+		runConformTest(
+				new String[] {
+						"X.java",
+						"""
+						public sealed interface X permits X.R {
+							record R(String s) implements X {
+							}
+
+							public static void add(X x) {
+								switch (x) {
+								case R r:
+									if (r.s == null) {
+										throw new NullPointerException();
+									}
+									System.out.println("R");
+									break;
+								}
+							}
+
+							public static void main(String[] args) {
+								add(new R("bar"));
+							}
+						}
+						"""
+				},
+				"R");
+	}
+
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3096
+	// [Switch][Sealed types] Bad static analysis with the old switch syntax + an exhautive pattern matching on a sealed type throws a MatchException
+	public void testIssue3096_full() {
+		runConformTest(
+				new String[] {
+						"EclipseBugFallThroughSwitch.java",
+						"""
+						public class EclipseBugFallThroughSwitch {
+						  sealed interface I permits A, B {}
+						  record A(String s) implements I {}
+						  record B(String s) implements I {}
+
+						  public void add(I i) {
+						    switch (i) {
+						    case A a:
+						      break;
+						    case B b:
+						      if (b.s == null) {
+						        throw new NullPointerException();
+						      }
+						      //break;  // this fix the issue
+						    }
+						  }
+
+						  public static void main(String[] args) {
+						    var container = new EclipseBugFallThroughSwitch();
+						    container.add(new B("bar"));
+
+						    // Exception in thread "main" java.lang.MatchException
+						    // at EclipseBugFallThroughSwitch.add(EclipseBugFallThroughSwitch.java:9)
+						    // at EclipseBugFallThroughSwitch.main(EclipseBugFallThroughSwitch.java:25)
+						  }
+						}
+						"""
+				},
+				"");
+	}
+
 }


### PR DESCRIPTION

## What it does

* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3096

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
