### PR TITLE
Fix problem with escaped character in text block with continuation char

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Scanner.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Scanner.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -2322,7 +2322,6 @@ protected int scanForTextBlock() throws InvalidInputException {
 						if (this.recordLineSeparator) {
 							pushLineSeparator();
 						}
-						this.currentCharacter = '\\';
 						break;
 					case '\"' :
 						this.currentPosition++;

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ScannerTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ScannerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -1589,6 +1589,42 @@ public class ScannerTest extends AbstractRegressionTest {
 			}
 			assertEquals("Wrong contents", "This is the new String", String.valueOf(buffer));
 			assertEquals("Missing line end for continuation", 44, scanner.lineEnds[2]);
+		} catch (InvalidInputException e) {
+			assertTrue(false);
+		}
+	}
+
+	public void testIssue3666_001_since_14() {
+		char[] source = ("class X {\n" +
+				"  String  s = \"\"\"\nThis is the new String\\\n\"\"\";\n" +
+				"}").toCharArray();
+		Scanner scanner = new Scanner(false, false, false, ClassFileConstants.MAJOR_LATEST_VERSION, null, null, false);
+		scanner.previewEnabled = true;
+		scanner.recordLineSeparator = true;
+		scanner.setSource(source);
+		scanner.resetTo(0, source.length - 1);
+		try {
+			int token;
+			StringBuilder buffer = new StringBuilder();
+			while ((token = scanner.getNextToken()) != TerminalTokens.TokenNameEOF) {
+				try {
+					switch(token) {
+						case TerminalTokens.TokenNameTextBlock :
+							buffer.append( new String(scanner.getCurrentTextBlock()));
+							break;
+						case TerminalTokens.TokenNameStringLiteral :
+							break;
+						case TerminalTokens.TokenNameEOF :
+							break;
+						default :
+							break;
+					}
+				} catch (ArrayIndexOutOfBoundsException e) {
+					e.printStackTrace();
+				}
+			}
+			assertEquals("Wrong contents", "This is the new String", String.valueOf(buffer));
+			assertEquals("Missing line end for continuation", 51, scanner.lineEnds[2]);
 		} catch (InvalidInputException e) {
 			assertTrue(false);
 		}


### PR DESCRIPTION
- fix Scanner.scanForTextBlock() to add line breaks to the withoutUnicodeBuffer
- add new test to ScannerTest
- fixes #3666

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
