### PR TITLE
ArrayIndexOutOfBoundsException in Parser due to static init block

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -3477,6 +3477,9 @@ private boolean isAFieldDeclarationInRecord() {
 				continue;
 			nestingTypeAndMethod = this.recordNestedMethodLevels.get(node);
 			if (nestingTypeAndMethod != null) { // record declaration is done yet
+				if (nestingTypeAndMethod[0] != this.nestedType
+					|| nestingTypeAndMethod[1] != this.nestedMethod[this.nestedType])
+					return false;
 				recordIndex = i;
 				break;
 			}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordsRestrictedClassTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordsRestrictedClassTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2024 IBM Corporation and others.
+ * Copyright (c) 2019, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -28,7 +28,7 @@ public class RecordsRestrictedClassTest extends AbstractRegressionTest {
 	static {
 //		TESTS_NUMBERS = new int [] { 40 };
 //		TESTS_RANGE = new int[] { 1, -1 };
-//		TESTS_NAMES = new String[] { "testIssue1641"};
+//		TESTS_NAMES = new String[] { "testBug3504_1"};
 	}
 
 	public static Class<?> testClass() {
@@ -9590,5 +9590,30 @@ public void testGH1939() {
 					"""
 			},
 		"OK!");
+}
+public void testBug3504_1() {
+	runNegativeTest(
+			new String[] {
+				"X.java",
+				"""
+					class X {
+					       public static void main(String[] args) {
+					           record R(int x) {
+					           		static {
+					                	static int i = 0;
+					          		}
+					        	}
+					        	R r =  new R(100);
+					        	System.out.println(r.x());
+					    	}
+					}
+				"""
+			},
+			"----------\n" +
+			"1. ERROR in X.java (at line 5)\n" +
+			"	static int i = 0;\n" +
+			"	           ^\n" +
+			"Illegal modifier for the variable i; only final is permitted\n" +
+			"----------\n");
 }
 }


### PR DESCRIPTION
issue #3506


## What it does
The static initializer block initializations were wrongly interpreted as field declarations of the record which resulted in removing intPtr entries - additional entries than required. This resulted in wrong integer values for dimensions - as an example the source position integer was written as dimensions though the dimension was zero - and subsequent looping through the dimensions resulted in AIOOBE. The root cause was identified as the erroneous interpretation of the initializations with var declarations as Field Declarations of Records. This is corrected in the PR.

The check is being done by checking whether the nesting method level is the same as that of the record - based on the fact that the static initializer block will increment the nesting level. If a declaration is inside this static initializer block, the values would be differnt at the point of testing. Thus the fix.

## How to test
A new test has been added which captures this by using a local record with a static field. Though not allowed and this has resulted in a negative test case, the fix is captured/covered by this test case - removal of the fix would result in the AIOOBE being thrown with this test case.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
