### PR TITLE
Enhanced switch v2.0 - Part I

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/.settings/.api_filters
+++ b/org.eclipse.jdt.core.compiler.batch/.settings/.api_filters
@@ -8,24 +8,4 @@
             </message_arguments>
         </filter>
     </resource>
-    <resource path="src/org/eclipse/jdt/core/compiler/IProblem.java" type="org.eclipse.jdt.core.compiler.IProblem">
-        <filter comment="renamed constant for JEP 482" id="405864542">
-            <message_arguments>
-                <message_argument value="org.eclipse.jdt.core.compiler.IProblem"/>
-                <message_argument value="DisallowedStatementInPrologue"/>
-            </message_arguments>
-        </filter>
-        <filter comment="this preview constant (marked @noreference) is unnecesary" id="405864542">
-            <message_arguments>
-                <message_argument value="org.eclipse.jdt.core.compiler.IProblem"/>
-                <message_argument value="DuplicateTotalPattern"/>
-            </message_arguments>
-        </filter>
-        <filter comment="renamed constant for JEP 482" id="405864542">
-            <message_arguments>
-                <message_argument value="org.eclipse.jdt.core.compiler.IProblem"/>
-                <message_argument value="ExpressionInPreConstructorContext"/>
-            </message_arguments>
-        </filter>
-    </resource>
 </component>

--- a/org.eclipse.jdt.core.compiler.batch/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.compiler.batch/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Main-Class: org.eclipse.jdt.internal.compiler.batch.Main
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse Compiler for Java(TM)
 Bundle-SymbolicName: org.eclipse.jdt.core.compiler.batch
-Bundle-Version: 3.40.0.qualifier
+Bundle-Version: 3.40.100.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: Eclipse.org
 Automatic-Module-Name: org.eclipse.jdt.core.compiler.batch

--- a/org.eclipse.jdt.core.compiler.batch/pom.xml
+++ b/org.eclipse.jdt.core.compiler.batch/pom.xml
@@ -17,7 +17,7 @@
     <version>4.35.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.eclipse.jdt.core.compiler.batch</artifactId>
-  <version>3.40.0-SNAPSHOT</version>
+  <version>3.40.100-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/BreakStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/BreakStatement.java
@@ -23,7 +23,6 @@ import org.eclipse.jdt.internal.compiler.lookup.BlockScope;
 
 public class BreakStatement extends BranchStatement {
 
-	public boolean isSynthetic;
 public BreakStatement(char[] label, int sourceStart, int e) {
 	super(label, sourceStart, e);
 }
@@ -114,11 +113,5 @@ public boolean doesNotCompleteNormally() {
 @Override
 public boolean canCompleteNormally() {
 	return false;
-}
-
-
-@Override
-protected boolean doNotReportUnreachable() {
-	return this.isSynthetic;
 }
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/CaseStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/CaseStatement.java
@@ -99,7 +99,7 @@ public Expression [] peeledLabelExpressions() {
 }
 
 private boolean essentiallyQualifiedEnumerator(Expression e, TypeBinding selectorType) { // "Essentially" as in not "superfluously" qualified.
-	return e instanceof QualifiedNameReference qnr && qnr.binding instanceof FieldBinding field
+	return e instanceof NameReference reference && reference.binding instanceof FieldBinding field
 				&& (field.modifiers & ClassFileConstants.AccEnum) != 0 && !TypeBinding.equalsEquals(e.resolvedType, selectorType); // <<-- essential qualification
 }
 
@@ -135,13 +135,12 @@ private Constant resolveConstantLabel(BlockScope scope, TypeBinding caseType, Ty
 		if (expression instanceof NameReference reference && reference.binding instanceof FieldBinding field) {
 			if ((field.modifiers & ClassFileConstants.AccEnum) == 0)
 				 scope.problemReporter().enumSwitchCannotTargetField(reference, field);
-			else if (reference instanceof QualifiedNameReference) {
-				if (options.complianceLevel < ClassFileConstants.JDK21)
-					scope.problemReporter().cannotUseQualifiedEnumConstantInCaseLabel(reference, field);
-				else if (!TypeBinding.equalsEquals(caseType, selectorType)) {
-					this.swich.switchBits |= SwitchStatement.QualifiedEnum;
-					return StringConstant.fromValue(CharOperation.toString(reference.getName()));
-				}
+			else if (reference instanceof QualifiedNameReference && options.complianceLevel < ClassFileConstants.JDK21)
+				scope.problemReporter().cannotUseQualifiedEnumConstantInCaseLabel(reference, field);
+
+			if (!TypeBinding.equalsEquals(caseType, selectorType)) {
+				this.swich.switchBits |= SwitchStatement.QualifiedEnum;
+				return StringConstant.fromValue(CharOperation.toString(reference.getName()));
 			}
 			return IntConstant.fromValue(field.original().id + 1); // (ordinal value + 1) zero should not be returned see bug 141810
 		}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/CaseStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/CaseStatement.java
@@ -10,13 +10,13 @@
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
+ *     Advantest R & D - Enhanced Switches v2.0
  *******************************************************************************/
 package org.eclipse.jdt.internal.compiler.ast;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 import java.util.stream.Stream;
+import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.internal.compiler.ASTVisitor;
 import org.eclipse.jdt.internal.compiler.ast.Pattern.PrimitiveConversionRoute;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
@@ -29,7 +29,6 @@ import org.eclipse.jdt.internal.compiler.impl.Constant;
 import org.eclipse.jdt.internal.compiler.impl.IntConstant;
 import org.eclipse.jdt.internal.compiler.impl.JavaFeature;
 import org.eclipse.jdt.internal.compiler.impl.StringConstant;
-import org.eclipse.jdt.internal.compiler.lookup.Binding;
 import org.eclipse.jdt.internal.compiler.lookup.BlockScope;
 import org.eclipse.jdt.internal.compiler.lookup.FieldBinding;
 import org.eclipse.jdt.internal.compiler.lookup.LocalVariableBinding;
@@ -39,19 +38,50 @@ import org.eclipse.jdt.internal.compiler.lookup.TypeIds;
 
 public class CaseStatement extends Statement {
 
-
 	public BranchLabel targetLabel;
 	public Expression[] constantExpressions; // case with multiple expressions - if you want a under-the-hood view, use peeledLabelExpressions()
 	public BranchLabel[] targetLabels; // for multiple expressions
 	public boolean isSwitchRule = false;
 
 	public SwitchStatement swich; // owning switch
-	public int typeSwitchIndex;   // for the first pattern among this.constantExpressions
+	public int labelExpressionOrdinal;   // for the first pattern among this.constantExpressions
 
 public CaseStatement(Expression[] constantExpressions, int sourceStart, int sourceEnd) {
 	this.constantExpressions = constantExpressions;
 	this.sourceStart = sourceStart;
 	this.sourceEnd = sourceEnd;
+}
+
+public static class LabelExpression {
+	public Constant constant;
+	public Expression expression;
+	public TypeBinding type; // For ease of access. This.e contains the type binding anyway.
+	public int index;
+	private int intValue;
+	private final boolean isPattern;
+	private final boolean isQualifiedEnum;
+	public int enumDescIdx;
+	public int classDescIdx;
+	public int primitivesBootstrapIdx; // index for a bootstrap method to args to indy typeSwitch for primitives
+
+	LabelExpression(Constant c, Expression e, TypeBinding t, int index, boolean isQualifiedEnum) {
+		this.constant = c;
+		this.expression = e;
+		this.type = t;
+		this.index = index;
+		this.intValue = c.typeID() == TypeIds.T_JavaLangString ? c.stringValue().hashCode() : c.intValue();
+		this.isPattern = e instanceof Pattern;
+		this.isQualifiedEnum = isQualifiedEnum;
+	}
+
+	public int intValue() { return this.intValue; }
+	public boolean isPattern() { return this.isPattern; }
+	public boolean isQualifiedEnum() { return this.isQualifiedEnum; }
+
+	@Override
+	public String toString() {
+		return "case " + this.expression + " [CONSTANT=" + this.constant + "]"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+	}
 }
 
 /** Provide an under-the-hood view of label expressions, peeling away any abstractions that package many expressions as one
@@ -60,188 +90,187 @@ public CaseStatement(Expression[] constantExpressions, int sourceStart, int sour
 public Expression [] peeledLabelExpressions() {
 	Expression [] constants = Expression.NO_EXPRESSIONS;
 	for (Expression e : this.constantExpressions) {
-		if (e instanceof Pattern p1) {
-			constants = Stream.concat(Arrays.stream(constants), Arrays.stream(p1.getAlternatives())).toArray(Expression[]::new);
-		} else {
+		if (e instanceof Pattern p)
+			constants = Stream.concat(Arrays.stream(constants), Arrays.stream(p.getAlternatives())).toArray(Expression[]::new);
+		else
 			constants = Stream.concat(Arrays.stream(constants), Stream.of(e)).toArray(Expression[]::new);
-		}
 	}
 	return constants;
 }
-@Override
-public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext, FlowInfo flowInfo) {
 
-	int nullPatternCount = 0;
-	for (int i = 0, length = this.constantExpressions.length; i < length; i++) {
-		Expression e = this.constantExpressions[i];
-		CompilerOptions compilerOptions = currentScope.compilerOptions();
-		long sourceLevel = compilerOptions.sourceLevel;
-		boolean enablePreviewFeatures = compilerOptions.enablePreviewFeatures;
-		if (!JavaFeature.UNNAMMED_PATTERNS_AND_VARS.isSupported(sourceLevel, enablePreviewFeatures)) {
-			for (LocalVariableBinding local : e.bindingsWhenTrue()) {
-				local.useFlag = LocalVariableBinding.USED; // these are structurally required even if not touched
-			}
-		}
-		nullPatternCount +=  e instanceof NullLiteral ? 1 : 0;
-		if (i > 0 && (e instanceof Pattern) && !JavaFeature.UNNAMMED_PATTERNS_AND_VARS.isSupported(sourceLevel, enablePreviewFeatures)) {
-			if (!(i == nullPatternCount && e instanceof TypePattern))
-				currentScope.problemReporter().IllegalFallThroughToPattern(e);
-		}
-		flowInfo = analyseConstantExpression(currentScope, flowContext, flowInfo, e);
-		if (nullPatternCount > 0 && e instanceof TypePattern) {
-			LocalVariableBinding binding = ((TypePattern) e).local.binding;
-			if (binding != null)
-				flowInfo.markNullStatus(binding, FlowInfo.POTENTIALLY_NULL);
-		}
-	}
-
-	return flowInfo;
-}
-private FlowInfo analyseConstantExpression(
-		BlockScope currentScope,
-		FlowContext flowContext,
-		FlowInfo flowInfo,
-		Expression e) {
-	if (e.constant == Constant.NotAConstant
-			&& !e.resolvedType.isEnum()) {
-		boolean caseNullorDefaultAllowed =
-				JavaFeature.PATTERN_MATCHING_IN_SWITCH.isSupported(currentScope.compilerOptions())
-				&& (e instanceof NullLiteral || e instanceof FakeDefaultLiteral || e instanceof Pattern);
-		if (!caseNullorDefaultAllowed)
-			currentScope.problemReporter().caseExpressionMustBeConstant(e);
-		if (e instanceof NullLiteral && flowContext.associatedNode instanceof SwitchStatement) {
-			Expression switchValue = ((SwitchStatement) flowContext.associatedNode).expression;
-			if (switchValue != null && switchValue.nullStatus(flowInfo, flowContext) == FlowInfo.NON_NULL) {
-				currentScope.problemReporter().unnecessaryNullCaseInSwitchOverNonNull(this);
-			}
-		}
-	}
-	return e.analyseCode(currentScope, flowContext, flowInfo);
+private boolean essentiallyQualifiedEnumerator(Expression e, TypeBinding selectorType) { // "Essentially" as in not "superfluously" qualified.
+	return e instanceof QualifiedNameReference qnr && qnr.binding instanceof FieldBinding field
+				&& (field.modifiers & ClassFileConstants.AccEnum) != 0 && !TypeBinding.equalsEquals(e.resolvedType, selectorType); // <<-- essential qualification
 }
 
-/**
- * No-op : should use resolveCase(...) instead.
- */
+private void checkDuplicateDefault(BlockScope scope, ASTNode node) {
+	if (this.swich.defaultCase != null)
+		scope.problemReporter().duplicateDefaultCase(node);
+	else if (this.swich.totalPattern != null)
+		scope.problemReporter().illegalTotalPatternWithDefault(this);
+	this.swich.defaultCase = this;
+}
+
+private Constant resolveConstantLabel(BlockScope scope, TypeBinding caseType, TypeBinding selectorType, Expression expression) {
+
+	if (expression instanceof NullLiteral) {
+		if (!caseType.isCompatibleWith(selectorType, scope))
+			scope.problemReporter().caseConstantIncompatible(TypeBinding.NULL, selectorType, expression);
+		return IntConstant.fromValue(-1);
+	}
+
+	if (expression instanceof StringLiteral) {
+		if (selectorType.id == T_JavaLangString)
+			return expression.constant;
+		scope.problemReporter().caseConstantIncompatible(expression.resolvedType, selectorType, expression);
+		return Constant.NotAConstant;
+	}
+
+	CompilerOptions options = scope.compilerOptions();
+	if (caseType.isEnum() && caseType.isCompatibleWith(selectorType)) {
+		if (((expression.bits & ASTNode.ParenthesizedMASK) >> ASTNode.ParenthesizedSHIFT) != 0) {
+			scope.problemReporter().enumConstantsCannotBeSurroundedByParenthesis(expression);
+			return Constant.NotAConstant;
+		}
+		if (expression instanceof NameReference reference && reference.binding instanceof FieldBinding field) {
+			if ((field.modifiers & ClassFileConstants.AccEnum) == 0)
+				 scope.problemReporter().enumSwitchCannotTargetField(reference, field);
+			else if (reference instanceof QualifiedNameReference) {
+				if (options.complianceLevel < ClassFileConstants.JDK21)
+					scope.problemReporter().cannotUseQualifiedEnumConstantInCaseLabel(reference, field);
+				else if (!TypeBinding.equalsEquals(caseType, selectorType)) {
+					this.swich.switchBits |= SwitchStatement.QualifiedEnum;
+					return StringConstant.fromValue(CharOperation.toString(reference.getName()));
+				}
+			}
+			return IntConstant.fromValue(field.original().id + 1); // (ordinal value + 1) zero should not be returned see bug 141810
+		}
+		scope.problemReporter().caseExpressionMustBeConstant(expression);
+		return Constant.NotAConstant;
+	}
+
+	if (this.swich.isNonTraditional && selectorType.isBaseType() && !expression.isConstantValueOfTypeAssignableToType(caseType, selectorType)) {
+		scope.problemReporter().caseConstantIncompatible(caseType, selectorType, expression);
+		return Constant.NotAConstant;
+	}
+
+	if (expression.isConstantValueOfTypeAssignableToType(caseType, selectorType) || caseType.isCompatibleWith(selectorType)) {
+		if (expression.constant == Constant.NotAConstant)
+			scope.problemReporter().caseExpressionMustBeConstant(expression);
+		return expression.constant;
+	}
+
+	boolean boxing = !JavaFeature.PATTERN_MATCHING_IN_SWITCH.isSupported(options) || this.swich.isAllowedType(selectorType);
+	if (boxing && isBoxingCompatible(caseType, selectorType, expression, scope)) {
+		if (expression.constant == Constant.NotAConstant)
+			scope.problemReporter().caseExpressionMustBeConstant(expression);
+		return expression.constant;
+	}
+	scope.problemReporter().caseConstantIncompatible(expression.resolvedType, selectorType, expression);
+	return Constant.NotAConstant;
+}
+
+private Constant resolvePatternLabel(BlockScope scope, TypeBinding caseType, TypeBinding selectorType, Pattern pattern, boolean isUnguarded) {
+
+	Constant constant = IntConstant.fromValue(this.swich.labelExpressionIndex);
+
+	if (pattern instanceof RecordPattern)
+		this.swich.containsRecordPatterns = true;
+
+	if (isUnguarded) {
+		this.swich.caseLabelElementTypes.add(caseType);
+		this.swich.caseLabelElements.add(pattern);
+	}
+
+	if (!caseType.isReifiable()) {
+		if (!pattern.isApplicable(selectorType, scope, pattern))
+			return Constant.NotAConstant;
+	} else if (caseType.isValidBinding()) { // already complained if invalid
+		if (Pattern.findPrimitiveConversionRoute(caseType, selectorType, scope) == PrimitiveConversionRoute.NO_CONVERSION_ROUTE) {
+			if (caseType.isPrimitiveType() && !JavaFeature.PRIMITIVES_IN_PATTERNS.isSupported(scope.compilerOptions())) {
+				scope.problemReporter().unexpectedTypeinSwitchPattern(caseType, pattern);
+				return Constant.NotAConstant;
+			} else if (!pattern.checkCastTypesCompatibility(scope, caseType, selectorType, null, false)) {
+				scope.problemReporter().typeMismatchError(selectorType, caseType, pattern, null);
+				return Constant.NotAConstant;
+			}
+		} else {
+			this.swich.isPrimitiveSwitch = true;
+		}
+	}
+	if (pattern.coversType(selectorType, scope)) {
+		this.swich.switchBits |= SwitchStatement.Exhaustive;
+		pattern.isTotalTypeNode = true;
+		if (pattern.isUnconditional(selectorType, scope)) // unguarded is implied from 'coversType()' above
+			this.swich.totalPattern = pattern;
+	}
+ 	return constant;
+}
+
 @Override
 public void resolve(BlockScope scope) {
-	// no-op : should use resolveCase(...) instead.
-}
-public static class ResolvedCase {
-	static final ResolvedCase[] UnresolvedCase = new ResolvedCase[0];
-	public Constant c;
-	public Expression e;
-	public TypeBinding t; // For ease of access. This.e contains the type binding anyway.
-	public int index;
-	private int intValue;
-	private final boolean isPattern;
-	private final boolean isQualifiedEnum;
-	public int enumDescIdx;
-	public int classDescIdx;
-	public int primitivesBootstrapIdx; // index for a bootstrap method to args to indy typeSwitch for primitives
-	ResolvedCase(Constant c, Expression e, TypeBinding t, int index, boolean isQualifiedEnum) {
-		this.c = c;
-		this.e = e;
-		this.t= t;
-		this.index = index;
-		if (c.typeID() == TypeIds.T_JavaLangString) {
-			this.intValue = c.stringValue().hashCode();
-		} else {
-			this.intValue = c.intValue();
-		}
-		this.isPattern = e instanceof Pattern;
-		this.isQualifiedEnum = isQualifiedEnum;
-	}
-	public int intValue() {
-		return this.intValue;
-	}
-	public boolean isPattern() {
-		return this.isPattern;
-	}
-	public boolean isQualifiedEnum() {
-		return this.isQualifiedEnum;
-	}
-	@Override
-	public String toString() {
-		StringBuilder builder = new StringBuilder();
-		builder.append("case "); //$NON-NLS-1$
-		builder.append(this.e);
-		builder.append(" [CONSTANT="); //$NON-NLS-1$
-		builder.append(this.c);
-		builder.append("]"); //$NON-NLS-1$
-		return builder.toString();
-	}
-}
 
-/**
- * Returns the constant intValue or ordinal for enum constants. If constant is NotAConstant, then answers Float.MIN_VALUE
- */
-public ResolvedCase[] resolveCase(BlockScope scope, TypeBinding switchExpressionType, SwitchStatement switchStatement) {
-	this.swich = switchStatement;
+	if (this.swich == null)
+		return;
+
+	TypeBinding selectorType = (this.swich.switchBits & SwitchStatement.InvalidSelector) != 0 ? null : this.swich.expression.resolvedType; // to inhibit secondary errors.
+	this.labelExpressionOrdinal = this.swich.labelExpressionIndex;
+	this.swich.cases[this.swich.caseCount++] = this;
 
 	if (this.isSwitchRule)
 		this.swich.switchBits |= SwitchStatement.LabeledRules;
 	else
 		this.swich.switchBits |= SwitchStatement.LabeledBlockStatementGroup;
 
-	if ((this.swich.switchBits & (SwitchStatement.LabeledRules | SwitchStatement.LabeledBlockStatementGroup)) == (SwitchStatement.LabeledRules | SwitchStatement.LabeledBlockStatementGroup)) {
+	if ((this.swich.switchBits & (SwitchStatement.LabeledRules | SwitchStatement.LabeledBlockStatementGroup)) == (SwitchStatement.LabeledRules | SwitchStatement.LabeledBlockStatementGroup))
 		scope.problemReporter().arrowColonMixup(this);
-	}
 
 	scope.enclosingCase = this; // record entering in a switch case block
 	if (this.constantExpressions == Expression.NO_EXPRESSIONS) {
-		checkDuplicateDefault(scope, switchStatement, this);
-		return ResolvedCase.UnresolvedCase;
+		checkDuplicateDefault(scope, this);
+		return;
 	}
 
-	switchStatement.cases[switchStatement.caseCount++] = this;
-
-	List<ResolvedCase> cases = new ArrayList<>();
 	int count = 0;
 	int nullCaseCount = 0;
-	boolean hasResolveErrors = false;
 	for (Expression e : this.constantExpressions) {
 		count++;
 		if (e instanceof FakeDefaultLiteral) {
-			 switchStatement.containsPatterns = switchStatement.isNonTraditional = true;
-			 checkDuplicateDefault(scope, switchStatement, this.constantExpressions.length > 1 ? e : this);
+			this.swich.containsPatterns = this.swich.isNonTraditional = true;
+			 checkDuplicateDefault(scope, this.constantExpressions.length > 1 ? e : this);
 			 if (count != 2 || nullCaseCount < 1)
 				 scope.problemReporter().patternSwitchCaseDefaultOnlyAsSecond(e);
 			 continue;
 		}
 		if (e instanceof NullLiteral) {
-			switchStatement.containsNull = switchStatement.isNonTraditional = true;
-			if (switchStatement.nullCase == null)
-				switchStatement.nullCase = this;
+			this.swich.containsNull = this.swich.isNonTraditional = true;
+			if (this.swich.nullCase == null)
+				this.swich.nullCase = this;
 			nullCaseCount++;
 			if (count > 1 && nullCaseCount < 2)
 				scope.problemReporter().patternSwitchNullOnlyOrFirstWithDefault(e);
 		}
 
 		// tag constant name with enum type for privileged access to its members
-		if (switchExpressionType != null && switchExpressionType.isEnum() && (e instanceof SingleNameReference))
-			((SingleNameReference) e).setActualReceiverType((ReferenceBinding)switchExpressionType);
+		if (selectorType != null && selectorType.isEnum() && (e instanceof SingleNameReference))
+			((SingleNameReference) e).setActualReceiverType((ReferenceBinding)selectorType);
 
 		e.setExpressionContext(ExpressionContext.TESTING_CONTEXT);
 		if (e instanceof Pattern p) {
-			switchStatement.containsPatterns = switchStatement.isNonTraditional =  true;
-			p.setOuterExpressionType(switchExpressionType);
+			this.swich.containsPatterns = this.swich.isNonTraditional =  true;
+			p.setOuterExpressionType(selectorType);
 		}
 
 		TypeBinding	caseType = e.resolveType(scope);
-
-		if (caseType == null || switchExpressionType == null) {
-			hasResolveErrors = true;
+		if (caseType == null || selectorType == null)
 			continue;
-		}
 
 		if (caseType.isValidBinding()) {
 			if (e instanceof Pattern) {
 				for (Pattern p : ((Pattern) e).getAlternatives()) {
-					Constant con =  resolveCasePattern(scope, p.resolvedType, switchExpressionType, switchStatement, p, ((Pattern) e).isUnguarded());
-					if (con != Constant.NotAConstant) {
-						int index = switchStatement.constantIndex++;
-						cases.add(new ResolvedCase(con, p, p.resolvedType, index, false));
-					}
+					Constant constant =  resolvePatternLabel(scope, p.resolvedType, selectorType, p, ((Pattern) e).isUnguarded());
+					if (constant != Constant.NotAConstant)
+						this.swich.gatherLabelExpression(new LabelExpression(constant, p, p.resolvedType, this.swich.labelExpressionIndex, false));
 				}
 			} else {
 				// check from §14.11.1 (JEP 455):
@@ -249,185 +278,58 @@ public ResolvedCase[] resolveCase(BlockScope scope, TypeBinding switchExpression
 				//  - [...]
 				//  - if T is one of long, float, double, or boolean, the type of the case constant is T.
 				//  - if T is one of Long, Float, Double, or Boolean, the type of the case constant is, respectively, long, float, double, or boolean.
-				TypeBinding expectedCaseType = switchExpressionType;
-				if (switchExpressionType.isBoxedPrimitiveType()) {
-					expectedCaseType = scope.environment().computeBoxingType(switchExpressionType); // in this case it's actually 'computeUnboxingType()'
-				}
-				switch (expectedCaseType.id) {
-					case TypeIds.T_long, TypeIds.T_float, TypeIds.T_double, TypeIds.T_boolean -> {
-						if (caseType.id != expectedCaseType.id) {
-							scope.problemReporter().caseExpressionWrongType(e, switchExpressionType, expectedCaseType);
-							continue;
+				if (caseType.id != T_null) {
+					TypeBinding expectedCaseType = selectorType.isBoxedPrimitiveType() ? selectorType.unboxedType() : selectorType;
+					switch (expectedCaseType.id) {
+						case TypeIds.T_long, TypeIds.T_float, TypeIds.T_double, TypeIds.T_boolean -> {
+							if (caseType.id != expectedCaseType.id) {
+								scope.problemReporter().caseExpressionWrongType(e, selectorType, expectedCaseType);
+								continue;
+							}
+							selectorType = expectedCaseType;
 						}
-						switchExpressionType = expectedCaseType;
 					}
 				}
-				//
-				Constant con = resolveConstantExpression(scope, caseType, switchExpressionType, switchStatement, e, cases);
-				if (con != Constant.NotAConstant) {
-					int index = this == switchStatement.nullCase && e instanceof NullLiteral ?
-							-1 : switchStatement.constantIndex++;
-					cases.add(new ResolvedCase(con, e, caseType, index, false));
+				Constant constant = resolveConstantLabel(scope, caseType, selectorType, e);
+				if (constant != Constant.NotAConstant) {
+					int index = -1;
+					boolean isQualifiedEnum = false;
+					if (essentiallyQualifiedEnumerator(e, selectorType))
+						isQualifiedEnum = true;
+					else if (!(e instanceof NullLiteral))
+						index = this.swich.labelExpressionIndex;
+					this.swich.gatherLabelExpression(new LabelExpression(constant, e, caseType, index, isQualifiedEnum));
 				}
 			}
 		}
 	}
-	return hasResolveErrors ? ResolvedCase.UnresolvedCase : cases.toArray(new ResolvedCase[cases.size()]);
-}
-
-/**
- * Precondition: this is a default case.
- * Check if (a) another default or (b) a total type pattern has been recorded already
- */
-private void checkDuplicateDefault(BlockScope scope, SwitchStatement switchStatement, ASTNode node) {
-	if (switchStatement.defaultCase != null) {
-		scope.problemReporter().duplicateDefaultCase(node);
-	} else if ((switchStatement.switchBits & SwitchStatement.TotalPattern) != 0) {
-		scope.problemReporter().illegalTotalPatternWithDefault(this);
-	}
-
-	// remember the default case into the associated switch statement
-	// on error the last default will be the selected one ...
-	switchStatement.defaultCase = this;
 }
 
 @Override
-public LocalVariableBinding[] bindingsWhenTrue() {
-	LocalVariableBinding [] variables = NO_VARIABLES;
+public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext, FlowInfo flowInfo) {
+	if (!JavaFeature.UNNAMMED_PATTERNS_AND_VARS.isSupported(currentScope.compilerOptions()))
+		for (LocalVariableBinding local : bindingsWhenTrue())
+			local.useFlag = LocalVariableBinding.USED; // these are structurally required even if not touched
+
 	for (Expression e : this.constantExpressions) {
-		variables = LocalVariableBinding.merge(variables, e.bindingsWhenTrue());
-	}
-	return variables;
-}
-
-public Constant resolveConstantExpression(BlockScope scope,
-											TypeBinding caseType,
-											TypeBinding switchType,
-											SwitchStatement switchStatement,
-											Expression expression,
-											List<ResolvedCase> cases) {
-
-	CompilerOptions options = scope.compilerOptions();
-	boolean patternSwitchAllowed = JavaFeature.PATTERN_MATCHING_IN_SWITCH.isSupported(options);
-	if (patternSwitchAllowed) {
-		if (expression instanceof Pattern) {
-			throw new AssertionError("Unexpected control flow"); //$NON-NLS-1$
-		} else if (expression instanceof NullLiteral) {
-			if (!caseType.isCompatibleWith(switchType, scope)) {
-				scope.problemReporter().caseConstantIncompatible(TypeBinding.NULL, switchType, expression);
-			}
-			switchStatement.switchBits |= SwitchStatement.NullCase;
-			return IntConstant.fromValue(-1);
-		} else if (expression instanceof FakeDefaultLiteral) {
-			// do nothing
-		} else {
-			if (switchStatement.isNonTraditional) {
-				if (switchType.isBaseType() && !expression.isConstantValueOfTypeAssignableToType(caseType, switchType)) {
-					scope.problemReporter().caseConstantIncompatible(caseType, switchType, expression);
-					return Constant.NotAConstant;
-				}
-			}
-
-	}
-	}
-	boolean boxing = !patternSwitchAllowed ||
-			switchStatement.isAllowedType(switchType);
-
-	if (expression.isConstantValueOfTypeAssignableToType(caseType, switchType)
-			||(caseType.isCompatibleWith(switchType)
-				&& !(expression instanceof StringLiteral))) {
-		if (caseType.isEnum()) {
-			if (((expression.bits & ASTNode.ParenthesizedMASK) >> ASTNode.ParenthesizedSHIFT) != 0) {
-				scope.problemReporter().enumConstantsCannotBeSurroundedByParenthesis(expression);
-			}
-
-			if (expression instanceof NameReference
-					&& (expression.bits & ASTNode.RestrictiveFlagMASK) == Binding.FIELD) {
-				NameReference reference = (NameReference) expression;
-				FieldBinding field = reference.fieldBinding();
-				if ((field.modifiers & ClassFileConstants.AccEnum) == 0) {
-					 scope.problemReporter().enumSwitchCannotTargetField(reference, field);
-				} else 	if (reference instanceof QualifiedNameReference) {
-					if (options.complianceLevel < ClassFileConstants.JDK21) {
-						scope.problemReporter().cannotUseQualifiedEnumConstantInCaseLabel(reference, field);
-					} else if (!TypeBinding.equalsEquals(caseType, switchType)) {
-						switchStatement.switchBits |= SwitchStatement.QualifiedEnum;
-						StringConstant constant = (StringConstant) StringConstant.fromValue(new String(field.name));
-						cases.add(new ResolvedCase(constant, expression, caseType, -1, true));
-						return Constant.NotAConstant;
-					}
-				}
-				return IntConstant.fromValue(field.original().id + 1); // (ordinal value + 1) zero should not be returned see bug 141810
-			}
-		} else {
-			return expression.constant;
+		if (e instanceof NullLiteral && flowContext.associatedNode instanceof SwitchStatement swichStatement) {
+			Expression switchValue = swichStatement.expression;
+			if (switchValue != null && switchValue.nullStatus(flowInfo, flowContext) == FlowInfo.NON_NULL)
+				currentScope.problemReporter().unnecessaryNullCaseInSwitchOverNonNull(this);
 		}
-	} else if (boxing && isBoxingCompatible(caseType, switchType, expression, scope)) {
-		// constantExpression.computeConversion(scope, caseType, switchExpressionType); - do not report boxing/unboxing conversion
-		return expression.constant;
+		flowInfo = e.analyseCode(currentScope, flowContext, flowInfo);
 	}
-	scope.problemReporter().caseConstantIncompatible(expression.resolvedType, switchType, expression);
-	return Constant.NotAConstant;
-}
-
-private Constant resolveCasePattern(BlockScope scope, TypeBinding caseType, TypeBinding switchExpressionType, SwitchStatement switchStatement, Pattern e, boolean isUnguarded) {
-
-	Constant constant = Constant.NotAConstant;
-
-	TypeBinding type = e.resolvedType;
-
-	if (type != null) {
-		constant = IntConstant.fromValue(switchStatement.constantIndex);
-		switchStatement.caseLabelElements.add(e);
-		if (e instanceof RecordPattern)
-			switchStatement.containsRecordPatterns = true;
-
-		if (isUnguarded)
-			switchStatement.caseLabelElementTypes.add(type);
-
-		TypeBinding expressionType = switchStatement.expression.resolvedType;
-		// The following code is copied from InstanceOfExpression#resolve()
-		// But there are enough differences to warrant a copy
-		if (!type.isReifiable()) {
-			if (!e.isApplicable(switchExpressionType, scope, e)) {
-				return Constant.NotAConstant;
-			}
-		} else if (type.isValidBinding()) {
-			// if not a valid binding, an error has already been reported for unresolved type
-			if (Pattern.findPrimitiveConversionRoute(type, expressionType, scope) == PrimitiveConversionRoute.NO_CONVERSION_ROUTE) {
-				if (type.isPrimitiveType() && !JavaFeature.PRIMITIVES_IN_PATTERNS.isSupported(scope.compilerOptions())) {
-					scope.problemReporter().unexpectedTypeinSwitchPattern(type, e);
-					return Constant.NotAConstant;
-				} else if (!e.checkCastTypesCompatibility(scope, type, expressionType, null, false)) {
-					scope.problemReporter().typeMismatchError(expressionType, type, e, null);
-					return Constant.NotAConstant;
-				}
-			} else {
-				this.swich.isPrimitiveSwitch = true;
-			}
-		}
-		if (e.coversType(expressionType, scope)) {
-			switchStatement.switchBits |= SwitchStatement.Exhaustive;
-			e.isTotalTypeNode = true;
-			if (e.isUnconditional(expressionType, scope)) // unguarded is implied from 'coversType()' above
-				switchStatement.switchBits |= SwitchStatement.TotalPattern;
-			if (switchStatement.nullCase == null)
-				constant = IntConstant.fromValue(-1);
-		}
-	}
- 	return constant;
+	return flowInfo;
 }
 
 @Override
 public void generateCode(BlockScope currentScope, CodeStream codeStream) {
-	if ((this.bits & ASTNode.IsReachable) == 0) {
+	if ((this.bits & ASTNode.IsReachable) == 0)
 		return;
-	}
 	int pc = codeStream.position;
 	if (this.targetLabels != null) {
-		for (BranchLabel label : this.targetLabels) {
+		for (BranchLabel label : this.targetLabels)
 			label.place();
-		}
 	}
 	if (this.targetLabel != null)
 		this.targetLabel.place();
@@ -438,7 +340,7 @@ public void generateCode(BlockScope currentScope, CodeStream codeStream) {
 		BranchLabel matchFailLabel = new BranchLabel(codeStream);
 
 		Pattern pattern = (Pattern) this.constantExpressions[0];
-		codeStream.load(this.swich.dispatchPatternCopy);
+		codeStream.load(this.swich.selector);
 		pattern.generateCode(currentScope, codeStream, patternMatchLabel, matchFailLabel);
 		codeStream.goto_(patternMatchLabel);
 		matchFailLabel.place();
@@ -450,43 +352,48 @@ public void generateCode(BlockScope currentScope, CodeStream codeStream) {
 		    */
 			final LocalVariableBinding[] bindingsWhenTrue = pattern.bindingsWhenTrue();
 			Stream.of(bindingsWhenTrue).forEach(v->v.recordInitializationEndPC(codeStream.position));
-			int caseIndex = this.typeSwitchIndex + pattern.getAlternatives().length;
+			codeStream.load(this.swich.selector);
+			int caseIndex = this.labelExpressionOrdinal + pattern.getAlternatives().length;
 			codeStream.loadInt(this.swich.nullProcessed ? caseIndex - 1 : caseIndex);
-			codeStream.store(this.swich.restartIndexLocal, false);
 			codeStream.goto_(this.swich.switchPatternRestartTarget);
 			Stream.of(bindingsWhenTrue).forEach(v->v.recordInitializationStartPC(codeStream.position));
 		}
 		patternMatchLabel.place();
 	} else {
-		if (this.swich.containsNull) {
+		if (this.swich.containsNull)
 			this.swich.nullProcessed |= true;
-		}
 	}
 	codeStream.recordPositionsFrom(pc, this.sourceStart);
 }
 
 @Override
+public LocalVariableBinding[] bindingsWhenTrue() {
+	LocalVariableBinding [] variables = NO_VARIABLES;
+	for (Expression e : this.constantExpressions)
+		variables = LocalVariableBinding.merge(variables, e.bindingsWhenTrue());
+	return variables;
+}
+
+@Override
 public StringBuilder printStatement(int tab, StringBuilder output) {
 	printIndent(tab, output);
-	if (this.constantExpressions == Expression.NO_EXPRESSIONS) {
+	if (this.constantExpressions == Expression.NO_EXPRESSIONS)
 		output.append("default"); //$NON-NLS-1$
-	} else {
+	else {
 		output.append("case "); //$NON-NLS-1$
-		for (int i = 0, l = this.constantExpressions.length; i < l; ++i) {
+		for (int i = 0, length = this.constantExpressions.length; i < length; ++i) {
 			this.constantExpressions[i].printExpression(0, output);
-			if (i < l -1) output.append(',');
+			if (i < length -1) output.append(',');
 		}
 	}
-	output.append(this.isSwitchRule ? " ->" : " :"); //$NON-NLS-1$ //$NON-NLS-2$
-	return output;
+	return output.append(this.isSwitchRule ? " ->" : " :"); //$NON-NLS-1$ //$NON-NLS-2$
 }
 
 @Override
 public void traverse(ASTVisitor visitor, 	BlockScope blockScope) {
 	if (visitor.visit(this, blockScope)) {
-		for (Expression e : this.constantExpressions) {
+		for (Expression e : this.constantExpressions)
 			e.traverse(visitor, blockScope);
-		}
 	}
 	visitor.endVisit(this, blockScope);
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Statement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Statement.java
@@ -385,8 +385,7 @@ public int complainIfUnreachable(FlowInfo flowInfo, BlockScope scope, int previo
 			this.bits &= ~ASTNode.IsReachable;
 		if (flowInfo == FlowInfo.DEAD_END) {
 			if (previousComplaintLevel < COMPLAINED_UNREACHABLE) {
-				if (!this.doNotReportUnreachable())
-					scope.problemReporter().unreachableCode(this);
+				scope.problemReporter().unreachableCode(this);
 				if (endOfBlock)
 					scope.checkUnclosedCloseables(flowInfo, null, null, null);
 			}
@@ -403,9 +402,6 @@ public int complainIfUnreachable(FlowInfo flowInfo, BlockScope scope, int previo
 	return previousComplaintLevel;
 }
 
-protected boolean doNotReportUnreachable() {
-	return false;
-}
 /**
  * Generate invocation arguments, considering varargs methods
  */

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchExpression.java
@@ -181,12 +181,6 @@ public class SwitchExpression extends SwitchStatement implements IPolyExpression
 		upperScope.problemReporter().missingEnumConstantCase(this, enumConstant);
 	}
 	@Override
-	protected int getFallThroughState(Statement stmt, BlockScope blockScope) {
-		if (stmt.isTrulyExpression() || stmt instanceof ThrowStatement)
-			return BREAKING;
-		return stmt.canCompleteNormally() ? FALLTHROUGH : BREAKING;
-	}
-	@Override
 	public boolean checkNPE(BlockScope skope, FlowContext flowContext, FlowInfo flowInfo, int ttlForFieldCheck) {
 		if ((this.nullStatus & FlowInfo.NULL) != 0)
 			skope.problemReporter().expressionNullReference(this);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TryStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TryStatement.java
@@ -961,7 +961,7 @@ public boolean generateFinallyBlock(BlockScope currentScope, CodeStream codeStre
 			((StackMapFrameCodeStream) codeStream).popStateIndex();
 			return false;
 		default:
-			throw EclipseCompiler.REACHED_DEAD_CODE;
+			throw EclipseCompiler.UNEXPECTED_CONTROL_FLOW;
 	}
 }
 @Override

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/CodeStream.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/CodeStream.java
@@ -7500,8 +7500,7 @@ public void swap() {
 	this.bCodeStream[this.classFileOffset++] = Opcodes.OPC_swap;
 }
 
-public void tableswitch(CaseLabel defaultLabel, int low, int high, int[] keys,
-		int[] sortedIndexes, int[] mapping, CaseLabel[] casesLabel) {
+public void tableswitch(CaseLabel defaultLabel, int low, int high, int[] keys, int[] sortedIndexes, CaseLabel[] casesLabel) {
 	this.countLabels = 0;
 	this.stackDepth--;
 	this.operandStack.pop(TypeBinding.INT);
@@ -7534,7 +7533,7 @@ public void tableswitch(CaseLabel defaultLabel, int low, int high, int[] keys,
 		int index = sortedIndexes[j];
 		int key = keys[index];
 		if (key == i) {
-			casesLabel[mapping[index]].branch();
+			casesLabel[index].branch();
 			j++;
 			if (i == high) break; // if high is maxint, then avoids wrapping to minint.
 		} else {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
@@ -9470,9 +9470,8 @@ protected void consumeCaseLabelElements() {
 	concatExpressionLists();
 	boolean thisLabelIsPattern = this.expressionStack[this.expressionPtr] instanceof Pattern;
 	boolean lastLabelIsPattern = this.expressionStack[this.expressionPtr - 1] instanceof Pattern;
-	if (thisLabelIsPattern != lastLabelIsPattern || (thisLabelIsPattern && !JavaFeature.UNNAMMED_PATTERNS_AND_VARS.isSupported(this.options.sourceLevel, this.previewEnabled))) {
+	if (thisLabelIsPattern != lastLabelIsPattern)
 		problemReporter().illegalCaseConstantCombination(this.expressionStack[this.expressionPtr]);
-	}
 	if (thisLabelIsPattern && lastLabelIsPattern) {
 		Pattern lastPattern = (Pattern) this.expressionStack[this.expressionPtr - 1];
 		Pattern thisPattern = (Pattern) this.expressionStack[this.expressionPtr];

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/tool/EclipseCompiler.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/tool/EclipseCompiler.java
@@ -59,7 +59,7 @@ public class EclipseCompiler implements JavaCompiler {
 	WeakHashMap<Thread, EclipseCompilerImpl> threadCache;
 	public DiagnosticListener<? super JavaFileObject> diagnosticListener;
 
-	public static final RuntimeException REACHED_DEAD_CODE = new RuntimeException() { private static final long serialVersionUID = 1L; };
+	public static final RuntimeException UNEXPECTED_CONTROL_FLOW = new RuntimeException() { private static final long serialVersionUID = 1L; };
 
 	public EclipseCompiler() {
 		this.threadCache = new WeakHashMap<>();

--- a/org.eclipse.jdt.core.tests.compiler/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.tests.compiler/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.core.tests.compiler;singleton:=true
-Bundle-Version: 3.13.600.qualifier
+Bundle-Version: 3.13.700.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jdt.core.tests.compiler,

--- a/org.eclipse.jdt.core.tests.compiler/pom.xml
+++ b/org.eclipse.jdt.core.tests.compiler/pom.xml
@@ -19,7 +19,7 @@
     <relativePath>../tests-pom/</relativePath>
   </parent>
   <artifactId>org.eclipse.jdt.core.tests.compiler</artifactId>
-  <version>3.13.600-SNAPSHOT</version>
+  <version>3.13.700-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ConstantTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ConstantTest.java
@@ -1578,12 +1578,7 @@ public void testBug566332_04() {
 				+ "} ",
 			},
 			"----------\n" +
-			"1. WARNING in X.java (at line 4)\n" +
-			"	String caseStr =  true ? \"abc\" : \"def\";\n" +
-			"	                                 ^^^^^\n" +
-			"Dead code\n" +
-			"----------\n" +
-			"2. ERROR in X.java (at line 6)\n" +
+			"1. ERROR in X.java (at line 6)\n" +
 			"	case caseStr: System.out.println(\"Pass\");\n" +
 			"	     ^^^^^^^\n" +
 			"case expressions must be constant expressions\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/EnumTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/EnumTest.java
@@ -435,14 +435,9 @@ public void test010() {
 			"}"
 		},
 		"----------\n" +
-		"1. ERROR in X.java (at line 12)\n" +
+		"1. ERROR in X.java (at line 14)\n" +
 		"	case BLEU :\n" +
-		"	^^^^^^^^^\n" +
-		"Duplicate case\n" +
-		"----------\n" +
-		"2. ERROR in X.java (at line 14)\n" +
-		"	case BLEU :\n" +
-		"	^^^^^^^^^\n" +
+		"	     ^^^^\n" +
 		"Duplicate case\n" +
 		"----------\n");
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LocalEnumTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LocalEnumTest.java
@@ -581,14 +581,9 @@ public void test010() {
 		"	                                 ^^^^\n" +
 		"The parameter args is hiding another local variable defined in an enclosing scope\n" +
 		"----------\n" +
-		"2. ERROR in X.java (at line 14)\n" +
+		"2. ERROR in X.java (at line 16)\n" +
 		"	case BLEU :\n" +
-		"	^^^^^^^^^\n" +
-		"Duplicate case\n" +
-		"----------\n" +
-		"3. ERROR in X.java (at line 16)\n" +
-		"	case BLEU :\n" +
-		"	^^^^^^^^^\n" +
+		"	     ^^^^\n" +
 		"Duplicate case\n" +
 		"----------\n");
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullAnnotationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullAnnotationTest.java
@@ -11425,4 +11425,89 @@ public void testBug565246() {
 		runner.runConformTest();
 	}
 }
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3319
+// [Enhanced Switch][Null] Inconsistent nullness propagation
+public void _testIssue3319() {
+	if (this.complianceLevel < ClassFileConstants.JDK21)
+		return;
+	Map customOptions = getCompilerOptions();
+	customOptions.put(JavaCore.COMPILER_PB_NULL_SPECIFICATION_VIOLATION, JavaCore.IGNORE); // has no effect
+	runNegativeTestWithLibs(
+		new String[] {
+			"X.java",
+			"""
+			import org.eclipse.jdt.annotation.NonNull;
+
+			public class X {
+				static @NonNull Object foo(Object o) {
+					switch (o) {
+						case String s -> {
+							if (o == null) {
+								System.out.println("o cannot be null at all!");
+							}
+							System.out.println();
+						}
+						default -> {
+							if (o == null) {
+								System.out.println("o cannot be null at all!");
+							}
+							System.out.println();
+						}
+					}
+					return new Object();
+				}
+
+				static @NonNull Object foo(X o) {
+					switch (o) {
+						case X s  -> {
+							if (o == null) {
+								System.out.println("o cannot be null at all!");
+							}
+							System.out.println(s);
+						}
+					}
+					return new Object();
+				}
+			}
+			""",
+		},
+		customOptions,
+		"----------\n" +
+		"1. ERROR in X.java (at line 7)\n" +
+		"	if (o == null) {\n" +
+		"	    ^\n" +
+		"Null comparison always yields false: The variable o cannot be null at this location\n" +
+		"----------\n" +
+		"2. WARNING in X.java (at line 7)\n" +
+		"	if (o == null) {\n" +
+		"					System.out.println(\"o cannot be null at all!\");\n" +
+		"				}\n" +
+		"	               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
+		"Dead code\n" +
+		"----------\n" +
+		"3. ERROR in X.java (at line 13)\n" +
+		"	if (o == null) {\n" +
+		"	    ^\n" +
+		"Null comparison always yields false: The variable o cannot be null at this location\n" +
+		"----------\n" +
+		"4. WARNING in X.java (at line 13)\n" +
+		"	if (o == null) {\n" +
+		"					System.out.println(\"o cannot be null at all!\");\n" +
+		"				}\n" +
+		"	               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
+		"Dead code\n" +
+		"----------\n" +
+		"5. ERROR in X.java (at line 25)\n" +
+		"	if (o == null) {\n" +
+		"	    ^\n" +
+		"Null comparison always yields false: The variable o cannot be null at this location\n" +
+		"----------\n" +
+		"6. WARNING in X.java (at line 25)\n" +
+		"	if (o == null) {\n" +
+		"					System.out.println(\"o cannot be null at all!\");\n" +
+		"				}\n" +
+		"	               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
+		"Dead code\n" +
+		"----------\n");
+}
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PrimitiveInPatternsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PrimitiveInPatternsTest.java
@@ -7091,8 +7091,8 @@ public class PrimitiveInPatternsTest extends AbstractRegressionTest9 {
 			"2");
    }
    // test from spec
-	public void _testSpec001() {
-		runConformTest(new String[] {
+	public void testSpec001() {
+		runNegativeTest(new String[] {
 			"X.java",
 				"""
 					public class X {
@@ -7112,10 +7112,15 @@ public class PrimitiveInPatternsTest extends AbstractRegressionTest9 {
 					}
 				"""
 			},
-			"100");
+			"----------\n" +
+			"1. ERROR in X.java (at line 8)\r\n" +
+			"	default -> -1;\r\n" +
+			"	^^^^^^^\n" +
+			"Switch case cannot have both unconditional pattern and default label\n" +
+			"----------\n");
 	}
-	public void _testSpec002() {
-		runConformTest(new String[] {
+	public void testSpec002() {
+		runNegativeTest(new String[] {
 			"X.java",
 				"""
 					public class X {
@@ -7136,9 +7141,14 @@ public class PrimitiveInPatternsTest extends AbstractRegressionTest9 {
 					}
 				"""
 			},
-			"100");
+			"----------\n" +
+			"1. ERROR in X.java (at line 9)\n" +
+			"	default -> -1;\n" +
+			"	^^^^^^^\n" +
+			"Switch case cannot have both unconditional pattern and default label\n" +
+			"----------\n");
 	}
-	public void _testSpec003() {
+	public void testSpec003() {
 		runConformTest(new String[] {
 			"X.java",
 				"""
@@ -7166,7 +7176,7 @@ public class PrimitiveInPatternsTest extends AbstractRegressionTest9 {
 			},
 			"JsonNumber[d=30.0]");
 	}
-	public void _testSpec004() {
+	public void testSpec004() {
 		runConformTest(new String[] {
 			"X.java",
 				"""
@@ -7201,7 +7211,7 @@ public class PrimitiveInPatternsTest extends AbstractRegressionTest9 {
 			},
 			"30");
 	}
-	public void _testSpec005() {
+	public void testSpec005() {
 		runConformTest(new String[] {
 			"X.java",
 				"""
@@ -7235,7 +7245,7 @@ public class PrimitiveInPatternsTest extends AbstractRegressionTest9 {
 			},
 			"double:30.0");
 	}
-	public void _testSpec006() {
+	public void testSpec006() {
 		runConformTest(new String[] {
 			"X.java",
 				"""
@@ -7283,6 +7293,30 @@ public class PrimitiveInPatternsTest extends AbstractRegressionTest9 {
 			"	^^^^\n" +
 			"The method Zork() is undefined for the type X\n" +
 			"----------\n");
+	}
+
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3336
+	// [Enhanced Switch][Primitive Patterns] Bogus error: Case constants in a switch on 'Long' must have type 'long'
+	public void testIssue3336() {
+		runConformTest(new String[] {
+			"X.java",
+			"""
+			public interface X {
+
+				public static void main(String[] args) {
+					Long lng = Long.valueOf(42);
+
+					switch (lng) {
+					case -1l -> System.out.println("-1L");
+					case null -> System.out.println("Null");
+					default -> System.out.println("Default");
+					}
+				}
+
+			}
+			"""
+			},
+			"Default");
 	}
 
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PrimitiveInPatternsTestSH.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PrimitiveInPatternsTestSH.java
@@ -1949,12 +1949,7 @@ public class PrimitiveInPatternsTestSH extends AbstractRegressionTest9 {
 			},
 			"""
 			----------
-			1. ERROR in XBoolean.java (at line 4)
-				case true -> 1;
-				     ^^^^
-			Duplicate case
-			----------
-			2. ERROR in XBoolean.java (at line 5)
+			1. ERROR in XBoolean.java (at line 5)
 				case true -> 2;
 				     ^^^^
 			Duplicate case
@@ -2427,204 +2422,9 @@ public class PrimitiveInPatternsTestSH extends AbstractRegressionTest9 {
 			"2.0");
 	}
 
-	// test from spec
-	public void _testSpec001() {
-		runConformTest(new String[] {
-			"X.java",
-				"""
-					public class X {
-						public int getStatus() {
-							return 100;
-						}
-						public static int foo(X x) {
-							return switch (x.getStatus()) {
-						    case int i -> i;
-							default -> -1;
-						};
-						}
-						public static void main(String[] args) {
-							X x = new X();
-							System.out.println(X.foo(x));
-						}
-					}
-				"""
-			},
-			"100");
-	}
-	public void _testSpec002() {
-		runConformTest(new String[] {
-			"X.java",
-				"""
-					public class X {
-						public int getStatus() {
-							return 100;
-						}
-						public static int foo(X x) {
-							return switch (x.getStatus()) {
-						    case int i when i > 10 -> i * i;
-						    case int i -> i;
-							default -> -1;
-						};
-						}
-						public static void main(String[] args) {
-							X x = new X();
-							System.out.println(X.foo(x));
-						}
-					}
-				"""
-			},
-			"100");
-	}
-	public void _testSpec003() {
-		runConformTest(new String[] {
-			"X.java",
-				"""
-					import java.util.Map;
-
-					sealed interface JsonValue {}
-					record JsonString(String s) implements JsonValue { }
-					record JsonNumber(double d) implements JsonValue { }
-					record JsonObject(Map<String, JsonValue> map) implements JsonValue { }
-
-
-					public class X {
-
-						public static void foo() {
-							var json = new JsonObject(Map.of("name", new JsonString("John"),
-					                "age",  new JsonNumber(30)));
-					        JsonValue v = json.map().get("age");
-							System.out.println(v);
-						}
-						public static void main(String[] args) {
-							X.foo();
-						}
-					}
-				"""
-			},
-			"JsonNumber[d=30.0]");
-	}
-	public void _testSpec004() {
-		runConformTest(new String[] {
-			"X.java",
-				"""
-					import java.util.Map;
-
-					sealed interface JsonValue {}
-					record JsonString(String s) implements JsonValue { }
-					record JsonNumber(double d) implements JsonValue { }
-					record JsonObject(Map<String, JsonValue> map) implements JsonValue { }
-
-
-					public class X {
-
-						public static JsonObject foo() {
-							var json = new JsonObject(Map.of("name", new JsonString("John"),
-					                "age",  new JsonNumber(30)));
-							return json;
-						}
-						public static void bar(Object json) {
-							if (json instanceof JsonObject(var map)
-								    && map.get("name") instanceof JsonString(String n)
-								    && map.get("age")  instanceof JsonNumber(double a)) {
-								    int age = (int)a;  // unavoidable (and potentially lossy!) cast
-								    System.out.println(age);
-								}
-						}
-						public static void main(String[] args) {
-							X.bar(X.foo());
-						}
-					}
-				"""
-			},
-			"30");
-	}
-	public void _testSpec005() {
-		runConformTest(new String[] {
-			"X.java",
-				"""
-					import java.util.HashMap;
-					import java.util.Map;
-
-					sealed interface I {}
-					record ZNumber(double d) implements I { }
-					record ZObject(Map<String, I> map) implements I { }
-
-
-					public class X {
-
-						public static ZObject foo() {
-							Map<String, I> myMap = new HashMap<>();
-							myMap.put("age",  new ZNumber(30));
-							return new ZObject(myMap);
-						}
-						public static void bar(Object json) {
-							if (json instanceof ZObject(var map)) {
-								if (map.get("age")  instanceof ZNumber(double d)) {
-									System.out.println("double:"+d);
-								}
-							}
-						}
-						public static void main(String[] args) {
-							X.bar(X.foo());
-						}
-					}
-				"""
-			},
-			"double:30.0");
-	}
-	public void _testSpec006() {
-		runConformTest(new String[] {
-			"X.java",
-				"""
-					import java.util.HashMap;
-					import java.util.Map;
-
-					sealed interface I {}
-					record ZNumber(double d) implements I { }
-					record ZObject(Map<String, I> map) implements I { }
-
-
-					public class X {
-
-						public static ZObject foo() {
-							Map<String, I> myMap = new HashMap<>();
-							myMap.put("age",  new ZNumber(30));
-							return new ZObject(myMap);
-						}
-						public static void bar(Object json) {
-							if (json instanceof ZObject(var map)) {
-								if (map.get("age")  instanceof ZNumber(int i)) {
-									System.out.println("int:"+i);
-								} else if (map.get("age")  instanceof ZNumber(double d)) {
-									System.out.println("double:"+d);
-								}
-							}
-						}
-						public static void main(String[] args) {
-							X.bar(X.foo());
-						}
-					}
-				"""
-			},
-			"int:30");
-	}
-	public void _testSpec00X() {
-		runNegativeTest(new String[] {
-			"X.java",
-				"""
-      			"""
-			},
-			"----------\n" +
-			"2. ERROR in X.java (at line 16)\n" +
-			"	Zork();\n" +
-			"	^^^^\n" +
-			"The method Zork() is undefined for the type X\n" +
-			"----------\n");
-	}
-
 	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3265
 	// [Primitive Patterns] Wrong duplicate case error
-	public void _testIssue3265() {
+	public void testIssue3265() {
 		runConformTest(new String[] {
 				"X.java",
 				"""
@@ -2649,4 +2449,69 @@ public class PrimitiveInPatternsTestSH extends AbstractRegressionTest9 {
 				"""},
 				"1.0|1.5|1.6|");
 	}
+
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3265
+	// [Primitive Patterns] Wrong duplicate case error
+	public void testIssue3265_2() {
+		runNegativeTest(new String[] {
+				"X.java",
+				"""
+				public class X {
+					public static String switchfloatMoreCases(float f) {
+						return switch (f) {
+						case 1.0f -> "1.0";
+						case 0.5f + 0.5f -> "1.0";
+						default -> String.valueOf(f);
+						};
+					}
+
+					public static void main(String... args) {
+						System.out.print(switchfloatMoreCases(1.0f));
+						System.out.print("|");
+						System.out.print(switchfloatMoreCases(1.5f));
+						System.out.print("|");
+						System.out.print(switchfloatMoreCases(1.6f));
+						System.out.print("|");
+					}
+				}
+				"""},
+				"----------\n" +
+				"1. ERROR in X.java (at line 5)\n" +
+				"	case 0.5f + 0.5f -> \"1.0\";\n" +
+				"	     ^^^^^^^^^^^\n" +
+				"Duplicate case\n" +
+				"----------\n");
+	}
+
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3337
+	// [Enhanced Switch][Primitive Patterns] ECJ tolerates default case in boolean switch with both true and false cases.
+	public void testIssue3337() {
+		runNegativeTest(new String[] {
+			"X.java",
+			"""
+			public class X {
+
+				public static void main(String[] args) {
+					Boolean b = true;
+					switch (b) {
+						case true -> System.out.println(1);
+						case false -> System.out.println(0);
+						case null, default -> System.out.println("Error");
+					}
+				}
+			}
+			"""
+			},
+			"----------\n" +
+			"1. ERROR in X.java (at line 5)\r\n" +
+			"	switch (b) {\n" +
+			"			case true -> System.out.println(1);\n" +
+			"			case false -> System.out.println(0);\n" +
+			"			case null, default -> System.out.println(\"Error\");\n" +
+			"		}\r\n" +
+			"	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
+			"Switch cannot have both boolean values and a default label\n" +
+			"----------\n");
+	}
+
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchExpressionsYieldTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchExpressionsYieldTest.java
@@ -631,16 +631,11 @@ public class SwitchExpressionsYieldTest extends AbstractRegressionTest {
 
 		String expectedProblemLog =
 				"----------\n" +
-						"1. ERROR in X.java (at line 4)\n" +
-						"	case SATURDAY, SUNDAY: \n" +
-						"	^^^^^^^^^^^^^^^^^^^^^\n" +
-						"Duplicate case\n" +
-						"----------\n" +
-						"2. ERROR in X.java (at line 7)\n" +
-						"	case SUNDAY : System.out.println(Day.SUNDAY);\n" +
-						"	^^^^^^^^^^^\n" +
-						"Duplicate case\n" +
-						"----------\n";
+				"1. ERROR in X.java (at line 7)\n" +
+				"	case SUNDAY : System.out.println(Day.SUNDAY);\n" +
+				"	     ^^^^^^\n" +
+				"Duplicate case\n" +
+				"----------\n";
 		this.runNegativeTest(
 				testFiles,
 				expectedProblemLog);
@@ -673,19 +668,14 @@ public class SwitchExpressionsYieldTest extends AbstractRegressionTest {
 						"	        ^^^\n" +
 						"The enum constant MONDAY needs a corresponding case label in this enum switch on Day\n" +
 						"----------\n" +
-						"2. ERROR in X.java (at line 4)\n" +
-						"	case SATURDAY, SUNDAY: \n" +
-						"	^^^^^^^^^^^^^^^^^^^^^\n" +
+						"2. ERROR in X.java (at line 7)\n" +
+						"	case SUNDAY, SATURDAY : \n" +
+						"	     ^^^^^^\n" +
 						"Duplicate case\n" +
 						"----------\n" +
 						"3. ERROR in X.java (at line 7)\n" +
 						"	case SUNDAY, SATURDAY : \n" +
-						"	^^^^^^^^^^^^^^^^^^^^^\n" +
-						"Duplicate case\n" +
-						"----------\n" +
-						"4. ERROR in X.java (at line 7)\n" +
-						"	case SUNDAY, SATURDAY : \n" +
-						"	^^^^^^^^^^^^^^^^^^^^^\n" +
+						"	             ^^^^^^^^\n" +
 						"Duplicate case\n" +
 						"----------\n";
 		this.runNegativeTest(
@@ -1025,14 +1015,9 @@ public class SwitchExpressionsYieldTest extends AbstractRegressionTest {
 		};
 		String expectedProblemLog =
 				"----------\n" +
-				"1. ERROR in X.java (at line 6)\n" +
-				"	case 1, 3: \n" +
-				"	^^^^^^^^^\n" +
-				"Duplicate case\n" +
-				"----------\n" +
-				"2. ERROR in X.java (at line 8)\n" +
+				"1. ERROR in X.java (at line 8)\n" +
 				"	case 3, 4: \n" +
-				"	^^^^^^^^^\n" +
+				"	     ^\n" +
 				"Duplicate case\n" +
 				"----------\n";
 		this.runNegativeTest(
@@ -1060,14 +1045,9 @@ public class SwitchExpressionsYieldTest extends AbstractRegressionTest {
 		};
 		String expectedProblemLog =
 				"----------\n" +
-				"1. ERROR in X.java (at line 6)\n" +
-				"	case \"a\", \"b\": \n" +
-				"	^^^^^^^^^^^^^\n" +
-				"Duplicate case\n" +
-				"----------\n" +
-				"2. ERROR in X.java (at line 8)\n" +
+				"1. ERROR in X.java (at line 8)\n" +
 				"	case \"b\", \"c\": \n" +
-				"	^^^^^^^^^^^^^\n" +
+				"	     ^^^\n" +
 				"Duplicate case\n" +
 				"----------\n";
 		this.runNegativeTest(
@@ -2204,7 +2184,7 @@ public class SwitchExpressionsYieldTest extends AbstractRegressionTest {
 			"----------\n" +
 			"1. ERROR in X.java (at line 4)\n" +
 			"	case SATURDAY, SUNDAY, SUNDAY:\n" +
-			"	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
+			"	                       ^^^^^^\n" +
 			"Duplicate case\n" +
 			"----------\n");
 	}
@@ -2229,19 +2209,14 @@ public class SwitchExpressionsYieldTest extends AbstractRegressionTest {
 				"}",
 			},
 			"----------\n" +
-			"1. ERROR in X.java (at line 4)\n" +
-			"	case SATURDAY, SUNDAY, MONDAY:\n" +
-			"	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
+			"1. ERROR in X.java (at line 6)\n" +
+			"	case MONDAY, SUNDAY:\n" +
+			"	     ^^^^^^\n" +
 			"Duplicate case\n" +
 			"----------\n" +
 			"2. ERROR in X.java (at line 6)\n" +
 			"	case MONDAY, SUNDAY:\n" +
-			"	^^^^^^^^^^^^^^^^^^^\n" +
-			"Duplicate case\n" +
-			"----------\n" +
-			"3. ERROR in X.java (at line 6)\n" +
-			"	case MONDAY, SUNDAY:\n" +
-			"	^^^^^^^^^^^^^^^^^^^\n" +
+			"	             ^^^^^^\n" +
 			"Duplicate case\n" +
 			"----------\n");
 	}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchPatternTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchPatternTest.java
@@ -47,9 +47,6 @@ public class SwitchPatternTest extends AbstractRegressionTest9 {
 	// Enables the tests to run individually
 	protected Map<String, String> getCompilerOptions() {
 		Map<String, String> defaultOptions = super.getCompilerOptions();
-		defaultOptions.put(CompilerOptions.OPTION_Compliance, CompilerOptions.VERSION_21);
-		defaultOptions.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_21);
-		defaultOptions.put(CompilerOptions.OPTION_TargetPlatform, CompilerOptions.VERSION_21);
 		defaultOptions.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
 		defaultOptions.put(CompilerOptions.OPTION_ReportPreviewFeatures, CompilerOptions.IGNORE);
 		defaultOptions.put(CompilerOptions.OPTION_Store_Annotations, CompilerOptions.ENABLED);
@@ -259,25 +256,15 @@ public class SwitchPatternTest extends AbstractRegressionTest9 {
 			"----------\n" +
 			"2. ERROR in X.java (at line 4)\n" +
 			"	case Integer t, String s, X x : System.out.println(\"Integer, String or X\");\n" +
-			"	                ^^^^^^^^\n" +
-			"Cannot mix pattern with other case labels\n" +
-			"----------\n" +
-			"3. ERROR in X.java (at line 4)\n" +
-			"	case Integer t, String s, X x : System.out.println(\"Integer, String or X\");\n" +
 			"	                       ^\n" +
 			"Named pattern variables are not allowed here\n" +
 			"----------\n" +
-			"4. ERROR in X.java (at line 4)\n" +
-			"	case Integer t, String s, X x : System.out.println(\"Integer, String or X\");\n" +
-			"	                          ^^^\n" +
-			"Cannot mix pattern with other case labels\n" +
-			"----------\n" +
-			"5. ERROR in X.java (at line 4)\n" +
+			"3. ERROR in X.java (at line 4)\n" +
 			"	case Integer t, String s, X x : System.out.println(\"Integer, String or X\");\n" +
 			"	                            ^\n" +
 			"Named pattern variables are not allowed here\n" +
 			"----------\n" +
-			"6. ERROR in X.java (at line 10)\n" +
+			"4. ERROR in X.java (at line 10)\n" +
 			"	Zork();\n" +
 			"	^^^^\n" +
 			"The method Zork() is undefined for the type X\n" +
@@ -309,35 +296,25 @@ public class SwitchPatternTest extends AbstractRegressionTest9 {
 			"----------\n" +
 			"2. ERROR in X.java (at line 4)\n" +
 			"	case Integer t, String s when s.length > 0, X x when x.hashCode() > 10 : System.out.println(\"Integer, String or X\");\n" +
-			"	                ^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
-			"Cannot mix pattern with other case labels\n" +
-			"----------\n" +
-			"3. ERROR in X.java (at line 4)\n" +
-			"	case Integer t, String s when s.length > 0, X x when x.hashCode() > 10 : System.out.println(\"Integer, String or X\");\n" +
 			"	                       ^\n" +
 			"Named pattern variables are not allowed here\n" +
 			"----------\n" +
-			"4. ERROR in X.java (at line 4)\n" +
+			"3. ERROR in X.java (at line 4)\n" +
 			"	case Integer t, String s when s.length > 0, X x when x.hashCode() > 10 : System.out.println(\"Integer, String or X\");\n" +
 			"	                         ^^^^^^^^^^^^^^^^^\n" +
 			"Syntax error on token(s), misplaced construct(s)\n" +
 			"----------\n" +
-			"5. ERROR in X.java (at line 4)\n" +
-			"	case Integer t, String s when s.length > 0, X x when x.hashCode() > 10 : System.out.println(\"Integer, String or X\");\n" +
-			"	                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
-			"Cannot mix pattern with other case labels\n" +
-			"----------\n" +
-			"6. ERROR in X.java (at line 4)\n" +
+			"4. ERROR in X.java (at line 4)\n" +
 			"	case Integer t, String s when s.length > 0, X x when x.hashCode() > 10 : System.out.println(\"Integer, String or X\");\n" +
 			"	                                              ^\n" +
 			"Named pattern variables are not allowed here\n" +
 			"----------\n" +
-			"7. ERROR in X.java (at line 4)\n" +
+			"5. ERROR in X.java (at line 4)\n" +
 			"	case Integer t, String s when s.length > 0, X x when x.hashCode() > 10 : System.out.println(\"Integer, String or X\");\n" +
 			"	                                                     ^\n" +
 			"x cannot be resolved\n" +
 			"----------\n" +
-			"8. ERROR in X.java (at line 10)\n" +
+			"6. ERROR in X.java (at line 10)\n" +
 			"	Zork();\n" +
 			"	^^^^\n" +
 			"The method Zork() is undefined for the type X\n" +
@@ -997,10 +974,10 @@ public class SwitchPatternTest extends AbstractRegressionTest9 {
 					"}",
 				},
 				"----------\n" +
-				"1. ERROR in X.java (at line 11)\n" +
+				"1. ERROR in X.java (at line 13)\n" +
 				"	case null, default:\n" +
 				"	     ^^^^\n" +
-				"Duplicate case\n" +
+				"This case label is dominated by one of the preceding case labels\n" +
 				"----------\n" +
 				"2. ERROR in X.java (at line 13)\n" +
 				"	case null, default:\n" +
@@ -1919,30 +1896,20 @@ public class SwitchPatternTest extends AbstractRegressionTest9 {
 			"----------\n" +
 			"3. ERROR in X.java (at line 7)\n" +
 			"	case var i, var j, var k  -> System.out.println(0);\n" +
-			"	            ^^^^^\n" +
-			"Cannot mix pattern with other case labels\n" +
-			"----------\n" +
-			"4. ERROR in X.java (at line 7)\n" +
-			"	case var i, var j, var k  -> System.out.println(0);\n" +
 			"	            ^^^\n" +
 			"'var' is not allowed here\n" +
 			"----------\n" +
-			"5. ERROR in X.java (at line 7)\n" +
+			"4. ERROR in X.java (at line 7)\n" +
 			"	case var i, var j, var k  -> System.out.println(0);\n" +
 			"	                ^\n" +
 			"Named pattern variables are not allowed here\n" +
 			"----------\n" +
-			"6. ERROR in X.java (at line 7)\n" +
-			"	case var i, var j, var k  -> System.out.println(0);\n" +
-			"	                   ^^^^^\n" +
-			"Cannot mix pattern with other case labels\n" +
-			"----------\n" +
-			"7. ERROR in X.java (at line 7)\n" +
+			"5. ERROR in X.java (at line 7)\n" +
 			"	case var i, var j, var k  -> System.out.println(0);\n" +
 			"	                   ^^^\n" +
 			"'var' is not allowed here\n" +
 			"----------\n" +
-			"8. ERROR in X.java (at line 7)\n" +
+			"6. ERROR in X.java (at line 7)\n" +
 			"	case var i, var j, var k  -> System.out.println(0);\n" +
 			"	                       ^\n" +
 			"Named pattern variables are not allowed here\n" +
@@ -2198,8 +2165,12 @@ public class SwitchPatternTest extends AbstractRegressionTest9 {
 			"	case String s, default, Integer i  -> System.out.println(0);\n" +
 			"	                        ^^^^^^^^^\n" +
 			"Cannot mix pattern with other case labels\n" +
-			"----------\n"
-);
+			"----------\n" +
+			"4. ERROR in X.java (at line 4)\n" +
+			"	case String s, default, Integer i  -> System.out.println(0);\n" +
+			"	                        ^^^^^^^^^\n" +
+			"This case label is dominated by one of the preceding case labels\n" +
+			"----------\n");
 	}
 	public void testBug574564_010() {
 		Map<String, String> options = getCompilerOptions();
@@ -2230,6 +2201,11 @@ public class SwitchPatternTest extends AbstractRegressionTest9 {
 			"	case String s, default, Integer i  -> System.out.println(0);\n" +
 			"	                        ^^^^^^^^^\n" +
 			"Cannot mix pattern with other case labels\n" +
+			"----------\n" +
+			"4. ERROR in X.java (at line 4)\n" +
+			"	case String s, default, Integer i  -> System.out.println(0);\n" +
+			"	                        ^^^^^^^^^\n" +
+			"This case label is dominated by one of the preceding case labels\n" +
 			"----------\n",
 			null,
 			true,
@@ -2280,11 +2256,6 @@ public class SwitchPatternTest extends AbstractRegressionTest9 {
 			},
 			"----------\n" +
 			"1. ERROR in X.java (at line 5)\n" +
-			"	case null, null  -> System.out.println(o);\n" +
-			"	     ^^^^\n" +
-			"Duplicate case\n" +
-			"----------\n" +
-			"2. ERROR in X.java (at line 5)\n" +
 			"	case null, null  -> System.out.println(o);\n" +
 			"	           ^^^^\n" +
 			"Duplicate case\n" +
@@ -3249,6 +3220,11 @@ public class SwitchPatternTest extends AbstractRegressionTest9 {
 				"	case default, null -> System.out.println(\"hello\");\n" +
 				"	              ^^^^\n" +
 				"A null case label has to be either the only expression in a case label or the first expression followed only by a default\n" +
+				"----------\n" +
+				"3. ERROR in X.java (at line 4)\n" +
+				"	case default, null -> System.out.println(\"hello\");\n" +
+				"	              ^^^^\n" +
+				"This case label is dominated by one of the preceding case labels\n" +
 				"----------\n");
 	}
 	public void testBug575356_04() {
@@ -4030,38 +4006,38 @@ public class SwitchPatternTest extends AbstractRegressionTest9 {
 				"----------\n" +
 				"2. ERROR in X.java (at line 4)\n" +
 				"	case Integer i1, String s1 ->\n" +
-				"	                 ^^^^^^^^^\n" +
-				"Cannot mix pattern with other case labels\n" +
-				"----------\n" +
-				"3. ERROR in X.java (at line 4)\n" +
-				"	case Integer i1, String s1 ->\n" +
 				"	                        ^^\n" +
 				"Named pattern variables are not allowed here\n" +
 				"----------\n" +
-				"4. ERROR in X.java (at line 5)\n" +
+				"3. ERROR in X.java (at line 5)\n" +
 				"	System.out.print(s1);\n" +
 				"	                 ^^\n" +
 				"s1 cannot be resolved to a variable\n" +
 				"----------\n" +
-				"5. ERROR in X.java (at line 7)\n" +
+				"4. ERROR in X.java (at line 7)\n" +
 				"	case Number n, null ->\n" +
 				"	     ^^^^^^^^\n" +
 				"This case label is dominated by one of the preceding case labels\n" +
 				"----------\n" +
-				"6. ERROR in X.java (at line 7)\n" +
+				"5. ERROR in X.java (at line 7)\n" +
 				"	case Number n, null ->\n" +
 				"	               ^^^^\n" +
 				"Cannot mix pattern with other case labels\n" +
 				"----------\n" +
-				"7. ERROR in X.java (at line 7)\n" +
+				"6. ERROR in X.java (at line 7)\n" +
 				"	case Number n, null ->\n" +
 				"	               ^^^^\n" +
 				"A null case label has to be either the only expression in a case label or the first expression followed only by a default\n" +
 				"----------\n" +
-				"8. ERROR in X.java (at line 7)\n" +
+				"7. ERROR in X.java (at line 7)\n" +
 				"	case Number n, null ->\n" +
 				"	               ^^^^\n" +
-				"Duplicate case\n" +
+				"This case label is dominated by one of the preceding case labels\n" +
+				"----------\n" +
+				"8. ERROR in X.java (at line 9)\n" +
+				"	case null, Class c ->\n" +
+				"	     ^^^^\n" +
+				"This case label is dominated by one of the preceding case labels\n" +
 				"----------\n" +
 				"9. ERROR in X.java (at line 9)\n" +
 				"	case null, Class c ->\n" +
@@ -7415,28 +7391,26 @@ public class SwitchPatternTest extends AbstractRegressionTest9 {
 
 		String expectedOutput =
 				"  // Method descriptor #22 (Ljava/lang/Object;)V\n" +
-				"  // Stack: 2, Locals: 3\n" +
+				"  // Stack: 2, Locals: 2\n" +
 				"  public static void foo(java.lang.Object o);\n" +
 				"     0  aload_0 [o]\n" +
 				"     1  dup\n" +
 				"     2  invokestatic java.util.Objects.requireNonNull(java.lang.Object) : java.lang.Object [30]\n" +
 				"     5  pop\n" +
 				"     6  astore_1\n" +
-				"     7  iconst_0\n" +
-				"     8  istore_2\n" +
-				"     9  aload_1\n" +
-				"    10  iload_2\n" +
-				"    11  invokedynamic 0 typeSwitch(java.lang.Object, int) : int [36]\n" +
-				"    16  tableswitch default: 56\n" +
-				"          case 0: 40\n" +
-				"          case 1: 48\n" +
-				"    40  getstatic java.lang.System.out : java.io.PrintStream [40]\n" +
-				"    43  ldc <String \"R Only\"> [46]\n" +
-				"    45  invokevirtual java.io.PrintStream.println(java.lang.String) : void [48]\n" +
-				"    48  getstatic java.lang.System.out : java.io.PrintStream [40]\n" +
-				"    51  ldc <String \"Either S or an R\"> [54]\n" +
-				"    53  invokevirtual java.io.PrintStream.println(java.lang.String) : void [48]\n" +
-				"    56  return\n";
+				"     7  aload_1\n" +
+				"     8  iconst_0\n" +
+				"     9  invokedynamic 0 typeSwitch(java.lang.Object, int) : int [36]\n" +
+				"    14  tableswitch default: 52\n" +
+				"          case 0: 36\n" +
+				"          case 1: 44\n" +
+				"    36  getstatic java.lang.System.out : java.io.PrintStream [40]\n" +
+				"    39  ldc <String \"R Only\"> [46]\n" +
+				"    41  invokevirtual java.io.PrintStream.println(java.lang.String) : void [48]\n" +
+				"    44  getstatic java.lang.System.out : java.io.PrintStream [40]\n" +
+				"    47  ldc <String \"Either S or an R\"> [54]\n" +
+				"    49  invokevirtual java.io.PrintStream.println(java.lang.String) : void [48]\n" +
+				"    52  return\n";
 
 		SwitchPatternTest.verifyClassFile(expectedOutput, "X.class", ClassFileBytesDisassembler.SYSTEM);
 	}
@@ -9293,5 +9267,244 @@ public class SwitchPatternTest extends AbstractRegressionTest9 {
 				"	                                 ^^\n" +
 				"Syntax error on token \"I2\", permits expected after this token\n" +
 				"----------\n");
+	}
+
+	public void testNoFallThrough() {
+		runConformTest(
+				new String[] {
+						"X.java",
+						"""
+						public class X {
+							public static void main(String[] args) {
+								switch ("Hello") {
+									case "Hello" -> {
+										System.out.println("Hello Block!");
+									}
+									case "World" -> {
+										System.out.println("World Block!");
+									}
+									default -> {
+										System.out.println("Default Block");
+									}
+								}
+							}
+						}
+						"""
+				},
+				"Hello Block!");
+	}
+
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3169
+	// [21][Enhanced Switch] Bogus error: "Cannot mix pattern with other case labels
+	public void testIssue3169() {
+		runNegativeTest(
+				new String[] {
+						"X.java",
+						"""
+						public class X {
+							static void foo(Object o) {
+							    switch (o) {
+							        case Character c, Integer i:                 // Compile-time error
+							            break;
+							        default:
+							        	break;
+							    }
+							}
+						}
+						"""
+				},
+				"----------\n" +
+				"1. ERROR in X.java (at line 4)\n" +
+				"	case Character c, Integer i:                 // Compile-time error\n" +
+				"	               ^\n" +
+				"Named pattern variables are not allowed here\n" +
+				"----------\n" +
+				"2. ERROR in X.java (at line 4)\n" +
+				"	case Character c, Integer i:                 // Compile-time error\n" +
+				"	                          ^\n" +
+				"Named pattern variables are not allowed here\n" +
+				"----------\n");
+	}
+
+	public void testEnumLocalCase() {
+		this.runNegativeTest(
+			new String[] {
+				"X.java",
+				"public enum X {\n" +
+				"	A, B, C;\n" +
+				"}\n" +
+				"\n" +
+				"class A {\n" +
+				"	private void foo(X x) {\n" +
+				"	    final X v = null;\n" +
+				"		switch (x) {\n" +
+				"			case v:\n" +
+				"		}\n" +
+				"	}\n" +
+				"}\n",
+			},
+			"----------\n" +
+			"1. ERROR in X.java (at line 9)\n" +
+			"	case v:\n" +
+			"	     ^\n" +
+			"v cannot be resolved or is not a field\n" +
+			"----------\n");
+	}
+
+	public void testEnumLocalCase_2() {
+		this.runNegativeTest(
+			new String[] {
+				"X.java",
+				"""
+				public sealed interface X {
+					enum E implements X {
+						E1, E2;
+					}
+					public static void main(String[] args) {
+						E e = null;
+						switch ((X) null) {
+							case e -> System.out.println();
+							case E.E2 -> System.out.println();
+							default -> System.out.println();
+						}
+					}
+				}
+				""",
+			},
+			"----------\n" +
+			"1. ERROR in X.java (at line 8)\n" +
+			"	case e -> System.out.println();\n" +
+			"	     ^\n" +
+			"case expressions must be constant expressions\n" +
+			"----------\n");
+	}
+
+	public void testEnumLocalCase_3() {
+		this.runNegativeTest(
+			new String[] {
+				"X.java",
+				"""
+				public sealed interface X {
+					enum E implements X {
+						E1, E2;
+					}
+				    public static final E e = E.E1;
+					public static void main(String[] args) {
+						switch ((X) null) {
+							case e -> System.out.println();
+							case E.E2 -> System.out.println();
+							default -> System.out.println();
+						}
+					}
+				}
+				""",
+			},
+			"----------\n" +
+			"1. ERROR in X.java (at line 8)\n" +
+			"	case e -> System.out.println();\n" +
+			"	     ^\n" +
+			"The field X.e cannot be referenced from an enum case label; only enum constants can be used in enum switch\n" +
+			"----------\n");
+	}
+
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3334
+	// [Enhanced Switch] Bogus duplicate case error from ECJ
+	public void testIssue3334() {
+		runConformTest(
+				new String[] {
+						"X.java",
+						"""
+						public sealed interface X {
+							public static void main(String[] args) {
+						        bar(E1.ONE);
+						        bar(E1.TWO);
+						        bar(E2.ONE);
+						        bar(E2.TWO);
+							}
+							public static void bar(X x) {
+								switch (x) {
+								case E1.ONE:
+									System.out.println("E1.ONE");
+								case E1.TWO:
+									System.out.println("E1.TWO");
+								case E2.ONE:
+									System.out.println("E2.ONE");
+								case E2.TWO:
+									System.out.println("E2.TWO");
+								}
+							}
+						}
+						enum E1 implements X { ONE, TWO}
+						enum E2 implements X { ONE, TWO}
+						"""
+				},
+				"E1.ONE\n" +
+				"E1.TWO\n" +
+				"E2.ONE\n" +
+				"E2.TWO\n" +
+				"E1.TWO\n" +
+				"E2.ONE\n" +
+				"E2.TWO\n" +
+				"E2.ONE\n" +
+				"E2.TWO\n" +
+				"E2.TWO");
+	}
+
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3335
+	// [Enhanced Switch][Record Patterns] ECJ compiles non-exhaustive switch resulting in MatchException being thrown at runtime
+	public void testIssue3335() {
+		runNegativeTest(
+				new String[] {
+						"X.java",
+						"""
+						public sealed interface X {
+
+							record R(X x) {}
+
+							final  class C1 implements X {}
+							final class C2 implements X {}
+
+							public static void main(String[] args) {
+						        bar(new R(new C1()));
+							}
+							public static void bar(R r) {
+								switch (r) {
+								case R(C1 c1) when c1 == null  -> System.out.println();
+								case R(C2 c1) -> System.out.println();
+								}
+							}
+						}
+						"""
+				},
+				"----------\n" +
+				"1. ERROR in X.java (at line 12)\n" +
+				"	switch (r) {\n" +
+				"	        ^\n" +
+				"An enhanced switch statement should be exhaustive; a default label expected\n" +
+				"----------\n");
+	}
+
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3339
+	// [Enhanced Switch][Regression] Incorrect duplicate case error since https://github.com/eclipse-jdt/eclipse.jdt.core/pull/3264
+	public void testIssue3339() {
+		runConformTest(
+				new String[] {
+						"X.java",
+						"""
+						public class X {
+							public static void main(String[] args) {
+								Integer i = 42;
+								switch (i) {
+									case 2 -> System.out.println(2);
+									case Integer ii when ii == 13 -> System.out.println("13");
+									case 13 -> System.out.println(13);
+									case 14 -> System.out.println(14);
+									default -> System.out.println("Default");
+								}
+							}
+						}
+						"""
+				},
+				"Default");
 	}
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchTest.java
@@ -187,14 +187,9 @@ public void test007() {
 			"}",
 		},
 		"----------\n" +
-		"1. ERROR in p\\X.java (at line 5)\n" +
-		"	case (int) (1.0 / 0.0) :\n" +
-		"	^^^^^^^^^^^^^^^^^^^^^^\n" +
-		"Duplicate case\n" +
-		"----------\n" +
-		"2. ERROR in p\\X.java (at line 7)\n" +
+		"1. ERROR in p\\X.java (at line 7)\n" +
 		"	case (int) (2.0 / 0.0) :\n" +
-		"	^^^^^^^^^^^^^^^^^^^^^^\n" +
+		"	     ^^^^^^^^^^^^^^^^^\n" +
 		"Duplicate case\n" +
 		"----------\n"
 	);
@@ -1095,28 +1090,10 @@ public void testCaseTypeMismatch3() {
 public void testDuplicateCase() {
 		String newMessage =
 			"----------\n" +
-			"1. ERROR in X.java (at line 4)\n" +
+			"1. ERROR in X.java (at line 5)\n" +
 			"	case \"123\": break;\n" +
-			"	^^^^^^^^^^\n" +
+			"	     ^^^^^\n" +
 			"Duplicate case\n" +
-			"----------\n" +
-			"2. ERROR in X.java (at line 5)\n" +
-			"	case \"123\": break;\n" +
-			"	^^^^^^^^^^\n" +
-			"Duplicate case\n" +
-			"----------\n" +
-			"3. ERROR in X.java (at line 6)\n" +
-			"	default: return args;\n" +
-			"	         ^^^^^^^^^^^^\n" +
-			"Void methods cannot return a value\n" +
-			"----------\n";
-
-		String oldMessage =
-			"----------\n" +
-			"1. ERROR in X.java (at line 3)\n" +
-			"	switch(args[0]) {\n" +
-			"	       ^^^^^^^\n" +
-			"Cannot switch on a value of type String for source level below 1.7. Only convertible int values or enum variables are permitted\n" +
 			"----------\n" +
 			"2. ERROR in X.java (at line 6)\n" +
 			"	default: return args;\n" +
@@ -1136,72 +1113,54 @@ public void testDuplicateCase() {
 			"	}\n" +
 			"}\n",
 		},
-		this.complianceLevel >= JDKLevelSupportingStringSwitch ? newMessage : oldMessage);
+		newMessage);
 }
 
 // JDK7: Strings in Switch.
 public void testDuplicateCase2() {
 		String newMessage =
 			"----------\n" +
-			"1. ERROR in X.java (at line 9)\n" +
+			"1. ERROR in X.java (at line 10)\n" +
 			"	case \"123\": break;\n" +
-			"	^^^^^^^^^^\n" +
+			"	     ^^^^^\n" +
 			"Duplicate case\n" +
 			"----------\n" +
-			"2. ERROR in X.java (at line 10)\n" +
-			"	case \"123\": break;\n" +
-			"	^^^^^^^^^^\n" +
-			"Duplicate case\n" +
-			"----------\n" +
-			"3. ERROR in X.java (at line 11)\n" +
+			"2. ERROR in X.java (at line 11)\n" +
 			"	case \"1\" + \"2\" + \"3\": break;\n" +
-			"	^^^^^^^^^^^^^^^^^^^^\n" +
+			"	     ^^^^^^^^^^^^^^^\n" +
 			"Duplicate case\n" +
 			"----------\n" +
-			"4. ERROR in X.java (at line 13)\n" +
+			"3. ERROR in X.java (at line 13)\n" +
 			"	case local: break;\n" +
-			"	^^^^^^^^^^\n" +
+			"	     ^^^^^\n" +
 			"Duplicate case\n" +
 			"----------\n" +
-			"5. ERROR in X.java (at line 14)\n" +
+			"4. ERROR in X.java (at line 14)\n" +
 			"	case field: break;\n" +
-			"	^^^^^^^^^^\n" +
+			"	     ^^^^^\n" +
 			"Duplicate case\n" +
 			"----------\n" +
-			"6. ERROR in X.java (at line 15)\n" +
+			"5. ERROR in X.java (at line 15)\n" +
 			"	case ifield: break;\n" +
 			"	     ^^^^^^\n" +
 			"Cannot make a static reference to the non-static field ifield\n" +
 			"----------\n" +
-			"7. ERROR in X.java (at line 16)\n" +
+			"6. ERROR in X.java (at line 16)\n" +
 			"	case inffield: break;\n" +
 			"	     ^^^^^^^^\n" +
 			"Cannot make a static reference to the non-static field inffield\n" +
 			"----------\n" +
-			"8. ERROR in X.java (at line 19)\n" +
-			"	default: break;\n" +
-			"	^^^^^^^\n" +
-			"The default case is already defined\n" +
-			"----------\n";
-
-		String oldMessage =
+			"7. ERROR in X.java (at line 17)\n" +
+			"	case nffield: break;\n" +
+			"	     ^^^^^^^\n" +
+			"case expressions must be constant expressions\n" +
 			"----------\n" +
-			"1. ERROR in X.java (at line 8)\n" +
-			"	switch(args[0]) {\n" +
-			"	       ^^^^^^^\n" +
-			"Cannot switch on a value of type String for source level below 1.7. Only convertible int values or enum variables are permitted\n" +
-			"----------\n" +
-			"2. ERROR in X.java (at line 15)\n" +
-			"	case ifield: break;\n" +
-			"	     ^^^^^^\n" +
-			"Cannot make a static reference to the non-static field ifield\n" +
-			"----------\n" +
-			"3. ERROR in X.java (at line 16)\n" +
-			"	case inffield: break;\n" +
+			"8. ERROR in X.java (at line 18)\n" +
+			"	case argument: break;\n" +
 			"	     ^^^^^^^^\n" +
-			"Cannot make a static reference to the non-static field inffield\n" +
+			"case expressions must be constant expressions\n" +
 			"----------\n" +
-			"4. ERROR in X.java (at line 19)\n" +
+			"9. ERROR in X.java (at line 19)\n" +
 			"	default: break;\n" +
 			"	^^^^^^^\n" +
 			"The default case is already defined\n" +
@@ -1232,7 +1191,7 @@ public void testDuplicateCase2() {
 			"    }\n" +
 			"}\n"
 		},
-		this.complianceLevel >= JDKLevelSupportingStringSwitch ? newMessage : oldMessage);
+		newMessage);
 }
 // JDK7: Strings in Switch.
 public void testVariableCase() {
@@ -1366,19 +1325,6 @@ public void testNullCase() {
 			"	case true ? (String) null : (String) null : break;\n" +
 			"	     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
 			"case expressions must be constant expressions\n" +
-			"----------\n" +
-			"7. WARNING in X.java (at line 12)\n" +
-			"	case true ? (String) null : (String) null : break;\n" +
-			"	                            ^^^^^^^^^^^^^\n" +
-			"Dead code\n" +
-			"----------\n";
-
-		String oldMessage =
-			"----------\n" +
-			"1. ERROR in X.java (at line 6)\n" +
-			"	switch(args[0]) {\n" +
-			"	       ^^^^^^^\n" +
-			"Cannot switch on a value of type String for source level below 1.7. Only convertible int values or enum variables are permitted\n" +
 			"----------\n";
 
 		this.runNegativeTest(new String[] {
@@ -1399,51 +1345,48 @@ public void testNullCase() {
 			"    }\n" +
 			"}\n"
 		},
-		this.complianceLevel >= JDKLevelSupportingStringSwitch ? newMessage : oldMessage);
+		newMessage);
 }
 // JDK7: Strings in Switch.
 public void testDuplicateCase3() {
 		String newMessage =
 			"----------\n" +
-			"1. ERROR in X.java (at line 9)\n" +
-			"	case \"123\": break;\n" +
-			"	^^^^^^^^^^\n" +
-			"Duplicate case\n" +
-			"----------\n" +
-			"2. ERROR in X.java (at line 10)\n" +
+			"1. ERROR in X.java (at line 10)\n" +
 			"	case \"1\" + \"2\" + \"3\": break;\n" +
-			"	^^^^^^^^^^^^^^^^^^^^\n" +
+			"	     ^^^^^^^^^^^^^^^\n" +
 			"Duplicate case\n" +
 			"----------\n" +
-			"3. ERROR in X.java (at line 12)\n" +
+			"2. ERROR in X.java (at line 12)\n" +
 			"	case local: break;\n" +
-			"	^^^^^^^^^^\n" +
+			"	     ^^^^^\n" +
 			"Duplicate case\n" +
 			"----------\n" +
-			"4. ERROR in X.java (at line 13)\n" +
+			"3. ERROR in X.java (at line 13)\n" +
 			"	case field: break;\n" +
-			"	^^^^^^^^^^\n" +
+			"	     ^^^^^\n" +
 			"Duplicate case\n" +
 			"----------\n" +
-			"5. ERROR in X.java (at line 14)\n" +
+			"4. ERROR in X.java (at line 14)\n" +
 			"	case ifield: break;\n" +
-			"	^^^^^^^^^^^\n" +
+			"	     ^^^^^^\n" +
 			"Duplicate case\n" +
 			"----------\n" +
-			"6. ERROR in X.java (at line 18)\n" +
-			"	default: break;\n" +
-			"	^^^^^^^\n" +
-			"The default case is already defined\n" +
-			"----------\n";
-
-		String oldMessage =
+			"5. ERROR in X.java (at line 15)\n" +
+			"	case inffield: break;\n" +
+			"	     ^^^^^^^^\n" +
+			"case expressions must be constant expressions\n" +
 			"----------\n" +
-			"1. ERROR in X.java (at line 8)\n" +
-			"	switch(args[0]) {\n" +
-			"	       ^^^^^^^\n" +
-			"Cannot switch on a value of type String for source level below 1.7. Only convertible int values or enum variables are permitted\n" +
+			"6. ERROR in X.java (at line 16)\n" +
+			"	case nffield: break;\n" +
+			"	     ^^^^^^^\n" +
+			"case expressions must be constant expressions\n" +
 			"----------\n" +
-			"2. ERROR in X.java (at line 18)\n" +
+			"7. ERROR in X.java (at line 17)\n" +
+			"	case argument: break;\n" +
+			"	     ^^^^^^^^\n" +
+			"case expressions must be constant expressions\n" +
+			"----------\n" +
+			"8. ERROR in X.java (at line 18)\n" +
 			"	default: break;\n" +
 			"	^^^^^^^\n" +
 			"The default case is already defined\n" +
@@ -1473,7 +1416,7 @@ public void testDuplicateCase3() {
 			"    }\n" +
 			"}\n"
 		},
-		this.complianceLevel >= JDKLevelSupportingStringSwitch ? newMessage : oldMessage);
+		newMessage);
 }
 
 public void testDuplicateHashCode() {
@@ -3567,6 +3510,33 @@ public void testIssue3276() throws Exception {
 		""",
 	},
 	"42");
+}
+
+public void testNonConstantCase() throws Exception {
+	if (this.complianceLevel < ClassFileConstants.JDK14)
+		return;
+	this.runNegativeTest(new String[] {
+		"X.java",
+		"""
+		public class X {
+			public static void main(String[] args) {
+				Integer i = Integer.valueOf(-1);
+				int b = 10;
+				switch (i) {
+					case b -> System.out.println("Null");
+					case -1 -> System.out.println(-1);
+					default -> System.out.println("default");
+				}
+			}
+		}
+		""",
+		},
+		"----------\n" +
+		"1. ERROR in X.java (at line 6)\n" +
+		"	case b -> System.out.println(\"Null\");\n" +
+		"	     ^\n" +
+		"case expressions must be constant expressions\n" +
+		"----------\n");
 }
 
 public static Class testClass() {

--- a/org.eclipse.jdt.core.tests.model/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.tests.model/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.core.tests.model;singleton:=true
-Bundle-Version: 3.13.200.qualifier
+Bundle-Version: 3.13.300.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jdt.core.tests,

--- a/org.eclipse.jdt.core.tests.model/pom.xml
+++ b/org.eclipse.jdt.core.tests.model/pom.xml
@@ -19,7 +19,7 @@
     <relativePath>../tests-pom/</relativePath>
   </parent>
   <artifactId>org.eclipse.jdt.core.tests.model</artifactId>
-  <version>3.13.200-SNAPSHOT</version>
+  <version>3.13.300-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/RunVariousSwitchTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/RunVariousSwitchTests.java
@@ -47,6 +47,9 @@ public class RunVariousSwitchTests extends TestCase {
 				UnnamedPatternsAndVariablesTest.class,
 				JEP441SnippetsTest.class,
 				FlowAnalysisTest.class,
+				EnumTest.class,
+				LocalEnumTest.class,
+				ConstantTest.class,
 
 				JavaSearchBugs14SwitchExpressionTests.class,
 				ASTRewritingSwitchExpressionsTest.class,

--- a/org.eclipse.jdt.core/.settings/.api_filters
+++ b/org.eclipse.jdt.core/.settings/.api_filters
@@ -24,81 +24,6 @@
             </message_arguments>
         </filter>
     </resource>
-    <resource path="dom/org/eclipse/jdt/core/dom/AST.java" type="org.eclipse.jdt.core.dom.AST">
-        <filter id="338792546">
-            <message_arguments>
-                <message_argument value="org.eclipse.jdt.core.dom.AST"/>
-                <message_argument value="newStringFragment()"/>
-            </message_arguments>
-        </filter>
-        <filter id="338792546">
-            <message_arguments>
-                <message_argument value="org.eclipse.jdt.core.dom.AST"/>
-                <message_argument value="newStringTemplateComponent()"/>
-            </message_arguments>
-        </filter>
-        <filter id="338792546">
-            <message_arguments>
-                <message_argument value="org.eclipse.jdt.core.dom.AST"/>
-                <message_argument value="newStringTemplateExpression()"/>
-            </message_arguments>
-        </filter>
-        <filter id="388194388">
-            <message_arguments>
-                <message_argument value="org.eclipse.jdt.core.dom.AST"/>
-                <message_argument value="JLS_Latest"/>
-                <message_argument value="22"/>
-            </message_arguments>
-        </filter>
-    </resource>
-    <resource path="dom/org/eclipse/jdt/core/dom/ASTMatcher.java" type="org.eclipse.jdt.core.dom.ASTMatcher">
-        <filter id="338792546">
-            <message_arguments>
-                <message_argument value="org.eclipse.jdt.core.dom.ASTMatcher"/>
-                <message_argument value="match(StringFragment, Object)"/>
-            </message_arguments>
-        </filter>
-        <filter id="338792546">
-            <message_arguments>
-                <message_argument value="org.eclipse.jdt.core.dom.ASTMatcher"/>
-                <message_argument value="match(StringTemplateComponent, Object)"/>
-            </message_arguments>
-        </filter>
-    </resource>
-    <resource path="dom/org/eclipse/jdt/core/dom/ASTNode.java" type="org.eclipse.jdt.core.dom.ASTNode">
-        <filter id="338755678">
-            <message_arguments>
-                <message_argument value="org.eclipse.jdt.core.dom.ASTNode"/>
-                <message_argument value="STRING_FRAGMENT"/>
-            </message_arguments>
-        </filter>
-        <filter id="338755678">
-            <message_arguments>
-                <message_argument value="org.eclipse.jdt.core.dom.ASTNode"/>
-                <message_argument value="STRING_TEMPLATE_COMPONENT"/>
-            </message_arguments>
-        </filter>
-        <filter id="338755678">
-            <message_arguments>
-                <message_argument value="org.eclipse.jdt.core.dom.ASTNode"/>
-                <message_argument value="STRING_TEMPLATE_EXPRESSION"/>
-            </message_arguments>
-        </filter>
-        <filter comment="constant value change" id="388194388">
-            <message_arguments>
-                <message_argument value="org.eclipse.jdt.core.dom.ASTNode"/>
-                <message_argument value="EitherOr_MultiPattern"/>
-                <message_argument value="117"/>
-            </message_arguments>
-        </filter>
-        <filter comment="constant value change" id="388194388">
-            <message_arguments>
-                <message_argument value="org.eclipse.jdt.core.dom.ASTNode"/>
-                <message_argument value="UNNAMED_CLASS"/>
-                <message_argument value="118"/>
-            </message_arguments>
-        </filter>
-    </resource>
     <resource path="dom/org/eclipse/jdt/core/dom/AbstractTagElement.java" type="org.eclipse.jdt.core.dom.AbstractTagElement">
         <filter id="576725006">
             <message_arguments>
@@ -184,24 +109,10 @@
         </filter>
     </resource>
     <resource path="dom/org/eclipse/jdt/core/dom/ImportDeclaration.java" type="org.eclipse.jdt.core.dom.ImportDeclaration">
-        <filter comment="Evolution to support module imports" id="336658481">
-            <message_arguments>
-                <message_argument value="org.eclipse.jdt.core.dom.ImportDeclaration"/>
-                <message_argument value="MODIFIERS_PROPERTY"/>
-            </message_arguments>
-        </filter>
         <filter id="576778288">
             <message_arguments>
                 <message_argument value="ASTNode"/>
                 <message_argument value="ImportDeclaration"/>
-            </message_arguments>
-        </filter>
-    </resource>
-    <resource path="dom/org/eclipse/jdt/core/dom/Javadoc.java" type="org.eclipse.jdt.core.dom.Javadoc">
-        <filter comment="Evolution: add property for markdown javadoc" id="336658481">
-            <message_arguments>
-                <message_argument value="org.eclipse.jdt.core.dom.Javadoc"/>
-                <message_argument value="MARKDOWN_PROPERTY"/>
             </message_arguments>
         </filter>
     </resource>
@@ -250,30 +161,10 @@
         </filter>
     </resource>
     <resource path="dom/org/eclipse/jdt/core/dom/Modifier.java" type="org.eclipse.jdt.core.dom.Modifier">
-        <filter comment="Withdraw incorrect modifier (tagged with noreference)" id="338755678">
-            <message_arguments>
-                <message_argument value="org.eclipse.jdt.core.dom.Modifier"/>
-                <message_argument value="WHEN"/>
-            </message_arguments>
-        </filter>
         <filter id="576725006">
             <message_arguments>
                 <message_argument value="IExtendedModifier"/>
                 <message_argument value="Modifier"/>
-            </message_arguments>
-        </filter>
-    </resource>
-    <resource path="dom/org/eclipse/jdt/core/dom/Modifier.java" type="org.eclipse.jdt.core.dom.Modifier$ModifierKeyword">
-        <filter comment="Evolution to support module imports" id="336658481">
-            <message_arguments>
-                <message_argument value="org.eclipse.jdt.core.dom.Modifier.ModifierKeyword"/>
-                <message_argument value="MODULE_KEYWORD"/>
-            </message_arguments>
-        </filter>
-        <filter comment="Withdraw incorrect modifier (tagged with noreference)" id="338755678">
-            <message_arguments>
-                <message_argument value="org.eclipse.jdt.core.dom.Modifier.ModifierKeyword"/>
-                <message_argument value="WHEN_KEYWORD"/>
             </message_arguments>
         </filter>
     </resource>
@@ -360,25 +251,6 @@
             <message_arguments>
                 <message_argument value="ISourceRange"/>
                 <message_argument value="SourceRange"/>
-            </message_arguments>
-        </filter>
-    </resource>
-    <resource path="model/org/eclipse/jdt/core/compiler/ITerminalSymbols.java" type="org.eclipse.jdt.core.compiler.ITerminalSymbols">
-        <filter id="405864542">
-            <message_arguments>
-                <message_argument value="org.eclipse.jdt.core.compiler.ITerminalSymbols"/>
-                <message_argument value="TokenNameStringTemplate"/>
-            </message_arguments>
-        </filter>
-        <filter id="405864542">
-            <message_arguments>
-                <message_argument value="org.eclipse.jdt.core.compiler.ITerminalSymbols"/>
-                <message_argument value="TokenNameTextBlockTemplate"/>
-            </message_arguments>
-        </filter>
-        <filter id="1211105284">
-            <message_arguments>
-                <message_argument value="TokenNameCOMMENT_MARKDOWN"/>
             </message_arguments>
         </filter>
     </resource>

--- a/org.eclipse.jdt.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.core; singleton:=true
-Bundle-Version: 3.40.0.qualifier
+Bundle-Version: 3.40.100.qualifier
 Bundle-Activator: org.eclipse.jdt.core.JavaCore
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/org.eclipse.jdt.core/pom.xml
+++ b/org.eclipse.jdt.core/pom.xml
@@ -17,7 +17,7 @@
     <version>4.35.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.eclipse.jdt.core</artifactId>
-  <version>3.40.0-SNAPSHOT</version>
+  <version>3.40.100-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>


### PR DESCRIPTION
* Reimplement resolution, analysis and bookkeeping involved with `CaseStatement` and resolution of `SwitchStatement` for a streamlined and cleaner implementation resulting in readily obvious control flow and minimization of state.
* Report non-constant label expressions during resolution rather than waiting for flow analysis phase.
* Change how duplicate label expressions are reported. Don't blame the whole case, just the duplicate expression; Don't blame the original, just the duplicate.
* Represent qualified enumerators with qualified names internally so to avoid name clashes
* Eliminate the hack to inject synthetic `BreakStatement` in label rule switch blocks. Enhance the code generator to handle these explicitly.
* Simplify the implementation of SwitchStatement.getFallThroughState correcting various issues.
* Eliminate the unnecessary vector `SwitchStatement.constMapping` that is passed to `org.eclipse.jdt.internal.compiler.codegen.CodeStream.tableswitch` - constanMapping[i] == i always!
* Enable various tests in `PrimitiveInPatternsTest.java` that were disabled, fixing broken tests; Remove their disabled cousins from `PrimitiveInPatternsTestSH.java`
* Add a disabled regression test for #3319 (not yet understood/fixed)
* Numerous defect fixes as listed below

* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3336
* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3318
* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3320
* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3321
* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3334
* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3335
* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3265
* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3169
* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3339
* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3337
* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3344