### PR TITLE
remove HashedParameterizedTypes

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/AnnotatableTypeSystem.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/AnnotatableTypeSystem.java
@@ -120,19 +120,14 @@ public class AnnotatableTypeSystem extends TypeSystem {
 		if (genericType.hasTypeAnnotations())   // @NonNull (List<String>) and not (@NonNull List)<String>
 			throw new IllegalStateException();
 
-		ParameterizedTypeBinding parameterizedType = this.parameterizedTypes.get(genericType, typeArguments, enclosingType, annotations);
-		if (parameterizedType != null)
-			return parameterizedType;
-
 		ParameterizedTypeBinding nakedType = super.getParameterizedType(genericType, typeArguments, enclosingType);
 
 		if (!haveTypeAnnotations(genericType, enclosingType, typeArguments, annotations))
 			return nakedType;
 
-		parameterizedType = new ParameterizedTypeBinding(genericType, typeArguments, enclosingType, this.environment);
+		ParameterizedTypeBinding parameterizedType = new ParameterizedTypeBinding(genericType, typeArguments, enclosingType, this.environment);
 		parameterizedType.id = nakedType.id;
 		parameterizedType.setTypeAnnotations(annotations, this.isAnnotationBasedNullAnalysisEnabled);
-		this.parameterizedTypes.put(genericType, typeArguments, enclosingType, parameterizedType);
 		return (ParameterizedTypeBinding) cacheDerivedType(genericType, nakedType, parameterizedType);
 	}
 


### PR DESCRIPTION
The PTBKey looks complicated and errorprone (updating hashCode on an Element in a HashMap). Let's find out what was really slow and then see if we find a better solution for
"linear effort during lookup"
(https://bugs.eclipse.org/bugs/show_bug.cgi?id=434326#c2)

partial revert commit 510e79670ef0450a78c7882799bbb7cd266ab2e6 (Bug 434326 - Slow compilation with a significant amount of generics)

keeps binary search in
TypeSystem.cacheDerivedType(TypeBinding keyType, TypeBinding derivedType)
