### PR TITLE
Try with a simpler search in BoundSet::incorporate(...) before falling back to a more thorough (and expensive) search

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest.java
@@ -4983,7 +4983,7 @@ public void testBug434044_comment36() {
 		"1. ERROR in EclipseJava8Generics.java (at line 28)\n" +
 		"	final Object propertyValue = typedProperty.getBar().doFoo(null);\n" +
 		"	                                                    ^^^^^\n" +
-		"The method doFoo(String) is ambiguous for the type capture#3-of ? extends EclipseJava8Generics.AbstractFoo<?>\n" +
+		"The method doFoo(String) is ambiguous for the type capture#2-of ? extends EclipseJava8Generics.AbstractFoo<?>\n" +
 		"----------\n");
 }
 public void testBug434793() {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NegativeLambdaExpressionsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NegativeLambdaExpressionsTest.java
@@ -8611,7 +8611,7 @@ public void test428177() {
 		"5. ERROR in X.java (at line 38)\n" +
 		"	return stream.collect(Collectors.toList()); // NO ERROR\n" +
 		"	       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
-		"Type mismatch: cannot convert from List<capture#16-of ? extends String> to Stream<String>\n" +
+		"Type mismatch: cannot convert from List<capture#17-of ? extends String> to Stream<String>\n" +
 		"----------\n");
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=428795, - [1.8]Internal compiler error: java.lang.NullPointerException at org.eclipse.jdt.internal.compiler.ast.MessageSend.analyseCode


### PR DESCRIPTION
## What it does

This PR brings back the simpler (faster) approach that was used in the method `org.eclipse.jdt.internal.compiler.lookup.BoundSet.incorporate(InferenceContext18, TypeBound[], TypeBound[])` and only falls back to the newer (slower) approach if the simple one failed.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3327

## Implementation details
This PR brings back the old approach by re-adding these methods:
- `deriveTypeArgumentConstraints` (renamed to `deriveTypeArgumentConstraintsSimple`)
- `superTypesWithCommonGenericType`

### Workspace and performance details
This has a drastic performance improvement when doing a full **clean and build** for our tool.

Some details about our workspace:
- Projects: **> 2000** (plugins, features and fragments) .
- Full build time up until version _2024-06_: **~10 minutes**.
- Full build time starting at _2024-09_: **~30 minutes**.
- Full build time with this PR: **~12 minutes** ([Sample.zip](https://github.com/user-attachments/files/17847208/Sample.zip))

## How to test

### Option 1: regression tests
- Run these regression tests in `org.eclipse.jdt.core.tests.compiler.regression.GenericsRegressionTest_1_8`:
   - `testGH2413`
   - `testGH2413_mini`
   - `testGH2413_direct`

### Option 2: Snippet
The following snippet should compile

```java
public class EjcBug2413 {

	public interface EventSource<L> {
	}

	public interface ObservableEventListener<V> {
	}

	public interface WritableProperty<V> extends EventSource<ObservableEventListener<V>> {
		static <P extends WritableProperty<?>> P getReadOnly(P property) {
			return null;
		}
	}

	public static class Property<V> implements EventSource<ObservableEventListener<V>>, WritableProperty<V> {
	}

	public static abstract class Bug2413<V, P extends Property<V>> {
		public void foo(P property) {
			P readOnly = WritableProperty.getReadOnly(property);
		}
	}
}
```

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
