### PR TITLE
Fix classes being 'lost' when earlier rounds of annotation processing succeed before a later round fails

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/Compiler.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/Compiler.java
@@ -17,9 +17,11 @@
 package org.eclipse.jdt.internal.compiler;
 
 import java.io.PrintWriter;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.eclipse.jdt.core.compiler.CategorizedProblem;
 import org.eclipse.jdt.core.compiler.CharOperation;
@@ -480,13 +482,14 @@ public class Compiler implements ITypeRequestor, ProblemSeverities {
 					// a generated type was referenced before it was created
 					// the compiler either created a MissingType or found a BinaryType for it
 					// so add the processor's generated files & start over,
-					// but remember to only pass the generated files to the annotation processor
+					// but remember to only pass the failing files to the annotation processor
 					int originalLength = originalUnits.length;
 					int newProcessedLength = e.newAnnotationProcessorUnits.length;
 					ICompilationUnit[] combinedUnits = new ICompilationUnit[originalLength + newProcessedLength];
 					System.arraycopy(originalUnits, 0, combinedUnits, 0, originalLength);
 					System.arraycopy(e.newAnnotationProcessorUnits, 0, combinedUnits, originalLength, newProcessedLength);
-					this.annotationProcessorStartIndex  = originalLength;
+					// need to offset by originalLength
+					this.annotationProcessorStartIndex = originalLength + e.annotationProcessorStartIndex;
 					compile(combinedUnits, e.isLastRound);
 					return;
 				}
@@ -982,6 +985,9 @@ public class Compiler implements ITypeRequestor, ProblemSeverities {
 		ReferenceBinding[] binaryTypeBindingsTemp = this.referenceBindings;
 		if (top == 0 && binaryTypeBindingsTemp == null) return;
 		this.referenceBindings = null;
+		// we can go through multiple rounds that each add newUnits - can't assume that the only units
+		// added were in the current round
+		List<ICompilationUnit> allNewUnits = new ArrayList<>();
 		do {
 			// extract units to process
 			int length = top - bottom;
@@ -1008,16 +1014,18 @@ public class Compiler implements ITypeRequestor, ProblemSeverities {
 			this.annotationProcessorStartIndex = top;
 			ICompilationUnit[] newUnits = this.annotationProcessorManager.getNewUnits();
 			newUnitSize = newUnits.length;
+			allNewUnits.addAll(Arrays.asList(newUnits));
 			ReferenceBinding[] newClassFiles = this.annotationProcessorManager.getNewClassFiles();
 			binaryTypeBindingsTemp = newClassFiles;
 			newClassFilesSize = newClassFiles.length;
 			if (newUnitSize != 0) {
-				ICompilationUnit[] newProcessedUnits = newUnits.clone(); // remember new units in case a source type collision occurs
 				try {
 					this.lookupEnvironment.isProcessingAnnotations = true;
 					internalBeginToCompile(newUnits, newUnitSize);
 				} catch (SourceTypeCollisionException e) {
-					e.newAnnotationProcessorUnits = newProcessedUnits;
+					e.newAnnotationProcessorUnits = allNewUnits.toArray(new ICompilationUnit[0]);
+					// need to restart again from where the *current* round failed, not all new units
+					e.annotationProcessorStartIndex = allNewUnits.size() - newUnitSize;
 					throw e;
 				} finally {
 					this.lookupEnvironment.isProcessingAnnotations = false;
@@ -1036,15 +1044,17 @@ public class Compiler implements ITypeRequestor, ProblemSeverities {
 		// process potential units added in the final round see 329156
 		ICompilationUnit[] newUnits = this.annotationProcessorManager.getNewUnits();
 		newUnitSize = newUnits.length;
+		allNewUnits.addAll(Arrays.asList(newUnits));
 		try {
 			if (newUnitSize != 0) {
-				ICompilationUnit[] newProcessedUnits = newUnits.clone(); // remember new units in case a source type collision occurs
 				try {
 					this.lookupEnvironment.isProcessingAnnotations = true;
 					internalBeginToCompile(newUnits, newUnitSize);
 				} catch (SourceTypeCollisionException e) {
 					e.isLastRound = true;
-					e.newAnnotationProcessorUnits = newProcessedUnits;
+					e.newAnnotationProcessorUnits = allNewUnits.toArray(new ICompilationUnit[0]);
+					// need to restart again from where the *current* round failed, not all new units
+					e.annotationProcessorStartIndex = allNewUnits.size() - newUnitSize;
 					throw e;
 				}
 			}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SourceTypeCollisionException.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SourceTypeCollisionException.java
@@ -19,4 +19,9 @@ public class SourceTypeCollisionException extends RuntimeException {
 	private static final long serialVersionUID = 4798247636899127380L;
 	public boolean isLastRound = false;
 	public ICompilationUnit[] newAnnotationProcessorUnits;
+	/**
+	 * The index within {@link #newAnnotationProcessorUnits} where annotation processing should
+	 * resume.
+	 */
+	public int annotationProcessorStartIndex;
 }


### PR DESCRIPTION
## What it does

Annotation processing can fail with a `SourceTypeCollisionException` when a to-be generated type is referenced by an 'existing' source file. When this happens the compiler 'recompiles' the original files together with the newly generated files. The current implementation is buggy because annotation processing can go through multiple rounds, with each round generating new files. It is possible for earlier rounds to 'succeed', only for a later round to fail with a `SourceTypeCollisionException` requiring a restart. The current implementation 'loses' those files generated in earlier successful rounds.

This PR fixes this issue by ensuring that files from earlier rounds are also included in the retry.

## How to test
Unfortunately I only have a local project I am working on (which is how I discovered the bug). It's a WIP but I could make it available.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
