### PR TITLE
Test case from JDK-8337980

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractRegressionTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractRegressionTest.java
@@ -1164,7 +1164,9 @@ protected static class JavacTestOptions {
 							MismatchType.EclipseErrorsJavacNone| MismatchType.EclipseErrorsJavacWarnings) : null,
 		    JavacBug8336255 = RUN_JAVAC ? // https://bugs.openjdk.org/browse/JDK-8336255
 					new JavacBugExtraJavacOptionsPlusMismatch(" --release 23 --enable-preview -Xlint:-preview",
-							MismatchType.JavacErrorsEclipseNone) : null;
+							MismatchType.JavacErrorsEclipseNone) : null,
+			JavacBug8337980 = RUN_JAVAC ? // https://bugs.openjdk.org/browse/JDK-8337980
+					new JavacHasABug(MismatchType.EclipseErrorsJavacNone /* add pivot JDK24 */) : null;
 
 		// bugs that have been fixed but that we've not identified
 		public static JavacHasABug

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/InterfaceMethodsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/InterfaceMethodsTest.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import junit.framework.Test;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.ToolFactory;
+import org.eclipse.jdt.core.tests.compiler.regression.AbstractRegressionTest.JavacTestOptions.JavacHasABug;
 import org.eclipse.jdt.core.tests.junit.extension.TestCase;
 import org.eclipse.jdt.core.tests.util.Util;
 import org.eclipse.jdt.core.util.ClassFileBytesDisassembler;
@@ -3238,5 +3239,37 @@ public class InterfaceMethodsTest extends AbstractComparableTest {
 			"}",
 		},
 		"");
+	}
+
+	public void testJDK8337980() {
+		Runner runner = new Runner();
+		runner.testFiles = new String[] {
+			"C.java",
+			"""
+			interface A {
+			    int op();
+			}
+			abstract class B {
+			    abstract int op();
+			}
+			public abstract class C extends B implements A {
+			    public static void main(String[] args) {
+			        test(1);
+			    }
+			    public static int test(int x) {
+			        return op();
+			    }
+			}
+			"""};
+		runner.expectedCompilerLog = """
+			----------
+			1. ERROR in C.java (at line 12)
+				return op();
+				       ^^
+			Cannot make a static reference to the non-static method op() from the type B
+			----------
+			""";
+		runner.javacTestOptions = JavacHasABug.JavacBug8337980;
+		runner.runNegativeTest();
 	}
 }


### PR DESCRIPTION
See https://bugs.openjdk.org/browse/JDK-8337980

Demonstrates that ecj is uneffected by that bug.

