### PR TITLE
Bug 561334 - [resource] leak should be classified as potential

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/FakedTrackingVariable.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/FakedTrackingVariable.java
@@ -546,6 +546,7 @@ public class FakedTrackingVariable extends LocalDeclaration {
 				acquisition.closeTracker = tracker;
 			}
 			tracker.acquisition = acquisition;
+			tracker.globalClosingState |= SHARED_WITH_OUTSIDE;
 			FlowInfo outsideInfo = flowInfo.copy();
 			outsideInfo.markAsDefinitelyNonNull(tracker.binding);
 			tracker.markNullStatus(flowInfo, flowContext, FlowInfo.NULL);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
@@ -589,9 +589,9 @@ public static int getIrritant(int problemID) {
 
 		case IProblem.UnclosedCloseable:
 		case IProblem.UnclosedCloseableAtExit:
+			return CompilerOptions.UnclosedCloseable;
 		case IProblem.MandatoryCloseNotShown:
 		case IProblem.MandatoryCloseNotShownAtExit:
-			return CompilerOptions.UnclosedCloseable;
 		case IProblem.PotentiallyUnclosedCloseable:
 		case IProblem.PotentiallyUnclosedCloseableAtExit:
 			return CompilerOptions.PotentiallyUnclosedCloseable;

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/CompilerInvocationTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/CompilerInvocationTests.java
@@ -1949,8 +1949,8 @@ public void test012_compiler_problems_tuning() {
 		expectedProblemAttributes.put("LocalVariableIsNeverUsed", new ProblemAttributes(JavaCore.COMPILER_PB_UNUSED_LOCAL));
 		expectedProblemAttributes.put("LocalVariableMayBeNull", SKIP);
 		expectedProblemAttributes.put("MaskedCatch", new ProblemAttributes(JavaCore.COMPILER_PB_HIDDEN_CATCH_BLOCK));
-		expectedProblemAttributes.put("MandatoryCloseNotShown", new ProblemAttributes(JavaCore.COMPILER_PB_UNCLOSED_CLOSEABLE));
-		expectedProblemAttributes.put("MandatoryCloseNotShownAtExit", new ProblemAttributes(JavaCore.COMPILER_PB_UNCLOSED_CLOSEABLE));
+		expectedProblemAttributes.put("MandatoryCloseNotShown", new ProblemAttributes(JavaCore.COMPILER_PB_POTENTIALLY_UNCLOSED_CLOSEABLE));
+		expectedProblemAttributes.put("MandatoryCloseNotShownAtExit", new ProblemAttributes(JavaCore.COMPILER_PB_POTENTIALLY_UNCLOSED_CLOSEABLE));
 		expectedProblemAttributes.put("MessageSendWithUnresolvedOwningAnnotation", SKIP);
 		expectedProblemAttributes.put("MethodButWithConstructorName", new ProblemAttributes(JavaCore.COMPILER_PB_METHOD_WITH_CONSTRUCTOR_NAME));
 		expectedProblemAttributes.put("MethodCanBePotentiallyStatic", new ProblemAttributes(JavaCore.COMPILER_PB_POTENTIALLY_MISSING_STATIC_ON_METHOD));

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ResourceLeakAnnotatedTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ResourceLeakAnnotatedTests.java
@@ -138,7 +138,7 @@ protected String getTest056e_log() {
 protected String getTest056y_log() {
 	return """
 			----------
-			1. ERROR in X.java (at line 4)
+			1. WARNING in X.java (at line 4)
 				final FileReader reader31 = new FileReader("file");
 				                 ^^^^^^^^
 			Mandatory close of resource 'reader31' has not been shown
@@ -197,6 +197,25 @@ protected String getTestBug440282_log() {
 		"	       ^^^^^^^^^^^^^^^\n" +
 		"Resource leak: \'<unassigned Closeable value>\' is never closed\n" +
 		"----------\n";
+}
+
+@Override
+String getBug561334_log() {
+	// 1. info is only reported when annotations are enabled
+	// 2. warning is more severe since we set OWNED_BY_DEFAULT on the resource from getFoo()
+	return	"""
+			----------
+			1. INFO in Foo.java (at line 18)
+				foo = new Foo("Hello, world!");
+				      ^^^^^^^^^^^^^^^^^^^^^^^^
+			Mandatory close of resource '<unassigned Closeable value>' has not been shown
+			----------
+			2. WARNING in Foo.java (at line 21)
+				System.out.println(getFoo().thing);
+				                   ^^^^^^^^
+			Resource leak: '<unassigned Closeable value>' is never closed
+			----------
+			""";
 }
 
 public void testBug411098_comment19_annotated() {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/OwningAnnotationModelTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/OwningAnnotationModelTests.java
@@ -160,6 +160,7 @@ public class OwningAnnotationModelTests extends ReconcilerTests {
 
 			IJavaProject p2 = createJavaProject("P2", new String[] {""}, new String[] {"JCL_23_LIB"}, "bin", "23");
 			p2.setOption(JavaCore.COMPILER_ANNOTATION_RESOURCE_ANALYSIS, JavaCore.ENABLED);
+			p2.setOption(JavaCore.COMPILER_PB_POTENTIALLY_UNCLOSED_CLOSEABLE, JavaCore.WARNING);
 			addClasspathEntry(p2, JavaCore.newProjectEntry(p1.getPath())); // no access to the annotation lib, since not re-exported
 
 			createFolder("/P2/client");
@@ -469,6 +470,7 @@ public class OwningAnnotationModelTests extends ReconcilerTests {
 
 			IJavaProject p2 = createJavaProject("P2", new String[] {""}, new String[] {"JCL_23_LIB"}, "bin", "23");
 			p2.setOption(JavaCore.COMPILER_ANNOTATION_RESOURCE_ANALYSIS, JavaCore.ENABLED);
+			p2.setOption(JavaCore.COMPILER_PB_POTENTIALLY_UNCLOSED_CLOSEABLE, JavaCore.WARNING);
 			addClasspathEntry(p2, JavaCore.newProjectEntry(p1.getPath())); // no access to the annotation lib, since not re-exported
 
 			createFolder("/P2/client");


### PR DESCRIPTION
```java
class Foo implements AutoCloseable {
    private final String thing;
    public Foo(String thing) {
        this.thing = thing;
    }

    @Override
    public void close() {
        //
    }

    private static Foo foo;
    private static Foo getFoo() {
        return foo;
    }

    public static void main(String[] args) {
        foo = new Foo("Hello, world!");
        try {
            // This is fine
            System.out.println(foo.thing);

            // getFoo(): "Resource leak: '<unassigned Closeable value>' is not closed at this location"
            System.out.println(getFoo().thing);
        } finally {
            getFoo().close();
        }
    }
}
```
without annotation support:
+ mark as shared, to change problem to MandatoryCloseNotShown
+ move this and sibling to irritant PotentiallyUnclosedCloseable

with annotation support:
+ nothing changed, since we assume OWNED_BY_DEFAULT

Fixes https://bugs.eclipse.org/561334