### PR TITLE
BinaryTypeBinding: enrich RuntimeException with filename

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BinaryTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BinaryTypeBinding.java
@@ -434,7 +434,17 @@ public MethodBinding[] availableMethods() {
 	return availableMethods;
 }
 
-void cachePartsFrom(IBinaryType binaryType, boolean needFieldsAndMethods) {
+final void cachePartsFrom(IBinaryType binaryType, boolean needFieldsAndMethods) {
+	try {
+		cachePartsFrom2(binaryType, needFieldsAndMethods);
+	} catch (AbortCompilation e) {
+		throw e;
+	} catch (RuntimeException e) {
+		throw new RuntimeException("RuntimeException loading " + new String(binaryType.getFileName()), e); //$NON-NLS-1$
+	}
+}
+
+private void cachePartsFrom2(IBinaryType binaryType, boolean needFieldsAndMethods) {
 	if (!isPrototype()) throw new IllegalStateException();
 	ReferenceBinding previousRequester = this.environment.requestingType;
 	this.environment.requestingType = this;


### PR DESCRIPTION
During internal errors it is not clear which file did contain the problematic binary. For example:

https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3516

Example output will be like: "java.lang.RuntimeException: RuntimeException caching =P/libGh375.jar|TestGh375.class"
