### PR TITLE
Isolate access to CompletionEngine in InternalCompletionProposal

### DIFF
--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/InternalCompletionProposal.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/InternalCompletionProposal.java
@@ -207,7 +207,7 @@ public class InternalCompletionProposal extends CompletionProposal {
 		int length = paramTypeNames.length;
 
 		char[] tName = CharOperation.concat(declaringTypePackageName,declaringTypeName,'.');
-		Object cachedType = this.completionEngine.typeCache.get(tName);
+		Object cachedType = getFromEngineTypeCache(tName);
 
 		IType type = null;
 		if(cachedType != null) {
@@ -226,7 +226,7 @@ public class InternalCompletionProposal extends CompletionProposal {
 				null);
 			type = answer == null ? null : answer.type;
 			if(type instanceof BinaryType){
-				this.completionEngine.typeCache.put(tName, type);
+				addToCompletionEngineTypeCache(tName, type);
 			} else {
 				type = null;
 			}
@@ -242,14 +242,15 @@ public class InternalCompletionProposal extends CompletionProposal {
 
 					IPackageFragmentRoot packageFragmentRoot = (IPackageFragmentRoot)type.getAncestor(IJavaElement.PACKAGE_FRAGMENT_ROOT);
 					if (packageFragmentRoot.isArchive() ||
-							this.completionEngine.openedBinaryTypes < getOpenedBinaryTypesThreshold()) {
+							getOpenedBinaryTypesCount() < getOpenedBinaryTypesThreshold()) {
 						SourceMapper mapper = ((JavaElement)method).getSourceMapper();
 						if (mapper != null) {
 							char[][] paramNames = mapper.getMethodParameterNames(method);
 
 							// map source and try to find parameter names
 							if(paramNames == null) {
-								if (!packageFragmentRoot.isArchive()) this.completionEngine.openedBinaryTypes++;
+								if (!packageFragmentRoot.isArchive())
+									incrementOpenedBinaryTypesCount();
 								IBinaryType info = ((BinaryType) type).getElementInfo();
 								char[] source = mapper.findSource(type, info);
 								if (source != null){
@@ -290,6 +291,22 @@ public class InternalCompletionProposal extends CompletionProposal {
 		return parameters;
 	}
 
+	protected void incrementOpenedBinaryTypesCount() {
+		this.completionEngine.openedBinaryTypes++;
+	}
+
+	protected int getOpenedBinaryTypesCount() {
+		return this.completionEngine.openedBinaryTypes;
+	}
+
+	protected void addToCompletionEngineTypeCache(char[] tName, IType type) {
+		this.completionEngine.typeCache.put(tName, type);
+	}
+
+	protected Object getFromEngineTypeCache(char[] tName) {
+		return this.completionEngine.typeCache.get(tName);
+	}
+
 	protected char[][] findMethodParameterNames(char[] declaringTypePackageName, char[] declaringTypeName, char[] selector, char[][] paramTypeNames){
 		if(paramTypeNames == null || declaringTypeName == null) return null;
 
@@ -297,7 +314,7 @@ public class InternalCompletionProposal extends CompletionProposal {
 		int length = paramTypeNames.length;
 
 		char[] tName = CharOperation.concat(declaringTypePackageName,declaringTypeName,'.');
-		Object cachedType = this.completionEngine.typeCache.get(tName);
+		Object cachedType = getFromEngineTypeCache(tName);
 
 		IType type = null;
 		if(cachedType != null) {
@@ -316,7 +333,7 @@ public class InternalCompletionProposal extends CompletionProposal {
 				null);
 			type = answer == null ? null : answer.type;
 			if(type instanceof BinaryType){
-				this.completionEngine.typeCache.put(tName, type);
+				addToCompletionEngineTypeCache(tName, type);
 			} else {
 				type = null;
 			}


### PR DESCRIPTION
We are trying to make a completion engine which does not depend directly on the existing CompletionEngine class. To do this, we may need to override some behavior in InternalCompletionProposal. This class makes limited use of its dependency on a CompletionEngine, but the classes are still tightly coupled. 

With small modifications, this class could be subclassable for our usecase. The class remains in an internal package, and so these new methods are not expanded to any level of API.  As consumers of internal API, we recognize the risk that the code could change at any time and we accept that risk. 

Please consider this small and targeted patch. Thanks. 

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
