### PR TITLE
Make PTBKey not extend ReferenceBinding

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ArrayBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ArrayBinding.java
@@ -39,7 +39,7 @@ import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jdt.internal.compiler.impl.Constant;
 
-public final class ArrayBinding extends TypeBinding {
+public final class ArrayBinding extends TypeBinding implements HotSwappable {
 	// creation and initialization of the length field
 	// the declaringClass of this field is intentionally set to null so it can be distinguished.
 	public static final FieldBinding ArrayLength = new FieldBinding(TypeConstants.LENGTH, TypeBinding.INT, ClassFileConstants.AccPublic | ClassFileConstants.AccFinal, null, Constant.NotAConstant);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/HotSwappable.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/HotSwappable.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2025 SSI and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     SSI - initial API and implementation
+ *******************************************************************************/
+
+package org.eclipse.jdt.internal.compiler.lookup;
+
+interface HotSwappable {
+	void swapUnresolved(UnresolvedReferenceBinding unresolvedType, ReferenceBinding resolvedType, LookupEnvironment env);
+}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedTypeBinding.java
@@ -66,7 +66,7 @@ import org.eclipse.jdt.internal.compiler.lookup.TypeConstants.BoundCheckStatus;
 /**
  * A parameterized type encapsulates a type with type arguments,
  */
-public class ParameterizedTypeBinding extends ReferenceBinding implements Substitution {
+public class ParameterizedTypeBinding extends ReferenceBinding implements Substitution, HotSwappable {
 
 	protected ReferenceBinding type; // must ensure the type is resolved
 	public TypeBinding[] arguments;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeBinding.java
@@ -1685,11 +1685,6 @@ public char[] signature() {
 
 public abstract char[] sourceName();
 
-public void swapUnresolved(UnresolvedReferenceBinding unresolvedType,
-		ReferenceBinding resolvedType, LookupEnvironment environment) {
-	// subclasses must override if they wrap another type binding
-}
-
 TypeBinding [] typeArguments () {
 	return null;
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeSystem.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeSystem.java
@@ -69,7 +69,7 @@ public class TypeSystem {
 
 	public final class HashedParameterizedTypes {
 
-		private final class PTBKey extends ReferenceBinding { // extends ReferenceBinding so it can be used as wrapper
+		private final class PTBKey implements HotSwappable {
 			protected ReferenceBinding type; // must ensure the type is resolved
 			public TypeBinding[] arguments;
 			private ReferenceBinding enclosingType;
@@ -87,8 +87,6 @@ public class TypeSystem {
 							TypeBinding argument = arguments[i];
 							if (argument instanceof UnresolvedReferenceBinding)
 								((UnresolvedReferenceBinding) argument).addWrapper(this, environment);
-							if (argument.hasNullTypeAnnotations())
-								this.tagBits |= TagBits.HasNullTypeAnnotation;
 							if (argument.getClass() == TypeVariableBinding.class) {
 								final int idx = i;
 								TypeVariableBinding typeVariableBinding = (TypeVariableBinding) argument;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/UnresolvedReferenceBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/UnresolvedReferenceBinding.java
@@ -20,10 +20,10 @@ package org.eclipse.jdt.internal.compiler.lookup;
 
 import org.eclipse.jdt.core.compiler.CharOperation;
 
-public class UnresolvedReferenceBinding extends ReferenceBinding {
+public class UnresolvedReferenceBinding extends ReferenceBinding implements HotSwappable {
 
 ReferenceBinding resolvedType;
-TypeBinding[] wrappers;
+HotSwappable[] wrappers;
 UnresolvedReferenceBinding prototype;
 ReferenceBinding requestingType;
 
@@ -53,7 +53,7 @@ public TypeBinding clone(TypeBinding outerType) {
 	return copy;
 }
 
-void addWrapper(TypeBinding wrapper, LookupEnvironment environment) {
+void addWrapper(HotSwappable wrapper, LookupEnvironment environment) {
 	if (this.resolvedType != null) {
 		// the type reference B<B<T>.M> means a signature of <T:Ljava/lang/Object;>LB<LB<TT;>.M;>;
 		// when the ParameterizedType for Unresolved B is created with args B<T>.M, the Unresolved B is resolved before the wrapper is added
@@ -61,10 +61,10 @@ void addWrapper(TypeBinding wrapper, LookupEnvironment environment) {
 		return;
 	}
 	if (this.wrappers == null) {
-		this.wrappers = new TypeBinding[] {wrapper};
+		this.wrappers = new HotSwappable[] {wrapper};
 	} else {
 		int length = this.wrappers.length;
-		System.arraycopy(this.wrappers, 0, this.wrappers = new TypeBinding[length + 1], 0, length);
+		System.arraycopy(this.wrappers, 0, this.wrappers = new HotSwappable[length + 1], 0, length);
 		this.wrappers[length] = wrapper;
 	}
 }
@@ -148,7 +148,7 @@ void setResolvedType(ReferenceBinding targetType, LookupEnvironment environment)
 	// must ensure to update any other type bindings that can contain the resolved type
 	// otherwise we could create 2 : 1 for this unresolved type & 1 for the resolved type
 	if (this.wrappers != null)
-		for (TypeBinding wrapper : this.wrappers)
+		for (HotSwappable wrapper : this.wrappers)
 			wrapper.swapUnresolved(this, targetType, environment);
 }
 
@@ -161,7 +161,7 @@ public void swapUnresolved(UnresolvedReferenceBinding unresolvedType, ReferenceB
 
 	environment.updateCaches(this, annotatedType);
 	if (this.wrappers != null)
-		for (TypeBinding wrapper : this.wrappers)
+		for (HotSwappable wrapper : this.wrappers)
 			wrapper.swapUnresolved(this, annotatedType, environment);
 }
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/WildcardBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/WildcardBinding.java
@@ -40,7 +40,7 @@ import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
  * abstract parameterized types, e.g. List<String> is not compatible with List<Object>,
  * but compatible with List<?>.
  */
-public class WildcardBinding extends ReferenceBinding {
+public class WildcardBinding extends ReferenceBinding implements HotSwappable{
 
 	public ReferenceBinding genericType;
 	public int rank;


### PR DESCRIPTION
* Introduces interface TypeBindingWrapper.
* Removes little code from PTBKey that is irrelevant for the wrapper

relates to https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3412
