### PR TITLE
[Switch Expressions] ArrayIndexOutOfBoundsException in Scope.leastContainingInvocation for sealed class and switch

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchExpression.java
@@ -120,11 +120,9 @@ public class SwitchExpression extends SwitchStatement implements IPolyExpression
 		/** Add an expression to known result expressions, gather some aggregate characteristics if in standalone context.
 		 *  @return a flag indicating the overall well-formedness of result expression set.
 		 */
-		public boolean add(/*@NonNull*/ Expression rxpression) {
+		public boolean add(/*@NonNull*/ Expression rxpression, TypeBinding rxpressionType) {
 
 			this.rExpressions.add(rxpression);
-
-			TypeBinding rxpressionType = rxpression.resolvedType;
 			if (rxpressionType == null) { // tolerate poly-expression resolving to null in the absence of target type.
 				if (!rxpression.isPolyExpression() || ((IPolyExpression) rxpression).expectedType() != null)
 					this.allWellFormed = false;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/YieldStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/YieldStatement.java
@@ -152,9 +152,9 @@ public void resolve(BlockScope scope) {
 		}
 	}
 
-	this.expression.resolveType(scope);
+	TypeBinding expressionType = this.expression.resolveType(scope);
 	if (this.switchExpression != null)
-		this.switchExpression.results.add(this.expression);
+		this.switchExpression.results.add(this.expression, expressionType);
 
 	if (this.isImplicit) {
 		if (this.switchExpression == null && !this.expression.statementExpression()) {


### PR DESCRIPTION


* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3554

