### PR TITLE
update for run.javac testing wrt JDK-8341408

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractRegressionTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractRegressionTest.java
@@ -1151,9 +1151,7 @@ protected static class JavacTestOptions {
 			JavacBug8337980 = // https://bugs.openjdk.org/browse/JDK-8337980
 					new JavacHasABug(MismatchType.EclipseErrorsJavacNone /* add pivot JDK24 */),
 			JavacBug8343306 = // https://bugs.openjdk.org/browse/JDK-8343306
-					new JavacHasABug(MismatchType.EclipseErrorsJavacNone /* add pivot JDK24 */),
-			JavacBug8341408 = // https://bugs.openjdk.org/browse/JDK-8341408
-					new JavacBug8341408();
+					new JavacHasABug(MismatchType.EclipseErrorsJavacNone /* add pivot JDK24 */);
 
 		// bugs that have been fixed but that we've not identified
 		public static JavacHasABug
@@ -1247,7 +1245,7 @@ protected static class JavacTestOptions {
 	}
 	public static class JavacBug8341408 extends JavacBugExtraJavacOptionsPlusMismatch {
 		public JavacBug8341408() {
-			super("--enable-preview -source 23 -Xlint:-preview", MismatchType.StandardOutputMismatch);
+			super("--enable-preview -source 24 -Xlint:-preview", MismatchType.StandardOutputMismatch);
 // FIXME	this.pivotCompliance = ClassFileConstants.JDK24;
 		}
 	}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PrimitiveInPatternsTestSH.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PrimitiveInPatternsTestSH.java
@@ -18,7 +18,6 @@ package org.eclipse.jdt.core.tests.compiler.regression;
 
 import java.util.Map;
 import junit.framework.Test;
-import org.eclipse.jdt.core.tests.compiler.regression.AbstractRegressionTest.JavacTestOptions.JavacHasABug;
 import org.eclipse.jdt.internal.compiler.batch.FileSystem;
 import org.eclipse.jdt.internal.compiler.env.INameEnvironment;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
@@ -1598,7 +1597,7 @@ public class PrimitiveInPatternsTestSH extends AbstractRegressionTest9 {
 					}
 				}
 				""");
-		runConformTest(new String[] {"X.java", clazz.toString()}, expectedOuts, getCompilerOptions(true), VMARGS, JavacHasABug.JavacBug8341408);
+		runConformTest(new String[] {"X.java", clazz.toString()}, expectedOuts);
 	}
 	public void testInstanceof_widenUnbox_Byte() {
 		testInstanceof_widenUnbox("Byte", 1, "49+49|49+49|49+49|49.0+49.0|49.0+49.0|");


### PR DESCRIPTION
https://bugs.openjdk.org/browse/JDK-8341408 has been resolved 

Since preview features can be tested only against latest there is no use in keeping Excuse JavacBug8341408 => remove
