### PR TITLE
Handle ClosedByInterruptException in JRTUtil#safeReadBytes only once

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/util/JrtUtilTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/util/JrtUtilTest.java
@@ -14,6 +14,10 @@
 package org.eclipse.jdt.core.tests.compiler.util;
 
 import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
 import java.nio.file.Paths;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.tests.junit.extension.TestCase;
@@ -68,6 +72,20 @@ public class JrtUtilTest extends TestCase {
 
 		Object jrtSystem3 = JRTUtil.getJrtSystem(this.image, null);
 		assertSame(jrtSystem, jrtSystem3);
+	}
+
+	@Test
+	public void testWorksUnderInterruptCondition() throws IOException {
+		FileSystem fs = FileSystems.getFileSystem(URI.create("jrt:/"));
+		try {
+			Thread.currentThread().interrupt();
+			assertNotNull(JRTUtil.safeReadBytes(fs.getPath("modules", "java.base", "java/lang/Object.class")));
+			assertTrue(Thread.currentThread().isInterrupted());
+			assertNull(JRTUtil.safeReadBytes(fs.getPath("xxxxxxxxx")));
+			assertTrue(Thread.currentThread().isInterrupted());
+		} finally {
+			Thread.interrupted();
+		}
 	}
 
 	private static int getMajorVersionSegment(String releaseVersion) {


### PR DESCRIPTION
Currently the method JRTUtil#safeReadBytes handles
ClosedByInterruptException in a problematic way:

1. The API states that all I/O errors are rethrown except
NoSuchFileException
2. There is no way for the caller to distinguish the case of notfound
and interrupted given the method return null in both cases
3. Some callers even expect a ClosedByInterruptException to function
properly, all other caller either rethrow or handle I/O errors already
4. ClosedByInterruptException is documented to set set interupt flag of
the thread, so reading it again will just again throw (and ignore) the
exception, there is not any documentation that this can ever throw
ClosedByInterruptException 'randomly' or in a recoverable way other than
maybe reset the interrupt flag of the thread

This now clear the interrupt flag when ClosedByInterruptException is
found and retry once again, if this still fails rethrow the exception to
the caller.

See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2877