### PR TITLE
Lambda passed to explicit constructor invocation may raise Internal compiler error

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BlockScope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BlockScope.java
@@ -828,12 +828,6 @@ public VariableBinding[] getEmulationPath(LocalVariableBinding outerLocalVariabl
 	MethodScope currentMethodScope = methodScope();
 	SourceTypeBinding sourceType = currentMethodScope.enclosingSourceType();
 
-	// identity check
-	BlockScope variableScope = outerLocalVariable.declaringScope;
-	if (variableScope == null /*val$this$0*/ || currentMethodScope == variableScope.methodScope()) {
-		return new VariableBinding[] { outerLocalVariable };
-		// implicit this is good enough
-	}
 	if (currentMethodScope.isLambdaScope()) {
 		LambdaExpression lambda = (LambdaExpression) currentMethodScope.referenceContext;
 		SyntheticArgumentBinding syntheticArgument;
@@ -841,6 +835,14 @@ public VariableBinding[] getEmulationPath(LocalVariableBinding outerLocalVariabl
 			return new VariableBinding[] { syntheticArgument };
 		}
 	}
+
+	// identity check
+	BlockScope variableScope = outerLocalVariable.declaringScope;
+	if (variableScope == null /*val$this$0*/ || currentMethodScope == variableScope.methodScope()) {
+		return new VariableBinding[] { outerLocalVariable };
+		// implicit this is good enough
+	}
+
 	// use synthetic constructor arguments if possible
 	if (currentMethodScope.isInsideInitializerOrConstructor()
 		&& (sourceType.isNestedType())) {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SuperAfterStatementsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SuperAfterStatementsTest.java
@@ -2929,4 +2929,66 @@ public class SuperAfterStatementsTest extends AbstractRegressionTest9 {
 				"""},
 				"");
 	}
+	public void testGH3655() {
+		runConformTest(new String[] {
+			"Test1.java",
+			"""
+			public class Test1 {
+				class Inner {
+					Inner() {
+						this(() -> new Object() { { Test1.this.print(); } });
+					}
+					Inner(Runnable r) {
+						r.run();
+					}
+				}
+				void print() {
+					System.out.print(3);
+				}
+				public static void main(String... args) {
+					new Test1().new Inner();
+				}
+			}
+			"""
+			},
+			"3");
+	}
+	public void testGH3653() {
+		runConformTest(new String[] {
+			"Outer.java",
+			"""
+			class Outer { // bug
+				interface A { }
+
+				class Inner {
+				   Inner() {
+					  this(() -> {
+							class Local {
+								void g() {
+									m();
+								}
+							}
+							new Object() {
+								void k() { new Local().g(); }
+							}.k();
+						});
+					}
+
+					Inner(Runnable tr) {
+						tr.run();
+					}
+				}
+
+				void m() {
+					System.out.println("Hello");
+				}
+
+				public static void main(String[] args) {
+					new Outer().new Inner();
+				}
+			}
+			"""
+			},
+			"Hello");
+	}
 }


### PR DESCRIPTION
improve outer access emulation:
+ match a synthetic lambda arg to synth. arg of enclosing constructor
+ consider lambdaScope before assuming implicit this is available

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3655
