### PR TITLE
ReferenceBindingSetWrapper: use System.identityHashCode

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
@@ -1213,10 +1213,6 @@ public int hashCode() {
 		: CharOperation.hashCode(this.compoundName[this.compoundName.length - 1]);
 }
 
-final int identityHashCode() {
-	return super.hashCode();
-}
-
 /**
  * Returns true if the two types have an incompatible common supertype,
  * e.g. {@code List<String>} and {@code List<Integer>}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBindingSetWrapper.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBindingSetWrapper.java
@@ -27,7 +27,7 @@ final class ReferenceBindingSetWrapper {
 
 	ReferenceBindingSetWrapper(ReferenceBinding referenceBinding) {
 		this.referenceBinding = referenceBinding;
-		this.hashCode = referenceBinding.identityHashCode();
+		this.hashCode = System.identityHashCode(referenceBinding);
 	}
 
 	@Override
@@ -35,8 +35,7 @@ final class ReferenceBindingSetWrapper {
 		if (obj == this) {
 			return true;
 		}
-		if (obj instanceof ReferenceBindingSetWrapper) {
-			ReferenceBindingSetWrapper other = (ReferenceBindingSetWrapper) obj;
+		if (obj instanceof ReferenceBindingSetWrapper other) {
 			return identityEqual(this.referenceBinding, other.referenceBinding);
 		}
 		return false;


### PR DESCRIPTION
Its just an IdentityWrapper - do not rely on ReferenceBinding implementation.

relates to
https://github.com/eclipse-jdt/eclipse.jdt.core/pull/3452
