### PR TITLE
[Switch Expressions] Use control flow analysis rather than structural analysis of syntax tree, to flag switch rule blocks that complete normally.

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ASTNode.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ASTNode.java
@@ -224,7 +224,7 @@ public abstract class ASTNode implements TypeConstants, TypeIds {
 	public static final int IsUsefulEmptyStatement = Bit1;
 
 	// for block and method declaration
-	public static final int SwitchRuleBlock = Bit1;
+	public static final int BlockShouldEndDead = Bit1;
 	public static final int UndocumentedEmptyBlock = Bit4;
 	public static final int OverridingMethodWithSupercall = Bit5;
 	public static final int CanBeStatic = Bit9;   // used to flag a method that can be declared static

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/BreakStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/BreakStatement.java
@@ -109,9 +109,4 @@ public void traverse(ASTVisitor visitor, BlockScope blockscope) {
 public boolean doesNotCompleteNormally() {
 	return true;
 }
-
-@Override
-public boolean canCompleteNormally() {
-	return false;
-}
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ContinueStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ContinueStatement.java
@@ -118,14 +118,4 @@ public boolean doesNotCompleteNormally() {
 public boolean completesByContinue() {
 	return true;
 }
-
-@Override
-public boolean canCompleteNormally() {
-	return false;
-}
-
-@Override
-public boolean continueCompletes() {
-	return true;
-}
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/DoStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/DoStatement.java
@@ -273,28 +273,4 @@ public boolean doesNotCompleteNormally() {
 public boolean completesByContinue() {
 	return this.action.continuesAtOuterLabel();
 }
-
-@Override
-public boolean canCompleteNormally() {
-	Constant cst = this.condition.constant;
-	boolean isConditionTrue = cst == null || cst != Constant.NotAConstant && cst.booleanValue() == true;
-	cst = this.condition.optimizedBooleanConstant();
-	boolean isConditionOptimizedTrue = cst == null ? true : cst != Constant.NotAConstant && cst.booleanValue() == true;
-
-	if (!(isConditionTrue || isConditionOptimizedTrue)) {
-		if (this.action == null || this.action.canCompleteNormally())
-			return true;
-		if (this.action != null && this.action.continueCompletes())
-			return true;
-	}
-	if (this.action != null && this.action.breaksOut(null))
-		return true;
-
-	return false;
-}
-@Override
-public boolean continueCompletes() {
-	return this.action.continuesAtOuterLabel();
-}
-
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ForStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ForStatement.java
@@ -489,23 +489,4 @@ public class ForStatement extends Statement {
 	public boolean completesByContinue() {
 		return this.action.continuesAtOuterLabel();
 	}
-	@Override
-	public boolean canCompleteNormally() {
-		Constant cst = this.condition == null ? null : this.condition.constant;
-		boolean isConditionTrue = cst == null || cst != Constant.NotAConstant && cst.booleanValue() == true;
-		cst = this.condition == null ? null : this.condition.optimizedBooleanConstant();
-		boolean isConditionOptimizedTrue = cst == null ? true : cst != Constant.NotAConstant && cst.booleanValue() == true;
-
-		if (!(isConditionTrue || isConditionOptimizedTrue))
-			return true;
-		if (this.action != null && this.action.breaksOut(null))
-			return true;
-		return false;
-	}
-
-	@Override
-	public boolean continueCompletes() {
-		return this.action.continuesAtOuterLabel();
-	}
-
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ForeachStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ForeachStatement.java
@@ -688,10 +688,4 @@ public class ForeachStatement extends Statement {
 	public boolean doesNotCompleteNormally() {
 		return false; // may not be entered at all.
 	}
-
-	@Override
-	public boolean canCompleteNormally() {
-		return true;
-	}
-
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/IfStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/IfStatement.java
@@ -340,14 +340,4 @@ public boolean doesNotCompleteNormally() {
 public boolean completesByContinue() {
 	return this.thenStatement != null && this.thenStatement.completesByContinue() || this.elseStatement != null && this.elseStatement.completesByContinue();
 }
-@Override
-public boolean canCompleteNormally() {
-	return ((this.thenStatement == null || this.thenStatement.canCompleteNormally()) ||
-		(this.elseStatement == null || this.elseStatement.canCompleteNormally()));
-}
-@Override
-public boolean continueCompletes() {
-	return this.thenStatement != null && this.thenStatement.continueCompletes() ||
-			this.elseStatement != null && this.elseStatement.continueCompletes();
-}
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LabeledStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LabeledStatement.java
@@ -165,17 +165,4 @@ public class LabeledStatement extends Statement {
 	public boolean completesByContinue() {
 		return this.statement instanceof ContinueStatement; // NOT this.statement.continuesAtOuterLabel
 	}
-
-	@Override
-	public boolean canCompleteNormally() {
-		if (this.statement.canCompleteNormally())
-			return true;
-		return this.statement.breaksOut(this.label);
-	}
-
-	@Override
-	public boolean continueCompletes() {
-		return this.statement instanceof ContinueStatement; // NOT this.statement.continuesAtOuterLabel
-	}
-
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ReturnStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ReturnStatement.java
@@ -217,13 +217,8 @@ public boolean doesNotCompleteNormally() {
 	return true;
 }
 
-@Override
-public boolean canCompleteNormally() {
-	return false;
-}
-
 /**
- * Retrun statement code generation
+ * Return statement code generation
  *
  *   generate the finallyInvocationSequence.
  *

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Statement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Statement.java
@@ -104,23 +104,6 @@ public boolean completesByContinue() {
 	return false;
 }
 
-/**
- * Switch Expression analysis: *Assuming* this is reachable, analyze if this completes normally
- *  i.e control flow can reach the textually next statement, as per JLS 14 Sec 14.22
- *  For blocks, we don't perform intra-reachability analysis.
- *  Note: delinking this from a similar (opposite) {@link #doesNotCompleteNormally()} since that was
- *  coded for a specific purpose of Lambda Shape Analysis.
- */
-public boolean canCompleteNormally() {
-	return true;
-}
-/**
- * The equivalent function of completesByContinue - implements both the rules concerning continue with
- * and without a label.
- */
-public boolean continueCompletes() {
-	return false;
-}
 	public static final int NOT_COMPLAINED = 0;
 	public static final int COMPLAINED_FAKE_REACHABLE = 1;
 	public static final int COMPLAINED_UNREACHABLE = 2;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchExpression.java
@@ -376,16 +376,6 @@ public class SwitchExpression extends SwitchStatement implements IPolyExpression
 	@Override
 	public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext, FlowInfo flowInfo) {
 		flowInfo = super.analyseCode(currentScope, flowContext, flowInfo);
-		if ((this.switchBits & LabeledRules) != 0) { // 15.28.1
-			for (Statement stmt : this.statements) {
-				if (stmt instanceof Block && stmt.canCompleteNormally())
-					currentScope.problemReporter().switchExpressionBlockCompletesNormally(stmt);
-			}
-		} else {
-			Statement ultimateStmt = this.statements[this.statements.length - 1]; // length guaranteed > 0
-			if (ultimateStmt.canCompleteNormally())
-				currentScope.problemReporter().switchExpressionBlockCompletesNormally(ultimateStmt);
-		}
 
 		if (currentScope.compilerOptions().enableSyntacticNullAnalysisForFields)
 			flowContext.expireNullCheckedFieldInfo(); // wipe information that was meant only for this result expression:

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SynchronizedStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SynchronizedStatement.java
@@ -248,14 +248,4 @@ public boolean doesNotCompleteNormally() {
 public boolean completesByContinue() {
 	return this.block.completesByContinue();
 }
-
-@Override
-public boolean canCompleteNormally() {
-	return this.block.canCompleteNormally();
-}
-
-@Override
-public boolean continueCompletes() {
-	return this.block.continueCompletes();
-}
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ThrowStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ThrowStatement.java
@@ -99,10 +99,4 @@ public void traverse(ASTVisitor visitor, BlockScope blockScope) {
 public boolean doesNotCompleteNormally() {
 	return true;
 }
-
-@Override
-public boolean canCompleteNormally() {
-	return false;
-}
-
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TryStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TryStatement.java
@@ -1270,34 +1270,4 @@ public boolean completesByContinue() {
 	}
 	return this.finallyBlock != null && this.finallyBlock.completesByContinue();
 }
-@Override
-public boolean canCompleteNormally() {
-	if (this.tryBlock.canCompleteNormally()) {
-		return (this.finallyBlock != null) ? this.finallyBlock.canCompleteNormally() : true;
-	}
-	if (this.catchBlocks != null) {
-		for (Block catchBlock : this.catchBlocks) {
-			if (catchBlock.canCompleteNormally()) {
-				return (this.finallyBlock != null) ? this.finallyBlock.canCompleteNormally() : true;
-			}
-		}
-	}
-	return false;
-}
-@Override
-public boolean continueCompletes() {
-	if (this.tryBlock.continueCompletes()) {
-		return (this.finallyBlock == null) ? true :
-			this.finallyBlock.canCompleteNormally() || this.finallyBlock.continueCompletes();
-	}
-	if (this.catchBlocks != null) {
-		for (Block catchBlock : this.catchBlocks) {
-			if (catchBlock.continueCompletes()) {
-				return (this.finallyBlock == null) ? true :
-					this.finallyBlock.canCompleteNormally() || this.finallyBlock.continueCompletes();
-			}
-		}
-	}
-	return this.finallyBlock != null && this.finallyBlock.continueCompletes();
-}
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/WhileStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/WhileStatement.java
@@ -339,20 +339,4 @@ public class WhileStatement extends Statement {
 	public boolean completesByContinue() {
 		return this.action.continuesAtOuterLabel();
 	}
-
-	@Override
-	public boolean canCompleteNormally() {
-		Constant cst = this.condition.constant;
-		boolean isConditionTrue = cst == null || cst != Constant.NotAConstant && cst.booleanValue() == true;
-		cst = this.condition.optimizedBooleanConstant();
-		boolean isConditionOptimizedTrue = cst == null ? true : cst != Constant.NotAConstant && cst.booleanValue() == true;
-		if (!(isConditionTrue || isConditionOptimizedTrue))
-			return true;
-		return this.action != null && this.action.breaksOut(null);
-	}
-
-	@Override
-	public boolean continueCompletes() {
-		return this.action.continuesAtOuterLabel();
-	}
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/YieldStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/YieldStatement.java
@@ -187,9 +187,4 @@ public void traverse(ASTVisitor visitor, BlockScope blockscope) {
 public boolean doesNotCompleteNormally() {
 	return true;
 }
-
-@Override
-public boolean canCompleteNormally() {
-	return false;
-}
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
@@ -9443,7 +9443,7 @@ protected void consumeSwitchRule(SwitchRuleKind kind) {
 		this.astStack[this.astPtr] = yieldStatement;
 	} else if (kind == SwitchRuleKind.BLOCK) {
 		Block block = (Block) this.astStack[this.astPtr];
-		block.bits |= ASTNode.SwitchRuleBlock;
+		block.bits |= ASTNode.BlockShouldEndDead;
 	}
 	concatNodeLists();
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/messages.properties
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/messages.properties
@@ -1035,7 +1035,7 @@
 1700 = Incompatible results expressions in switch
 ###[obsolete] 1701 = A switch expression should have a non-empty switch block
 1702 = A switch expression should have at least one result expression
-1703 = A switch labeled block in a switch expression should not complete normally
+1703 = A switch labeled block in a switch expression must yield a value or throw an an exception
 ###[obsolete] 1704 = The last statement of a switch block in a switch expression should not complete normally
 ###[obsolete] 1705 = Trailing switch labels are not allowed in a switch expression.
 1706 = Mixing of '->' and ':' case statement styles is not allowed within a switch

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullAnnotationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullAnnotationTest.java
@@ -10931,7 +10931,12 @@ public void testBug548418_001a() {
 			"	^^^^^^^^\n" +
 			"Breaking out of switch expressions not permitted\n" +
 			"----------\n" +
-			"3. ERROR in X.java (at line 15)\n" +
+			"3. ERROR in X.java (at line 14)\n" +
+			"	}\n" +
+			"	^^\n" +
+			"A switch labeled block in a switch expression must yield a value or throw an an exception\n" +
+			"----------\n" +
+			"4. ERROR in X.java (at line 15)\n" +
 			"	default -> null;\n" +
 			"	           ^^^^\n" +
 			"Null type mismatch: required '@NonNull X' but the provided value is null\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchExpressionsYieldTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchExpressionsYieldTest.java
@@ -486,7 +486,7 @@ public class SwitchExpressionsYieldTest extends AbstractRegressionTest {
 					"1. ERROR in X.java (at line 8)\n" +
 					"	default :v = 2;\n" +
 					"	            ^^\n" +
-					"A switch labeled block in a switch expression should not complete normally\n" +
+					"A switch labeled block in a switch expression must yield a value or throw an an exception\n" +
 					"----------\n";
 			this.runNegativeTest(
 					testFiles,
@@ -2127,6 +2127,11 @@ public class SwitchExpressionsYieldTest extends AbstractRegressionTest {
 			"	continue;\n" +
 			"	^^^^^^^^^\n" +
 			"Continue out of switch expressions not permitted\n" +
+			"----------\n" +
+			"2. ERROR in X.java (at line 11)\n" +
+			"	continue;\n" +
+			"	       ^^\n" +
+			"A switch labeled block in a switch expression must yield a value or throw an an exception\n" +
 			"----------\n");
 	}
 	public void testBug544073_077() {
@@ -4989,7 +4994,7 @@ public class SwitchExpressionsYieldTest extends AbstractRegressionTest {
 		"1. ERROR in X.java (at line 9)\n" +
 		"	default :v = 2;\n" +
 		"	            ^^\n" +
-		"A switch labeled block in a switch expression should not complete normally\n" +
+		"A switch labeled block in a switch expression must yield a value or throw an an exception\n" +
 		"----------\n");
 	}
 	public void testBug562728_006() {
@@ -5021,12 +5026,12 @@ public class SwitchExpressionsYieldTest extends AbstractRegressionTest {
 		"1. ERROR in X.java (at line 8)\n" +
 		"	case 2 ->{v = 2;}\n" +
 		"	               ^^\n" +
-		"A switch labeled block in a switch expression should not complete normally\n" +
+		"A switch labeled block in a switch expression must yield a value or throw an an exception\n" +
 		"----------\n" +
 		"2. ERROR in X.java (at line 9)\n" +
 		"	default ->{v = 2;}\n" +
 		"	                ^^\n" +
-		"A switch labeled block in a switch expression should not complete normally\n" +
+		"A switch labeled block in a switch expression must yield a value or throw an an exception\n" +
 		"----------\n");
 	}
     public void testBug562728_007() {
@@ -5113,7 +5118,7 @@ public class SwitchExpressionsYieldTest extends AbstractRegressionTest {
 		"1. ERROR in X.java (at line 13)\n" +
 		"	}\n" +
 		"	^^\n" +
-		"A switch labeled block in a switch expression should not complete normally\n" +
+		"A switch labeled block in a switch expression must yield a value or throw an an exception\n" +
         "----------\n");
 }
     public void testBug563023_003() {
@@ -5142,7 +5147,7 @@ public class SwitchExpressionsYieldTest extends AbstractRegressionTest {
 		"1. ERROR in X.java (at line 10)\n" +
 		"	}\n" +
 		"	^^\n" +
-		"A switch labeled block in a switch expression should not complete normally\n" +
+		"A switch labeled block in a switch expression must yield a value or throw an an exception\n" +
         "----------\n");
 }
     public void testBug563023_004() {
@@ -5202,7 +5207,7 @@ public class SwitchExpressionsYieldTest extends AbstractRegressionTest {
 		"1. ERROR in X.java (at line 11)\n" +
 		"	}\n" +
 		"	^^\n" +
-		"A switch labeled block in a switch expression should not complete normally\n" +
+		"A switch labeled block in a switch expression must yield a value or throw an an exception\n" +
         "----------\n");
 }
 	public void testBug563023_006() {
@@ -5269,7 +5274,7 @@ public class SwitchExpressionsYieldTest extends AbstractRegressionTest {
 		"2. ERROR in X.java (at line 10)\n" +
 		"	}\n" +
 		"	^^\n" +
-		"A switch labeled block in a switch expression should not complete normally\n" +
+		"A switch labeled block in a switch expression must yield a value or throw an an exception\n" +
         "----------\n");
 }
 	public void testBug563147_001() {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchPatternTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchPatternTest.java
@@ -1850,7 +1850,7 @@ public class SwitchPatternTest extends AbstractRegressionTest9 {
 				"1. ERROR in X.java (at line 6)\n" +
 				"	}\n" +
 				"	^^\n" +
-				"A switch labeled block in a switch expression should not complete normally\n" +
+				"A switch labeled block in a switch expression must yield a value or throw an an exception\n" +
 				"----------\n");
 	}
 	public void testBug574564_001() {
@@ -4911,7 +4911,7 @@ public class SwitchPatternTest extends AbstractRegressionTest9 {
 				"1. ERROR in X.java (at line 11)\n" +
 				"	}\n" +
 				"	^^\n" +
-				"A switch labeled block in a switch expression should not complete normally\n" +
+				"A switch labeled block in a switch expression must yield a value or throw an an exception\n" +
 				"----------\n");
 	}
 	public void testBug578416() {


### PR DESCRIPTION


* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3455


