### PR TITLE
Mark `RequiresDirective`'s name as `MANDATORY`

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter9Test.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter9Test.java
@@ -1596,6 +1596,39 @@ public class ASTConverter9Test extends ConverterTestSetup {
 			deleteProject("P2");
 		}
 	}
+	public void testRequiresDirectiveNameIsMandatory() throws JavaModelException, CoreException {
+		try {
+			assertTrue(RequiresDirective.NAME_PROPERTY.isMandatory());
+
+			IJavaProject project1 = createJavaProject("ASTParserModelTests", new String[] { "src" },
+					new String[] { "CONVERTER_JCL9_LIB" }, "bin", "9");
+			project1.open(null);
+			addClasspathEntry(project1, JavaCore.newContainerEntry(new Path("org.eclipse.jdt.MODULE_PATH")));
+			String content = """
+			module first {
+				requires other;
+			}
+			""";
+			createFile("/ASTParserModelTests/src/module-info.java", content);
+			this.workingCopy = getCompilationUnit("/ASTParserModelTests/src/module-info.java");
+
+			ASTParser astParser = ASTParser.newParser(AST.getJLSLatest());
+			astParser.setSource(this.workingCopy);
+			astParser.setResolveBindings(true);
+			astParser.setStatementsRecovery(true);
+			CompilationUnit compilationUnit = (CompilationUnit) astParser.createAST(new NullProgressMonitor());
+			ModuleDeclaration moduleDeclaration = compilationUnit.getModule();
+			RequiresDirective requiresDirective = (RequiresDirective)moduleDeclaration.moduleStatements().get(0);
+			try {
+				requiresDirective.setName(null);
+				fail("Expected an IllegalArgumentException to be thrown");
+			} catch (IllegalArgumentException e) {
+				// do nothing
+			}
+		} finally {
+			deleteProject("ASTParserModelTests");
+		}
+	}
 
 // Add new tests here
 }

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/RequiresDirective.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/RequiresDirective.java
@@ -39,7 +39,7 @@ public class RequiresDirective extends ModuleDirective {
 	 * The module structural property of this node type (child type: {@link Name}).
 	 */
 	public static final ChildPropertyDescriptor NAME_PROPERTY =
-		new ChildPropertyDescriptor(RequiresDirective.class, "name", Name.class, OPTIONAL, NO_CYCLE_RISK); //$NON-NLS-1$
+		new ChildPropertyDescriptor(RequiresDirective.class, "name", Name.class, MANDATORY, NO_CYCLE_RISK); //$NON-NLS-1$
 
 	/**
 	 * A list of property descriptors (element type:
@@ -204,8 +204,7 @@ public class RequiresDirective extends ModuleDirective {
 			synchronized (this) {
 				if (this.name == null) {
 					preLazyInit();
-					this.name = postLazyInit(
-							this.ast.newQualifiedName(new SimpleName(this.ast), new SimpleName(this.ast)),
+					this.name = postLazyInit(new SimpleName(this.ast),
 							NAME_PROPERTY);
 				}
 			}
@@ -221,6 +220,7 @@ public class RequiresDirective extends ModuleDirective {
 	 * <ul>
 	 * <li>the node belongs to a different AST</li>
 	 * <li>the node already has a parent</li>
+	 * <li>the node is null</li>
 	 * </ul>
 	 */
 	public void setName(Name name) {


### PR DESCRIPTION
Elsewhere in the code, it's treated as a mandatory property (for instance in AST rewrites), so it makes sense to update the property descriptor and Javadoc to reflect this.

## What it does
- Mark `RequiresDirective`'s name field as `MANDATORY`
- Switch the value of the lazily initialized name to be a `SimpleName`
- Document that `RequiredDirective.setName(Name name)` throws an `IllegalArgumentException` when attempting to set the name to `null`

## How to test
- [x] Write an integration test

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
