### PR TITLE
[javac] some differences ecj <-> javac regarding 'recent' features

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractRegressionTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractRegressionTest.java
@@ -680,7 +680,7 @@ static class JavaRuntime {
 			cmdLine.append(options);
 			cmdLine.append(' ');
 			cmdLine.append(className);
-			executionProcess = Runtime.getRuntime().exec(cmdLine.toString().split("\\s"), env, directory);
+			executionProcess = Runtime.getRuntime().exec(cmdLine.toString().split("\\s+"), env, directory);
 			Logger outputLogger = new Logger(executionProcess.getInputStream(),
 					"RUNTIME OUTPUT", stdout == null ? new StringBuilder() : stdout);
 			outputLogger.start();
@@ -1180,7 +1180,9 @@ protected static class JavacTestOptions {
 			JavacBug8337980 = // https://bugs.openjdk.org/browse/JDK-8337980
 					new JavacHasABug(MismatchType.EclipseErrorsJavacNone, ClassFileConstants.JDK24, 0000),
 			JavacBug8343306 = // https://bugs.openjdk.org/browse/JDK-8343306
-					new JavacHasABug(MismatchType.EclipseErrorsJavacNone, ClassFileConstants.JDK24, 0000);
+					new JavacHasABug(MismatchType.EclipseErrorsJavacNone, ClassFileConstants.JDK24, 0000),
+			JavacBug8348928 = // https://bugs.openjdk.org/browse/JDK-8348928
+					new JavacHasABug(MismatchType.EclipseErrorsJavacWarnings);
 
 		// bugs that have been fixed but that we've not identified
 		public static JavacHasABug

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ModuleImportTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ModuleImportTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 GK Software SE, and others.
+ * Copyright (c) 2024, 2025 GK Software SE, and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -67,7 +67,7 @@ public class ModuleImportTests extends AbstractModuleCompilationTest {
 			filtered.append(
 				log.toString().lines()
 					.filter(line -> !line.equals("Note: Recompile with -Xlint:preview for details."))
-					.filter(line -> !(line.startsWith("Note: ") && line.endsWith("uses preview features of Java SE 24.")))
+					.filter(line -> !(line.startsWith("Note: ") && line.endsWith(" preview features of Java SE 24.")))
 					.collect(Collectors.joining("\n")));
 			return filtered;
 		}
@@ -870,7 +870,7 @@ public class ModuleImportTests extends AbstractModuleCompilationTest {
 				----------
 				1 problem (1 error)
 				""",
-				"transitive modifier for java.base are not supported");
+				"transitive modifier for java.base are a preview feature");
 	}
 
 	public void testIllegalModifierRequiresJavaBase_2() {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchPatternTest22.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchPatternTest22.java
@@ -1,11 +1,15 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
+ *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
@@ -14,6 +18,7 @@ package org.eclipse.jdt.core.tests.compiler.regression;
 
 import java.util.Map;
 import junit.framework.Test;
+import org.eclipse.jdt.core.tests.compiler.regression.AbstractRegressionTest.JavacTestOptions.JavacHasABug;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 
 public class SwitchPatternTest22 extends AbstractBatchCompilerTest {
@@ -646,7 +651,8 @@ public class SwitchPatternTest22 extends AbstractBatchCompilerTest {
 	}
 	// javac jdk21 allows components to be named, but they can't be referenced.
 	public void testNaming() throws Exception {
-		runNegativeTest(
+		Runner runner = new Runner();
+		runner.testFiles =
 			new String[] {
 				"X.java",
 				"""
@@ -663,13 +669,16 @@ public class SwitchPatternTest22 extends AbstractBatchCompilerTest {
 				  }
 				}
 				"""
-			},
+			};
+		runner.expectedCompilerLog =
 			"----------\n" +
 			"1. ERROR in X.java (at line 5)\n" +
 			"	case Integer _, Point(int x, int _), String _  : System.out.println(\"Integer\");\n" +
 			"	                          ^\n" +
 			"Named pattern variables are not allowed here\n" +
-			"----------\n");
+			"----------\n";
+		runner.javacTestOptions = JavacHasABug.JavacBug8348928;
+		runner.runNegativeTest();
 	}
 	public void testGuard_0() {
 		this.runConformTest(

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TestAll.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TestAll.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -258,7 +258,7 @@ public static Test suite() {
 	 since_23.add(MarkdownCommentsTest.class);
 
 	 ArrayList since_24 = new ArrayList();
-	 since_23.add(ModuleImportTests.class);
+	 since_24.add(ModuleImportTests.class);
 	 since_24.add(SuperAfterStatementsTest.class);
 	 since_24.add(ImplicitlyDeclaredClassesTest.class);
 	 since_24.add(PrimitiveInPatternsTest.class);


### PR DESCRIPTION
+ more infra fixes for run.javac mode
+ don't run ModuleImportTests at 23 (needs 24-preview)
+ bookkeeping re https://bugs.openjdk.org/browse/JDK-8348928 (SwitchPatternTest22 doesn't yet OptIn to run.javac)

Relates to https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2959

