### PR TITLE
TouchJob: ignore projects that have been deleted

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelManager.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelManager.java
@@ -376,7 +376,9 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 					try {
 						iProject.touch(subMonitor.split(1));
 					} catch (CoreException e) {
-						Util.log(e, "Could not touch project " + iProject.getName()); //$NON-NLS-1$
+						if (e.getStatus().getCode() != IResourceStatus.RESOURCE_NOT_FOUND) {
+							Util.log(e, "Could not touch project " + iProject.getName()); //$NON-NLS-1$
+						}
 					}
 				}
 				return true;


### PR DESCRIPTION
Junit tests log exceptions like "Resource '/P1' does not exist" when they asynchronously clean up resources. The isAccessible() check is not enough as the check is not atomic with the touch.

seen in
https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3081
