### PR TITLE
fix PTBKey updateWhenSettingTypeAnnotations

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeSystem.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeSystem.java
@@ -94,9 +94,10 @@ public class TypeSystem {
 								TypeVariableBinding typeVariableBinding = (TypeVariableBinding) argument;
 								Consumer<TypeVariableBinding> previousConsumer = typeVariableBinding.updateWhenSettingTypeAnnotations;
 								typeVariableBinding.updateWhenSettingTypeAnnotations = (newTvb) -> {
-									// update the TVB argument and simulate a re-hash:
-									ParameterizedTypeBinding[] value = HashedParameterizedTypes.this.hashedParameterizedTypes.get(this);
-									arguments[idx] = newTvb;
+									// Changing arguments[idx] changes PTBKey.equals() and PTBKey.hashCode().
+									// So the old PTBKey has to be removed and a new has to be inserted:
+									ParameterizedTypeBinding[] value = HashedParameterizedTypes.this.hashedParameterizedTypes.remove(this);
+									this.arguments[idx] = newTvb;
 									HashedParameterizedTypes.this.hashedParameterizedTypes.put(this, value);
 									// for the unlikely case of multiple PTBKeys referring to this TVB chain to the next consumer:
 									if (previousConsumer != null)


### PR DESCRIPTION
Changing PTBKey.arguments[idx] changes PTBKey.equals() and PTBKey.hashCode().
So the old PTBKey has to be removed and a new has to be inserted. It was wrong to keep the PTBKey in hashedParameterizedTypes. Found by codereview. It is not clear if that could produce an error other then having bad performance by having garbage entries in the HashMap that could furthermore not found because the hash/equals contract was violated.

Code is executed for example during
compiler.apt.tests.Java8ElementsTests.testTypeAnnotations()

relates to
https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3412
