### PR TITLE
Fixed AIOOBE for javadoc <pre>{@code}</pre> with missing closing brace #3372

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/formatter/FormatterCommentsBugsTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/formatter/FormatterCommentsBugsTest.java
@@ -7813,4 +7813,23 @@ public void testIssue2127b() {
 		""",
 		CodeFormatter.K_MODULE_INFO | CodeFormatter.F_INCLUDE_COMMENTS);
 }
+/**
+ * https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3372
+ */
+public void testIssue3372() {
+	String source =
+		"""
+		/**
+		 * <pre>
+		 * {@code
+		 * void test() {
+		 *   int i;
+		 * }
+		 * </pre>
+		 */
+		class Test {
+		}
+		""";
+	formatSource(source);
+}
 }

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/CommentsPreparator.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/CommentsPreparator.java
@@ -1017,7 +1017,8 @@ public class CommentsPreparator extends ASTVisitor {
 						// int closingBracePos = src.lastIndexOf('}', tag.getStartPosition() + tag.getLength());
 						// TODO bug 570137 workaround
 						int closingBracePos = tag.getStartPosition() + 1;
-						for (int braces = 1; braces > 0 && closingBracePos < src.length(); closingBracePos++) {
+						int lastPos = this.ctm.get(this.ctm.size() - 2).originalEnd;
+						for (int braces = 1; braces > 0 && closingBracePos < lastPos; closingBracePos++) {
 							if (src.charAt(closingBracePos) == '{')
 								braces++;
 							if (src.charAt(closingBracePos) == '}')


### PR DESCRIPTION

## What it does

Fix for issue #3372

## How to test

unit test included

## Author checklist

- [/] I have thoroughly tested my changes
- [/] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [/] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
