### PR TITLE
Fix FieldLocator and MethodLocator to support local/anonymous classes

### DIFF
--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/FieldLocator.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/FieldLocator.java
@@ -15,6 +15,7 @@ package org.eclipse.jdt.internal.core.search.matching;
 
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IField;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IType;
@@ -280,6 +281,27 @@ protected void reportDeclaration(FieldBinding fieldBinding, MatchLocator locator
 
 	ReferenceBinding declaringClass = fieldBinding.declaringClass;
 	IType type = locator.lookupType(declaringClass);
+	if (type == null) {
+		if (declaringClass instanceof LocalTypeBinding) {
+			ReferenceBinding refBinding= declaringClass;
+			while (refBinding instanceof LocalTypeBinding localBinding) {
+				MethodBinding enclosingBinding= localBinding.enclosingMethod;
+				refBinding= enclosingBinding.declaringClass;
+			}
+			type= locator.lookupType(refBinding);
+			if (type != null) {
+				if (type.getTypeRoot() instanceof ICompilationUnit cu) {
+					FieldDeclaration fieldDecl= fieldBinding.sourceField();
+					if (fieldDecl != null) {
+						IJavaElement element= cu.getElementAt(fieldDecl.sourceStart());
+						if (element instanceof IField) {
+							type= ((IField) element).getDeclaringType();
+						}
+					}
+				}
+			}
+		}
+	}
 	if (type == null) return; // case of a secondary type
 
 	char[] bindingName = fieldBinding.name;


### PR DESCRIPTION
- Fix FieldLocator.reportDeclaration() and MethodLocator.reportDeclaration() to find the anonymous or local type for the declaration rather than to return
- add new tests to JavaSearchBugsTests
- fixes #3308

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes SearchEngine to report method and field accesses for methods in anonymous or local types which is needed by JDT UI refactoring code.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See new tests or original UI issue.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
