### PR TITLE
[Performance] Full build takes more time since 2024-09 (type inference)

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BoundSet.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BoundSet.java
@@ -1267,11 +1267,14 @@ class BoundSet {
 		if (s == null || s.id == TypeIds.T_JavaLangObject || t == null || t.id == TypeIds.T_JavaLangObject)
 			return Collections.emptyList();
 		List<Pair<TypeBinding>> result = new ArrayList<>();
-		if (TypeBinding.equalsEquals(s.original(), t.original())) {
+		if ((s.isParameterizedType() || t.isParameterizedType()) // optimization #1: clients of this method only want to inspect type arguments
+				&& TypeBinding.equalsEquals(s.original(), t.original())) {
 			result.add(new Pair<>(s, t));
 		}
+		if (TypeBinding.equalsEquals(s,  t))
+			return result; // optimization #2: nothing interesting above equal types
 		TypeBinding tSuper = t.findSuperTypeOriginatingFrom(s);
-		if (tSuper != null) {
+		if (tSuper != null && s.isParameterizedType() && tSuper.isParameterizedType()) { // optimization #1 again
 			result.add(new Pair<>(s, tSuper));
 		}
 		result.addAll(allSuperPairsWithCommonGenericType(s.superclass(), t));

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BoundSet.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BoundSet.java
@@ -1267,7 +1267,7 @@ class BoundSet {
 		if (s == null || s.id == TypeIds.T_JavaLangObject || t == null || t.id == TypeIds.T_JavaLangObject)
 			return Collections.emptyList();
 		List<Pair<TypeBinding>> result = new ArrayList<>();
-		if ((s.isParameterizedType() || t.isParameterizedType()) // optimization #1: clients of this method only want to inspect type arguments
+		if (s.isParameterizedType() && t.isParameterizedType() // optimization #1: clients of this method only want to compare type arguments
 				&& TypeBinding.equalsEquals(s.original(), t.original())) {
 			result.add(new Pair<>(s, t));
 		}


### PR DESCRIPTION
optimize 1:
+ don't record pairs without any type arguments

optimize 2:
+ stop traversal when both types are the same

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3327
