### PR TITLE
Fix source type binding key on windows

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SourceTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SourceTypeBinding.java
@@ -55,6 +55,7 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.compiler.lookup;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -1050,7 +1051,7 @@ public char[] computeUniqueKey(boolean isLeaf) {
 	// insert compilation unit name if the type name is not the main type name
 	int end = CharOperation.lastIndexOf('.', this.fileName);
 	if (end != -1) {
-		int start = CharOperation.lastIndexOf('/', this.fileName) + 1;
+		int start = CharOperation.lastIndexOf(File.separatorChar, this.fileName) + 1;
 		char[] mainTypeName = CharOperation.subarray(this.fileName, start, end);
 		start = CharOperation.lastIndexOf('/', uniqueKey) + 1;
 		if (start == 0)


### PR DESCRIPTION
On Windows since path separator is `\` the binding key ends up being `Lp/<path to the java file>~X`, i.e. includes file path. On Linux and Mac due to separator being `/` the key is `Lp/X;` as expected.
PR should fix the binding key on Windows 