### PR TITLE
Limit scope of JavaModelManager#rootPathToRawEntries field

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelManager.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelManager.java
@@ -1305,7 +1305,7 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 		public volatile boolean writtingRawClasspath;
 		public volatile IClasspathEntry[] resolvedClasspath;
 		public volatile IJavaModelStatus unresolvedEntryStatus;
-		public volatile Map<IPath, IClasspathEntry> rootPathToRawEntries; // reverse map from a package fragment root's path to the raw entry
+		private volatile Map<IPath, IClasspathEntry> rootPathToRawEntries; // reverse map from a package fragment root's path to the raw entry
 		private Map<IPath, IClasspathEntry> rootPathToResolvedEntries; // map from a package fragment root's path to the resolved entry
 		public volatile IPath outputLocation;
 		public volatile Map<IPath, ObjectVector> jrtRoots; // A map between a JRT file system (as a string) and the package fragment roots found in it.
@@ -1323,6 +1323,13 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 			this.project = project;
 			this.javadocCache = new LRUCache<>(JAVADOC_CACHE_INITIAL_SIZE);
 			this.secondaryTypes = new SecondaryTypes();
+		}
+
+		public synchronized Optional<IClasspathEntry> getRawClasspathEntry(IPath path) {
+			if (this.rootPathToRawEntries == null) {
+				return Optional.empty();
+			}
+			return Optional.ofNullable(this.rootPathToRawEntries.get(path));
 		}
 
 		public synchronized IClasspathEntry[] getResolvedClasspath() {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/PackageFragmentRoot.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/PackageFragmentRoot.java
@@ -610,17 +610,8 @@ public IPath internalPath() {
  */
 @Override
 public IClasspathEntry getRawClasspathEntry() throws JavaModelException {
-
-	IClasspathEntry rawEntry = null;
-	JavaProject project = getJavaProject();
-	Map rootPathToRawEntries = project.getPerProjectInfo().rootPathToRawEntries;
-	if (rootPathToRawEntries != null) {
-		rawEntry = (IClasspathEntry) rootPathToRawEntries.get(getPath());
-	}
-	if (rawEntry == null) {
-		throw new JavaModelException(new JavaModelStatus(IJavaModelStatusConstants.ELEMENT_NOT_ON_CLASSPATH, this));
-	}
-	return rawEntry;
+	return getJavaProject().getPerProjectInfo().getRawClasspathEntry(getPath())//
+			.orElseThrow(()->new JavaModelException(new JavaModelStatus(IJavaModelStatusConstants.ELEMENT_NOT_ON_CLASSPATH, this)));
 }
 /*
  * @see IPackageFragmentRoot

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/JavaSearchScope.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/JavaSearchScope.java
@@ -15,7 +15,6 @@ package org.eclipse.jdt.internal.core.search;
 
 import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
@@ -136,11 +135,7 @@ void add(JavaProject javaProject, IPath pathToAdd, int includeMask, Set<JavaProj
 		access = cpEntry.getAccessRuleSet();
 		switch (entry.getEntryKind()) {
 			case IClasspathEntry.CPE_LIBRARY:
-				IClasspathEntry rawEntry = null;
-				Map<IPath, IClasspathEntry> rootPathToRawEntries = perProjectInfo.rootPathToRawEntries;
-				if (rootPathToRawEntries != null) {
-					rawEntry = rootPathToRawEntries.get(entry.getPath());
-				}
+				IClasspathEntry rawEntry = perProjectInfo.getRawClasspathEntry(entry.getPath()).orElse(null);
 				if (rawEntry == null) break;
 				rawKind: switch (rawEntry.getEntryKind()) {
 					case IClasspathEntry.CPE_LIBRARY:


### PR DESCRIPTION
Currently rootPathToRawEntries is a public field and as those can possibly written/modified outside of control of the containing class.

This now makes the field private and adds an accessory method for its consumers removing the need for some boilerplate checks as well.