### PR TITLE
Test updates from recent discussions with Oracle

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractRegressionTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractRegressionTest.java
@@ -1182,7 +1182,10 @@ protected static class JavacTestOptions {
 			JavacBug8343306 = // https://bugs.openjdk.org/browse/JDK-8343306
 					new JavacHasABug(MismatchType.EclipseErrorsJavacNone, ClassFileConstants.JDK24, 0000),
 			JavacBug8348928 = // https://bugs.openjdk.org/browse/JDK-8348928
-					new JavacHasABug(MismatchType.EclipseErrorsJavacWarnings);
+					new JavacHasABug(MismatchType.EclipseErrorsJavacWarnings),
+			JavacBug8348410 = // https://bugs.openjdk.org/browse/JDK-8348410
+					new JavacHasABug(MismatchType.EclipseErrorsJavacNone);
+
 
 		// bugs that have been fixed but that we've not identified
 		public static JavacHasABug

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractRegressionTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractRegressionTest.java
@@ -1174,9 +1174,7 @@ protected static class JavacTestOptions {
 			JavacBug8226510_switchExpression = // https://bugs.openjdk.java.net/browse/JDK-8226510
 					new JavacBug8226510(" --release 12 --enable-preview -Xlint:-preview"),
 //		    JavacBug8299416 = // https://bugs.openjdk.java.net/browse/JDK-8299416 was active only in some builds of JDK 20
-		    JavacBug8336255 = // https://bugs.openjdk.org/browse/JDK-8336255
-					new JavacBugExtraJavacOptionsPlusMismatch(" --release 23 --enable-preview -Xlint:-preview",
-							MismatchType.JavacErrorsEclipseNone),
+//		    JavacBug8336255 = // https://bugs.openjdk.org/browse/JDK-8336255 was active only during preview 23
 			JavacBug8337980 = // https://bugs.openjdk.org/browse/JDK-8337980
 					new JavacHasABug(MismatchType.EclipseErrorsJavacNone, ClassFileConstants.JDK24, 0000),
 			JavacBug8343306 = // https://bugs.openjdk.org/browse/JDK-8343306

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ModuleImportTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ModuleImportTests.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
 import junit.framework.Test;
 import org.eclipse.jdt.core.util.ClassFileBytesDisassembler;
 import org.eclipse.jdt.core.util.ClassFormatException;
+import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 
 public class ModuleImportTests extends AbstractModuleCompilationTest {
 
@@ -916,7 +917,8 @@ public class ModuleImportTests extends AbstractModuleCompilationTest {
 				----------
 				1 problem (1 warning)
 				""");
-		verifyClassFile("version 24 : 68.65535", "module-info.class", ClassFileBytesDisassembler.SYSTEM, true); // FIXME skip due to https://bugs.openjdk.org/browse/JDK-8347646
+		verifyClassFile("version 24 : 68.65535", "module-info.class", ClassFileBytesDisassembler.SYSTEM,
+				this.complianceLevel <= ClassFileConstants.JDK24); // Skipped for javac 24 due to https://bugs.openjdk.org/browse/JDK-8347646 - fixed in 25
 	}
 
 	public void testIllegalModifierRequiresJavaBase_4() {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PrimitiveInPatternsTestSH.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PrimitiveInPatternsTestSH.java
@@ -19,6 +19,7 @@ package org.eclipse.jdt.core.tests.compiler.regression;
 import java.io.IOException;
 import java.util.Map;
 import junit.framework.Test;
+import org.eclipse.jdt.core.tests.compiler.regression.AbstractRegressionTest.JavacTestOptions.JavacHasABug;
 import org.eclipse.jdt.core.util.ClassFileBytesDisassembler;
 import org.eclipse.jdt.core.util.ClassFormatException;
 import org.eclipse.jdt.internal.compiler.batch.FileSystem;
@@ -2537,5 +2538,86 @@ public class PrimitiveInPatternsTestSH extends AbstractRegressionTest9 {
 			"Switch cannot have both boolean values and a default label\n" +
 			"----------\n");
 	}
+	public void testJDK8348410_negative() {
+		Runner runner = new Runner();
+		runner.customOptions = getCompilerOptions(false); // preview NOT enabled
+		runner.testFiles = new String[] {
+				"Test.java",
+				"""
+				 public class Test {
+					public static void main(String[] args) {
+						new Test().d(true);
+					}
 
+					void d(Boolean b) {
+						switch (b) {
+							case true -> System.out.println("1");
+							case false -> System.out.println("2");
+						};
+					}
+				}
+				"""
+			};
+		runner.expectedCompilerLog = """
+			----------
+			1. ERROR in Test.java (at line 7)
+				switch (b) {
+				        ^
+			An enhanced switch statement should be exhaustive; a default label expected
+			----------
+			2. ERROR in Test.java (at line 8)
+				case true -> System.out.println("1");
+				     ^^^^
+			Case constant of type boolean is incompatible with switch selector type Boolean
+			----------
+			3. ERROR in Test.java (at line 9)
+				case false -> System.out.println("2");
+				     ^^^^^
+			Case constant of type boolean is incompatible with switch selector type Boolean
+			----------
+			""";
+		runner.javacTestOptions = JavacHasABug.JavacBug8348410;
+		runner.runNegativeTest();
+	}
+	public void testJDK8348410_positive() {
+		Runner runner = new Runner();
+		runner.customOptions = getCompilerOptions(true); // preview enabled
+		runner.testFiles = new String[] {
+				"Test.java",
+				"""
+				 public class Test {
+					public static void main(String[] args) {
+						new Test().d(true);
+					}
+
+					void d(Boolean b) {
+						switch (b) {
+							case true -> System.out.println("1");
+							case false -> System.out.println("2");
+						};
+					}
+				}
+				"""
+			};
+		runner.vmArguments = VMARGS;
+		runner.expectedOutputString = "1";
+		runner.runConformTest();
+	}
+	public void testJDK8348901() {
+		// according to https://bugs.openjdk.org/browse/JDK-8348901 the null type is to be admitted when case null is present
+		runConformTest(new String[] {
+				"X.java",
+				"""
+				public class X {
+					public static void main(String[] args) {
+						switch (null) {
+							case null -> System.out.println("Null");
+							default-> System.out.println("Default");
+						}
+					}
+				}
+				"""
+			},
+			"Null");
+	}
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PrimitiveInPatternsTestSH.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PrimitiveInPatternsTestSH.java
@@ -1637,6 +1637,68 @@ public class PrimitiveInPatternsTestSH extends AbstractRegressionTest9 {
 		testInstanceof_widenUnbox("Float", 6, "49.0+49.0|");
 	}
 
+	public void testInstanceof_widenUnboxWiden() {
+		// see https://bugs.openjdk.org/browse/JDK-8342397
+		// which links to our https://mail.openjdk.org/pipermail/compiler-dev/2024-September/027630.html
+		runConformTest(new String[] {
+				"X.java",
+				"""
+				import java.util.List;
+				import java.util.Collections;
+				public class X {
+					static <T extends Short> void typeVariableSingle(T single) {
+						int i1 = single;
+						System.out.print(i1);
+						if (single instanceof int i)
+							System.out.print(i);
+						else
+							System.out.print('-');
+						switch (single) {
+							case int i -> System.out.print(i);
+							default -> System.out.print('-');
+						}
+						System.out.println();
+					}
+					static <T extends Short> void typeVariableList(List<T> list) {
+						int i1 = list.get(0);
+						System.out.print(i1);
+						if (list.get(0) instanceof int i)
+							System.out.print(i);
+						else
+							System.out.print('-');
+						switch (list.get(0)) {
+							case int i -> System.out.print(i);
+							default -> System.out.print('-');
+						}
+						System.out.println();
+					}
+					static void wildcard(List<? extends Short> list) {
+						int i1 = list.get(0);
+						System.out.print(i1);
+						if (list.get(0) instanceof int i)
+							System.out.print(i);
+						else
+							System.out.print('-');
+						switch (list.get(0)) {
+							case int i -> System.out.print(i);
+							default -> System.out.print('-');
+						}
+						System.out.println();
+					}
+					public static void main(String... args) {
+						Short s = 1;
+						typeVariableSingle(s);
+						typeVariableList(Collections.singletonList(s));
+						wildcard(Collections.singletonList(s));
+					}
+				}
+				"""
+			},
+			"""
+			111
+			111
+			111""");
+	}
 	public void testInstanceof_genericExpression() { // regression test for a checkCast which we failed to generate earlier
 		runConformTest(new String[] {
 				"X.java",

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SuperAfterStatementsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SuperAfterStatementsTest.java
@@ -2032,8 +2032,9 @@ public class SuperAfterStatementsTest extends AbstractRegressionTest9 {
 		        }
 			}
 			"""};
+		runner.vmArguments = VMARGS;
+		runner.javacTestOptions = JAVAC_OPTIONS;
 		runner.expectedOutputString = "f3f1";
-		runner.javacTestOptions = JavacTestOptions.JavacHasABug.JavacBug8336255;
 		runner.runConformTest();
 	}
 	public void testComplexNesting_NOK() {


### PR DESCRIPTION
+ test https://bugs.openjdk.org/browse/JDK-8348410 (OK in ecj)
+ we skip one check due to https://bugs.openjdk.org/browse/JDK-8347646
   -  auto-enable this when compliance >= 25
+ test https://bugs.openjdk.org/browse/JDK-8348901 : codify revised rule

