### PR TITLE
[24] constructor reference in early construction context generates bad bytecode

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ReferenceExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ReferenceExpression.java
@@ -1,10 +1,14 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2024 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
  * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
  *
  * SPDX-License-Identifier: EPL-2.0
  *
@@ -497,8 +501,10 @@ public class ReferenceExpression extends FunctionalExpression implements IPolyEx
 			TypeBinding type = this.receiverType.leafComponentType();
 			if (type.isNestedType() &&
 				type instanceof ReferenceBinding && !((ReferenceBinding)type).isStatic()) {
-				currentScope.tagAsAccessingEnclosingInstanceStateOf((ReferenceBinding)type, false);
-				this.shouldCaptureInstance = true;
+				if (!type.isLocalType()) {
+					currentScope.tagAsAccessingEnclosingInstanceStateOf((ReferenceBinding)type, false);
+					this.shouldCaptureInstance = true;
+				}
 				ReferenceBinding allocatedTypeErasure = (ReferenceBinding) type.erasure();
 				if (allocatedTypeErasure.isLocalType()) {
 					((LocalTypeBinding) allocatedTypeErasure).addInnerEmulationDependent(currentScope, false);

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractRegressionTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractRegressionTest.java
@@ -6,6 +6,10 @@
  * which accompanies this distribution, and is available at
  * https://www.eclipse.org/legal/epl-2.0/
  *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
@@ -306,6 +310,8 @@ static class JavacCompiler {
 			return JavaCore.VERSION_22;
 		} else if(rawVersion.startsWith("23")) {
 			return JavaCore.VERSION_23;
+		} else if(rawVersion.startsWith("24")) {
+			return JavaCore.VERSION_24;
 		} else {
 			throw new RuntimeException("unknown javac version: " + rawVersion);
 		}
@@ -315,39 +321,6 @@ static class JavacCompiler {
 	// of the same version; two latest digits are used for variants into levels
 	// denoted by the two first digits
 	static int minorFromRawVersion (String version, String rawVersion) {
-		if (version == JavaCore.VERSION_1_5) {
-			if ("1.5.0_15-ea".equals(rawVersion)) {
-				return 1500;
-			}
-			if ("1.5.0_16-ea".equals(rawVersion)) { // b01
-				return 1600;
-			}
-		}
-		if (version == JavaCore.VERSION_1_6) {
-			if ("1.6.0_10-ea".equals(rawVersion)) {
-				return 1000;
-			}
-			if ("1.6.0_10-beta".equals(rawVersion)) { // b24
-				return 1010;
-			}
-			if ("1.6.0_45".equals(rawVersion)) {
-				return 1045;
-			}
-		}
-		if (version == JavaCore.VERSION_1_7) {
-			if ("1.7.0-ea".equals(rawVersion)) {
-				return 0000;
-			}
-			if ("1.7.0_10".equals(rawVersion)) {
-				return 1000;
-			}
-			if ("1.7.0_25".equals(rawVersion)) {
-				return 2500;
-			}
-			if ("1.7.0_80".equals(rawVersion)) {
-				return 8000;
-			}
-		}
 		if (version == JavaCore.VERSION_1_8) {
 			if ("1.8.0-ea".equals(rawVersion) || ("1.8.0".equals(rawVersion))) {
 				return 0000;
@@ -564,6 +537,12 @@ static class JavacCompiler {
 		if (version == JavaCore.VERSION_23) {
 			switch(rawVersion) {
 				case "23-ea", "23":
+					return 0000;
+			}
+		}
+		if (version == JavaCore.VERSION_24) {
+			switch(rawVersion) {
+				case "24-ea", "24":
 					return 0000;
 			}
 		}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NegativeLambdaExpressionsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NegativeLambdaExpressionsTest.java
@@ -8,6 +8,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Jesper S Moller - Contributions for
@@ -6720,6 +6724,54 @@ public void test406773() {
 			compilerOptions /* custom options */
 		);
 }
+public void test406773_positive() {
+	// demonstrate that access to 'local' works in ctors for Y and Z
+	this.runConformTest(
+		new String[] {
+				"X.java",
+				"interface I {\n" +
+				"	X makeX(int x);\n" +
+				"}\n" +
+				"public class X {\n" +
+				"	void foo() {\n" +
+				"		int local = 10;\n" +
+				"		class Y extends X {\n" +
+				"			class Z extends X {\n" +
+				"				void f() {\n" +
+				"					I i = X::new;\n" +
+				"					i.makeX(123456);\n" +
+				"					i = Y::new;\n" +
+				"					i.makeX(987654);\n" +
+				"					i = Z::new;\n" +
+				"					i.makeX(456789);\n" +
+				"				}\n" +
+				"				private Z(int z) {\n" +
+				"					System.out.print(local);\n" +
+				"				}\n" +
+				"				Z() {}\n" +
+				"			}\n" +
+				"			private Y(int y) {\n" +
+				"				System.out.print(local);\n" +
+				"			}\n" +
+				"			private Y() {\n" +
+				"			}\n" +
+				"		}\n" +
+				"		new Y().new Z().f();\n" +
+				"	}\n" +
+				"	private X(int x) {\n" +
+				"		System.out.print(\"X\");\n" +
+				"	}\n" +
+				"	X() {\n" +
+				"	}\n" +
+				"	public static void main(String[] args) {\n" +
+				"		new X().foo();\n" +
+				"	}\n" +
+				"}\n"
+		},
+		"X1010"
+	);
+}
+
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=406859,  [1.8][compiler] Bad hint that method could be declared static
 public void test406859a() {
 		Map compilerOptions = getCompilerOptions();

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SuperAfterStatementsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SuperAfterStatementsTest.java
@@ -5,6 +5,10 @@
  * which accompanies this distribution, and is available at
  * https://www.eclipse.org/legal/epl-2.0/
  *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
  * SPDX-License-Identifier: EPL-2.0
  *
  * This is an implementation of an early-draft specification developed under the Java
@@ -2433,5 +2437,25 @@ public class SuperAfterStatementsTest extends AbstractRegressionTest9 {
 			"""
 			},
 			"g");
+	}
+
+	public void testGH3188() {
+		runConformTest(new String[] {
+			"EarlyLocalCtorRef.java",
+			"""
+			import java.util.function.Supplier;
+			class EarlyLocalCtorRef {
+			    EarlyLocalCtorRef() {
+			        class InnerLocal { }
+			        this(InnerLocal::new);
+			    }
+			    EarlyLocalCtorRef(Supplier<Object> s) {
+			    }
+			    public static void main(String... args0) {
+			    	new EarlyLocalCtorRef();
+			    }
+			}
+			"""},
+			"");
 	}
 }


### PR DESCRIPTION
+ avoid unnecessary access to 'this'
+ support run.javac for 24 (removing obsolete versions)

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3188
