### PR TITLE
[Internal][Switch Expressions] Eliminate double book keeping in SwitchExpression handling

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Statement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Statement.java
@@ -192,12 +192,11 @@ void analyseOneArgument18(BlockScope currentScope, FlowContext flowContext, Flow
 		ce.internalAnalyseOneArgument18(currentScope, flowContext, expectedType, ce.valueIfTrue, flowInfo, ce.ifTrueNullStatus, expectedNonNullness, originalExpected);
 		ce.internalAnalyseOneArgument18(currentScope, flowContext, expectedType, ce.valueIfFalse, flowInfo, ce.ifFalseNullStatus, expectedNonNullness, originalExpected);
 		return;
-	} else 	if (argument instanceof SwitchExpression && argument.isPolyExpression()) {
-		SwitchExpression se = (SwitchExpression) argument;
-		for (int i = 0; i < se.resultExpressions().size(); i++) {
+	} else 	if (argument instanceof SwitchExpression se && se.isPolyExpression()) {
+		for (Expression rExpression : se.resultExpressions()) {
 			se.internalAnalyseOneArgument18(currentScope, flowContext, expectedType,
-					se.resultExpressions.get(i), flowInfo,
-					se.resultExpressionNullStatus.get(i), expectedNonNullness, originalExpected);
+					rExpression, flowInfo,
+					rExpression.nullStatus(flowInfo, flowContext), expectedNonNullness, originalExpected);
 		}
 		return;
 	}
@@ -259,12 +258,11 @@ protected void checkAgainstNullTypeAnnotation(BlockScope scope, TypeBinding requ
 		internalCheckAgainstNullTypeAnnotation(scope, requiredType, ce.valueIfTrue, ce.ifTrueNullStatus, flowContext, flowInfo);
 		internalCheckAgainstNullTypeAnnotation(scope, requiredType, ce.valueIfFalse, ce.ifFalseNullStatus, flowContext, flowInfo);
 		return;
-	} else 	if (expression instanceof SwitchExpression && expression.isPolyExpression()) {
-		SwitchExpression se = (SwitchExpression) expression;
-		for (int i = 0; i < se.resultExpressions().size(); i++) {
+	} else 	if (expression instanceof SwitchExpression se && se.isPolyExpression()) {
+		for (Expression rExpression : se.resultExpressions()) {
 			internalCheckAgainstNullTypeAnnotation(scope, requiredType,
-					se.resultExpressions.get(i),
-					se.resultExpressionNullStatus.get(i), flowContext, flowInfo);
+					rExpression,
+					rExpression.nullStatus(flowInfo, flowContext), flowContext, flowInfo);
 		}
 		return;
 	}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullAnnotationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullAnnotationTest.java
@@ -10460,13 +10460,13 @@ public void testBug530970_on_field_bin() {
 	);
 }
 public void testBug542707_001() {
-	if (this.complianceLevel < ClassFileConstants.JDK12)
+	if (this.complianceLevel < ClassFileConstants.JDK14)
 		return;
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_POTENTIAL_NULL_REFERENCE, JavaCore.ERROR);
-	options.put(CompilerOptions.OPTION_Compliance, CompilerOptions.VERSION_12);
-	options.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_12);
-	options.put(CompilerOptions.OPTION_TargetPlatform, CompilerOptions.VERSION_12);
+	options.put(CompilerOptions.OPTION_Compliance, CompilerOptions.VERSION_14);
+	options.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_14);
+	options.put(CompilerOptions.OPTION_TargetPlatform, CompilerOptions.VERSION_14);
 	options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.ENABLED);
 	options.put(CompilerOptions.OPTION_ReportPreviewFeatures, CompilerOptions.IGNORE);
 	runNegativeTestWithLibs(
@@ -10506,7 +10506,7 @@ public void testBug542707_001() {
 		"1. ERROR in X.java (at line 0)\n" +
 		"	import java.io.IOException;\n" +
 		"	^\n" +
-		"Preview features enabled at an invalid source release level 12, preview can be enabled only at source level "+AbstractRegressionTest.PREVIEW_ALLOWED_LEVEL+"\n" +
+		"Preview features enabled at an invalid source release level 14, preview can be enabled only at source level " + AbstractRegressionTest.PREVIEW_ALLOWED_LEVEL+"\n" +
 		"----------\n"
 	);
 }
@@ -10514,13 +10514,13 @@ public void testBug542707_001() {
  * should not throw IOOBE while building - a safety check test case.
  */
 public void testBug542707_002() {
-	if (this.complianceLevel != ClassFileConstants.JDK12)
+	if (this.complianceLevel != ClassFileConstants.JDK14)
 		return;
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_POTENTIAL_NULL_REFERENCE, JavaCore.ERROR);
-	options.put(CompilerOptions.OPTION_Compliance, CompilerOptions.VERSION_12);
-	options.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_12);
-	options.put(CompilerOptions.OPTION_TargetPlatform, CompilerOptions.VERSION_12);
+	options.put(CompilerOptions.OPTION_Compliance, CompilerOptions.VERSION_14);
+	options.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_14);
+	options.put(CompilerOptions.OPTION_TargetPlatform, CompilerOptions.VERSION_14);
 	options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.ENABLED);
 	options.put(CompilerOptions.OPTION_ReportPreviewFeatures, CompilerOptions.IGNORE);
 	runNegativeTestWithLibs(
@@ -10547,17 +10547,15 @@ public void testBug542707_002() {
 		"1. ERROR in X.java (at line 0)\n" +
 		"	import org.eclipse.jdt.annotation.*;\n" +
 		"	^\n" +
-		"Preview features enabled at an invalid source release level 12, preview can be enabled only at source level "+AbstractRegressionTest.PREVIEW_ALLOWED_LEVEL+"\n" +
+		"Preview features enabled at an invalid source release level 14, preview can be enabled only at source level " + AbstractRegressionTest.PREVIEW_ALLOWED_LEVEL+"\n" +
 		"----------\n"
 	);
 }
 public void testBug542707_003() {
-	if (this.complianceLevel < ClassFileConstants.JDK12 || useDeclarationAnnotations()) return; // switch expression
+	if (this.complianceLevel < ClassFileConstants.JDK14 || useDeclarationAnnotations()) return; // switch expression
 	// outer expected type (from assignment) is propagated deeply into a switch expression
 	Runner runner = new Runner();
 	runner.customOptions = getCompilerOptions();
-	runner.customOptions.put(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, JavaCore.ENABLED);
-	runner.customOptions.put(CompilerOptions.OPTION_ReportPreviewFeatures, CompilerOptions.IGNORE);
 	runner.classLibraries = this.LIBS;
 	runner.testFiles = new String[] {
 		"X.java",
@@ -10573,29 +10571,220 @@ public void testBug542707_003() {
 		"	}\n" +
 		"}\n"
 	};
-	runner.expectedCompilerLog = checkPreviewAllowed() ?
+	runner.expectedCompilerLog =
 			"----------\n" +
 			"1. ERROR in X.java (at line 7)\n" +
 			"	default -> i == 3 ? maybe() : \"\";\n" +
 			"	                    ^^^^^^^\n" +
 			"Null type mismatch (type annotations): required \'@NonNull String\' but this expression has type \'@Nullable String\'\n" +
-			"----------\n" :
-			"----------\n" +
-			"1. ERROR in X.java (at line 0)\n" +
-			"	import org.eclipse.jdt.annotation.*;\n" +
-			"	^\n" +
-			"Preview features enabled at an invalid source release level "+CompilerOptions.versionFromJdkLevel(this.complianceLevel)+", preview can be enabled only at source level "+AbstractRegressionTest.PREVIEW_ALLOWED_LEVEL+"\n" +
 			"----------\n";
 	runner.runNegativeTest();
 }
+
+public void testBug542707_003_1() {
+	if (this.complianceLevel < ClassFileConstants.JDK14 || useDeclarationAnnotations()) return; // switch expression
+	// outer expected type (from assignment) is propagated deeply into a switch expression
+	Runner runner = new Runner();
+	runner.customOptions = getCompilerOptions();
+	runner.classLibraries = this.LIBS;
+	runner.testFiles = new String[] {
+		"X.java",
+		"import org.eclipse.jdt.annotation.*;\n" +
+		"public class X {\n" +
+		"	@Nullable String maybe() { return null; }\n" +
+		"	void test(int i) {\n" +
+		"		@NonNull String s = switch (i) {\n" +
+		"			case 1 -> \"\";\n" +
+		"			default -> maybe();\n" +
+		"		};\n" +
+		"		System.out.println(s.toLowerCase());\n" +
+		"	}\n" +
+		"}\n"
+	};
+	runner.expectedCompilerLog =
+			"----------\n" +
+			"1. ERROR in X.java (at line 7)\n" +
+			"	default -> maybe();\n" +
+			"	           ^^^^^^^\n" +
+			"Null type mismatch (type annotations): required \'@NonNull String\' but this expression has type \'@Nullable String\'\n" +
+			"----------\n";
+	runner.runNegativeTest();
+}
+
+public void testBug542707_003_2() {
+	if (this.complianceLevel < ClassFileConstants.JDK14 || useDeclarationAnnotations()) return; // switch expression
+	// no expected type due to LVTI
+	Runner runner = new Runner();
+	runner.customOptions = getCompilerOptions();
+	runner.classLibraries = this.LIBS;
+	runner.testFiles = new String[] {
+		"X.java",
+		"""
+		import org.eclipse.jdt.annotation.NonNull;
+		import org.eclipse.jdt.annotation.Nullable;
+
+		public class X {
+
+			static void foo(@NonNull String s) {}
+
+			@Nullable static String maybe() {
+				return null;
+			}
+
+			public static void main(String[] args) {
+				int x = 42;
+				var s = switch (x) {
+				case 42 -> "Hello";
+				default -> maybe();
+				};
+				foo(s);
+			}
+
+		}
+		"""
+	};
+	runner.expectedCompilerLog =
+			"----------\n" +
+			"1. ERROR in X.java (at line 18)\n" +
+			"	foo(s);\n" +
+			"	    ^\n" +
+			"Null type mismatch (type annotations): required '@NonNull String' but this expression has type '@Nullable String'\n" +
+			"----------\n";
+	runner.runNegativeTest();
+}
+
+public void testBug542707_003_3() {
+	if (this.complianceLevel < ClassFileConstants.JDK14 || useDeclarationAnnotations()) return; // switch expression
+	// no expected type due to LVTI
+	Runner runner = new Runner();
+	runner.customOptions = getCompilerOptions();
+	runner.classLibraries = this.LIBS;
+	runner.testFiles = new String[] {
+		"X.java",
+		"""
+		import org.eclipse.jdt.annotation.NonNull;
+		import org.eclipse.jdt.annotation.Nullable;
+
+		public class X {
+
+			static void foo(@NonNull String s) {}
+
+			@Nullable static String maybe() {
+				return null;
+			}
+
+			public static void main(String[] args) {
+				int x = 42;
+				var s = switch (x) {
+				case 42 -> maybe();
+				default -> "Hello";
+				};
+				foo(s);
+			}
+
+		}
+		"""
+	};
+	runner.expectedCompilerLog =
+			"----------\n" +
+			"1. ERROR in X.java (at line 18)\n" +
+			"	foo(s);\n" +
+			"	    ^\n" +
+			"Null type mismatch (type annotations): required '@NonNull String' but this expression has type '@Nullable String'\n" +
+			"----------\n";
+	runner.runNegativeTest();
+}
+
+public void testBug542707_003_4() {
+	if (this.complianceLevel < ClassFileConstants.JDK14 || useDeclarationAnnotations()) return; // switch expression
+	// no expected type due to LVTI
+	Runner runner = new Runner();
+	runner.customOptions = getCompilerOptions();
+	runner.classLibraries = this.LIBS;
+	runner.testFiles = new String[] {
+		"X.java",
+		"""
+		import org.eclipse.jdt.annotation.NonNull;
+		import org.eclipse.jdt.annotation.Nullable;
+
+		public class X {
+
+			static void foo(@Nullable String s) {}
+
+			@NonNull static String maybe() {
+				return null;
+			}
+
+			public static void main(String[] args) {
+				int x = 42;
+				var s = switch (x) {
+				case 42 -> "Hello";
+				default -> maybe();
+				};
+				foo(s);
+			}
+
+		}
+		"""
+	};
+	runner.expectedCompilerLog =
+			"----------\n" +
+			"1. ERROR in X.java (at line 9)\n" +
+			"	return null;\n" +
+			"	       ^^^^\n" +
+			"Null type mismatch: required '@NonNull String' but the provided value is null\n" +
+			"----------\n";
+	runner.runNegativeTest();
+}
+
+public void testBug542707_003_5() {
+	if (this.complianceLevel < ClassFileConstants.JDK14 || useDeclarationAnnotations()) return; // switch expression
+	// no expected type due to LVTI
+	Runner runner = new Runner();
+	runner.customOptions = getCompilerOptions();
+	runner.classLibraries = this.LIBS;
+	runner.testFiles = new String[] {
+		"X.java",
+		"""
+		import org.eclipse.jdt.annotation.NonNull;
+		import org.eclipse.jdt.annotation.Nullable;
+
+		public class X {
+
+			static void foo(@NonNull Object o) {}
+
+			@Nullable static String maybe() {
+				return null;
+			}
+
+			public static void main(String[] args) {
+				int x = 42;
+				var s = switch (x) {
+				case 42 -> new X();
+				default -> maybe();
+				};
+				foo(s);
+			}
+
+		}
+		"""
+	};
+	runner.expectedCompilerLog =
+			"----------\n" +
+			"1. ERROR in X.java (at line 18)\n" +
+			"	foo(s);\n" +
+			"	    ^\n" +
+			"Null type mismatch: required '@NonNull Object' but the provided value is inferred as @Nullable\n" +
+			"----------\n";
+	runner.runNegativeTest();
+}
+
 // failing, see https://bugs.eclipse.org/543860
 public void _testBug542707_004() {
-	if (this.complianceLevel < ClassFileConstants.JDK12) return; // switch expression
+	if (this.complianceLevel < ClassFileConstants.JDK14) return; // switch expression
 	// outer expected type (from method parameter) is propagated deeply into a switch expression
 	Runner runner = new Runner();
 	runner.customOptions = getCompilerOptions();
-	runner.customOptions.put(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, JavaCore.ENABLED);
-	runner.customOptions.put(CompilerOptions.OPTION_ReportPreviewFeatures, CompilerOptions.IGNORE);
 	runner.classLibraries = this.LIBS;
 	runner.testFiles = new String[] {
 		"X.java",
@@ -10623,12 +10812,10 @@ public void _testBug542707_004() {
 	runner.runNegativeTest();
 }
 public void testBug542707_005() {
-	if (this.complianceLevel < ClassFileConstants.JDK12 || useDeclarationAnnotations()) return; // switch expression
+	if (this.complianceLevel < ClassFileConstants.JDK14 || useDeclarationAnnotations()) return; // switch expression
 	// switch value must not be null (@Nullable)
 	Runner runner = new Runner();
 	runner.customOptions = getCompilerOptions();
-	runner.customOptions.put(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, JavaCore.ENABLED);
-	runner.customOptions.put(CompilerOptions.OPTION_ReportPreviewFeatures, CompilerOptions.IGNORE);
 	runner.classLibraries = this.LIBS;
 	runner.testFiles = new String[] {
 		"X.java",
@@ -10644,28 +10831,20 @@ public void testBug542707_005() {
 		"	}\n" +
 		"}\n"
 	};
-	runner.expectedCompilerLog = checkPreviewAllowed() ?
+	runner.expectedCompilerLog =
 			"----------\n" +
 			"1. ERROR in X.java (at line 5)\n" +
 			"	return switch(day) {\n" +
 			"	              ^^^\n" +
 			"Potential null pointer access: this expression has a \'@Nullable\' type\n" +
-			"----------\n" :
-			"----------\n" +
-			"1. ERROR in X.java (at line 0)\n" +
-			"	import org.eclipse.jdt.annotation.*;\n" +
-			"	^\n" +
-			"Preview features enabled at an invalid source release level "+CompilerOptions.versionFromJdkLevel(this.complianceLevel)+", preview can be enabled only at source level "+AbstractRegressionTest.PREVIEW_ALLOWED_LEVEL+"\n" +
 			"----------\n";
 	runner.runNegativeTest();
 }
 public void testBug542707_006() {
-	if (this.complianceLevel < ClassFileConstants.JDK12) return; // switch expression
+	if (this.complianceLevel < ClassFileConstants.JDK14) return; // switch expression
 	// switch value must not be null (pot-null by flow analysis)
 	Runner runner = new Runner();
 	runner.customOptions = getCompilerOptions();
-	runner.customOptions.put(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, JavaCore.ENABLED);
-	runner.customOptions.put(CompilerOptions.OPTION_ReportPreviewFeatures, CompilerOptions.IGNORE);
 	runner.classLibraries = this.LIBS;
 	runner.testFiles = new String[] {
 		"X.java",
@@ -10681,26 +10860,16 @@ public void testBug542707_006() {
 		"	}\n" +
 		"}\n"
 	};
-	runner.expectedCompilerLog = checkPreviewAllowed() ?
+	runner.expectedCompilerLog =
 			"----------\n" +
 			"2. ERROR in X.java (at line 5)\n" +
 			"	return switch(day) {\n" +
 			"	              ^^^\n" +
 			"Potential null pointer access: The variable day may be null at this location\n" +
-			"----------\n" :
-			"----------\n" +
-			"1. ERROR in X.java (at line 0)\n" +
-			"	enum SomeDays { Mon, Wed, Fri }\n" +
-			"	^\n" +
-			"Preview features enabled at an invalid source release level "+CompilerOptions.versionFromJdkLevel(this.complianceLevel)+", preview can be enabled only at source level "+AbstractRegressionTest.PREVIEW_ALLOWED_LEVEL+"\n" +
 			"----------\n";
 	runner.runNegativeTest();
 }
 public void testBug545715() {
-	if (!checkPreviewAllowed()) return; // switch expression
-	Map<String, String>  customOptions = getCompilerOptions();
-	customOptions.put(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, JavaCore.ENABLED);
-	customOptions.put(CompilerOptions.OPTION_ReportPreviewFeatures, CompilerOptions.IGNORE);
 	runConformTest(
 		new String[] {
 			"X.java",
@@ -10715,9 +10884,7 @@ public void testBug545715() {
 			"    }\n"+
 			"}\n"
 		},
-	    "",
-	    customOptions,
-	    new String[] {"--enable-preview"});
+	    "");
 }
 public void testBug548418_001a() {
 	if (this.complianceLevel < ClassFileConstants.JDK14 || useDeclarationAnnotations()) return;

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullReferenceTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullReferenceTest.java
@@ -18287,11 +18287,10 @@ public void testBug536408() {
 	runner.runNegativeTest();
 }
 public void testBug542707_1() {
-	if (!checkPreviewAllowed()) return; // switch expression
+	if (this.complianceLevel < ClassFileConstants.JDK14) // switch expression
+		return;
 	Runner runner = new Runner();
 	runner.customOptions = new HashMap<>();
-	runner.customOptions.put(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, JavaCore.ENABLED);
-	runner.customOptions.put(JavaCore.COMPILER_PB_REPORT_PREVIEW_FEATURES, JavaCore.IGNORE);
 	runner.testFiles = new String[] {
 		"X.java",
 		"public class X {\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullTypeAnnotationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullTypeAnnotationTest.java
@@ -18026,12 +18026,11 @@ public void testBug540264() {
 	);
 }
 public void testBug542707_1() {
-	if (!checkPreviewAllowed()) return; // switch expression
+	if (this.complianceLevel < ClassFileConstants.JDK14)
+		return;
 	// switch expression has a functional type with interesting type inference and various null issues:
 	Runner runner = new Runner();
 	runner.customOptions = getCompilerOptions();
-	runner.customOptions.put(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, JavaCore.ENABLED);
-	runner.customOptions.put(JavaCore.COMPILER_PB_REPORT_PREVIEW_FEATURES, JavaCore.IGNORE);
 	runner.classLibraries = this.LIBS;
 	runner.testFiles = new String[] {
 		"X.java",

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ResourceLeakTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ResourceLeakTests.java
@@ -5658,12 +5658,11 @@ public void testBug541705b() {
 	runner.runConformTest();
 }
 public void testBug542707_001() {
-	if (!checkPreviewAllowed()) return; // uses switch expression
+	if (this.complianceLevel < ClassFileConstants.JDK14) // switch expression
+		return;
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_UNCLOSED_CLOSEABLE, CompilerOptions.ERROR);
 	options.put(JavaCore.COMPILER_PB_POTENTIALLY_UNCLOSED_CLOSEABLE, CompilerOptions.ERROR);
-	options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.ENABLED);
-	options.put(CompilerOptions.OPTION_ReportPreviewFeatures, CompilerOptions.IGNORE);
 	runLeakTest(
 		new String[] {
 			"X.java",
@@ -5710,7 +5709,7 @@ public void testBug542707_001() {
 		options);
 }
 public void testBug542707_002() {
-	if (this.complianceLevel < ClassFileConstants.JDK15) return; // uses switch expression
+	if (this.complianceLevel < ClassFileConstants.JDK14) return; // uses switch expression
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_UNCLOSED_CLOSEABLE, CompilerOptions.ERROR);
 	options.put(JavaCore.COMPILER_PB_POTENTIALLY_UNCLOSED_CLOSEABLE, CompilerOptions.ERROR);
@@ -5778,12 +5777,11 @@ public void testBug542707_002() {
 		options);
 }
 public void testBug542707_003() {
-	if (!checkPreviewAllowed()) return; // uses switch expression
+	if (this.complianceLevel < ClassFileConstants.JDK14)
+		return;  // uses switch expression
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_UNCLOSED_CLOSEABLE, CompilerOptions.ERROR);
 	options.put(JavaCore.COMPILER_PB_POTENTIALLY_UNCLOSED_CLOSEABLE, CompilerOptions.ERROR);
-	options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.ENABLED);
-	options.put(CompilerOptions.OPTION_ReportPreviewFeatures, CompilerOptions.IGNORE);
 	runLeakTest(
 		new String[] {
 			"X.java",
@@ -5840,7 +5838,7 @@ public void testBug542707_003() {
 		options);
 }
 public void testBug486506() {
-	if (this.complianceLevel < ClassFileConstants.JDK1_8) return; // uses switch expression
+	if (this.complianceLevel < ClassFileConstants.JDK1_8) return;
 	Map options = getCompilerOptions();
 	options.put(JavaCore.COMPILER_PB_UNCLOSED_CLOSEABLE, CompilerOptions.ERROR);
 	options.put(JavaCore.COMPILER_PB_POTENTIALLY_UNCLOSED_CLOSEABLE, CompilerOptions.ERROR);


### PR DESCRIPTION
* Eliminate double book keeping by getting rid of `org.eclipse.jdt.internal.compiler.ast.SwitchExpression.resultExpressions`
* Eliminate the convenience copy state held in  `org.eclipse.jdt.internal.compiler.ast.SwitchExpression.resultExpressions`resultExpressionNullStatus` as it makes assumptions about the collection (that it is a List/supports `get(int)` method which doesn't gel with the latest changes.
* Rather than use the convenience copy of the null status of result expressions, reach for them from the result expressions when required.
* Inline  `org.eclipse.jdt.internal.compiler.ast.SwitchExpression.computeNullStatus()` into `analyzeCode()` and simplify a bit
* Null annotation tests have carried a measure of bit rot. A bunch of tests were not running - fixed.
* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3224

