### PR TITLE
Fix compile error in builder test harness under javac

### DIFF
--- a/org.eclipse.jdt.core.tests.builder/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.tests.builder/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.core.tests.builder; singleton:=true
-Bundle-Version: 3.12.700.qualifier
+Bundle-Version: 3.12.800.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jdt.core.tests.builder

--- a/org.eclipse.jdt.core.tests.builder/pom.xml
+++ b/org.eclipse.jdt.core.tests.builder/pom.xml
@@ -18,7 +18,7 @@
     <relativePath>../tests-pom/</relativePath>
   </parent>
   <artifactId>org.eclipse.jdt.core.tests.builder</artifactId>
-  <version>3.12.700-SNAPSHOT</version>
+  <version>3.12.800-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>

--- a/org.eclipse.jdt.core.tests.builder/src/org/eclipse/jdt/core/tests/builder/BuilderTests.java
+++ b/org.eclipse.jdt.core.tests.builder/src/org/eclipse/jdt/core/tests/builder/BuilderTests.java
@@ -519,7 +519,7 @@ public class BuilderTests extends TestCase {
 	}
 
 	private static Class[] getAllTestClasses() {
-		Class[] classes = new Class[] {
+		Class<?>[] classes = new Class[] {
 			AbstractMethodTests.class,
 			BasicBuildTests.class,
 			BuildpathTests.class,


### PR DESCRIPTION
When compiling the builder tests with javac, a "failed to infer type parameters" compiler error is generated.

The following minimal example also produces the compiler error under javac (but not ECJ):

```java
import java.util.List;
import java.util.ArrayList;
import java.util.Arrays;

public class HelloWorld {
	public static void main(String... args) {
		Class[] classes = new Class[] { String.class, List.class };
		List<Class<?>> asdf = new ArrayList<>(Arrays.asList(classes));
	}
}
```

It's unclear to me which compiler is doing the wrong thing. The code change I made seems to compile under both compilers.

## What it does
Fix a compile error in the builder test harness when compiling under javac.

## How to test
To reproduce the compiler error (before this change), add the following to the `./org.eclipse.jdt.core.tests.builder/pom.xml` "\<plugins\>" section to configure Tycho to run with javac:

```xml
<plugin>
  <groupId>org.eclipse.tycho</groupId>
  <artifactId>tycho-compiler-plugin</artifactId>
  <configuration>
    <compilerArgs>
      <args></args>
    </compilerArgs>
    <deriveReleaseCompilerArgumentFromTargetLevel>false</deriveReleaseCompilerArgumentFromTargetLevel>
    <compilerId>javac</compilerId>
</plugin>
```

Then, clean and compile the test bundle (`mvn clean compile`).

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
