### PR TITLE
StringLiteral.getLiteralValue is not thread-safe #3424

### DIFF
--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/StringLiteral.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/StringLiteral.java
@@ -226,10 +226,10 @@ public class StringLiteral extends Expression {
 				case TerminalTokens.TokenNameStringLiteral:
 					return scanner.getCurrentStringLiteral();
 				default:
-					throw new IllegalArgumentException();
+					throw new IllegalArgumentException("tokenType: " + tokenType); //$NON-NLS-1$
 			}
 		} catch(InvalidInputException e) {
-			throw new IllegalArgumentException();
+			throw new IllegalArgumentException(e);
 		}
 	}
 


### PR DESCRIPTION
org.eclipse.jdt.core.dom.StringLiteral.getLiteralValue() unsynchronized use of shared org.eclipse.jdt.core.dom.AST.scanner

reproducer for
https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3424

