### PR TITLE
Restore compliance.jre.24 setting after bogus merge from master

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/test.xml
+++ b/org.eclipse.jdt.core.tests.compiler/test.xml
@@ -61,7 +61,7 @@
       <property name="classname" 
                 value="org.eclipse.jdt.core.tests.compiler.regression.TestAll"/>
       <property name="vmargs" 
-      	value="-Dcompliance.jre.17=1.8,11,17 -Dcompliance.jre.21=1.8,11,17,21 -Dcompliance.jre.22=1.8,11,17,21,22 -Dcompliance.jre.23=1.8,11,17,21,23"
+      	value="-Dcompliance.jre.17=1.8,11,17 -Dcompliance.jre.21=1.8,11,17,20,21 -Dcompliance.jre.22=1.8,11,17,21,22 -Dcompliance.jre.23=1.8,11,17,21,23 -Dcompliance.jre.24=1.8,11,17,21,24"
       />
     </ant>
 


### PR DESCRIPTION
See discussion starting at https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2625#issuecomment-2571276163