### PR TITLE
[24] modifiers allowed / disallowed for 'requires java.base' (#3553)

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
@@ -11649,7 +11649,7 @@ public void modifierRequiresJavaBase(RequiresStatement stat, JavaFeature moduleI
 		if (moduleImports.isSupported(this.options))
 			return;
 		if (moduleImports.matchesCompliance(this.options)) {
-			this.handle(IProblem.ModifierOnRequiresJavaBase, NoArgument, NoArgument, stat.modifiersSourceStart, stat.sourceEnd);
+			this.handle(IProblem.ModifierOnRequiresJavaBasePreview, NoArgument, NoArgument, stat.modifiersSourceStart, stat.sourceEnd);
 			return;
 		}
 	}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ModuleImportTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ModuleImportTests.java
@@ -859,7 +859,7 @@ public class ModuleImportTests extends AbstractModuleCompilationTest {
 				1. ERROR in ---OUTPUT_DIR_PLACEHOLDER---/module-info.java (at line 2)
 					requires transitive java.base;
 					         ^^^^^^^^^^^^^^^^^^^^
-				Modifiers are not allowed for dependence on module 'java.base'
+				Modifier 'transitive' is allowed for dependence on module 'java.base' only when preview is enabled
 				----------
 				1 problem (1 error)
 				""",


### PR DESCRIPTION
+ correction regarding 'transitive' at 24 but without preview enabled

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3019
