### PR TITLE
Migrate tests from getTypeDeclaration to getDeclaration

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterTest.java
@@ -3732,7 +3732,6 @@ public class ASTConverterTest extends ConverterTestSetup {
 
 	/**
 	 * Test binding for local type declaration
-	 * @deprecated using deprecated code
 	 */
 	public void test0165() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0165", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
@@ -3741,7 +3740,7 @@ public class ASTConverterTest extends ConverterTestSetup {
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		assertTrue("Not an type declaration", node instanceof TypeDeclarationStatement); //$NON-NLS-1$
 		TypeDeclarationStatement statement = (TypeDeclarationStatement) node;
-		TypeDeclaration typeDeclaration = statement.getTypeDeclaration();
+		TypeDeclaration typeDeclaration = (TypeDeclaration) statement.getDeclaration();
 		ITypeBinding typeBinding = typeDeclaration.resolveBinding();
 		assertNotNull("No binding", typeBinding); //$NON-NLS-1$
 		assertTrue("An anonymous class", !typeBinding.isAnonymous()); //$NON-NLS-1$
@@ -4791,7 +4790,6 @@ public class ASTConverterTest extends ConverterTestSetup {
 
 	/**
 	 * Local class end position when trailing comment
-	 * @deprecated using deprecated code
 	 */
 	public void test0205() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0205", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
@@ -4800,7 +4798,7 @@ public class ASTConverterTest extends ConverterTestSetup {
 		ASTNode node2 = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertTrue("TypeDeclarationStatement", node2 instanceof TypeDeclarationStatement); //$NON-NLS-1$
 		TypeDeclarationStatement typeDeclarationStatement = (TypeDeclarationStatement) node2;
-		TypeDeclaration typeDeclaration = typeDeclarationStatement.getTypeDeclaration();
+		TypeDeclaration typeDeclaration = (TypeDeclaration) typeDeclarationStatement.getDeclaration();
 		assertEquals("wrong name", "AA", typeDeclaration.getName().getIdentifier()); //$NON-NLS-1$ //$NON-NLS-2$
 		checkSourceRange(typeDeclaration, "class AA extends Test {}", source); //$NON-NLS-1$
 	}
@@ -5565,7 +5563,6 @@ public class ASTConverterTest extends ConverterTestSetup {
 
 	/**
 	 * Check ThisExpression
-	 * @deprecated using deprecated code
 	 */
 	public void test0238() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0238", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
@@ -5576,7 +5573,7 @@ public class ASTConverterTest extends ConverterTestSetup {
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertTrue("Not a type declaration statement", node instanceof TypeDeclarationStatement); //$NON-NLS-1$
 		TypeDeclarationStatement typeDeclarationStatement = (TypeDeclarationStatement) node;
-		TypeDeclaration typeDecl = typeDeclarationStatement.getTypeDeclaration();
+		TypeDeclaration typeDecl = (TypeDeclaration) typeDeclarationStatement.getDeclaration();
 		Object o = typeDecl.bodyDeclarations().get(0);
 		assertTrue("Not a method", o instanceof MethodDeclaration); //$NON-NLS-1$
 		MethodDeclaration methodDecl = (MethodDeclaration) o;
@@ -5601,7 +5598,6 @@ public class ASTConverterTest extends ConverterTestSetup {
 
 	/**
 	 * Check ThisExpression
-	 * @deprecated using deprecated code
 	 */
 	public void test0239() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0239", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
@@ -5611,7 +5607,7 @@ public class ASTConverterTest extends ConverterTestSetup {
 		ASTNode node = getASTNode((CompilationUnit) result, 1, 0, 0);
 		assertTrue("Not a type declaration statement", node instanceof TypeDeclarationStatement); //$NON-NLS-1$
 		TypeDeclarationStatement typeDeclarationStatement = (TypeDeclarationStatement) node;
-		TypeDeclaration typeDecl = typeDeclarationStatement.getTypeDeclaration();
+		TypeDeclaration typeDecl = (TypeDeclaration) typeDeclarationStatement.getDeclaration();
 		Object o = typeDecl.bodyDeclarations().get(0);
 		assertTrue("Not a method", o instanceof MethodDeclaration); //$NON-NLS-1$
 		MethodDeclaration methodDecl = (MethodDeclaration) o;
@@ -5640,7 +5636,6 @@ public class ASTConverterTest extends ConverterTestSetup {
 
 	/**
 	 * Check FieldAccess
-	 * @deprecated using deprecated code
 	 */
 	public void test0240() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0240", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
@@ -5650,7 +5645,7 @@ public class ASTConverterTest extends ConverterTestSetup {
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertTrue("Not a type declaration statement", node instanceof TypeDeclarationStatement); //$NON-NLS-1$
 		TypeDeclarationStatement typeDeclarationStatement = (TypeDeclarationStatement) node;
-		TypeDeclaration typeDecl = typeDeclarationStatement.getTypeDeclaration();
+		TypeDeclaration typeDecl = (TypeDeclaration) typeDeclarationStatement.getDeclaration();
 		Object o = typeDecl.bodyDeclarations().get(0);
 		assertTrue("Not a method", o instanceof MethodDeclaration); //$NON-NLS-1$
 		MethodDeclaration methodDecl = (MethodDeclaration) o;
@@ -5718,7 +5713,6 @@ public class ASTConverterTest extends ConverterTestSetup {
 
 	/**
 	 * Check ThisExpression
-	 * @deprecated using deprecated code
 	 */
 	public void test0242() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0242", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
@@ -5728,7 +5722,7 @@ public class ASTConverterTest extends ConverterTestSetup {
 		ASTNode node = getASTNode((CompilationUnit) result, 1, 0, 0);
 		assertTrue("Not a type declaration statement", node instanceof TypeDeclarationStatement); //$NON-NLS-1$
 		TypeDeclarationStatement typeDeclarationStatement = (TypeDeclarationStatement) node;
-		TypeDeclaration typeDecl = typeDeclarationStatement.getTypeDeclaration();
+		TypeDeclaration typeDecl = (TypeDeclaration) typeDeclarationStatement.getDeclaration();
 		Object o = typeDecl.bodyDeclarations().get(0);
 		assertTrue("Not a method", o instanceof MethodDeclaration); //$NON-NLS-1$
 		MethodDeclaration methodDecl = (MethodDeclaration) o;

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterTest2.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterTest2.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -2936,7 +2936,7 @@ public class ASTConverterTest2 extends ConverterTestSetup {
 
 		// 'B' in 'foo()'
 		TypeDeclarationStatement typeDeclarationStatement = (TypeDeclarationStatement) getASTNode(unit, 0, 1, 3);
-		TypeDeclaration typeDeclaration = typeDeclarationStatement.getTypeDeclaration();
+		AbstractTypeDeclaration typeDeclaration = typeDeclarationStatement.getDeclaration();
 		ITypeBinding typeBinding = typeDeclaration.resolveBinding();
 		assertEquals("Unexpected key", "Ltest0502/A$206$B;", typeBinding.getKey()); //$NON-NLS-1$
 	}
@@ -2958,7 +2958,6 @@ public class ASTConverterTest2 extends ConverterTestSetup {
 
 	/**
 	 * http://bugs.eclipse.org/bugs/show_bug.cgi?id=46013
-	 * @deprecated using deprecated code
 	 */
 	public void test0502i() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0502", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
@@ -2966,7 +2965,7 @@ public class ASTConverterTest2 extends ConverterTestSetup {
 
 		// 'field' in 'B' in 'foo()'
 		TypeDeclarationStatement typeDeclarationStatement = (TypeDeclarationStatement) getASTNode(unit, 0, 1, 3);
-		TypeDeclaration typeDeclaration = typeDeclarationStatement.getTypeDeclaration();
+		TypeDeclaration typeDeclaration = (TypeDeclaration) typeDeclarationStatement.getDeclaration();
 		FieldDeclaration fieldDeclaration = typeDeclaration.getFields()[0];
 		VariableDeclarationFragment fragment = (VariableDeclarationFragment) fieldDeclaration.fragments().get(0);
 		IVariableBinding fieldBinding = fragment.resolveBinding();
@@ -2975,7 +2974,6 @@ public class ASTConverterTest2 extends ConverterTestSetup {
 
 	/**
 	 * http://bugs.eclipse.org/bugs/show_bug.cgi?id=46013
-	 * @deprecated using deprecated code
 	 */
 	public void test0502j() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0502", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
@@ -2983,7 +2981,7 @@ public class ASTConverterTest2 extends ConverterTestSetup {
 
 		// 'bar()' in 'B' in 'foo()'
 		TypeDeclarationStatement typeDeclarationStatement = (TypeDeclarationStatement) getASTNode(unit, 0, 1, 3);
-		TypeDeclaration typeDeclaration = typeDeclarationStatement.getTypeDeclaration();
+		TypeDeclaration typeDeclaration = (TypeDeclaration) typeDeclarationStatement.getDeclaration();
 		MethodDeclaration methodDeclaration = typeDeclaration.getMethods()[0];
 		IMethodBinding methodBinding = methodDeclaration.resolveBinding();
 		assertEquals("Unexpected key", "Ltest0502/A$206$B;.bar()V", methodBinding.getKey()); //$NON-NLS-1$
@@ -3017,7 +3015,6 @@ public class ASTConverterTest2 extends ConverterTestSetup {
 
 	/**
 	 * http://bugs.eclipse.org/bugs/show_bug.cgi?id=46057
-	 * @deprecated using deprecated code
 	 */
 	public void test0503c() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0503", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
@@ -3025,7 +3022,7 @@ public class ASTConverterTest2 extends ConverterTestSetup {
 
 		// local type E in foo() in A
 		TypeDeclarationStatement typeDeclarationStatement = (TypeDeclarationStatement) getASTNode(unit, 0, 1, 0);
-		TypeDeclaration typeDeclaration = typeDeclarationStatement.getTypeDeclaration();
+		TypeDeclaration typeDeclaration = (TypeDeclaration) typeDeclarationStatement.getDeclaration();
 		ITypeBinding typeBinding = typeDeclaration.resolveBinding();
 		assertEquals("Unexpected binary name", "test0503.A$1E", typeBinding.getBinaryName()); //$NON-NLS-1$
 	}
@@ -3063,7 +3060,6 @@ public class ASTConverterTest2 extends ConverterTestSetup {
 
 	/**
 	 * http://bugs.eclipse.org/bugs/show_bug.cgi?id=46057
-	 * @deprecated using deprecated code
 	 */
 	public void test0503f() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0503", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
@@ -3072,7 +3068,7 @@ public class ASTConverterTest2 extends ConverterTestSetup {
 		// local type C in bar() in B in A
 		MethodDeclaration method = (MethodDeclaration) getASTNode(unit, 0, 0, 0);
 		TypeDeclarationStatement typeDeclarationStatement = (TypeDeclarationStatement) method.getBody().statements().get(0);
-		TypeDeclaration typeDeclaration = typeDeclarationStatement.getTypeDeclaration();
+		TypeDeclaration typeDeclaration = (TypeDeclaration) typeDeclarationStatement.getDeclaration();
 		ITypeBinding typeBinding = typeDeclaration.resolveBinding();
 		assertEquals("Unexpected binary name", "test0503.A$B$1C", typeBinding.getBinaryName()); //$NON-NLS-1$
 	}
@@ -3112,7 +3108,6 @@ public class ASTConverterTest2 extends ConverterTestSetup {
 
 	/**
 	 * http://bugs.eclipse.org/bugs/show_bug.cgi?id=46057
-	 * @deprecated using deprecated code
 	 */
 	public void test0503i() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0503", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
@@ -3122,7 +3117,7 @@ public class ASTConverterTest2 extends ConverterTestSetup {
 		IfStatement ifStatement = (IfStatement) getASTNode(unit, 0, 1, 2);
 		Block block = (Block)ifStatement.getThenStatement();
 		TypeDeclarationStatement typeDeclarationStatement = (TypeDeclarationStatement) block.statements().get(0);
-		TypeDeclaration typeDeclaration = typeDeclarationStatement.getTypeDeclaration();
+		TypeDeclaration typeDeclaration = (TypeDeclaration) typeDeclarationStatement.getDeclaration();
 		ITypeBinding typeBinding = typeDeclaration.resolveBinding();
 		assertEquals("Unexpected binary name", null, typeBinding.getBinaryName()); //$NON-NLS-1$
 	}
@@ -4717,7 +4712,6 @@ public class ASTConverterTest2 extends ConverterTestSetup {
 
 	/**
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=60078
-	 * @deprecated using deprecated code
 	 */
 	public void test0547() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0547", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
@@ -4727,7 +4721,7 @@ public class ASTConverterTest2 extends ConverterTestSetup {
 		ASTNode node = getASTNode(unit, 0, 0, 0);
 		assertEquals("not a type declaration statement", ASTNode.TYPE_DECLARATION_STATEMENT, node.getNodeType()); //$NON-NLS-1$
 		TypeDeclarationStatement typeDeclarationStatement = (TypeDeclarationStatement) node;
-		TypeDeclaration typeDeclaration = typeDeclarationStatement.getTypeDeclaration();
+		TypeDeclaration typeDeclaration = (TypeDeclaration) typeDeclarationStatement.getDeclaration();
 		ITypeBinding typeBinding = typeDeclaration.resolveBinding();
 		assertEquals("Wrong key", "Ltest0547/A$74$Local;", typeBinding.getKey());
 
@@ -5188,7 +5182,6 @@ public class ASTConverterTest2 extends ConverterTestSetup {
 
 	/**
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=74369
-	 * @deprecated using deprecated code
 	 */
 	public void test0569() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0569", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
@@ -5200,7 +5193,7 @@ public class ASTConverterTest2 extends ConverterTestSetup {
 		ASTNode node = getASTNode(unit, 0, 0, 1);
 		assertEquals("not a type declaration statement", ASTNode.TYPE_DECLARATION_STATEMENT, node.getNodeType()); //$NON-NLS-1$
 		TypeDeclarationStatement typeDeclarationStatement = (TypeDeclarationStatement) node;
-		TypeDeclaration typeDeclaration = typeDeclarationStatement.getTypeDeclaration();
+		TypeDeclaration typeDeclaration = (TypeDeclaration) typeDeclarationStatement.getDeclaration();
 		assertEquals("wrong name", "Local", typeDeclaration.getName().getIdentifier());
 		assertNull("Got a javadoc", typeDeclaration.getJavadoc());
 		node = getASTNode(unit, 0);

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -4895,11 +4895,7 @@ public class ASTTest extends org.eclipse.jdt.core.tests.junit.extension.TestCase
 		previousCount = this.ast.modificationCount();
 		assertTrue(x.getAST() == this.ast);
 		assertTrue(x.getParent() == null);
-		if (this.ast.apiLevel() == AST.JLS2) {
-			assertTrue(x.getTypeDeclaration() == x1);
-		} else {
-			assertTrue(x.getDeclaration() == x1);
-		}
+		assertTrue(x.getDeclaration() == x1);
 		assertTrue(x1.getParent() == x);
 		assertTrue(x.getNodeType() == ASTNode.TYPE_DECLARATION_STATEMENT);
 		assertTrue(x.structuralPropertiesForType() ==
@@ -4942,7 +4938,7 @@ public class ASTTest extends org.eclipse.jdt.core.tests.junit.extension.TestCase
 				}
 				@Override
 				public ASTNode get() {
-					return x.getTypeDeclaration();
+					return x.getDeclaration();
 				}
 				@Override
 				public void set(ASTNode value) {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/rewrite/describing/ASTRewritingStatementsTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/rewrite/describing/ASTRewritingStatementsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -5698,8 +5698,7 @@ public class ASTRewritingStatementsTest extends ASTRewritingTest {
 		}
 	}
 
-	/** @deprecated using deprecated code */
-	public void testTypeDeclarationStatement_only_2() throws Exception {
+	public void testTypeDeclarationStatement() throws Exception {
 		IPackageFragment pack1= this.sourceFolder.createPackageFragment("test1", false, null);
 		StringBuilder buf= new StringBuilder();
 		buf.append("package test1;\n");
@@ -5730,7 +5729,7 @@ public class ASTRewritingStatementsTest extends ASTRewritingTest {
 			newDeclaration.setName(ast.newSimpleName("X"));
 			newDeclaration.setInterface(true);
 
-			rewrite.replace(stmt.getTypeDeclaration(), newDeclaration, null);
+			rewrite.replace(stmt.getDeclaration(), newDeclaration, null);
 		}
 
 		String preview= evaluateRewrite(cu, rewrite);


### PR DESCRIPTION
The new getDeclaration API is backward compatible and works on all JLS versions while getTypeDeclaration is limited to JLS2. This allows tests to run on newer JLS versions too.
