### PR TITLE
Don't evaluate the same type twice when renaming a method

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/hierarchy/HierarchyResolver.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/hierarchy/HierarchyResolver.java
@@ -29,6 +29,7 @@ package org.eclipse.jdt.internal.core.hierarchy;
 
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.Map;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IResource;
@@ -967,18 +968,24 @@ public boolean subOrSuperOfFocus(ReferenceBinding typeBinding) {
 	return false;
 }
 private boolean subTypeOfType(ReferenceBinding subType, ReferenceBinding typeBinding) {
+	return subTypeOfType(subType, typeBinding, new IdentityHashMap<>());
+}
+
+private boolean subTypeOfType(ReferenceBinding subType, ReferenceBinding typeBinding,
+		Map<ReferenceBinding, Object> visited) {
 	if (typeBinding == null || subType == null) return false;
+	if (visited.put(subType, subType) != null) return false; // don't evaluate the same "subType" twice
 	if (TypeBinding.equalsEquals(subType, typeBinding)) return true;
 	ReferenceBinding superclass = subType.superclass();
 	if (superclass != null) superclass = (ReferenceBinding) superclass.erasure();
 //	if (superclass != null && superclass.id == TypeIds.T_JavaLangObject && subType.isHierarchyInconsistent()) return false;
-	if (subTypeOfType(superclass, typeBinding)) return true;
+	if (subTypeOfType(superclass, typeBinding, visited)) return true;
 	ReferenceBinding[] superInterfaces = subType.superInterfaces();
 	if (superInterfaces != null) {
 		for (ReferenceBinding si : superInterfaces) {
 			ReferenceBinding superInterface = (ReferenceBinding) si.erasure();
 			if (superInterface.isHierarchyInconsistent()) return false;
-			if (subTypeOfType(superInterface, typeBinding)) return true;
+			if (subTypeOfType(superInterface, typeBinding, visited)) return true;
 		}
 	}
 	return false;


### PR DESCRIPTION
Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1945