### PR TITLE
Fix never-ending TestBug261722

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchBugsTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchBugsTests.java
@@ -10737,11 +10737,14 @@ public void testBug261722() throws Exception {
 		    }
 		};
 		Thread thread = new Thread(search);
+		long start = System.nanoTime();
+		long maxEnd = start + 10_000_000_000L;
+
 		thread.start();
 
 		// Delete project in current thread after being sure that the search
 		// request was started
-		while (requestor.count < (MAX/3)) {
+		while (requestor.count < (MAX/3) && System.nanoTime() < maxEnd) {
 			Thread.sleep(10);
 		}
 		deleteProject(javaProject);


### PR DESCRIPTION
If the test case is failing or no results are found, this test never completes. It waits for at least 1/3 of the expected results to be found before continuing. If the search operation completes with 0 results found, the test will wait forever. 

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
