### PR TITLE
[23] ECJ rejects local instantiation in early construction context

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypeDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypeDeclaration.java
@@ -1069,7 +1069,7 @@ public void manageEnclosingInstanceAccessIfNecessary(BlockScope currentScope, Fl
 		Scope outerScope = currentScope.parent;
 		if (!methodScope.isConstructorCall) {
 			nestedType.addSyntheticArgumentAndField(nestedType.enclosingType());
-			outerScope = outerScope.enclosingClassScope();
+			outerScope = outerScope.enclosingInstanceScope();
 			earlySeen = methodScope.isInsideEarlyConstructionContext(nestedType.enclosingType(), false);
 		}
 		if (JavaFeature.FLEXIBLE_CONSTRUCTOR_BODIES.isSupported(currentScope.compilerOptions())) {
@@ -1087,6 +1087,8 @@ public void manageEnclosingInstanceAccessIfNecessary(BlockScope currentScope, Fl
 					earlySeen = cs.insideEarlyConstructionContext;
 				}
 				outerScope = outerScope.parent;
+				if (outerScope instanceof MethodScope ms && ms.isStatic)
+					break;
 			}
 		}
 	}
@@ -1123,6 +1125,7 @@ public void manageEnclosingInstanceAccessIfNecessary(BlockScope currentScope, Fl
 		}
 	}
 }
+
 
 /**
  * Access emulation for a local member type

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Scope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Scope.java
@@ -1154,6 +1154,18 @@ public abstract class Scope {
 		return null; // may answer null if no type around
 	}
 
+	public ClassScope enclosingInstanceScope() {
+		Scope scope = this;
+		while (true) {
+			scope = scope.parent;
+			if (scope == null || scope instanceof MethodScope ms && ms.isStatic) {
+				return null;
+			} else if (scope instanceof ClassScope cs) {
+				return cs;
+			}
+		}
+	}
+
 	public final ClassScope enclosingTopMostClassScope() {
 		Scope scope = this;
 		while (scope != null) {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SuperAfterStatementsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SuperAfterStatementsTest.java
@@ -2330,4 +2330,25 @@ public class SuperAfterStatementsTest extends AbstractRegressionTest9 {
 			};
 		runner.runConformTest();
 	}
+
+	public void testGH3153() {
+		runConformTest(new String[] {
+			"X.java",
+			"""
+			public class X {
+			  public static void main(String[] argv) {
+			    class Inner {
+			      Inner() {
+			        class Local {}
+			        new Local() {}; // Error: No enclosing instance of the type X is accessible in scope
+			        super();
+			      }
+			    }
+			    new Inner();
+			  }
+			}
+			""" },
+			"");
+	}
+
 }


### PR DESCRIPTION
Avoid allocating enclosing instance beyond a static method scope

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3153
