### PR TITLE
ECJ fails to recognize "yield" as a contextual keyword when there is a case fall-through

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchExpressionsYieldTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchExpressionsYieldTest.java
@@ -8321,4 +8321,29 @@ public class SwitchExpressionsYieldTest extends AbstractRegressionTest {
 				},
 				"special");
 	}
+
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3283
+	// ECJ fails to recognize "yield" as a contextual keyword when there is a case fall-through
+	public void testIssue3283() {
+		this.runConformTest(
+				new String[] {
+				"X.java",
+				"""
+				public class X {
+					public static int var = 0;
+					public static void main(String argv[]) {
+				        int j = switch(var){
+				        case 0: yield (0 + 42); // If this is removed, there's a different error
+				        case 1: // If I remove this line, the error goes away
+				        case 2: yield 1; // multiple errors
+				        default:
+				          throw new IllegalArgumentException("Unexpected value: " + var);
+				    };
+				    System.out.println("Yield = " + j);
+				    }
+				}
+				"""
+				},
+				"Yield = 42");
+	}
 }


### PR DESCRIPTION
* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3283