### PR TITLE
Guard lookup in BoundSet::allSuperPairsWithCommonGenericTypeRecursive

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BoundSet.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BoundSet.java
@@ -1279,8 +1279,9 @@ class BoundSet {
 		}
 		if (TypeBinding.equalsEquals(s,  t))
 			return result; // optimization #2: nothing interesting above equal types
-		TypeBinding tSuper = t.findSuperTypeOriginatingFrom(s);
-		if (tSuper != null && s.isParameterizedType() && tSuper.isParameterizedType()) { // optimization #1 again
+
+		TypeBinding tSuper = s.isParameterizedType() ? t.findSuperTypeOriginatingFrom(s) : null;
+		if (tSuper != null && tSuper.isParameterizedType()) { // optimization #1 again
 			result.add(new Pair<>(s, tSuper));
 		}
 		result.addAll(allSuperPairsWithCommonGenericTypeRecursive(s.superclass(), t, visited));

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BoundSet.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BoundSet.java
@@ -1264,34 +1264,38 @@ class BoundSet {
 	}
 
 	protected List<Pair<TypeBinding>> allSuperPairsWithCommonGenericType(TypeBinding s, TypeBinding t) {
-		return allSuperPairsWithCommonGenericTypeRecursive(s, t, new HashSet<>());
+		ArrayList<Pair<TypeBinding>> result = new ArrayList<>();
+		allSuperPairsWithCommonGenericTypeRecursive(s, t, result, new HashSet<>());
+		return result;
 	}
 
-	private List<Pair<TypeBinding>> allSuperPairsWithCommonGenericTypeRecursive(TypeBinding s, TypeBinding t, HashSet<TypeBinding> visited) {
+	private void allSuperPairsWithCommonGenericTypeRecursive(TypeBinding s, TypeBinding t, List<Pair<TypeBinding>> result, HashSet<Integer> visited) {
 		if (s == null || s.id == TypeIds.T_JavaLangObject || t == null || t.id == TypeIds.T_JavaLangObject)
-			return Collections.emptyList();
-		if (!visited.add(s.prototype()))
-			return Collections.emptyList();
-		List<Pair<TypeBinding>> result = new ArrayList<>();
-		if (s.isParameterizedType() && t.isParameterizedType() // optimization #1: clients of this method only want to compare type arguments
-				&& TypeBinding.equalsEquals(s.original(), t.original())) {
-			result.add(new Pair<>(s, t));
-		}
-		if (TypeBinding.equalsEquals(s,  t))
-			return result; // optimization #2: nothing interesting above equal types
+			return;
+		if (!visited.add(s.id))
+			return;
 
-		TypeBinding tSuper = s.isParameterizedType() ? t.findSuperTypeOriginatingFrom(s) : null;
-		if (tSuper != null && tSuper.isParameterizedType()) { // optimization #1 again
-			result.add(new Pair<>(s, tSuper));
+		// optimization: nothing interesting above equal types
+		if (TypeBinding.equalsEquals(s,  t))
+			return;
+
+		if (s.isParameterizedType()) { // optimization here and below: clients of this method only want to compare type arguments
+			if (TypeBinding.equalsEquals(s.original(), t.original())) {
+				if (t.isParameterizedType())
+					result.add(new Pair<>(s, t));
+			} else {
+				TypeBinding tSuper = t.findSuperTypeOriginatingFrom(s);
+				if (tSuper != null && tSuper.isParameterizedType())
+					result.add(new Pair<>(s, tSuper));
+			}
 		}
-		result.addAll(allSuperPairsWithCommonGenericTypeRecursive(s.superclass(), t, visited));
+		allSuperPairsWithCommonGenericTypeRecursive(s.superclass(), t, result, visited);
 		ReferenceBinding[] superInterfaces = s.superInterfaces();
 		if (superInterfaces != null) {
 			for (ReferenceBinding superInterface : superInterfaces) {
-				result.addAll(allSuperPairsWithCommonGenericTypeRecursive(superInterface, t, visited));
+				allSuperPairsWithCommonGenericTypeRecursive(superInterface, t, result, visited);
 			}
 		}
-		return result;
 	}
 
 	public TypeBinding getEquivalentOuterVariable(InferenceVariable variable, InferenceVariable[] outerVariables) {


### PR DESCRIPTION
See proposal from @szarnekow in https://github.com/eclipse-jdt/eclipse.jdt.core/pull/3387#discussion_r1871077718

The compilation time was further reduced from ~12 min to **~10.5 min** 👏 

[Sample.zip](https://github.com/user-attachments/files/18036065/Sample.zip)

Contributes to https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3327