### PR TITLE
[23] anonymous creation in super call allowed?

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AllocationExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AllocationExpression.java
@@ -546,7 +546,13 @@ public TypeBinding resolveType(BlockScope scope) {
 protected void checkEarlyConstructionContext(BlockScope scope) {
 	if (JavaFeature.FLEXIBLE_CONSTRUCTOR_BODIES.isSupported(scope.compilerOptions())
 			&& this.type != null && this.type.resolvedType instanceof ReferenceBinding currentType) {
-		TypeBinding uninitialized = scope.getMatchingUninitializedType(currentType, !currentType.isLocalType());
+		// only enclosing types of non-static member types are relevant
+		if (currentType.isStatic() || currentType.isLocalType())
+			return;
+		currentType = currentType.enclosingType();
+		if (currentType == null)
+			return;
+		TypeBinding uninitialized = scope.getMatchingUninitializedType(currentType, true);
 		if (uninitialized != null)
 			scope.problemReporter().allocationInEarlyConstructionContext(this, this.resolvedType, uninitialized);
 	}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Scope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Scope.java
@@ -5756,6 +5756,8 @@ public abstract class Scope {
 							|| (currentTarget instanceof ReferenceBinding currentRefBind && !currentRefBind.hasEnclosingInstanceContext())) {
 						break;
 					}
+					if (currentTarget.isStatic() || currentTarget.isLocalType())
+						break;
 					currentTarget = currentTarget.enclosingType();
 				}
 				currentEnclosing = currentEnclosing.parent.classScope();

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SuperAfterStatementsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SuperAfterStatementsTest.java
@@ -2281,4 +2281,53 @@ public class SuperAfterStatementsTest extends AbstractRegressionTest9 {
 			""";
 		runner.runNegativeTest();
 	}
+
+	public void testGH3132() {
+		Runner runner = new Runner();
+		runner.testFiles = new String[] {
+				"X.java",
+				"""
+				public class X {
+					class Nested {
+						Nested(Object o) {}
+					}
+					class AnotherNested extends Nested {
+						AnotherNested() {
+							super(new Object() { // Cannot instantiate class new Object(){} in an early construction context of class X.AnotherNested
+							});
+						}
+					}
+					public static void main(String... args) {
+						new X().new AnotherNested();
+					}
+				}
+				"""
+			};
+		runner.runConformTest();
+	}
+
+	public void testGH3132_2() {
+		Runner runner = new Runner();
+		runner.testFiles = new String[] {
+				"X.java",
+				"""
+				class O {} // demonstrates the the bug was not specific to j.l.Object
+				public class X {
+					class Nested extends O {
+						Nested(Object o) {}
+					}
+					class AnotherNested extends Nested {
+						AnotherNested() {
+							super(new O() {
+							});
+						}
+					}
+					public static void main(String... args) {
+						new X().new AnotherNested();
+					}
+				}
+				"""
+			};
+		runner.runConformTest();
+	}
 }


### PR DESCRIPTION
For allocation expressions:
 + only check enclosing types
 + but never travel out past static / local types

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3132
