### PR TITLE
Code review driven incremental clean up of sealed types implementation

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ClassFile.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ClassFile.java
@@ -6043,7 +6043,7 @@ public class ClassFile implements TypeConstants, TypeIds {
 		if (aType.isAnonymousType()) {
 			ReferenceBinding superClass = aType.superclass;
 			if (superClass == null || !(superClass.isEnum() && superClass.isSealed()))
-			accessFlags &= ~ClassFileConstants.AccFinal;
+				accessFlags &= ~ClassFileConstants.AccFinal;
 		}
 		int finalAbstract = ClassFileConstants.AccFinal | ClassFileConstants.AccAbstract;
 		if ((accessFlags & finalAbstract) == finalAbstract) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/ClassFileReader.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/ClassFileReader.java
@@ -528,9 +528,7 @@ public ClassFileReader(byte[] classFileBytes, char[] fileName, boolean fullyInit
 							offset += 2;
 							this.permittedSubtypesNames = new char[this.permittedSubtypesCount][];
 							for (int j = 0; j < this.permittedSubtypesCount; j++) {
-								utf8Offset =
-									this.constantPoolOffsets[u2At(this.constantPoolOffsets[u2At(offset)] + 1)];
-								this.permittedSubtypesNames[j] = CharDeduplication.intern(utf8At(utf8Offset + 3, u2At(utf8Offset + 1)));
+								this.permittedSubtypesNames[j] = CharDeduplication.intern(getConstantClassNameAt(u2At(offset)));
 		 						offset += 2;
 							}
 						}
@@ -1113,7 +1111,7 @@ public boolean hasStructuralChanges(byte[] newBytes, boolean orderRequired, bool
 					return true;
 		}
 
-		// permitted sub-types
+		// permitted subtypes
 		char[][] newPermittedSubtypesNames = newClassFile.getPermittedSubtypesNames();
 		if (this.permittedSubtypesNames != newPermittedSubtypesNames) {
 			int newPermittedSubtypesLength = newPermittedSubtypesNames == null ? 0 : newPermittedSubtypesNames.length;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/env/IBinaryType.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/env/IBinaryType.java
@@ -94,11 +94,11 @@ char[] getGenericSignature();
 char[][] getInterfaceNames();
 
 /**
- * Answer the unresolved names of the receiver's permitted sub types
+ * Answer the unresolved names of the receiver's permitted subtypes in the
+ * class file format as specified in section 4.2 of the Java 2 VM spec
  * or null if the array is empty.
  *
- * A name is a simple name or a qualified, dot separated name.
- * For example, Hashtable or java.util.Hashtable.
+ * For example, java.lang.String is java/lang/String.
  */
 default char[][] getPermittedSubtypesNames() {
 	return null;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BinaryTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BinaryTypeBinding.java
@@ -567,12 +567,6 @@ void cachePartsFrom(IBinaryType binaryType, boolean needFieldsAndMethods) {
 						break;
 					}
 				}
-				for (TypeBinding permsub : this.permittedTypes) {
-					if (permsub.hasNullTypeAnnotations()) {
-						this.externalAnnotationStatus = ExternalAnnotationStatus.TYPE_IS_ANNOTATED;
-						break;
-					}
-				}
 			}
 		}
 
@@ -2558,9 +2552,8 @@ public ReferenceBinding[] permittedTypes() {
 		return this.permittedTypes = this.prototype.permittedTypes();
 	}
 	for (int i = this.permittedTypes.length; --i >= 0;)
-		this.permittedTypes[i] = (ReferenceBinding) resolveType(this.permittedTypes[i], this.environment, false);
+		this.permittedTypes[i] = (ReferenceBinding) resolveType(this.permittedTypes[i], this.environment, false); // re-resolution seems harmless
 
-	// Note: unlike for superinterfaces() hierarchy check not required here since these are subtypes
 	return this.permittedTypes;
 }
 @Override
@@ -2635,13 +2628,13 @@ public String toString() {
 		if (this.permittedTypes != Binding.NO_PERMITTED_TYPES) {
 			buffer.append("\n\tpermits : "); //$NON-NLS-1$
 			for (int i = 0, length = this.permittedTypes.length; i < length; i++) {
-				if (i  > 0)
+				if (i > 0)
 					buffer.append(", "); //$NON-NLS-1$
 				buffer.append((this.permittedTypes[i] != null) ? this.permittedTypes[i].debugName() : "NULL TYPE"); //$NON-NLS-1$
 			}
 		}
 	} else {
-		buffer.append("NULL PERMITTEDSUBTYPES"); //$NON-NLS-1$
+		buffer.append("NULL PERMITTED SUBTYPES"); //$NON-NLS-1$
 	}
 
 	if (this.enclosingType != null) {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/BinaryType.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/BinaryType.java
@@ -770,7 +770,6 @@ public boolean isRecord() throws JavaModelException {
 }
 /**
  * @see IType#isSealed()
- * @noreference This method is not intended to be referenced by clients as it is a part of Java preview feature.
  */
 @Override
 public boolean isSealed() throws JavaModelException {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SourceType.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SourceType.java
@@ -705,7 +705,6 @@ public boolean isRecord() throws JavaModelException {
 }
 /**
  * @see IType#isSealed()
- * @noreference This method is not intended to be referenced by clients as it is a part of Java preview feature.
  */
 @Override
 public boolean isSealed() throws JavaModelException {


### PR DESCRIPTION
## What it does

* Get rid of stale @noreference tags
* Fix javadoc
* Fix indentation problems
* Align method names with JLS terminology
* Reuse standard code patterns
* Prevent further checks on a `iterator.remove()`d element
* Get rid of type annotation handling code where no type annotations are legal

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
