### PR TITLE
"Regression" in 3.39.0

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
@@ -4874,7 +4874,7 @@ public void invalidType(ASTNode location, TypeBinding type) {
 			}
 		}
 
-		if (type.isParameterizedType()) {
+		if (!(type instanceof MissingTypeBinding)) {
 			List<TypeBinding> missingTypes = type.collectMissingTypes(null);
 			if (missingTypes != null) {
 				ReferenceContext savedContext = this.referenceContext;


### PR DESCRIPTION
+ find missing types in more kinds of types to avoid abort due to ProblemReporter.needImplementation()

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3064
