### PR TITLE
[17][compiler][sealed] Incorrect compile error when sealed class tries to permit an interface

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/messages.properties
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/messages.properties
@@ -1139,7 +1139,7 @@
 1854 = A type declaration {0} that has a permits clause should have a sealed modifier
 1855 = The interface {1} with a sealed direct superinterface {0} should be declared either sealed or non-sealed
 1856 = Duplicate permitted type {0}
-1857 = Permitted class {0} does not declare {1} as direct super class
+1857 = Permitted type {0} does not declare {1} as a direct supertype
 1858 = Permitted type {0} in a named module {1} should be declared in the same module {1} of declaring type {2}
 1859 = Permitted type {0} in an unnamed module should be declared in the same package {1} of declaring type {2}
 1860 = Sealed type {0} lacks a permits clause and no type from the same compilation unit declares {0} as its direct supertype

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SealedTypesTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SealedTypesTests.java
@@ -419,12 +419,12 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 			"1. ERROR in X.java (at line 1)\n" +
 			"	public sealed class X permits Y, Z{\n" +
 			"	                              ^\n" +
-			"Permitted class Y does not declare X as direct super class\n" +
+			"Permitted type Y does not declare X as a direct supertype\n" +
 			"----------\n" +
 			"2. ERROR in X.java (at line 1)\n" +
 			"	public sealed class X permits Y, Z{\n" +
 			"	                                 ^\n" +
-			"Permitted class Z does not declare X as direct super class\n" +
+			"Permitted type Z does not declare X as a direct supertype\n" +
 			"----------\n");
 	}
 	public void testBug563806_002() {
@@ -444,7 +444,7 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 			"1. ERROR in p1\\X.java (at line 2)\n" +
 			"	public sealed class X permits Y{\n" +
 			"	                              ^\n" +
-			"Permitted class Y does not declare p1.X as direct super class\n" +
+			"Permitted type Y does not declare p1.X as a direct supertype\n" +
 			"----------\n" +
 			"2. ERROR in p1\\X.java (at line 5)\n" +
 			"	class Z extends X{}\n" +
@@ -859,7 +859,7 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 			"2. ERROR in p1\\X.java (at line 2)\n" +
 			"	public sealed class X permits Y, p2.Y {\n" +
 			"	                                 ^^^^\n" +
-			"Permitted class Y does not declare p1.X as direct super class\n" +
+			"Permitted type Y does not declare p1.X as a direct supertype\n" +
 			"----------\n";
 		runner.runNegativeTest();
 	}
@@ -1362,7 +1362,7 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 				"1. ERROR in p1\\X.java (at line 3)\n" +
 				"	sealed class Y extends X permits Z {}\n" +
 				"	                                 ^\n" +
-				"Permitted class Z does not declare p1.X.Y as direct super class\n" +
+				"Permitted type Z does not declare p1.X.Y as a direct supertype\n" +
 				"----------\n");
 	}
 	// Test that implicit permitted member type with explicit permits clause


### PR DESCRIPTION

## What it does

* Fixes https://bugs.eclipse.org/bugs/show_bug.cgi?id=574943

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
