### PR TITLE
Fire CHange events of an operation in a new job

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelOperation.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelOperation.java
@@ -788,7 +788,7 @@ public abstract class JavaModelOperation implements IWorkspaceRunnable, IProgres
 					if (isTopLevelOperation()) {
 						if ((deltaProcessor.javaModelDeltas.size() > previousDeltaCount || !deltaProcessor.reconcileDeltas.isEmpty())
 								&& !hasModifiedResource()) {
-							deltaProcessor.fire(null, DeltaProcessor.DEFAULT_CHANGE_EVENT);
+							deltaProcessor.fire(null, DeltaProcessor.DEFAULT_CHANGE_EVENT, true);
 						} // else deltas are fired while processing the resource delta
 					}
 				} finally {


### PR DESCRIPTION
Currently events are fired in sync with the operation, this can lead to code executed as part of an operation.

This now fire events in an own job.
