### PR TITLE
Stop building jdt.annotations v1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
 
   <modules>
     <module>org.eclipse.jdt.annotation</module>
-    <module>org.eclipse.jdt.annotation_v1</module>
+    <!--module>org.eclipse.jdt.annotation_v1</module-->
     <module>org.eclipse.jdt.core.compiler.batch</module>
     <module>org.eclipse.jdt.core</module>
     <module>org.eclipse.jdt.core.formatterapp</module>


### PR DESCRIPTION
Ensure that o.e.jdt.annotations 1.x is not picked by accident when there is unversioned require (like
https://github.com/eclipse-jdt/eclipse.jdt/pull/118 ) as it will no longer be in the reactor.
