### PR TITLE
Use Import-Package instead of Require-Bundle for o.e.c.runtime to prevent importing unnecessary classes

### DIFF
--- a/org.eclipse.jdt.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core/META-INF/MANIFEST.MF
@@ -6,6 +6,16 @@ Bundle-Version: 3.40.100.qualifier
 Bundle-Activator: org.eclipse.jdt.core.JavaCore
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
+Import-Package: org.eclipse.core.internal.runtime,
+ org.eclipse.core.runtime,
+ org.eclipse.core.runtime.content,
+ org.eclipse.core.runtime.jobs,
+ org.eclipse.core.runtime.preferences,
+ org.eclipse.equinox.app,
+ org.eclipse.osgi.service.debug,
+ org.eclipse.osgi.util,
+ org.osgi.framework,
+ org.osgi.service.prefs
 Export-Package: org.eclipse.jdt.core,
  org.eclipse.jdt.core.compiler,
  org.eclipse.jdt.core.dom,
@@ -43,7 +53,6 @@ Export-Package: org.eclipse.jdt.core,
  org.eclipse.jdt.internal.formatter.linewrap;x-friends:="org.eclipse.jdt.core.tests.model, org.eclipse.jdt.core.tests.compiler, org.eclipse.jdt.core.tests.builder, org.eclipse.jdt.core.tests.performance, org.eclipse.jdt.ui.tests",
  org.eclipse.jdt.internal.formatter.old;x-friends:="org.eclipse.jdt.core.tests.model, org.eclipse.jdt.core.tests.compiler, org.eclipse.jdt.core.tests.builder, org.eclipse.jdt.core.tests.performance, org.eclipse.jdt.ui.tests"
 Require-Bundle: org.eclipse.core.resources;bundle-version="[3.22.0,4.0.0)",
- org.eclipse.core.runtime;bundle-version="[3.29.0,4.0.0)",
  org.eclipse.core.filesystem;bundle-version="[1.11.0,2.0.0)",
  org.eclipse.text;bundle-version="[3.6.0,4.0.0)",
  org.eclipse.team.core;bundle-version="[3.1.0,4.0.0)";resolution:=optional,


### PR DESCRIPTION
## What it does
Based on the discussion in https://github.com/eclipse-equinox/equinox/discussions/697#discussioncomment-11262689, using `Require-Bundle` for `org.eclipse.core.runtime` will pull in all of `org.eclipse.osgi` which in-turn exposes you to all the JDK packages because this horrible re-export:

https://github.com/eclipse-platform/eclipse.platform/blob/6dd67323474b1b49d541bcd1e4ea8007ab2a36a4/runtime/bundles/org.eclipse.core.runtime/META-INF/MANIFEST.MF#L12C17-L12C87.

In our downstream project, we try to override some part of JRE packages within our fragment of `org.eclipse.jdt.core`. However, the default JDK packages always take precedence because of this `Require-Bundle` thing. The equinox team's recommendation is to use `Import-Package` instead of `Require-Bundle` for finer control over the imported classes.

## How to test
This PR just minimizes the imported packages from the bundle `o.e.c.runtime`, without affecting the overall functionality of the feature.