### PR TITLE
Fix failing ModelUtilTests #3247

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/apt/model/ElementsImpl.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/apt/model/ElementsImpl.java
@@ -402,7 +402,7 @@ public class ElementsImpl implements Elements {
 	 * Javac's behavior with regard to tab expansion and trimming of whitespace and
 	 * asterisks is bizarre and undocumented.  We do our best here to emulate it.
 	 */
-	private static String formatJavadoc(char[] unparsed)
+	protected static String formatJavadoc(char[] unparsed)
 	{
 		if (unparsed == null || unparsed.length < 5) { // delimiters take 5 chars
 			return null;


### PR DESCRIPTION
Make sure that the older spec method getDocComment() does not reference the JLS 23 method getDocCommentKind()

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
Fixes #3247

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
