### PR TITLE
Update default set of root modules for unnamed modules

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/core/JavaCore.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/core/JavaCore.java
@@ -6500,9 +6500,22 @@ public final class JavaCore extends Plugin {
 	 * @param allSystemRoots all physically available system modules, represented by their package fragment roots
 	 * @return the list of names of default root modules
 	 * @since 3.14
+	 * @deprecated This method cannot distinguish strategies for old (9/10) vs new (11+) JDK versions. Please use {@link #defaultRootModules(Iterable, String)}
 	 */
+	@Deprecated
 	public static List<String> defaultRootModules(Iterable<IPackageFragmentRoot> allSystemRoots) {
 		return JavaProject.defaultRootModules(allSystemRoots);
+	}
+
+	/**
+	 * Filter the given set of system roots by the rules for root modules from JEP 261.
+	 * @param allSystemRoots all physically available system modules, represented by their package fragment roots
+	 * @param release JDK version to select strategies before / after resolution of https://bugs.openjdk.org/browse/JDK-8205169
+	 * @return the list of names of default root modules
+	 * @since 3.41
+	 */
+	public static List<String> defaultRootModules(Iterable<IPackageFragmentRoot> allSystemRoots, String release) {
+		return JavaProject.defaultRootModules(allSystemRoots, release);
 	}
 
 	/**

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaProject.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaProject.java
@@ -741,7 +741,9 @@ public class JavaProject
 								if (limitModules != null) {
 									rootModules = Arrays.asList(limitModules.split(",")); //$NON-NLS-1$
 								} else if (isUnNamedModule()) {
-									rootModules = defaultRootModules((Iterable) imageRoots);
+									String release = JavaCore.ENABLED.equals(getOption(JavaCore.COMPILER_RELEASE, true))
+											? getOption(JavaCore.COMPILER_COMPLIANCE, true) : null;
+									rootModules = defaultRootModules((Iterable) imageRoots, release);
 								}
 								if (rootModules != null) {
 									imageRoots = filterLimitedModules(entryPath, imageRoots, rootModules);
@@ -792,30 +794,50 @@ public class JavaProject
 		}
 	}
 
-	/** Implements selection of root modules per JEP 261. */
+	/**
+	 * Implements selection of root modules per JEP 261.
+	 * @deprecated This method cannot distinguish strategies for old (9/10) vs new (11+) JDK versions. Please use {@link #defaultRootModules(Iterable, String)}
+	 */
+	@Deprecated
 	public static List<String> defaultRootModules(Iterable<IPackageFragmentRoot> allSystemRoots) {
-		return internalDefaultRootModules(allSystemRoots,
-				IPackageFragmentRoot::getElementName,
-				r ->  (r instanceof JrtPackageFragmentRoot) ? ((JrtPackageFragmentRoot) r).getModule() : null);
+		return defaultRootModules(allSystemRoots, JavaCore.VERSION_11); // 11 is fix version of https://bugs.openjdk.org/browse/JDK-8205169
 	}
 
-	public static <T> List<String> internalDefaultRootModules(Iterable<T> allSystemModules, Function<T,String> getModuleName, Function<T,IModule> getModule) {
+	/**
+	 * Implements selection of root modules per JEP 261.
+	 * @param allSystemRoots all modules found in the JRT system
+	 * @param releaseVersion the release version which decides about the strategy for selecting root modules
+	 */
+	public static List<String> defaultRootModules(Iterable<IPackageFragmentRoot> allSystemRoots, String releaseVersion) {
+		return internalDefaultRootModules(allSystemRoots,
+				IPackageFragmentRoot::getElementName,
+				r ->  (r instanceof JrtPackageFragmentRoot) ? ((JrtPackageFragmentRoot) r).getModule() : null,
+				releaseVersion);
+	}
+
+	public static <T> List<String> internalDefaultRootModules(Iterable<T> allSystemModules, Function<T,String> getModuleName, Function<T,IModule> getModule, String releaseVersion) {
 		List<String> result = new ArrayList<>();
+		boolean beforeJDK8205169 = JavaCore.VERSION_9.equals(releaseVersion) || JavaCore.VERSION_10.equals(releaseVersion);
 		boolean hasJavaDotSE = false;
-		for (T mod : allSystemModules) {
-			String moduleName = getModuleName.apply(mod);
-			if ("java.se".equals(moduleName)) { //$NON-NLS-1$
-				result.add(moduleName);
-				hasJavaDotSE = true;
-				break;
+		if (beforeJDK8205169) {
+			for (T mod : allSystemModules) {
+				String moduleName = getModuleName.apply(mod);
+				if ("java.se".equals(moduleName)) { //$NON-NLS-1$
+					result.add(moduleName);
+					hasJavaDotSE = true;
+					break;
+				}
 			}
 		}
 		for (T mod : allSystemModules) {
 			String moduleName = getModuleName.apply(mod);
-			boolean isJavaDotStart = moduleName.startsWith("java."); //$NON-NLS-1$
-			boolean isPotentialRoot = !isJavaDotStart;	// always include non-java.*
-			if (!hasJavaDotSE)
-				isPotentialRoot |= isJavaDotStart;		// no java.se => add all java.*
+			boolean isPotentialRoot = true;  // since JDK-8205169 all system modules are considered
+			if (beforeJDK8205169) {
+				boolean isJavaDotStart = moduleName.startsWith("java."); //$NON-NLS-1$
+				isPotentialRoot = !isJavaDotStart;	// always include non-java.*
+				if (!hasJavaDotSE)
+					isPotentialRoot |= isJavaDotStart;		// no java.se => add all java.*
+			}
 
 			if (isPotentialRoot) {
 				IModule module = getModule.apply(mod);

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/ClasspathJrt.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/ClasspathJrt.java
@@ -242,12 +242,16 @@ protected Collection<String> selectModules(Set<String> keySet, Collection<String
 		result.retainAll(limitModules);
 		rootModules = result;
 	} else {
-		rootModules = JavaProject.internalDefaultRootModules(keySet, s -> s, this::getModule);
+		rootModules = JavaProject.internalDefaultRootModules(keySet, s -> s, this::getModule, getReleaseVersion());
 	}
 	Set<String> allModules = new HashSet<>(rootModules);
 	for (String mod : rootModules)
 		addRequired(mod, allModules);
 	return allModules;
+}
+
+protected String getReleaseVersion() {
+	return null;
 }
 
 protected void addRequired(String mod, Set<String> allModules) {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/ClasspathJrtWithReleaseOption.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/ClasspathJrtWithReleaseOption.java
@@ -115,6 +115,11 @@ public class ClasspathJrtWithReleaseOption extends ClasspathJrt {
 		}
 	}
 
+	@Override
+	protected String getReleaseVersion() {
+		return this.release;
+	}
+
 	public void loadModules() {
 		if (this.fs == null || !this.ctSym.isJRE12Plus()) {
 			ClasspathJrt.loadModules(this);


### PR DESCRIPTION
+ Implement new (simplified) rules as of https://bugs.openjdk.org/browse/JDK-8205169
+ New methods to query the default root modules in a version-aware way
+ Deprecate old version-agnostic methods

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2786
