### PR TITLE
Remove custom ReferenceBinding.hashCode()

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
@@ -1202,15 +1202,6 @@ public TypeVariableBinding getTypeVariable(char[] variableName) {
 	return null;
 }
 
-@Override
-public int hashCode() {
-	// ensure ReferenceBindings hash to the same position as UnresolvedReferenceBindings so they can be replaced without rehashing
-	// ALL ReferenceBindings are unique when created so equals() is the same as ==
-	return (this.compoundName == null || this.compoundName.length == 0)
-		? super.hashCode()
-		: CharOperation.hashCode(this.compoundName[this.compoundName.length - 1]);
-}
-
 /**
  * Returns true if the two types have an incompatible common supertype,
  * e.g. {@code List<String>} and {@code List<Integer>}


### PR DESCRIPTION
To avoid possible hash collisions.

Instead of manipulating the existing key in a map remove exiting entry and put the updated entry.
Use a HashMap instead of SimpleLookupTable.

https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3412
