### PR TITLE
Forward release setting to AbstractImageBuilder

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/impl/CompilerOptions.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/impl/CompilerOptions.java
@@ -434,6 +434,11 @@ public class CompilerOptions {
 	/** Java source level, refers to a JDK version, e.g. {@link ClassFileConstants#JDK1_4} */
 	public long sourceLevel;
 	/**
+	 * Use <code>-release</code> setting to pass compliance version and enable checking for
+	 * availability of system APIs for the compliance version.
+	 */
+	public boolean release;
+	/**
 	 * Initially requested source version, not necessarily consistent with {@link #sourceLevel} as
 	 * sourceLevel forcibly contain a version that is compatible with ECJ.
 	 * <p>Consumers are free to use {@code sourceLevel} or this
@@ -1410,7 +1415,7 @@ public class CompilerOptions {
 		optionsMap.put(OPTION_ReportUnusedLabel, getSeverityString(UnusedLabel));
 		optionsMap.put(OPTION_ReportUnusedTypeArgumentsForMethodInvocation, getSeverityString(UnusedTypeArguments));
 		optionsMap.put(OPTION_Compliance, versionFromJdkLevel(this.complianceLevel));
-		optionsMap.put(OPTION_Release, DISABLED);
+		optionsMap.put(OPTION_Release, this.release ? ENABLED : DISABLED);
 		optionsMap.put(OPTION_Source, versionFromJdkLevel(this.sourceLevel));
 		optionsMap.put(OPTION_TargetPlatform, versionFromJdkLevel(this.targetJDK));
 		optionsMap.put(OPTION_FatalOptionalError, this.treatOptionalErrorAsFatal ? ENABLED : DISABLED);
@@ -1579,6 +1584,7 @@ public class CompilerOptions {
 		this.complianceLevel = firstSupportedJdkLevel;
 		this.sourceLevel = firstSupportedJdkLevel;
 		this.targetJDK = firstSupportedJdkLevel;
+		this.release = false;
 
 		this.defaultEncoding = null; // will use the platform default encoding
 
@@ -1776,6 +1782,7 @@ public class CompilerOptions {
 			long level = versionToJdkLevel(optionValue);
 			if (level != 0) this.sourceLevel = level;
 		}
+		this.release = ENABLED.equals(optionsMap.get(OPTION_Release));
 		if ((optionValue = optionsMap.get(OPTION_TargetPlatform)) != null) {
 			long level = versionToJdkLevel(optionValue);
 			if (level != 0) {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/OptionTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/OptionTests.java
@@ -996,4 +996,12 @@ public void testBug550081() {
 	}
 	assertEquals("latest should be unchanged", latestVersion, JavaCore.latestSupportedJavaVersion());
 }
+
+public void testReleasePersistedInOptions() {
+	for (String value : List.of(CompilerOptions.ENABLED, CompilerOptions.DISABLED)) {
+		CompilerOptions options = new CompilerOptions(Map.of(CompilerOptions.OPTION_Release, value));
+		assertEquals("OPTION_Release=" + value + " ignored when building CompilerOptions", CompilerOptions.ENABLED.equals(value), options.release);
+		assertEquals("OPTION_Release=" + value + " incorectly returned in map", value, options.getMap().get(CompilerOptions.OPTION_Release));
+	}
+}
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does

Honor the OPTION_release setting in CompilerOptions so it can easily be used in downstream AbstractImageBuilder.

Note that there is currently no practical consumer for this option in ECJ-based builder; but it still seems interesting to allow proper access to this setting anyway.

## How to test

Run tests, see no regression.

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
