### PR TITLE
Fix "Missing code implementation in the compiler"

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LambdaExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LambdaExpression.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2024 IBM Corporation and others.
+ * Copyright (c) 2012, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -7,6 +7,10 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
+ *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
@@ -1310,7 +1314,7 @@ public class LambdaExpression extends FunctionalExpression implements IPolyExpre
 				return;
 		}
 		System.arraycopy(this.outerLocalVariables, 0, this.outerLocalVariables = new SyntheticArgumentBinding[newSlot + 1], 0, newSlot);
-		this.outerLocalVariables[newSlot] = syntheticLocal = new SyntheticArgumentBinding(actualOuterLocalVariable);
+		this.outerLocalVariables[newSlot] = syntheticLocal = new SyntheticArgumentBinding(actualOuterLocalVariable, this.scope);
 		syntheticLocal.resolvedPosition = this.outerLocalVariablesSlotSize; // may need adjusting later if we need to generate an instance method for the lambda.
 		syntheticLocal.declaringScope = this.scope;
 		int parameterCount = this.binding.parameters.length;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/CodeStream.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/CodeStream.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -7,6 +7,10 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
+ *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
@@ -2457,7 +2461,20 @@ public void generateOuterAccess(Object[] mappingSequence, ASTNode invocationSite
 		aload_0();
 		fieldAccess(Opcodes.OPC_getfield, fieldBinding, null /* default declaringClass */);
 	} else {
-		load((LocalVariableBinding) mappingSequence[0]);
+		LocalVariableBinding localBinding = (LocalVariableBinding) mappingSequence[0];
+		if (localBinding instanceof SyntheticArgumentBinding synth && synth.accessingScope != null) {
+			if (!isOuterLocalInInstanceScope(scope, synth.accessingScope)) {
+				if (invocationSite instanceof AllocationExpression alloc
+						&& alloc.resolvedType instanceof LocalTypeBinding localType) {
+					scope.problemReporter().allocationInStaticContext(invocationSite, localType);
+					return;
+				} else {
+					scope.problemReporter().needImplementation(invocationSite); //TODO improve reporting if this is ever triggered
+					return;
+				}
+			}
+		}
+		load(localBinding);
 	}
 	for (int i = 1, length = mappingSequence.length; i < length; i++) {
 		if (mappingSequence[i] instanceof FieldBinding) {
@@ -2467,6 +2484,25 @@ public void generateOuterAccess(Object[] mappingSequence, ASTNode invocationSite
 			invoke(Opcodes.OPC_invokestatic, (MethodBinding) mappingSequence[i], null /* default declaringClass */);
 		}
 	}
+}
+
+private boolean isOuterLocalInInstanceScope(Scope scope, Scope accessingScope) {
+	Scope current = scope;
+	while (current != null) {
+		if (current == accessingScope)
+			return true;
+		if (current instanceof MethodScope ms && !ms.isConstructorCall && ms.isStatic) {
+			return false;
+		} else if (current instanceof ClassScope cs) {
+			SourceTypeBinding binding = cs.referenceContext.binding;
+			if (binding.superclass instanceof LocalTypeBinding superLocal) {
+				if (isOuterLocalInInstanceScope(superLocal.scope, accessingScope))
+					return true;
+			}
+		}
+		current = current.parent;
+	}
+	return false;
 }
 
 public void generateReturnBytecode(Expression expression) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/NestedTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/NestedTypeBinding.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2014 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -7,6 +7,10 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
+ *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
@@ -52,7 +56,7 @@ public SyntheticArgumentBinding addSyntheticArgument(LocalVariableBinding actual
 	SyntheticArgumentBinding synthLocal = null;
 
 	if (this.outerLocalVariables == null) {
-		synthLocal = new SyntheticArgumentBinding(actualOuterLocalVariable);
+		synthLocal = new SyntheticArgumentBinding(actualOuterLocalVariable, this.scope);
 		this.outerLocalVariables = new SyntheticArgumentBinding[] {synthLocal};
 	} else {
 		int size = this.outerLocalVariables.length;
@@ -65,7 +69,7 @@ public SyntheticArgumentBinding addSyntheticArgument(LocalVariableBinding actual
 		}
 		SyntheticArgumentBinding[] synthLocals = new SyntheticArgumentBinding[size + 1];
 		System.arraycopy(this.outerLocalVariables, 0, synthLocals, 0, newArgIndex);
-		synthLocals[newArgIndex] = synthLocal = new SyntheticArgumentBinding(actualOuterLocalVariable);
+		synthLocals[newArgIndex] = synthLocal = new SyntheticArgumentBinding(actualOuterLocalVariable, this.scope);
 		System.arraycopy(this.outerLocalVariables, newArgIndex, synthLocals, newArgIndex + 1, size - newArgIndex);
 		this.outerLocalVariables = synthLocals;
 	}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SyntheticArgumentBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SyntheticArgumentBinding.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2009 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -7,6 +7,10 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
+ *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
@@ -38,8 +42,9 @@ public class SyntheticArgumentBinding extends LocalVariableBinding {
 	public LocalVariableBinding actualOuterLocalVariable;
 	// if the argument has a matching synthetic field
 	public FieldBinding matchingField;
+	public Scope accessingScope; // scope from where the synth arg can be accessed
 
-	public SyntheticArgumentBinding(LocalVariableBinding actualOuterLocalVariable) {
+	public SyntheticArgumentBinding(LocalVariableBinding actualOuterLocalVariable, Scope declaringScope) {
 
 		super(
 			CharOperation.concat(TypeConstants.SYNTHETIC_OUTER_LOCAL_PREFIX, actualOuterLocalVariable.name),
@@ -47,6 +52,7 @@ public class SyntheticArgumentBinding extends LocalVariableBinding {
 			ClassFileConstants.AccFinal,
 			true);
 		this.actualOuterLocalVariable = actualOuterLocalVariable;
+		this.accessingScope = declaringScope;
 	}
 
 	public SyntheticArgumentBinding(ReferenceBinding enclosingType) {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SuperAfterStatementsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SuperAfterStatementsTest.java
@@ -2867,4 +2867,40 @@ public class SuperAfterStatementsTest extends AbstractRegressionTest9 {
 		----------
 		""");
 	}
+	// test case from https://bugs.openjdk.org/browse/JDK-8322882
+	public void testJDK8322882() throws Exception {
+		runNegativeTest(
+			new String[] {
+				"TestUseTree2.java",
+				"""
+				 public class TestUseTree2 {
+					public static void main(String[] args) {
+						String i = "111";
+						class TestUseTree2_ROOT {
+							// ctor arg i
+							void f() {
+								System.out.println(i);
+							}
+						}
+
+						class TestUseTree2_ROOT1 {
+							// clinit args: i?
+							// should be prohibited to use `new TestUseTree2_ROOT()` in a static context
+							static TestUseTree2_ROOT r = new TestUseTree2_ROOT();
+						}
+
+						TestUseTree2_ROOT1.r.f();
+					}
+				}
+				"""
+			},
+			"""
+			----------
+			1. ERROR in TestUseTree2.java (at line 14)
+				static TestUseTree2_ROOT r = new TestUseTree2_ROOT();
+				                             ^^^^^^^^^^^^^^^^^^^^^^^
+			Cannot instantiate local class 'TestUseTree2_ROOT' in a static context
+			----------
+			""");
+	}
 }


### PR DESCRIPTION
Need to detect illegal access to outer local from static context
+ capture the scope which requested a synthetic argument
+ check if any intermediate static context forbids access to that scope

Test case from https://bugs.openjdk.org/browse/JDK-8322882
