### PR TITLE
Remove tests for malformed Java 8 source on older JLS versions

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter15JLS4Test.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter15JLS4Test.java
@@ -434,19 +434,6 @@ public class ASTConverter15JLS4Test extends ConverterTestSetup {
 		assertTrue("not static", importDeclaration.isStatic());
 	}
 
-	/** @deprecated using deprecated code */
-	public void test0008() throws JavaModelException {
-		ICompilationUnit sourceUnit = getCompilationUnit("Converter15" , "src", "test0008", "X.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(AST.JLS2, sourceUnit, true);
-		assertTrue("Not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT);
-		CompilationUnit compilationUnit = (CompilationUnit) result;
-		assertProblemsSize(compilationUnit, 0);
-		List imports = compilationUnit.imports();
-		assertEquals("Wrong size", 2, imports.size());
-		ImportDeclaration importDeclaration = (ImportDeclaration) imports.get(1);
-		assertTrue("Not malformed", isMalformed(importDeclaration));
-	}
-
 	public void test0009() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter15" , "src", "test0009", "X.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		ASTNode result = runConversion(getJLS4(), sourceUnit, true);
@@ -11287,30 +11274,6 @@ public class ASTConverter15JLS4Test extends ConverterTestSetup {
 		assertBindingKeyEquals(
 				"Lp/X$;",	// should not be Lp/X$~X$;
 			binding.getKey());
-	}
-	/*
-	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=339864
-	 */
-	public void test0349() throws JavaModelException {
-		String contents =
-			"import java.util.*;\n" +
-			"public class X {\n" +
-			"	public static Object foo() {\n" +
-			"		List<String> l = new ArrayList<>();\n" +
-			"		return l;\n" +
-			"	}\n" +
-			"}";
-		this.workingCopy = getWorkingCopy("/Converter15/src/X.java", true/*resolve*/);
-		CompilationUnit unit = (CompilationUnit) buildAST(
-			getJLS3(),
-			contents,
-			this.workingCopy,
-			false,
-			true,
-			true);
-		VariableDeclarationStatement statement = (VariableDeclarationStatement) getASTNode(unit, 0, 0, 0);
-		ClassInstanceCreation classInstanceCreation = (ClassInstanceCreation) ((VariableDeclarationFragment) statement.fragments().get(0)).getInitializer();
-		assertTrue("Should be malformed", isMalformed(classInstanceCreation.getType()));
 	}
 	/*
 	 * 3.7 maintenance - Fixed bug 348024: Empty AST for class with static inner class in a package with package-info.java

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter15JLS8Test.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter15JLS8Test.java
@@ -430,19 +430,6 @@ public class ASTConverter15JLS8Test extends ConverterTestSetup {
 		assertTrue("not static", importDeclaration.isStatic());
 	}
 
-	/** @deprecated using deprecated code */
-	public void test0008() throws JavaModelException {
-		ICompilationUnit sourceUnit = getCompilationUnit("Converter15" , "src", "test0008", "X.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(AST.JLS2, sourceUnit, true);
-		assertTrue("Not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT);
-		CompilationUnit compilationUnit = (CompilationUnit) result;
-		assertProblemsSize(compilationUnit, 0);
-		List imports = compilationUnit.imports();
-		assertEquals("Wrong size", 2, imports.size());
-		ImportDeclaration importDeclaration = (ImportDeclaration) imports.get(1);
-		assertTrue("Not malformed", isMalformed(importDeclaration));
-	}
-
 	public void test0009() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter15" , "src", "test0009", "X.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		ASTNode result = runConversion(getJLS8(), sourceUnit, true);
@@ -11284,30 +11271,6 @@ public class ASTConverter15JLS8Test extends ConverterTestSetup {
 		assertBindingKeyEquals(
 				"Lp/X$;",	// should not be Lp/X$~X$;
 			binding.getKey());
-	}
-	/*
-	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=339864
-	 */
-	public void test0349() throws JavaModelException {
-		String contents =
-			"import java.util.*;\n" +
-			"public class X {\n" +
-			"	public static Object foo() {\n" +
-			"		List<String> l = new ArrayList<>();\n" +
-			"		return l;\n" +
-			"	}\n" +
-			"}";
-		this.workingCopy = getWorkingCopy("/Converter15/src/X.java", true/*resolve*/);
-		CompilationUnit unit = (CompilationUnit) buildAST(
-			getJLS3(),
-			contents,
-			this.workingCopy,
-			false,
-			true,
-			true);
-		VariableDeclarationStatement statement = (VariableDeclarationStatement) getASTNode(unit, 0, 0, 0);
-		ClassInstanceCreation classInstanceCreation = (ClassInstanceCreation) ((VariableDeclarationFragment) statement.fragments().get(0)).getInitializer();
-		assertTrue("Should be malformed", isMalformed(classInstanceCreation.getType()));
 	}
 	/*
 	 * 3.7 maintenance - Fixed bug 348024: Empty AST for class with static inner class in a package with package-info.java

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter15Test.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter15Test.java
@@ -446,19 +446,6 @@ public class ASTConverter15Test extends ConverterTestSetup {
 		assertTrue("not static", importDeclaration.isStatic());
 	}
 
-	/** @deprecated using deprecated code */
-	public void test0008() throws JavaModelException {
-		ICompilationUnit sourceUnit = getCompilationUnit("Converter15" , "src", "test0008", "X.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(AST.JLS2, sourceUnit, true);
-		assertTrue("Not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT);
-		CompilationUnit compilationUnit = (CompilationUnit) result;
-		assertProblemsSize(compilationUnit, 0);
-		List imports = compilationUnit.imports();
-		assertEquals("Wrong size", 2, imports.size());
-		ImportDeclaration importDeclaration = (ImportDeclaration) imports.get(1);
-		assertTrue("Not malformed", isMalformed(importDeclaration));
-	}
-
 	public void test0009() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter15" , "src", "test0009", "X.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
@@ -11573,37 +11560,6 @@ public class ASTConverter15Test extends ConverterTestSetup {
 		}
 	}
 
-	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=404489
-	public void testBug404489() throws JavaModelException {
-		ICompilationUnit sourceUnit = getCompilationUnit("Converter18" , "src", "test404489.bug", "X.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(this.ast.apiLevel(), sourceUnit, true);
-		assertTrue("Not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT);
-		CompilationUnit compilationUnit = (CompilationUnit) result;
-		assertProblemsSize(compilationUnit, 0);
-		ASTNode node = getASTNode(compilationUnit, 0, 0, 0);
-		TypeDeclaration typeDeclaration =  (TypeDeclaration) compilationUnit.types().get(0);
-
-		node = (ASTNode) typeDeclaration.bodyDeclarations().get(2);
-		assertEquals("Not a method declaration", ASTNode.METHOD_DECLARATION, node.getNodeType());
-		MethodDeclaration methodDecl = (MethodDeclaration) node;
-		Type type = methodDecl.getReturnType2();
-		assertTrue(type.isQualifiedType());
-		assertTrue(isMalformed(type));
-
-		// parameter
-		SingleVariableDeclaration param = (SingleVariableDeclaration) methodDecl.parameters().get(0);
-		type = param.getType();
-		assertTrue(type.isQualifiedType());
-		assertTrue(isMalformed(type));
-
-		node = (ASTNode) typeDeclaration.bodyDeclarations().get(3);
-		assertEquals("Not a field declaration", ASTNode.FIELD_DECLARATION, node.getNodeType());
-		FieldDeclaration field = (FieldDeclaration) node;
-		type = field.getType();
-		assertTrue(type.isQualifiedType());
-		assertTrue(type.isQualifiedType());
-		assertTrue(isMalformed(type));
-	}
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=460422
 	public void testBug460422() throws JavaModelException {
 		String str =

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter18Test.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter18Test.java
@@ -1244,39 +1244,6 @@ public class ASTConverter18Test extends ConverterTestSetup {
 		ArrayInitializer initializer = creation.getInitializer();
 		checkSourceRange(initializer, "{{{1, 2, 3}}}", contents.toCharArray());
 	}
-	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=391894
-	// Force to use JLS4 and confirm malformed flags are set.
-	public void test0021() throws JavaModelException {
-		String contents =
-				"import java.lang.annotation.ElementType;\n" +
-				"public class X {\n" +
-				" 	public void foo() {\n" +
-				"		int @Marker [][][] i = new @Marker2 int @Marker @Marker2 [] @Marker2 @Marker3 [] @Marker3 @Marker [] {{{1, 2, 3}}}; \n" +
-				"	}\n" +
-				"}\n" +
-				"@java.lang.annotation.Target (ElementType.TYPE_USE)\n" +
-				"@interface Marker {}\n" +
-				"@java.lang.annotation.Target (ElementType.TYPE_USE)\n" +
-				"@interface Marker2 {}\n" +
-				"@java.lang.annotation.Target (ElementType.TYPE_USE)\n" +
-				"@interface Marker3 {}";
-		this.workingCopy = getWorkingCopy("/Converter18/src/X.java", true);
-		CompilationUnit unit = (CompilationUnit) buildAST(getJLS4(), contents, this.workingCopy, true, true, true);
-
-		ASTNode node = getASTNode(unit, 0, 0);
-		assertEquals("Not a Method Declaration", ASTNode.METHOD_DECLARATION, node.getNodeType());
-		MethodDeclaration method = (MethodDeclaration) node;
-		List list = method.getBody().statements();
-		assertEquals("Incorrect no of statements", 1, list.size());
-		VariableDeclarationStatement statement1 = (VariableDeclarationStatement) list.get(0);
-		list = statement1.fragments();
-		assertEquals("Incorrect no of fragments", 1, list.size());
-		VariableDeclarationFragment fragment = (VariableDeclarationFragment) list.get(0);
-		ArrayCreation creation = (ArrayCreation) fragment.getInitializer();
-		Type type = creation.getType();
-		assertEquals("Incorrect type", true, type.isArrayType());
-		assertEquals("Type should be malformed", ASTNode.MALFORMED, (type.getFlags() & ASTNode.MALFORMED));
-	}
 	/**
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=399768
 	 */


### PR DESCRIPTION
These tests use valid Java 8+ to create AST with older JLS level and check that it's malformed.
As JDT no longer supports pre 1.8 projects these takes are useless.
