### PR TITLE
[24] ModuleImportASTConverterTest.test002 fails after recent merge from master

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ModuleImportASTConverterTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ModuleImportASTConverterTest.java
@@ -18,7 +18,7 @@
 package org.eclipse.jdt.core.tests.dom;
 
 import java.util.List;
-
+import junit.framework.Test;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.JavaCore;
@@ -31,8 +31,6 @@ import org.eclipse.jdt.core.dom.ImportDeclaration;
 import org.eclipse.jdt.core.dom.Javadoc;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
 import org.eclipse.jdt.core.dom.Modifier;
-
-import junit.framework.Test;
 
 public class ModuleImportASTConverterTest extends ConverterTestSetup {
 
@@ -121,7 +119,7 @@ public class ModuleImportASTConverterTest extends ConverterTestSetup {
 					    System.out.println("Eclipse");
 					}
 				""";
-		this.workingCopy = getWorkingCopy("/Converter_23/src/X.java", true/*resolve*/);
+		this.workingCopy = getWorkingCopy("/Converter_24/src/X.java", true/*resolve*/);
 		ASTNode node = buildAST(contents, this.workingCopy);
 		assertEquals("Wrong type of statement", ASTNode.COMPILATION_UNIT, node.getNodeType());
 		CompilationUnit compilationUnit = (CompilationUnit) node;

--- a/org.eclipse.jdt.core.tests.model/workspace/Converter_24/.project
+++ b/org.eclipse.jdt.core.tests.model/workspace/Converter_24/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>Converter_23</name>
+	<name>Converter_24</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/org.eclipse.jdt.core.tests.model/workspace/Converter_24/src/X.java
+++ b/org.eclipse.jdt.core.tests.model/workspace/Converter_24/src/X.java
@@ -1,0 +1,4 @@
+public/// {
+	public/// {
+	}
+}


### PR DESCRIPTION
module import is now a preview for **24**, switch to new test project

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3195
