### PR TITLE
[dom ast] ASTNode.setSourceRange(...) throws IllegalArgumentException

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter_23Test.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter_23Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 GK Software SE and others.
+ * Copyright (c) 2024, 2025 GK Software SE and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -14,6 +14,7 @@
 package org.eclipse.jdt.core.tests.dom;
 
 import java.util.HashMap;
+import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
 import junit.framework.Test;
@@ -528,5 +529,38 @@ public class ASTConverter_23Test extends ConverterTestSetup {
 	    ITypeBinding aBinding = a.resolveBinding();
 	    assertTrue(Modifier.isStrictfp(aBinding.getModifiers()));
 	    assertTrue(Modifier.isPublic(aBinding.getModifiers()));
+	}
+
+	public void testBug549248_01() throws CoreException {
+	    String contents = """
+	        public enum X {
+	            JAPAN(new java.lang.String[] {"1","2"}){
+	    		    @Override
+	    		    public String getGreeting() {
+	    				return "Hello from Japan!";
+	    			}
+	            },
+
+	            public enum LoginType {
+	                public com.naver.linewebtoon.common.localization.X.LoginType EMAIL = "null";
+	            }
+	        }
+	        """;
+
+	    ASTParser parser = ASTParser.newParser(AST.getJLSLatest());
+	    parser.setSource(contents.toCharArray());
+	    parser.setEnvironment(null, null, null, true);
+	    parser.setResolveBindings(false);
+
+	    Hashtable<String, String> options = JavaCore.getDefaultOptions();
+	    options.put(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_23);
+	    options.put(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_23);
+	    options.put(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, JavaCore.VERSION_23);
+
+	    parser.setCompilerOptions(options);
+
+	    ASTNode node = parser.createAST(null);
+
+	    assertNotNull("ASTNode creation failed. Node is null!", node);
 	}
 }

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ASTConverter.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ASTConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -1831,8 +1831,13 @@ class ASTConverter {
 				if (anonymousType != null) {
 					AnonymousClassDeclaration anonymousClassDeclaration = new AnonymousClassDeclaration(this.ast);
 					int start = retrieveStartBlockPosition(anonymousType.sourceEnd, anonymousType.bodyEnd);
+					if (start == -1) start = anonymousType.bodyStart;
+
 					int end = retrieveRightBrace(anonymousType.bodyEnd +1, declarationSourceEnd);
 					if (end == -1) end = anonymousType.bodyEnd;
+
+					if(end < start) start = end;
+
 					anonymousClassDeclaration.setSourceRange(start, end - start + 1);
 					enumConstantDeclaration.setAnonymousClassDeclaration(anonymousClassDeclaration);
 					buildBodyDeclarations(anonymousType, anonymousClassDeclaration);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does

```
public enum X {
	            JAPAN(new java.lang.String[]{"440", "441"}) {
	            };
	            public enum LoginType {
	                public static final com.naver.linewebtoon.common.localization.X.LoginType EMAIL = null;
	            }
	        }
```
Consider the above code, which fails to create the compilation unit because the DOM AST Converter fails to convert the `FieldDeclaration`. To address this issue, a new `NullEnumConstantDeclaration` node was added.

## How to test
This PR closes #3309 

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
