### PR TITLE
Improve DeltaProcessor file change detection #3036

### DIFF
--- a/org.eclipse.jdt.core.tests.builder/src/org/eclipse/jdt/core/tests/builder/BuildpathTests.java
+++ b/org.eclipse.jdt.core.tests.builder/src/org/eclipse/jdt/core/tests/builder/BuildpathTests.java
@@ -369,7 +369,7 @@ public void testChangeZIPArchive1() throws Exception {
 
 		env.addExternalJars(projectPath, Util.getJavaClassLibs());
 		env.addExternalJars(projectPath, new String[] {externalLib});
-
+		long lastModified = new File(externalLib).lastModified();
 		IPath root = env.getPackageFragmentRootPath(projectPath, ""); //$NON-NLS-1$
 		env.setOutputFolder(projectPath, "");
 
@@ -394,7 +394,7 @@ public void testChangeZIPArchive1() throws Exception {
 			},
 			externalLib,
 			CompilerOptions.getFirstSupportedJavaVersion());
-
+		new File(externalLib).setLastModified(lastModified + 1000); // make sure lastModified has changed
 		IJavaProject p = env.getJavaProject(projectPath);
 		p.getJavaModel().refreshExternalArchives(new IJavaElement[] {p}, null);
 

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/DeltaProcessor.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/DeltaProcessor.java
@@ -226,7 +226,7 @@ public class DeltaProcessor {
 	 * Used for detecting external JAR changes
 	 */
 	public static long getTimeStamp(File file) {
-		return file.lastModified() + file.length();
+		return file.lastModified() + Long.hashCode(file.length()) * 31;
 	}
 
 	/*


### PR DESCRIPTION
Try to fix BuildpathTests.testChangeZIPArchive1() on linux.

Small changes in file length and timeStamp could have produced hash collisions due to simple hash function.

https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3036
