### PR TITLE
[24] modifiers allowed / disallowed for 'requires java.base'

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/core/compiler/IProblem.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/core/compiler/IProblem.java
@@ -2099,6 +2099,13 @@ void setSourceStart(int sourceStart);
 	int UndefinedModuleAddReads = ModuleRelated + 1319;
 	/** @since 3.20 */
 	int ExportingForeignPackage = ModuleRelated + 1320;
+	/** @since 3.41 */
+	int ModifierOnRequiresJavaBase = ModuleRelated + 1321;
+	/**
+	 * @since 3.41
+	 * @noreference related to preview feature module imports
+	 */
+	int ModifierOnRequiresJavaBasePreview = ModuleRelated + 1322;
 
 
 	/** @since 3.14 */

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/RequiresStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/RequiresStatement.java
@@ -8,15 +8,22 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *
  *******************************************************************************/
 package org.eclipse.jdt.internal.compiler.ast;
 
+import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
+import org.eclipse.jdt.internal.compiler.impl.JavaFeature;
 import org.eclipse.jdt.internal.compiler.lookup.ModuleBinding;
 import org.eclipse.jdt.internal.compiler.lookup.Scope;
+import org.eclipse.jdt.internal.compiler.lookup.TypeConstants;
 
 public class RequiresStatement extends ModuleStatement {
 
@@ -52,8 +59,17 @@ public class RequiresStatement extends ModuleStatement {
 		if (scope != null) {
 			if (this.resolvedBinding == null) {
 				scope.problemReporter().invalidModule(this.module);
-			} else if (this.resolvedBinding.hasUnstableAutoName()) {
-				scope.problemReporter().autoModuleWithUnstableName(this.module);
+			} else {
+				if (this.resolvedBinding.hasUnstableAutoName()) {
+					scope.problemReporter().autoModuleWithUnstableName(this.module);
+				}
+				if (CharOperation.equals(TypeConstants.JAVA_DOT_BASE, this.module.moduleName)) {
+					if (this.isStatic()) {
+						scope.problemReporter().modifierRequiresJavaBase(this, null);
+					} else if (this.isTransitive()) { // conditionally legal (requires preview)
+						scope.problemReporter().modifierRequiresJavaBase(this, JavaFeature.MODULE_IMPORTS);
+					}
+				}
 			}
 		}
 		return this.resolvedBinding;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
@@ -11644,6 +11644,17 @@ public void invalidServiceRef(int problem, TypeReference type) {
 		NoArgument, new String[] { CharOperation.charToString(type.resolvedType.readableName()) },
 		type.sourceStart, type.sourceEnd);
 }
+public void modifierRequiresJavaBase(RequiresStatement stat, JavaFeature moduleImports) {
+	if (moduleImports != null) {
+		if (moduleImports.isSupported(this.options))
+			return;
+		if (moduleImports.matchesCompliance(this.options)) {
+			this.handle(IProblem.ModifierOnRequiresJavaBase, NoArgument, NoArgument, stat.modifiersSourceStart, stat.sourceEnd);
+			return;
+		}
+	}
+	this.handle(IProblem.ModifierOnRequiresJavaBase, NoArgument, NoArgument, stat.modifiersSourceStart, stat.sourceEnd);
+}
 
 public void unlikelyArgumentType(Expression argument, MethodBinding method, TypeBinding argumentType,
 							TypeBinding receiverType, DangerousMethod dangerousMethod)

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/messages.properties
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/messages.properties
@@ -952,6 +952,8 @@
 1318 = Illegal modifier for module {0}; only open is permitted
 1319 = {0} cannot be resolved to a module, it is referenced from an add-reads directive
 1320 = Cannot export the package {0} which belongs to module {1}
+1321 = Modifiers are not allowed for dependence on module ''java.base''
+1322 = Modifier ''transitive'' is allowed for dependence on module ''java.base'' only when preview is enabled
 
 #### Java 9
 1351 = Variable resource not allowed here for source level below 9

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractModuleCompilationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractModuleCompilationTest.java
@@ -8,6 +8,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
  * Contributors:
  *     Stephan Herrmann - initial API and implementation
  *******************************************************************************/
@@ -288,6 +292,10 @@ public abstract class AbstractModuleCompilationTest extends AbstractBatchCompile
 			case "-23":
 				if (versionOptions == null)
 					buf.append(' ').append(" --release 23 ");
+				continue;
+			case "-24":
+				if (versionOptions == null)
+					buf.append(' ').append(" --release 24 ");
 				continue;
 			}
 			if (tokens[i].startsWith("-warn") || tokens[i].startsWith("-err") || tokens[i].startsWith("-info")) {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/CompilerInvocationTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/CompilerInvocationTests.java
@@ -848,6 +848,8 @@ public void test011_problem_categories() {
 		expectedProblemAttributes.put("MissingSynchronizedModifierInInheritedMethod", new ProblemAttributes(CategorizedProblem.CAT_POTENTIAL_PROGRAMMING_PROBLEM));
 		expectedProblemAttributes.put("MissingTypeInConstructor", new ProblemAttributes(CategorizedProblem.CAT_MEMBER));
 		expectedProblemAttributes.put("MissingTypeInLambda", new ProblemAttributes(CategorizedProblem.CAT_MEMBER));
+		expectedProblemAttributes.put("ModifierOnRequiresJavaBase", new ProblemAttributes(CategorizedProblem.CAT_MODULE));
+		expectedProblemAttributes.put("ModifierOnRequiresJavaBasePreview", new ProblemAttributes(CategorizedProblem.CAT_MODULE));
 		expectedProblemAttributes.put("UnterminatedTextBlock", new ProblemAttributes(CategorizedProblem.CAT_PREVIEW_RELATED));
 		expectedProblemAttributes.put("MissingTypeInMethod", new ProblemAttributes(CategorizedProblem.CAT_MEMBER));
 		expectedProblemAttributes.put("MissingValueForAnnotationMember", new ProblemAttributes(CategorizedProblem.CAT_TYPE));
@@ -1988,6 +1990,8 @@ public void test012_compiler_problems_tuning() {
 		expectedProblemAttributes.put("MissingSynchronizedModifierInInheritedMethod", new ProblemAttributes(JavaCore.COMPILER_PB_MISSING_SYNCHRONIZED_ON_INHERITED_METHOD));
 		expectedProblemAttributes.put("MissingTypeInConstructor", SKIP);
 		expectedProblemAttributes.put("MissingTypeInLambda", SKIP);
+		expectedProblemAttributes.put("ModifierOnRequiresJavaBase", SKIP);
+		expectedProblemAttributes.put("ModifierOnRequiresJavaBasePreview", SKIP);
 		expectedProblemAttributes.put("UnterminatedTextBlock", SKIP);
 		expectedProblemAttributes.put("MissingTypeInMethod", SKIP);
 		expectedProblemAttributes.put("MissingValueForAnnotationMember", SKIP);

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ModuleImportTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ModuleImportTests.java
@@ -8,6 +8,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
  * Contributors:
  *     Stephan Herrmann - initial API and implementation
  *******************************************************************************/
@@ -60,7 +64,7 @@ public class ModuleImportTests extends AbstractModuleCompilationTest {
 			filtered.append(
 				log.toString().lines()
 					.filter(line -> !line.equals("Note: Recompile with -Xlint:preview for details."))
-					.filter(line -> !(line.startsWith("Note: ") && line.endsWith("uses preview features of Java SE 23.")))
+					.filter(line -> !(line.startsWith("Note: ") && line.endsWith("uses preview features of Java SE 24.")))
 					.collect(Collectors.joining("\n")));
 			return filtered;
 		}
@@ -87,7 +91,7 @@ public class ModuleImportTests extends AbstractModuleCompilationTest {
 					}
 					"""
 	        },
-			" -23 \"" + OUTPUT_DIR +  File.separator + "module-info.java\" "
+			" -24 \"" + OUTPUT_DIR +  File.separator + "module-info.java\" "
 	        + "\"" + OUTPUT_DIR +  File.separator + "p/X.java\"",
 	        "",
 	        """
@@ -135,7 +139,7 @@ public class ModuleImportTests extends AbstractModuleCompilationTest {
 				Preview of features is supported only at the latest source level
 				""",
 	        true,
-	        "only supported for release 23");
+	        "only supported for release 24");
 	}
 
 	public void test001_simpleOK() {
@@ -160,7 +164,7 @@ public class ModuleImportTests extends AbstractModuleCompilationTest {
 					}
 					"""
 	        },
-			" -23 --enable-preview \"" + OUTPUT_DIR +  File.separator + "module-info.java\" "
+			" -24 --enable-preview \"" + OUTPUT_DIR +  File.separator + "module-info.java\" "
 	        + "\"" + OUTPUT_DIR +  File.separator + "p/X.java\"",
 	        "",
 	        "",
@@ -187,7 +191,7 @@ public class ModuleImportTests extends AbstractModuleCompilationTest {
 					}
 					"""
 	        },
-			" -23 --enable-preview \"" + OUTPUT_DIR +  File.separator + "module-info.java\" "
+			" -24 --enable-preview \"" + OUTPUT_DIR +  File.separator + "module-info.java\" "
 	        + "\"" + OUTPUT_DIR +  File.separator + "p/X.java\"",
 	        "",
 	        """
@@ -234,7 +238,7 @@ public class ModuleImportTests extends AbstractModuleCompilationTest {
 					}
 					"""
 	        },
-			" -23 --enable-preview \"" + OUTPUT_DIR +  File.separator + "module-info.java\" "
+			" -24 --enable-preview \"" + OUTPUT_DIR +  File.separator + "module-info.java\" "
 	        + "\"" + OUTPUT_DIR +  File.separator + "p/X.java\"",
 	        "",
 	        """
@@ -287,7 +291,7 @@ public class ModuleImportTests extends AbstractModuleCompilationTest {
 					}
 					""");
 		StringBuilder commandLine = new StringBuilder();
-		commandLine.append(" -23 --enable-preview ");
+		commandLine.append(" -24 --enable-preview ");
 		runConformModuleTest(
 				files,
 				commandLine,
@@ -321,7 +325,7 @@ public class ModuleImportTests extends AbstractModuleCompilationTest {
 					}
 					""");
 		StringBuilder commandLine = new StringBuilder();
-		commandLine.append(" -23 --enable-preview ");
+		commandLine.append(" -24 --enable-preview ");
 
 		runNegativeModuleTest(
 				files,
@@ -367,7 +371,7 @@ public class ModuleImportTests extends AbstractModuleCompilationTest {
 					}
 					""");
 		StringBuilder commandLine = new StringBuilder();
-		commandLine.append(" -23 --enable-preview ");
+		commandLine.append(" -24 --enable-preview ");
 		runConformModuleTest(
 				files,
 				commandLine,
@@ -405,7 +409,7 @@ public class ModuleImportTests extends AbstractModuleCompilationTest {
 					}
 					""");
 		StringBuilder commandLine = new StringBuilder();
-		commandLine.append(" -23 --enable-preview ");
+		commandLine.append(" -24 --enable-preview ");
 
 		runConformModuleTest(
 				files,
@@ -444,7 +448,7 @@ public class ModuleImportTests extends AbstractModuleCompilationTest {
 					}
 					""");
 		StringBuilder commandLine = new StringBuilder();
-		commandLine.append(" -23 --enable-preview ");
+		commandLine.append(" -24 --enable-preview ");
 
 		runNegativeModuleTest(
 				files,
@@ -512,7 +516,7 @@ public class ModuleImportTests extends AbstractModuleCompilationTest {
 					}
 					""");
 		StringBuilder commandLine = new StringBuilder();
-		commandLine.append(" -23 --enable-preview ");
+		commandLine.append(" -24 --enable-preview ");
 		commandLine.append(" --module-source-path \"").append(srcDir).append("\"");
 		commandLine.append(" -d \"").append(OUTPUT_DIR).append(File.separatorChar).append("bin").append("\"");
 
@@ -578,7 +582,7 @@ public class ModuleImportTests extends AbstractModuleCompilationTest {
 					}
 					""");
 		StringBuilder commandLine = new StringBuilder();
-		commandLine.append(" -23 --enable-preview");
+		commandLine.append(" -24 --enable-preview");
 		commandLine.append(" --module-source-path ").append(srcDir);
 		commandLine.append(" -d ").append(OUTPUT_DIR+File.separator+"bin");
 
@@ -639,7 +643,7 @@ public class ModuleImportTests extends AbstractModuleCompilationTest {
 					}
 					""");
 		StringBuilder commandLine = new StringBuilder();
-		commandLine.append(" -23 --enable-preview");
+		commandLine.append(" -24 --enable-preview");
 		commandLine.append(" --module-source-path ").append(srcDir);
 		commandLine.append(" -d ").append(OUTPUT_DIR+File.separator+"bin");
 
@@ -675,7 +679,7 @@ public class ModuleImportTests extends AbstractModuleCompilationTest {
 					""");
 
 		StringBuilder commandLine = new StringBuilder();
-		commandLine.append(" -23 --enable-preview");
+		commandLine.append(" -24 --enable-preview");
 
 		runNegativeModuleTest(
 				files,
@@ -712,7 +716,7 @@ public class ModuleImportTests extends AbstractModuleCompilationTest {
 					}
 					"""
 	        },
-			" -23 --enable-preview "
+			" -24 --enable-preview "
 	        + "\"" + OUTPUT_DIR +  File.separator + "p/X.java\"",
 	        "",
 	        "",
@@ -732,7 +736,7 @@ public class ModuleImportTests extends AbstractModuleCompilationTest {
 					import module.Z;
 					public class X extends Z {}
 					""");
-		StringBuilder commandLine = new StringBuilder(" -23 --enable-preview");
+		StringBuilder commandLine = new StringBuilder(" -24 --enable-preview");
 		runConformModuleTest(files, commandLine, "", "");
 	}
 
@@ -751,7 +755,113 @@ public class ModuleImportTests extends AbstractModuleCompilationTest {
 						uses Z;
 					}
 					""");
-		StringBuilder commandLine = new StringBuilder(" -23 --enable-preview");
+		StringBuilder commandLine = new StringBuilder(" -24 --enable-preview");
 		runConformModuleTest(files, commandLine, "", "");
 	}
+
+	public void testIllegalModifierRequiresJavaBase_1() {
+		List<String> files = new ArrayList<>();
+		writeFileCollecting(files, OUTPUT_DIR, "module-info.java",
+				"""
+					module one {
+						requires transitive java.base;
+					}
+					""");
+		runNegativeModuleTest(files,
+				new StringBuilder(" --release 24"),
+				"",
+				"""
+				----------
+				1. ERROR in ---OUTPUT_DIR_PLACEHOLDER---/module-info.java (at line 2)
+					requires transitive java.base;
+					         ^^^^^^^^^^^^^^^^^^^^
+				Modifiers are not allowed for dependence on module 'java.base'
+				----------
+				1 problem (1 error)
+				""",
+				"transitive modifier for java.base are not supported");
+	}
+
+	public void testIllegalModifierRequiresJavaBase_2() {
+		List<String> files = new ArrayList<>();
+		writeFileCollecting(files, OUTPUT_DIR, "module-info.java",
+				"""
+					module one {
+						requires static java.base;
+					}
+					""");
+		runNegativeModuleTest(files,
+				new StringBuilder(" --release 24"),
+				"",
+				"""
+				----------
+				1. ERROR in ---OUTPUT_DIR_PLACEHOLDER---/module-info.java (at line 2)
+					requires static java.base;
+					         ^^^^^^^^^^^^^^^^
+				Modifiers are not allowed for dependence on module 'java.base'
+				----------
+				1 problem (1 error)
+				""",
+				"modifier static not allowed here");
+	}
+
+	public void testIllegalModifierRequiresJavaBase_3() {
+		List<String> files = new ArrayList<>();
+		writeFileCollecting(files, OUTPUT_DIR, "module-info.java",
+				"""
+					module one {
+						requires transitive java.base;
+					}
+					""");
+		runConformModuleTest(files,
+				new StringBuilder(" --release 24 --enable-preview"),
+				"", "");
+	}
+
+	public void testIllegalModifierRequiresJavaBase_4() {
+		List<String> files = new ArrayList<>();
+		writeFileCollecting(files, OUTPUT_DIR, "module-info.java",
+				"""
+					module one {
+						requires static java.base;
+					}
+					""");
+		runNegativeModuleTest(files,
+				new StringBuilder(" --release 24 --enable-preview"),
+				"",
+				"""
+				----------
+				1. ERROR in ---OUTPUT_DIR_PLACEHOLDER---/module-info.java (at line 2)
+					requires static java.base;
+					         ^^^^^^^^^^^^^^^^
+				Modifiers are not allowed for dependence on module 'java.base'
+				----------
+				1 problem (1 error)
+				""",
+				"modifier static not allowed here");
+	}
+
+
+	public void testUseRequiresTransitiveJavaBase() {
+		List<String> files = new ArrayList<>();
+		writeFileCollecting(files, OUTPUT_DIR, "module-info.java",
+				"""
+					module one {
+						requires transitive java.base;
+					}
+					""");
+		writeFileCollecting(files, OUTPUT_DIR + File.separator + "p1", "Client.java",
+				"""
+				package p1;
+				import module one;
+				@SuppressWarnings("preview")
+				public class Client {
+					BigDecimal num;
+				}
+				""");
+		runConformModuleTest(files,
+				new StringBuilder(" --release 24 --enable-preview"),
+				"", "");
+	}
+
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TestAll.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TestAll.java
@@ -246,7 +246,7 @@ public static Test suite() {
 	 since_21.add(NullAnnotationTests21.class);
 	 since_21.add(BatchCompilerTest_21.class);
 	 since_21.add(JEP441SnippetsTest.class);
-	 
+
 
 	 // add 21 specific test here (check duplicates)
 	 ArrayList since_22 = new ArrayList();
@@ -258,6 +258,7 @@ public static Test suite() {
 	 since_23.add(MarkdownCommentsTest.class);
 
 	 ArrayList since_24 = new ArrayList();
+	 since_23.add(ModuleImportTests.class);
 	 since_24.add(SuperAfterStatementsTest.class);
 	 since_24.add(ImplicitlyDeclaredClassesTest.class);
 	 since_24.add(PrimitiveInPatternsTest.class);


### PR DESCRIPTION
+ implement new checks for modifiers on 'requires java.base'
   + 'static' always illegal
   + 'transitive' legal in preview
+ hook test into TestAll (forgotten during BETA_JAVA23)
+ make test fit for Java 24
