### PR TITLE
Simplify AST tests setup

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/AbstractASTTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/AbstractASTTests.java
@@ -36,32 +36,8 @@ import org.eclipse.jdt.internal.core.dom.SourceRangeVerifier;
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class AbstractASTTests extends ModifyingResourceTests implements DefaultMarkedNodeLabelProviderOptions {
 
-	/** @deprecated Using deprecated code */
-	private static final int AST_INTERNAL_JLS2 = AST.JLS2;
-	/**
-	 * Internal synonym for deprecated constant AST.JSL3
-	 * to alleviate deprecation warnings.
-	 * @deprecated
-	 */
-	/*package*/ static final int AST_INTERNAL_JLS3 = AST.JLS3;
-	/**
-	 * Internal synonym for deprecated constant AST.JSL4
-	 * to alleviate deprecation warnings.
-	 * @deprecated
-	 */
-	/*package*/ static final int AST_INTERNAL_JLS4 = AST.JLS4;
-	/**
-	 * Internal synonym for deprecated constant AST.JSL8
-	 * to alleviate deprecation warnings.
-	 * @deprecated
-	 */
-	/*package*/ static final int AST_INTERNAL_JLS8 = AST.JLS8;
-	public static final int astInternalJLS2() {
-		return AST_INTERNAL_JLS2;
-	}
-
 	// TODO (frederic) use this field while converting instead of method argument
-	protected int testLevel = AST_INTERNAL_JLS2;
+	protected int testLevel = AST.getAllSupportedVersions().getFirst();
 
 	public AbstractASTTests(String name) {
 		super(name);
@@ -303,7 +279,7 @@ public class AbstractASTTests extends ModifyingResourceTests implements DefaultM
 	 * and returns the AST node that was delimited by the astStart and astEnd of the marker info.
 	 */
 	protected ASTNode buildAST(MarkerInfo markerInfo, IClassFile classFile, boolean reportErrors) throws JavaModelException {
-		ASTParser parser = ASTParser.newParser(AST_INTERNAL_JLS3);
+		ASTParser parser = ASTParser.newParser(AST.getAllSupportedVersions().getFirst());
 		parser.setSource(classFile);
 		parser.setResolveBindings(true);
 		CompilationUnit unit = (CompilationUnit) parser.createAST(null);
@@ -376,13 +352,13 @@ public class AbstractASTTests extends ModifyingResourceTests implements DefaultM
 		CompilationUnit unit;
 		if (cu.isWorkingCopy()) {
 			cu.getBuffer().setContents(newContents);
-			unit = cu.reconcile(AST_INTERNAL_JLS3, flags, null, null);
+			unit = cu.reconcile(AST.getAllSupportedVersions().getFirst(), flags, null, null);
 		} else {
 			IBuffer buffer = cu.getBuffer();
 			buffer.setContents(newContents);
 			buffer.save(null, false);
 
-			ASTParser parser = ASTParser.newParser(AST_INTERNAL_JLS3);
+			ASTParser parser = ASTParser.newParser(AST.getAllSupportedVersions().getFirst());
 			parser.setSource(cu);
 			parser.setResolveBindings(true);
 			parser.setStatementsRecovery((flags & ICompilationUnit.ENABLE_STATEMENTS_RECOVERY) != 0);
@@ -465,7 +441,7 @@ public class AbstractASTTests extends ModifyingResourceTests implements DefaultM
 	protected ASTNode[] buildASTs(String newContents, ICompilationUnit cu, boolean reportErrors, boolean enableStatementRecovery, boolean bindingRecovery) throws JavaModelException {
 		String option = cu.getJavaProject().getOption(JavaCore.COMPILER_COMPLIANCE, true);
 		long jdkLevel = CompilerOptions.versionToJdkLevel(option);
-		int JLSLevel = AST_INTERNAL_JLS3;
+		int JLSLevel = AST.getAllSupportedVersions().getFirst();
 		if (jdkLevel >= ClassFileConstants.getComplianceLevelForJavaVersion(ClassFileConstants.MAJOR_VERSION_23)) {
 			JLSLevel = AST_INTERNAL_JLS23;
 		} else if (jdkLevel >= ClassFileConstants.getComplianceLevelForJavaVersion(ClassFileConstants.MAJOR_VERSION_22)) {
@@ -497,7 +473,7 @@ public class AbstractASTTests extends ModifyingResourceTests implements DefaultM
 		} else if (jdkLevel >= ClassFileConstants.JDK9) {
 			JLSLevel = AST_INTERNAL_JLS9;
 		} else if (jdkLevel <= CompilerOptions.getFirstSupportedJdkLevel()) {
-			JLSLevel = AST_INTERNAL_JLS8;
+			JLSLevel = AST.getAllSupportedVersions().getFirst();
 		}
 		return buildASTs(
 				JLSLevel,
@@ -689,7 +665,7 @@ public class AbstractASTTests extends ModifyingResourceTests implements DefaultM
 	}
 
 	protected void resolveASTs(ICompilationUnit[] cus, String[] bindingKeys, ASTRequestor requestor, IJavaProject project, WorkingCopyOwner owner) {
-		ASTParser parser = ASTParser.newParser(AST_INTERNAL_JLS3);
+		ASTParser parser = ASTParser.newParser(AST.getAllSupportedVersions().getFirst());
 		parser.setResolveBindings(true);
 		parser.setProject(project);
 		parser.setWorkingCopyOwner(owner);

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ConverterTestSetup.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ConverterTestSetup.java
@@ -320,27 +320,27 @@ public abstract class ConverterTestSetup extends AbstractASTTests {
 
 	public ASTNode runConversion(ICompilationUnit unit, boolean resolveBindings,
 			boolean bindingsRecovery) {
-		return runConversion(astInternalJLS2(), unit, resolveBindings, false, bindingsRecovery);
+		return runConversion(AST.getAllSupportedVersions().getFirst(), unit, resolveBindings, false, bindingsRecovery);
 	}
 
 	public ASTNode runConversion(ICompilationUnit unit, boolean resolveBindings) {
-		return runConversion(astInternalJLS2(), unit, resolveBindings);
+		return runConversion(AST.getAllSupportedVersions().getFirst(), unit, resolveBindings);
 	}
 
 	public ASTNode runConversion(ICompilationUnit unit, int position, boolean resolveBindings) {
-		return runConversion(astInternalJLS2(), unit, position, resolveBindings);
+		return runConversion(AST.getAllSupportedVersions().getFirst(), unit, position, resolveBindings);
 	}
 
 	public ASTNode runConversion(IClassFile classFile, int position, boolean resolveBindings) {
-		return runConversion(astInternalJLS2(), classFile, position, resolveBindings);
+		return runConversion(AST.getAllSupportedVersions().getFirst(), classFile, position, resolveBindings);
 	}
 
 	public ASTNode runConversion(char[] source, String unitName, IJavaProject project) {
-		return runConversion(astInternalJLS2(), source, unitName, project);
+		return runConversion(AST.getAllSupportedVersions().getFirst(), source, unitName, project);
 	}
 
 	public ASTNode runConversion(char[] source, String unitName, IJavaProject project, boolean resolveBindings) {
-		return runConversion(astInternalJLS2(), source, unitName, project, resolveBindings);
+		return runConversion(AST.getAllSupportedVersions().getFirst(), source, unitName, project, resolveBindings);
 	}
 
 	public ASTNode runConversion(int astLevel, ICompilationUnit unit, boolean resolveBindings) {
@@ -752,10 +752,10 @@ public abstract class ConverterTestSetup extends AbstractASTTests {
 	}
 
 	public ASTNode runConversion(char[] source, String unitName, IJavaProject project, Map<String, String> options, boolean resolveBindings) {
-		return runConversion(astInternalJLS2(), source, unitName, project, options, resolveBindings);
+		return runConversion(AST.getAllSupportedVersions().getFirst(), source, unitName, project, options, resolveBindings);
 	}
 	public ASTNode runConversion(char[] source, String unitName, IJavaProject project, Map<String, String> options) {
-		return runConversion(astInternalJLS2(), source, unitName, project, options);
+		return runConversion(AST.getAllSupportedVersions().getFirst(), source, unitName, project, options);
 	}
 
 	protected ASTNode getASTNodeToCompare(org.eclipse.jdt.core.dom.CompilationUnit unit) {


### PR DESCRIPTION
Instead of hardcoding AST 2/3/etc. use the first supported version. This makes future changes to the supported list automatically switch tests thus uncovering issues without manually changing the tests.
