### PR TITLE
[performance] avoid File.getCanonicalPath()

### DIFF
--- a/org.eclipse.jdt.apt.tests/src/org/eclipse/jdt/apt/tests/AnnotationProcessingCompilerToolTest.java
+++ b/org.eclipse.jdt.apt.tests/src/org/eclipse/jdt/apt/tests/AnnotationProcessingCompilerToolTest.java
@@ -92,7 +92,7 @@ public class AnnotationProcessingCompilerToolTest extends AbstractBatchCompilerT
 			+ "	last round: false\n"
 			+ "Discovered processor service org.eclipse.jdt.apt.tests.external.annotations.batch.BatchGenProcessor\n"
 			+ "  supporting [org.eclipse.jdt.apt.tests.external.annotations.batch.BatchGen]\n"
-			+ "  in jar:"  + Path.of(_extJar.getCanonicalPath()).toUri().toURL().toString() +"!/\n"
+			+ "  in jar:"  + Path.of(_extJar.toPath().normalize().toAbsolutePath().toString()).toUri().toURL().toString() +"!/\n"
 			+ "Processor org.eclipse.jdt.apt.tests.external.annotations.batch.BatchGenProcessor matches [org.eclipse.jdt.apt.tests.external.annotations.batch.BatchGen] and returns true\n"
 			+ "Round 2:\n"
 			+ "	input files: {p1.gen.Class1,p1.gen.Class2,p1.Class0}\n"
@@ -178,7 +178,7 @@ public class AnnotationProcessingCompilerToolTest extends AbstractBatchCompilerT
 			},
 			"Discovered processor service org.eclipse.jdt.apt.tests.external.annotations.batch.BatchGenProcessor\n" +
 			"  supporting [org.eclipse.jdt.apt.tests.external.annotations.batch.BatchGen]\n" + 
-			"  in jar:"  + Path.of(_extJar.getCanonicalPath()).toUri().toURL().toString() + "!/\n" + 
+			"  in jar:"  + Path.of(_extJar.toPath().normalize().toAbsolutePath().toString()).toUri().toURL().toString() + "!/\n" + 
 			"Processor org.eclipse.jdt.apt.tests.external.annotations.batch.BatchGenProcessor matches [org.eclipse.jdt.apt.tests.external.annotations.batch.BatchGen] and returns true\n" + 
 			"Processor org.eclipse.jdt.apt.tests.external.annotations.batch.BatchGenProcessor matches [] and returns false\n",
 			"" /* expectedErrOutputString */,

--- a/org.eclipse.jdt.compiler.apt.tests/src/org/eclipse/jdt/compiler/apt/tests/BatchTestUtils.java
+++ b/org.eclipse.jdt.compiler.apt.tests/src/org/eclipse/jdt/compiler/apt/tests/BatchTestUtils.java
@@ -700,7 +700,7 @@ public class BatchTestUtils {
 		File destinationDir = new File(tmpDir);
 		File destinationFile = new File(destinationDir, processorJar);
 		copyResource(libFile, destinationFile);
-		return destinationFile.getCanonicalPath();
+		return destinationFile.toPath().normalize().toAbsolutePath().toString();
 	}
 
 	/**

--- a/org.eclipse.jdt.compiler.tool.tests/src/org/eclipse/jdt/compiler/tool/tests/CompilerToolTests.java
+++ b/org.eclipse.jdt.compiler.tool.tests/src/org/eclipse/jdt/compiler/tool/tests/CompilerToolTests.java
@@ -1157,7 +1157,7 @@ static final String[] FAKE_ZERO_ARG_OPTIONS = new String[] {
 
 
 	public void testCompilerUnusedVariable() throws Exception {
-		String tmpFolder = new File(System.getProperty("java.io.tmpdir")).getCanonicalPath();
+		String tmpFolder = new File(System.getProperty("java.io.tmpdir")).toPath().normalize().toAbsolutePath().toString();
 		File inputFile = new File(tmpFolder, "NoWarn.java");
 		BufferedWriter writer = null;
 		try {
@@ -1208,7 +1208,7 @@ static final String[] FAKE_ZERO_ARG_OPTIONS = new String[] {
 		assertEquals("Expected no warnings to be generated.", "", stringWriter.toString());
 	}
 	public void testCompilerUnusedVariable2() throws Exception {
-		String tmpFolder = new File(System.getProperty("java.io.tmpdir")).getCanonicalPath();
+		String tmpFolder = new File(System.getProperty("java.io.tmpdir")).toPath().normalize().toAbsolutePath().toString();
 		File inputFile = new File(tmpFolder, "NoWarn.java");
 		BufferedWriter writer = null;
 		try {
@@ -1264,7 +1264,7 @@ static final String[] FAKE_ZERO_ARG_OPTIONS = new String[] {
 	}
 
 	private void suppressTest(String fileName, String source, String expectedDiagnostics, String expectedOutput) throws Exception {
-		String tmpFolder = new File(System.getProperty("java.io.tmpdir")).getCanonicalPath();
+		String tmpFolder = new File(System.getProperty("java.io.tmpdir")).toPath().normalize().toAbsolutePath().toString();
 		File inputFile = new File(tmpFolder, fileName);
 		BufferedWriter writer = null;
 		try {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/ClasspathDirectory.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/ClasspathDirectory.java
@@ -66,12 +66,7 @@ ClasspathDirectory(File directory, String encoding, int mode,
 	super(accessRuleSet, destinationPath);
 	this.mode = mode;
 	this.options = options;
-	try {
-		this.path = directory.getCanonicalPath();
-	} catch (IOException e) {
-		// should not happen as we know that the file exists
-		this.path = directory.getAbsolutePath();
-	}
+	this.path = directory.toPath().normalize().toAbsolutePath().toString();
 	if (!this.path.endsWith(File.separator))
 		this.path += File.separator;
 	this.encoding = encoding;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/ClasspathJar.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/ClasspathJar.java
@@ -310,12 +310,7 @@ public char[] normalizedPath() {
 @Override
 public String getPath() {
 	if (this.path == null) {
-		try {
-			this.path = this.file.getCanonicalPath();
-		} catch (IOException e) {
-			// in case of error, simply return the absolute path
-			this.path = this.file.getAbsolutePath();
-		}
+		this.path = this.file.toPath().normalize().toAbsolutePath().toString();
 	}
 	return this.path;
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/ClasspathJep247.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/ClasspathJep247.java
@@ -285,12 +285,7 @@ public class ClasspathJep247 extends ClasspathJrt {
 	@Override
 	public String getPath() {
 		if (this.path == null) {
-			try {
-				this.path = this.file.getCanonicalPath();
-			} catch (IOException e) {
-				// in case of error, simply return the absolute path
-				this.path = this.file.getAbsolutePath();
-			}
+			this.path = this.file.toPath().normalize().toAbsolutePath().toString();
 		}
 		return this.path;
 	}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/ClasspathJrt.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/ClasspathJrt.java
@@ -339,12 +339,7 @@ public class ClasspathJrt extends ClasspathLocation implements IMultiModuleEntry
 	@Override
 	public String getPath() {
 		if (this.path == null) {
-			try {
-				this.path = this.file.getCanonicalPath();
-			} catch (IOException e) {
-				// in case of error, simply return the absolute path
-				this.path = this.file.getAbsolutePath();
-			}
+			this.path = this.file.toPath().normalize().toAbsolutePath().toString();
 		}
 		return this.path;
 	}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/Main.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/Main.java
@@ -475,13 +475,9 @@ public class Main implements ProblemSeverities, SuffixConstants {
 					}
 				}
 				File f = new File(fileName);
-				try {
-					HashMap<String, Object> parameters = new HashMap<>();
-					parameters.put(Logger.PATH, f.getCanonicalPath());
-					printTag(Logger.CLASS_FILE, parameters, true, true);
-				} catch (IOException e) {
-					logNoClassFileCreated(outputPath, relativeFileName, e);
-				}
+				HashMap<String, Object> parameters = new HashMap<>();
+				parameters.put(Logger.PATH, f.toPath().normalize().toAbsolutePath().toString());
+				printTag(Logger.CLASS_FILE, parameters, true, true);
 			}
 		}
 		public void logClasspath(FileSystem.Classpath[] classpaths) {

--- a/org.eclipse.jdt.core.tests.builder/src/org/eclipse/jdt/core/tests/builder/BasicBuildTests.java
+++ b/org.eclipse.jdt.core.tests.builder/src/org/eclipse/jdt/core/tests/builder/BasicBuildTests.java
@@ -845,7 +845,7 @@ public class BasicBuildTests extends BuilderTests {
 			try {
 				Files.copy(from.toPath(), to.toPath(), StandardCopyOption.REPLACE_EXISTING);
 			} catch (IOException e) {
-				ILog.get().error("Failed to copy the file - " + from.getCanonicalPath(), e); //$NON-NLS-1$
+				ILog.get().error("Failed to copy the file - " + from.toPath().normalize().toAbsolutePath().toString(), e); //$NON-NLS-1$
 				throw e;
 			}
 		}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/parser/TypeAnnotationSyntaxTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/parser/TypeAnnotationSyntaxTest.java
@@ -212,7 +212,7 @@ void traverse (File f) throws IOException {
 		}
 	} else {
 		if (f.getName().endsWith(".java")) {
-			System.out.println(f.getCanonicalPath());
+			System.out.println(f.toPath().normalize().toAbsolutePath().toString());
 			char [] contents = new char[(int) f.length()];
 			FileInputStream fs = new FileInputStream(f);
 			InputStreamReader isr = null;
@@ -222,7 +222,7 @@ void traverse (File f) throws IOException {
 				if (isr != null) isr.close();
 			}
 			isr.read(contents);
-			checkParse(contents, null, f.getCanonicalPath(), null);
+			checkParse(contents, null, f.toPath().normalize().toAbsolutePath().toString(), null);
 		}
 	}
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractRegressionTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractRegressionTest.java
@@ -216,7 +216,7 @@ static class JavacCompiler {
 	JavacCompiler(String rootDirectoryPath, String rawVersion) throws IOException, InterruptedException {
 		this.rootDirectoryPath = rootDirectoryPath;
 		this.javacPathName = new File(rootDirectoryPath + File.separator
-				+ "bin" + File.separator + JAVAC_NAME).getCanonicalPath();
+				+ "bin" + File.separator + JAVAC_NAME).toPath().normalize().toAbsolutePath().toString();
 		// WORK don't need JAVAC_NAME any more; suppress this as we work towards code cleanup
 		if (rawVersion == null) {
 			rawVersion = getVersion(this.javacPathName);
@@ -655,7 +655,7 @@ static class JavaRuntime {
 	private JavaRuntime(String rootDirectoryPath, String version, String rawVersion, int minor) throws IOException, InterruptedException {
 		this.rootDirectoryPath = rootDirectoryPath;
 		this.javaPathName = new File(this.rootDirectoryPath + File.separator
-				+ "bin" + File.separator + JAVA_NAME).getCanonicalPath();
+				+ "bin" + File.separator + JAVA_NAME).toPath().normalize().toAbsolutePath().toString();
 		this.version = version;
 		this.rawVersion = rawVersion;
 		this.minor = minor;

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/dom/StandAloneASTParserTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/dom/StandAloneASTParserTest.java
@@ -216,7 +216,7 @@ public class StandAloneASTParserTest extends AbstractRegressionTest {
 		}
 
 		try {
-			final String canonicalPath = file.getCanonicalPath();
+			final String filePath = file.toPath().normalize().toAbsolutePath().toString();
 			final CompilationUnit[] units = new CompilationUnit[1];
 
 			FileASTRequestor requestor = new FileASTRequestor() {
@@ -226,15 +226,15 @@ public class StandAloneASTParserTest extends AbstractRegressionTest {
 					}
 				}
 				public void acceptAST(String sourceFilePath, CompilationUnit ast) {
-					if (canonicalPath.equals(sourceFilePath)) {
+					if (filePath.equals(sourceFilePath)) {
 						units[0] = ast;
 					}
 				}
 			};
 
-			parser.setEnvironment(null, new String[] { rootDir.getCanonicalPath() }, null, true);
+			parser.setEnvironment(null, new String[] { rootDir.toPath().normalize().toAbsolutePath().toString() }, null, true);
 
-			parser.createASTs(new String[] {canonicalPath}, null, new String[] {key}, requestor, null);
+			parser.createASTs(new String[] {filePath}, null, new String[] {key}, requestor, null);
 
 			assertNotNull("No binding", bindings[0]);
 			assertEquals("Wrong type of binding", IBinding.TYPE, bindings[0].getKind());
@@ -327,7 +327,7 @@ public class StandAloneASTParserTest extends AbstractRegressionTest {
 		}
 
 		try {
-			final String canonicalPath = file.getCanonicalPath();
+			final String filePath = file.toPath().normalize().toAbsolutePath().toString();
 			final CompilationUnit[] units = new CompilationUnit[1];
 
 			FileASTRequestor requestor = new FileASTRequestor() {
@@ -341,15 +341,15 @@ public class StandAloneASTParserTest extends AbstractRegressionTest {
 					}
 				}
 				public void acceptAST(String sourceFilePath, CompilationUnit ast) {
-					if (canonicalPath.equals(sourceFilePath)) {
+					if (filePath.equals(sourceFilePath)) {
 						units[0] = ast;
 					}
 				}
 			};
 
-			parser.setEnvironment(null, new String[] { rootDir.getCanonicalPath() }, null, true);
+			parser.setEnvironment(null, new String[] { rootDir.toPath().normalize().toAbsolutePath().toString() }, null, true);
 
-			parser.createASTs(new String[] {canonicalPath}, null, new String[] {key}, requestor, null);
+			parser.createASTs(new String[] {filePath}, null, new String[] {key}, requestor, null);
 
 			assertNotNull("No binding", bindings[0]);
 			assertEquals("Wrong type of binding", IBinding.TYPE, bindings[0].getKind());
@@ -426,7 +426,7 @@ public class StandAloneASTParserTest extends AbstractRegressionTest {
 		}
 
 		try {
-			final String canonicalPath = fileY.getCanonicalPath();
+			final String fileYPath = fileY.toPath().normalize().toAbsolutePath().toString();
 			final CompilationUnit[] units = new CompilationUnit[1];
 
 			FileASTRequestor requestor = new FileASTRequestor() {
@@ -440,15 +440,15 @@ public class StandAloneASTParserTest extends AbstractRegressionTest {
 					}
 				}
 				public void acceptAST(String sourceFilePath, CompilationUnit ast) {
-					if (canonicalPath.equals(sourceFilePath)) {
+					if (fileYPath.equals(sourceFilePath)) {
 						units[0] = ast;
 					}
 				}
 			};
 
-			parser.setEnvironment(null, new String[] { rootDir.getCanonicalPath() }, null, true);
+			parser.setEnvironment(null, new String[] { rootDir.toPath().normalize().toAbsolutePath().toString() }, null, true);
 			org.eclipse.jdt.internal.core.builder.AbstractImageBuilder.MAX_AT_ONCE = 0;
-			parser.createASTs(new String[] {canonicalPath}, null, new String[] {key}, requestor, null);
+			parser.createASTs(new String[] {fileYPath}, null, new String[] {key}, requestor, null);
 			assertNotNull("No ast", units[0]);
 			assertEquals("No problem", 0, units[0].getProblems().length);
 		} finally {
@@ -515,7 +515,7 @@ public class StandAloneASTParserTest extends AbstractRegressionTest {
 		}
 
 		try {
-			final String canonicalPath = fileY.getCanonicalPath();
+			final String fileYPath = fileY.toPath().normalize().toAbsolutePath().toString();
 			final CompilationUnit[] units = new CompilationUnit[1];
 
 			FileASTRequestor requestor = new FileASTRequestor() {
@@ -529,14 +529,14 @@ public class StandAloneASTParserTest extends AbstractRegressionTest {
 					}
 				}
 				public void acceptAST(String sourceFilePath, CompilationUnit ast) {
-					if (canonicalPath.equals(sourceFilePath)) {
+					if (fileYPath.equals(sourceFilePath)) {
 						units[0] = ast;
 					}
 				}
 			};
 
-			parser.setEnvironment(null, new String[] { rootDir.getCanonicalPath() }, null, true);
-			parser.createASTs(new String[] {canonicalPath}, null, new String[] {key}, requestor, null);
+			parser.setEnvironment(null, new String[] { rootDir.toPath().normalize().toAbsolutePath().toString() }, null, true);
+			parser.createASTs(new String[] {fileYPath}, null, new String[] {key}, requestor, null);
 			assertNotNull("No ast", units[0]);
 			IProblem[] problems = units[0].getProblems();
 			assertEquals("No problem", 1, problems.length);
@@ -596,7 +596,7 @@ public class StandAloneASTParserTest extends AbstractRegressionTest {
 			parser.setKind(ASTParser.K_COMPILATION_UNIT);
 			parser.setCompilerOptions(JavaCore.getOptions());
 			parser.createASTs(
-					new String[] { file.getCanonicalPath(), fileY.getCanonicalPath() },
+					new String[] { file.toPath().normalize().toAbsolutePath().toString(), fileY.toPath().normalize().toAbsolutePath().toString() },
 					null,
 					new String[] {},
 					new FileASTRequestor() {},
@@ -770,18 +770,9 @@ public class StandAloneASTParserTest extends AbstractRegressionTest {
 			parser.setBindingsRecovery(true);
 			parser.setKind(ASTParser.K_COMPILATION_UNIT);
 			parser.setEnvironment(new String[0], new String[] { rootDir.getAbsolutePath() }, null, true);
-		    String[] files = null;
-			try {
-				files = new String[] {file.getCanonicalPath(), fileY.getCanonicalPath()};
-				parser.createASTs(files,
-						null,
-						new String[0],
-						astRequestor,
-						null);
-			} catch (IOException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
-			}
+			String[] files = new String[] { file.toPath().normalize().toAbsolutePath().toString(),
+					fileY.toPath().normalize().toAbsolutePath().toString() };
+			parser.createASTs(files, null, new String[0], astRequestor, null);
 		} finally {
 			file.delete();
 			fileY.delete();
@@ -1576,18 +1567,9 @@ public class StandAloneASTParserTest extends AbstractRegressionTest {
 			parser.setBindingsRecovery(true);
 			parser.setKind(ASTParser.K_COMPILATION_UNIT);
 			parser.setEnvironment(new String[0], new String[] { rootDir.getAbsolutePath() }, null, true);
-		    String[] files = null;
-			try {
-				files = new String[] {file.getCanonicalPath(), fileY.getCanonicalPath()};
-				parser.createASTs(files,
-						null,
-						new String[0],
-						astRequestor,
-						null);
-			} catch (IOException e) {
-				// TODO Auto-generated catch block
-				e.printStackTrace();
-			}
+			String[] files = new String[] { file.toPath().normalize().toAbsolutePath().toString(),
+					fileY.toPath().normalize().toAbsolutePath().toString() };
+			parser.createASTs(files, null, new String[0], astRequestor, null);
 		} finally {
 			file.delete();
 			fileY.delete();
@@ -1652,12 +1634,12 @@ public class StandAloneASTParserTest extends AbstractRegressionTest {
 		File packageDir = new File(rootDir, "p");
 		packageDir.mkdir();
 		File fileY = new File(packageDir, "Y.java");
-		String canonicalPath = fileY.getCanonicalPath();
+		String fileYPath = fileY.toPath().normalize().toAbsolutePath().toString();
 
 		packageDir = new File(rootDir, "p");
 		packageDir.mkdir();
 		fileY = new File(packageDir, "Z.java");
-		String canonicalPath2 = fileY.getCanonicalPath();
+		String fileZPath = fileY.toPath().normalize().toAbsolutePath().toString();
 
 		contents =
 				"enum X {\n" +
@@ -1687,7 +1669,7 @@ public class StandAloneASTParserTest extends AbstractRegressionTest {
 			parser.setResolveBindings(true);
 			parser.setCompilerOptions(JavaCore.getOptions());
 			parser.createASTs(
-					new String[] { file.getCanonicalPath(), canonicalPath, canonicalPath2, file2.getCanonicalPath() },
+					new String[] { file.toPath().normalize().toAbsolutePath().toString(), fileYPath, fileZPath, file2.toPath().normalize().toAbsolutePath().toString() },
 					null,
 					new String[] {},
 					new FileASTRequestor() {},

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/util/Util.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/util/Util.java
@@ -172,13 +172,7 @@ public class Util {
 
         // Computed test run directory name based on current time
         File dateDir = new File(dir, "run."+System.currentTimeMillis());
-        String pathDir = null;
-        try {
-        	pathDir = dateDir.getCanonicalPath();
-		} catch (IOException e) {
-			pathDir = dateDir.getAbsolutePath();
-		}
-		OUTPUT_DIRECTORY = pathDir;
+		OUTPUT_DIRECTORY = dateDir.toPath().normalize().toAbsolutePath().toString();
    }
 
 public static void appendProblem(StringBuilder problems, IProblem problem, char[] source, int problemCount) {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AbstractJavaModelTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AbstractJavaModelTests.java
@@ -2669,17 +2669,13 @@ public abstract class AbstractJavaModelTests extends SuiteOfTestCases {
 	 */
 	protected String getExternalPath() {
 		if (EXTERNAL_JAR_DIR_PATH == null) {
-			try {
-				String path = getWorkspaceRoot().getLocation().toFile().getParentFile().getCanonicalPath();
-				if (path.charAt(path.length()-1) != File.separatorChar) {
-					path += File.separatorChar;
-				}
-				EXTERNAL_JAR_DIR_PATH = path;
-				System.out.println("EXTERNAL_JAR_DIR_PATH=" + EXTERNAL_JAR_DIR_PATH);
-				System.out.println("EXTERNAL_JAR_DIR_PATH writable? " + Files.isWritable(Paths.get(EXTERNAL_JAR_DIR_PATH)));
-			} catch (IOException e) {
-				throw new IllegalStateException(e);
+			String path = getWorkspaceRoot().getLocation().toFile().getParentFile().toPath().normalize().toAbsolutePath().toString();
+			if (path.charAt(path.length()-1) != File.separatorChar) {
+				path += File.separatorChar;
 			}
+			EXTERNAL_JAR_DIR_PATH = path;
+			System.out.println("EXTERNAL_JAR_DIR_PATH=" + EXTERNAL_JAR_DIR_PATH);
+			System.out.println("EXTERNAL_JAR_DIR_PATH writable? " + Files.isWritable(Paths.get(EXTERNAL_JAR_DIR_PATH)));
 		}
 		return EXTERNAL_JAR_DIR_PATH;
 	}
@@ -2688,15 +2684,12 @@ public abstract class AbstractJavaModelTests extends SuiteOfTestCases {
 	 * This path ends with a File.separatorChar.
 	 */
 	protected String getWorkspacePath() {
-		if (WORKSPACE_DIR_PATH == null)
-			try {
-				String path = getWorkspaceRoot().getLocation().toFile().getCanonicalPath();
-				if (path.charAt(path.length()-1) != File.separatorChar)
-					path += File.separatorChar;
-				WORKSPACE_DIR_PATH = path;
-			} catch (IOException e) {
-				e.printStackTrace();
-			}
+		if (WORKSPACE_DIR_PATH == null) {
+			String path = getWorkspaceRoot().getLocation().toFile().toPath().normalize().toAbsolutePath().toString();
+			if (path.charAt(path.length()-1) != File.separatorChar)
+				path += File.separatorChar;
+			WORKSPACE_DIR_PATH = path;
+		}
 		return WORKSPACE_DIR_PATH;
 	}
 	protected IFile getFile(String path) {
@@ -3410,7 +3403,7 @@ public abstract class AbstractJavaModelTests extends SuiteOfTestCases {
 	protected IJavaProject setUpJavaProject(final String projectName, String compliance, boolean useFullJCL) throws CoreException, IOException {
 		// copy files in project from source workspace to target workspace
 		String sourceWorkspacePath = getSourceWorkspacePath();
-		String targetWorkspacePath = getWorkspaceRoot().getLocation().toFile().getCanonicalPath();
+		String targetWorkspacePath = getWorkspaceRoot().getLocation().toFile().toPath().normalize().toAbsolutePath().toString();
 		copyDirectory(new File(sourceWorkspacePath, projectName), new File(targetWorkspacePath, projectName));
 
 		// ensure variables are set

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ExternalJarDeltaTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ExternalJarDeltaTests.java
@@ -115,7 +115,7 @@ public void testExternalJarChanged1() throws CoreException, IOException {
 		assertDeltas(
 			"Unexpected delta",
 			"P[*]: {CHILDREN}\n"+
-			"	"+f.getCanonicalPath()+"[*]: {CONTENT | ARCHIVE CONTENT CHANGED}"
+			"	"+f.toPath().normalize().toAbsolutePath().toString()+"[*]: {CONTENT | ARCHIVE CONTENT CHANGED}"
 		);
 	} finally {
 		if(f != null) {
@@ -148,7 +148,7 @@ public void testExternalJarChanged2() throws CoreException, IOException {
 		assertDeltas(
 			"Unexpected delta",
 			"P[*]: {CHILDREN}\n"+
-			"	"+f.getCanonicalPath()+"[*]: {CONTENT | ARCHIVE CONTENT CHANGED}"
+			"	"+f.toPath().normalize().toAbsolutePath().toString()+"[*]: {CONTENT | ARCHIVE CONTENT CHANGED}"
 		);
 	} finally {
 		if(f != null) {
@@ -182,7 +182,7 @@ public void testExternalJarChanged3() throws CoreException, IOException {
 		assertDeltas(
 			"Unexpected delta",
 			"P[*]: {CHILDREN}\n"+
-			"	"+f.getCanonicalPath()+"[*]: {CONTENT | ARCHIVE CONTENT CHANGED}"
+			"	"+f.toPath().normalize().toAbsolutePath().toString()+"[*]: {CONTENT | ARCHIVE CONTENT CHANGED}"
 		);
 	} finally {
 		if(f != null) {
@@ -223,7 +223,7 @@ public void testExternalJarChanged4() throws CoreException, IOException {
 		assertDeltas(
 			"Unexpected delta",
 			"P[*]: {CHILDREN}\n"+
-			"	"+f.getCanonicalPath()+"[*]: {CONTENT | ARCHIVE CONTENT CHANGED}"
+			"	"+f.toPath().normalize().toAbsolutePath().toString()+"[*]: {CONTENT | ARCHIVE CONTENT CHANGED}"
 		);
 	} finally {
 		if(f != null) {
@@ -265,7 +265,7 @@ public void testExternalJarChanged5() throws CoreException, IOException {
 		assertDeltas(
 			"Unexpected delta",
 			"P[*]: {CHILDREN}\n"+
-			"	"+f.getCanonicalPath()+"[*]: {CONTENT | ARCHIVE CONTENT CHANGED}"
+			"	"+f.toPath().normalize().toAbsolutePath().toString()+"[*]: {CONTENT | ARCHIVE CONTENT CHANGED}"
 		);
 	} finally {
 		if(f != null) {
@@ -300,7 +300,7 @@ public void testExternalJarChanged6() throws CoreException, IOException {
 			"Unexpected delta",
 			"P[*]: {CHILDREN | CONTENT | RAW CLASSPATH CHANGED | RESOLVED CLASSPATH CHANGED}\n" +
 			"	<project root>[*]: {ADDED TO CLASSPATH}\n" +
-			"	"+f.getCanonicalPath()+"[*]: {CONTENT | ARCHIVE CONTENT CHANGED}\n" +
+			"	"+f.toPath().normalize().toAbsolutePath().toString()+"[*]: {CONTENT | ARCHIVE CONTENT CHANGED}\n" +
 			"	ResourceDelta(/P/.classpath)[*]"
 		);
 	} finally {
@@ -333,7 +333,7 @@ public void testExternalJarAdded1() throws CoreException, IOException {
 		assertDeltas(
 			"Unexpected delta",
 			"P[*]: {CHILDREN}\n"+
-			"	"+f.getCanonicalPath()+"[+]: {}"
+			"	"+f.toPath().normalize().toAbsolutePath().toString()+"[+]: {}"
 		);
 	} finally {
 		if(f != null) {
@@ -365,7 +365,7 @@ public void testExternalJarAdded2() throws CoreException, IOException {
 		assertDeltas(
 			"Unexpected delta",
 			"P[*]: {CHILDREN}\n"+
-			"	"+f.getCanonicalPath()+"[+]: {}"
+			"	"+f.toPath().normalize().toAbsolutePath().toString()+"[+]: {}"
 		);
 	} finally {
 		if(f != null) {
@@ -398,7 +398,7 @@ public void testExternalJarAdded3() throws CoreException, IOException {
 		assertDeltas(
 			"Unexpected delta",
 			"P[*]: {CHILDREN}\n"+
-			"	"+f.getCanonicalPath()+"[+]: {}"
+			"	"+f.toPath().normalize().toAbsolutePath().toString()+"[+]: {}"
 		);
 	} finally {
 		if(f != null) {
@@ -431,7 +431,7 @@ public void testExternalJarRemoved1() throws CoreException, IOException {
 		assertDeltas(
 			"Unexpected delta",
 			"P[*]: {CHILDREN}\n"+
-			"	"+f.getCanonicalPath()+"[-]: {}"
+			"	"+f.toPath().normalize().toAbsolutePath().toString()+"[-]: {}"
 		);
 	} finally {
 		if(f != null) {
@@ -464,7 +464,7 @@ public void testExternalJarRemoved2() throws CoreException, IOException {
 		assertDeltas(
 			"Unexpected delta",
 			"P[*]: {CHILDREN}\n"+
-			"	"+f.getCanonicalPath()+"[-]: {}"
+			"	"+f.toPath().normalize().toAbsolutePath().toString()+"[-]: {}"
 		);
 	} finally {
 		if(f != null) {
@@ -498,7 +498,7 @@ public void testExternalJarRemoved3() throws CoreException, IOException {
 		assertDeltas(
 			"Unexpected delta",
 			"P[*]: {CHILDREN}\n"+
-			"	"+f.getCanonicalPath()+"[-]: {}"
+			"	"+f.toPath().normalize().toAbsolutePath().toString()+"[-]: {}"
 		);
 	} finally {
 		if(f != null) {
@@ -528,7 +528,7 @@ public void testExternalJarInternalExternalJar() throws CoreException, IOExcepti
 		startDeltas();
 
 		// canonicalize the external path as this is not done on case sensitive platforms when creating a new lib entry
-		IPath externalFooPath = new Path(fooIFile.getLocation().toFile().getCanonicalPath());
+		IPath externalFooPath = new Path(fooIFile.getLocation().toFile().toPath().normalize().toAbsolutePath().toString());
 		setClasspath(project, new IClasspathEntry[]{JavaCore.newLibraryEntry(externalFooPath, null, null)});
 
 		project.open(null); // ensure that project is opened, as external jar delta is optimized for this case (if the project is not opened, there is no need for broadcasting an external jar delta)
@@ -536,7 +536,7 @@ public void testExternalJarInternalExternalJar() throws CoreException, IOExcepti
 		touch(f);
 		getJavaModel().refreshExternalArchives(null,null);
 
-		String externalFooPathString = f.getCanonicalPath();
+		String externalFooPathString = f.toPath().normalize().toAbsolutePath().toString();
 		assertDeltas(
 			"Unexpected delta",
 			"P[*]: {CHILDREN | CONTENT | RAW CLASSPATH CHANGED | RESOLVED CLASSPATH CHANGED}\n"+

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaIndexTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaIndexTests.java
@@ -880,7 +880,7 @@ public class JavaIndexTests extends AbstractJavaSearchTests  {
 	// Test shared index location functionality
 	public void testSharedIndexLocation() throws CoreException, IOException {
 		// Create temporary testing folder
-		String sharedIndexDir = Files.createTempDirectory("shared_index").toFile().getCanonicalPath();
+		String sharedIndexDir = Files.createTempDirectory("shared_index").toFile().toPath().normalize().toAbsolutePath().toString();
 		// enable shared index
 		ClasspathEntry.setSharedIndexLocation(sharedIndexDir, getClass());
 		// path of library must be platform neutral

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchTests.java
@@ -2459,7 +2459,7 @@ public void testSearchScope05() throws CoreException, IOException { // was testE
 			scope,
 			this.resultCollector);
 		assertSearchResults(
-			externalJar.getCanonicalPath()+ " p0.X",
+			externalJar.toPath().normalize().toAbsolutePath().toString()+ " p0.X",
 			this.resultCollector);
 
 	} finally {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ModelTestsUtil.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ModelTestsUtil.java
@@ -250,15 +250,10 @@ static public String getExternalJCLSourcePathString(String compliance) {
  * This path ends with a File.separatorChar.
  */
 static public String getExternalPath() {
-	try {
-		String path = getWorkspaceRoot().getLocation().toFile().getParentFile().getCanonicalPath();
-		if (path.charAt(path.length()-1) != File.separatorChar)
-			path += File.separatorChar;
-		return path;
-	} catch (IOException e) {
-		e.printStackTrace();
-	}
-	return  null;
+	String path = getWorkspaceRoot().getLocation().toFile().getParentFile().toPath().normalize().toAbsolutePath().toString();
+	if (path.charAt(path.length()-1) != File.separatorChar)
+		path += File.separatorChar;
+	return path;
 }
 
 /**

--- a/org.eclipse.jdt.core.tests.performance/src/org/eclipse/jdt/core/tests/performance/FullSourceWorkspaceBuildTests.java
+++ b/org.eclipse.jdt.core.tests.performance/src/org/eclipse/jdt/core/tests/performance/FullSourceWorkspaceBuildTests.java
@@ -251,9 +251,9 @@ public class FullSourceWorkspaceBuildTests extends FullSourceWorkspaceTests {
 	void compile(String pluginID, String options, String compliance, boolean log, String[] srcPaths) throws IOException, CoreException {
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();
 		final IWorkspaceRoot workspaceRoot = workspace.getRoot();
-		final String targetWorkspacePath = workspaceRoot.getProject(pluginID).getLocation().toFile().getCanonicalPath();
+		final String targetWorkspacePath = workspaceRoot.getProject(pluginID).getLocation().toFile().toPath().normalize().toAbsolutePath().toString();
 		String logFileName = targetWorkspacePath + File.separator + getName()+".log";
-		String workspacePath = workspaceRoot.getLocation().toFile().getCanonicalPath()+File.separator;
+		String workspacePath = workspaceRoot.getLocation().toFile().toPath().normalize().toAbsolutePath().toString()+File.separator;
 		String binPath = File.separator+"bin"+File.pathSeparator;
 		String classpath = " -cp " +
 			workspacePath+"org.eclipse.osgi" + binPath +
@@ -277,7 +277,7 @@ public class FullSourceWorkspaceBuildTests extends FullSourceWorkspaceTests {
 
 	// compile the file from org.eclipse.jdt.core.tests.binaries bundle using batch compiler
 	void compile (String srcPath, long fileSize, String options, String compliance, boolean log) throws IOException {
-		final String targetWorkspacePath = ResourcesPlugin.getWorkspace().getRoot().getLocation().toFile().getCanonicalPath();
+		final String targetWorkspacePath = ResourcesPlugin.getWorkspace().getRoot().getLocation().toFile().toPath().normalize().toAbsolutePath().toString();
 		String logFileName = targetWorkspacePath + File.separator + getName()+".log";
 
 		File file = fetchFromBinariesProject(srcPath, fileSize);
@@ -432,7 +432,7 @@ public class FullSourceWorkspaceBuildTests extends FullSourceWorkspaceTests {
 		// Get workspace path
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();
 		final IWorkspaceRoot workspaceRoot = workspace.getRoot();
-		final String workspacePath = workspaceRoot.getLocation().toFile().getCanonicalPath();
+		final String workspacePath = workspaceRoot.getLocation().toFile().toPath().normalize().toAbsolutePath().toString();
 
 		// Run test
 		for (int i=0; i<MEASURES_COUNT; i++) {
@@ -581,7 +581,7 @@ public class FullSourceWorkspaceBuildTests extends FullSourceWorkspaceTests {
 		// Get workspace path
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();
 		final IWorkspaceRoot workspaceRoot = workspace.getRoot();
-		final String workspacePath = workspaceRoot.getLocation().toFile().getCanonicalPath();
+		final String workspacePath = workspaceRoot.getLocation().toFile().toPath().normalize().toAbsolutePath().toString();
 
 		// Run test
 		IWorkspaceRunnable compilation = new IWorkspaceRunnable() {

--- a/org.eclipse.jdt.core.tests.performance/src/org/eclipse/jdt/core/tests/performance/FullSourceWorkspaceModelTests.java
+++ b/org.eclipse.jdt.core.tests.performance/src/org/eclipse/jdt/core/tests/performance/FullSourceWorkspaceModelTests.java
@@ -110,7 +110,7 @@ private void setUpBigProject() throws CoreException, IOException {
 	try {
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();
 		IWorkspaceRoot workspaceRoot = workspace.getRoot();
-		String targetWorkspacePath = workspaceRoot.getLocation().toFile().getCanonicalPath();
+		String targetWorkspacePath = workspaceRoot.getLocation().toFile().toPath().normalize().toAbsolutePath().toString();
 		long startNanos = System.nanoTime();
 
 		// Print for log in case of project creation troubles...

--- a/org.eclipse.jdt.core.tests.performance/src/org/eclipse/jdt/core/tests/performance/FullSourceWorkspaceTests.java
+++ b/org.eclipse.jdt.core.tests.performance/src/org/eclipse/jdt/core/tests/performance/FullSourceWorkspaceTests.java
@@ -133,19 +133,11 @@ public abstract class FullSourceWorkspaceTests extends TestCase {
 			IWorkspace workspace = ResourcesPlugin.getWorkspace();
 			IWorkspaceRoot workspaceRoot = workspace.getRoot();
 			File pluginDir = workspaceRoot.getProject(JavaCore.PLUGIN_ID).getLocation().toFile();
-			try {
-				outputDir = pluginDir.getCanonicalPath() + File.separator + "bin";
-			} catch (IOException e) {
-				// skip
-			}
+			outputDir = pluginDir.toPath().normalize().toAbsolutePath().toString() + File.separator + "bin";
 		} else {
 			outputDir = Util.toNativePath(container) + File.separator + "bin";
 		}
-		if (outputDir == null) {
-			COMPILER_OUTPUT_DIR = "none";
-		} else {
-			COMPILER_OUTPUT_DIR = "\""+outputDir+"\"";
-		}
+		COMPILER_OUTPUT_DIR = "\""+outputDir+"\"";
 	}
 
 
@@ -625,7 +617,7 @@ public abstract class FullSourceWorkspaceTests extends TestCase {
 		// Get wksp info
 		IWorkspace workspace = ResourcesPlugin.getWorkspace();
 		final IWorkspaceRoot workspaceRoot = workspace.getRoot();
-		String targetWorkspacePath = workspaceRoot.getLocation().toFile().getCanonicalPath();
+		String targetWorkspacePath = workspaceRoot.getLocation().toFile().toPath().normalize().toAbsolutePath().toString();
 
 		// Modify resources workspace preferences to avoid disturbing tests while running them
 		IEclipsePreferences resourcesPreferences = InstanceScope.INSTANCE.getNode(ResourcesPlugin.PI_RESOURCES);
@@ -1217,14 +1209,10 @@ public abstract class FullSourceWorkspaceTests extends TestCase {
 	}
 
 	protected String getExternalPath() {
-		String path = "";
-		try {
-			path = ResourcesPlugin.getWorkspace().getRoot().getLocation().toFile().getParentFile().getCanonicalPath();
-			if (path.charAt(path.length()-1) != File.separatorChar)
-				path += File.separatorChar;
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
+		String path = ResourcesPlugin.getWorkspace().getRoot().getLocation().toFile().getParentFile().toPath()
+				.normalize().toAbsolutePath().toString();
+		if (path.charAt(path.length() - 1) != File.separatorChar)
+			path += File.separatorChar;
 		return path;
 	}
 


### PR DESCRIPTION
File.getCanonicalPath() is a IO Operation that is costly especially on windows OS.
Instead use a NON-IO .toPath().normalize().toAbsolutePath().toString()

https://bugs.eclipse.org/bugs/show_bug.cgi?id=571614

