### PR TITLE
Fix new failure in run.javac comparison from verifyClassFile()

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractModuleCompilationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractModuleCompilationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 GK Software SE, and others.
+ * Copyright (c) 2025 GK Software SE, and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -21,7 +21,6 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.nio.file.DirectoryNotEmptyException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -31,7 +30,9 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import junit.framework.AssertionFailedError;
+import org.eclipse.jdt.core.util.ClassFormatException;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 
 public abstract class AbstractModuleCompilationTest extends AbstractBatchCompilerTest {
@@ -45,7 +46,7 @@ public abstract class AbstractModuleCompilationTest extends AbstractBatchCompile
 
 	class Runner extends AbstractRegressionTest.Runner {
 		StringBuilder commandLine = new StringBuilder();
-		String outputDir = OUTPUT_DIR + File.separator + "javac";
+		String outputDir = OUTPUT_DIR;
 		List<String> fileNames = new ArrayList<>();
 		/** will replace any -8, -9 ... option for javac */
 		String javacVersionOptions;
@@ -72,9 +73,20 @@ public abstract class AbstractModuleCompilationTest extends AbstractBatchCompile
 			String javacCommandLine = adjustForJavac(commandLineString, this.javacVersionOptions);
 			return AbstractModuleCompilationTest.this.runConformModuleTest(this.testFiles, commandLineString,
 					this.expectedOutputString, this.expectedErrorString,
-					this.shouldFlushOutputDirectory, this.outputDir,
-					this.javacTestOptions, javacCommandLine);
+					this.shouldFlushOutputDirectory, this.javacTestOptions,
+					javacCommandLine);
 		}
+	}
+
+	protected String getSourceDir() {
+		return OUTPUT_DIR + File.separatorChar + "src";
+	}
+
+	protected String getEcjOutputDir() {
+		return OUTPUT_DIR + File.separatorChar + "bin";
+	}
+	protected String getJavacOutputDir() {
+		return OUTPUT_DIR + File.separatorChar + "javac";
 	}
 
 	protected void writeFileCollecting(List<String> collectedFiles, String directoryName, String fileName, String source) {
@@ -104,44 +116,47 @@ public abstract class AbstractModuleCompilationTest extends AbstractBatchCompile
 
 	protected void runConformModuleTest(List<String> testFileNames, StringBuilder commandLine, String expectedFailureOutOutputString, String expectedFailureErrOutputString) {
 		runConformModuleTest(testFileNames, commandLine,
-				expectedFailureOutOutputString, expectedFailureErrOutputString, OUTPUT_DIR + File.separator + "javac");
-	}
-
-	protected void runConformModuleTest(List<String> testFileNames, StringBuilder commandLine,
-			String expectedFailureOutOutputString, String expectedFailureErrOutputString,
-			String output) {
-		runConformModuleTest(testFileNames, commandLine,
-				expectedFailureOutOutputString, expectedFailureErrOutputString, output,
-				JavacTestOptions.DEFAULT);
+				expectedFailureOutOutputString, expectedFailureErrOutputString, JavacTestOptions.DEFAULT);
 	}
 	protected void runConformModuleTest(List<String> testFileNames, StringBuilder commandLine,
 			String expectedFailureOutOutputString, String expectedFailureErrOutputString,
-			String output, JavacTestOptions javacTestOptions) {
+			JavacTestOptions javacTestOptions) {
 		for (String file : testFileNames)
 			commandLine.append(" \"").append(file).append("\"");
 		runConformModuleTest(new String[0], commandLine.toString(),
 				expectedFailureOutOutputString, expectedFailureErrOutputString, false,
-				output, javacTestOptions, null);
+				javacTestOptions, null);
 	}
 
 	protected Set<String> runConformModuleTest(String[] testFiles, String commandLine, String expectedFailureOutOutputString, String expectedFailureErrOutputString, boolean shouldFlushOutputDirectory) {
 		return runConformModuleTest(testFiles, commandLine, expectedFailureErrOutputString, expectedFailureErrOutputString,
-				shouldFlushOutputDirectory, OUTPUT_DIR, JavacTestOptions.DEFAULT, null);
+				shouldFlushOutputDirectory, JavacTestOptions.DEFAULT, null);
 	}
 
-	protected Set<String> runConformModuleTest(String[] testFiles, String commandLine, String expectedFailureOutOutputString, String expectedFailureErrOutputString, boolean shouldFlushOutputDirectory, String output,
-			JavacTestOptions options, String javacCommandLine) {
-				runConformTest(testFiles, commandLine, expectedFailureOutOutputString, expectedFailureErrOutputString, shouldFlushOutputDirectory);
+	protected Set<String> runConformModuleTest(String[] testFiles, String commandLine, String expectedFailureOutOutputString, String expectedFailureErrOutputString, boolean shouldFlushOutputDirectory, JavacTestOptions options,
+			String javacCommandLine) {
+				String ecjOutput = getEcjOutputDir();
+				File ecjOutFile = new File(ecjOutput);
+				if (!ecjOutFile.exists()) {
+					ecjOutFile.mkdir();
+				}
+				String ecjCommandLine = commandLine.contains("-d ")
+						? commandLine
+						: " -d " + ecjOutput + ' ' + commandLine;
+				runConformTest(testFiles, ecjCommandLine, expectedFailureOutOutputString, expectedFailureErrOutputString, shouldFlushOutputDirectory);
 				if (shouldRunJavac()) {
-					File outputDir = new File(output);
 					final Set<String> outFiles = new HashSet<>();
-					walkOutFiles(output, outFiles, true);
+					walkOutFiles(ecjOutput, outFiles, true);
+
+					String javacOutput = getJavacOutputDir();
+					File javacOutputDir = new File(javacOutput);
+
 					String[] testFileNames = new String[testFiles.length/2];
 					for (int i = 0; i < testFileNames.length; i++) {
 						testFileNames[i] = testFiles[i*2];
 					}
 					if (javacCommandLine == null) {
-						javacCommandLine = adjustForJavac(commandLine, null);
+						javacCommandLine = " -d " + javacOutput + ' ' + adjustForJavac(commandLine, null);
 					}
 					for (JavacCompiler javacCompiler : javacCompilers) {
 						if (javacCompiler.compliance < ClassFileConstants.JDK9)
@@ -153,7 +168,7 @@ public abstract class AbstractModuleCompilationTest extends AbstractBatchCompile
 						StringBuilder log = new StringBuilder();
 						try {
 							long compileResult = javacCompiler.compile(
-													outputDir, /* directory */
+													javacOutputDir, /* directory */
 													javacCommandLine /* options */,
 													testFileNames /* source file names */,
 													log,
@@ -172,8 +187,8 @@ public abstract class AbstractModuleCompilationTest extends AbstractBatchCompile
 							e.printStackTrace();
 							throw new AssertionFailedError(e.getMessage());
 						}
-						final Set<String> expectedFiles = new HashSet<>(outFiles);
-						walkOutFiles(output, expectedFiles, false);
+						final Set<String> expectedFiles = outFiles.stream().map(s -> s.replace(ecjOutput, javacOutput)).collect(Collectors.toSet());
+						walkOutFiles(javacOutput, expectedFiles, false);
 						for (String missingFile : expectedFiles)
 							System.err.println("Missing output file from javac:    "+missingFile);
 					}
@@ -188,78 +203,88 @@ public abstract class AbstractModuleCompilationTest extends AbstractBatchCompile
 	}
 
 	protected void runNegativeModuleTest(List<String> testFileNames, StringBuilder commandLine, String expectedFailureOutOutputString, String expectedFailureErrOutputString, String javacErrorMatch) {
-				runNegativeModuleTest(testFileNames, commandLine, expectedFailureOutOutputString,
-						expectedFailureErrOutputString, javacErrorMatch, OUTPUT_DIR + File.separator + "javac");
-			}
+		runNegativeModuleTest(testFileNames, commandLine, expectedFailureOutOutputString, expectedFailureErrOutputString,
+				javacErrorMatch, JavacTestOptions.DEFAULT);
+	}
 
 	protected void runNegativeModuleTest(List<String> testFileNames, StringBuilder commandLine, String expectedFailureOutOutputString, String expectedFailureErrOutputString, String javacErrorMatch,
-			String output) {
-				runNegativeModuleTest(testFileNames, commandLine, expectedFailureOutOutputString, expectedFailureErrOutputString,
-						javacErrorMatch, output, JavacTestOptions.DEFAULT);
-			}
-
-	protected void runNegativeModuleTest(List<String> testFileNames, StringBuilder commandLine, String expectedFailureOutOutputString, String expectedFailureErrOutputString, String javacErrorMatch,
-			String output, JavacTestOptions options) {
-				for (String file : testFileNames)
-					commandLine.append(" \"").append(file).append("\"");
-				runNegativeModuleTest(new String[0], commandLine.toString(),
-						expectedFailureOutOutputString, expectedFailureErrOutputString, false, javacErrorMatch, output,
-						options);
-			}
+			JavacTestOptions options) {
+		for (String file : testFileNames)
+			commandLine.append(" \"").append(file).append("\"");
+		runNegativeModuleTest(new String[0], commandLine.toString(),
+				expectedFailureOutOutputString, expectedFailureErrOutputString, false, javacErrorMatch, options);
+	}
 
 	protected void runNegativeModuleTest(String[] testFiles, String commandLine, String expectedFailureOutOutputString, String expectedFailureErrOutputString, boolean shouldFlushOutputDirectory,
 			String javacErrorMatch) {
-				runNegativeModuleTest(testFiles, commandLine, expectedFailureOutOutputString, expectedFailureErrOutputString,
-						shouldFlushOutputDirectory, javacErrorMatch, OUTPUT_DIR, JavacTestOptions.DEFAULT);
-			}
+		String prefix = "src" + File.separatorChar;
+		for (int i = 0; i + 1 < testFiles.length; i+=2) {
+			testFiles[i] = prefix + testFiles[i];
+		}
+		runNegativeModuleTest(testFiles, commandLine, expectedFailureOutOutputString, expectedFailureErrOutputString,
+				shouldFlushOutputDirectory, javacErrorMatch, JavacTestOptions.DEFAULT);
+	}
 
 	void runNegativeModuleTest(String[] testFiles, String commandLine, String expectedFailureOutOutputString, String expectedFailureErrOutputString, boolean shouldFlushOutputDirectory, String javacErrorMatch,
-			String output, JavacTestOptions options) {
-				runNegativeTest(testFiles, commandLine, expectedFailureOutOutputString, expectedFailureErrOutputString, shouldFlushOutputDirectory);
-				if (shouldRunJavac()) {
-					String[] testFileNames = new String[testFiles.length/2];
-					for (int i = 0; i < testFileNames.length; i++) {
-						testFileNames[i] = testFiles[i*2];
-					}
-					File outputDir = new File(OUTPUT_DIR);
-					final Set<String> outFiles = new HashSet<>();
-					walkOutFiles(output, outFiles, true);
-					for (JavacCompiler javacCompiler : javacCompilers) {
-						if (javacCompiler.compliance < ClassFileConstants.JDK9)
-							continue;
-						JavacTestOptions.Excuse excuse = options.excuseFor(javacCompiler);
+			JavacTestOptions options) {
+		String ecjOutput = getEcjOutputDir();
+		File ecjOutFile = new File(ecjOutput);
+		if (!ecjOutFile.exists()) {
+			ecjOutFile.mkdir();
+		}
+		String ecjCommandLine = commandLine.contains("-d ")
+				? commandLine
+				: " -d " + ecjOutput + ' ' + commandLine;
+		runNegativeTest(testFiles, ecjCommandLine, expectedFailureOutOutputString, expectedFailureErrOutputString, shouldFlushOutputDirectory);
+		if (shouldRunJavac()) {
+			final Set<String> outFiles = new HashSet<>();
+			walkOutFiles(ecjOutput, outFiles, true);
 
-						commandLine = adjustForJavac(commandLine, null);
-						StringBuilder log = new StringBuilder();
-						int mismatch = 0;
-						try {
-							long compileResult = javacCompiler.compile(
-													outputDir, /* directory */
-													commandLine /* options */,
-													testFileNames /* source file names */,
-													log);
-							if (compileResult == 0) {
-								mismatch = JavacTestOptions.MismatchType.EclipseErrorsJavacNone;
-								javacErrorMatch = expectedFailureErrOutputString;
-								System.err.println("Previous error was from "+testName());
-							} else if (!log.toString().contains(javacErrorMatch)) {
-								mismatch = JavacTestOptions.MismatchType.CompileErrorMismatch;
-								System.err.println(testName()+": Error match " + javacErrorMatch + " not found in \n"+log.toString());
-							}
-						} catch (IOException | InterruptedException e) {
-							e.printStackTrace();
-							throw new AssertionFailedError(e.getMessage());
-						}
-						handleMismatch(javacCompiler, testName(), testFiles, javacErrorMatch,
-								"", "", log, "", "",
-								excuse, mismatch);
-						final Set<String> expectedFiles = new HashSet<>(outFiles);
-						walkOutFiles(output, expectedFiles, false);
-						for (String missingFile : expectedFiles)
-							System.err.println("Missing output file from javac:    "+missingFile);
-					}
-				}
+			String javacOutput = getJavacOutputDir();
+			File outputDir = new File(javacOutput);
+
+			String[] testFileNames = new String[testFiles.length/2];
+			for (int i = 0; i < testFileNames.length; i++) {
+				testFileNames[i] = testFiles[i*2];
 			}
+
+			for (JavacCompiler javacCompiler : javacCompilers) {
+				if (javacCompiler.compliance < ClassFileConstants.JDK9)
+					continue;
+				JavacTestOptions.Excuse excuse = options.excuseFor(javacCompiler);
+
+				String javacCommandLine = " -d " + javacOutput + ' ' + adjustForJavac(commandLine, null);
+				StringBuilder log = new StringBuilder();
+				int mismatch = 0;
+				try {
+					long compileResult = javacCompiler.compile(
+											outputDir, /* directory */
+											javacCommandLine /* options */,
+											testFileNames /* source file names */,
+											log,
+											false);
+					if (compileResult == 0) {
+						mismatch = JavacTestOptions.MismatchType.EclipseErrorsJavacNone;
+						javacErrorMatch = expectedFailureErrOutputString;
+						System.err.println("Previous error was from "+testName());
+					} else if (!log.toString().contains(javacErrorMatch)) {
+						mismatch = JavacTestOptions.MismatchType.CompileErrorMismatch;
+						System.err.println(testName()+": Error match " + javacErrorMatch + " not found in \n"+log.toString());
+					}
+				} catch (IOException | InterruptedException e) {
+					e.printStackTrace();
+					throw new AssertionFailedError(e.getMessage());
+				}
+				handleMismatch(javacCompiler, testName(), testFiles, javacErrorMatch,
+						"", "", log, "", "",
+						excuse, mismatch);
+				final Set<String> expectedFiles = outFiles.stream().map(s -> s.replace(ecjOutput, javacOutput)).collect(Collectors.toSet());
+				walkOutFiles(javacOutput, expectedFiles, false);
+				for (String missingFile : expectedFiles)
+					System.out.println("Missing output file from javac in negative test:    "+missingFile);
+			}
+		}
+	}
 
 	/**
 	 * @param commandLine command line arguments as used for ecj
@@ -329,20 +354,8 @@ public abstract class AbstractModuleCompilationTest extends AbstractBatchCompile
 							if (!fileNames.remove(file.toString()))
 								System.err.println("Unexpected output file from javac: "+file.toString());
 						}
-						Files.delete(file);
 					}
 					return FileVisitResult.CONTINUE;
-				}
-				@Override
-				public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
-					if (!dir.toString().equals(outputLocation)) {
-						try {
-							Files.delete(dir);
-						} catch (DirectoryNotEmptyException ex) {
-							// expected
-						}
-					}
-			        return FileVisitResult.CONTINUE;
 				}
 			});
 		} catch (IOException e) {
@@ -358,5 +371,15 @@ public abstract class AbstractModuleCompilationTest extends AbstractBatchCompile
 			assertTrue(msg, (new File(fileName).exists()));
 		}
 	}
-
+	@Override
+	protected void verifyClassFile(String expectedOutput, String classFileName, int mode) throws IOException, ClassFormatException {
+		verifyClassFile(expectedOutput, classFileName, mode, false);
+	}
+	protected void verifyClassFile(String expectedOutput, String classFileName, int mode, boolean skipJavac)
+			throws IOException, ClassFormatException {
+		verifyClassFile(expectedOutput, null, getEcjOutputDir()+File.separatorChar+classFileName, mode);
+		if (!skipJavac && shouldRunJavac()) {
+			verifyClassFile(expectedOutput, null, getJavacOutputDir()+File.separatorChar+classFileName, mode);
+		}
+	}
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractRegressionTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractRegressionTest.java
@@ -1510,7 +1510,9 @@ protected static class JavacTestOptions {
 
 	protected static void verifyClassFile(String expectedOutput, String unexpectedOutput, String classFileName, int mode)
 			throws IOException, ClassFormatException {
-		File f = new File(OUTPUT_DIR + File.separator + classFileName);
+		if (!classFileName.startsWith(OUTPUT_DIR))
+			classFileName = OUTPUT_DIR + File.separator + classFileName;
+		File f = new File(classFileName);
 		byte[] classFileBytes = org.eclipse.jdt.internal.compiler.util.Util.getFileByteContent(f);
 		ClassFileBytesDisassembler disassembler = ToolFactory.createDefaultClassFileBytesDisassembler();
 		String result = disassembler.disassemble(classFileBytes, "\n", mode);

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ModuleCompilationTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ModuleCompilationTests.java
@@ -69,11 +69,11 @@ public class ModuleCompilationTests extends AbstractModuleCompilationTest {
 				"	requires java.base;\n" +
 				"}"
 	        },
-			" -9 \"" + OUTPUT_DIR +  File.separator + "module-info.java\" "
-	        + "\"" + OUTPUT_DIR +  File.separator + "p/X.java\"",
+			" -9 \"" + getSourceDir() +  File.separator + "module-info.java\" "
+	        + "\"" + getSourceDir() +  File.separator + "p/X.java\"",
 	        "",
 	        "----------\n" +
-    		"1. ERROR in ---OUTPUT_DIR_PLACEHOLDER---/p/X.java (at line 4)\n" +
+    		"1. ERROR in ---OUTPUT_DIR_PLACEHOLDER---/src/p/X.java (at line 4)\n" +
     		"	java.sql.Connection con = null;\n" +
     		"	^^^^^^^^^^^^^^^^^^^\n" +
     		"The type java.sql.Connection is not accessible\n" +
@@ -135,7 +135,7 @@ public class ModuleCompilationTests extends AbstractModuleCompilationTest {
 	        "",
 	        "",
 	        true);
-		String fileName = OUTPUT_DIR + File.separator + "module-info.class";
+		String fileName = getEcjOutputDir() + File.separator + "module-info.class";
 		assertClassFile("Missing modul-info.class: " + fileName, fileName, classFiles);
 	}
 	public void test005() {
@@ -160,12 +160,11 @@ public class ModuleCompilationTests extends AbstractModuleCompilationTest {
 	        },
 			" -9 \"" + OUTPUT_DIR + File.separator + "module-info.java\" "
 			+ "\"" + OUTPUT_DIR + File.separator + "q/Y.java\" "
-	        + "\"" + OUTPUT_DIR + File.separator + "p/X.java\" "
-	        + "-d " + OUTPUT_DIR ,
+	        + "\"" + OUTPUT_DIR + File.separator + "p/X.java\"",
 	        "",
 	        "",
 	        true);
-		String fileName = OUTPUT_DIR  + File.separator + "module-info.class";
+		String fileName = getEcjOutputDir()  + File.separator + "module-info.class";
 		assertClassFile("Missing modul-info.class: " + fileName, fileName, classFiles);
 	}
 	public void test006() {
@@ -518,8 +517,7 @@ public class ModuleCompilationTests extends AbstractModuleCompilationTest {
 		runConformModuleTest(files,
 				buffer,
 				"",
-				"",
-				outDir);
+				"");
 	}
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=487421
 	public void test011() {
@@ -617,8 +615,7 @@ public class ModuleCompilationTests extends AbstractModuleCompilationTest {
 		runConformModuleTest(files,
 				buffer,
 				"",
-				"",
-				outDir);
+				"");
 	}
 	//https://bugs.eclipse.org/bugs/show_bug.cgi?id=495500
 	//-source 9
@@ -770,7 +767,6 @@ public class ModuleCompilationTests extends AbstractModuleCompilationTest {
 				"----------\n" +
 				"1 problem (1 error)\n",
 				"does not read it",
-				OUTPUT_DIR + File.separator + out,
 				JavacTestOptions.JavacHasABug.JavacBug8207032);
 	}
 	public void test016() {
@@ -868,8 +864,7 @@ public class ModuleCompilationTests extends AbstractModuleCompilationTest {
 				"The type p.X is not accessible\n" +
 				"----------\n" +
 				"1 problem (1 error)\n",
-				"visible",
-				OUTPUT_DIR + File.separator + out);
+				"visible");
 	}
 	public void test018() {
 		File outputDirectory = new File(OUTPUT_DIR);
@@ -996,8 +991,7 @@ public class ModuleCompilationTests extends AbstractModuleCompilationTest {
 		runConformModuleTest(files,
 				buffer,
 				"",
-				"",
-				OUTPUT_DIR + File.separator + out);
+				"");
 	}
 
 	/*
@@ -1047,7 +1041,6 @@ public class ModuleCompilationTests extends AbstractModuleCompilationTest {
 				"----------\n" +
 				"1 problem (1 error)\n",
 				"package s",
-				 OUTPUT_DIR + File.separator + out,
 				 JavacTestOptions.JavacHasABug.JavacBug8204534);
 	}
 	/*
@@ -1365,8 +1358,7 @@ public class ModuleCompilationTests extends AbstractModuleCompilationTest {
 				"The type p1.X1 is not accessible\n" +
 				"----------\n" +
 				"1 problem (1 error)\n",
-				"visible",
-				outDir);
+				"visible");
 	}
 	public void test029() {
 		File outputDirectory = new File(OUTPUT_DIR);
@@ -1483,8 +1475,7 @@ public class ModuleCompilationTests extends AbstractModuleCompilationTest {
 			"Connection cannot be resolved to a type\n"+
 			"----------\n"+
 			"2 problems (2 errors)\n",
-			"visible",
-			OUTPUT_DIR + File.separator + out);
+			"visible");
 	}
 	public void test031() {
 		File outputDirectory = new File(OUTPUT_DIR);
@@ -1542,8 +1533,7 @@ public class ModuleCompilationTests extends AbstractModuleCompilationTest {
 			"Connection cannot be resolved to a type\n"+
 			"----------\n"+
 			"2 problems (2 errors)\n",
-			"visible",
-			OUTPUT_DIR + File.separator + out);
+			"visible");
 	}
 	public void test032() {
 		File outputDirectory = new File(OUTPUT_DIR);
@@ -1574,8 +1564,7 @@ public class ModuleCompilationTests extends AbstractModuleCompilationTest {
 		runConformModuleTest(files,
 			buffer,
 			"",
-			"",
-			OUTPUT_DIR + File.separator + out);
+			"");
 	}
 	/**
 	 * Test that a module can't access types/packages in a plain Jar put in classpath
@@ -1932,8 +1921,7 @@ public class ModuleCompilationTests extends AbstractModuleCompilationTest {
 				"The method m1(impl.SomeImpl) in the type C1 is not applicable for the arguments (impl.SomeImpl)\n" +
 				"----------\n" +
 				"2 problems (1 error, 0 warnings, 1 info)\n",
-				"incompatible",
-				OUTPUT_DIR + File.separator + out);
+				"incompatible");
 	}
 
 	// conflict even without any reference to the conflicting package
@@ -2172,8 +2160,7 @@ public class ModuleCompilationTests extends AbstractModuleCompilationTest {
 				"The package pm conflicts with a package accessible from another module: mod.one\n" +
 				"----------\n" +
 				"1 problem (1 error)\n",
-				"",
-				OUTPUT_DIR + File.separator + out);
+				"");
 	}
 	public void testPackageConflict4() {
 		File outputDirectory = new File(OUTPUT_DIR);
@@ -2604,8 +2591,7 @@ public class ModuleCompilationTests extends AbstractModuleCompilationTest {
 				buffer,
 				"",
 				"cannot specify both -source-path and --module-source-path\n",
-				"cannot specify both",
-				OUTPUT_DIR + File.separator + out);
+				"cannot specify both");
 	}
 
 	// causes: non-public type (C0), non-exported package (p.priv)
@@ -3081,8 +3067,7 @@ public class ModuleCompilationTests extends AbstractModuleCompilationTest {
 		runConformModuleTest(files,
 				buffer,
 				"",
-				"",
-				outDir);
+				"");
 	}
 	public void testUnnamedPackage_Bug520839() {
 		File outputDirectory = new File(OUTPUT_DIR);
@@ -3117,8 +3102,7 @@ public class ModuleCompilationTests extends AbstractModuleCompilationTest {
 			"Must declare a named package because this compilation unit is associated to the named module \'mod.one\'\n" +
 			"----------\n" +
 			"1 problem (1 error)\n",
-			"unnamed package is not allowed in named modules",
-			OUTPUT_DIR + File.separator + out);
+			"unnamed package is not allowed in named modules");
 	}
 	public void testAutoModule1() throws Exception {
 		File outputDirectory = new File(OUTPUT_DIR);
@@ -3164,8 +3148,7 @@ public class ModuleCompilationTests extends AbstractModuleCompilationTest {
 			"	         ^^^^^\n" +
 			"Name of automatic module \'lib.x\' is unstable, it is derived from the module\'s file name.\n" +
 			"----------\n" +
-			"1 problem (1 info)\n",
-			OUTPUT_DIR + File.separator + out);
+			"1 problem (1 info)\n");
 	}
 	public void testBug521458a() {
 		Util.flushDirectoryContent(new File(OUTPUT_DIR));
@@ -3262,8 +3245,7 @@ public void testBug521362_emptyFile() {
 			"The package p1 does not exist or is empty\n" +
 			"----------\n" +
 			"1 problem (1 error)\n",
-			"empty",
-			OUTPUT_DIR + File.separator + out);
+			"empty");
 	}
 	public void testBug521362_mismatchingdeclaration() {
 		File outputDirectory = new File(OUTPUT_DIR);
@@ -3297,8 +3279,7 @@ public void testBug521362_emptyFile() {
 			"The package p1 does not exist or is empty\n" +
 			"----------\n" +
 			"1 problem (1 error)\n",
-			"package is empty",
-			OUTPUT_DIR + File.separator + out);
+			"package is empty");
 	}
 	public void testBug521362_multiplePackages() {
 		File outputDirectory = new File(OUTPUT_DIR);
@@ -3342,8 +3323,7 @@ public void testBug521362_emptyFile() {
 			"The package p2 does not exist or is empty\n" +
 			"----------\n" +
 			"2 problems (2 errors)\n",
-			"package is empty",
-			OUTPUT_DIR + File.separator + out);
+			"package is empty");
 	}
 	public void testBug521362_multiplePackages2() {
 		File outputDirectory = new File(OUTPUT_DIR);
@@ -3387,8 +3367,7 @@ public void testBug521362_emptyFile() {
 			"The package p2 does not exist or is empty\n" +
 			"----------\n" +
 			"2 problems (2 errors)\n",
-			"package is empty",
-			OUTPUT_DIR + File.separator + out);
+			"package is empty");
 	}
 	/*
 	 * Test that when module-info is the only file being compiled, the class is still
@@ -3397,8 +3376,7 @@ public void testBug521362_emptyFile() {
 	public void testBug500170a() {
 		File outputDirectory = new File(OUTPUT_DIR);
 		Util.flushDirectoryContent(outputDirectory);
-		String out = "bin";
-		String directory = OUTPUT_DIR + File.separator + "src";
+		String directory = getSourceDir();
 		String moduleLoc = directory + File.separator + "mod.one";
 		List<String> files = new ArrayList<>();
 		writeFileCollecting(files, moduleLoc, "module-info.java",
@@ -3406,7 +3384,7 @@ public void testBug521362_emptyFile() {
 						"	requires java.sql;\n" +
 						"}");
 		StringBuilder buffer = new StringBuilder();
-		buffer.append("-d " + OUTPUT_DIR + File.separator + out )
+		buffer.append("-d " + getEcjOutputDir() )
 			.append(" -9 ")
 			.append(" -classpath \"")
 			.append(Util.getJavaClassLibsAsString())
@@ -3420,7 +3398,7 @@ public void testBug521362_emptyFile() {
 				"",
 				"",
 				false);
-		String fileName = OUTPUT_DIR + File.separator + out + File.separator + "mod.one" + File.separator + "module-info.class";
+		String fileName = getEcjOutputDir() + File.separator + "mod.one" + File.separator + "module-info.class";
 		assertClassFile("Missing modul-info.class: " + fileName, fileName, classFiles);
 	}
 	/*
@@ -3843,21 +3821,21 @@ public void testBug521362_emptyFile() {
 				"module mod.one { \n" +
 				"}"
 			},
-			" --release 8 \"" + OUTPUT_DIR +  File.separator + "module-info.java\" ",
+			" --release 8 \"" + getSourceDir() +  File.separator + "module-info.java\" ",
 			"",
 			"""
 			----------
-			1. ERROR in ---OUTPUT_DIR_PLACEHOLDER---/module-info.java (at line 1)
+			1. ERROR in ---OUTPUT_DIR_PLACEHOLDER---/src/module-info.java (at line 1)
 				module mod.one {\s
 				^^^^^^
 			Syntax error on token(s), misplaced construct(s)
 			----------
-			2. ERROR in ---OUTPUT_DIR_PLACEHOLDER---/module-info.java (at line 1)
+			2. ERROR in ---OUTPUT_DIR_PLACEHOLDER---/src/module-info.java (at line 1)
 				module mod.one {\s
 				           ^^^
 			Syntax error, insert "Identifier (" to complete MethodHeaderName
 			----------
-			3. ERROR in ---OUTPUT_DIR_PLACEHOLDER---/module-info.java (at line 1)
+			3. ERROR in ---OUTPUT_DIR_PLACEHOLDER---/src/module-info.java (at line 1)
 				module mod.one {\s
 				           ^^^
 			Syntax error, insert ")" to complete MethodDeclaration
@@ -3907,11 +3885,11 @@ public void testBug521362_emptyFile() {
 				"	}\n" +
 				"}"
 	        },
-			" -source 9 \"" + OUTPUT_DIR +  File.separator + "foo" + File.separator + "Module.java\" " +
-			"\"" +  OUTPUT_DIR +  File.separator + "bar" + File.separator + "X.java\" ",
+			" -source 9 \"" + getSourceDir() +  File.separator + "foo" + File.separator + "Module.java\" " +
+			"\"" +  getSourceDir() +  File.separator + "bar" + File.separator + "X.java\" ",
 	        "",
 	        "----------\n" +
-    		"1. ERROR in ---OUTPUT_DIR_PLACEHOLDER---/bar/X.java (at line 4)\n" +
+    		"1. ERROR in ---OUTPUT_DIR_PLACEHOLDER---/src/bar/X.java (at line 4)\n" +
     		"	public Module getModule(String name) {\n" +
     		"	       ^^^^^^\n" +
     		"The type Module is ambiguous\n" +
@@ -4690,8 +4668,7 @@ public void testBug521362_emptyFile() {
 		runConformModuleTest(files,
 				buffer,
 				"",
-				"",
-				OUTPUT_DIR + "javac");
+				"");
 	}
 	/*
 	 * Test that when module-info is not included in the command line, the class is still
@@ -5329,8 +5306,7 @@ public void testBug521362_emptyFile() {
 				+ "	       ^^^^^\n"
 				+ "The import x.y.z is never used\n"
 				+ "----------\n"
-				+ "2 problems (2 warnings)\n",
-				"package conflict");
+				+ "2 problems (2 warnings)\n");
 	}
 	/*
 	 * Same as above test case, but two binary modules export the package, without any .class files
@@ -5675,7 +5651,6 @@ public void testBug521362_emptyFile() {
 				"",
 				"location ---OUTPUT_DIR_PLACEHOLDER---/src1 is specified more than once in --patch-module\n",
 				"",
-				"",
 				JavacTestOptions.SKIP);
 	}
 
@@ -5699,7 +5674,6 @@ public void testBug521362_emptyFile() {
 				buffer,
 				"",
 				"location ---OUTPUT_DIR_PLACEHOLDER---/src1 is specified more than once in --patch-module\n",
-				"",
 				"",
 				JavacTestOptions.SKIP);
 	}
@@ -6065,7 +6039,6 @@ public void testBug521362_emptyFile() {
 					Name of automatic module 'autoModule' is unstable, it is derived from the module's file name.
 					----------
 					1 problem (1 warning)
-					""",
-					outFinal);
+					""");
 	}
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ModuleImportTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ModuleImportTests.java
@@ -94,17 +94,17 @@ public class ModuleImportTests extends AbstractModuleCompilationTest {
 					}
 					"""
 	        },
-			" -24 \"" + OUTPUT_DIR +  File.separator + "module-info.java\" "
-	        + "\"" + OUTPUT_DIR +  File.separator + "p/X.java\"",
+			" -24 \"" + getSourceDir() +  File.separator + "module-info.java\" "
+	        + "\"" + getSourceDir() +  File.separator + "p/X.java\"",
 	        "",
 	        """
 				----------
-				1. ERROR in ---OUTPUT_DIR_PLACEHOLDER---/p/X.java (at line 2)
+				1. ERROR in ---OUTPUT_DIR_PLACEHOLDER---/src/p/X.java (at line 2)
 					import module java.sql;
 					              ^^^^^^^^
 				Module Import Declarations is a preview feature and disabled by default. Use --enable-preview to enable
 				----------
-				2. ERROR in ---OUTPUT_DIR_PLACEHOLDER---/p/X.java (at line 6)
+				2. ERROR in ---OUTPUT_DIR_PLACEHOLDER---/src/p/X.java (at line 6)
 					Connection con = null;
 					^^^^^^^^^^
 				Connection cannot be resolved to a type
@@ -135,8 +135,8 @@ public class ModuleImportTests extends AbstractModuleCompilationTest {
 					}
 					"""
 	        },
-			" -22 --enable-preview \"" + OUTPUT_DIR +  File.separator + "module-info.java\" "
-	        + "\"" + OUTPUT_DIR +  File.separator + "p/X.java\"",
+			" -22 --enable-preview \"" + getSourceDir() +  File.separator + "module-info.java\" "
+	        + "\"" + getSourceDir() +  File.separator + "p/X.java\"",
 	        "",
 	        """
 				Preview of features is supported only at the latest source level
@@ -195,22 +195,22 @@ public class ModuleImportTests extends AbstractModuleCompilationTest {
 					}
 					"""
 	        },
-			" -24 --enable-preview \"" + OUTPUT_DIR +  File.separator + "module-info.java\" "
-	        + "\"" + OUTPUT_DIR +  File.separator + "p/X.java\"",
+			" -24 --enable-preview \"" + getSourceDir() +  File.separator + "module-info.java\" "
+	        + "\"" + getSourceDir() +  File.separator + "p/X.java\"",
 	        "",
 	        """
 				----------
-				1. WARNING in ---OUTPUT_DIR_PLACEHOLDER---/p/X.java (at line 2)
+				1. WARNING in ---OUTPUT_DIR_PLACEHOLDER---/src/p/X.java (at line 2)
 					import module java.sql;
 					              ^^^^^^^^
 				You are using a preview language feature that may or may not be supported in a future release
 				----------
-				2. ERROR in ---OUTPUT_DIR_PLACEHOLDER---/p/X.java (at line 2)
+				2. ERROR in ---OUTPUT_DIR_PLACEHOLDER---/src/p/X.java (at line 2)
 					import module java.sql;
 					              ^^^^^^^^
 				Module mod.one does not read module java.sql
 				----------
-				3. ERROR in ---OUTPUT_DIR_PLACEHOLDER---/p/X.java (at line 6)
+				3. ERROR in ---OUTPUT_DIR_PLACEHOLDER---/src/p/X.java (at line 6)
 					Connection con = null;
 					^^^^^^^^^^
 				Connection cannot be resolved to a type
@@ -242,17 +242,17 @@ public class ModuleImportTests extends AbstractModuleCompilationTest {
 					}
 					"""
 	        },
-			" -24 --enable-preview \"" + OUTPUT_DIR +  File.separator + "module-info.java\" "
-	        + "\"" + OUTPUT_DIR +  File.separator + "p/X.java\"",
+			" -24 --enable-preview \"" + getSourceDir() +  File.separator + "module-info.java\" "
+	        + "\"" + getSourceDir() +  File.separator + "p/X.java\"",
 	        "",
 	        """
 				----------
-				1. ERROR in ---OUTPUT_DIR_PLACEHOLDER---/p/X.java (at line 2)
+				1. ERROR in ---OUTPUT_DIR_PLACEHOLDER---/src/p/X.java (at line 2)
 					import module missing;
 					              ^^^^^^^
 				The import missing cannot be resolved
 				----------
-				2. ERROR in ---OUTPUT_DIR_PLACEHOLDER---/p/X.java (at line 7)
+				2. ERROR in ---OUTPUT_DIR_PLACEHOLDER---/src/p/X.java (at line 7)
 					Connection con = null;
 					^^^^^^^^^^
 				Connection cannot be resolved to a type
@@ -264,7 +264,7 @@ public class ModuleImportTests extends AbstractModuleCompilationTest {
 	}
 
 	public void test004_selfImport_OK() throws IOException, ClassFormatException {
-		String modsDir = OUTPUT_DIR +  File.separator + "mods";
+		String modsDir = getSourceDir() +  File.separator + "mods";
 		String modOneDir = modsDir + File.separator + "mod.one";
 		List<String> files = new ArrayList<>();
 		writeFileCollecting(files, modOneDir + File.separator + "p1", "X1.java",
@@ -300,14 +300,13 @@ public class ModuleImportTests extends AbstractModuleCompilationTest {
 				files,
 				commandLine,
 				"",
-				"",
-				OUTPUT_DIR);
-		String classFile = String.join(File.separator, "mods", "mod.one", "p", "X.class");
+				"");
+		String classFile = String.join(File.separator, "p", "X.class");
 		verifyClassFile("version 24 : 68.65535", classFile, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test005_selfImport_NOK() {
-		String modsDir = OUTPUT_DIR +  File.separator + "mods";
+		String modsDir = getSourceDir() +  File.separator + "mods";
 		String modOneDir = modsDir + File.separator + "mod.one";
 		List<String> files = new ArrayList<>();
 		writeFileCollecting(files, modOneDir + File.separator + "p1", "X1.java",
@@ -339,7 +338,7 @@ public class ModuleImportTests extends AbstractModuleCompilationTest {
 				"",
 				"""
 				----------
-				1. ERROR in ---OUTPUT_DIR_PLACEHOLDER---/mods/mod.one/p/X.java (at line 5)
+				1. ERROR in ---OUTPUT_DIR_PLACEHOLDER---/src/mods/mod.one/p/X.java (at line 5)
 					X1 x1;
 					^^
 				X1 cannot be resolved to a type
@@ -350,7 +349,7 @@ public class ModuleImportTests extends AbstractModuleCompilationTest {
 	}
 
 	public void test006_selfImportInModule() throws IOException, ClassFormatException {
-		String modsDir = OUTPUT_DIR +  File.separator + "mods";
+		String modsDir = getSourceDir()+  File.separator + "mods";
 		String modOneDir = modsDir + File.separator + "mod.one";
 		List<String> files = new ArrayList<>();
 		writeFileCollecting(files, modOneDir + File.separator + "api", "IService.java",
@@ -382,14 +381,12 @@ public class ModuleImportTests extends AbstractModuleCompilationTest {
 				files,
 				commandLine,
 				"",
-				"",
-				OUTPUT_DIR);
-		String classFile = String.join(File.separator, "mods", "mod.one", "module-info.class");
-		verifyClassFile("version 24 : 68.65535", classFile, ClassFileBytesDisassembler.SYSTEM);
+				"");
+		verifyClassFile("version 24 : 68.65535", "module-info.class", ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test007_shadowing() throws IOException, ClassFormatException {
-		String srcDir = OUTPUT_DIR + File.separator + "src";
+		String srcDir = getSourceDir();
 		List<String> files = new ArrayList<>();
 		writeFileCollecting(files, srcDir + File.separator + "p1", "Connection.java",
 				"""
@@ -423,14 +420,13 @@ public class ModuleImportTests extends AbstractModuleCompilationTest {
 				files,
 				commandLine,
 				"",
-				"",
-				OUTPUT_DIR);
-		String classFile = String.join(File.separator, "src", "p2", "Client.class");
+				"");
+		String classFile = String.join(File.separator, "p2", "Client.class");
 		verifyClassFile("version 24 : 68.65535", classFile, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test008_shadowing() throws IOException, ClassFormatException {
-		String srcDir = OUTPUT_DIR + File.separator + "src";
+		String srcDir = getSourceDir();
 		List<String> files = new ArrayList<>();
 		writeFileCollecting(files, srcDir + File.separator + "p1", "Connection.java",
 				"""
@@ -465,12 +461,12 @@ public class ModuleImportTests extends AbstractModuleCompilationTest {
 				commandLine,
 				"",
 				"");
-		String classFile = String.join(File.separator, "src", "p2", "Client.class");
+		String classFile = String.join(File.separator, "p2", "Client.class");
 		verifyClassFile("version 24 : 68.65535", classFile, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test008_shadowing_static_nested() throws IOException, ClassFormatException {
-		String srcDir = OUTPUT_DIR + File.separator + "src";
+		String srcDir = getSourceDir() + File.separator + "src";
 		List<String> files = new ArrayList<>();
 		writeFileCollecting(files, srcDir + File.separator + "p1", "Outer.java",
 				"""
@@ -503,12 +499,12 @@ public class ModuleImportTests extends AbstractModuleCompilationTest {
 		commandLine.append(" -24 --enable-preview ");
 
 		runConformModuleTest(files, commandLine, "", "");
-		String classFile = String.join(File.separator, "src", "p2", "Client.class");
+		String classFile = String.join(File.separator, "p2", "Client.class");
 		verifyClassFile("version 24 : 68.65535", classFile, ClassFileBytesDisassembler.SYSTEM);
 	}
 
 	public void test009_ambiguous_modules() {
-		String srcDir = OUTPUT_DIR + File.separator + "src";
+		String srcDir = getSourceDir();
 		List<String> files = new ArrayList<>();
 		String modOneDir = srcDir + File.separator + "mod.one";
 		writeFileCollecting(files, modOneDir, "module-info.java",
@@ -578,13 +574,12 @@ public class ModuleImportTests extends AbstractModuleCompilationTest {
 					----------
 					2 problems (2 errors)
 					""",
-				"reference to Connection is ambiguous",
-				OUTPUT_DIR);
+				"reference to Connection is ambiguous");
 	}
 
 	public void test009_ambiguous_modules2() {
 		// module conflict via separate module imports based on separate requires directly in mod.two
-		String srcDir = OUTPUT_DIR + File.separator + "src";
+		String srcDir = getSourceDir();
 		List<String> files = new ArrayList<>();
 		String modOneDir = srcDir + File.separator + "mod.one";
 		writeFileCollecting(files, modOneDir, "module-info.java",
@@ -636,8 +631,7 @@ public class ModuleImportTests extends AbstractModuleCompilationTest {
 					----------
 					1 problem (1 error)
 					""",
-				"reference to Connection is ambiguous",
-				OUTPUT_DIR);
+				"reference to Connection is ambiguous");
 	}
 
 	public void test010_notAccessible() {
@@ -697,8 +691,7 @@ public class ModuleImportTests extends AbstractModuleCompilationTest {
 					----------
 					1 problem (1 error)
 					""",
-				"cannot find symbol",
-				OUTPUT_DIR);
+				"cannot find symbol");
 	}
 
 	public void test011_transitive() throws IOException, ClassFormatException {
@@ -743,15 +736,13 @@ public class ModuleImportTests extends AbstractModuleCompilationTest {
 		StringBuilder commandLine = new StringBuilder();
 		commandLine.append(" -24 --enable-preview");
 		commandLine.append(" --module-source-path ").append(srcDir);
-		commandLine.append(" -d ").append(OUTPUT_DIR+File.separator+"bin");
 
 		runConformModuleTest(
 				files,
 				commandLine,
 				"",
-				"",
-				OUTPUT_DIR);
-		String classFile = String.join(File.separator, "bin", "mod.three", "p2", "Client.class");
+				"");
+		String classFile = String.join(File.separator, "mod.three", "p2", "Client.class");
 		verifyClassFile("version 24 : 68.65535", classFile, ClassFileBytesDisassembler.SYSTEM);
 	}
 
@@ -799,8 +790,7 @@ public class ModuleImportTests extends AbstractModuleCompilationTest {
 					----------
 					2 problems (1 error, 1 warning)
 					""",
-				"cannot find symbol",
-				OUTPUT_DIR);
+				"cannot find symbol");
 	}
 
 	public void test013_inUnnamedModule() throws IOException, ClassFormatException {
@@ -926,7 +916,7 @@ public class ModuleImportTests extends AbstractModuleCompilationTest {
 				----------
 				1 problem (1 warning)
 				""");
-		verifyClassFile("version 24 : 68.65535", "module-info.class", ClassFileBytesDisassembler.SYSTEM);
+		verifyClassFile("version 24 : 68.65535", "module-info.class", ClassFileBytesDisassembler.SYSTEM, true); // FIXME skip due to https://bugs.openjdk.org/browse/JDK-8347646
 	}
 
 	public void testIllegalModifierRequiresJavaBase_4() {
@@ -982,7 +972,7 @@ public class ModuleImportTests extends AbstractModuleCompilationTest {
 				----------
 				1 problem (1 warning)
 				""");
-		verifyClassFile("version 24 : 68.65535", "module-info.class", ClassFileBytesDisassembler.SYSTEM);
+		verifyClassFile("version 24 : 68.65535", "module-info.class", ClassFileBytesDisassembler.SYSTEM, true); // FIXME skip due to https://bugs.openjdk.org/browse/JDK-8347646
 		verifyClassFile("version 24 : 68.65535", "p1/Client.class", ClassFileBytesDisassembler.SYSTEM);
 	}
 


### PR DESCRIPTION
After recent additions (#3604) ModuleImportTests had 8 failures in run.javac mode, because the branch for javac compilation wiped those class files that should be inspected for proper setting of the preview indicator.