### PR TITLE
[javac] some differences ecj <-> javac regarding 'recent' features

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractRegressionTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractRegressionTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -1179,9 +1179,9 @@ protected static class JavacTestOptions {
 					new JavacBugExtraJavacOptionsPlusMismatch(" --release 23 --enable-preview -Xlint:-preview",
 							MismatchType.JavacErrorsEclipseNone),
 			JavacBug8337980 = // https://bugs.openjdk.org/browse/JDK-8337980
-					new JavacHasABug(MismatchType.EclipseErrorsJavacNone /* add pivot JDK24 */),
+					new JavacHasABug(MismatchType.EclipseErrorsJavacNone, ClassFileConstants.JDK24, 0000),
 			JavacBug8343306 = // https://bugs.openjdk.org/browse/JDK-8343306
-					new JavacHasABug(MismatchType.EclipseErrorsJavacNone /* add pivot JDK24 */);
+					new JavacHasABug(MismatchType.EclipseErrorsJavacNone, ClassFileConstants.JDK24, 0000);
 
 		// bugs that have been fixed but that we've not identified
 		public static JavacHasABug

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/InterfaceMethodsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/InterfaceMethodsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2021 GK Software AG, IBM Corporation and others.
+ * Copyright (c) 2013, 2025 GK Software AG, IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -57,6 +57,19 @@ public class InterfaceMethodsTest extends AbstractComparableTest {
 	public InterfaceMethodsTest(String name) {
 		super(name);
 	}
+
+	// ========= OPT-IN to run.javac mode: ===========
+	@Override
+	protected void setUp() throws Exception {
+		this.runJavacOptIn = true;
+		super.setUp();
+	}
+	@Override
+	protected void tearDown() throws Exception {
+		super.tearDown();
+		this.runJavacOptIn = false; // do it last, so super can still clean up
+	}
+	// =================================================
 
 	// default methods with various modifiers, positive cases
 	public void testModifiers1() {


### PR DESCRIPTION
* acknowledge fix versions of javac bugs:
   * https://bugs.openjdk.org/browse/JDK-8343306
   * https://bugs.openjdk.org/browse/JDK-8337980
* let InterfaceMethodsTest opt-in to run.javac mode

Relates to https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2959

