### PR TITLE
Restrict system library check to require Java nature

### DIFF
--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ASTParser.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ASTParser.java
@@ -272,6 +272,9 @@ public class ASTParser {
 	}
 
 	private void checkForSystemLibrary(List<Classpath> allClasspaths) {
+		if (!hasJavaNature()) {
+			return;
+		}
 		boolean hasSystemLibrary = true; // default for 1.8 setting without a valid project
 		boolean hasModule = false;
 		Throwable exception = null;
@@ -1655,5 +1658,9 @@ public class ASTParser {
 					compilationUnit.types().add(typeDeclaration);
 				}
 		}
+	}
+
+	private boolean hasJavaNature() {
+		return this.project == null || JavaProject.hasJavaNature(this.project.getProject());
 	}
 }


### PR DESCRIPTION
The validation of the project classpath introduced with 74d062b38d3003638127127cc5358dd9f79df0f4 always fails, if the project doesn't have a Java nature (and thus usually no .classpath file).

This causes issues when e.g. trying to open a source file with the Java editor or simply when trying to use the AST parser outside of a Java project. With this change, the check becomes more conservative and only fails, if both the Java nature exists and no system library is configured.

Note that one can avoid this exception by disabling the binding resolution. But given that this requires changes in user code, it is more prudent to only fail in cases where this is the desired behavior.

Resolves https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3298

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
