### PR TITLE
[Enhanced Switch][Null] Missing Null pointer access warning with total/unconditional patterns in case labels

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
@@ -373,9 +373,9 @@ public class SwitchStatement extends Expression {
 	public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext, FlowInfo flowInfo) {
 		try {
 			flowInfo = this.expression.analyseCode(currentScope, flowContext, flowInfo);
-			if (isNullHostile()) {
+			if (!this.containsNull && this.expression.resolvedType instanceof ReferenceBinding)
 				this.expression.checkNPE(currentScope, flowContext, flowInfo, 1);
-			}
+
 			SwitchFlowContext switchContext =
 				new SwitchFlowContext(flowContext, this, (this.breakLabel = new BranchLabel()), true, true);
 
@@ -461,16 +461,6 @@ public class SwitchStatement extends Expression {
 			if (this.scope != null) this.scope.enclosingCase = null; // no longer inside switch case block
 		}
 	}
-	private boolean isNullHostile() {
-		if (this.containsNull)
-			return false;
-		if ((this.expression.implicitConversion & TypeIds.UNBOXING) != 0)
-			return true;
-		if (this.expression.resolvedType != null && (this.expression.resolvedType.id == T_JavaLangString || this.expression.resolvedType.isEnum()))
-			return true;
-		return this.totalPattern == null;
-	}
-
 	/**
 	 * Switch on String code generation
 	 * This assumes that hashCode() specification for java.lang.String is API

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypePattern.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypePattern.java
@@ -69,18 +69,7 @@ public class TypePattern extends Pattern implements IGenerateTypeCheck {
 			return patternInfo; // exclude anonymous blokes from flow analysis.
 
 		patternInfo.markAsDefinitelyAssigned(this.local.binding);
-		if (!this.isTotalTypeNode) {
-			// non-total type patterns create a nonnull local:
-			patternInfo.markAsDefinitelyNonNull(this.local.binding);
-		} else {
-			// total type patterns inherit the nullness of the value being switched over, unless ...
-			if (flowContext.associatedNode instanceof SwitchStatement swStmt) {
-				int nullStatus = swStmt.containsNull
-						? FlowInfo.NON_NULL // ... null is handled in a separate case
-						: swStmt.expression.nullStatus(patternInfo, flowContext);
-				patternInfo.markNullStatus(this.local.binding, nullStatus);
-			}
-		}
+		patternInfo.markAsDefinitelyNonNull(this.local.binding);
 		return patternInfo;
 	}
 


### PR DESCRIPTION


* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3381

