### PR TITLE
Make StringLiteral.getLiteralValue thread safe

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTVisitorTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTVisitorTest.java
@@ -15,6 +15,11 @@
 package org.eclipse.jdt.core.tests.dom;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import junit.framework.Test;
 import org.eclipse.jdt.core.dom.*;
 
@@ -1370,6 +1375,25 @@ public class ASTVisitorTest extends org.eclipse.jdt.core.tests.junit.extension.T
 		String result = this.b.toString();
 		assertTrue(result.equals("[(eCL'q''q'eCL)]")); //$NON-NLS-1$
 	}
+	public void testCharacterLiteralConcurrent() throws Exception {
+		CharacterLiteral x1 = this.ast.newCharacterLiteral();
+		x1.setCharValue('q');
+
+		ExecutorService executorService = Executors.newFixedThreadPool(10);
+		List<CompletableFuture<Void>> futures = new ArrayList<>();
+		for (int i = 0; i < 100; i++) {
+			CompletableFuture<Void> future = CompletableFuture.runAsync(() -> {
+				try {
+					x1.charValue();
+				} catch (Exception e) {
+					throw new RuntimeException(e);
+				}
+			}, executorService);
+			futures.add(future);
+		}
+		CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get();
+		executorService.shutdown();
+	}
 	/** @deprecated using deprecated code */
 	public void testClassInstanceCreation() {
 		ClassInstanceCreation x1 = this.ast.newClassInstanceCreation();
@@ -2028,6 +2052,26 @@ public class ASTVisitorTest extends org.eclipse.jdt.core.tests.junit.extension.T
 		String result = this.b.toString();
 		assertTrue(result.equals("[(eSLHHeSL)]")); //$NON-NLS-1$
 	}
+	public void testStringLiteralConcurrent() throws Exception {
+		StringLiteral x1 = this.ast.newStringLiteral();
+		x1.setEscapedValue("\"hello\\nworld\""); //$NON-NLS-1$
+
+		ExecutorService executorService = Executors.newFixedThreadPool(10);
+		List<CompletableFuture<Void>> futures = new ArrayList<>();
+		for (int i = 0; i < 100; i++) {
+			CompletableFuture<Void> future = CompletableFuture.runAsync(() -> {
+				try {
+					x1.getLiteralValue();
+				} catch (Exception e) {
+					throw new RuntimeException(e);
+				}
+			}, executorService);
+			futures.add(future);
+		}
+		CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).get();
+		executorService.shutdown();
+	}
+
 	/** @deprecated using deprecated code */
 	public void testSuperConstructorInvocation() {
 		SuperConstructorInvocation x1 = this.ast.newSuperConstructorInvocation();

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/CharacterLiteral.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/CharacterLiteral.java
@@ -205,7 +205,18 @@ public class CharacterLiteral extends Expression {
 	 * @exception IllegalArgumentException if the literal value cannot be converted
 	 */
 	public char charValue() {
-		Scanner scanner = this.ast.scanner;
+		// create a new local scanner to allow concurrent use
+		Scanner scanner = new Scanner(
+				this.ast.scanner.tokenizeComments,
+				this.ast.scanner.tokenizeWhiteSpace,
+				this.ast.scanner.checkNonExternalizedStringLiterals,
+				this.ast.scanner.sourceLevel,
+				this.ast.scanner.complianceLevel,
+				this.ast.scanner.taskTags,
+				this.ast.scanner.taskPriorities,
+				this.ast.scanner.isTaskCaseSensitive,
+				this.ast.scanner.previewEnabled);
+
 		char[] source = this.escapedValue.toCharArray();
 		scanner.setSource(source);
 		scanner.resetTo(0, source.length);

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/StringLiteral.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/StringLiteral.java
@@ -216,7 +216,18 @@ public class StringLiteral extends Expression {
 			throw new IllegalArgumentException();
 		}
 
-		Scanner scanner = this.ast.scanner;
+		// create a new local scanner to allow concurrent use
+		Scanner scanner = new Scanner(
+				this.ast.scanner.tokenizeComments,
+				this.ast.scanner.tokenizeWhiteSpace,
+				this.ast.scanner.checkNonExternalizedStringLiterals,
+				this.ast.scanner.sourceLevel,
+				this.ast.scanner.complianceLevel,
+				this.ast.scanner.taskTags,
+				this.ast.scanner.taskPriorities,
+				this.ast.scanner.isTaskCaseSensitive,
+				this.ast.scanner.previewEnabled);
+
 		char[] source = s.toCharArray();
 		scanner.setSource(source);
 		scanner.resetTo(0, source.length);
@@ -226,10 +237,10 @@ public class StringLiteral extends Expression {
 				case TerminalTokens.TokenNameStringLiteral:
 					return scanner.getCurrentStringLiteral();
 				default:
-					throw new IllegalArgumentException();
+					throw new IllegalArgumentException("tokenType: " + tokenType); //$NON-NLS-1$
 			}
 		} catch(InvalidInputException e) {
-			throw new IllegalArgumentException();
+			throw new IllegalArgumentException(e);
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3424 + slightly improved tests from https://github.com/eclipse-jdt/eclipse.jdt.core/pull/3509

The exact same issue happens for CharacterLiteral.charValue, for which I added a test case and a fix as well.