### PR TITLE
Extension point to replace `CompletionEngine` implementation

### DIFF
--- a/org.eclipse.jdt.core.tests.model/plugin.xml
+++ b/org.eclipse.jdt.core.tests.model/plugin.xml
@@ -99,5 +99,11 @@
            id="org.eclipse.jdt.core.tests.model.resolver1">
      </resolver>
   </extension>
-	
+  
+  <extension point="org.eclipse.jdt.core.completionEngineProvider">
+    <resolver
+      class="org.eclipse.jdt.core.tests.model.TestCompletionEngineProvider"
+      id="org.eclipse.jdt.core.tests.model.TestCompletionEngineProvider" />
+  </extension>
+
 </plugin>

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionEngineProviderTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionEngineProviderTests.java
@@ -1,0 +1,91 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jdt.core.tests.model;
+
+import junit.framework.Test;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
+
+/**
+ * Test for the `org.eclipse.jdt.core.completionEngineProvider` extension point
+ * and {@link org.eclipse.jdt.internal.core.CompletionEngineProviderDiscovery}.
+ */
+@SuppressWarnings("javadoc")
+public class CompletionEngineProviderTests extends AbstractJavaModelCompletionTests {
+
+	private String oldSystemProperty;
+	private static final String ENGINE_PROPERTY = "ICompletionEngineProvider";
+
+	public CompletionEngineProviderTests(String name) {
+		super(name);
+	}
+
+	public static Test suite() {
+		return buildModelTestSuite(CompletionEngineProviderTests.class, ALPHABETICAL_SORT);
+	}
+
+	@Override
+	public void setUpSuite() throws Exception {
+		super.setUpSuite();
+		setupExternalJCL("jclMin");
+		if (COMPLETION_PROJECT == null)  {
+			COMPLETION_PROJECT = setUpJavaProject("Completion");
+		} else {
+			setUpProjectCompliance(COMPLETION_PROJECT, CompilerOptions.getFirstSupportedJavaVersion());
+		}
+		this.currentProject = COMPLETION_PROJECT;
+	}
+
+	@Override
+	protected void setUp() throws Exception {
+		super.setUp();
+		this.oldSystemProperty = System.getProperty(ENGINE_PROPERTY);
+		System.setProperty(ENGINE_PROPERTY, "org.eclipse.jdt.core.tests.model.TestCompletionEngineProvider");
+	}
+
+	@Override
+	protected void tearDown() throws Exception {
+		super.tearDown();
+		if (this.oldSystemProperty != null) {
+			System.setProperty(ENGINE_PROPERTY, this.oldSystemProperty);
+		} else {
+			System.clearProperty(ENGINE_PROPERTY);
+		}
+	}
+
+	public void testAlwaysProvidesSameResult() throws JavaModelException {
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy(
+			"/Completion/src/ArrayInitializer.java",
+			"public class ArrayInitializer {\n"+
+			"	int bar() {return 0;}\n"+
+			"	void foo(int[] i) {\n"+
+			"		i = new int[] {\n"+
+			"			bar()\n"+
+			"		};\n"+
+			"	}\n"+
+			"}\n");
+
+		CompletionTestsRequestor2 requestor = new CompletionTestsRequestor2();
+
+		String str = this.workingCopies[0].getSource();
+		String completeBehind = "bar(";
+		int cursorLocation = str.lastIndexOf(completeBehind) + completeBehind.length();
+		this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner);
+
+		// this result would not be returned in the default CompletionEngine
+		assertResults(
+				"test[FIELD_REF]{test, null, null, test, 100}",
+				requestor.getResults());
+	}
+
+}

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/RunCompletionModelTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/RunCompletionModelTests.java
@@ -55,6 +55,7 @@ public class RunCompletionModelTests extends junit.framework.TestCase {
 			COMPLETION_SUITES.add(SnippetCompletionContextTests.class);
 			COMPLETION_SUITES.add(SubstringCompletionTests.class);
 			COMPLETION_SUITES.add(SubwordCompletionTests.class);
+			COMPLETION_SUITES.add(CompletionEngineProviderTests.class);
 		}
 		COMPLETION_SUITES.add(JavadocTypeCompletionModelTest.class);
 		COMPLETION_SUITES.add(JavadocFieldCompletionModelTest.class);

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/TestCompletionEngineProvider.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/TestCompletionEngineProvider.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jdt.core.tests.model;
+
+import java.util.Map;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.CompletionProposal;
+import org.eclipse.jdt.core.CompletionRequestor;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.ITypeRoot;
+import org.eclipse.jdt.core.WorkingCopyOwner;
+import org.eclipse.jdt.internal.codeassist.ICompletionEngine;
+import org.eclipse.jdt.internal.codeassist.ICompletionEngineProvider;
+import org.eclipse.jdt.internal.compiler.env.ICompilationUnit;
+import org.eclipse.jdt.internal.core.SearchableEnvironment;
+
+/**
+ * Test implementation of ICompletionEngineProvider for {@link CompletionEngineProviderTests}.
+ */
+public class TestCompletionEngineProvider implements ICompletionEngineProvider {
+
+	private static final char[] COMPLETION_TEXT = "test".toCharArray();
+
+	@Override
+	public ICompletionEngine newCompletionEngine(SearchableEnvironment nameEnvironment, CompletionRequestor requestor,
+			Map<String, String> settings, IJavaProject javaProject, WorkingCopyOwner owner, IProgressMonitor monitor) {
+		return new TestCompletionEngine(requestor);
+	}
+
+	private static class TestCompletionEngine implements ICompletionEngine {
+
+		private CompletionRequestor requestor;
+
+		public TestCompletionEngine(CompletionRequestor requestor) {
+			this.requestor = requestor;
+		}
+
+		@Override
+		public void complete(ICompilationUnit sourceUnit, int completionPosition, int unused, ITypeRoot root) {
+			this.requestor.accept(createProposal(completionPosition));
+		}
+
+		private final CompletionProposal createProposal(int pos) {
+			CompletionProposal res = CompletionProposal.create(CompletionProposal.FIELD_REF, pos);
+			res.setCompletion(COMPLETION_TEXT);
+			res.setName(COMPLETION_TEXT);
+			res.setRelevance(100);
+			return res;
+		}
+
+	}
+
+}

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/CompletionEngine.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/CompletionEngine.java
@@ -97,7 +97,7 @@ import org.eclipse.jdt.internal.core.util.Util;
 @SuppressWarnings({ "rawtypes", "unchecked" })
 public final class CompletionEngine
 	extends Engine
-	implements ISearchRequestor, TypeConstants , TerminalTokens , RelevanceConstants, SuffixConstants {
+	implements ISearchRequestor, TypeConstants , TerminalTokens , RelevanceConstants, SuffixConstants, ICompletionEngine {
 
 	private static class AcceptedConstructor {
 		public int modifiers;
@@ -1950,8 +1950,13 @@ public final class CompletionEngine
 	 *  @param completionPosition int
 	 *      a position in the source where the completion is taking place.
 	 *      This position is relative to the source provided.
+	 *
+	 *  @param adjustment the amount to subtract from all positions in completion proposals passed to the requestor
+	 *
+	 *  @param root the type root of the compilation unit being completed
 	 */
-	public void complete(ICompilationUnit sourceUnit, int completionPosition, int pos, ITypeRoot root) {
+	@Override
+	public void complete(ICompilationUnit sourceUnit, int completionPosition, int adjustment, ITypeRoot root) {
 
 		if(DEBUG) {
 			trace("COMPLETION IN " + new String(sourceUnit.getFileName()) + " AT POSITION " + completionPosition);  //$NON-NLS-1$//$NON-NLS-2$
@@ -1963,7 +1968,7 @@ public final class CompletionEngine
 		try {
 			this.fileName = sourceUnit.getFileName();
 			this.actualCompletionPosition = completionPosition - 1;
-			this.offset = pos;
+			this.offset = adjustment;
 			this.typeRoot = root;
 			this.source = sourceUnit.getContents();
 

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/ICompletionEngine.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/ICompletionEngine.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jdt.internal.codeassist;
+
+import org.eclipse.jdt.core.ITypeRoot;
+import org.eclipse.jdt.internal.compiler.env.ICompilationUnit;
+
+/**
+ * Represents a class that can provide completion for a compilation unit.
+ */
+public interface ICompletionEngine {
+
+	/**
+	 * Provide completion items based on the given source unit and completion position to the configured requestor.
+	 *
+	 * @param sourceUnit the compilation unit for which completion was triggered
+	 * @param completionPosition the position that completion was triggered at
+	 * @param adjustment the amount to subtract from all positions in completion proposals passed to the requestor
+	 * @param root the type root for which completion was triggered
+	 */
+	public void complete(ICompilationUnit sourceUnit, int completionPosition, int adjustment, ITypeRoot root);
+
+}

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/ICompletionEngineProvider.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/ICompletionEngineProvider.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jdt.internal.codeassist;
+
+import java.util.Map;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jdt.core.CompletionRequestor;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.WorkingCopyOwner;
+import org.eclipse.jdt.internal.core.SearchableEnvironment;
+
+/**
+ * Describes a class that can build a completion engine.
+ */
+public interface ICompletionEngineProvider {
+
+	/**
+	 * Returns a new completion engine built with the given parameters.
+	 *
+	 * @param nameEnvironment the name environment
+	 * @param requestor the search requestor
+	 * @param settings the settings
+	 * @param javaProject the java project that  completion will be invoked under
+	 * @param owner the working copy owner of the
+	 * @param monitor the progress monitor
+	 * @return a completion engine built with the given parameters
+	 */
+	ICompletionEngine newCompletionEngine(
+			SearchableEnvironment nameEnvironment,
+			CompletionRequestor requestor,
+			Map<String, String> settings,
+			IJavaProject javaProject,
+			WorkingCopyOwner owner,
+			IProgressMonitor monitor);
+
+}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/CompletionEngineProviderDiscovery.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/CompletionEngineProviderDiscovery.java
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc. and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jdt.internal.core;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.IExtension;
+import org.eclipse.core.runtime.IExtensionPoint;
+import org.eclipse.core.runtime.ILog;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.internal.codeassist.CompletionEngine;
+import org.eclipse.jdt.internal.codeassist.ICompletionEngineProvider;
+
+class CompletionEngineProviderDiscovery {
+	private static final String SELECTED_SYSPROP = "ICompletionEngineProvider"; //$NON-NLS-1$
+	private static final String CODE_ASSIST_PROVIDER_EXTPOINT_ID = "completionEngineProvider" ; //$NON-NLS-1$
+	private static boolean ERROR_LOGGED = false;
+
+	private static String lastId;
+	private static IConfigurationElement lastExtension;
+
+	private static final Map<String, ICompletionEngineProvider> ENGINE_PROVIDER_CACHE = new HashMap<>();
+
+	public static ICompletionEngineProvider getInstance() {
+		String id = System.getProperty(SELECTED_SYSPROP);
+		IConfigurationElement configElement = getConfigurationElement(id);
+		lastId = id;
+		lastExtension = configElement;
+		if (configElement != null) {
+			try {
+				if (ENGINE_PROVIDER_CACHE.get(id) != null) {
+					return ENGINE_PROVIDER_CACHE.get(id);
+				}
+				Object executableExtension = configElement.createExecutableExtension("class"); //$NON-NLS-1$
+				if (executableExtension instanceof ICompletionEngineProvider icep) {
+					ENGINE_PROVIDER_CACHE.put(id, icep);
+					return icep;
+				}
+			} catch (CoreException e) {
+				if (!setErrorLogged()) {
+					ILog.get().error("Could not instantiate ICompletionEngineProvider: '" + id + "' with class: " + configElement.getAttribute("class"), e); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+				}
+			}
+		}
+		return CompletionEngine::new;
+	}
+
+	/**
+	 *
+	 * @param id
+	 * @return The extension element with the given id or <code>null</null> if not found
+	 */
+	private static IConfigurationElement getConfigurationElement(String id) {
+		if (id == null || id.isBlank()) {
+			return null;
+		}
+		if (lastExtension != null && Objects.equals(id, lastId)) {
+			return lastExtension;
+		}
+		IExtensionPoint extension = Platform.getExtensionRegistry().getExtensionPoint(JavaCore.PLUGIN_ID, CODE_ASSIST_PROVIDER_EXTPOINT_ID);
+		if (extension != null) {
+			IExtension[] extensions = extension.getExtensions();
+			for (IExtension ext : extensions) {
+				IConfigurationElement[] configElements = ext.getConfigurationElements();
+				for (final IConfigurationElement configElement : configElements) {
+					String elementId = configElement.getAttribute("id"); //$NON-NLS-1$
+					if (id.equals(elementId) && "resolver".equals(configElement.getName())) { //$NON-NLS-1$
+						return configElement;
+					}
+				}
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Set the ERROR_LOGGED field to <code>true</code>.
+	 * @return the previous value of ERROR_LOGGED.
+	 */
+	private static synchronized boolean setErrorLogged() {
+		boolean prev = ERROR_LOGGED;
+		ERROR_LOGGED = true;
+		return prev;
+	}
+}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/Openable.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/Openable.java
@@ -24,6 +24,8 @@ import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.PerformanceStats;
 import org.eclipse.jdt.core.*;
 import org.eclipse.jdt.internal.codeassist.CompletionEngine;
+import org.eclipse.jdt.internal.codeassist.ICompletionEngine;
+import org.eclipse.jdt.internal.codeassist.ICompletionEngineProvider;
 import org.eclipse.jdt.internal.codeassist.SelectionEngine;
 import org.eclipse.jdt.internal.compiler.env.IElementInfo;
 import org.eclipse.jdt.internal.core.util.Util;
@@ -132,8 +134,10 @@ protected void codeComplete(
 	environment.unitToSkip = unitToSkip;
 
 	// code complete
-	CompletionEngine engine = new CompletionEngine(environment, requestor, project.getOptions(true), project, owner, monitor);
-	engine.complete(cu, position, 0, typeRoot);
+	ICompletionEngineProvider completionEngineProvider = CompletionEngineProviderDiscovery.getInstance();
+	ICompletionEngine completionEngine = completionEngineProvider.newCompletionEngine(environment, requestor, project.getOptions(true), project, owner, monitor);
+	completionEngine.complete(cu, position, 0, typeRoot);
+
 	if(performanceStats != null) {
 		performanceStats.endRun();
 	}

--- a/org.eclipse.jdt.core/plugin.properties
+++ b/org.eclipse.jdt.core/plugin.properties
@@ -24,6 +24,7 @@ classpathContainerInitializersName=Classpath Container Initializers
 codeFormattersName=Source Code Formatters
 compilationParticipantsName=Compilation Participants
 compilationUnitResolverName=Compilation Unit Resolver
+completionEngineProviderName=Completion Engine Provider
 annotationProcessorManagerName=Java 6 Annotation Processor Manager
 javaTaskName=Java Task
 javaPropertiesName=Java Properties File

--- a/org.eclipse.jdt.core/plugin.xml
+++ b/org.eclipse.jdt.core/plugin.xml
@@ -70,6 +70,14 @@
 <extension-point name="%compilationUnitResolverName" 
 	id="compilationUnitResolver"
 	schema="schema/compilationUnitResolver.exsd"/>
+	
+<!-- =================================================================================== -->
+<!-- Extension Point: CompletionEngine Provider                                          -->
+<!-- =================================================================================== -->
+
+<extension-point name="%completionEngineProviderName"
+	id="completionEngineProvider"
+	schema="schema/completionEngineProvider.exsd"/>
 
 <!-- =================================================================================== -->
 <!-- Extension Point: Java 6 Annotation Processor Manager                                -->

--- a/org.eclipse.jdt.core/schema/completionEngineProvider.exsd
+++ b/org.eclipse.jdt.core/schema/completionEngineProvider.exsd
@@ -1,0 +1,121 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!-- Schema file written by PDE -->
+<schema targetNamespace="org.eclipse.jdt.core" xmlns="http://www.w3.org/2001/XMLSchema">
+<annotation>
+      <appInfo>
+         <meta.schema plugin="org.eclipse.jdt.core" id="completionEngineProvider" name="Completion Engine Provider"/>
+      </appInfo>
+      <documentation>
+         This extension point provides the ability to replace the completion engine used for all `Openable`s. The resolver will be instantiated on-demand based on the value of the system property `ICompletionEngineProvider`, which must be set to the id of an implementing extension. This extension point is not intended to be implemented by clients. This extension point is not considered API. This extension point may be modified or removed at any moment.
+      </documentation>
+   </annotation>
+
+   <element name="extension">
+      <annotation>
+         <appInfo>
+            <meta.element />
+         </appInfo>
+      </annotation>
+      <complexType>
+         <sequence>
+            <element ref="resolver" minOccurs="0" maxOccurs="1"/>
+         </sequence>
+         <attribute name="point" type="string" use="required">
+            <annotation>
+               <documentation>
+
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="id" type="string">
+            <annotation>
+               <documentation>
+
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="name" type="string">
+            <annotation>
+               <documentation>
+
+               </documentation>
+               <appInfo>
+                  <meta.attribute translatable="true"/>
+               </appInfo>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <element name="resolver">
+      <annotation>
+         <documentation>
+            Definition of a completion provider.
+         </documentation>
+      </annotation>
+      <complexType>
+         <attribute name="class" type="string" use="required">
+            <annotation>
+               <documentation>
+                  The class that implements this completion engine provider. This class must implement the  &lt;code&gt;org.eclipse.jdt.internal.core.dom.ICompletionEngineProvider&lt;/code&gt; interface with a public 0-arg constructor.
+               </documentation>
+               <appInfo>
+                  <meta.attribute kind="java" basedOn=":org.eclipse.jdt.internal.codeassist.ICompletionEngineProvider"/>
+               </appInfo>
+            </annotation>
+         </attribute>
+         <attribute name="id" type="string" use="required">
+            <annotation>
+               <documentation>
+                  A unique identifier for this resolver.
+               </documentation>
+            </annotation>
+         </attribute>
+      </complexType>
+   </element>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="since"/>
+      </appInfo>
+      <documentation>
+         3.38
+      </documentation>
+   </annotation>
+
+   <annotation>
+      <appInfo>
+         <meta.section type="examples"/>
+      </appInfo>
+      <documentation>
+         Example of a declaration of a &lt;code&gt;completionEngineProvider&lt;/code&gt;:  &lt;pre&gt;
+&lt;extension
+      point=&quot;org.eclipse.jdt.core.completionEngineProvider&quot;&gt;
+   &lt;resolver
+         class=&quot;org.eclipse.jdt.core.MyCompletionEngineProvider&quot;
+         id=&quot;org.eclipse.jdt.core.MyCompletionEngineProvider&quot;&gt;
+   &lt;/resolver&gt;
+&lt;/extension&gt;
+&lt;/pre&gt;
+      </documentation>
+   </annotation>
+
+
+
+   <annotation>
+      <appInfo>
+         <meta.section type="copyright"/>
+      </appInfo>
+      <documentation>
+         Copyright (c) 2025 Red Hat, Inc. and others.&lt;br&gt;
+
+This program and the accompanying materials
+are made available under the terms of the Eclipse Public License 2.0
+which accompanies this distribution, and is available at 
+&lt;a href=&quot;https://www.eclipse.org/legal/epl-2.0&quot;&gt;https://www.eclipse.org/legal/epl-v20.html&lt;/a&gt;/
+
+SPDX-License-Identifier: EPL-2.0
+      </documentation>
+   </annotation>
+
+</schema>


### PR DESCRIPTION
## What it does
This PR allows plugins to replace the implementation of `CompletionEngine` used in `Openable`. This covers most completion cases.

In order to accomplish this, this PR introduces the extension point `completionEngineProvider`, which allows plugins to specify an implementation of `ICompletionEngineProvider`. `ICompletionEngineProvider` consists of a method with the same parameters as the `CompletionEngine` constructor that returns an `ICompletionEngine`.
`ICompletionEngine` consists of one method that is identical to the existing method `CompletionEngine.complete(ICompilationUnit sourceUnit, int completionPosition, int pos, ITypeRoot root)`.

In order to configure a new `ICompletionEngineProvider`, register the class in `plugin.xml` using the newly introduced extension point. Also, set the Java argument `ICompletionEngineProvider` to the implementation, eg. `-DICompletionEngineProvider=dev.datho7561.completion.MyCompletionEngineProvider`.

## How to test
I've added a regression test in which I configure a simple test implementation of `ICompletionEngineProvider` that provides an `ICompletionEngine` that always returns the same result. I make sure the result is the one provided by the test implementation, instead of the one returned by the default `CompletionEngine`.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
