### PR TITLE
Fixes #3428 - Ensure calls to ASTParser.createBindings use the correct unit resolver

### DIFF
--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ASTParser.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ASTParser.java
@@ -27,6 +27,7 @@ import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.jdt.core.*;
 import org.eclipse.jdt.core.compiler.CategorizedProblem;
 import org.eclipse.jdt.core.compiler.CharOperation;
+import org.eclipse.jdt.core.dom.CompilationUnitResolver.IntArrayList;
 import org.eclipse.jdt.internal.compiler.ast.ConstructorDeclaration;
 import org.eclipse.jdt.internal.compiler.ast.ExplicitConstructorCall;
 import org.eclipse.jdt.internal.compiler.batch.FileSystem.Classpath;
@@ -38,16 +39,13 @@ import org.eclipse.jdt.internal.compiler.lookup.TypeConstants;
 import org.eclipse.jdt.internal.compiler.parser.RecoveryScanner;
 import org.eclipse.jdt.internal.compiler.parser.RecoveryScannerData;
 import org.eclipse.jdt.internal.compiler.parser.Scanner;
+import org.eclipse.jdt.internal.compiler.util.HashtableOfObjectToInt;
 import org.eclipse.jdt.internal.compiler.util.SuffixConstants;
-import org.eclipse.jdt.internal.core.BasicCompilationUnit;
-import org.eclipse.jdt.internal.core.BinaryType;
-import org.eclipse.jdt.internal.core.ClassFileWorkingCopy;
-import org.eclipse.jdt.internal.core.DefaultWorkingCopyOwner;
-import org.eclipse.jdt.internal.core.JavaModelManager;
-import org.eclipse.jdt.internal.core.PackageFragment;
+import org.eclipse.jdt.internal.core.*;
 import org.eclipse.jdt.internal.core.dom.ICompilationUnitResolver;
 import org.eclipse.jdt.internal.core.dom.util.DOMASTUtil;
 import org.eclipse.jdt.internal.core.util.CodeSnippetParsingUtil;
+import org.eclipse.jdt.internal.core.util.DOMFinder;
 import org.eclipse.jdt.internal.core.util.RecordedParsingInformation;
 import org.eclipse.jdt.internal.core.util.Util;
 
@@ -1166,11 +1164,107 @@ public class ASTParser {
 			if ((this.bits & CompilationUnitResolver.IGNORE_METHOD_BODIES) != 0) {
 				flags |= ICompilationUnit.IGNORE_METHOD_BODIES;
 			}
-			return CompilationUnitResolver.resolve(elements, this.apiLevel, this.compilerOptions, this.project, this.workingCopyOwner, flags, monitor);
+
+			return resolve(elements, this.apiLevel, this.compilerOptions, this.project, this.workingCopyOwner, flags, this.unitResolver, monitor);
 		} finally {
 			// reset to defaults to allow reuse (and avoid leaking)
 			initializeDefaults();
 		}
+	}
+
+	/**
+	 * Parse and resolve bindings for the given java elements with the following options.
+	 *
+	 * @param elements
+	 * @param apiLevel
+	 * @param compilerOptions
+	 * @param javaProject
+	 * @param owner
+	 * @param flags
+	 * @param monitor
+	 * @return an array of bindings that match the resolved elements
+	 */
+	static IBinding[] resolve(
+		final IJavaElement[] elements,
+		int apiLevel,
+		Map<String,String> compilerOptions,
+		IJavaProject javaProject,
+		WorkingCopyOwner owner,
+		int flags,
+		ICompilationUnitResolver unitResolver,
+		IProgressMonitor monitor) {
+
+		final int length = elements.length;
+		final HashMap<IJavaElement, IntArrayList> sourceElementPositions = new HashMap<>(); // a map from ICompilationUnit to int[] (positions in elements)
+		int cuNumber = 0;
+		final HashtableOfObjectToInt binaryElementPositions = new HashtableOfObjectToInt(); // a map from String (binding key) to int (position in elements)
+		for (int i = 0; i < length; i++) {
+			IJavaElement element = elements[i];
+			if (!(element instanceof SourceRefElement))
+				throw new IllegalStateException(element + " is not part of a compilation unit or class file"); //$NON-NLS-1$
+			IJavaElement cu = element.getAncestor(IJavaElement.COMPILATION_UNIT);
+			if (cu != null) {
+				// source member
+				IntArrayList intList = sourceElementPositions.get(cu);
+				if (intList == null) {
+					sourceElementPositions.put(cu, intList = new IntArrayList());
+					cuNumber++;
+				}
+				intList.add(i);
+			} else {
+				// binary member or method argument
+				try {
+					String key;
+					if (element instanceof BinaryMember)
+						key = ((BinaryMember) element).getKey(true/*open to get resolved info*/);
+					else if (element instanceof LocalVariable)
+						key = ((LocalVariable) element).getKey(true/*open to get resolved info*/);
+					else if (element instanceof org.eclipse.jdt.internal.core.TypeParameter)
+						key = ((org.eclipse.jdt.internal.core.TypeParameter) element).getKey(true/*open to get resolved info*/);
+					else if (element instanceof BinaryModule)
+						key = ((BinaryModule) element).getKey(true);
+					else
+						throw new IllegalArgumentException(element + " has an unexpected type"); //$NON-NLS-1$
+					binaryElementPositions.put(key, i);
+				} catch (JavaModelException e) {
+					throw new IllegalArgumentException(element + " does not exist", e); //$NON-NLS-1$
+				}
+			}
+		}
+		ICompilationUnit[] cus = new ICompilationUnit[cuNumber];
+		sourceElementPositions.keySet().toArray(cus);
+
+		int bindingKeyNumber = binaryElementPositions.size();
+		String[] bindingKeys = new String[bindingKeyNumber];
+		binaryElementPositions.keysToArray(bindingKeys);
+
+		class Requestor extends ASTRequestor {
+			IBinding[] bindings = new IBinding[length];
+			@Override
+			public void acceptAST(ICompilationUnit source, CompilationUnit ast) {
+				// TODO (jerome) optimize to visit the AST only once
+				IntArrayList intList = sourceElementPositions.get(source);
+				for (int i = 0; i < intList.length; i++) {
+					final int index = intList.list[i];
+					SourceRefElement element = (SourceRefElement) elements[index];
+					DOMFinder finder = new DOMFinder(ast, element, true/*resolve binding*/);
+					try {
+						finder.search();
+					} catch (JavaModelException e) {
+						throw new IllegalArgumentException(element + " does not exist", e); //$NON-NLS-1$
+					}
+					this.bindings[index] = finder.foundBinding;
+				}
+			}
+			@Override
+			public void acceptBinding(String bindingKey, IBinding binding) {
+				int index = binaryElementPositions.get(bindingKey);
+				this.bindings[index] = binding;
+			}
+		}
+		Requestor requestor = new Requestor();
+		unitResolver.resolve(cus, bindingKeys, requestor, apiLevel, compilerOptions, javaProject, owner, flags, monitor);
+		return requestor.bindings;
 	}
 
 	private ASTNode internalCreateAST(IProgressMonitor monitor) {

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/CompilationUnitResolver.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/CompilationUnitResolver.java
@@ -19,7 +19,6 @@ package org.eclipse.jdt.core.dom;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -60,14 +59,18 @@ import org.eclipse.jdt.internal.compiler.problem.AbortCompilation;
 import org.eclipse.jdt.internal.compiler.problem.DefaultProblemFactory;
 import org.eclipse.jdt.internal.compiler.problem.ProblemReporter;
 import org.eclipse.jdt.internal.compiler.util.HashtableOfObject;
-import org.eclipse.jdt.internal.compiler.util.HashtableOfObjectToInt;
 import org.eclipse.jdt.internal.compiler.util.Messages;
 import org.eclipse.jdt.internal.compiler.util.Util;
-import org.eclipse.jdt.internal.core.*;
+import org.eclipse.jdt.internal.core.CancelableNameEnvironment;
+import org.eclipse.jdt.internal.core.CancelableProblemFactory;
+import org.eclipse.jdt.internal.core.ClasspathEntry;
+import org.eclipse.jdt.internal.core.INameEnvironmentWithProgress;
+import org.eclipse.jdt.internal.core.JavaProject;
+import org.eclipse.jdt.internal.core.NameLookup;
+import org.eclipse.jdt.internal.core.SourceTypeElementInfo;
 import org.eclipse.jdt.internal.core.dom.ICompilationUnitResolver;
 import org.eclipse.jdt.internal.core.util.BindingKeyResolver;
 import org.eclipse.jdt.internal.core.util.CommentRecorderParser;
-import org.eclipse.jdt.internal.core.util.DOMFinder;
 
 @SuppressWarnings({ "rawtypes", "unchecked" })
 class CompilationUnitResolver extends Compiler {
@@ -866,6 +869,19 @@ class CompilationUnitResolver extends Compiler {
 			}
 		}
 	}
+
+	/**
+	 * Parse and resolve bindings for the given java elements with the following options.
+	 *
+	 * @param elements
+	 * @param apiLevel
+	 * @param compilerOptions
+	 * @param javaProject
+	 * @param owner
+	 * @param flags
+	 * @param monitor
+	 * @return an array of bindings that match the resolved elements
+	 */
 	public static IBinding[] resolve(
 		final IJavaElement[] elements,
 		int apiLevel,
@@ -874,79 +890,11 @@ class CompilationUnitResolver extends Compiler {
 		WorkingCopyOwner owner,
 		int flags,
 		IProgressMonitor monitor) {
-
-		final int length = elements.length;
-		final HashMap sourceElementPositions = new HashMap(); // a map from ICompilationUnit to int[] (positions in elements)
-		int cuNumber = 0;
-		final HashtableOfObjectToInt binaryElementPositions = new HashtableOfObjectToInt(); // a map from String (binding key) to int (position in elements)
-		for (int i = 0; i < length; i++) {
-			IJavaElement element = elements[i];
-			if (!(element instanceof SourceRefElement))
-				throw new IllegalStateException(element + " is not part of a compilation unit or class file"); //$NON-NLS-1$
-			Object cu = element.getAncestor(IJavaElement.COMPILATION_UNIT);
-			if (cu != null) {
-				// source member
-				IntArrayList intList = (IntArrayList) sourceElementPositions.get(cu);
-				if (intList == null) {
-					sourceElementPositions.put(cu, intList = new IntArrayList());
-					cuNumber++;
-				}
-				intList.add(i);
-			} else {
-				// binary member or method argument
-				try {
-					String key;
-					if (element instanceof BinaryMember)
-						key = ((BinaryMember) element).getKey(true/*open to get resolved info*/);
-					else if (element instanceof LocalVariable)
-						key = ((LocalVariable) element).getKey(true/*open to get resolved info*/);
-					else if (element instanceof org.eclipse.jdt.internal.core.TypeParameter)
-						key = ((org.eclipse.jdt.internal.core.TypeParameter) element).getKey(true/*open to get resolved info*/);
-					else if (element instanceof BinaryModule)
-						key = ((BinaryModule) element).getKey(true);
-					else
-						throw new IllegalArgumentException(element + " has an unexpected type"); //$NON-NLS-1$
-					binaryElementPositions.put(key, i);
-				} catch (JavaModelException e) {
-					throw new IllegalArgumentException(element + " does not exist", e); //$NON-NLS-1$
-				}
-			}
-		}
-		ICompilationUnit[] cus = new ICompilationUnit[cuNumber];
-		sourceElementPositions.keySet().toArray(cus);
-
-		int bindingKeyNumber = binaryElementPositions.size();
-		String[] bindingKeys = new String[bindingKeyNumber];
-		binaryElementPositions.keysToArray(bindingKeys);
-
-		class Requestor extends ASTRequestor {
-			IBinding[] bindings = new IBinding[length];
-			@Override
-			public void acceptAST(ICompilationUnit source, CompilationUnit ast) {
-				// TODO (jerome) optimize to visit the AST only once
-				IntArrayList intList = (IntArrayList) sourceElementPositions.get(source);
-				for (int i = 0; i < intList.length; i++) {
-					final int index = intList.list[i];
-					SourceRefElement element = (SourceRefElement) elements[index];
-					DOMFinder finder = new DOMFinder(ast, element, true/*resolve binding*/);
-					try {
-						finder.search();
-					} catch (JavaModelException e) {
-						throw new IllegalArgumentException(element + " does not exist", e); //$NON-NLS-1$
-					}
-					this.bindings[index] = finder.foundBinding;
-				}
-			}
-			@Override
-			public void acceptBinding(String bindingKey, IBinding binding) {
-				int index = binaryElementPositions.get(bindingKey);
-				this.bindings[index] = binding;
-			}
-		}
-		Requestor requestor = new Requestor();
-		resolve(cus, bindingKeys, requestor, apiLevel, compilerOptions, javaProject, owner, flags, monitor);
-		return requestor.bindings;
+		// Should not be called anymore? Candidate for deprecation
+		return ASTParser.resolve(elements, apiLevel, compilerOptions, javaProject, owner, flags, getInstance(), monitor);
 	}
+
+
 	/*
 	 * When unit result is about to be accepted, removed back pointers
 	 * to unresolved bindings


### PR DESCRIPTION
Most entry points to resolving bindings or parsing compilation units have been updated to make use of the recently-added extension point, to ensure that adopters that wish to extend this functionality are able to do so. 

Unfortunately, one of the entry points was missed.  ASTParser still had code that traversed directly into ECJ code without checking for the proper resolver. 

This PR would fix that. 


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
