### PR TITLE
Remove needless TypeBinding hashCode() implementations #3412

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ArrayBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ArrayBinding.java
@@ -258,11 +258,6 @@ public PackageBinding getPackage() {
 	return this.leafComponentType.getPackage();
 }
 
-@Override
-public int hashCode() {
-	return this.leafComponentType == null ? super.hashCode() : this.leafComponentType.hashCode();
-}
-
 /* Answer true if the receiver type can be assigned to the argument type (right)
 */
 @Override

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/LocalTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/LocalTypeBinding.java
@@ -165,10 +165,6 @@ public TypeBinding clone(TypeBinding outerType) {
 	return copy;
 }
 
-@Override
-public int hashCode() {
-	return this.enclosingType.hashCode();
-}
 /*
  * Overriden for code assist. In this case, the constantPoolName() has not been computed yet.
  * Slam the source name so that the signature is syntactically correct.

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/WildcardBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/WildcardBinding.java
@@ -615,11 +615,6 @@ public class WildcardBinding extends ReferenceBinding {
     }
 
 	@Override
-	public int hashCode() {
-		return this.genericType.hashCode();
-	}
-
-	@Override
 	public boolean hasTypeBit(int bit) {
 		if (this.typeBits == TypeIds.BitUninitialized) {
 			// initialize from upper bounds


### PR DESCRIPTION
Without overriding equals() any custom hashCode() implementation is likely to introduce hash collisions. 

https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3412