### PR TITLE
Primitives in record component type patterns to be enabled with null check

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/RecordPattern.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/RecordPattern.java
@@ -244,6 +244,7 @@ public class RecordPattern extends Pattern {
 			labels.add(exceptionLabel);
 
 			TypeBinding componentType = p.accessorMethod.returnType;
+			checkForPrimitiveType(currentScope, p, componentType);
 			if (TypeBinding.notEquals(p.accessorMethod.original().returnType.erasure(),
 					componentType.erasure()))
 				codeStream.checkcast(componentType); // lastComponent ? [C] : [R, C]
@@ -288,6 +289,18 @@ public class RecordPattern extends Pattern {
 				eLabels.addAll(labels);
 			}
 			codeStream.patternAccessorMap.put(trapScope, eLabels);
+		}
+	}
+
+	private void checkForPrimitiveType(BlockScope currentScope, Pattern p, TypeBinding componentType) {
+		if (p.isTotalTypeNode && !componentType.isPrimitiveType() &&  p instanceof TypePattern tp) {
+			TypeBinding providedType = tp.resolvedType;
+			if (providedType != null && providedType.isPrimitiveType()) {
+				PrimitiveConversionRoute route = Pattern.findPrimitiveConversionRoute(componentType, providedType, currentScope);
+				if (route != PrimitiveConversionRoute.NO_CONVERSION_ROUTE) {
+					p.isTotalTypeNode = false;
+				}
+			}
 		}
 	}
 

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PrimitiveInPatternsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PrimitiveInPatternsTest.java
@@ -25,7 +25,7 @@ public class PrimitiveInPatternsTest extends AbstractRegressionTest9 {
 	static {
 //		TESTS_NUMBERS = new int [] { 1 };
 //		TESTS_RANGE = new int[] { 1, -1 };
-//		TESTS_NAMES = new String[] { "testIssue2936" };
+//		TESTS_NAMES = new String[] { "testIssuePrimitivesWithNull" };
 	}
 	private String extraLibPath;
 	public static Class<?> testClass() {
@@ -7331,6 +7331,24 @@ public class PrimitiveInPatternsTest extends AbstractRegressionTest9 {
 		"43.0");
 	}
 
+	public void testIssuePrimitivesWithNull() {
+		runConformTest(new String[] {
+				"X.java",
+				"""
+				public class X  {
+				    record R(Integer i) {}
+				    public static int foo(R r) {
+				        if (r instanceof R(int i)) { return i; }
+				        return -1;
+				    }
+				    public static void main(String argv[]) {
+				        System.out.println(foo(new R(null)));
+				    }
+				}
+				"""
+				},
+				"-1");
+	}
 	public void _testSpec00X() {
 		runNegativeTest(new String[] {
 			"X.java",


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
When primitives in type patterns are present, before calling the accessor a null check needs to be done since null does not match the primitive anyway.
## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
