### PR TITLE
Modify AST rewrite/sort tests to run against JLS8

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/SortCompilationUnitElementsTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/SortCompilationUnitElementsTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -23,9 +23,11 @@ import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.AbstractTextElement;
 import org.eclipse.jdt.core.dom.BodyDeclaration;
 import org.eclipse.jdt.core.dom.EnumConstantDeclaration;
 import org.eclipse.jdt.core.dom.Javadoc;
+import org.eclipse.jdt.core.dom.TagElement;
 import org.eclipse.jdt.core.util.CompilationUnitSorter;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jface.text.BadLocationException;
@@ -53,30 +55,21 @@ public void setUpSuite() throws Exception {
 	this.createJavaProject("P", new String[] {"src"}, new String[] {getExternalJCLPathString(compliance)}, "bin", compliance); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 	this.createFolder("/P/src/p"); //$NON-NLS-1$
 }
-/** @deprecated */
+
+@SuppressWarnings("deprecation")
 private void sortUnit(ICompilationUnit unit, String expectedResult) throws CoreException {
-	this.sortUnit(AST.JLS2, unit, expectedResult, true);
+	this.sortUnit(AST.JLS8, unit, expectedResult, true);
 }
 
-private void sortUnit(int apiLevel, ICompilationUnit unit, String expectedResult) throws CoreException {
-	this.sortUnit(apiLevel, unit, expectedResult, true);
-}
-/** @deprecated */
+@SuppressWarnings("deprecation")
 private void sortUnit(ICompilationUnit unit, String expectedResult, boolean testPositions) throws CoreException {
-	this.sortUnit(AST.JLS2, unit, expectedResult, testPositions);
+	this.sortUnit(AST.JLS8, unit, expectedResult, testPositions);
 }
 private void sortUnit(int apiLevel, ICompilationUnit unit, String expectedResult, boolean testPositions) throws CoreException {
 	this.sortUnit(apiLevel, unit, expectedResult, testPositions, new DefaultJavaElementComparator(1,2,3,4,5,6,7,8,9));
 }
 
-/**
- * Internal synonym for deprecated constant AST.JSL3
- * to alleviate deprecation warnings.
- * @deprecated
- */
-/*package*/ static final int JLS3_INTERNAL = AST.JLS3;
-
-/** @deprecated */
+@SuppressWarnings("deprecation")
 private void oldAPISortUnit(ICompilationUnit unit, String expectedResult, boolean testPositions, Comparator comparator) throws CoreException {
 	String initialSource = unit.getSource();
 	int[] positions = null;
@@ -1236,7 +1229,7 @@ public void test019() throws CoreException {
 			"public enum X {\n" +
 			"	A, B, C, Z;\n" +
 			"}";
-		sortUnit(JLS3_INTERNAL, this.getCompilationUnit("/P/src/X.java"), expectedResult);
+		sortUnit(this.getCompilationUnit("/P/src/X.java"), expectedResult);
 	} finally {
 		deleteFile("/P/src/X.java");
 	}
@@ -1266,7 +1259,7 @@ public void test020() throws CoreException {
 			"		\n" +
 			"	}\n" +
 			"}";
-		sortUnit(JLS3_INTERNAL, this.getCompilationUnit("/P/src/X.java"), expectedResult);
+		sortUnit(this.getCompilationUnit("/P/src/X.java"), expectedResult);
 	} finally {
 		deleteFile("/P/src/X.java");
 	}
@@ -1312,7 +1305,7 @@ public void test021() throws CoreException {
 			"	\n" +
 			"	public void method2() { }\n" +
 			"}";
-		sortUnit(JLS3_INTERNAL, this.getCompilationUnit("/P/src/X.java"), expectedResult);
+		sortUnit(this.getCompilationUnit("/P/src/X.java"), expectedResult);
 	} finally {
 		deleteFile("/P/src/X.java");
 	}
@@ -1684,7 +1677,7 @@ public void test023() throws CoreException {
 			"	int id() default 0;\n" +
 			"	String name();\n" +
 			"}";
-		sortUnit(JLS3_INTERNAL, this.getCompilationUnit("/P/src/X.java"), expectedResult);
+		sortUnit(this.getCompilationUnit("/P/src/X.java"), expectedResult);
 	} finally {
 		deleteFile("/P/src/X.java");
 	}
@@ -1718,7 +1711,7 @@ public void test024() throws CoreException {
 			"		}\n" +
 			"	}\n" +
 			"}";
-		sortUnit(JLS3_INTERNAL, this.getCompilationUnit("/P/src/X.java"), expectedResult);
+		sortUnit( this.getCompilationUnit("/P/src/X.java"), expectedResult);
 	} finally {
 		deleteFile("/P/src/X.java");
 	}
@@ -1770,7 +1763,7 @@ public void test025() throws CoreException {
 			"		return null;\n" +
 			"	}\n" +
 			"}";
-		sortUnit(JLS3_INTERNAL, this.getCompilationUnit("/P/src/X.java"), expectedResult);
+		sortUnit(this.getCompilationUnit("/P/src/X.java"), expectedResult);
 	} finally {
 		deleteFile("/P/src/X.java");
 	}
@@ -1856,7 +1849,6 @@ public void test027() throws CoreException {
 	}
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=101453
-/** @deprecated */
 public void test028() throws CoreException {
 	try {
 		this.createFile(
@@ -1885,7 +1877,9 @@ public void test028() throws CoreException {
 				Javadoc javadoc1 = bodyDeclaration1.getJavadoc();
 				Javadoc javadoc2 = bodyDeclaration2.getJavadoc();
 				if (javadoc1 != null && javadoc2 != null) {
-					return javadoc1.getComment().compareTo(javadoc2.getComment());
+				    var comment1 = ((AbstractTextElement)((TagElement)javadoc1.tags().get(0)).fragments().get(0)).getText();
+                    var comment2 = ((AbstractTextElement)((TagElement)javadoc2.tags().get(0)).fragments().get(0)).getText();
+                    return comment1.compareTo(comment2);
 				}
 				final int sourceStart1 = ((Integer) bodyDeclaration1.getProperty(CompilationUnitSorter.RELATIVE_ORDER)).intValue();
 				final int sourceStart2 = ((Integer) bodyDeclaration2.getProperty(CompilationUnitSorter.RELATIVE_ORDER)).intValue();
@@ -1897,6 +1891,7 @@ public void test028() throws CoreException {
 	}
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=101885
+@SuppressWarnings("deprecation")
 public void test029() throws CoreException {
 	try {
 		this.createFile(
@@ -1909,7 +1904,7 @@ public void test029() throws CoreException {
 			"public enum X {\n" +
 			"	Z, A, C, B;\n" +
 			"}";
-		sortUnit(JLS3_INTERNAL, this.getCompilationUnit("/P/src/X.java"), expectedResult, false, new Comparator() {
+		sortUnit(AST.JLS8, this.getCompilationUnit("/P/src/X.java"), expectedResult, false, new Comparator() {
 			@Override
 			public int compare(Object o1, Object o2) {
 				BodyDeclaration bodyDeclaration1 = (BodyDeclaration) o1;
@@ -1974,7 +1969,7 @@ public void test030() throws CoreException {
 			"	public <K> I<K<K,T> bar3(C<T,K> c);\n" +
 			"	public <K,E> I<K<K,E> bar3(C<T,K> c, C<T,E> c2);\n" +
 			"}";
-		sortUnit(JLS3_INTERNAL, this.getCompilationUnit("/P/src/I.java"), expectedResult);
+		sortUnit(this.getCompilationUnit("/P/src/I.java"), expectedResult);
 	} finally {
 		deleteFile("/P/src/I.java");
 	}
@@ -2004,7 +1999,7 @@ public void test031() throws CoreException {
 			"	public <S> I<S> foo3(C<T,I<S>> c);\n" +
 			"	public I<T> foo(A<T> A);\n" +
 			"}";
-		sortUnit(JLS3_INTERNAL, this.getCompilationUnit("/P/src/I.java"), expectedResult);
+		sortUnit(this.getCompilationUnit("/P/src/I.java"), expectedResult);
 	} finally {
 		deleteFile("/P/src/I.java");
 	}
@@ -2026,7 +2021,7 @@ public void test032() throws CoreException {
 			"	<K> List<Map<K,T> foo(Map<T,K> m);\n" +
 			"	<K,E> List<Map<K,E> bar(Map<T,K> m, Map<T,E> e);\n" +
 			"}";
-		sortUnit(JLS3_INTERNAL, this.getCompilationUnit("/P/src/X.java"), expectedResult);
+		sortUnit(this.getCompilationUnit("/P/src/X.java"), expectedResult);
 	} finally {
 		deleteFile("/P/src/X.java");
 	}
@@ -2051,7 +2046,8 @@ public void test033() throws CoreException {
 		String source = unit.getSource();
 		Document document = new Document(source);
 		CompilerOptions options = new CompilerOptions(unit.getJavaProject().getOptions(true));
-		ASTParser parser = ASTParser.newParser(JLS3_INTERNAL);
+		@SuppressWarnings("deprecation")
+        ASTParser parser = ASTParser.newParser(AST.JLS8);
 		parser.setCompilerOptions(options.getMap());
 		parser.setSource(unit);
 		parser.setKind(ASTParser.K_COMPILATION_UNIT);
@@ -2103,7 +2099,8 @@ public void test034() throws CoreException {
 		unit = this.getCompilationUnit("/P/src/X.java");
 		unit.becomeWorkingCopy(null);
 		CompilerOptions options = new CompilerOptions(unit.getJavaProject().getOptions(true));
-		ASTParser parser = ASTParser.newParser(JLS3_INTERNAL);
+		@SuppressWarnings("deprecation")
+        ASTParser parser = ASTParser.newParser(AST.JLS8);
 		parser.setCompilerOptions(options.getMap());
 		parser.setSource(unit);
 		parser.setKind(ASTParser.K_COMPILATION_UNIT);

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/rewrite/modifying/ASTRewritingModifyingCopyTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/rewrite/modifying/ASTRewritingModifyingCopyTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -141,7 +141,6 @@ public class ASTRewritingModifyingCopyTest extends ASTRewritingModifyingTest {
 		assertEqualString(preview, buf.toString());
 	}
 
-	/** @deprecated using deprecated code */
 	public void test0003() throws Exception {
 		IPackageFragment pack1= this.sourceFolder.createPackageFragment("test0003", false, null);
 		StringBuilder buf= new StringBuilder();
@@ -166,9 +165,9 @@ public class ASTRewritingModifyingCopyTest extends ASTRewritingModifyingTest {
 		List types = astRoot.types();
 		TypeDeclaration typeDeclaration1 = (TypeDeclaration)types.get(0);
 		TypeDeclaration typeDeclaration2 = (TypeDeclaration)types.get(1);
-		Name name = typeDeclaration1.getSuperclass();
-		Name name2 = (Name)ASTNode.copySubtree(a, name);
-		typeDeclaration2.setSuperclass(name2);
+		Type name = typeDeclaration1.getSuperclassType();
+		Type name2 = (Type)ASTNode.copySubtree(a, name);
+		typeDeclaration2.setSuperclassType(name2);
 
 		String preview = evaluateRewrite(cu, astRoot);
 
@@ -188,7 +187,6 @@ public class ASTRewritingModifyingCopyTest extends ASTRewritingModifyingTest {
 		assertEqualString(preview, buf.toString());
 	}
 
-	/** @deprecated using deprecated code */
 	public void test0004() throws Exception {
 		IPackageFragment pack1= this.sourceFolder.createPackageFragment("test0004", false, null);
 		StringBuilder buf= new StringBuilder();
@@ -213,11 +211,11 @@ public class ASTRewritingModifyingCopyTest extends ASTRewritingModifyingTest {
 		List types = astRoot.types();
 		TypeDeclaration typeDeclaration1 = (TypeDeclaration)types.get(0);
 		TypeDeclaration typeDeclaration2 = (TypeDeclaration)types.get(1);
-		Name name = typeDeclaration1.getSuperclass();
-		QualifiedName name2 = (QualifiedName)ASTNode.copySubtree(a, name);
-		Name name3 = name2.getQualifier();
-		name2.setQualifier(a.newSimpleName("A"));
-		typeDeclaration2.setSuperclass(name3);
+		Type type = typeDeclaration1.getSuperclassType();
+		SimpleType type2 = (SimpleType)ASTNode.copySubtree(a, type);
+		QualifiedName name3 = (QualifiedName)((QualifiedName)type2.getName()).getQualifier();
+		((QualifiedName)type2.getName()).setQualifier(a.newSimpleName("A"));
+		typeDeclaration2.setSuperclassType(a.newSimpleType(name3));
 
 		String preview = evaluateRewrite(cu, astRoot);
 
@@ -236,7 +234,6 @@ public class ASTRewritingModifyingCopyTest extends ASTRewritingModifyingTest {
 		assertEqualString(Util.convertToIndependantLineDelimiter(preview), Util.convertToIndependantLineDelimiter(buf.toString()));
 	}
 
-	/** @deprecated using deprecated code */
 	public void test0005() throws Exception {
 		IPackageFragment pack1= this.sourceFolder.createPackageFragment("test0005", false, null);
 		StringBuilder buf= new StringBuilder();
@@ -261,12 +258,12 @@ public class ASTRewritingModifyingCopyTest extends ASTRewritingModifyingTest {
 		List types = astRoot.types();
 		TypeDeclaration typeDeclaration1 = (TypeDeclaration)types.get(0);
 		TypeDeclaration typeDeclaration2 = (TypeDeclaration)types.get(1);
-		Name name = typeDeclaration1.getSuperclass();
-		QualifiedName name2 = (QualifiedName)ASTNode.copySubtree(a, name);
-		QualifiedName name3 = (QualifiedName)name2.getQualifier();
-		name2.setQualifier(a.newSimpleName("A"));
+		Type name = typeDeclaration1.getSuperclassType();
+		SimpleType name2 = (SimpleType)ASTNode.copySubtree(a, name);
+		QualifiedName name3 = (QualifiedName) ((QualifiedName)name2.getName()).getQualifier();
+		((QualifiedName)name2.getName()).setQualifier(a.newSimpleName("A"));
 		name3.getName().setIdentifier("B");
-		typeDeclaration2.setSuperclass(name3);
+		typeDeclaration2.setSuperclassType(a.newSimpleType(name3));
 
 		String preview = evaluateRewrite(cu, astRoot);
 
@@ -338,7 +335,6 @@ public class ASTRewritingModifyingCopyTest extends ASTRewritingModifyingTest {
 	}
 
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=93208
-	/** @deprecated using deprecated code */
 	public void test0007() throws Exception {
 		IPackageFragment pack1= this.sourceFolder.createPackageFragment("test", false, null);
 		StringBuilder buf= new StringBuilder();
@@ -357,7 +353,7 @@ public class ASTRewritingModifyingCopyTest extends ASTRewritingModifyingTest {
 
 		Block block = ast.newBlock();
 		m.setName(ast.newSimpleName("foo"));
-		m.setReturnType(ast.newPrimitiveType(PrimitiveType.VOID));
+		m.setReturnType2(ast.newPrimitiveType(PrimitiveType.VOID));
 		m.setBody(block);
 
 		FieldAccess fa = ast.newFieldAccess();
@@ -413,7 +409,8 @@ public class ASTRewritingModifyingCopyTest extends ASTRewritingModifyingTest {
 				"}");
 		ICompilationUnit cu = pack1.createCompilationUnit("Test.java", buf.toString(), false, null);
 
-		ASTParser astParser = ASTParser.newParser(getJLS3());
+		@SuppressWarnings("deprecation")
+        ASTParser astParser = ASTParser.newParser(AST.JLS8);
 		astParser.setSource(cu);
 		ASTNode root = astParser.createAST(new NullProgressMonitor());
 		AST ast = root.getAST();
@@ -523,7 +520,8 @@ public class ASTRewritingModifyingCopyTest extends ASTRewritingModifyingTest {
 		buf.append("}\n");
 		ICompilationUnit cu= pack1.createCompilationUnit("X.java", buf.toString(), false, null);
 
-		ASTParser astParser = ASTParser.newParser(getJLS3());
+		@SuppressWarnings("deprecation")
+        ASTParser astParser = ASTParser.newParser(AST.JLS8);
 		astParser.setSource(cu);
 		CompilationUnit compilationUnit = (CompilationUnit) astParser.createAST(new NullProgressMonitor());
 		AST ast = compilationUnit.getAST();

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/rewrite/modifying/ASTRewritingModifyingInsertTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/rewrite/modifying/ASTRewritingModifyingInsertTest.java
@@ -461,7 +461,7 @@ public class ASTRewritingModifyingInsertTest extends ASTRewritingModifyingTest {
 		astRoot.setPackage(packageDeclaration);
 		TypeDeclaration typeDeclaration =  a.newTypeDeclaration();
 		typeDeclaration.setName(a.newSimpleName("X"));
-		typeDeclaration.setModifiers(Modifier.PUBLIC);
+		typeDeclaration.modifiers().addAll(a.newModifiers(Modifier.PUBLIC));
 
 		astRoot.types().add(typeDeclaration);
 
@@ -505,7 +505,7 @@ public class ASTRewritingModifyingInsertTest extends ASTRewritingModifyingTest {
 
 		TypeDeclaration typeDeclaration =  a.newTypeDeclaration();
 		typeDeclaration.setName(a.newSimpleName("X"));
-		typeDeclaration.setModifiers(Modifier.PUBLIC);
+		typeDeclaration.modifiers().addAll(a.newModifiers(Modifier.PUBLIC));
 
 		astRoot.types().add(typeDeclaration);
 
@@ -530,7 +530,7 @@ public class ASTRewritingModifyingInsertTest extends ASTRewritingModifyingTest {
 		buf.append("}\n");
 		ICompilationUnit cu= pack1.createCompilationUnit("X.java", buf.toString(), false, null);
 
-		CompilationUnit astRoot= createCU(cu, false, getJLS3());
+		CompilationUnit astRoot= createCU(cu, false);
 
 		astRoot.recordModifications();
 
@@ -566,7 +566,7 @@ public class ASTRewritingModifyingInsertTest extends ASTRewritingModifyingTest {
 		buf.append("}\n");
 		ICompilationUnit cu= pack1.createCompilationUnit("X.java", buf.toString(), false, null);
 
-		CompilationUnit astRoot= createCU(cu, false, getJLS3());
+		CompilationUnit astRoot= createCU(cu, false);
 
 		astRoot.recordModifications();
 
@@ -602,7 +602,7 @@ public class ASTRewritingModifyingInsertTest extends ASTRewritingModifyingTest {
 		buf.append("}\n");
 		ICompilationUnit cu= pack1.createCompilationUnit("X.java", buf.toString(), false, null);
 
-		CompilationUnit astRoot= createCU(cu, false, getJLS3());
+		CompilationUnit astRoot= createCU(cu, false);
 
 		astRoot.recordModifications();
 
@@ -635,7 +635,7 @@ public class ASTRewritingModifyingInsertTest extends ASTRewritingModifyingTest {
 		buf.append("package test0016;\n");
 		ICompilationUnit cu= pack1.createCompilationUnit("package-info.java", buf.toString(), false, null);
 
-		CompilationUnit astRoot= createCU(cu, false, getJLS3());
+		CompilationUnit astRoot= createCU(cu, false);
 
 		astRoot.recordModifications();
 

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/rewrite/modifying/ASTRewritingModifyingMoveTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/rewrite/modifying/ASTRewritingModifyingMoveTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -21,8 +21,8 @@ import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.Block;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.MethodDeclaration;
-import org.eclipse.jdt.core.dom.Name;
 import org.eclipse.jdt.core.dom.Statement;
+import org.eclipse.jdt.core.dom.Type;
 import org.eclipse.jdt.core.dom.TypeDeclaration;
 
 @SuppressWarnings({"rawtypes", "unchecked"})
@@ -346,7 +346,6 @@ public class ASTRewritingModifyingMoveTest extends ASTRewritingModifyingTest {
 		assertEqualString(preview, buf.toString());
 	}
 
-	/** @deprecated using deprecated code */
 	public void test0008() throws Exception {
 		IPackageFragment pack1= this.sourceFolder.createPackageFragment("test0008", false, null);
 		StringBuilder buf= new StringBuilder();
@@ -369,9 +368,9 @@ public class ASTRewritingModifyingMoveTest extends ASTRewritingModifyingTest {
 		List types = astRoot.types();
 		TypeDeclaration typeDeclaration1 = (TypeDeclaration)types.get(0);
 		TypeDeclaration typeDeclaration2 = (TypeDeclaration)types.get(1);
-		Name name = typeDeclaration1.getSuperclass();
-		typeDeclaration1.setSuperclass(null);
-		typeDeclaration2.setSuperclass(name);
+		Type name = typeDeclaration1.getSuperclassType();
+		typeDeclaration1.setSuperclassType(null);
+		typeDeclaration2.setSuperclassType(name);
 
 		String preview = evaluateRewrite(cu, astRoot);
 

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/rewrite/modifying/ASTRewritingModifyingOtherTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/rewrite/modifying/ASTRewritingModifyingOtherTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -200,7 +200,7 @@ public class ASTRewritingModifyingOtherTest extends ASTRewritingModifyingTest {
 		buf.append("@A(X.class) public class C {}");
 		ICompilationUnit cu= pack1.createCompilationUnit("C.java", buf.toString(), false, null);
 
-		CompilationUnit astRoot= createCU(cu, true, getJLS3());
+		CompilationUnit astRoot= createCU(cu, true);
 		astRoot.recordModifications();
 		{
 			// change to interface
@@ -226,7 +226,7 @@ public class ASTRewritingModifyingOtherTest extends ASTRewritingModifyingTest {
 		buf.append("public @A(X.class) class C {}");
 		ICompilationUnit cu= pack1.createCompilationUnit("C.java", buf.toString(), false, null);
 
-		CompilationUnit astRoot= createCU(cu, true, getJLS3());
+		CompilationUnit astRoot= createCU(cu, true);
 		astRoot.recordModifications();
 		{
 			// change to interface

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/rewrite/modifying/ASTRewritingModifyingReplaceTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/rewrite/modifying/ASTRewritingModifyingReplaceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -248,7 +248,7 @@ public class ASTRewritingModifyingReplaceTest extends ASTRewritingModifyingTest 
 
 		ICompilationUnit cu= pack1.createCompilationUnit("X.java", buf.toString(), false, null);
 
-		CompilationUnit astRoot= createCU(cu, false, getJLS3());
+		CompilationUnit astRoot= createCU(cu, false);
 
 		astRoot.recordModifications();
 
@@ -280,7 +280,7 @@ public class ASTRewritingModifyingReplaceTest extends ASTRewritingModifyingTest 
 
 		ICompilationUnit cu= pack1.createCompilationUnit("X.java", buf.toString(), false, null);
 
-		CompilationUnit astRoot= createCU(cu, false, getJLS3());
+		CompilationUnit astRoot= createCU(cu, false);
 
 		astRoot.recordModifications();
 
@@ -312,7 +312,7 @@ public class ASTRewritingModifyingReplaceTest extends ASTRewritingModifyingTest 
 
 		ICompilationUnit cu= pack1.createCompilationUnit("X.java", buf.toString(), false, null);
 
-		CompilationUnit astRoot= createCU(cu, false, getJLS3());
+		CompilationUnit astRoot= createCU(cu, false);
 
 		astRoot.recordModifications();
 
@@ -344,7 +344,7 @@ public class ASTRewritingModifyingReplaceTest extends ASTRewritingModifyingTest 
 
 		ICompilationUnit cu= pack1.createCompilationUnit("X.java", buf.toString(), false, null);
 
-		CompilationUnit astRoot= createCU(cu, false, getJLS3());
+		CompilationUnit astRoot= createCU(cu, false);
 
 		astRoot.recordModifications();
 
@@ -377,7 +377,7 @@ public class ASTRewritingModifyingReplaceTest extends ASTRewritingModifyingTest 
 
 		ICompilationUnit cu= pack1.createCompilationUnit("X.java", buf.toString(), false, null);
 
-		CompilationUnit astRoot= createCU(cu, false, getJLS3());
+		CompilationUnit astRoot= createCU(cu, false);
 
 		astRoot.recordModifications();
 
@@ -410,7 +410,7 @@ public class ASTRewritingModifyingReplaceTest extends ASTRewritingModifyingTest 
 
 		ICompilationUnit cu= pack1.createCompilationUnit("X.java", buf.toString(), false, null);
 
-		CompilationUnit astRoot= createCU(cu, false, getJLS3());
+		CompilationUnit astRoot= createCU(cu, false);
 
 		astRoot.recordModifications();
 
@@ -443,7 +443,7 @@ public class ASTRewritingModifyingReplaceTest extends ASTRewritingModifyingTest 
 
 		ICompilationUnit cu= pack1.createCompilationUnit("X.java", buf.toString(), false, null);
 
-		CompilationUnit astRoot= createCU(cu, false, getJLS3());
+		CompilationUnit astRoot= createCU(cu, false);
 
 		astRoot.recordModifications();
 

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/rewrite/modifying/ASTRewritingModifyingTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/rewrite/modifying/ASTRewritingModifyingTest.java
@@ -40,16 +40,6 @@ import org.eclipse.text.edits.TextEdit;
 @SuppressWarnings({"rawtypes", "unchecked"})
 public abstract class ASTRewritingModifyingTest extends AbstractJavaModelTests {
 
-	/** @deprecated using deprecated code */
-	private static final int AST_INTERNAL_JLS2 = AST.JLS2;
-
-	/**
-	 * Internal synonym for deprecated constant AST.JSL3
-	 * to alleviate deprecation warnings.
-	 * @deprecated
-	 */
-	/*package*/ static final int JLS3_INTERNAL = AST.JLS3;
-
 	protected IJavaProject javaProject;
 	protected IPackageFragmentRoot sourceFolder;
 
@@ -122,17 +112,19 @@ public abstract class ASTRewritingModifyingTest extends AbstractJavaModelTests {
 		}
 	}
 
-	public CompilationUnit createCU(
+	@SuppressWarnings("deprecation")
+    public CompilationUnit createCU(
 			ICompilationUnit unit,
 			boolean resolveBindings) {
-		return createCU(unit, resolveBindings, AST_INTERNAL_JLS2);
+		return createCU(unit, resolveBindings, AST.JLS8);
 	}
 
 	public CompilationUnit createCU(char[] source) {
 		if (source == null) {
 			throw new IllegalArgumentException();
 		}
-		ASTParser c = ASTParser.newParser(AST_INTERNAL_JLS2);
+		@SuppressWarnings("deprecation")
+        ASTParser c = ASTParser.newParser(AST.JLS8);
 		c.setSource(source);
 		ASTNode result = c.createAST(null);
 		return (CompilationUnit) result;
@@ -238,7 +230,4 @@ public abstract class ASTRewritingModifyingTest extends AbstractJavaModelTests {
 		return buffer.toString();
 	}
 
-	static int getJLS3() {
-		return JLS3_INTERNAL;
-	}
 }


### PR DESCRIPTION
Now that ECJ doesn't support pre 1.8 and JDT doesn't provide a way to use older versions these tests have to run against a JLS that could be used.

