### PR TITLE
Indexer: improve logging for empty .class/.jar files

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/ClassFileReader.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/ClassFileReader.java
@@ -240,6 +240,10 @@ public ClassFileReader(byte[] classFileBytes, char[] fileName, boolean fullyInit
 	// by index are tweaked to have their value in inst vars, this minor cost at read-time makes
 	// all subsequent uses of the constant pool element faster.
 	super(classFileBytes, null, 0);
+	if (classFileBytes == null || classFileBytes.length == 0) {
+		throw new ClassFormatException(ClassFormatException.ErrBadMagic);
+	}
+
 	this.classFileName = fileName;
 	int readOffset = 10;
 	try {

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/AddJarFileToIndex.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/AddJarFileToIndex.java
@@ -28,10 +28,8 @@ import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Status;
-import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.core.search.IJavaSearchScope;
 import org.eclipse.jdt.core.search.SearchEngine;
@@ -285,8 +283,9 @@ class AddJarFileToIndex extends BinaryContainer {
 			}
 		} catch (IOException | ZipError e) {
 			if (e instanceof NoSuchFileException) {
-				IStatus info = new Status(IStatus.INFO, JavaCore.PLUGIN_ID, "File no longer exists: " + this.containerPath, e); //$NON-NLS-1$
-				org.eclipse.jdt.internal.core.util.Util.log(info);
+				org.eclipse.jdt.internal.core.util.Util.log(Status.info("Can not index not existing zip " + this.containerPath)); //$NON-NLS-1$
+			} else if ("zip file is empty".equals(e.getMessage())) { //$NON-NLS-1$
+				org.eclipse.jdt.internal.core.util.Util.log(Status.info("Can not index empty zip " + this.containerPath)); //$NON-NLS-1$
 			} else {
 				org.eclipse.jdt.internal.core.util.Util.log(e, "Failed to index " + this.containerPath); //$NON-NLS-1$
 			}

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/BinaryIndexer.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/BinaryIndexer.java
@@ -873,6 +873,11 @@ public class BinaryIndexer extends AbstractIndexer implements SuffixConstants {
 			// logging the entry that could not be indexed and continue with the next one
 			// we remove all entries relative to the boggus document
 			this.document.removeAllIndexEntries();
+			if (e instanceof ClassFormatException cfe && cfe.getErrorCode() == ClassFormatException.ErrBadMagic) {
+				Util.log(new Status(IStatus.INFO, JavaCore.PLUGIN_ID,
+						"Could not index empty " + this.document.getPath())); //$NON-NLS-1$
+				return;
+			}
 			Util.log(new Status(IStatus.WARNING,
 					JavaCore.PLUGIN_ID,
 					"The Java indexing could not index " + this.document.getPath() + ". This .class file doesn't follow the class file format specification. Please report this issue against the .class file vendor", //$NON-NLS-1$ //$NON-NLS-2$


### PR DESCRIPTION
As happening with empty dummy ".class" / empty.jar files in tests for example during:
 JavaElementDeltaTests.testChangeExternalLibFolder3(),
 CompletionTests2.testBug281598b().
Empty files are no real problem they just do not need to be indexed.

was ArrayIndexOutOfBoundsException / "java.util.zip.ZipException: zip file is empty" with long stacktraces flooding the logfile
