### PR TITLE
Rewrite for-each pattern variable completion tests to use regular for

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTestsForRecordPattern.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTestsForRecordPattern.java
@@ -466,7 +466,7 @@ public class CompletionTestsForRecordPattern extends AbstractJavaModelCompletion
 					+ "    public static boolean foo(Object o) {\n"
 					+ "        boolean ret = false;\n"
 					+ "        R[] recArray = {new R(0)};\n"
-					+ "        for (R(int x_1) : recArray) {\n"
+					+ "        for (int i = 0; i < recArray.length && recArray[i] instanceof R(int x_1); i++) {\n"
 					+ "            System.out.println(x_);  \n"
 					+ "            ret = true;\n"
 					+ "        }\n"
@@ -490,7 +490,7 @@ public class CompletionTestsForRecordPattern extends AbstractJavaModelCompletion
 					"/Completion/src/X.java",
 					"public class X {\n"
 					+ "    public static void foo(ColoredRectangle[] array) {\n"
-					+ "       for(ColoredRectangle(int x_1, int y_1, Color col) : array) {\n"
+					+ "       for(int i = 0; i < array.length && array[i] instanceof ColoredRectangle(int x_1, int y_1, Color col); i++) {\n"
 					+ "    	  int per = 2 * x_ + 2 * y_1;\n"
 					+ "       }\n"
 					+ "    }\n"
@@ -515,7 +515,7 @@ public class CompletionTestsForRecordPattern extends AbstractJavaModelCompletion
 					"/Completion/src/X.java",
 					"public class X {\n"
 					+ "    public static void foo(ColoredRectangle[] array) {\n"
-					+ "       for(ColoredRectangle(int x_1, int y_1, Color col) : array) {\n"
+					+ "       for(int i = 0; i < array.length && array[i] instanceof ColoredRectangle(int x_1, int y_1, Color col); i++) {\n"
 					+ "    	  int per = 2 * x_1 + 2 * y_;\n"
 					+ "       }\n"
 					+ "    }\n"
@@ -540,7 +540,7 @@ public class CompletionTestsForRecordPattern extends AbstractJavaModelCompletion
 					"/Completion/src/X.java",
 					"public class X {\n"
 					+ "    public static void foo(ColoredRectangle[] ar_ray) {\n"
-					+ "       for(ColoredRectangle(int x_1, int y_1, Color col) : ar_) {\n"
+					+ "       for(int i = 0; i < ar_ray.length && ar_ray[i] instanceof ColoredRectangle(int x_1, int y_1, Color col); i++) {\n"
 					+ "    	  int per = 2 * x_1 + 2 * y_1;\n"
 					+ "       }\n"
 					+ "    }\n"


### PR DESCRIPTION
## What it does
The syntax used in these tests was withdrawn before the feature was delivered (see #1907). I've altered the tests to use a regular for loop with an `instanceof` in it, so that the tests still check that the scoping of the pattern variables is working properly for completion.

Fixes #3589

## How to test
Make sure that the modified integration tests still pass.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
