### PR TITLE
Fix for NPE with short-to-Byte in record component issue #3536

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/RecordPattern.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/RecordPattern.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 IBM Corporation and others.
+ * Copyright (c) 2022, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -297,7 +297,8 @@ public class RecordPattern extends Pattern {
 			TypeBinding providedType = tp.resolvedType;
 			if (providedType != null && providedType.isPrimitiveType()) {
 				PrimitiveConversionRoute route = Pattern.findPrimitiveConversionRoute(componentType, providedType, currentScope);
-				if (route != PrimitiveConversionRoute.NO_CONVERSION_ROUTE) {
+				if (route != PrimitiveConversionRoute.NO_CONVERSION_ROUTE
+						|| !componentType.isPrimitiveType()) {
 					p.isTotalTypeNode = false;
 				}
 			}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PrimitiveInPatternsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PrimitiveInPatternsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -29,7 +29,7 @@ public class PrimitiveInPatternsTest extends AbstractRegressionTest9 {
 	static {
 //		TESTS_NUMBERS = new int [] { 1 };
 //		TESTS_RANGE = new int[] { 1, -1 };
-//		TESTS_NAMES = new String[] { "testIssue3535" };
+//		TESTS_NAMES = new String[] { "testIssue3536" };
 	}
 	private String extraLibPath;
 	public static Class<?> testClass() {
@@ -7448,5 +7448,25 @@ public class PrimitiveInPatternsTest extends AbstractRegressionTest9 {
 				"""
 			},
 			"3");
+	}
+	public void testIssue3536() {
+		runConformTest(new String[] {
+			"X.java",
+			"""
+				record Record(Byte b) {}
+				public class X {
+					public static void main(String argv[]) {
+						X x = new X();
+						System.out.println(x.foo(new Record(null)));
+					}
+					public int foo(Record r) {
+						int result = 0;
+						result = r instanceof Record(short s) ? 0 : 1;
+						return result;
+					}
+				}
+			"""
+			},
+			"1");
 	}
 }


### PR DESCRIPTION
## What it does
Fix for the NPE while passing `null` in a record component with record pattern with primitive - `short` to `Byte` here Issue #3536.   The fix checks whether a primitive is the component in a record pattern and whether there is reference type (non-primitive type) that is being expected. In such a case the fix effects a `instanceof` check with Object with the false branching to failed-match-label. Given that `null` does not match `Object` a jump to false-label would happen thus avoiding the null pointer.

Additional info: Why this is behaviour of not throwing a null deemed as the correct behaviour? 
Ans: This is because the primitives cannot have null as null is not in the domain of a primitive type.


## How to test
Run the unit test in the PR 

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
