### PR TITLE
AssertionError: array store with invalid types at org.eclipse.jdt.internal.compiler.codegen.OperandStack.xastore

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/OperandStack.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/OperandStack.java
@@ -18,6 +18,7 @@ import java.util.Stack;
 import java.util.function.Supplier;
 import org.eclipse.jdt.internal.compiler.ClassFile;
 import org.eclipse.jdt.internal.compiler.lookup.ArrayBinding;
+import org.eclipse.jdt.internal.compiler.lookup.IntersectionTypeBinding18;
 import org.eclipse.jdt.internal.compiler.lookup.ReferenceBinding;
 import org.eclipse.jdt.internal.compiler.lookup.Scope;
 import org.eclipse.jdt.internal.compiler.lookup.TypeBinding;
@@ -31,18 +32,21 @@ public class OperandStack {
 
 	private Stack<TypeBinding> stack;
 	private ClassFile classFile;
+	private Scope scope;
 
 	public OperandStack() {}
 
 	public OperandStack(ClassFile classFile) {
 		this.stack = new Stack<>();
 		this.classFile = classFile;
+		this.scope = classFile.referenceBinding.scope;
 	}
 
 	@SuppressWarnings("unchecked")
 	private OperandStack(OperandStack operandStack) {
 		this.stack = (Stack<TypeBinding>) operandStack.stack.clone();
 		this.classFile = operandStack.classFile;
+		this.scope = operandStack.scope;
 	}
 
 	protected OperandStack copy() {
@@ -61,8 +65,15 @@ public class OperandStack {
 		*/
 		this.stack.push(switch(typeBinding.id) {
 			case TypeIds.T_boolean, TypeIds.T_byte, TypeIds.T_short, TypeIds.T_char -> TypeBinding.INT;
-			default -> typeBinding.erasure();
+			default -> erasure(typeBinding);
 		});
+	}
+
+	private TypeBinding erasure(TypeBinding type) {
+		TypeBinding erasure = type.erasure();
+		if (erasure instanceof ArrayBinding array && array.leafComponentType instanceof IntersectionTypeBinding18)
+			erasure = this.scope.createArrayType(this.scope.getJavaLangObject(), array.dimensions);
+		return erasure;
 	}
 
 	public void push(int localSlot) {
@@ -74,8 +85,7 @@ public class OperandStack {
 	}
 
 	public void push(char[] typeName) {
-		Scope scope = this.classFile.referenceBinding.scope;
-		Supplier<ReferenceBinding> finder = scope.getCommonReferenceBinding(typeName);
+		Supplier<ReferenceBinding> finder = this.scope.getCommonReferenceBinding(typeName);
 		TypeBinding type = finder != null ? finder.get() : TypeBinding.NULL;
 		push(type);
 	}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest.java
@@ -7017,5 +7017,33 @@ public void testIssue1802() {
 			"----------\n";
 	runner.runWarningTest();
 }
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3624
+// Internal compiler error: java.lang.AssertionError: array store with invalid types at org.eclipse.jdt.internal.compiler.codegen.OperandStack.xastore
+public void testIssue3624() {
+	if (this.complianceLevel >= ClassFileConstants.JDK14)
+		this.runConformTest(
+			new String[] {
+				"FailToCompile.java",
+				"""
+				import java.util.Arrays;
+
+				public class FailToCompile {
+				    public static void main(String[] args) {
+				        D<Object> a = new ACDClass();
+				        C<Object, Object> c = new ACDClass();
+				        Arrays.asList(a, c); // fail to compile
+				        Arrays.<A<Object>>asList(a, c);// compile
+				    }
+
+				    static class ACDClass implements A, C, D {}
+				    interface A<AA> {}
+				    interface B<AA> {}
+				    interface C<AA, BB> extends A<AA>, B<BB> {}
+				    interface D<AA> extends A<AA>, B<Object> {}
+				}
+				"""
+			}
+		);
+}
 }
 


### PR DESCRIPTION
Do not admit arrays with non-reifiable element types into book keeping. 

* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3624
