### PR TITLE
improve JavaSearchScopeTests.testBug250211() cleanup performance

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchScopeTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchScopeTests.java
@@ -1132,12 +1132,13 @@ public void testBug250211() throws CoreException {
 		},
 		null);
 		SearchEngine.createJavaSearchScope(projects);
-	}
-	finally {
-		for (int i = 0; i < max; i++){
-			assertNotNull("Unexpected null project!", projects[i]);
-			deleteProject(projects[i]);
-		}
+	} finally {
+		JavaCore.run(m -> {
+			for (int i = 0; i < max; i++) {
+				assertNotNull("Unexpected null project!", projects[i]);
+				deleteProject(projects[i]);
+			}
+		}, null);
 	}
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=397818


### PR DESCRIPTION
use single workspace operation for all projects

18s -> 5s
