### PR TITLE
Revert "Remove resolve classpath when fetching a raw classpath (#3531)"

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/PackageFragmentRoot.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/PackageFragmentRoot.java
@@ -613,6 +613,7 @@ public IClasspathEntry getRawClasspathEntry() throws JavaModelException {
 
 	IClasspathEntry rawEntry = null;
 	JavaProject project = getJavaProject();
+	project.getResolvedClasspath(); // force the reverse rawEntry cache to be populated
 	Map rootPathToRawEntries = project.getPerProjectInfo().rootPathToRawEntries;
 	if (rootPathToRawEntries != null) {
 		rawEntry = (IClasspathEntry) rootPathToRawEntries.get(getPath());


### PR DESCRIPTION
This reverts commit b79bd1dc3aa63a35b1963a01b9941eee167dca75 as it introduces regressions.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3534
