### PR TITLE
NPE when --module-source-path encounters an inaccessible directory

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/ModuleFinder.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/ModuleFinder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2024 IBM Corporation.
+ * Copyright (c) 2016, 2025 IBM Corporation.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -70,8 +70,9 @@ public class ModuleFinder {
 			} else {
 				if (file.isDirectory()) {
 					File[] files = file.listFiles();
-					for (File f : files) {
-						scanForModules(destinationPath, parser, options, isModulepath, isModulepath, collector, f, release);
+					if (files != null) {
+						for (File f : files)
+							scanForModules(destinationPath, parser, options, isModulepath, isModulepath, collector, f, release);
 					}
 				}
 			}
@@ -90,7 +91,7 @@ public class ModuleFinder {
 					return false;
 				}
 			});
-			if (list.length > 0) {
+			if (list != null && list.length > 0) { // null results from I/O errors (like missing permission)
 				String fileName = list[0];
 				switch (fileName) {
 					case IModule.MODULE_INFO_CLASS:


### PR DESCRIPTION
null check to account for I/O error

no test case as we can't easily trigger the I/O error during tests

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3658
