### PR TITLE
Incorrect control flow analysis causes statement subsequent to a switch statement to be flagged unreachable under some circumstances

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ASTNode.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ASTNode.java
@@ -224,6 +224,7 @@ public abstract class ASTNode implements TypeConstants, TypeIds {
 	public static final int IsUsefulEmptyStatement = Bit1;
 
 	// for block and method declaration
+	public static final int SwitchRuleBlock = Bit1;
 	public static final int UndocumentedEmptyBlock = Bit4;
 	public static final int OverridingMethodWithSupercall = Bit5;
 	public static final int CanBeStatic = Bit9;   // used to flag a method that can be declared static

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Block.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Block.java
@@ -42,36 +42,42 @@ public Block(int explicitDeclarations) {
 
 @Override
 public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext, FlowInfo flowInfo) {
-	// empty block
-	if (this.statements == null)	return flowInfo;
-	int complaintLevel = (flowInfo.reachMode() & FlowInfo.UNREACHABLE) != 0 ? Statement.COMPLAINED_FAKE_REACHABLE : Statement.NOT_COMPLAINED;
-	CompilerOptions compilerOptions = currentScope.compilerOptions();
-	boolean enableSyntacticNullAnalysisForFields = compilerOptions.enableSyntacticNullAnalysisForFields;
-	for (Statement stat : this.statements) {
-		if ((complaintLevel = stat.complainIfUnreachable(flowInfo, this.scope, complaintLevel, true)) < Statement.COMPLAINED_UNREACHABLE) {
-			flowInfo = stat.analyseCode(this.scope, flowContext, flowInfo);
-		}
-		// record the effect of stat on the finally block of an enclosing try-finally, if any:
-		flowContext.mergeFinallyNullInfo(flowInfo);
-		if (enableSyntacticNullAnalysisForFields) {
-			flowContext.expireNullCheckedFieldInfo();
-		}
-		if (compilerOptions.analyseResourceLeaks) {
-			FakedTrackingVariable.cleanUpUnassigned(this.scope, stat, flowInfo, false);
-		}
-	}
-	if (this.scope != currentScope) {
-		// if block is tracking any resources other than the enclosing 'currentScope', analyse them now:
-		this.scope.checkUnclosedCloseables(flowInfo, flowContext, null, null);
-	}
-	if (this.explicitDeclarations > 0) {
-		// cleanup assignment info for locals that are scoped to this block:
-		LocalVariableBinding[] locals = this.scope.locals;
-		if (locals != null) {
-			int numLocals = this.scope.localIndex;
-			for (int i = 0; i < numLocals; i++) {
-				flowInfo.resetAssignmentInfo(locals[i]);
+	if (this.statements != null) {
+		int complaintLevel = (flowInfo.reachMode() & FlowInfo.UNREACHABLE) != 0 ? Statement.COMPLAINED_FAKE_REACHABLE : Statement.NOT_COMPLAINED;
+		CompilerOptions compilerOptions = currentScope.compilerOptions();
+		boolean enableSyntacticNullAnalysisForFields = compilerOptions.enableSyntacticNullAnalysisForFields;
+		for (Statement stat : this.statements) {
+			if ((complaintLevel = stat.complainIfUnreachable(flowInfo, this.scope, complaintLevel, true)) < Statement.COMPLAINED_UNREACHABLE) {
+				flowInfo = stat.analyseCode(this.scope, flowContext, flowInfo);
 			}
+			// record the effect of stat on the finally block of an enclosing try-finally, if any:
+			flowContext.mergeFinallyNullInfo(flowInfo);
+			if (enableSyntacticNullAnalysisForFields) {
+				flowContext.expireNullCheckedFieldInfo();
+			}
+			if (compilerOptions.analyseResourceLeaks) {
+				FakedTrackingVariable.cleanUpUnassigned(this.scope, stat, flowInfo, false);
+			}
+		}
+		if (this.scope != currentScope) {
+			// if block is tracking any resources other than the enclosing 'currentScope', analyse them now:
+			this.scope.checkUnclosedCloseables(flowInfo, flowContext, null, null);
+		}
+		if (this.explicitDeclarations > 0) {
+			// cleanup assignment info for locals that are scoped to this block:
+			LocalVariableBinding[] locals = this.scope.locals;
+			if (locals != null) {
+				int numLocals = this.scope.localIndex;
+				for (int i = 0; i < numLocals; i++) {
+					flowInfo.resetAssignmentInfo(locals[i]);
+				}
+			}
+		}
+	}
+	if ((this.bits & ASTNode.SwitchRuleBlock) != 0) { // switch rule blocks don't fall through
+		if (flowInfo != FlowInfo.DEAD_END) {
+			flowContext.recordBreakFrom(flowInfo);
+			return FlowInfo.DEAD_END;
 		}
 	}
 	return flowInfo;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
@@ -97,8 +97,7 @@ public class SwitchStatement extends Expression {
 	// fallthrough
 	public final static int CASE = 0;
 	public final static int FALLTHROUGH = 1;
-	public final static int ESCAPING = 2;
-	public final static int BREAKING  = 3;
+	public final static int BREAKING  = 2;
 
 	// Other bits
 	public final static int LabeledRules = ASTNode.Bit1;
@@ -432,8 +431,6 @@ public class SwitchStatement extends Expression {
 					}
 					if ((complaintLevel = statement.complainIfUnreachable(caseInits, this.scope, complaintLevel, true)) < Statement.COMPLAINED_UNREACHABLE) {
 						caseInits = statement.analyseCode(this.scope, switchContext, caseInits);
-						if (caseInits == FlowInfo.DEAD_END)
-							fallThroughState = ESCAPING;
 						if (compilerOptions.enableSyntacticNullAnalysisForFields)
 							switchContext.expireNullCheckedFieldInfo();
 						if (compilerOptions.analyseResourceLeaks)

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
@@ -9441,6 +9441,9 @@ protected void consumeSwitchRule(SwitchRuleKind kind) {
 		expr.bits &= ~ASTNode.InsideExpressionStatement;
 		YieldStatement yieldStatement = new YieldStatement(expr, true, expr.sourceStart, this.endStatementPosition);
 		this.astStack[this.astPtr] = yieldStatement;
+	} else if (kind == SwitchRuleKind.BLOCK) {
+		Block block = (Block) this.astStack[this.astPtr];
+		block.bits |= ASTNode.SwitchRuleBlock;
 	}
 	concatNodeLists();
 }


### PR DESCRIPTION


* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3376


