### PR TITLE
Add AST getAll[Supported]Versions and isSupportedVersion

### DIFF
--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/AST.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/AST.java
@@ -558,6 +558,17 @@ public final class AST {
 	@Deprecated
 	public static final int JLS_Latest = JLS_INTERNAL_Latest;
 
+	private static final List<Integer> ALL_VERSIONS = List.of(JLS2, JLS3, JLS4, JLS8, JLS9, JLS10, JLS11, JLS12, JLS13, JLS14, JLS15, JLS16, JLS17, JLS18, JLS19, JLS20, JLS21, JLS22, JLS23);
+	private static final List<Integer> UNSUPPORTED_VERSIONS = List.of(JLS2, JLS3, JLS4);
+	private static final List<Integer> SUPPORTED_VERSIONS;
+	static {
+		List<Integer> temp = new ArrayList<>();
+		temp.addAll(ALL_VERSIONS);
+		temp.removeAll(UNSUPPORTED_VERSIONS);
+		SUPPORTED_VERSIONS = Collections.unmodifiableList(temp);
+	}
+
+
 	/*
 	 * Must not collide with a value for ICompilationUnit constants
 	 */
@@ -1193,7 +1204,7 @@ public final class AST {
 						false/*isPreviewEnabled*/);
 				break;
 			default:
-				if (level < JLS2_INTERNAL && level > JLS_Latest) {
+				if (!ALL_VERSIONS.contains(level)) {
 					throw new IllegalArgumentException("Unsupported JLS level : " + level); //$NON-NLS-1$
 				}
 				this.apiLevel = level;
@@ -4019,4 +4030,39 @@ public final class AST {
 	public static int getJLSLatest() {
 		return JLS_INTERNAL_Latest;
 	}
+
+	/**
+	 * Returns all {@link AST}{@code #JLS*} levels in the order of their
+	 * introduction. For e.g., {@link AST#JLS8} appears before {@link AST#JLS10}
+	 *
+	 * @return all available versions
+	 * @since 3.41
+	 */
+	public static List<Integer> getAllVersions() {
+		return ALL_VERSIONS;
+	}
+
+	/**
+	 * Returns all {@link AST}{@code #JLS*} levels fully supported by JDT in the order of their
+	 * introduction. For e.g., {@link AST#JLS8} appears before {@link AST#JLS10}
+	 *
+	 * @return all available versions
+	 * @since 3.41
+	 */
+	public static List<Integer> getAllSupportedVersions() {
+		return SUPPORTED_VERSIONS;
+	}
+
+	/**
+	 * Not all known JLS versions are fully supported by JDT. This method answers if the given Java source
+	 * version is fully supported.
+	 *
+	 * @return {@code true} if the given string represents Java language standard version is fully supported
+	 * @see #getAllSupportedVersions()
+	 * @since 3.41
+	 */
+	public static boolean isSupportedVersion(int version) {
+		return SUPPORTED_VERSIONS.contains(version);
+	}
+
 }

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/util/DOMASTUtil.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/util/DOMASTUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2024 IBM Corporation and others.
+ * Copyright (c) 2019, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -199,16 +199,9 @@ public class DOMASTUtil {
 
 
 	public static void checkASTLevel(int level) {
-		// Clients can use AST.getJLSLatest()
-		if(level >=AST.JLS8 && level <= AST.getJLSLatest() )
-			return;
-		switch (level) {
-	        case AST.JLS2 :
-	        case AST.JLS3 :
-	        case AST.JLS4 :
-	        	return;
+		if (!AST.getAllVersions().contains(level)) {
+			throw new IllegalArgumentException(Integer.toString(level));
 		}
-		throw new IllegalArgumentException(Integer.toString(level));
 	}
 
 	private static final String[] AST_COMPLIANCE_MAP = {"-1","-1",JavaCore.VERSION_1_2, JavaCore.VERSION_1_3, JavaCore.VERSION_1_7, //$NON-NLS-1$ //$NON-NLS-2$
@@ -223,7 +216,7 @@ public class DOMASTUtil {
 	 * @return JavaCore Option value string corresponding to the ast level
 	 */
 	public static String getCompliance(int astLevel) {
-		if (astLevel < AST.JLS2 && astLevel > AST.getJLSLatest()) return JavaCore.latestSupportedJavaVersion();
+		if (!AST.getAllVersions().contains(astLevel)) return JavaCore.latestSupportedJavaVersion();
 		return AST_COMPLIANCE_MAP[astLevel];
 	}
 


### PR DESCRIPTION
New methods to ease finding all/supported JLS versions. Supported JLS versions helpers are needed in order ease limiting AST support to what compiler supports.

