### PR TITLE
Remove resolve classpath when fetching a raw classpath

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/PackageFragmentRoot.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/PackageFragmentRoot.java
@@ -613,7 +613,6 @@ public IClasspathEntry getRawClasspathEntry() throws JavaModelException {
 
 	IClasspathEntry rawEntry = null;
 	JavaProject project = getJavaProject();
-	project.getResolvedClasspath(); // force the reverse rawEntry cache to be populated
 	Map rootPathToRawEntries = project.getPerProjectInfo().rootPathToRawEntries;
 	if (rootPathToRawEntries != null) {
 		rawEntry = (IClasspathEntry) rootPathToRawEntries.get(getPath());


### PR DESCRIPTION
As it seems misplaced here, see 
- https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3468