### PR TITLE
[Switch Expressions] Code review driven iterative clean up of Switch Expressions support

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/core/compiler/IProblem.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/core/compiler/IProblem.java
@@ -2317,7 +2317,9 @@ void setSourceStart(int sourceStart);
 	/* Java14 errors - begin */
 	/** @since 3.21  */
 	int SwitchExpressionsYieldIncompatibleResultExpressionTypes = TypeRelated + 1700;
-	/** @since 3.21  */
+	/** @since 3.21
+	 * @deprecated no longer issued - will be removed
+	 */
 	int SwitchExpressionsYieldEmptySwitchBlock = Syntax + 1701;
 	/** @since 3.21  */
 	int SwitchExpressionsYieldNoResultExpression = Internal + 1702;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
@@ -478,19 +478,6 @@ public class SwitchStatement extends Expression {
 						complaintLevel = initialComplaintLevel; // reset complaint
 						fallThroughState = this.containsPatterns ? FALLTHROUGH : CASE;
 					} else {
-						if (!isTrulyExpression() &&
-							compilerOptions.complianceLevel >= ClassFileConstants.JDK14 &&
-							statement instanceof YieldStatement &&
-							((YieldStatement) statement).isImplicit) {
-							YieldStatement y = (YieldStatement) statement;
-							Expression e = ((YieldStatement) statement).expression;
-							/* JLS 13 14.11.2
-									Switch labeled rules in switch statements differ from those in switch expressions (15.28).
-									In switch statements they must be switch labeled statement expressions, ... */
-							if (!y.expression.statementExpression()) {
-								this.scope.problemReporter().invalidExpressionAsStatement(e);
-							}
-						}
 						fallThroughState = getFallThroughState(statement, currentScope); // reset below if needed
 					}
 					if ((complaintLevel = statement.complainIfUnreachable(caseInits, this.scope, complaintLevel, true)) < Statement.COMPLAINED_UNREACHABLE) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Scanner.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Scanner.java
@@ -5615,9 +5615,6 @@ int disambiguatedRestrictedIdentifierWhen(int restrictedIdentifierToken) {
 					TokenNameIdentifier : TokenNameRestrictedIdentifierWhen;
 }
 int disambiguatedRestrictedIdentifierYield(int restrictedIdentifierToken) {
-	// and here's the kludge
-	if (restrictedIdentifierToken != TokenNameRestrictedIdentifierYield)
-		return restrictedIdentifierToken;
 	if (this.sourceLevel < ClassFileConstants.JDK14)
 		return TokenNameIdentifier;
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
@@ -11680,14 +11680,6 @@ public void switchExpressionIncompatibleResultExpressions(SwitchExpression expre
 		expression.sourceStart,
 		expression.sourceEnd);
 }
-public void switchExpressionEmptySwitchBlock(SwitchExpression expression) {
-	this.handle(
-		IProblem.SwitchExpressionsYieldEmptySwitchBlock,
-		NoArgument,
-		NoArgument,
-		expression.sourceStart,
-		expression.sourceEnd);
-}
 public void switchExpressionNoResultExpressions(SwitchExpression expression) {
 	this.handle(
 		IProblem.SwitchExpressionsYieldNoResultExpression,

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/messages.properties
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/messages.properties
@@ -1014,23 +1014,23 @@
 1513 = 'var' cannot be used with type arguments
 
 # Switch-Expressions Java 12 Preview
-1600 = Incompatible switch results expressions {0}
-1601 = A switch expression should have a non-empty switch block
-1602 = A switch expression should have at least one result expression
-1603 = A switch labeled block in a switch expression should not complete normally
-1604 = The last statement of a switch block in a switch expression should not complete normally
-1605 = Trailing switch labels are not allowed in a switch expression.
-1606 = Mixing of different kinds of case statements '->' and  ':' is not allowed within a switch
-1607 = A switch expression should have a default case
-1608 = Switch expressions are allowed only at source level 12 or above
-1609 = Switch Case Labels with '->' are allowed only at source level 12 or above
-1610 = Break of a switch expression should have a value
-1611 = A Switch expression should cover all possible values
-1612 = 'continue' or 'return' cannot be the last statement in a Switch expression case body
+###[obsolete] 1600 = Incompatible switch results expressions {0}
+###[obsolete] 1601 = A switch expression should have a non-empty switch block
+###[obsolete] 1602 = A switch expression should have at least one result expression
+###[obsolete] 1603 = A switch labeled block in a switch expression should not complete normally
+###[obsolete] 1604 = The last statement of a switch block in a switch expression should not complete normally
+###[obsolete] 1605 = Trailing switch labels are not allowed in a switch expression.
+###[obsolete] 1606 = Mixing of different kinds of case statements '->' and  ':' is not allowed within a switch
+###[obsolete] 1607 = A switch expression should have a default case
+###[obsolete] 1608 = Switch expressions are allowed only at source level 12 or above
+###[obsolete] 1609 = Switch Case Labels with '->' are allowed only at source level 12 or above
+###[obsolete] 1610 = Break of a switch expression should have a value
+###[obsolete] 1611 = A Switch expression should cover all possible values
+###[obsolete] 1612 = 'continue' or 'return' cannot be the last statement in a Switch expression case body
 
 # Switch-Expressions Java 14
 1700 = Incompatible switch results expressions {0}
-1701 = A switch expression should have a non-empty switch block
+###[obsolete] 1701 = A switch expression should have a non-empty switch block
 1702 = A switch expression should have at least one result expression
 1703 = A switch labeled block in a switch expression should not complete normally
 1704 = The last statement of a switch block in a switch expression should not complete normally

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchExpressionsYieldTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchExpressionsYieldTest.java
@@ -168,7 +168,7 @@ public class SwitchExpressionsYieldTest extends AbstractRegressionTest {
 			"	int tw = switch (i) {\n" +
 			"		};\n" +
 			"	         ^^^^^^^^^^^^^^^^\n" +
-			"A switch expression should have a non-empty switch block\n" +
+			"A switch expression should have at least one result expression\n" +
 			"----------\n" +
 			"2. ERROR in X.java (at line 6)\n" +
 			"	int tw = switch (i) {\n" +

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionParser.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionParser.java
@@ -2696,14 +2696,6 @@ protected void consumeCompilationUnit() {
 	super.consumeCompilationUnit();
 }
 @Override
-protected void consumeSwitchExpression() {
-	super.consumeSwitchExpression();
-	if (this.assistNode != null) {
-		SwitchExpression expr = (SwitchExpression) this.expressionStack[this.expressionPtr];
-		expr.resolveAll = true;
-	}
-}
-@Override
 protected void consumeConditionalExpression(int op) {
 	popElement(K_CONDITIONAL_OPERATOR);
 	super.consumeConditionalExpression(op);


### PR DESCRIPTION
## What it does

* Get rid of `SwitchExpression.resolveAll` and the kludge introduced by https://bugs.eclipse.org/bugs/show_bug.cgi?id=542560
* Withdraw the error `A switch expression should have a non-empty switch block` as it is subsumed by `A switch expression should have at least one result expression`
* Delete obsolete diagnostic property strings from messages.properties leaving corresponding IProblem constants deprecated
* Remove dead code in the Scanner
* Revert earlier ill thought out renaming of `YieldStatement.switchExpression` that actually _reduces_ readability
* Remove misplaced attempt to diagnose about expression in place of statement from `SwitchStatement.analyseCode` - this is already diagnosed in `SwitchExpression.resolveType()`
* SwitchExpression.java: Eliminate unnecessary null checks; Opt for clearer variable names; Withdraw AST traversal method that is identical to super implementation.