### PR TITLE
Selectively revive run.javac test mode

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractRegressionTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractRegressionTest.java
@@ -1160,21 +1160,21 @@ protected static class JavacTestOptions {
 			JavacBug8144832 = // https://bugs.openjdk.java.net/browse/JDK-8144832
 					new JavacHasABug(MismatchType.JavacErrorsEclipseNone, ClassFileConstants.JDK9, 0000),
 			JavacBug8179483_switchExpression = // https://bugs.openjdk.java.net/browse/JDK-8179483
-					new JavacBug8179483(" --release 13 --enable-preview -Xlint:-preview"),
+					new JavacBug8179483(" --release 23 --enable-preview -Xlint:-preview"),
 			JavacBug8221413_switchExpression = // https://bugs.openjdk.java.net/browse/JDK-8221413
 					new JavacBug8221413(" --release 12 --enable-preview -Xlint:-preview"),
 			JavacBug8226510_switchExpression = // https://bugs.openjdk.java.net/browse/JDK-8226510
 					new JavacBug8226510(" --release 12 --enable-preview -Xlint:-preview"),
-		    JavacBug8299416 = // https://bugs.openjdk.java.net/browse/JDK-8299416
-					new JavacBugExtraJavacOptionsPlusMismatch(" --release 20 --enable-preview -Xlint:-preview",
-							MismatchType.EclipseErrorsJavacNone| MismatchType.EclipseErrorsJavacWarnings),
+//		    JavacBug8299416 = // https://bugs.openjdk.java.net/browse/JDK-8299416 was active only in some builds of JDK 20
 		    JavacBug8336255 = // https://bugs.openjdk.org/browse/JDK-8336255
 					new JavacBugExtraJavacOptionsPlusMismatch(" --release 23 --enable-preview -Xlint:-preview",
 							MismatchType.JavacErrorsEclipseNone),
 			JavacBug8337980 = // https://bugs.openjdk.org/browse/JDK-8337980
 					new JavacHasABug(MismatchType.EclipseErrorsJavacNone /* add pivot JDK24 */),
 			JavacBug8343306 = // https://bugs.openjdk.org/browse/JDK-8343306
-					new JavacHasABug(MismatchType.EclipseErrorsJavacNone /* add pivot JDK24 */);
+					new JavacHasABug(MismatchType.EclipseErrorsJavacNone /* add pivot JDK24 */),
+			JavacBug8341408 = // https://bugs.openjdk.org/browse/JDK-8341408
+					new JavacBug8341408();
 
 		// bugs that have been fixed but that we've not identified
 		public static JavacHasABug
@@ -1225,7 +1225,7 @@ protected static class JavacTestOptions {
 	public static class JavacBug8179483 extends JavacHasABug {
 		String extraJavacOptions;
 		public JavacBug8179483(String extraJavacOptions) {
-			super(MismatchType.EclipseErrorsJavacWarnings);
+			super(MismatchType.EclipseErrorsJavacNone);
 			this.extraJavacOptions = extraJavacOptions;
 		}
 		@Override
@@ -1264,6 +1264,12 @@ protected static class JavacTestOptions {
 		@Override
 		String getCompilerOptions() {
 			return super.getCompilerOptions() + this.extraJavacOptions;
+		}
+	}
+	public static class JavacBug8341408 extends JavacBugExtraJavacOptionsPlusMismatch {
+		public JavacBug8341408() {
+			super("--enable-preview -source 23 -Xlint:-preview", MismatchType.StandardOutputMismatch);
+// FIXME	this.pivotCompliance = ClassFileConstants.JDK24;
 		}
 	}
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ImplicitlyDeclaredClassesTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ImplicitlyDeclaredClassesTest.java
@@ -9,12 +9,11 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  *******************************************************************************/
-package org.eclipse.jdt.core.tests.compiler.parser;
+package org.eclipse.jdt.core.tests.compiler.regression;
 
 import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Stream;
-import org.eclipse.jdt.core.tests.compiler.regression.AbstractRegressionTest9;
 import org.eclipse.jdt.internal.compiler.CompilationResult;
 import org.eclipse.jdt.internal.compiler.DefaultErrorHandlingPolicies;
 import org.eclipse.jdt.internal.compiler.ast.CompilationUnitDeclaration;
@@ -40,6 +39,19 @@ public class ImplicitlyDeclaredClassesTest extends AbstractRegressionTest9 {
 	public ImplicitlyDeclaredClassesTest(String testName){
 		super(testName);
 	}
+
+	// ========= OPT-IN to run.javac mode: ===========
+	@Override
+	protected void setUp() throws Exception {
+		this.runJavacOptIn = true;
+		super.setUp();
+	}
+	@Override
+	protected void tearDown() throws Exception {
+		super.tearDown();
+		this.runJavacOptIn = false; // do it last, so super can still clean up
+	}
+	// =================================================
 
 	public static Class<?> testClass() {
 		return ImplicitlyDeclaredClassesTest.class;
@@ -360,8 +372,12 @@ public class ImplicitlyDeclaredClassesTest extends AbstractRegressionTest9 {
 				public static void main(String[] args) {
 					String str = readln("Enter:");
 					println(str);
-				}"""
+				}
+				"""
 		},
-		"Enter:");
+		"Enter:",
+		null,
+		VMARGS,
+		JavacTestOptions.SKIP);
 	}
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ModuleImportTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ModuleImportTests.java
@@ -31,6 +31,19 @@ public class ModuleImportTests extends AbstractModuleCompilationTest {
 		super(name);
 	}
 
+	// ========= OPT-IN to run.javac mode: ===========
+	@Override
+	protected void setUp() throws Exception {
+		this.runJavacOptIn = true;
+		super.setUp();
+	}
+	@Override
+	protected void tearDown() throws Exception {
+		super.tearDown();
+		this.runJavacOptIn = false; // do it last, so super can still clean up
+	}
+	// =================================================
+
 	public static Test suite() {
 		return buildMinimalComplianceTestSuite(testClass(), F_23);
 	}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PrimitiveInPatternsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PrimitiveInPatternsTest.java
@@ -37,6 +37,20 @@ public class PrimitiveInPatternsTest extends AbstractRegressionTest9 {
 	public PrimitiveInPatternsTest(String testName) {
 		super(testName);
 	}
+
+	// ========= OPT-IN to run.javac mode: ===========
+	@Override
+	protected void setUp() throws Exception {
+		this.runJavacOptIn = true;
+		super.setUp();
+	}
+	@Override
+	protected void tearDown() throws Exception {
+		super.tearDown();
+		this.runJavacOptIn = false; // do it last, so super can still clean up
+	}
+	// =================================================
+
 	// Enables the tests to run individually
 	protected Map<String, String> getCompilerOptions(boolean preview) {
 		Map<String, String> defaultOptions = super.getCompilerOptions();

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PrimitiveInPatternsTestSH.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PrimitiveInPatternsTestSH.java
@@ -14,6 +14,7 @@ package org.eclipse.jdt.core.tests.compiler.regression;
 
 import java.util.Map;
 import junit.framework.Test;
+import org.eclipse.jdt.core.tests.compiler.regression.AbstractRegressionTest.JavacTestOptions.JavacHasABug;
 import org.eclipse.jdt.internal.compiler.batch.FileSystem;
 import org.eclipse.jdt.internal.compiler.env.INameEnvironment;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
@@ -81,6 +82,20 @@ public class PrimitiveInPatternsTestSH extends AbstractRegressionTest9 {
 	public PrimitiveInPatternsTestSH(String testName) {
 		super(testName);
 	}
+
+	// ========= OPT-IN to run.javac mode: ===========
+	@Override
+	protected void setUp() throws Exception {
+		this.runJavacOptIn = true;
+		super.setUp();
+	}
+	@Override
+	protected void tearDown() throws Exception {
+		super.tearDown();
+		this.runJavacOptIn = false; // do it last, so super can still clean up
+	}
+	// =================================================
+
 	// Enables the tests to run individually
 	protected Map<String, String> getCompilerOptions(boolean preview) {
 		Map<String, String> defaultOptions = super.getCompilerOptions();
@@ -1579,7 +1594,7 @@ public class PrimitiveInPatternsTestSH extends AbstractRegressionTest9 {
 					}
 				}
 				""");
-		runConformTest(new String[] {"X.java", clazz.toString()}, expectedOuts);
+		runConformTest(new String[] {"X.java", clazz.toString()}, expectedOuts, getCompilerOptions(true), VMARGS, JavacHasABug.JavacBug8341408);
 	}
 	public void testInstanceof_widenUnbox_Byte() {
 		testInstanceof_widenUnbox("Byte", 1, "49+49|49+49|49+49|49.0+49.0|49.0+49.0|");

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SuperAfterStatementsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SuperAfterStatementsTest.java
@@ -38,6 +38,20 @@ public class SuperAfterStatementsTest extends AbstractRegressionTest9 {
 	public SuperAfterStatementsTest(String testName) {
 		super(testName);
 	}
+
+	// ========= OPT-IN to run.javac mode: ===========
+	@Override
+	protected void setUp() throws Exception {
+		this.runJavacOptIn = true;
+		super.setUp();
+	}
+	@Override
+	protected void tearDown() throws Exception {
+		super.tearDown();
+		this.runJavacOptIn = false; // do it last, so super can still clean up
+	}
+	// =================================================
+
 	// Enables the tests to run individually
 	protected Map<String, String> getCompilerOptions(boolean preview) {
 		Map<String, String> defaultOptions = super.getCompilerOptions();

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchExpressionsYieldTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchExpressionsYieldTest.java
@@ -15,6 +15,7 @@ package org.eclipse.jdt.core.tests.compiler.regression;
 import java.util.Map;
 import junit.framework.Test;
 import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.tests.compiler.regression.AbstractRegressionTest.JavacTestOptions.Excuse;
 import org.eclipse.jdt.core.tests.compiler.regression.AbstractRegressionTest.JavacTestOptions.JavacHasABug;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
@@ -576,7 +577,8 @@ public class SwitchExpressionsYieldTest extends AbstractRegressionTest {
 	 * A simple multi constant case statement, compiler reports missing enum constants
 	 */
 	public void testBug544073_018() {
-		String[] testFiles = new String[] {
+		Runner runner = new Runner();
+		runner.testFiles = new String[] {
 				"X.java",
 				"public class X {\n" +
 						"	public static void main(String[] args) {\n" +
@@ -594,16 +596,15 @@ public class SwitchExpressionsYieldTest extends AbstractRegressionTest {
 						"enum Day { SATURDAY, SUNDAY, MONDAY, TUESDAY;}",
 		};
 
-		String expectedProblemLog =
+		runner.expectedCompilerLog =
 						"----------\n" +
 						"1. WARNING in X.java (at line 5)\n" +
 						"	switch (day) {\n" +
 						"	        ^^^\n" +
 						"The enum constant TUESDAY needs a corresponding case label in this enum switch on Day\n" +
 						"----------\n";
-		this.runWarningTest(
-				testFiles,
-				expectedProblemLog);
+		runner.javacTestOptions = Excuse.EclipseHasSomeMoreWarnings;
+		runner.runWarningTest();
 	}
 	/*
 	 * A simple multi constant case statement with duplicate enums
@@ -694,7 +695,8 @@ public class SwitchExpressionsYieldTest extends AbstractRegressionTest {
 	/*
 	 */
 	public void testBug544073_021() {
-		String[] testFiles = new String[] {
+		Runner runner = new Runner();
+		runner.testFiles = new String[] {
 				"X.java",
 				"public class X {\n" +
 						"public static void bar(Day day) {\n" +
@@ -713,16 +715,15 @@ public class SwitchExpressionsYieldTest extends AbstractRegressionTest {
 						"enum Day { SATURDAY, SUNDAY, MONDAY, TUESDAY;}",
 		};
 
-		String expectedProblemLog =
+		runner.expectedCompilerLog =
 				"----------\n" +
 				"1. WARNING in X.java (at line 3)\n" +
 				"	switch (day) {\n" +
 				"	        ^^^\n" +
 				"The enum constant MONDAY needs a corresponding case label in this enum switch on Day\n" +
 				"----------\n";
-		this.runWarningTest(
-				testFiles,
-				expectedProblemLog);
+		runner.javacTestOptions = Excuse.EclipseHasSomeMoreWarnings;
+		runner.runWarningTest();
 	}
 	public void testBug544073_022() {
 		String[] testFiles = new String[] {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchPatternTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchPatternTest.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.util.Map;
 import junit.framework.Test;
 import org.eclipse.jdt.core.ToolFactory;
+import org.eclipse.jdt.core.tests.compiler.regression.AbstractRegressionTest.JavacTestOptions.Excuse;
 import org.eclipse.jdt.core.tests.util.Util;
 import org.eclipse.jdt.core.util.ClassFileBytesDisassembler;
 import org.eclipse.jdt.core.util.ClassFormatException;
@@ -31,7 +32,7 @@ public class SwitchPatternTest extends AbstractRegressionTest9 {
 //		TESTS_NAMES = new String[] { "testBug575053_002"};
 	}
 
-	private static String previewLevel = "21";
+	private static String previewLevel = "23";
 
 	public static Class<?> testClass() {
 		return SwitchPatternTest.class;
@@ -3836,10 +3837,10 @@ public class SwitchPatternTest extends AbstractRegressionTest9 {
 				"");
 	}
 	public void testBug575571_1() {
-		Map<String, String> options = getCompilerOptions();
-		options.put(CompilerOptions.OPTION_ReportMissingDefaultCase, CompilerOptions.WARNING);
-		runWarningTest(
-		new String[] {
+		Runner runner = new Runner();
+		runner.customOptions = getCompilerOptions();
+		runner.customOptions.put(CompilerOptions.OPTION_ReportMissingDefaultCase, CompilerOptions.WARNING);
+		runner.testFiles = new String[] {
 		"X.java",
 		"public class X {\n" +
 		"       public void foo(Color o) {\n" +
@@ -3851,14 +3852,16 @@ public class SwitchPatternTest extends AbstractRegressionTest9 {
 		"       public static void main(String[] args) {}\n" +
 		"}\n" +
 		"enum Color {   Blue;  }\n",
-		},
+		};
+		runner.expectedCompilerLog =
 		"----------\n" +
 		"1. WARNING in X.java (at line 3)\n" +
 		"	switch (o) {\n" +
 		"	        ^\n" +
 		"The switch over the enum type Color should have a default case\n" +
-		"----------\n",
-		options);
+		"----------\n";
+		runner.javacTestOptions = Excuse.EclipseHasSomeMoreWarnings;
+		runner.runWarningTest();
 	}
 	public void testBug575571_2() {
 		runNegativeTest(
@@ -4809,8 +4812,6 @@ public class SwitchPatternTest extends AbstractRegressionTest9 {
 	}
 	public void testBug578553_7() {
 		runNegativeTest(
-				false /*skipJavac */,
-				JavacTestOptions.JavacHasABug.JavacBug8299416,
 				new String[] {
 					"X.java",
 					"public class X {\n"
@@ -8238,6 +8239,7 @@ public class SwitchPatternTest extends AbstractRegressionTest9 {
 				"	        ^\n" +
 				"The enum constant THREE should have a corresponding case label in this enum switch on NUM. To suppress this problem, add a comment //$CASES-OMITTED$ on the line above the 'default:'\n" +
 				"----------\n";
+		runner.javacTestOptions = Excuse.EclipseWarningConfiguredAsError;
 		runner.runNegativeTest();
 	}
 

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TestAll.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TestAll.java
@@ -26,7 +26,6 @@ package org.eclipse.jdt.core.tests.compiler.regression;
 import java.util.ArrayList;
 import junit.framework.Test;
 import junit.framework.TestSuite;
-import org.eclipse.jdt.core.tests.compiler.parser.ImplicitlyDeclaredClassesTest;
 import org.eclipse.jdt.core.tests.compiler.util.HashtableOfObjectTest;
 import org.eclipse.jdt.core.tests.compiler.util.JrtUtilTest;
 import org.eclipse.jdt.core.tests.dom.StandAloneASTParserTest;


### PR DESCRIPTION
+ some more classes to opt in
+ declare one more excuse, update existing excuses
+ unblock ImplicitlyDeclaredClassesTest.testGH3137b()
  - test execution hangs - in run.javac mode infinitely

+ incomplete work on
  - SwitchExpressionYieldTest
  - SwitchPatternTest

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/386
