### PR TITLE
Fix insert of annotation to not change indent of following line

### DIFF
--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/ASTRewriteAnalyzer.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/ASTRewriteAnalyzer.java
@@ -1733,6 +1733,9 @@ public final class ASTRewriteAnalyzer extends ASTVisitor {
 				String separator;
 				if (lastChild.getNewValue() instanceof Annotation) {
 					separator= formatterPrefix.getPrefix(getIndent(pos));
+					for (int i= 0; i < this.formatter.computeIndentInSpaces(getIndentOfLine(pos)) % this.formatter.getTabWidth(); ++i) {
+						separator += " "; //$NON-NLS-1$
+					}
 				} else {
 					separator= String.valueOf(' ');
 				}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/ASTRewriteFormatter.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/ASTRewriteFormatter.java
@@ -212,6 +212,10 @@ public final class ASTRewriteFormatter {
 		return IndentManipulation.measureIndentUnits(line, this.tabWidth, this.indentWidth);
 	}
 
+	public int computeIndentInSpaces(String line) {
+		return IndentManipulation.measureIndentInSpaces(line, this.tabWidth);
+	}
+
 	/**
 	 * Evaluates the edit on the given string.
 	 * @param string The string to format


### PR DESCRIPTION
- add new method computeIndentInSpaces() to ASTRewriteFormatter
- modify ASTRewriteAnalyzer.rewriteModifiers2() to add spaces as needed to separator of added annotation to match current indent
- fixes #1940

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
