### PR TITLE
[Enhanced Switch] Compiler tolerates pure expressions in switch rule expressions in a switch statement

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Statement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Statement.java
@@ -284,6 +284,33 @@ private void internalCheckAgainstNullTypeAnnotation(BlockScope scope, TypeBindin
 }
 
 /**
+ * Returns the immediately enclosing switch expression (carried by closest blockScope),
+ */
+public SwitchExpression enclosingSwitchExpression(Scope current) {
+	boolean implicitYield = this instanceof YieldStatement yield && yield.isImplicit;
+	do {
+		switch(current.kind) {
+			case Scope.METHOD_SCOPE :
+			case Scope.CLASS_SCOPE :
+			case Scope.COMPILATION_UNIT_SCOPE :
+			case Scope.MODULE_SCOPE :
+				return null;
+			case Scope.BLOCK_SCOPE: {
+				BlockScope bs = (BlockScope) current;
+				if (bs.enclosingCase != null) {
+					if (bs.enclosingCase.swich instanceof SwitchExpression se)
+						return se;
+					if (implicitYield)
+						return null; // do not ascend to enclosing: implicit yield always binds to closest switch{expression|statement}
+				}
+				break;
+			}
+		}
+	} while ((current = current.parent) != null);
+	return null;
+}
+
+/**
  * INTERNAL USE ONLY.
  * This is used to redirect inter-statements jumps.
  */

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TryStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TryStatement.java
@@ -1071,7 +1071,7 @@ public void resolve(BlockScope upperScope) {
 	// special scope for secret locals optimization.
 	this.scope = new BlockScope(upperScope);
 
-	if (upperScope.enclosingSwitchExpression() instanceof SwitchExpression swich) {
+	if (enclosingSwitchExpression(upperScope) instanceof SwitchExpression swich) {
 		swich.jvmStackVolatile = true; // ought to prepare for any raised exception blowing up the the operand stack to smithereens
 	}
 	BlockScope finallyScope = null;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/YieldStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/YieldStatement.java
@@ -147,7 +147,7 @@ public void generateCode(BlockScope currentScope, CodeStream codeStream) {
 public void resolve(BlockScope scope) {
 
 	if (this.switchExpression == null) {
-		this.switchExpression = scope.enclosingSwitchExpression();
+		this.switchExpression = enclosingSwitchExpression(scope);
 		if (this.switchExpression != null && this.switchExpression.isPolyExpression()) {
 			this.expression.setExpressionContext(this.switchExpression.expressionContext); // result expressions feature in same context ...
 			this.expression.setExpectedType(this.switchExpression.expectedType);           // ... with the same target type

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Scope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Scope.java
@@ -3826,29 +3826,6 @@ public abstract class Scope {
 		return null;
 	}
 
-	/**
-	 * Returns the immediately enclosing switch expression (carried by closest blockScope),
-	 */
-	public SwitchExpression enclosingSwitchExpression() {
-		Scope current = this;
-		do {
-			switch(current.kind) {
-				case METHOD_SCOPE :
-				case CLASS_SCOPE :
-				case COMPILATION_UNIT_SCOPE :
-				case MODULE_SCOPE :
-					return null;
-				case BLOCK_SCOPE: {
-					BlockScope bs = (BlockScope) current;
-					if (bs.enclosingCase != null && bs.enclosingCase.swich instanceof SwitchExpression se)
-						return se;
-					break;
-				}
-			}
-		} while ((current = current.parent) != null);
-		return null;
-	}
-
 	// Tie break IS running to determine the most specific method binding.
 	protected boolean isAcceptableMethod(MethodBinding one, MethodBinding two) {
 		TypeBinding[] oneParams = one.parameters;

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchTest.java
@@ -3502,6 +3502,40 @@ public void testIssue1777_3() throws Exception {
 	},
 	"DefaultEND");
 }
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3274
+// [Enhanced Switch] Compiler tolerates pure expressions in switch rule expressions in a switch statement
+public void testIssue3274() throws Exception {
+	if (this.complianceLevel < ClassFileConstants.JDK14)
+		return;
+
+	this.runNegativeTest(new String[] {
+		"X.java",
+		"""
+		public class X {
+		       static public void main (String[] args) {
+		               int a = 0x21;
+		               int b = 0xff;
+		               System.out.println(
+		               switch (a) {
+		               case 0x21 : {
+		                       switch (b) {
+		                       default -> "default";
+		                       }
+		               }
+		               case 0x3b : yield "3b <- WTH?";
+		               default : yield "default";
+		               });
+		       }
+		}
+		""",
+	},
+	"----------\n" +
+	"1. ERROR in X.java (at line 9)\n" +
+	"	default -> \"default\";\n" +
+	"	           ^^^^^^^^^\n" +
+	"Invalid expression as statement\n" +
+	"----------\n");
+}
 public static Class testClass() {
 	return SwitchTest.class;
 }


### PR DESCRIPTION
* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3274