### PR TITLE
tests: add GC in waitUntilResourceDeleted

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/util/Util.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/util/Util.java
@@ -1374,6 +1374,7 @@ public static boolean waitUntilResourceDeleted(IResource resource) {
     while (count < maxRetry) {
         try {
             count++;
+            System.gc(); // workaround
             Thread.sleep(delay);
             time += delay;
             if (time > DELETE_MAX_TIME) DELETE_MAX_TIME = time;


### PR DESCRIPTION
As in waitUntilFileDeleted a Garabage Collection may help to free resources that should be deleted.

May help with failing tests
https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3081
