### PR TITLE
Prevent too long Marker messages, fixes #1269

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchScopeTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchScopeTests.java
@@ -18,15 +18,19 @@ import java.net.URL;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import junit.framework.Test;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IWorkspaceRunnable;
 import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ILogListener;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.jdt.core.IClasspathContainer;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaElement;
@@ -52,11 +56,24 @@ import org.eclipse.jdt.internal.core.search.indexing.IndexManager;
  * Tests the Java search engine accross multiple projects.
  */
 public class JavaSearchScopeTests extends ModifyingResourceTests implements IJavaSearchConstants {
-public JavaSearchScopeTests(String name) {
+	private Queue<Throwable> exceptions = new ConcurrentLinkedQueue<>();
+	private ILogListener expectNoErrorLogging = (status, plugin) -> {
+		if (status.getException() != null) {
+			this.exceptions.add(new AssertionError(status.getMessage(), status.getException()));
+		}
+	};
+
+	public JavaSearchScopeTests(String name) {
 	super(name);
 }
 public static Test suite() {
 	return buildModelTestSuite(JavaSearchScopeTests.class);
+}
+
+@Override
+protected void setUp() throws Exception {
+	super.setUp();
+	Platform.addLogListener(this.expectNoErrorLogging);
 }
 // Use this static initializer to specify subset for tests
 // All specified tests which do not belong to the class are skipped...
@@ -68,6 +85,11 @@ static {
 
 @Override
 protected void tearDown() throws Exception {
+	Throwable firstException = this.exceptions.poll();
+	if (firstException!=null) {
+		throw new AssertionError(firstException);
+	}
+	Platform.removeLogListener(this.expectNoErrorLogging);
 	Util.cleanupClassPathVariablesAndContainers();
 	super.tearDown();
 }

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaProject.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaProject.java
@@ -1198,6 +1198,16 @@ public class JavaProject
 
 		try {
 			marker = this.project.createMarker(IJavaModelMarker.BUILDPATH_PROBLEM_MARKER);
+			String message = status.getMessage();
+			int msgLength = message.length();
+			if (!(msgLength < 21000)) {
+				// prevent too long messages, see MarkerInfo.checkValidAttribute()
+				byte[] bytes = message.getBytes(StandardCharsets.UTF_8);
+				if (bytes.length > 65535) {
+					msgLength = 21000 - 15;
+				}
+				message = message.substring(0, msgLength) + "..."; //$NON-NLS-1$
+			}
 			marker.setAttributes(
 				new String[] {
 					IMarker.MESSAGE,
@@ -1212,7 +1222,7 @@ public class JavaProject
 					IMarker.SOURCE_ID,
 				},
 				new Object[] {
-					status.getMessage(),
+					message,
 					Integer.valueOf(severity),
 					Messages.classpath_buildPath,
 					isCycleProblem ? "true" : "false",//$NON-NLS-1$ //$NON-NLS-2$


### PR DESCRIPTION
tested by JavaSearchScopeTests.testBug250211

https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1269

