### PR TITLE
[Enhanced Switch] Wasteful generation of switch ordinal mapping table for enum switches that are dispatched via enumSwitch indy

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
@@ -440,7 +440,7 @@ public class SwitchStatement extends Expression {
 			}
 
 			final TypeBinding resolvedTypeBinding = this.expression.resolvedType;
-			if (resolvedTypeBinding.isEnum()) {
+			if (resolvedTypeBinding.isEnum() && !needPatternDispatchCopy()) {
 				final SourceTypeBinding sourceTypeBinding = currentScope.classScope().referenceContext.binding;
 				this.synthetic = sourceTypeBinding.addSyntheticMethodForSwitchEnum(resolvedTypeBinding, this);
 			}


### PR DESCRIPTION
* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3447

