### PR TITLE
Improve performance in CharOperation

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/core/compiler/CharOperation.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/core/compiler/CharOperation.java
@@ -3750,7 +3750,7 @@ public static final char[] replace(
 		next : for (int i = 0; i < max;) {
 			int index = indexOf(toBeReplaced, array, true, i);
 			if (index == -1) {
-				i++;
+				i = max; // end
 				continue next;
 			}
 			if (occurrenceCount == starts.length) {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/CharOperationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/CharOperationTest.java
@@ -170,4 +170,26 @@ public void test012() {
 			4,
 			true));
 }
+
+public void testReplacePerformance001() {
+	// This is the test that takes an excessively long time
+	// The improvement here is drastic, 99% reduction in time
+	testReplaceImpl("This is one line with no matches\n", 9, 0.01);
+}
+
+private void testReplaceImpl(String oneLine, int power, double multiplier) {
+	String total = oneLine;
+	for( int i = 0; i < power; i++ ) {
+		total = total + total; // Double the length
+	}
+	total = oneLine + total;
+
+	// Now replace
+	long start = System.currentTimeMillis();
+	char[] found = CharOperation.replace(total.toCharArray(), new char[]{'/'}, new char[] {'z'});
+	assertNotNull(found);
+	long end = System.currentTimeMillis();
+	long spent = end - start;
+	assertTrue(spent < 10);
+}
 }


### PR DESCRIPTION
When no matching characters / replacements are found in the string, the current replace method seems to be performing at an n^2 rate. The performance is actually really really bad. 

Specifically, if the indexOf(etc) call returns -1, it clearly means there's no more work left to do here, but instead the existing logic continues to loop, and the indexOf(etc) call itself has a loop. 

It seems not only needlessly complicated, but also inefficient. 

This code seems to have originated in org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/pdom/util/CharArrayUtils.java, a file that was later renamed to org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/nd/util/CharArrayUtils.java.  

The replace(etc) method in CharArrayUtils differs from that in CharOperation.  The performance of the version in CharArrayUtils appears normal in comparison to that in CharOperation. 

However, I can't tell how long ago this code was written, but, it would appear to me that simply using String functions performs comparably, so there's no reason whatsoever for all this complicated code? 


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
