### PR TITLE
Fix position computation in dereferencingNullableExpression()

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
@@ -11248,7 +11248,7 @@ public void dereferencingNullableExpression(long positions, LookupEnvironment en
 	char[][] nullableName = env.getNullableAnnotationName();
 	char[] nullableShort = nullableName[nullableName.length-1];
 	String[] arguments = { String.valueOf(nullableShort) };
-	this.handle(IProblem.DereferencingNullableExpression, arguments, arguments, (int)(positions>>>32), (int)(positions&0xFFFF));
+	this.handle(IProblem.DereferencingNullableExpression, arguments, arguments, (int)(positions>>>32), (int)(positions));
 }
 public void onlyReferenceTypesInIntersectionCast(TypeReference typeReference) {
 	this.handle(

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullTypeAnnotationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullTypeAnnotationTest.java
@@ -19455,4 +19455,31 @@ public void testGH3192() {
 		};
 	runner.runConformTest();
 }
+public void testErrorPosition() {
+	StringBuilder padding = new StringBuilder();
+	// push the relevant source to a position beyond 0xFFFF to trigger bug in position computation
+	for (int i=0; i<1000; i++)
+		padding.append("// ============================== padding ================================\n");
+	runNegativeTestWithLibs(new String[]{
+			"X.java",
+			padding.toString() +
+			"""
+			import org.eclipse.jdt.annotation.*;
+			class X {
+				@Nullable String s;
+				String test() {
+					return this.s.toLowerCase();
+				}
+			}
+			"""
+		},
+		"""
+		----------
+		1. ERROR in X.java (at line 1005)
+			return this.s.toLowerCase();
+			            ^
+		Potential null pointer access: this expression has a '@Nullable' type
+		----------
+		""");
+}
 }


### PR DESCRIPTION
One particular error message could be reported against a huge code region in the editor, when the end position of the problem was bogusly computed to a value lower than the start position.