### PR TITLE
Possible fix for issue #2716

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelInfo.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelInfo.java
@@ -14,7 +14,10 @@
 package org.eclipse.jdt.internal.core;
 
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
 
 /**
  * Implementation of IJavaModel. A Java Model is specific to a
@@ -28,7 +31,14 @@ public class JavaModelInfo extends OpenableElementInfo {
  * Compute the non-java resources contained in this java project.
  */
 private Object[] computeNonJavaResources() {
-	IProject[] projects = ResourcesPlugin.getWorkspace().getRoot().getProjects();
+	IWorkspaceRoot workspaceRoot = ResourcesPlugin.getWorkspace().getRoot();
+	try {
+		workspaceRoot.refreshLocal(IResource.DEPTH_INFINITE, null);
+	} catch (CoreException e) {
+		e.printStackTrace();
+		return null;
+	}
+	IProject[] projects = workspaceRoot.getProjects();
 	int length = projects.length;
 	Object[] resources = null;
 	int index = 0;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
Possible fix for issue #2716 
Scenario: JMT.testGetNonJavaResources().

After delete_SP1, model.getNonJavaResources() is used to check whether its deleted or not.
This uses ElementTree tree; which possibly may be out of sync.
The javadoc of Workspace says:
"The tree caches
	 * the structure and state of files and directories on disk (their existence
	 * and last modified times).  When external parties make changes to
	 * the files on disk, this representation becomes out of sync. A local refresh
	 * reconciles the state of the files on disk with this tree (@link {@link IResource#refreshLocal(int, IProgressMonitor)})."

So, a refreshLocal() may solve this out-of-sync issue.
Point to ponder: performance ?


## How to test

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
