### PR TITLE
[23] Formatter Support for Implicit classes - investigate #2977

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/formatter/FormatterRegressionTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/formatter/FormatterRegressionTests.java
@@ -16464,4 +16464,29 @@ public void testIssue3070_2() {
 		}
 		""");
 }
+//https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2977
+//[23] Formatter Support for Implicit classes - investigate
+public void testIssue2977() {
+	setComplianceLevel(CompilerOptions.VERSION_23);
+	this.formatterOptions.put(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, JavaCore.ENABLED);
+	String source =
+		"""
+		import java.util.List;
+		String greeting() { return "Hello, World!"; }
+		void  main( )  {println(greeting());}
+		""";
+	formatSource(source,
+		"""
+		import java.util.List;
+
+		String greeting() {
+			return "Hello, World!";
+		}
+
+		void main() {
+			println(greeting());
+		}
+		""",
+		CodeFormatter.K_COMPILATION_UNIT);
+}
 }


### PR DESCRIPTION

## What it does
Adds a test to make sure the formatter supports the implicit classes as per issue #2977

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
