### PR TITLE
Stop using JLS3 in converter tests

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter15Test.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter15Test.java
@@ -48,7 +48,7 @@ public class ASTConverter15Test extends ConverterTestSetup {
 	@Override
 	public void setUpSuite() throws Exception {
 		super.setUpSuite();
-		this.ast = AST.newAST(getJLS3(), false);
+		this.ast = AST.newAST(getJLSFirst(), false);
 	}
 
 	public ASTConverter15Test(String name) {
@@ -412,7 +412,7 @@ public class ASTConverter15Test extends ConverterTestSetup {
 	public void test0006() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter15" , "src", "test0006", "X.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertTrue("Not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT);
 		CompilationUnit compilationUnit = (CompilationUnit) result;
 		final String expectedOutput = "Package annotations must be in file package-info.java";
@@ -432,7 +432,7 @@ public class ASTConverter15Test extends ConverterTestSetup {
 	public void test0007() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter15" , "src", "test0007", "X.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertTrue("Not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT);
 		CompilationUnit compilationUnit = (CompilationUnit) result;
 		assertProblemsSize(compilationUnit, 0);
@@ -448,7 +448,7 @@ public class ASTConverter15Test extends ConverterTestSetup {
 
 	public void test0009() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter15" , "src", "test0009", "X.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		char[] source = sourceUnit.getSource().toCharArray();
 		assertTrue("Not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT);
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -472,7 +472,7 @@ public class ASTConverter15Test extends ConverterTestSetup {
 
 	public void test0010() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter15" , "src", "test0010", "X.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		char[] source = sourceUnit.getSource().toCharArray();
 		assertTrue("Not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT);
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -502,7 +502,7 @@ public class ASTConverter15Test extends ConverterTestSetup {
 
 	public void test0011() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter15" , "src", "test0011", "X.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		char[] source = sourceUnit.getSource().toCharArray();
 		assertTrue("Not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT);
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -533,7 +533,7 @@ public class ASTConverter15Test extends ConverterTestSetup {
 
 	public void test0012() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter15" , "src", "test0012", "X.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		char[] source = sourceUnit.getSource().toCharArray();
 		assertTrue("Not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT);
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -2230,7 +2230,7 @@ public class ASTConverter15Test extends ConverterTestSetup {
 	 */
 	public void test0072() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter15", "src", "test0072", "X.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertEquals("not a compilation unit", ASTNode.COMPILATION_UNIT, result.getNodeType()); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		assertProblemsSize(unit, 0);
@@ -3249,7 +3249,7 @@ public class ASTConverter15Test extends ConverterTestSetup {
 			"}";
 		this.workingCopy = getWorkingCopy("/Converter15/src/X.java", true/*resolve*/);
 		this.workingCopy.getBuffer().setContents(contents.toCharArray());
-		ASTNode node = runConversion(getJLS3(), this.workingCopy, true);
+		ASTNode node = runConversion(this.workingCopy, true);
 		assertEquals("Not a compilation unit", ASTNode.COMPILATION_UNIT, node.getNodeType());
 		CompilationUnit compilationUnit = (CompilationUnit) node;
 		String expectedOutput = "Dead code";
@@ -5906,7 +5906,7 @@ public class ASTConverter15Test extends ConverterTestSetup {
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=99510
 	public void test0191() throws CoreException, IOException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter15" , "src", "test0191", "X.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode node = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode node = runConversion(sourceUnit, true);
 		assertNotNull("No node", node);
 		assertEquals("Not a compilation unit", ASTNode.COMPILATION_UNIT, node.getNodeType());
 		CompilationUnit unit = (CompilationUnit) node;
@@ -7510,7 +7510,7 @@ public class ASTConverter15Test extends ConverterTestSetup {
 		IType type = sourceUnit.getType("Test3");//$NON-NLS-1$
 
 		assertNotNull("Should not be null", type);
-		ASTParser parser= ASTParser.newParser(getJLS3());
+		ASTParser parser= ASTParser.newParser(getJLSFirst());
 		parser.setProject(type.getJavaProject());
 		IBinding[] bindings= parser.createBindings(new IJavaElement[] { type }, null);
 		if (bindings.length == 1 && bindings[0] instanceof ITypeBinding) {
@@ -7534,7 +7534,7 @@ public class ASTConverter15Test extends ConverterTestSetup {
 		IType type = sourceUnit.getType("Test3");//$NON-NLS-1$
 
 		assertNotNull("Should not be null", type);
-		ASTParser parser= ASTParser.newParser(getJLS3());
+		ASTParser parser= ASTParser.newParser(getJLSFirst());
 		parser.setSource(sourceUnit);
 		parser.setKind(ASTParser.K_COMPILATION_UNIT);
 		parser.setResolveBindings(true);
@@ -8139,7 +8139,7 @@ public class ASTConverter15Test extends ConverterTestSetup {
 	 */
 	public void test0247() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter15" , "src", "test0247", "EclipseCompiler.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true, true);
+		ASTNode result = runConversion(sourceUnit, true, true);
 		assertNotNull("Not a compilation unit", result);
 	}
 
@@ -8278,7 +8278,7 @@ public class ASTConverter15Test extends ConverterTestSetup {
 	//https://bugs.eclipse.org/bugs/show_bug.cgi?id=174436
 	public void test0251() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter15" , "src", "test0251", "X.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode node = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode node = runConversion(sourceUnit, false);
 		assertEquals("Not a compilation unit", ASTNode.COMPILATION_UNIT, node.getNodeType());
 		CompilationUnit unit = (CompilationUnit) node;
 		assertProblemsSize(unit, 0);
@@ -8308,7 +8308,7 @@ public class ASTConverter15Test extends ConverterTestSetup {
 	//https://bugs.eclipse.org/bugs/show_bug.cgi?id=174436
 	public void test0252() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter15" , "src", "test0252", "X.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode node = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode node = runConversion(sourceUnit, false);
 		assertEquals("Not a compilation unit", ASTNode.COMPILATION_UNIT, node.getNodeType());
 		CompilationUnit unit = (CompilationUnit) node;
 		assertProblemsSize(unit, 0);
@@ -8348,7 +8348,7 @@ public class ASTConverter15Test extends ConverterTestSetup {
 			"}";
 		this.workingCopy = getWorkingCopy("/Converter15/src/X.java", true/*resolve*/);
 		this.workingCopy.getBuffer().setContents(contents);
-		ASTNode node = runConversion(getJLS3(), this.workingCopy, true, true, true);
+		ASTNode node = runConversion(this.workingCopy, true, true, true);
 		assertEquals("Not a compilation unit", ASTNode.COMPILATION_UNIT, node.getNodeType());
 		CompilationUnit unit = (CompilationUnit) node;
 		String expectedError = "List cannot be resolved to a type";
@@ -8386,7 +8386,7 @@ public class ASTConverter15Test extends ConverterTestSetup {
 			"}";
 		this.workingCopy = getWorkingCopy("/Converter15/src/X.java", true/*resolve*/);
 		this.workingCopy.getBuffer().setContents(contents);
-		ASTNode node = runConversion(getJLS3(), this.workingCopy, true, true, true);
+		ASTNode node = runConversion(this.workingCopy, true, true, true);
 		assertEquals("Not a compilation unit", ASTNode.COMPILATION_UNIT, node.getNodeType());
 		CompilationUnit unit = (CompilationUnit) node;
 		assertProblemsSize(unit, 0);
@@ -9456,7 +9456,7 @@ public class ASTConverter15Test extends ConverterTestSetup {
 		}
 
 		CompilationUnitRequestor requestor = new CompilationUnitRequestor();
-		ASTParser parser = ASTParser.newParser(getJLS3());
+		ASTParser parser = ASTParser.newParser(getJLSFirst());
 		parser.setResolveBindings(true);
 		parser.setProject(getJavaProject("Converter15"));
 		parser.setKind(ASTParser.K_COMPILATION_UNIT);
@@ -9632,7 +9632,7 @@ public class ASTConverter15Test extends ConverterTestSetup {
 			"}";
 		this.workingCopy = getWorkingCopy("/Converter15/src/X.java", true/*resolve*/);
 		this.workingCopy.getBuffer().setContents(contents);
-		ASTNode node = runConversion(getJLS3(), this.workingCopy, true, true, true);
+		ASTNode node = runConversion(this.workingCopy, true, true, true);
 		assertEquals("Not a compilation unit", ASTNode.COMPILATION_UNIT, node.getNodeType());
 		CompilationUnit unit = (CompilationUnit) node;
 		assertProblemsSize(unit, 0);
@@ -9686,7 +9686,7 @@ public class ASTConverter15Test extends ConverterTestSetup {
 			"}";
 		this.workingCopy = getWorkingCopy("/Converter15/src/X.java", true/*resolve*/);
 		this.workingCopy.getBuffer().setContents(contents);
-		ASTNode node = runConversion(getJLS3(), this.workingCopy, true, true, true);
+		ASTNode node = runConversion(this.workingCopy, true, true, true);
 		assertEquals("Not a compilation unit", ASTNode.COMPILATION_UNIT, node.getNodeType());
 		CompilationUnit unit = (CompilationUnit) node;
 		assertProblemsSize(unit, 1, "Bar2 cannot be resolved to a type");
@@ -10761,7 +10761,7 @@ public class ASTConverter15Test extends ConverterTestSetup {
 			BindingKey.createTypeBindingKey(typeName)
 		};
 		final BindingRequestor requestor = new BindingRequestor();
-		final ASTParser parser = ASTParser.newParser(getJLS3());
+		final ASTParser parser = ASTParser.newParser(getJLSFirst());
 		parser.setResolveBindings(true);
 		parser.setProject(javaProject);
 		// this doesn't really do a parse; it's a type lookup
@@ -10796,7 +10796,7 @@ public class ASTConverter15Test extends ConverterTestSetup {
 			BindingKey.createTypeBindingKey(typeName)
 		};
 		final BindingRequestor requestor = new BindingRequestor();
-		final ASTParser parser = ASTParser.newParser(getJLS3());
+		final ASTParser parser = ASTParser.newParser(getJLSFirst());
 		parser.setResolveBindings(true);
 		parser.setProject(javaProject);
 		// this doesn't really do a parse; it's a type lookup
@@ -10834,7 +10834,7 @@ public class ASTConverter15Test extends ConverterTestSetup {
 			BindingKey.createTypeBindingKey(typeName)
 		};
 		final BindingRequestor requestor = new BindingRequestor();
-		final ASTParser parser = ASTParser.newParser(getJLS3());
+		final ASTParser parser = ASTParser.newParser(getJLSFirst());
 		parser.setResolveBindings(true);
 		parser.setProject(javaProject);
 		// this doesn't really do a parse; it's a type lookup
@@ -11257,7 +11257,7 @@ public class ASTConverter15Test extends ConverterTestSetup {
 		//IType type2 = sourceUnit2.getType("TestAnnotationWithStringDefault");//$NON-NLS-1$
 
 		assertNotNull("Should not be null", type);
-		ASTParser parser= ASTParser.newParser(getJLS3());
+		ASTParser parser= ASTParser.newParser(getJLSFirst());
 		parser.setProject(type.getJavaProject());
 		IBinding[] bindings= parser.createBindings(new IJavaElement[] { type }, null);
 		if (bindings.length == 1 && bindings[0] instanceof ITypeBinding) {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter16Test.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter16Test.java
@@ -32,7 +32,7 @@ public class ASTConverter16Test extends ConverterTestSetup {
 	@Override
 	public void setUpSuite() throws Exception {
 		super.setUpSuite();
-		this.ast = AST.newAST(getJLS3(), false);
+		this.ast = AST.newAST(getJLSFirst(), false);
 	}
 
 	public ASTConverter16Test(String name) {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterAST3Test.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterAST3Test.java
@@ -36,7 +36,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	@Override
 	public void setUpSuite() throws Exception {
 		super.setUpSuite();
-		this.ast = AST.newAST(getJLS3(), false);
+		this.ast = AST.newAST(getJLSFirst(), false);
 	}
 
 	public ASTConverterAST3Test(String name) {
@@ -53,7 +53,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0001() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0001", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 
 		// check that we have the right tree
 		CompilationUnit unit = this.ast.newCompilationUnit();
@@ -122,7 +122,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0002() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0002", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode expression = getASTNodeToCompare((CompilationUnit) result);
 		assertNotNull("Expression should not be null", expression); //$NON-NLS-1$
 		ClassInstanceCreation classInstanceCreation = this.ast.newClassInstanceCreation();
@@ -137,7 +137,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0003() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0003", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode expression = getASTNodeToCompare((CompilationUnit) result);
 		assertNotNull("Expression should not be null", expression); //$NON-NLS-1$
 		ClassInstanceCreation classInstanceCreation = this.ast.newClassInstanceCreation();
@@ -158,7 +158,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0004() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0004", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode expression = getASTNodeToCompare((CompilationUnit) result);
 		assertNotNull("Expression should not be null", expression); //$NON-NLS-1$
 		ClassInstanceCreation classInstanceCreation = this.ast.newClassInstanceCreation();
@@ -182,7 +182,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0005() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0005", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode expression = getASTNodeToCompare((CompilationUnit) result);
 		assertNotNull("Expression should not be null", expression); //$NON-NLS-1$
 		ClassInstanceCreation classInstanceCreation = this.ast.newClassInstanceCreation();
@@ -209,7 +209,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0006() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0006", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode expression = getASTNodeToCompare((CompilationUnit) result);
 		assertNotNull("Expression should not be null", expression); //$NON-NLS-1$
 		ClassInstanceCreation classInstanceCreation = this.ast.newClassInstanceCreation();
@@ -239,7 +239,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0007() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0007", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertTrue("Not an ExpressionStatement", node instanceof ExpressionStatement); //$NON-NLS-1$
 		ExpressionStatement expressionStatement = (ExpressionStatement) node;
@@ -260,7 +260,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0008() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0008", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode expression = getASTNodeToCompare((CompilationUnit) result);
 		assertNotNull("Expression should not be null", expression); //$NON-NLS-1$
 		ArrayCreation arrayCreation = this.ast.newArrayCreation();
@@ -281,7 +281,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0009() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0009", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode expression = getASTNodeToCompare((CompilationUnit) result);
 		assertNotNull("Expression should not be null", expression); //$NON-NLS-1$
 		ArrayCreation arrayCreation = this.ast.newArrayCreation();
@@ -304,7 +304,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0010() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0010", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode expression = getASTNodeToCompare((CompilationUnit) result);
 		assertNotNull("Expression should not be null", expression); //$NON-NLS-1$
 		ArrayCreation arrayCreation = this.ast.newArrayCreation();
@@ -320,7 +320,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0011() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0011", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode expression = getASTNodeToCompare((CompilationUnit) result);
 		assertNotNull("Expression should not be null", expression); //$NON-NLS-1$
 		ArrayCreation arrayCreation = this.ast.newArrayCreation();
@@ -336,7 +336,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0012() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0012", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode expression = getASTNodeToCompare((CompilationUnit) result);
 		assertNotNull("Expression should not be null", expression); //$NON-NLS-1$
 		ArrayCreation arrayCreation = this.ast.newArrayCreation();
@@ -357,7 +357,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0013() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0013", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		VariableDeclarationFragment variableDeclarationFragment = this.ast.newVariableDeclarationFragment();
@@ -374,7 +374,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0014() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0014", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		VariableDeclarationFragment variableDeclarationFragment = this.ast.newVariableDeclarationFragment();
@@ -393,7 +393,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0015() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0015", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 1);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		Assignment assignment = this.ast.newAssignment();
@@ -411,7 +411,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0016() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0016", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 1);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		Assignment assignment = this.ast.newAssignment();
@@ -429,7 +429,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0017() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0017", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 1);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		Assignment assignment = this.ast.newAssignment();
@@ -447,7 +447,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0018() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0018", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 1);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		Assignment assignment = this.ast.newAssignment();
@@ -465,7 +465,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0019() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0019", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 1);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		Assignment assignment = this.ast.newAssignment();
@@ -483,7 +483,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0020() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0020", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 1);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		Assignment assignment = this.ast.newAssignment();
@@ -501,7 +501,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0021() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0021", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 1);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		Assignment assignment = this.ast.newAssignment();
@@ -519,7 +519,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0022() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0022", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 1);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		Assignment assignment = this.ast.newAssignment();
@@ -537,7 +537,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0023() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0023", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 1);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		Assignment assignment = this.ast.newAssignment();
@@ -555,7 +555,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0024() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0024", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 1);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		Assignment assignment = this.ast.newAssignment();
@@ -573,7 +573,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0025() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0025", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 1);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		Assignment assignment = this.ast.newAssignment();
@@ -591,7 +591,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0026() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0026", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 1);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		Assignment assignment = this.ast.newAssignment();
@@ -609,7 +609,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0027() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0027", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 1);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		PrefixExpression prefixExpression = this.ast.newPrefixExpression();
@@ -626,7 +626,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0028() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0028", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 1);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		PrefixExpression prefixExpression = this.ast.newPrefixExpression();
@@ -643,7 +643,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0029() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0029", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 1);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		PostfixExpression postfixExpression = this.ast.newPostfixExpression();
@@ -660,7 +660,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0030() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0030", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 1);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		PostfixExpression postfixExpression = this.ast.newPostfixExpression();
@@ -677,7 +677,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0031() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0031", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 1);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		VariableDeclarationFragment variableDeclarationFragment = this.ast.newVariableDeclarationFragment();
@@ -698,7 +698,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0032() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0032", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 1);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		VariableDeclarationFragment variableDeclarationFragment = this.ast.newVariableDeclarationFragment();
@@ -719,7 +719,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0033() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0033", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 1);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 
@@ -742,7 +742,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0034() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0034", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 1);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 
@@ -765,7 +765,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0035() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0035", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 1);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 
@@ -788,7 +788,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0036() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0036", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 1);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 
@@ -811,7 +811,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0037() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0037", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 1);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 
@@ -834,7 +834,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0038() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0038", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 
@@ -856,7 +856,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0039() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0039", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 
@@ -878,7 +878,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0040() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0040", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 
@@ -900,7 +900,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0041() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0041", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 
@@ -922,7 +922,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0042() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0042", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode expression = getASTNodeToCompare((CompilationUnit) result);
 		assertNotNull("Expression should not be null", expression); //$NON-NLS-1$
 		BooleanLiteral literal = this.ast.newBooleanLiteral(false);
@@ -936,7 +936,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0043() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0043", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode expression = getASTNodeToCompare((CompilationUnit) result);
 		assertNotNull("Expression should not be null", expression); //$NON-NLS-1$
 		BooleanLiteral literal = this.ast.newBooleanLiteral(true);
@@ -950,7 +950,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0044() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0044", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode expression = getASTNodeToCompare((CompilationUnit) result);
 		assertNotNull("Expression should not be null", expression); //$NON-NLS-1$
 		NullLiteral literal = this.ast.newNullLiteral();
@@ -964,7 +964,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0045() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0045", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode expression = getASTNodeToCompare((CompilationUnit) result);
 		assertNotNull("Expression should not be null", expression); //$NON-NLS-1$
 		CharacterLiteral literal = this.ast.newCharacterLiteral();
@@ -979,7 +979,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0046() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0046", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode expression = getASTNodeToCompare((CompilationUnit) result);
 		assertNotNull("Expression should not be null", expression); //$NON-NLS-1$
 		NumberLiteral literal = this.ast.newNumberLiteral("1.00001");//$NON-NLS-1$
@@ -993,7 +993,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0047() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0047", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode expression = getASTNodeToCompare((CompilationUnit) result);
 		assertNotNull("Expression should not be null", expression); //$NON-NLS-1$
 		NumberLiteral literal = this.ast.newNumberLiteral("1.00001f");//$NON-NLS-1$
@@ -1007,7 +1007,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0048() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0048", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode expression = getASTNodeToCompare((CompilationUnit) result);
 		assertNotNull("Expression should not be null", expression); //$NON-NLS-1$
 		NumberLiteral literal = this.ast.newNumberLiteral("30000");//$NON-NLS-1$
@@ -1021,7 +1021,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0049() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0049", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode expression = getASTNodeToCompare((CompilationUnit) result);
 		assertNotNull("Expression should not be null", expression); //$NON-NLS-1$
 		NumberLiteral literal = this.ast.newNumberLiteral("-2147483648");//$NON-NLS-1$
@@ -1035,7 +1035,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0050() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0050", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode expression = getASTNodeToCompare((CompilationUnit) result);
 		assertNotNull("Expression should not be null", expression); //$NON-NLS-1$
 		NumberLiteral literal = this.ast.newNumberLiteral("2147483648L");//$NON-NLS-1$
@@ -1049,7 +1049,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0051() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0051", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode expression = getASTNodeToCompare((CompilationUnit) result);
 		assertNotNull("Expression should not be null", expression); //$NON-NLS-1$
 		NumberLiteral literal = this.ast.newNumberLiteral("2147483648L");//$NON-NLS-1$
@@ -1066,7 +1066,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0052() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0052", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode expression = getASTNodeToCompare((CompilationUnit) result);
 		assertNotNull("Expression should not be null", expression); //$NON-NLS-1$
 		NumberLiteral literal = this.ast.newNumberLiteral("-9223372036854775808L");//$NON-NLS-1$
@@ -1080,7 +1080,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0053() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0053", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode expression = getASTNodeToCompare((CompilationUnit) result);
 		assertNotNull("Expression should not be null", expression); //$NON-NLS-1$
 		/*
@@ -1105,7 +1105,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0054() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0054", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 2);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 
@@ -1129,7 +1129,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0055() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0055", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 2);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 
@@ -1153,7 +1153,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0056() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0056", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 2);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 
@@ -1177,7 +1177,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0057() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0057", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 2);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 
@@ -1201,7 +1201,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0058() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0058", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 2);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 
@@ -1225,7 +1225,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0059() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0059", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 2);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 
@@ -1249,7 +1249,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0060() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0060", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 2);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 
@@ -1273,7 +1273,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0061() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0061", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 2);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 
@@ -1297,7 +1297,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0062() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0062", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 2);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 
@@ -1321,7 +1321,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0063() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0063", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 2);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 
@@ -1345,7 +1345,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0064() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0064", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 2);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 
@@ -1369,7 +1369,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0065() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0065", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 2);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 
@@ -1393,7 +1393,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0066() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0066", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 2);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 
@@ -1417,7 +1417,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0067() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0067", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 2);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 
@@ -1441,7 +1441,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0068() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0068", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 2);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 
@@ -1465,7 +1465,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0069() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0069", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 2);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 
@@ -1489,7 +1489,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0070() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0070", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 1);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		VariableDeclarationFragment variableDeclarationFragment = this.ast.newVariableDeclarationFragment();
@@ -1512,7 +1512,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0071() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0071", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 1);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 
@@ -1542,7 +1542,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0072() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0072", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 1);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		VariableDeclarationFragment variableDeclarationFragment = this.ast.newVariableDeclarationFragment();
@@ -1564,7 +1564,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0073() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0073", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 1);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		VariableDeclarationFragment variableDeclarationFragment = this.ast.newVariableDeclarationFragment();
@@ -1586,7 +1586,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0074() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0074", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 
@@ -1609,7 +1609,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0075() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0075", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 
@@ -1633,7 +1633,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0076() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0076", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 
@@ -1660,7 +1660,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0077() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0077", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		VariableDeclarationFragment variableDeclarationFragment = this.ast.newVariableDeclarationFragment();
@@ -1687,7 +1687,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0078() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0078", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		SuperMethodInvocation superMethodInvocation = this.ast.newSuperMethodInvocation();
@@ -1703,7 +1703,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0079() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0079", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		SuperMethodInvocation superMethodInvocation = this.ast.newSuperMethodInvocation();
@@ -1720,7 +1720,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0080() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0080", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		MethodInvocation methodInvocation = this.ast.newMethodInvocation();
@@ -1737,7 +1737,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0081() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0081", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		MethodInvocation methodInvocation = this.ast.newMethodInvocation();
@@ -1755,7 +1755,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0082() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0082", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		ForStatement forStatement = this.ast.newForStatement();
@@ -1770,7 +1770,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0083() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0083", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		ForStatement forStatement = this.ast.newForStatement();
@@ -1800,7 +1800,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0084() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0084", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		ForStatement forStatement = this.ast.newForStatement();
@@ -1832,7 +1832,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0085() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0085", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		ForStatement forStatement = this.ast.newForStatement();
@@ -1859,7 +1859,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0086() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0086", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		ForStatement forStatement = this.ast.newForStatement();
@@ -1883,7 +1883,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0087() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0087", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		ForStatement forStatement = this.ast.newForStatement();
@@ -1902,7 +1902,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0088() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0088", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 
@@ -1922,7 +1922,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0089() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0089", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 
@@ -1950,7 +1950,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0090() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0090", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 
@@ -1973,7 +1973,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0091() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0091", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		MethodDeclaration method = (MethodDeclaration)((TypeDeclaration) ((CompilationUnit) result).types().get(0)).bodyDeclarations().get(0);
 		SingleVariableDeclaration node = (SingleVariableDeclaration) method.parameters().get(0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
@@ -1990,7 +1990,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0092() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0092", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		MethodDeclaration method = (MethodDeclaration)((TypeDeclaration) ((CompilationUnit) result).types().get(0)).bodyDeclarations().get(0);
 		SingleVariableDeclaration node = (SingleVariableDeclaration) method.parameters().get(0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
@@ -2009,7 +2009,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0093() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0093", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		ForStatement forStatement = (ForStatement) node;
 		BreakStatement statement = (BreakStatement) ((Block) forStatement.getBody()).statements().get(0);
@@ -2025,7 +2025,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0094() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0094", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		ForStatement forStatement = (ForStatement) node;
 		ContinueStatement statement = (ContinueStatement) ((Block) forStatement.getBody()).statements().get(0);
@@ -2041,7 +2041,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0095() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0095", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		LabeledStatement labeledStatement = (LabeledStatement) getASTNode((CompilationUnit) result, 0, 0, 0);
 		ForStatement forStatement = (ForStatement) labeledStatement.getBody();
 		ContinueStatement statement = (ContinueStatement) ((Block) forStatement.getBody()).statements().get(0);
@@ -2058,7 +2058,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0096() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0096", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		LabeledStatement labeledStatement = (LabeledStatement) getASTNode((CompilationUnit) result, 0, 0, 0);
 		ForStatement forStatement = (ForStatement) labeledStatement.getBody();
 		BreakStatement statement = (BreakStatement) ((Block) forStatement.getBody()).statements().get(0);
@@ -2076,7 +2076,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0097() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0097", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		SwitchStatement switchStatement = this.ast.newSwitchStatement();
@@ -2140,7 +2140,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0098() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0098", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		EmptyStatement emptyStatement = this.ast.newEmptyStatement();
@@ -2154,7 +2154,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0099() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0099", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		DoStatement doStatement = this.ast.newDoStatement();
@@ -2174,7 +2174,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0100() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0100", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		WhileStatement whileStatement = this.ast.newWhileStatement();
@@ -2190,7 +2190,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0101() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0101", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		WhileStatement whileStatement = this.ast.newWhileStatement();
@@ -2206,7 +2206,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0102() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0102", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode expression = getASTNodeToCompare((CompilationUnit) result);
 		assertNotNull("Expression should not be null", expression); //$NON-NLS-1$
 		InfixExpression infixExpression = this.ast.newInfixExpression();
@@ -2230,7 +2230,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0103() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0103", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode expression = getASTNodeToCompare((CompilationUnit) result);
 		assertNotNull("Expression should not be null", expression); //$NON-NLS-1$
 		InfixExpression infixExpression = this.ast.newInfixExpression();
@@ -2257,7 +2257,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0104() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0104", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode expression = getASTNodeToCompare((CompilationUnit) result);
 		assertNotNull("Expression should not be null", expression); //$NON-NLS-1$
 		InfixExpression infixExpression = this.ast.newInfixExpression();
@@ -2284,7 +2284,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0105() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0105", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode expression = getASTNodeToCompare((CompilationUnit) result);
 		assertNotNull("Expression should not be null", expression); //$NON-NLS-1$
 		InfixExpression infixExpression = this.ast.newInfixExpression();
@@ -2311,7 +2311,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0106() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0106", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode expression = getASTNodeToCompare((CompilationUnit) result);
 		assertNotNull("Expression should not be null", expression); //$NON-NLS-1$
 		InfixExpression infixExpression = this.ast.newInfixExpression();
@@ -2347,7 +2347,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0107() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0107", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode expression = getASTNodeToCompare((CompilationUnit) result);
 		assertNotNull("Expression should not be null", expression); //$NON-NLS-1$
 		InfixExpression infixExpression = this.ast.newInfixExpression();
@@ -2374,7 +2374,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0108() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0108", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode expression = getASTNodeToCompare((CompilationUnit) result);
 		assertNotNull("Expression should not be null", expression); //$NON-NLS-1$
 		InfixExpression infixExpression = this.ast.newInfixExpression();
@@ -2401,7 +2401,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0109() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0109", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode expression = getASTNodeToCompare((CompilationUnit) result);
 		assertNotNull("Expression should not be null", expression); //$NON-NLS-1$
 		InfixExpression infixExpression = this.ast.newInfixExpression();
@@ -2437,7 +2437,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0110() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0110", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		ReturnStatement returnStatement = this.ast.newReturnStatement();
@@ -2454,7 +2454,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0111() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0111", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		ReturnStatement returnStatement = this.ast.newReturnStatement();
@@ -2471,7 +2471,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0112() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0112", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		SynchronizedStatement synchronizedStatement = this.ast.newSynchronizedStatement();
@@ -2489,7 +2489,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0113() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0113", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		TryStatement tryStatement = this.ast.newTryStatement();
@@ -2516,7 +2516,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0114() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0114", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		TryStatement tryStatement = this.ast.newTryStatement();
@@ -2541,7 +2541,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0115() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0115", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		TryStatement tryStatement = this.ast.newTryStatement();
@@ -2573,7 +2573,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0116() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0116", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		ThrowStatement throwStatement = this.ast.newThrowStatement();
@@ -2588,7 +2588,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0117() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0117", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		ThrowStatement throwStatement = this.ast.newThrowStatement();
@@ -2603,7 +2603,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0118() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0118", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		ThrowStatement throwStatement = this.ast.newThrowStatement();
@@ -2618,7 +2618,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0119() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0119", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		IfStatement ifStatement = this.ast.newIfStatement();
@@ -2634,7 +2634,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0120() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0120", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		IfStatement ifStatement = this.ast.newIfStatement();
@@ -2653,7 +2653,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0121() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0121", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		IfStatement ifStatement = this.ast.newIfStatement();
@@ -2672,7 +2672,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0122() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0122", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		IfStatement ifStatement = this.ast.newIfStatement();
@@ -2692,7 +2692,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0123() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0123", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		IfStatement ifStatement = this.ast.newIfStatement();
@@ -2719,7 +2719,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
     public void test0124() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0124", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		VariableDeclarationFragment fragment = this.ast.newVariableDeclarationFragment();
@@ -2758,7 +2758,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
     public void test0125() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0125", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		VariableDeclarationFragment fragment = this.ast.newVariableDeclarationFragment();
@@ -2797,7 +2797,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
     public void test0126() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0126", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		ForStatement forStatement = this.ast.newForStatement();
@@ -2825,7 +2825,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
     public void test0127() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0127", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		ForStatement forStatement = this.ast.newForStatement();
@@ -2853,7 +2853,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
     public void test0128() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0128", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		ForStatement forStatement = this.ast.newForStatement();
@@ -2881,7 +2881,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0129() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0129", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		assertTrue("The node is not a FieldDeclaration", node instanceof FieldDeclaration); //$NON-NLS-1$
@@ -2901,7 +2901,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
     public void test0130() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0130", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		assertTrue("The node is not a FieldDeclaration", node instanceof FieldDeclaration); //$NON-NLS-1$
@@ -2942,7 +2942,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0131() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0131", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		assertTrue("The node is not a MethodDeclaration", node instanceof MethodDeclaration); //$NON-NLS-1$
@@ -2966,7 +2966,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0132() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0132", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		assertTrue("The node is not a MethodDeclaration", node instanceof MethodDeclaration); //$NON-NLS-1$
@@ -2981,7 +2981,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0133() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0133", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		assertTrue("The node is not a MethodDeclaration", node instanceof MethodDeclaration); //$NON-NLS-1$
@@ -2996,7 +2996,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0134() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0134", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		assertTrue("The node is not a MethodDeclaration", node instanceof MethodDeclaration); //$NON-NLS-1$
@@ -3012,7 +3012,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0135() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0135", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		assertTrue("The node is not a FieldDeclaration", node instanceof FieldDeclaration); //$NON-NLS-1$
@@ -3026,7 +3026,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0136() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0136", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		assertTrue("The node is not a FieldDeclaration", node instanceof FieldDeclaration); //$NON-NLS-1$
@@ -3041,7 +3041,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0137() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0137", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		assertTrue("The node is not a FieldDeclaration", node instanceof FieldDeclaration); //$NON-NLS-1$
@@ -3056,7 +3056,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0138() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0138", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		assertTrue("The node is not a TypeDeclaration", node instanceof TypeDeclaration); //$NON-NLS-1$
@@ -3074,7 +3074,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0139() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0139", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		assertTrue("The node is not a TypeDeclaration", node instanceof TypeDeclaration); //$NON-NLS-1$
@@ -3093,7 +3093,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0140() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0140", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		assertTrue("The node is not a TypeDeclaration", node instanceof TypeDeclaration); //$NON-NLS-1$
@@ -3114,7 +3114,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0141() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0141", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		assertTrue("The node is not a TypeDeclaration", node instanceof TypeDeclaration); //$NON-NLS-1$
@@ -3132,7 +3132,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0142() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0142", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		assertTrue("The node is not a TypeDeclaration", node instanceof TypeDeclaration); //$NON-NLS-1$
@@ -3147,7 +3147,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0143() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0143", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		assertTrue("The node is not a TypeDeclaration", node instanceof TypeDeclaration); //$NON-NLS-1$
@@ -3162,7 +3162,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0144() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0144", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		assertTrue("The node is not a TypeDeclaration", node instanceof TypeDeclaration); //$NON-NLS-1$
@@ -3177,7 +3177,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0145() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0145", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		checkSourceRange(node, "{}", source); //$NON-NLS-1$
@@ -3189,7 +3189,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0146() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0146", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		checkSourceRange(node, "static {}", source); //$NON-NLS-1$
@@ -3202,7 +3202,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0147() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0147", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		Javadoc actualJavadoc = ((Initializer) node).getJavadoc();
@@ -3222,7 +3222,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0148() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0148", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		Javadoc actualJavadoc = ((Initializer) node).getJavadoc();
@@ -3241,7 +3241,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0149() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0149", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		Javadoc actualJavadoc = ((Initializer) node).getJavadoc();
@@ -3254,7 +3254,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0150() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0150", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		assertNotNull("Expression should not be null", result); //$NON-NLS-1$
 		assertTrue("The result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
@@ -3270,7 +3270,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0151() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0151", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		assertNotNull("Expression should not be null", result); //$NON-NLS-1$
 		assertTrue("The compilation unit is malformed", !isMalformed(result)); //$NON-NLS-1$
 	}
@@ -3280,7 +3280,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0152() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0152", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		assertNotNull("Expression should not be null", result); //$NON-NLS-1$
 		assertTrue("The compilation unit is malformed", !isMalformed(result)); //$NON-NLS-1$
 		ASTNode node = getASTNode((CompilationUnit) result, 0);
@@ -3299,7 +3299,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0153() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0153", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		assertNotNull("Expression should not be null", result); //$NON-NLS-1$
 		assertTrue("The compilation unit is malformed", !isMalformed(result)); //$NON-NLS-1$
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
@@ -3313,7 +3313,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0154() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0154", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("Expression should not be null", result); //$NON-NLS-1$
 		assertTrue("The result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -3332,7 +3332,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0155() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0155", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("Expression should not be null", result); //$NON-NLS-1$
 		assertTrue("The result is not a compilation unit", result instanceof CompilationUnit);  //$NON-NLS-1$
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
@@ -3354,7 +3354,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0156() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0156", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("Expression should not be null", result); //$NON-NLS-1$
 		assertTrue("The result is not a compilation unit", result instanceof CompilationUnit);  //$NON-NLS-1$
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
@@ -3377,7 +3377,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0157() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "", "Test0157.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("Expression should not be null", result); //$NON-NLS-1$
 		assertTrue("The result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -3415,7 +3415,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0158() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "", "Test0158.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("Expression should not be null", result); //$NON-NLS-1$
 		assertTrue("The result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -3453,7 +3453,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0159() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0159", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("Expression should not be null", result); //$NON-NLS-1$
 		assertTrue("The result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 	}
@@ -3463,7 +3463,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0160() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0160", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("Expression should not be null", result); //$NON-NLS-1$
 		assertTrue("The result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -3524,7 +3524,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0161() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0161", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("Expression should not be null", result); //$NON-NLS-1$
 		assertTrue("The result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -3583,7 +3583,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0162() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0162", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("Expression should not be null", result); //$NON-NLS-1$
 		assertTrue("The result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -3619,7 +3619,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0163() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0163", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		ASTNode expression = getASTNodeToCompare((CompilationUnit) result);
 		assertNotNull("Expression should not be null", expression); //$NON-NLS-1$
 		assertTrue("Not an anonymous type declaration", expression instanceof ClassInstanceCreation); //$NON-NLS-1$
@@ -3654,7 +3654,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0164() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0164", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		assertTrue("Not an type declaration", node instanceof TypeDeclaration); //$NON-NLS-1$
@@ -3688,7 +3688,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0165() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0165", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		assertTrue("Not an type declaration", node instanceof TypeDeclarationStatement); //$NON-NLS-1$
@@ -3724,7 +3724,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0166() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0166", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertTrue("Not a VariableDeclarationStatement", node instanceof VariableDeclarationStatement); //$NON-NLS-1$
 		VariableDeclarationStatement variableDeclarationStatement = (VariableDeclarationStatement) node;
@@ -3794,7 +3794,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0167() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0167", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		assertTrue("Instance of VariableDeclarationStatement", node instanceof VariableDeclarationStatement); //$NON-NLS-1$
@@ -3813,7 +3813,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0168() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0168.test1", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("Expression should not be null", result); //$NON-NLS-1$
 		assertTrue("The result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -3840,7 +3840,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0169() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0169", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("Expression should not be null", result); //$NON-NLS-1$
 		assertTrue("The result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -3866,7 +3866,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0170() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "", "Test0170.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("Expression should not be null", result); //$NON-NLS-1$
 		assertTrue("The result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -3891,7 +3891,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0171() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0171", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("Expression should not be null", result); //$NON-NLS-1$
 		assertTrue("The result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -3924,7 +3924,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0172() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0172", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("Expression should not be null", result); //$NON-NLS-1$
 		assertTrue("The result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -4031,7 +4031,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0173() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0173", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 1);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		assertTrue("Not an expressionStatement", node instanceof ExpressionStatement); //$NON-NLS-1$
@@ -4061,7 +4061,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0174() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0174", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 1, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		assertTrue("Not an expressionStatement", node instanceof ExpressionStatement); //$NON-NLS-1$
@@ -4090,7 +4090,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0175() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0175", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		ASTNode node2 = getASTNode((CompilationUnit) result, 0, 0);
 		assertTrue("VariableDeclarationStatement", node2 instanceof FieldDeclaration); //$NON-NLS-1$
 		FieldDeclaration fieldDeclaration = (FieldDeclaration) node2;
@@ -4110,7 +4110,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0176() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0176", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		ASTNode node2 = getASTNode((CompilationUnit) result, 0, 1, 0);
 		assertTrue("Return statement", node2 instanceof ReturnStatement); //$NON-NLS-1$
 		ReturnStatement returnStatement = (ReturnStatement) node2;
@@ -4133,7 +4133,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0177() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0177", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 1, 1);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		assertTrue("Not an expressionStatement", node instanceof ExpressionStatement); //$NON-NLS-1$
@@ -4163,7 +4163,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0178() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0178", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		ASTNode node2 = getASTNode((CompilationUnit) result, 1, 0, 0);
 		assertTrue("Return statement", node2 instanceof ReturnStatement); //$NON-NLS-1$
 		ReturnStatement returnStatement = (ReturnStatement) node2;
@@ -4181,7 +4181,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0179() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0179", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		ASTNode node2 = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertTrue("VariableDeclarationStatement", node2 instanceof VariableDeclarationStatement); //$NON-NLS-1$
 		VariableDeclarationStatement variableDeclarationStatement = (VariableDeclarationStatement) node2;
@@ -4200,7 +4200,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0180() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0180", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		ASTNode node2 = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertTrue("VariableDeclarationStatement", node2 instanceof VariableDeclarationStatement); //$NON-NLS-1$
 		VariableDeclarationStatement variableDeclarationStatement = (VariableDeclarationStatement) node2;
@@ -4221,7 +4221,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0181() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0181", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		ASTNode node2 = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertTrue("VariableDeclarationStatement", node2 instanceof VariableDeclarationStatement); //$NON-NLS-1$
 		VariableDeclarationStatement variableDeclarationStatement = (VariableDeclarationStatement) node2;
@@ -4242,7 +4242,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0182() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0182", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		ASTNode node2 = getASTNode((CompilationUnit) result, 0, 0, 1);
 		assertTrue("IfStatement", node2 instanceof IfStatement); //$NON-NLS-1$
 		IfStatement ifStatement = (IfStatement) node2;
@@ -4260,7 +4260,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0183() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0183", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		ASTNode node2 = getASTNode((CompilationUnit) result, 0, 0, 1);
 		assertTrue("IfStatement", node2 instanceof IfStatement); //$NON-NLS-1$
 		IfStatement ifStatement = (IfStatement) node2;
@@ -4278,7 +4278,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0184() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0184", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		ASTNode node2 = getASTNode((CompilationUnit) result, 0, 0, 1);
 		assertTrue("IfStatement", node2 instanceof IfStatement); //$NON-NLS-1$
 		IfStatement ifStatement = (IfStatement) node2;
@@ -4296,7 +4296,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0185() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0185", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		ASTNode node2 = getASTNode((CompilationUnit) result, 0, 0, 1);
 		assertTrue("IfStatement", node2 instanceof IfStatement); //$NON-NLS-1$
 		IfStatement ifStatement = (IfStatement) node2;
@@ -4314,7 +4314,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0186() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0186", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		ASTNode node2 = getASTNode((CompilationUnit) result, 0, 0, 1);
 		assertTrue("IfStatement", node2 instanceof IfStatement); //$NON-NLS-1$
 		IfStatement ifStatement = (IfStatement) node2;
@@ -4332,7 +4332,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0187() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0187", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		ASTNode node2 = getASTNode((CompilationUnit) result, 0, 0, 1);
 		assertTrue("IfStatement", node2 instanceof WhileStatement); //$NON-NLS-1$
 		WhileStatement whileStatement = (WhileStatement) node2;
@@ -4350,7 +4350,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0188() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0188", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		ASTNode node2 = getASTNode((CompilationUnit) result, 0, 0, 2);
 		assertTrue("DoStatement", node2 instanceof DoStatement); //$NON-NLS-1$
 		DoStatement statement = (DoStatement) node2;
@@ -4368,7 +4368,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0189() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0189", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		ASTNode node2 = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertTrue("ForStatement", node2 instanceof ForStatement); //$NON-NLS-1$
 		ForStatement statement = (ForStatement) node2;
@@ -4386,7 +4386,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0190() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0190", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		ASTNode node2 = getASTNode((CompilationUnit) result, 0, 2, 1);
 		assertTrue("IfStatement", node2 instanceof IfStatement); //$NON-NLS-1$
 		IfStatement statement = (IfStatement) node2;
@@ -4404,7 +4404,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0191() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0191", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		ASTNode node2 = getASTNode((CompilationUnit) result, 0, 0, 1);
 		assertTrue("ExpressionStatement", node2 instanceof ExpressionStatement); //$NON-NLS-1$
 		ExpressionStatement expressionStatement = (ExpressionStatement) node2;
@@ -4428,7 +4428,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0192() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0192", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		ASTNode node2 = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertTrue("VariableDeclarationStatement", node2 instanceof VariableDeclarationStatement); //$NON-NLS-1$
 		VariableDeclarationStatement variableDeclarationStatement = (VariableDeclarationStatement) node2;
@@ -4449,7 +4449,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0193() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0193", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		ASTNode node2 = getASTNode((CompilationUnit) result, 0, 1, 0);
 		assertTrue("VariableDeclarationStatement", node2 instanceof VariableDeclarationStatement); //$NON-NLS-1$
 		VariableDeclarationStatement variableDeclarationStatement = (VariableDeclarationStatement) node2;
@@ -4471,7 +4471,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0194() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0194", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		ASTNode node2 = getASTNode((CompilationUnit) result, 0, 1, 0);
 		assertTrue("VariableDeclarationStatement", node2 instanceof VariableDeclarationStatement); //$NON-NLS-1$
 		VariableDeclarationStatement variableDeclarationStatement = (VariableDeclarationStatement) node2;
@@ -4494,7 +4494,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0195() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0195", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		ASTNode node2 = getASTNode((CompilationUnit) result, 1, 0, 1);
 		assertTrue("ExpressionStatement", node2 instanceof ExpressionStatement); //$NON-NLS-1$
 		ExpressionStatement expressionStatement = (ExpressionStatement) node2;
@@ -4518,7 +4518,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0196() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0196", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		ASTNode node2 = getASTNode((CompilationUnit) result, 0, 1, 2);
 		assertTrue("ExpressionStatement", node2 instanceof ExpressionStatement); //$NON-NLS-1$
 		ExpressionStatement expressionStatement = (ExpressionStatement) node2;
@@ -4539,7 +4539,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0197() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0197", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertEquals("Not a compilation unit", ASTNode.COMPILATION_UNIT, result.getNodeType());
 		CompilationUnit unit = (CompilationUnit) result;
 		assertProblemsSize(unit, 0);
@@ -4565,7 +4565,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0198() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0198", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		ASTNode node2 = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertTrue("ReturnStatement", node2 instanceof ReturnStatement); //$NON-NLS-1$
 		ReturnStatement returnStatement = (ReturnStatement) node2;
@@ -4591,7 +4591,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0199() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0199", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		ASTNode node2 = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertTrue("VariableDeclarationStatement", node2 instanceof VariableDeclarationStatement); //$NON-NLS-1$
 		VariableDeclarationStatement variableDeclarationStatement = (VariableDeclarationStatement) node2;
@@ -4620,7 +4620,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0200() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0200", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		ASTNode node2 = getASTNode((CompilationUnit) result, 1, 0, 0);
 		assertTrue("VariableDeclarationStatement", node2 instanceof VariableDeclarationStatement); //$NON-NLS-1$
 		VariableDeclarationStatement variableDeclarationStatement = (VariableDeclarationStatement) node2;
@@ -4650,7 +4650,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0201() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0201", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		ASTNode node2 = getASTNode((CompilationUnit) result, 0, 0, 1);
 		assertTrue("ForStatement", node2 instanceof ForStatement); //$NON-NLS-1$
 		ForStatement forStatement = (ForStatement) node2;
@@ -4666,7 +4666,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0202() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0202", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		ASTNode node2 = getASTNode((CompilationUnit) result, 0, 0);
 		assertTrue("FieldDeclaration", node2 instanceof FieldDeclaration); //$NON-NLS-1$
 		FieldDeclaration fieldDeclaration = (FieldDeclaration) node2;
@@ -4688,7 +4688,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0203() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0203", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		ASTNode node2 = getASTNode((CompilationUnit) result, 0, 0);
 		assertTrue("FieldDeclaration", node2 instanceof FieldDeclaration); //$NON-NLS-1$
 		FieldDeclaration fieldDeclaration = (FieldDeclaration) node2;
@@ -4714,7 +4714,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0204() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0204", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		ASTNode node2 = getASTNode((CompilationUnit) result, 0, 0);
 		assertTrue("FieldDeclaration", node2 instanceof FieldDeclaration); //$NON-NLS-1$
 		FieldDeclaration fieldDeclaration = (FieldDeclaration) node2;
@@ -4748,7 +4748,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0205() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0205", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		ASTNode node2 = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertTrue("TypeDeclarationStatement", node2 instanceof TypeDeclarationStatement); //$NON-NLS-1$
 		TypeDeclarationStatement typeDeclarationStatement = (TypeDeclarationStatement) node2;
@@ -4836,7 +4836,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0207() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0207", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		assertTrue("The node is not a MethodDeclaration", node instanceof MethodDeclaration); //$NON-NLS-1$
@@ -4851,7 +4851,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0208() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0208", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		assertTrue("The node is not a MethodDeclaration", node instanceof MethodDeclaration); //$NON-NLS-1$
@@ -4866,7 +4866,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0209() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0209", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		assertTrue("The node is not a MethodDeclaration", node instanceof MethodDeclaration); //$NON-NLS-1$
@@ -4882,7 +4882,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0210() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0210", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		assertTrue("The node is not a FieldDeclaration", node instanceof FieldDeclaration); //$NON-NLS-1$
@@ -4896,7 +4896,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0211() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0211", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		assertTrue("The node is not a FieldDeclaration", node instanceof FieldDeclaration); //$NON-NLS-1$
@@ -4911,7 +4911,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0212() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0212", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		assertTrue("The node is not a FieldDeclaration", node instanceof FieldDeclaration); //$NON-NLS-1$
@@ -4926,7 +4926,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0213() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0213", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		assertTrue("The node is not a TypeDeclaration", node instanceof TypeDeclaration); //$NON-NLS-1$
@@ -4944,7 +4944,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0214() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0214", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		assertTrue("The node is not a TypeDeclaration", node instanceof TypeDeclaration); //$NON-NLS-1$
@@ -4963,7 +4963,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0215() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0215", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		assertTrue("The node is not a TypeDeclaration", node instanceof TypeDeclaration); //$NON-NLS-1$
@@ -4984,7 +4984,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0216() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0216", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		assertTrue("The node is not a TypeDeclaration", node instanceof TypeDeclaration); //$NON-NLS-1$
@@ -5002,7 +5002,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0217() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0217", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		assertTrue("The node is not a TypeDeclaration", node instanceof TypeDeclaration); //$NON-NLS-1$
@@ -5017,7 +5017,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0218() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0218", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		assertTrue("The node is not a TypeDeclaration", node instanceof TypeDeclaration); //$NON-NLS-1$
@@ -5032,7 +5032,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0219() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0219", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		assertTrue("The node is not a TypeDeclaration", node instanceof TypeDeclaration); //$NON-NLS-1$
@@ -5047,7 +5047,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0220() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0220", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		checkSourceRange(node, "{}", source); //$NON-NLS-1$
@@ -5059,7 +5059,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0221() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0221", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		checkSourceRange(node, "static {}", source); //$NON-NLS-1$
@@ -5072,7 +5072,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0222() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0222", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		Javadoc actualJavadoc = ((Initializer) node).getJavadoc();
@@ -5092,7 +5092,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0223() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0223", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		Javadoc actualJavadoc = ((Initializer) node).getJavadoc();
@@ -5111,7 +5111,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0224() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0224", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		Javadoc actualJavadoc = ((Initializer) node).getJavadoc();
@@ -5125,7 +5125,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0225() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0225", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		LabeledStatement labeledStatement = (LabeledStatement) getASTNode((CompilationUnit) result, 0, 0, 0);
 		checkSourceRange(labeledStatement.getLabel(), "label", source); //$NON-NLS-1$
 		ForStatement forStatement = (ForStatement) labeledStatement.getBody();
@@ -5144,7 +5144,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0226() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0226", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		LabeledStatement labeledStatement = (LabeledStatement) getASTNode((CompilationUnit) result, 0, 0, 0);
 		checkSourceRange(labeledStatement.getLabel(), "label", source); //$NON-NLS-1$
 		ForStatement forStatement = (ForStatement) labeledStatement.getBody();
@@ -5163,7 +5163,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0227() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0227", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		ASTNode node2 = getASTNode((CompilationUnit) result, 3, 2, 0);
 		assertTrue("ReturnStatement", node2 instanceof ReturnStatement); //$NON-NLS-1$
 		ReturnStatement returnStatement = (ReturnStatement) node2;
@@ -5250,7 +5250,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0228() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0228", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		ASTNode node2 = getASTNode((CompilationUnit) result, 0, 1, 0);
 		assertTrue("ReturnStatement", node2 instanceof ReturnStatement); //$NON-NLS-1$
 		ReturnStatement returnStatement = (ReturnStatement) node2;
@@ -5278,7 +5278,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0229() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0229", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		ASTNode node2 = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertTrue("ExpressionStatement", node2 instanceof ExpressionStatement); //$NON-NLS-1$
 		ExpressionStatement expressionStatement = (ExpressionStatement) node2;
@@ -5308,7 +5308,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0230() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0230", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		ASTNode node2 = getASTNode((CompilationUnit) result, 0, 1, 0);
 		assertTrue("ExpressionStatement", node2 instanceof ExpressionStatement); //$NON-NLS-1$
 		ExpressionStatement expressionStatement = (ExpressionStatement) node2;
@@ -5333,7 +5333,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0231() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0231", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		ASTNode node2 = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertTrue("ExpressionStatement", node2 instanceof ExpressionStatement); //$NON-NLS-1$
 		ExpressionStatement expressionStatement = (ExpressionStatement) node2;
@@ -5368,7 +5368,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0232() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0232", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		ASTNode node2 = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertTrue("VariableDeclarationStatement", node2 instanceof VariableDeclarationStatement); //$NON-NLS-1$
 		VariableDeclarationStatement variableDeclarationStatement = (VariableDeclarationStatement) node2;
@@ -5399,7 +5399,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0233() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0233", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("Expression should not be null", result); //$NON-NLS-1$
 		assertTrue("The compilation unit is malformed", !isMalformed(result)); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
@@ -5415,7 +5415,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0234() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0234", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true, true, true);
+		ASTNode result = runConversion(sourceUnit, true, true, true);
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
 		assertTrue("The fiels is not malformed", !isMalformed(node)); //$NON-NLS-1$
@@ -5437,7 +5437,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0234_2() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0234", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true, true, false);
+		ASTNode result = runConversion(sourceUnit, true, true, false);
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
 		assertTrue("The fiels is not malformed", !isMalformed(node)); //$NON-NLS-1$
@@ -5458,7 +5458,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0235() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0235", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
 		assertTrue("The fiels is not malformed", !isMalformed(node)); //$NON-NLS-1$
@@ -5479,7 +5479,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0237() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "junit.framework", "TestCase.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 	}
@@ -5489,7 +5489,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0238() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0238", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		char[] source = sourceUnit.getSource().toCharArray();
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
@@ -5524,7 +5524,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0239() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0239", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		ASTNode node = getASTNode((CompilationUnit) result, 1, 0, 0);
@@ -5562,7 +5562,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0240() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0240", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
@@ -5603,7 +5603,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0241() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0241", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		ASTNode node = getASTNode((CompilationUnit) result, 0);
@@ -5639,7 +5639,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0242() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0242", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		ASTNode node = getASTNode((CompilationUnit) result, 1, 0, 0);
@@ -5682,7 +5682,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0243() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0243", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
@@ -5701,7 +5701,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0244() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0244", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
@@ -5720,7 +5720,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0245() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0245", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
@@ -5746,7 +5746,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0246() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0246", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
@@ -5774,7 +5774,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0247() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0247", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
@@ -5791,7 +5791,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0248() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0248", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
@@ -5814,7 +5814,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0249() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0249", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 2, 1);
@@ -5842,7 +5842,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0250() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0250", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
@@ -5866,7 +5866,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0251() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0251", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
@@ -5896,7 +5896,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0252() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0252", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 1);
@@ -5918,7 +5918,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0253() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0253", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
@@ -5939,7 +5939,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0254() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0254", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 1, 0);
@@ -5959,7 +5959,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0255() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0255", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
@@ -5984,7 +5984,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0256() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0256", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
@@ -6015,7 +6015,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0257() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0257", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
@@ -6040,7 +6040,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0258() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0258", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
@@ -6071,7 +6071,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0259() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0259", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 	}
@@ -6081,7 +6081,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0260() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0260", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
@@ -6110,7 +6110,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0261() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0261", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -6129,7 +6129,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0262() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0262", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -6159,7 +6159,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0263() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0263", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -6184,7 +6184,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0264() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0264", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -6219,7 +6219,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0265() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0265", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 	}
@@ -6230,7 +6230,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0266() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0266", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -6257,7 +6257,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0267() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0267", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -6284,7 +6284,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0268() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0268", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -6310,7 +6310,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0269() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0269", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -6336,7 +6336,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0270() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0270", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -6358,7 +6358,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0271() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0271", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -6384,7 +6384,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0272() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0272", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -6402,7 +6402,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0273() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0273", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -6426,7 +6426,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0274() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0274", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -6450,7 +6450,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0275() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0275", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -6468,7 +6468,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0276() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0276", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -6493,7 +6493,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0277() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0277", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -6516,7 +6516,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0278() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0278", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -6540,7 +6540,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0279() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0279", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -6564,7 +6564,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0280() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0280", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		AST newAst = result.getAST();
@@ -6651,7 +6651,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0281() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0281", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -6672,7 +6672,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0282() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0282", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -6693,7 +6693,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0283() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0283", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -6714,7 +6714,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0284() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0284", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -6735,7 +6735,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0285() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0285", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -6756,7 +6756,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0286() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0286", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -6777,7 +6777,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0287() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0287", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -6798,7 +6798,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0288() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0288", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -6819,7 +6819,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0289() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0289", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -6840,7 +6840,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0290() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0290", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -6860,7 +6860,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0291() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0291", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
@@ -6873,7 +6873,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0292() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0292", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -6905,7 +6905,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0293() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0293", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -6941,7 +6941,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0294() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0294", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -6972,7 +6972,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0295() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0295", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true, false, true);
+		ASTNode result = runConversion(sourceUnit, true, false, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -6997,7 +6997,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0296() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0296", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -7028,7 +7028,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0297() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0297", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		runConversion(getJLS3(), sourceUnit, false);
+		runConversion(sourceUnit, false);
 	}
 
 	/**
@@ -7037,7 +7037,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0298() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0298", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -7055,7 +7055,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0299() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0299", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -7080,7 +7080,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0300() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0300", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -7102,7 +7102,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0301() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0301", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -7123,7 +7123,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0302() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0302", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -7142,7 +7142,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0303() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0303", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -7170,7 +7170,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0304() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0304", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -7193,7 +7193,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 				"	public void foo(int arg) {}\n" +  //$NON-NLS-1$
 				"}").toCharArray(); //$NON-NLS-1$
 		IJavaProject project = getJavaProject("Converter"); //$NON-NLS-1$
-		ASTNode result = runConversion(getJLS3(), source, "Test.java", project, true); //$NON-NLS-1$
+		ASTNode result = runConversion(source, "Test.java", project, true); //$NON-NLS-1$
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -7218,7 +7218,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 				"	public void foo(int arg) {}\n" +  //$NON-NLS-1$
 				"}").toCharArray(); //$NON-NLS-1$
 		IJavaProject project = getJavaProject("Converter"); //$NON-NLS-1$
-		ASTNode result = runConversion(getJLS3(), source, "Object.java", project, true); //$NON-NLS-1$
+		ASTNode result = runConversion(source, "Object.java", project, true); //$NON-NLS-1$
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -7239,7 +7239,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0307() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0307", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -7260,7 +7260,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0308() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0308", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -7285,7 +7285,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0309() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0309", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -7308,7 +7308,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0310() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0310", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -7333,7 +7333,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0311() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0311", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -7382,7 +7382,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0312() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0312", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -7427,7 +7427,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0313() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0313", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -7458,7 +7458,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0314() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0314", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		assertNotNull("No result", result); //$NON-NLS-1$
 		assertTrue("Not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -7475,7 +7475,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0315() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0315", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -7511,7 +7511,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0316() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "", "Hello.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No result", result); //$NON-NLS-1$
 		assertTrue("Not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -7524,7 +7524,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0317() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0317", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -7562,7 +7562,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0318() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0318", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
@@ -7575,7 +7575,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0319() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0319", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -7609,7 +7609,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0320() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0320", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -7634,7 +7634,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0321() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0321", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -7656,7 +7656,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0322() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0322", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -7680,7 +7680,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0323() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0323", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -7707,7 +7707,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0324() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0324", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -7734,7 +7734,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0325() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0325", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -7761,7 +7761,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0326() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0326", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		char[] source = sourceUnit.getSource().toCharArray();
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
@@ -7778,7 +7778,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0327() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0327", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -7807,7 +7807,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0328() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0328", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -7848,7 +7848,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0329() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0329", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -7888,7 +7888,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0330() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0330", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -7921,7 +7921,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0331() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0331", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -7948,7 +7948,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0332() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0332", "LocalSelectionTransfer.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 	}
@@ -7958,7 +7958,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0333() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0333", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -7993,7 +7993,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0334() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0334", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -8030,7 +8030,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0335() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0335", "ExceptionTestCaseTest.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -8064,7 +8064,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0336() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0336", "SorterTest.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -8097,7 +8097,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0337() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0337", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -8118,7 +8118,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0338() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0338", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -8141,7 +8141,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0339() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0339", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -8177,7 +8177,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0340() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "p3", "B.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -8232,7 +8232,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0341() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0341", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -8350,7 +8350,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0343() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0343", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -8381,7 +8381,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 			project.setOption(JavaCore.COMPILER_PB_ASSERT_IDENTIFIER, JavaCore.ERROR);
 			project.setOption(JavaCore.COMPILER_SOURCE, CompilerOptions.getFirstSupportedJavaVersion());
 			project.setOption(JavaCore.COMPILER_COMPLIANCE, CompilerOptions.getFirstSupportedJavaVersion());
-			ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+			ASTNode result = runConversion(sourceUnit, true);
 			assertNotNull("No compilation unit", result); //$NON-NLS-1$
 			assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 			CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -8400,7 +8400,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0345() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0345", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -8454,7 +8454,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0346() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0346", "Test2.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -8490,7 +8490,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0347() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0347", "Test2.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -8516,7 +8516,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0348() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0348", "Test2.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -8542,7 +8542,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0349() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0349", "Test2.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -8568,7 +8568,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0350() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0350", "Test2.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -8594,7 +8594,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0351() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0351", "Test2.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -8627,7 +8627,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0352() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0352", "Test2.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -8660,7 +8660,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0353() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0353", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -8694,7 +8694,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0354() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0354", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -8706,7 +8706,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0355() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0355", "Foo.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -8730,7 +8730,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0356() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0356", "X.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -8763,7 +8763,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0357() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0357", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -8782,7 +8782,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0358() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0358", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -8801,7 +8801,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0359() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0359", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -8819,7 +8819,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0360() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0360", "X.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -8837,7 +8837,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0361() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0361", "X.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -8855,7 +8855,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0362() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0362", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		ForStatement forStatement = this.ast.newForStatement();
@@ -8909,7 +8909,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0363() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0363", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -8933,7 +8933,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0364() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0364", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -8956,7 +8956,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0365() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0365", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -8982,7 +8982,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0366() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0366", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -9003,7 +9003,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0367() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0367", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -9024,7 +9024,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0368() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0368", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -9045,7 +9045,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0369() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0369", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -9066,7 +9066,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0370() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0370", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertNotNull("Expression should not be null", node); //$NON-NLS-1$
 		DoStatement doStatement = this.ast.newDoStatement();
@@ -9087,7 +9087,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0371() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0371", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -9108,7 +9108,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0372() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0372", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -9129,7 +9129,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0373() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0373", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -9155,7 +9155,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0374() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0374", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -9180,7 +9180,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0375() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0375", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -9199,7 +9199,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0376() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0376", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -9222,7 +9222,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0377() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0377", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -9245,7 +9245,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0378() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0378", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -9264,7 +9264,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0379() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0379", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		ASTNode expression = getASTNodeToCompare((CompilationUnit) result);
 		assertNotNull("Expression should not be null", expression); //$NON-NLS-1$
 		assertTrue("Not a class instance creation", expression.getNodeType() == ASTNode.CLASS_INSTANCE_CREATION);		//$NON-NLS-1$
@@ -9278,7 +9278,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0380() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0380", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -9306,7 +9306,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0381() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0381", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -9324,7 +9324,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0382() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0382", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -9342,7 +9342,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0383() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0383", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -9360,7 +9360,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0384() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0384", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -9378,7 +9378,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0385() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0385", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -9391,7 +9391,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0386() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0386", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -9416,7 +9416,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0387() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0387", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -9439,7 +9439,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0388() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0388", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -9458,7 +9458,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0389() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0389", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -9477,7 +9477,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0390() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0390", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -9497,7 +9497,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0391() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0391", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -9517,7 +9517,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0392() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0392", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -9538,7 +9538,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0393() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0393", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -9568,7 +9568,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0394() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0394", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -9592,7 +9592,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0395() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0395", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -9622,7 +9622,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0396() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0396", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
 		assertNotNull(node);
 		assertTrue("Not a method declaration", node.getNodeType() == ASTNode.METHOD_DECLARATION); //$NON-NLS-1$
@@ -9654,7 +9654,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0397() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0397", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
 		assertNotNull(node);
 		assertTrue("Not a method declaration", node.getNodeType() == ASTNode.METHOD_DECLARATION); //$NON-NLS-1$
@@ -9686,7 +9686,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0398() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0398", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertNotNull(node);
 		assertTrue("Not a variable declaration statement", node.getNodeType() == ASTNode.VARIABLE_DECLARATION_STATEMENT); //$NON-NLS-1$
@@ -9711,7 +9711,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	 */
 	public void test0399() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0399", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
 		assertNotNull(node);
 		assertTrue("Not a method declaration", node.getNodeType() == ASTNode.METHOD_DECLARATION); //$NON-NLS-1$
@@ -9728,7 +9728,7 @@ public class ASTConverterAST3Test extends ConverterTestSetup {
 	public void test0400() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0400", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
 		assertNotNull(node);
 		assertTrue("Not a method declaration", node.getNodeType() == ASTNode.METHOD_DECLARATION); //$NON-NLS-1$

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterBindingsTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterBindingsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -430,7 +430,7 @@ public class ASTConverterBindingsTest extends ConverterTestSetup {
 	@Override
 	public void setUpSuite() throws Exception {
 		super.setUpSuite();
-		this.ast = AST.newAST(getJLS3(), false);
+		this.ast = AST.newAST(getJLSFirst(), false);
 	}
 
 	public ASTConverterBindingsTest(String name) {
@@ -463,10 +463,10 @@ public class ASTConverterBindingsTest extends ConverterTestSetup {
 		compilationUnitscollector.toArray(units);
 		for (int j = 0; j < length; j++) {
 			ICompilationUnit currentUnit = units[j];
-			ASTNode result = runConversion(getJLS3(), currentUnit, true);
+			ASTNode result = runConversion(currentUnit, true);
 			assertEquals("Not a compilation unit", ASTNode.COMPILATION_UNIT, result.getNodeType());
 			CompilationUnit unit = (CompilationUnit) result;
-			result = runConversion(getJLS3(), currentUnit, true);
+			result = runConversion(currentUnit, true);
 			assertEquals("Not a compilation unit", ASTNode.COMPILATION_UNIT, result.getNodeType());
 			if (DEBUG) {
 				if (unit.types().size() > 0 ) {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterBugsTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterBugsTest.java
@@ -636,7 +636,7 @@ public void testBug214002b() throws CoreException, IOException {
 			);
 			ICompilationUnit cuA = getCompilationUnit("P/A.java");
 			try {
-				runConversion(getJLS3(), cuA, true, true, true);
+				runConversion(cuA, true, true, true);
 			} catch(IllegalArgumentException e) {
 				assertTrue("Unexpected IllegalArgumentException", false);
 			}

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterBugsTestJLS3.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterBugsTestJLS3.java
@@ -37,7 +37,6 @@ public class ASTConverterBugsTestJLS3 extends ASTConverterBugsTest {
 
 public ASTConverterBugsTestJLS3(String name) {
     super(name);
-    this.testLevel = getJLS3();
 }
 
 public static Test suite() {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterJavadocTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterJavadocTest.java
@@ -30,7 +30,6 @@ import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.compiler.IProblem;
 import org.eclipse.jdt.core.dom.*;
-import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jdt.internal.compiler.parser.ScannerHelper;
 
 /**
@@ -1203,14 +1202,6 @@ public class ASTConverterJavadocTest extends ConverterTestSetup {
 		List unitComments = null;
 		String sourceLevel = null;
 		String complianceLevel = null;
-		if (this.currentProject != null) {
-			if (this.astLevel == getJLS3()) {
-				complianceLevel = this.currentProject.getOption(JavaCore.COMPILER_COMPLIANCE, true);
-				sourceLevel = this.currentProject.getOption(JavaCore.COMPILER_SOURCE, true);
-				this.currentProject.setOption(JavaCore.COMPILER_COMPLIANCE, CompilerOptions.getFirstSupportedJavaVersion());
-				this.currentProject.setOption(JavaCore.COMPILER_SOURCE, CompilerOptions.getFirstSupportedJavaVersion());
-			}
-		}
 		CompilationUnit compilUnit = (CompilationUnit) runConversion(testedSource, fileName, this.currentProject, options);
 		if (this.compilerOption.equals(JavaCore.ERROR)) {
 			assumeEquals(this.prefix+"Unexpected problems", 0, compilUnit.getProblems().length); //$NON-NLS-1$
@@ -2113,15 +2104,9 @@ public class ASTConverterJavadocTest extends ConverterTestSetup {
 	 * @see "http://bugs.eclipse.org/bugs/show_bug.cgi?id=70892"
 	 * @deprecated using deprecated code
 	 */
-	public void testBug70892_JLS2() throws JavaModelException {
-		int level = this.astLevel;
-		this.astLevel = AST.JLS2;
-		verifyComments("testBug70892");
-		this.astLevel = level;
-	}
 	public void testBug70892_JLS3() throws JavaModelException {
 		int level = this.astLevel;
-		this.astLevel = getJLS3();
+		this.astLevel = getJLSFirst();
 		verifyComments("testBug70892");
 		this.astLevel = level;
 	}
@@ -2156,7 +2141,6 @@ public class ASTConverterJavadocTest extends ConverterTestSetup {
 	 */
 	public void testBug79809() throws JavaModelException {
 		this.workingCopies = new ICompilationUnit[1];
-		this.astLevel = getJLS3();
 		this.workingCopies[0] = getWorkingCopy("/Converter/src/javadoc/b79809/Test.java",
 			"package javadoc.b79809;\n" +
 			"/**\n" +
@@ -2174,7 +2158,6 @@ public class ASTConverterJavadocTest extends ConverterTestSetup {
 	}
 	public void testBug79809b() throws JavaModelException {
 		this.workingCopies = new ICompilationUnit[1];
-		this.astLevel = getJLS3();
 		this.workingCopies[0] = getWorkingCopy("/Converter/src/javadoc/b79809/Test.java",
 			"package javadoc.b79809;\n" +
 			"\n" +
@@ -2196,7 +2179,6 @@ public class ASTConverterJavadocTest extends ConverterTestSetup {
 	 */
 	public void testBug79904() throws JavaModelException {
 		this.workingCopies = new ICompilationUnit[1];
-		this.astLevel = getJLS3();
 		this.workingCopies[0] = getWorkingCopy("/Converter/src/javadoc/b79904/Test.java",
 			"package javadoc.b79904;\n" +
 			"/**\n" +
@@ -2219,7 +2201,6 @@ public class ASTConverterJavadocTest extends ConverterTestSetup {
 	 */
 	public void testBug80221() throws JavaModelException {
 		this.workingCopies = new ICompilationUnit[1];
-		this.astLevel = getJLS3();
 		this.workingCopies[0] = getWorkingCopy("/Converter/src/javadoc/b80221/Test.java",
 			"package javadoc.b80221;\n" +
 			"public class Test {\n" +
@@ -2240,7 +2221,6 @@ public class ASTConverterJavadocTest extends ConverterTestSetup {
 	 */
 	public void testBug80257() throws JavaModelException {
 		this.workingCopies = new ICompilationUnit[1];
-		this.astLevel = getJLS3();
 		this.workingCopies[0] = getWorkingCopy("/Converter15/src/javadoc/b80257/Test.java",
 			"package javadoc.b80257;\n" +
 			"import java.util.*;\n" +
@@ -2297,14 +2277,12 @@ public class ASTConverterJavadocTest extends ConverterTestSetup {
 	 * @see "http://bugs.eclipse.org/bugs/show_bug.cgi?id=83804"
 	 */
 	public void testBug83804() throws CoreException, JavaModelException {
-		this.astLevel = getJLS3();
 		this.workingCopies = new ICompilationUnit[2];
 		this.workingCopies[0] = getCompilationUnit("Converter15", "src", "javadoc.b83804", "package-info.java");
 		this.workingCopies[1] = getCompilationUnit("Converter15", "src", "javadoc.b83804", "Test.java");
 		verifyWorkingCopiesComments();
 	}
 	public void testBug83804a() throws CoreException, JavaModelException {
-		this.astLevel = getJLS3();
 		this.workingCopies = new ICompilationUnit[2];
 		this.workingCopies[0] = getCompilationUnit("Converter15", "src", "javadoc.b83804a", "package-info.java");
 		this.workingCopies[1] = getCompilationUnit("Converter15", "src", "javadoc.b83804a", "Test.java");
@@ -2317,7 +2295,6 @@ public class ASTConverterJavadocTest extends ConverterTestSetup {
 	 */
 	public void testBug84049() throws JavaModelException {
 		this.workingCopies = new ICompilationUnit[1];
-		this.astLevel = getJLS3();
 		this.workingCopies[0] = getWorkingCopy("/Converter15/src/javadoc/b84049/Test.java",
 			"package javadoc.b84049;\n" +
 			"public class Test {\n" +
@@ -2353,7 +2330,6 @@ public class ASTConverterJavadocTest extends ConverterTestSetup {
 	 */
 	public void testBug87845() throws JavaModelException {
 		this.workingCopies = new ICompilationUnit[1];
-		this.astLevel = getJLS3();
 		this.workingCopies[0] = getWorkingCopy("/Converter15/src/javadoc/b87845/Test.java",
 			"package javadoc.b87845;\n" +
 			"public class Test {\n" +
@@ -2428,7 +2404,6 @@ public class ASTConverterJavadocTest extends ConverterTestSetup {
 	 */
 	public void testBug93880_15a() throws JavaModelException {
 		this.workingCopies = new ICompilationUnit[1];
-		this.astLevel = getJLS3();
 		this.workingCopies[0] = getWorkingCopy("/Converter15/src/javadoc/b93880/Test.java",
 			"/**\n" +
 			" * Javadoc\n" +
@@ -2452,7 +2427,6 @@ public class ASTConverterJavadocTest extends ConverterTestSetup {
 	}
 	public void testBug93880_15b() throws JavaModelException {
 		this.workingCopies = new ICompilationUnit[1];
-		this.astLevel = getJLS3();
 		this.workingCopies[0] = getWorkingCopy("/Converter15/src/javadoc/b93880/package-info.java",
 			"/**\n" +
 			" * Javadoc for all package\n" +
@@ -2474,7 +2448,6 @@ public class ASTConverterJavadocTest extends ConverterTestSetup {
 	}
 	public void testBug93880_15c() throws JavaModelException {
 		this.workingCopies = new ICompilationUnit[1];
-		this.astLevel = getJLS3();
 		this.workingCopies[0] = getWorkingCopy("/Converter15/src/javadoc/b93880/package-info.java",
 			"/**\n" +
 			" * Javadoc for all package\n" +
@@ -2496,7 +2469,6 @@ public class ASTConverterJavadocTest extends ConverterTestSetup {
 	}
 	public void testBug93880_15d() throws JavaModelException {
 		this.workingCopies = new ICompilationUnit[1];
-		this.astLevel = getJLS3();
 		this.workingCopies[0] = getWorkingCopy("/Converter15/src/javadoc/b93880/package-info.java",
 			"/**\n" +
 			" * Javadoc for all package\n" +
@@ -2520,7 +2492,6 @@ public class ASTConverterJavadocTest extends ConverterTestSetup {
 	}
 	public void testBug93880_15e() throws JavaModelException {
 		this.workingCopies = new ICompilationUnit[1];
-		this.astLevel = getJLS3();
 		this.workingCopies[0] = getWorkingCopy("/Converter15/src/javadoc/b93880/package-info.java",
 			"/* (non-javadoc)\n" +
 			" * No comment\n" +
@@ -2544,7 +2515,6 @@ public class ASTConverterJavadocTest extends ConverterTestSetup {
 	}
 	public void testBug93880_14a() throws JavaModelException {
 		this.workingCopies = new ICompilationUnit[1];
-		this.astLevel = getJLS3();
 		this.workingCopies[0] = getWorkingCopy("/Converter15/src/javadoc/b93880/Test.java",
 			"/**\n" +
 			" * Javadoc\n" +
@@ -2565,7 +2535,6 @@ public class ASTConverterJavadocTest extends ConverterTestSetup {
 	}
 	public void testBug93880_14b() throws JavaModelException {
 		this.workingCopies = new ICompilationUnit[1];
-		this.astLevel = getJLS3();
 		this.workingCopies[0] = getWorkingCopy("/Converter15/src/javadoc/b93880/package-info.java",
 			"/**\n" +
 			" * Javadoc for all package\n" +
@@ -2584,7 +2553,6 @@ public class ASTConverterJavadocTest extends ConverterTestSetup {
 	}
 	public void testBug93880_14c() throws JavaModelException {
 		this.workingCopies = new ICompilationUnit[1];
-		this.astLevel = getJLS3();
 		this.workingCopies[0] = getWorkingCopy("/Converter15/src/javadoc/b93880/package-info.java",
 			"/**\n" +
 			" * Javadoc for all package\n" +
@@ -2603,7 +2571,6 @@ public class ASTConverterJavadocTest extends ConverterTestSetup {
 	}
 	public void testBug93880_14d() throws JavaModelException {
 		this.workingCopies = new ICompilationUnit[1];
-		this.astLevel = getJLS3();
 		this.workingCopies[0] = getWorkingCopy("/Converter15/src/javadoc/b93880/package-info.java",
 			"/**\n" +
 			" * Javadoc for all package\n" +
@@ -2624,7 +2591,6 @@ public class ASTConverterJavadocTest extends ConverterTestSetup {
 	}
 	public void testBug93880_14e() throws JavaModelException {
 		this.workingCopies = new ICompilationUnit[1];
-		this.astLevel = getJLS3();
 		this.workingCopies[0] = getWorkingCopy("/Converter15/src/javadoc/b93880/package-info.java",
 			"/* (non-javadoc)\n" +
 			" * No comment\n" +
@@ -2650,7 +2616,6 @@ public class ASTConverterJavadocTest extends ConverterTestSetup {
 	 */
 	public void testBug94150() throws JavaModelException {
 		this.workingCopies = new ICompilationUnit[1];
-		this.astLevel = getJLS3();
 		this.workingCopies[0] = getWorkingCopy("/Converter15/src/javadoc/b94150/Category.java",
 			"package javadoc.b94150;\n" +
 			"public enum Category {\n" +
@@ -2701,7 +2666,7 @@ public class ASTConverterJavadocTest extends ConverterTestSetup {
 	}
 	public void testBug99507b() throws JavaModelException {
         String source = "/**\n@param country*/";
-		ASTParser parser = ASTParser.newParser(getJLS3());
+		ASTParser parser = ASTParser.newParser(getJLSFirst());
 		parser.setKind(ASTParser.K_COMPILATION_UNIT);
 		parser.setSource(source.toCharArray());
 		parser.createAST(null);
@@ -2920,7 +2885,6 @@ public class ASTConverterJavadocTest extends ConverterTestSetup {
 	 */
 	public void testBug106581() throws JavaModelException {
 		this.workingCopies = new ICompilationUnit[1];
-		this.astLevel = getJLS3();
 		this.workingCopies[0] = getWorkingCopy("/Converter15/src/javadoc/b106581/A.java",
 			"package javadoc.b106581;\n" +
 			"public class A {\n" +
@@ -2955,7 +2919,6 @@ public class ASTConverterJavadocTest extends ConverterTestSetup {
 	 */
 	public void testBug108622() throws JavaModelException {
 		this.workingCopies = new ICompilationUnit[1];
-		this.astLevel = getJLS3();
 		this.workingCopies[0] = getWorkingCopy("/Converter15/src/javadoc/b108622/Test.java",
 			"package javadoc.b108622;\n" +
 			"/**\n" +
@@ -3004,7 +2967,6 @@ public class ASTConverterJavadocTest extends ConverterTestSetup {
 	 */
 	public void testBug113108a() throws JavaModelException {
 		this.workingCopies = new ICompilationUnit[1];
-		this.astLevel = getJLS3();
 		this.workingCopies[0] = getWorkingCopy("/Converter15/src/javadoc/b113108/Test.java",
 			"package javadoc.b113108;\n" +
 			"/** C0 */\n" +
@@ -3041,7 +3003,6 @@ public class ASTConverterJavadocTest extends ConverterTestSetup {
 	}
 	public void testBug113108b() throws JavaModelException {
 		this.workingCopies = new ICompilationUnit[1];
-		this.astLevel = getJLS3();
 		this.workingCopies[0] = getWorkingCopy("/Converter15/src/javadoc/b113108/Test.java",
 			"package javadoc.b113108;\n" +
 			"/** C0 */\n" +
@@ -3078,7 +3039,6 @@ public class ASTConverterJavadocTest extends ConverterTestSetup {
 	}
 	public void testBug113108c() throws JavaModelException {
 		this.workingCopies = new ICompilationUnit[1];
-		this.astLevel = getJLS3();
 		this.workingCopies[0] = getWorkingCopy("/Converter15/src/javadoc/b113108/Test.java",
 			"package javadoc.b113108;\n" +
 			"/** C0 */\n" +
@@ -3120,7 +3080,6 @@ public class ASTConverterJavadocTest extends ConverterTestSetup {
 	 */
 	public void testBug125676() throws JavaModelException {
 		this.workingCopies = new ICompilationUnit[3];
-		this.astLevel = getJLS3();
 		this.workingCopies[0] = getWorkingCopy("/Converter15/src/javadoc/b125676/A.java",
 			"package javadoc.b125676;\n" +
 			"public class A {\n" +
@@ -3183,7 +3142,6 @@ public class ASTConverterJavadocTest extends ConverterTestSetup {
 	 */
 	public void testBug125903() throws JavaModelException {
 		this.workingCopies = new ICompilationUnit[1];
-		this.astLevel = getJLS3();
 		this.workingCopies[0] = getWorkingCopy("/Converter15/src/javadoc/b125903/Test.java",
 			"package javadoc.b125903;\n" +
 			"/**\n" +
@@ -3291,7 +3249,7 @@ public class ASTConverterJavadocTest extends ConverterTestSetup {
 			"	String b = \"b\"; //$NON-NLS-1$\n" +
 			"}\n"
 		);
-		CompilationUnit compilUnit = (CompilationUnit) runConversion(getJLS3(), this.workingCopies[0], true);
+		CompilationUnit compilUnit = (CompilationUnit) runConversion(this.workingCopies[0], true);
 		verifyWorkingCopiesComments();
 		if (this.docCommentSupport.equals(JavaCore.ENABLED)) {
 			// Verify comment type
@@ -3388,7 +3346,7 @@ public class ASTConverterJavadocTest extends ConverterTestSetup {
 			"	public X(String foo, String bar) { }\n" +
 			"}"
 		);
-		CompilationUnit unit = (CompilationUnit) runConversion(getJLS3(), this.workingCopies[0], true);
+		CompilationUnit unit = (CompilationUnit) runConversion(this.workingCopies[0], true);
 		assumeEquals(this.prefix+"Wrong number of comments", 1, unit.getCommentList().size());
 	}
 	/**
@@ -3402,7 +3360,7 @@ public class ASTConverterJavadocTest extends ConverterTestSetup {
 				"	Serializable {\n" +
 				"}"
 		);
-		CompilationUnit unit = (CompilationUnit) runConversion(getJLS3(), this.workingCopies[0], true);
+		CompilationUnit unit = (CompilationUnit) runConversion(this.workingCopies[0], true);
 		assumeEquals(this.prefix+"Wrong number of comments", 1, unit.getCommentList().size());
 	}
 	/**
@@ -3416,7 +3374,7 @@ public class ASTConverterJavadocTest extends ConverterTestSetup {
 				"	{\n" +
 				"}"
 		);
-		CompilationUnit unit = (CompilationUnit) runConversion(getJLS3(), this.workingCopies[0], true);
+		CompilationUnit unit = (CompilationUnit) runConversion(this.workingCopies[0], true);
 		assumeEquals(this.prefix+"Wrong number of comments", 1, unit.getCommentList().size());
 	}
 

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterRecoveryTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterRecoveryTest.java
@@ -36,7 +36,7 @@ public class ASTConverterRecoveryTest extends ConverterTestSetup {
 	@Override
 	public void setUpSuite() throws Exception {
 		super.setUpSuite();
-		this.ast = AST.newAST(getJLS3(), false);
+		this.ast = AST.newAST(getJLSFirst(), false);
 	}
 
 	public void test0001() throws JavaModelException {
@@ -53,7 +53,7 @@ public class ASTConverterRecoveryTest extends ConverterTestSetup {
 			"}\n");
 
 		char[] source = this.workingCopies[0].getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), this.workingCopies[0], true, true);
+		ASTNode result = runConversion(this.workingCopies[0], true, true);
 
 		assertASTNodeEquals(
 			"package test;\n" +
@@ -120,7 +120,7 @@ public class ASTConverterRecoveryTest extends ConverterTestSetup {
 			"}\n");
 
 		char[] source = this.workingCopies[0].getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), this.workingCopies[0], true, true);
+		ASTNode result = runConversion(this.workingCopies[0], true, true);
 
 		assertASTNodeEquals(
 			"package test;\n" +
@@ -188,7 +188,7 @@ public class ASTConverterRecoveryTest extends ConverterTestSetup {
 			"}\n");
 
 		char[] source = this.workingCopies[0].getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), this.workingCopies[0], true, true);
+		ASTNode result = runConversion(this.workingCopies[0], true, true);
 
 		assertASTNodeEquals(
 			"package test;\n" +
@@ -256,7 +256,7 @@ public class ASTConverterRecoveryTest extends ConverterTestSetup {
 			"}\n");
 
 		char[] source = this.workingCopies[0].getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), this.workingCopies[0], true, true);
+		ASTNode result = runConversion(this.workingCopies[0], true, true);
 
 		assertASTNodeEquals(
 			"package test;\n" +
@@ -298,7 +298,7 @@ public class ASTConverterRecoveryTest extends ConverterTestSetup {
 			"}\n");
 
 		char[] source = this.workingCopies[0].getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), this.workingCopies[0], true, true);
+		ASTNode result = runConversion(this.workingCopies[0], true, true);
 
 		assertASTNodeEquals(
 			"package test;\n" +
@@ -355,7 +355,7 @@ public class ASTConverterRecoveryTest extends ConverterTestSetup {
 			"}\n");
 
 		char[] source = this.workingCopies[0].getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), this.workingCopies[0], true, true);
+		ASTNode result = runConversion(this.workingCopies[0], true, true);
 
 		assertASTNodeEquals(
 			"package test;\n" +
@@ -401,7 +401,7 @@ public class ASTConverterRecoveryTest extends ConverterTestSetup {
 			"}\n");
 
 		char[] source = this.workingCopies[0].getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), this.workingCopies[0], true, true);
+		ASTNode result = runConversion(this.workingCopies[0], true, true);
 
 		assertASTNodeEquals(
 			"package test;\n" +
@@ -454,7 +454,7 @@ public class ASTConverterRecoveryTest extends ConverterTestSetup {
 			"}\n");
 
 		char[] source = this.workingCopies[0].getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), this.workingCopies[0], true, true);
+		ASTNode result = runConversion(this.workingCopies[0], true, true);
 
 		assertASTNodeEquals(
 			"package test;\n" +
@@ -516,7 +516,7 @@ public class ASTConverterRecoveryTest extends ConverterTestSetup {
 			"}\n");
 
 		char[] source = this.workingCopies[0].getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), this.workingCopies[0], true, true);
+		ASTNode result = runConversion(this.workingCopies[0], true, true);
 
 		assertASTNodeEquals(
 			"package test;\n" +
@@ -569,7 +569,7 @@ public class ASTConverterRecoveryTest extends ConverterTestSetup {
 			"}\n");
 
 		char[] source = this.workingCopies[0].getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), this.workingCopies[0], true, true);
+		ASTNode result = runConversion(this.workingCopies[0], true, true);
 
 		assertASTNodeEquals(
 			"package test;\n" +
@@ -622,7 +622,7 @@ public class ASTConverterRecoveryTest extends ConverterTestSetup {
 			"}\n");
 
 		char[] source = this.workingCopies[0].getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), this.workingCopies[0], true, true);
+		ASTNode result = runConversion(this.workingCopies[0], true, true);
 
 		assertASTNodeEquals(
 			"package test;\n" +
@@ -675,7 +675,7 @@ public class ASTConverterRecoveryTest extends ConverterTestSetup {
 			"}\n");
 
 		char[] source = this.workingCopies[0].getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), this.workingCopies[0], true, true);
+		ASTNode result = runConversion(this.workingCopies[0], true, true);
 
 		assertASTNodeEquals(
 			"package test;\n" +
@@ -721,7 +721,7 @@ public class ASTConverterRecoveryTest extends ConverterTestSetup {
 			"}\n");
 
 		char[] source = this.workingCopies[0].getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), this.workingCopies[0], true, true);
+		ASTNode result = runConversion(this.workingCopies[0], true, true);
 
 		assertASTNodeEquals(
 			"package test;\n" +
@@ -771,7 +771,7 @@ public class ASTConverterRecoveryTest extends ConverterTestSetup {
 			"}\n");
 
 		char[] source = this.workingCopies[0].getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), this.workingCopies[0], true, true);
+		ASTNode result = runConversion(this.workingCopies[0], true, true);
 
 		assertASTNodeEquals(
 			"package test;\n" +
@@ -816,7 +816,7 @@ public class ASTConverterRecoveryTest extends ConverterTestSetup {
 			"}\n");
 
 		char[] source = this.workingCopies[0].getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), this.workingCopies[0], true, true);
+		ASTNode result = runConversion(this.workingCopies[0], true, true);
 
 		assertASTNodeEquals(
 			"package test;\n" +
@@ -861,7 +861,7 @@ public class ASTConverterRecoveryTest extends ConverterTestSetup {
 			"}\n");
 
 		char[] source = this.workingCopies[0].getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), this.workingCopies[0], true, true);
+		ASTNode result = runConversion(this.workingCopies[0], true, true);
 
 		assertASTNodeEquals(
 			"package test;\n" +
@@ -905,7 +905,7 @@ public class ASTConverterRecoveryTest extends ConverterTestSetup {
 			"}\n");
 
 		char[] source = this.workingCopies[0].getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), this.workingCopies[0], true, true);
+		ASTNode result = runConversion(this.workingCopies[0], true, true);
 
 		assertASTNodeEquals(
 			"package test;\n" +
@@ -984,7 +984,7 @@ public class ASTConverterRecoveryTest extends ConverterTestSetup {
 			"}\n");
 
 		char[] source = this.workingCopies[0].getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), this.workingCopies[0], true, true);
+		ASTNode result = runConversion(this.workingCopies[0], true, true);
 
 		assertASTNodeEquals(
 			"package test;\n" +
@@ -1024,7 +1024,7 @@ public class ASTConverterRecoveryTest extends ConverterTestSetup {
 			"}\n");
 
 		char[] source = this.workingCopies[0].getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), this.workingCopies[0], true, true);
+		ASTNode result = runConversion(this.workingCopies[0], true, true);
 
 		assertASTNodeEquals(
 			"package test;\n" +
@@ -1067,7 +1067,7 @@ public class ASTConverterRecoveryTest extends ConverterTestSetup {
 				"		synchronized new Object();\n" +
 				"	}\n" +
 				"}\n");
-			ASTNode result = runConversion(getJLS3(), this.workingCopies[0], true, true);
+			ASTNode result = runConversion(this.workingCopies[0], true, true);
 
 			assertASTNodeEquals(
 				"package test;\n" +

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterTest2.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterTest2.java
@@ -5185,7 +5185,7 @@ public class ASTConverterTest2 extends ConverterTestSetup {
 				"}";
 			addLibrary(p, "test0571.jar", "test0571.zip", new String[] {"X.java", source	}, CompilerOptions.getFirstSupportedJavaVersion());
 			IOrdinaryClassFile classFile = getClassFile("P", "/P/test0571.jar", "", "X$Y.class");
-			CompilationUnit unit = (CompilationUnit) runConversion(getJLS3(), classFile, 0, true);
+			CompilationUnit unit = (CompilationUnit) runConversion(classFile, 0, true);
 			IProblem[] problems = unit.getProblems();
 			StringBuilder buffer = new StringBuilder();
 			for (int i = 0, length = problems.length; i < length; i++)
@@ -5476,7 +5476,7 @@ public class ASTConverterTest2 extends ConverterTestSetup {
 				"        }\n" +
 				"}"
 			);
-			ASTNode cu = workingCopy.reconcile(getJLS3(), true, true, null, null);
+			ASTNode cu = workingCopy.reconcile(getJLSFirst(), true, true, null, null);
 			assertNotNull("Should get an AST", cu);
 		} finally {
 			if (workingCopy != null)
@@ -5501,7 +5501,7 @@ public class ASTConverterTest2 extends ConverterTestSetup {
 			);
 
 			// Create parser
-			ASTParser parser = ASTParser.newParser(getJLS3());
+			ASTParser parser = ASTParser.newParser(getJLSFirst());
 			parser.setSource(workingCopy);
 			parser.setFocalPosition(0);
 			parser.setResolveBindings(true);

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterTestAST3_2.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterTestAST3_2.java
@@ -257,7 +257,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0408() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0408", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertEquals("Wrong number of problems", 0, ((CompilationUnit) result).getProblems().length); //$NON-NLS-1$
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
 		assertNotNull(node);
@@ -291,7 +291,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 			newOptions.put(JavaCore.COMPILER_SOURCE, CompilerOptions.getFirstSupportedJavaVersion());
 			JavaCore.setOptions(newOptions);
 			ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0409", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-			ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+			ASTNode result = runConversion(sourceUnit, true);
 			assertTrue("Not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 			CompilationUnit compilationUnit = (CompilationUnit) result;
 			assertProblemsSize(compilationUnit, 0);
@@ -377,7 +377,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0410() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0410", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertEquals("Wrong number of problems", 0, ((CompilationUnit) result).getProblems().length); //$NON-NLS-1$
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertNotNull(node);
@@ -394,7 +394,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0411() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0411", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertEquals("Wrong number of problems", 0, ((CompilationUnit) result).getProblems().length); //$NON-NLS-1$
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
 		assertNotNull(node);
@@ -411,7 +411,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0412() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0412", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 0, unit.getProblems().length); //$NON-NLS-1$
@@ -441,7 +441,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0413() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0413", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true, false, true);
+		ASTNode result = runConversion(sourceUnit, true, false, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 2, unit.getProblems().length); //$NON-NLS-1$
@@ -463,7 +463,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0414() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0414", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 0, unit.getProblems().length); //$NON-NLS-1$
@@ -489,7 +489,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 
 		ICompilationUnit sourceUnit2 = getCompilationUnit("Converter" , "src", "test0414", "B.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 
-		result = runConversion(getJLS3(), sourceUnit2, true);
+		result = runConversion(sourceUnit2, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit unit2 = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 0, unit2.getProblems().length); //$NON-NLS-1$
@@ -506,7 +506,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0415() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0415", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 0, unit.getProblems().length); //$NON-NLS-1$<
@@ -528,7 +528,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0416() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0416", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 0, unit.getProblems().length); //$NON-NLS-1$<
@@ -561,7 +561,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0417() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0417", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 1, unit.getProblems().length); //$NON-NLS-1$<
@@ -586,7 +586,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0418() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0418", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 1, unit.getProblems().length); //$NON-NLS-1$<
@@ -607,7 +607,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0419() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0419", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 1, unit.getProblems().length); //$NON-NLS-1$<
@@ -630,7 +630,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0420() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0420", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 0, unit.getProblems().length); //$NON-NLS-1$<
@@ -657,7 +657,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0421() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0421", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 0, unit.getProblems().length); //$NON-NLS-1$<
@@ -685,7 +685,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0422() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0422", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 0, unit.getProblems().length); //$NON-NLS-1$<
@@ -713,7 +713,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0423() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0423", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 0, unit.getProblems().length); //$NON-NLS-1$<
@@ -740,7 +740,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0424() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0424", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 0, unit.getProblems().length); //$NON-NLS-1$<
@@ -764,7 +764,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0425() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0425", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 0, unit.getProblems().length); //$NON-NLS-1$<
@@ -791,7 +791,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0426() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0426", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true, false, true);
+		ASTNode result = runConversion(sourceUnit, true, false, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 1, unit.getProblems().length); //$NON-NLS-1$<
@@ -812,7 +812,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0427() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0427", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 1, unit.getProblems().length); //$NON-NLS-1$<
@@ -837,7 +837,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0428() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0428", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 1, unit.getProblems().length); //$NON-NLS-1$<
@@ -862,7 +862,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0429() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0429", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 1, unit.getProblems().length); //$NON-NLS-1$<
@@ -888,7 +888,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0430() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0430", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 1, unit.getProblems().length); //$NON-NLS-1$<
@@ -911,7 +911,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0431() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0431", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 1, unit.getProblems().length); //$NON-NLS-1$<
@@ -932,7 +932,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0432() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0432", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 1, unit.getProblems().length); //$NON-NLS-1$<
@@ -954,7 +954,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0433() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0433", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 1, unit.getProblems().length); //$NON-NLS-1$<
@@ -983,7 +983,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0434() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0434", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 1, unit.getProblems().length); //$NON-NLS-1$<
@@ -1007,7 +1007,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0435() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0435", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 1, unit.getProblems().length); //$NON-NLS-1$<
@@ -1031,7 +1031,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0436() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0436", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true, false, true);
+		ASTNode result = runConversion(sourceUnit, true, false, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		assertProblemsSize(unit, 1, "The type A.CInner is not visible"); //$NON-NLS-1$
@@ -1057,7 +1057,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0437() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0437", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true, false, true);
+		ASTNode result = runConversion(sourceUnit, true, false, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		assertProblemsSize(unit, 1, "The type CInner is not visible"); //$NON-NLS-1$
@@ -1079,7 +1079,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0438() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0438", "D.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true, false, true);
+		ASTNode result = runConversion(sourceUnit, true, false, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 1, unit.getProblems().length); //$NON-NLS-1$<
@@ -1095,7 +1095,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0439() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0439", "E.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true, false, true);
+		ASTNode result = runConversion(sourceUnit, true, false, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 1, unit.getProblems().length); //$NON-NLS-1$<
@@ -1116,7 +1116,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0440() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0440", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 0, unit.getProblems().length); //$NON-NLS-1$<
@@ -1156,7 +1156,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0441() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0441", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 0, unit.getProblems().length); //$NON-NLS-1$<
@@ -1184,7 +1184,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0442() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0442", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 0, unit.getProblems().length); //$NON-NLS-1$<
@@ -1213,7 +1213,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0443() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0443", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 3, unit.getProblems().length); //$NON-NLS-1$<
@@ -1237,7 +1237,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0444() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0444", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 2, unit.getProblems().length); //$NON-NLS-1$<
@@ -1260,7 +1260,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0445() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0445", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 1, unit.getProblems().length); //$NON-NLS-1$<
@@ -1271,7 +1271,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0446() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0446", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 2, unit.getProblems().length); //$NON-NLS-1$<
@@ -1282,7 +1282,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0447() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0447", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 3, unit.getProblems().length); //$NON-NLS-1$<
@@ -1293,7 +1293,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0448() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0448", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 0, unit.getProblems().length); //$NON-NLS-1$<
@@ -1312,7 +1312,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0449() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0449", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 0, unit.getProblems().length); //$NON-NLS-1$<
@@ -1330,7 +1330,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0450() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0450", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 0, unit.getProblems().length); //$NON-NLS-1$
@@ -1418,7 +1418,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0451() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0451", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 2, unit.getProblems().length); //$NON-NLS-1$
@@ -1435,7 +1435,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0452() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "", "NO_WORKING.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
 		ASTNode node = getASTNode(compilationUnit, 0, 0);
@@ -1451,7 +1451,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0453() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0453", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
 		ASTNode node = getASTNode(compilationUnit, 0, 0,0);
@@ -1471,7 +1471,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0454() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0454", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
 		ASTNode node = getASTNode(compilationUnit, 0, 0,1);
@@ -1496,7 +1496,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0455() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0455", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
 		ASTNode node = getASTNode(compilationUnit, 0, 0, 0);
@@ -1524,7 +1524,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0456() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0456", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
 		ASTNode node = getASTNode(compilationUnit, 0, 0, 0);
@@ -1545,7 +1545,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0457() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0457", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
 		ASTNode node = getASTNode(compilationUnit, 0, 0, 0);
@@ -1572,7 +1572,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0458() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0458", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
 		ASTNode node = getASTNode(compilationUnit, 0, 0, 0);
@@ -1601,7 +1601,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0459() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0459", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
 		ASTNode node = getASTNode(compilationUnit, 0, 0, 0);
@@ -1629,7 +1629,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0460() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0460", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
 		assertTrue("Has error", compilationUnit.getProblems().length == 0); //$NON-NLS-1$
@@ -1643,7 +1643,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0461() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0461", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		char[] source = sourceUnit.getSource().toCharArray();
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -1680,7 +1680,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0462() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "", "Test462.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
 		assertTrue("Has error", compilationUnit.getProblems().length == 0); //$NON-NLS-1$
@@ -1699,7 +1699,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0463() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0463", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		CompilationUnit compilationUnit = (CompilationUnit) result;
 		char[] source = sourceUnit.getSource().toCharArray();
 		ASTNode node = getASTNode(compilationUnit, 0, 0, 0);
@@ -1720,7 +1720,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0464() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0464", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		CompilationUnit compilationUnit = (CompilationUnit) result;
 		ASTNode node = getASTNode(compilationUnit, 0, 0, 0);
 		assertEquals("No error", 1, compilationUnit.getProblems().length); //$NON-NLS-1$
@@ -1742,7 +1742,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0465() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0465", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		CompilationUnit compilationUnit = (CompilationUnit) result;
 		ASTNode node = getASTNode(compilationUnit, 0, 1, 0);
 		assertEquals("No error", 0, compilationUnit.getProblems().length); //$NON-NLS-1$
@@ -1774,7 +1774,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 			newOptions.put(JavaCore.COMPILER_SOURCE, CompilerOptions.getFirstSupportedJavaVersion());
 			JavaCore.setOptions(newOptions);
 			ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0466", "Assert.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-			ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+			ASTNode result = runConversion(sourceUnit, true);
 			CompilationUnit compilationUnit = (CompilationUnit) result;
 			char[] source = sourceUnit.getSource().toCharArray();
 			ASTNode node = getASTNode(compilationUnit, 0, 0, 0);
@@ -1798,7 +1798,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 			newOptions.put(JavaCore.COMPILER_SOURCE, CompilerOptions.getFirstSupportedJavaVersion());
 			JavaCore.setOptions(newOptions);
 			ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0467", "Assert.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-			ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+			ASTNode result = runConversion(sourceUnit, true);
 			CompilationUnit compilationUnit = (CompilationUnit) result;
 			char[] source = sourceUnit.getSource().toCharArray();
 			ASTNode node = getASTNode(compilationUnit, 0, 0, 0);
@@ -1823,7 +1823,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0468() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0468", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		CompilationUnit compilationUnit = (CompilationUnit) result;
 		ASTNode node = getASTNode(compilationUnit, 0, 1, 0);
 		assertEquals("No error", 0, compilationUnit.getProblems().length); //$NON-NLS-1$
@@ -1862,7 +1862,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0469() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "codeManipulation", "bug.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		CompilationUnit compilationUnit = (CompilationUnit) result;
 		ASTNode node = getASTNode(compilationUnit, 0, 2, 0);
 		assertEquals("No error", 0, compilationUnit.getProblems().length); //$NON-NLS-1$
@@ -1879,7 +1879,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0470() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0470", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		CompilationUnit compilationUnit = (CompilationUnit) result;
 		ASTNode node = getASTNode(compilationUnit, 0, 0, 0);
 		assertEquals("No error", 0, compilationUnit.getProblems().length); //$NON-NLS-1$
@@ -1906,7 +1906,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0471() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0471", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		CompilationUnit compilationUnit = (CompilationUnit) result;
 		assertEquals("No error", 1, compilationUnit.getProblems().length); //$NON-NLS-1$
 		ASTNode node = getASTNode(compilationUnit, 0, 0);
@@ -1927,7 +1927,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0472() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "junit.textui", "ResultPrinter.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		CompilationUnit compilationUnit = (CompilationUnit) result;
 		assertEquals("No error", 2, compilationUnit.getProblems().length); //$NON-NLS-1$
 		ASTNode node = getASTNode(compilationUnit, 0, 2);
@@ -1950,7 +1950,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 
 			ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0473", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 			char[] source = sourceUnit.getSource().toCharArray();
-			ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+			ASTNode result = runConversion(sourceUnit, true);
 			CompilationUnit compilationUnit = (CompilationUnit) result;
 			assertEquals("No error", 2, compilationUnit.getProblems().length); //$NON-NLS-1$
 			ASTNode node = getASTNode(compilationUnit, 0, 0, 0);
@@ -1971,7 +1971,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0474() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0474", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		CompilationUnit compilationUnit = (CompilationUnit) result;
 		assertEquals("No error", 0, compilationUnit.getProblems().length); //$NON-NLS-1$
 		ASTNode node = getASTNode(compilationUnit, 0, 1, 0);
@@ -1995,7 +1995,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0475() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0475", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		CompilationUnit compilationUnit = (CompilationUnit) result;
 		assertEquals("No error", 0, compilationUnit.getProblems().length); //$NON-NLS-1$
 		ASTNode node = getASTNode(compilationUnit, 0, 1, 0);
@@ -2019,7 +2019,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0476() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0476", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		CompilationUnit compilationUnit = (CompilationUnit) result;
 		assertEquals("No error", 0, compilationUnit.getProblems().length); //$NON-NLS-1$
 		ASTNode node = getASTNode(compilationUnit, 0, 1, 0);
@@ -2044,7 +2044,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0477() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0477", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		CompilationUnit compilationUnit = (CompilationUnit) result;
 		assertEquals("No error", 1, compilationUnit.getProblems().length); //$NON-NLS-1$
 		ASTNode node = getASTNode(compilationUnit, 0, 1, 0);
@@ -2073,7 +2073,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 		assertEquals("wrong size", 1, methods.length);
 		IMethod method = methods[0];
 		ISourceRange sourceRange = method.getSourceRange();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, sourceRange.getOffset() + sourceRange.getLength() / 2, true);
+		ASTNode result = runConversion(sourceUnit, sourceRange.getOffset() + sourceRange.getLength() / 2, true);
 		assertNotNull(result);
 		assertTrue("Not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		ASTNode node = getASTNode((CompilationUnit) result, 1, 0);
@@ -2122,7 +2122,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 		assertEquals("wrong size", 1, methods.length);
 		IMethod method = methods[0];
 		ISourceRange sourceRange = method.getSourceRange();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, sourceRange.getOffset() + sourceRange.getLength() / 2, false);
+		ASTNode result = runConversion(sourceUnit, sourceRange.getOffset() + sourceRange.getLength() / 2, false);
 		assertNotNull(result);
 		assertTrue("Not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		ASTNode node = getASTNode((CompilationUnit) result, 1, 0);
@@ -2161,7 +2161,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 		assertEquals("wrong size", 1, methods.length);
 		IMethod method = methods[0];
 		ISourceRange sourceRange = method.getSourceRange();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, sourceRange.getOffset() + sourceRange.getLength() / 2, false);
+		ASTNode result = runConversion(sourceUnit, sourceRange.getOffset() + sourceRange.getLength() / 2, false);
 		assertNotNull(result);
 		assertTrue("Not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
@@ -2189,7 +2189,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 		assertEquals("wrong size", 1, methods.length);
 		IMethod method = methods[0];
 		ISourceRange sourceRange = method.getSourceRange();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, sourceRange.getOffset() + sourceRange.getLength() / 2, true);
+		ASTNode result = runConversion(sourceUnit, sourceRange.getOffset() + sourceRange.getLength() / 2, true);
 		assertNotNull(result);
 		assertTrue("Not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
@@ -2229,7 +2229,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 		assertEquals("wrong size", 1, methods.length);
 		IMethod method = methods[0];
 		ISourceRange sourceRange = method.getSourceRange();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, sourceRange.getOffset() + sourceRange.getLength() / 2, true);
+		ASTNode result = runConversion(sourceUnit, sourceRange.getOffset() + sourceRange.getLength() / 2, true);
 		assertNotNull(result);
 		assertTrue("Not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
@@ -2267,7 +2267,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 		assertEquals("wrong size", 1, methods.length);
 		IMethod method = methods[0];
 		ISourceRange sourceRange = method.getSourceRange();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, sourceRange.getOffset() + sourceRange.getLength() / 2, true);
+		ASTNode result = runConversion(sourceUnit, sourceRange.getOffset() + sourceRange.getLength() / 2, true);
 		assertNotNull(result);
 		assertTrue("Not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
@@ -2310,7 +2310,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 		assertEquals("wrong size", 1, memberTypes.length);
 		IType memberType = memberTypes[0];
 		ISourceRange sourceRange = memberType.getSourceRange();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, sourceRange.getOffset() + sourceRange.getLength() / 2, true);
+		ASTNode result = runConversion(sourceUnit, sourceRange.getOffset() + sourceRange.getLength() / 2, true);
 		assertNotNull(result);
 		assertTrue("Not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
@@ -2341,7 +2341,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 		assertEquals("wrong size", 1, memberTypes.length);
 		IType memberType = memberTypes[0];
 		ISourceRange sourceRange = memberType.getSourceRange();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, sourceRange.getOffset() + sourceRange.getLength() / 2, false);
+		ASTNode result = runConversion(sourceUnit, sourceRange.getOffset() + sourceRange.getLength() / 2, false);
 		assertNotNull(result);
 		assertTrue("Not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
@@ -2371,7 +2371,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 		assertEquals("wrong size", 2, methods.length);
 		IMethod method = methods[1];
 		ISourceRange sourceRange = method.getSourceRange();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, sourceRange.getOffset() + sourceRange.getLength() / 2, false);
+		ASTNode result = runConversion(sourceUnit, sourceRange.getOffset() + sourceRange.getLength() / 2, false);
 		assertNotNull(result);
 		assertTrue("Not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 2);
@@ -2402,7 +2402,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 		assertEquals("wrong size", 3, methods.length);
 		IMethod method = methods[1];
 		ISourceRange sourceRange = method.getSourceRange();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, sourceRange.getOffset() + sourceRange.getLength() / 2, false);
+		ASTNode result = runConversion(sourceUnit, sourceRange.getOffset() + sourceRange.getLength() / 2, false);
 		assertNotNull(result);
 		assertTrue("Not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 
@@ -2475,7 +2475,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 		assertEquals("wrong size", 2, initializers.length);
 		IInitializer init = initializers[1];
 		ISourceRange sourceRange = init.getSourceRange();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, sourceRange.getOffset() + sourceRange.getLength() / 2, false);
+		ASTNode result = runConversion(sourceUnit, sourceRange.getOffset() + sourceRange.getLength() / 2, false);
 		assertNotNull(result);
 		assertTrue("Not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 
@@ -2539,7 +2539,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0489() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0489", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 3, unit.getProblems().length); //$NON-NLS-1$<
@@ -2555,7 +2555,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0490() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0490", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 0, unit.getProblems().length); //$NON-NLS-1$<
@@ -2572,7 +2572,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 			JavaCore.setOptions(newOptions);
 			ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0491", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 			char[] source = sourceUnit.getSource().toCharArray();
-			ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+			ASTNode result = runConversion(sourceUnit, true);
 			assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 			CompilationUnit unit = (CompilationUnit) result;
 			assertEquals("Wrong number of problems", 0, unit.getProblems().length); //$NON-NLS-1$<
@@ -2598,7 +2598,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 			JavaCore.setOptions(newOptions);
 			ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0492", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 			char[] source = sourceUnit.getSource().toCharArray();
-			ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+			ASTNode result = runConversion(sourceUnit, true);
 			assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 			CompilationUnit unit = (CompilationUnit) result;
 			assertEquals("Wrong number of problems", 0, unit.getProblems().length); //$NON-NLS-1$<
@@ -2660,7 +2660,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0495() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0495", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 0, unit.getProblems().length); //$NON-NLS-1$<
@@ -2702,7 +2702,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0497() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0497", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 0, unit.getProblems().length); //$NON-NLS-1$<
@@ -2719,7 +2719,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 
 	public void test0498() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0498", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 	}
 
@@ -2728,7 +2728,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0499() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0499", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 1, unit.getProblems().length); //$NON-NLS-1$
@@ -2765,7 +2765,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 			project.setOption(JavaCore.COMPILER_PB_INVALID_JAVADOC, JavaCore.ERROR);
 			project.setOption(JavaCore.COMPILER_PB_MISSING_JAVADOC_TAGS, JavaCore.ERROR);
 			project.setOption(JavaCore.COMPILER_PB_MISSING_JAVADOC_COMMENTS, JavaCore.ERROR);
-			CompilationUnit result = (CompilationUnit)runConversion(getJLS3(), sourceUnit, true);
+			CompilationUnit result = (CompilationUnit)runConversion(sourceUnit, true);
 			IProblem[] problems= result.getProblems();
 			assertTrue(problems.length == 1);
 			assertEquals("Invalid warning", "Javadoc: Missing tag for parameter a", problems[0].getMessage());
@@ -2779,7 +2779,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0501() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0501", "JavaEditor.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		assertNotNull(result);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 	}
@@ -2789,7 +2789,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0502a() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0502", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		CompilationUnit unit = (CompilationUnit)runConversion(getJLS3(), sourceUnit, true);
+		CompilationUnit unit = (CompilationUnit)runConversion(sourceUnit, true);
 
 		// 'i' in initializer
 		VariableDeclarationStatement variableDeclarationStatement = (VariableDeclarationStatement)getASTNode(unit, 0, 0, 0);
@@ -2803,7 +2803,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0502b() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0502", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		CompilationUnit unit = (CompilationUnit)runConversion(getJLS3(), sourceUnit, true);
+		CompilationUnit unit = (CompilationUnit)runConversion(sourceUnit, true);
 
 		// 'j' in 'then' block in initializer
 		IfStatement ifStatement = (IfStatement) getASTNode(unit, 0, 0, 1);
@@ -2819,7 +2819,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0502c() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0502", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		CompilationUnit unit = (CompilationUnit)runConversion(getJLS3(), sourceUnit, true);
+		CompilationUnit unit = (CompilationUnit)runConversion(sourceUnit, true);
 
 		// 'i' in 'foo()'
 		VariableDeclarationStatement variableDeclarationStatement = (VariableDeclarationStatement)getASTNode(unit, 0, 1, 0);
@@ -2833,7 +2833,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0502d() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0502", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		CompilationUnit unit = (CompilationUnit)runConversion(getJLS3(), sourceUnit, true);
+		CompilationUnit unit = (CompilationUnit)runConversion(sourceUnit, true);
 
 		// 'j' in 'then' block in 'foo()'
 		IfStatement ifStatement = (IfStatement) getASTNode(unit, 0, 1, 1);
@@ -2849,7 +2849,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0502e() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0502", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		CompilationUnit unit = (CompilationUnit)runConversion(getJLS3(), sourceUnit, true);
+		CompilationUnit unit = (CompilationUnit)runConversion(sourceUnit, true);
 
 		// 'j' in 'else' block in 'foo()'
 		IfStatement ifStatement = (IfStatement) getASTNode(unit, 0, 1, 1);
@@ -2865,7 +2865,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0502f() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0502", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		CompilationUnit unit = (CompilationUnit)runConversion(getJLS3(), sourceUnit, true);
+		CompilationUnit unit = (CompilationUnit)runConversion(sourceUnit, true);
 
 		// first 'new Object(){...}' in 'foo()'
 		ExpressionStatement expressionStatement = (ExpressionStatement) getASTNode(unit, 0, 1, 2);
@@ -2880,7 +2880,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0502g() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0502", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		CompilationUnit unit = (CompilationUnit)runConversion(getJLS3(), sourceUnit, true);
+		CompilationUnit unit = (CompilationUnit)runConversion(sourceUnit, true);
 
 		// 'B' in 'foo()'
 		TypeDeclarationStatement typeDeclarationStatement = (TypeDeclarationStatement) getASTNode(unit, 0, 1, 3);
@@ -2894,7 +2894,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0502h() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0502", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		CompilationUnit unit = (CompilationUnit)runConversion(getJLS3(), sourceUnit, true);
+		CompilationUnit unit = (CompilationUnit)runConversion(sourceUnit, true);
 
 		// second 'new Object(){...}' in 'foo()'
 		ExpressionStatement expressionStatement = (ExpressionStatement) getASTNode(unit, 0, 1, 4);
@@ -2909,7 +2909,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0502i() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0502", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		CompilationUnit unit = (CompilationUnit)runConversion(getJLS3(), sourceUnit, true);
+		CompilationUnit unit = (CompilationUnit)runConversion(sourceUnit, true);
 
 		// 'field' in 'B' in 'foo()'
 		TypeDeclarationStatement typeDeclarationStatement = (TypeDeclarationStatement) getASTNode(unit, 0, 1, 3);
@@ -2927,7 +2927,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0502j() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0502", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		CompilationUnit unit = (CompilationUnit)runConversion(getJLS3(), sourceUnit, true);
+		CompilationUnit unit = (CompilationUnit)runConversion(sourceUnit, true);
 
 		// 'bar()' in 'B' in 'foo()'
 		TypeDeclarationStatement typeDeclarationStatement = (TypeDeclarationStatement) getASTNode(unit, 0, 1, 3);
@@ -2944,7 +2944,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0503a() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0503", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		CompilationUnit unit = (CompilationUnit)runConversion(getJLS3(), sourceUnit, true);
+		CompilationUnit unit = (CompilationUnit)runConversion(sourceUnit, true);
 
 		// top level type A
 		TypeDeclaration type = (TypeDeclaration)getASTNode(unit, 0);
@@ -2957,7 +2957,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0503b() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0503", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		CompilationUnit unit = (CompilationUnit)runConversion(getJLS3(), sourceUnit, true);
+		CompilationUnit unit = (CompilationUnit)runConversion(sourceUnit, true);
 
 		// member type B in A
 		TypeDeclaration type = (TypeDeclaration)getASTNode(unit, 0, 0);
@@ -2970,7 +2970,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0503c() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0503", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		CompilationUnit unit = (CompilationUnit)runConversion(getJLS3(), sourceUnit, true);
+		CompilationUnit unit = (CompilationUnit)runConversion(sourceUnit, true);
 
 		// local type E in foo() in A
 		TypeDeclarationStatement typeDeclarationStatement = (TypeDeclarationStatement) getASTNode(unit, 0, 1, 0);
@@ -2984,7 +2984,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0503d() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0503", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		CompilationUnit unit = (CompilationUnit)runConversion(getJLS3(), sourceUnit, true);
+		CompilationUnit unit = (CompilationUnit)runConversion(sourceUnit, true);
 
 		// anonymous type new Object() {...} in foo() in A
 		ExpressionStatement expressionStatement = (ExpressionStatement) getASTNode(unit, 0, 1, 1);
@@ -2999,7 +2999,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0503e() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0503", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		CompilationUnit unit = (CompilationUnit)runConversion(getJLS3(), sourceUnit, true);
+		CompilationUnit unit = (CompilationUnit)runConversion(sourceUnit, true);
 
 		// type F in anonymous type new Object() {...} in foo() in A
 		ExpressionStatement expressionStatement = (ExpressionStatement) getASTNode(unit, 0, 1, 1);
@@ -3015,7 +3015,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0503f() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0503", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		CompilationUnit unit = (CompilationUnit)runConversion(getJLS3(), sourceUnit, true);
+		CompilationUnit unit = (CompilationUnit)runConversion(sourceUnit, true);
 
 		// local type C in bar() in B in A
 		MethodDeclaration method = (MethodDeclaration) getASTNode(unit, 0, 0, 0);
@@ -3030,7 +3030,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0503g() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0503", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		CompilationUnit unit = (CompilationUnit)runConversion(getJLS3(), sourceUnit, true);
+		CompilationUnit unit = (CompilationUnit)runConversion(sourceUnit, true);
 
 		// anonymous type new Object() {...} in bar() in B in A
 		MethodDeclaration method = (MethodDeclaration) getASTNode(unit, 0, 0, 0);
@@ -3046,7 +3046,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0503h() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0503", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		CompilationUnit unit = (CompilationUnit)runConversion(getJLS3(), sourceUnit, true);
+		CompilationUnit unit = (CompilationUnit)runConversion(sourceUnit, true);
 
 		// type D in anonymous type new Object() {...} in bar() in B in A
 		MethodDeclaration method = (MethodDeclaration) getASTNode(unit, 0, 0, 0);
@@ -3063,7 +3063,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0503i() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0503", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		CompilationUnit unit = (CompilationUnit)runConversion(getJLS3(), sourceUnit, true);
+		CompilationUnit unit = (CompilationUnit)runConversion(sourceUnit, true);
 
 		// unreachable type G in foo() in A
 		IfStatement ifStatement = (IfStatement) getASTNode(unit, 0, 1, 2);
@@ -3080,7 +3080,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0504() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0504", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 1, unit.getProblems().length); //$NON-NLS-1$
@@ -3098,7 +3098,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0505() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0505", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 1, unit.getProblems().length); //$NON-NLS-1$
@@ -3115,7 +3115,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0506() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0506", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		final CompilationUnit unit = (CompilationUnit) result;
 		ASTNode node = getASTNode(unit, 0, 0, 0);
 		assertEquals("Wrong number of problems", 0, (unit).getProblems().length); //$NON-NLS-1$
@@ -3135,7 +3135,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0507() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0507", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		final CompilationUnit unit = (CompilationUnit) result;
 		ASTNode node = getASTNode(unit, 0, 0, 0);
 		assertEquals("Wrong number of problems", 0, (unit).getProblems().length); //$NON-NLS-1$
@@ -3155,7 +3155,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0508() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0508", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		final CompilationUnit unit = (CompilationUnit) result;
 		ASTNode node = getASTNode(unit, 0, 1, 0);
 		assertEquals("Wrong number of problems", 0, (unit).getProblems().length); //$NON-NLS-1$
@@ -3175,7 +3175,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0509() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0509", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		final CompilationUnit unit = (CompilationUnit) result;
 		ASTNode node = getASTNode(unit, 0, 0, 0);
 		assertEquals("Wrong number of problems", 0, (unit).getProblems().length); //$NON-NLS-1$
@@ -3195,7 +3195,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0510() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0510", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		final CompilationUnit unit = (CompilationUnit) result;
 		ASTNode node = getASTNode(unit, 0, 0, 0);
 		assertEquals("Wrong number of problems", 0, (unit).getProblems().length); //$NON-NLS-1$
@@ -3215,7 +3215,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0511() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0511", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		final CompilationUnit unit = (CompilationUnit) result;
 		ASTNode node = getASTNode(unit, 0, 0, 0);
 		assertEquals("Wrong number of problems", 0, (unit).getProblems().length); //$NON-NLS-1$
@@ -3236,7 +3236,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0512() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0512", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		final CompilationUnit unit = (CompilationUnit) result;
 		ASTNode node = getASTNode(unit, 0, 0);
 		assertEquals("Wrong number of problems", 2, unit.getProblems().length); //$NON-NLS-1$
@@ -3252,7 +3252,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0513() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0513", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		final CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 1, unit.getProblems().length); //$NON-NLS-1$
 	}
@@ -3263,7 +3263,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0514() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0514", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		final CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 1, unit.getProblems().length); //$NON-NLS-1$
 	}
@@ -3274,7 +3274,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0515() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0515", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		final CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 1, unit.getProblems().length); //$NON-NLS-1$
 		ASTNode node = getASTNode(unit, 0, 0, 0);
@@ -3298,14 +3298,14 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0516() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0516", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		final CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 0, unit.getProblems().length); //$NON-NLS-1$
 		ASTNode node = getASTNode(unit, 0, 0);
 		assertNotNull("No node", node);
 		assertTrue("not a method declaration", node.getNodeType() == ASTNode.METHOD_DECLARATION);
 		MethodDeclaration declaration = (MethodDeclaration) node;
-		ASTParser parser = ASTParser.newParser(getJLS3());
+		ASTParser parser = ASTParser.newParser(getJLSFirst());
 		parser.setKind(ASTParser.K_CLASS_BODY_DECLARATIONS);
 		parser.setSource(source);
 		parser.setSourceRange(declaration.getStartPosition(), declaration.getLength());
@@ -3332,7 +3332,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0517() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0517", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		final CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 0, unit.getProblems().length); //$NON-NLS-1$
 		assertNotNull("No comments", unit.getCommentList());
@@ -3341,7 +3341,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 		assertNotNull("No node", node);
 		assertTrue("not a field declaration", node.getNodeType() == ASTNode.FIELD_DECLARATION);
 		FieldDeclaration declaration = (FieldDeclaration) node;
-		ASTParser parser = ASTParser.newParser(getJLS3());
+		ASTParser parser = ASTParser.newParser(getJLSFirst());
 		parser.setKind(ASTParser.K_CLASS_BODY_DECLARATIONS);
 		parser.setSource(source);
 		parser.setSourceRange(declaration.getStartPosition(), declaration.getLength());
@@ -3368,14 +3368,14 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0518() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0518", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		final CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 0, unit.getProblems().length); //$NON-NLS-1$
 		ASTNode node = getASTNode(unit, 0, 0);
 		assertNotNull("No node", node);
 		assertTrue("not an initializer", node.getNodeType() == ASTNode.INITIALIZER);
 		Initializer declaration = (Initializer) node;
-		ASTParser parser = ASTParser.newParser(getJLS3());
+		ASTParser parser = ASTParser.newParser(getJLSFirst());
 		parser.setKind(ASTParser.K_CLASS_BODY_DECLARATIONS);
 		parser.setSource(source);
 		parser.setSourceRange(declaration.getStartPosition(), declaration.getLength());
@@ -3402,7 +3402,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0519() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0519", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		final CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 0, unit.getProblems().length); //$NON-NLS-1$
 		assertNotNull("No comments", unit.getCommentList());
@@ -3410,7 +3410,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 		ASTNode node = getASTNode(unit, 0, 0, 0);
 		assertNotNull("No node", node);
 		ASTNode statement = node;
-		ASTParser parser = ASTParser.newParser(getJLS3());
+		ASTParser parser = ASTParser.newParser(getJLSFirst());
 		parser.setKind(ASTParser.K_STATEMENTS);
 		parser.setSource(source);
 		parser.setSourceRange(statement.getStartPosition(), statement.getLength());
@@ -3437,7 +3437,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0520() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0520", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		final CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 0, unit.getProblems().length); //$NON-NLS-1$
 		assertNotNull("No comments", unit.getCommentList());
@@ -3447,7 +3447,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 		assertTrue("not a block", node.getNodeType() == ASTNode.EXPRESSION_STATEMENT);
 		ExpressionStatement expressionStatement = (ExpressionStatement) node;
 		Expression expression = expressionStatement.getExpression();
-		ASTParser parser = ASTParser.newParser(getJLS3());
+		ASTParser parser = ASTParser.newParser(getJLSFirst());
 		parser.setKind(ASTParser.K_EXPRESSION);
 		parser.setSource(source);
 		parser.setSourceRange(expression.getStartPosition(), expression.getLength());
@@ -3517,7 +3517,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 		assertEquals("wrong size", 2, methods.length);
 		IMethod method = methods[1];
 		ISourceRange sourceRange = method.getSourceRange();
-		ASTNode result = runConversion(getJLS3(), classFile, sourceRange.getOffset() + sourceRange.getLength() / 2, true);
+		ASTNode result = runConversion(classFile, sourceRange.getOffset() + sourceRange.getLength() / 2, true);
 		assertNotNull(result);
 		assertTrue("Not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		ASTNode node = getASTNode((CompilationUnit) result, 1, 0);
@@ -3566,7 +3566,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 		assertEquals("wrong size", 2, methods.length);
 		IMethod method = methods[1];
 		ISourceRange sourceRange = method.getSourceRange();
-		ASTNode result = runConversion(getJLS3(), classFile, sourceRange.getOffset() + sourceRange.getLength() / 2, false);
+		ASTNode result = runConversion(classFile, sourceRange.getOffset() + sourceRange.getLength() / 2, false);
 		assertNotNull(result);
 		assertTrue("Not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		ASTNode node = getASTNode((CompilationUnit) result, 1, 0);
@@ -3605,7 +3605,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 		assertEquals("wrong size", 2, methods.length);
 		IMethod method = methods[1];
 		ISourceRange sourceRange = method.getSourceRange();
-		ASTNode result = runConversion(getJLS3(), classFile, sourceRange.getOffset() + sourceRange.getLength() / 2, false);
+		ASTNode result = runConversion(classFile, sourceRange.getOffset() + sourceRange.getLength() / 2, false);
 		assertNotNull(result);
 		assertTrue("Not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
@@ -3633,7 +3633,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 		assertEquals("wrong size", 2, methods.length);
 		IMethod method = methods[1];
 		ISourceRange sourceRange = method.getSourceRange();
-		ASTNode result = runConversion(getJLS3(), classFile, sourceRange.getOffset() + sourceRange.getLength() / 2, true);
+		ASTNode result = runConversion(classFile, sourceRange.getOffset() + sourceRange.getLength() / 2, true);
 		assertNotNull(result);
 		assertTrue("Not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
@@ -3672,7 +3672,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 		assertEquals("wrong size", 2, methods.length);
 		IMethod method = methods[1];
 		ISourceRange sourceRange = method.getSourceRange();
-		ASTNode result = runConversion(getJLS3(), classFile, sourceRange.getOffset() + sourceRange.getLength() / 2, true);
+		ASTNode result = runConversion(classFile, sourceRange.getOffset() + sourceRange.getLength() / 2, true);
 		assertNotNull(result);
 		assertTrue("Not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0, 0);
@@ -3710,7 +3710,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 		assertEquals("wrong size", 1, methods.length);
 		IMethod method = methods[0];
 		ISourceRange sourceRange = method.getSourceRange();
-		ASTNode result = runConversion(getJLS3(), classFile, sourceRange.getOffset() + sourceRange.getLength() / 2, true);
+		ASTNode result = runConversion(classFile, sourceRange.getOffset() + sourceRange.getLength() / 2, true);
 		assertNotNull(result);
 		assertTrue("Not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
@@ -3751,7 +3751,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 		assertEquals("wrong size", 1, memberTypes.length);
 		IType memberType = memberTypes[0];
 		ISourceRange sourceRange = memberType.getSourceRange();
-		ASTNode result = runConversion(getJLS3(), classFile, sourceRange.getOffset() + sourceRange.getLength() / 2, true);
+		ASTNode result = runConversion(classFile, sourceRange.getOffset() + sourceRange.getLength() / 2, true);
 		assertNotNull(result);
 		assertTrue("Not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
@@ -3780,7 +3780,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 		assertEquals("wrong size", 1, memberTypes.length);
 		IType memberType = memberTypes[0];
 		ISourceRange sourceRange = memberType.getSourceRange();
-		ASTNode result = runConversion(getJLS3(), classFile, sourceRange.getOffset() + sourceRange.getLength() / 2, false);
+		ASTNode result = runConversion(classFile, sourceRange.getOffset() + sourceRange.getLength() / 2, false);
 		assertNotNull(result);
 		assertTrue("Not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 0);
@@ -3809,7 +3809,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 		assertEquals("wrong size", 3, methods.length);
 		IMethod method = methods[2];
 		ISourceRange sourceRange = method.getSourceRange();
-		ASTNode result = runConversion(getJLS3(), classFile, sourceRange.getOffset() + sourceRange.getLength() / 2, false);
+		ASTNode result = runConversion(classFile, sourceRange.getOffset() + sourceRange.getLength() / 2, false);
 		assertNotNull(result);
 		assertTrue("Not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		ASTNode node = getASTNode((CompilationUnit) result, 0, 2);
@@ -3838,7 +3838,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 		assertEquals("wrong size", 5, methods.length);
 		IMethod method = methods[3];
 		ISourceRange sourceRange = method.getSourceRange();
-		ASTNode result = runConversion(getJLS3(), classFile, sourceRange.getOffset() + sourceRange.getLength() / 2, false);
+		ASTNode result = runConversion(classFile, sourceRange.getOffset() + sourceRange.getLength() / 2, false);
 		assertNotNull(result);
 		assertTrue("Not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 
@@ -3919,7 +3919,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 		type = classFile.getType();
 		initializers = type.getInitializers();
 		assertEquals("wrong size", 0, initializers.length);
-		ASTNode result = runConversion(getJLS3(), classFile, position, false);
+		ASTNode result = runConversion(classFile, position, false);
 		assertNotNull(result);
 		assertTrue("Not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 
@@ -3985,7 +3985,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0533() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0533", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		final CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 1, unit.getProblems().length); //$NON-NLS-1$
 		ASTNode node = getASTNode(unit, 0, 0);
@@ -4010,7 +4010,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0534() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0534", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		final CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 1, unit.getProblems().length); //$NON-NLS-1$
 		ASTNode node = getASTNode(unit, 0, 0);
@@ -4035,7 +4035,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0535() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0535", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		final CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 1, unit.getProblems().length); //$NON-NLS-1$
 		ASTNode node = getASTNode(unit, 0, 0);
@@ -4058,7 +4058,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0536() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0536", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		assertNotNull("No compilation unit", result);
 	}
 	/**
@@ -4066,7 +4066,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0537a() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0537", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		assertNotNull("No compilation unit", result);
 	}
 	/**
@@ -4074,7 +4074,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0537b() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0537", "B.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		assertNotNull("No compilation unit", result);
 	}
 	/**
@@ -4287,7 +4287,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0539() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0539", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		final CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 0, unit.getProblems().length); //$NON-NLS-1$
 		ASTNode node = getASTNode(unit, 0, 1, 0);
@@ -4326,7 +4326,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 		options.put(JavaCore.COMPILER_SOURCE, CompilerOptions.getFirstSupportedJavaVersion());
 		options.put(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, CompilerOptions.getFirstSupportedJavaVersion());
 		options.put(JavaCore.COMPILER_COMPLIANCE, CompilerOptions.getFirstSupportedJavaVersion());
-		ASTNode result = runConversion(getJLS3(), source, "Test.java", project, options, true); //$NON-NLS-1$
+		ASTNode result = runConversion(source, "Test.java", project, options, true); //$NON-NLS-1$
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -4346,7 +4346,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0541() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0541", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		final CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 0, unit.getProblems().length); //$NON-NLS-1$
 		ASTNode node = getASTNode(unit, 0, 0);
@@ -4375,7 +4375,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0542() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0542", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		final CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 0, unit.getProblems().length); //$NON-NLS-1$
 		ASTNode node = getASTNode(unit, 0, 0);
@@ -4543,7 +4543,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0543() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0543", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		final CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 0, unit.getProblems().length); //$NON-NLS-1$
 		unit.accept(new GetKeyVisitor());
@@ -4554,7 +4554,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0544() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0544", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		final CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 1, unit.getProblems().length); //$NON-NLS-1$
 		ASTNode node = getASTNode(unit, 0, 0);
@@ -4571,7 +4571,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0545() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0545", "First.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 0, unit.getProblems().length); //$NON-NLS-1$
 		ASTNode node = getASTNode(unit, 0, 0);
@@ -4581,7 +4581,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 		assertEquals("Wrong key", "Ltest0545/First$Test;", typeBinding.getKey());
 
 		sourceUnit = getCompilationUnit("Converter", "src", "test0545", "Second.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		result = runConversion(getJLS3(), sourceUnit, true);
+		result = runConversion(sourceUnit, true);
 		unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 0, unit.getProblems().length); //$NON-NLS-1$
 		node = getASTNode(unit, 0, 0);
@@ -4591,7 +4591,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 		assertEquals("Wrong key", "Ltest0545/Second$Test;", typeBinding.getKey());
 
 		sourceUnit = getCompilationUnit("Converter", "src", "test0545", "Third.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		result = runConversion(getJLS3(), sourceUnit, true);
+		result = runConversion(sourceUnit, true);
 		unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 0, unit.getProblems().length); //$NON-NLS-1$
 		node = getASTNode(unit, 0, 0);
@@ -4602,7 +4602,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 
 
 		sourceUnit = getCompilationUnit("Converter", "src", "test0545", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		result = runConversion(getJLS3(), sourceUnit, true);
+		result = runConversion(sourceUnit, true);
 		unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 0, unit.getProblems().length); //$NON-NLS-1$
 		node = getASTNode(unit, 0);
@@ -4617,7 +4617,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0546() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0546", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		final CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 0, unit.getProblems().length); //$NON-NLS-1$
 		ASTNode node = getASTNode(unit, 1, 0, 0);
@@ -4660,7 +4660,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0547() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0547", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 1, unit.getProblems().length); //$NON-NLS-1$
 		ASTNode node = getASTNode(unit, 0, 0, 0);
@@ -4685,7 +4685,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0548() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0548", "PaletteStackEditPart.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		assertEquals("not a compilation unit", ASTNode.COMPILATION_UNIT, result.getNodeType()); //$NON-NLS-1$
 	}
 
@@ -4694,7 +4694,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0549() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0549", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		assertEquals("not a compilation unit", ASTNode.COMPILATION_UNIT, result.getNodeType()); //$NON-NLS-1$
 	}
 
@@ -4703,7 +4703,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0550() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0550", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		assertEquals("not a compilation unit", ASTNode.COMPILATION_UNIT, result.getNodeType()); //$NON-NLS-1$
 	}
 
@@ -4713,7 +4713,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0551() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0551", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		assertEquals("not a compilation unit", ASTNode.COMPILATION_UNIT, result.getNodeType()); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		final IProblem[] problems = unit.getProblems();
@@ -4725,7 +4725,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0552() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0552", "Test.java");
 		char[] source = sourceUnit.getSource().toCharArray();
-		CompilationUnit result = (CompilationUnit) runConversion(getJLS3(), sourceUnit, true);
+		CompilationUnit result = (CompilationUnit) runConversion(sourceUnit, true);
 		assertEquals("Got errors", 0, result.getProblems().length);
 		TypeDeclaration declaration = (TypeDeclaration) result.types().get(0);
 		Block body = declaration.getMethods()[0].getBody();
@@ -4756,7 +4756,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0553() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0553", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertEquals("not a compilation unit", ASTNode.COMPILATION_UNIT, result.getNodeType()); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		final IProblem[] problems = unit.getProblems();
@@ -4779,7 +4779,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0554() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0554", "B.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertEquals("not a compilation unit", ASTNode.COMPILATION_UNIT, result.getNodeType()); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		final IProblem[] problems = unit.getProblems();
@@ -4808,7 +4808,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0555() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0555", "B.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertEquals("not a compilation unit", ASTNode.COMPILATION_UNIT, result.getNodeType()); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		final IProblem[] problems = unit.getProblems();
@@ -4837,7 +4837,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0556() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0556", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertEquals("not a compilation unit", ASTNode.COMPILATION_UNIT, result.getNodeType()); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		final IProblem[] problems = unit.getProblems();
@@ -4862,7 +4862,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0557() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0557", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertEquals("not a compilation unit", ASTNode.COMPILATION_UNIT, result.getNodeType()); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		final IProblem[] problems = unit.getProblems();
@@ -4906,7 +4906,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0559() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0559", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertEquals("not a compilation unit", ASTNode.COMPILATION_UNIT, result.getNodeType()); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		final IProblem[] problems = unit.getProblems();
@@ -4934,7 +4934,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0560() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0560", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertEquals("not a compilation unit", ASTNode.COMPILATION_UNIT, result.getNodeType()); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		final IProblem[] problems = unit.getProblems();
@@ -4962,7 +4962,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0561() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0561", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertEquals("not a compilation unit", ASTNode.COMPILATION_UNIT, result.getNodeType()); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		final IProblem[] problems = unit.getProblems();
@@ -4990,7 +4990,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0562() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0562", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertEquals("not a compilation unit", ASTNode.COMPILATION_UNIT, result.getNodeType()); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		final IProblem[] problems = unit.getProblems();
@@ -5018,7 +5018,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0563() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0563", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertEquals("not a compilation unit", ASTNode.COMPILATION_UNIT, result.getNodeType()); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		final IProblem[] problems = unit.getProblems();
@@ -5045,7 +5045,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0564() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0564", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertEquals("not a compilation unit", ASTNode.COMPILATION_UNIT, result.getNodeType()); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		final IProblem[] problems = unit.getProblems();
@@ -5072,7 +5072,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0565() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0565", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertEquals("not a compilation unit", ASTNode.COMPILATION_UNIT, result.getNodeType()); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		final IProblem[] problems = unit.getProblems();
@@ -5099,7 +5099,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0566() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0566", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertEquals("not a compilation unit", ASTNode.COMPILATION_UNIT, result.getNodeType()); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		final IProblem[] problems = unit.getProblems();
@@ -5115,7 +5115,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0567() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0567", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertEquals("not a compilation unit", ASTNode.COMPILATION_UNIT, result.getNodeType()); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		final IProblem[] problems = unit.getProblems();
@@ -5130,7 +5130,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0568() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0568", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertEquals("not a compilation unit", ASTNode.COMPILATION_UNIT, result.getNodeType()); //$NON-NLS-1$
 	}
 
@@ -5139,7 +5139,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0570() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0570", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertEquals("not a compilation unit", ASTNode.COMPILATION_UNIT, result.getNodeType()); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		final IProblem[] problems = unit.getProblems();
@@ -5150,7 +5150,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 * No binding when there is no unit name set
 	 */
 	public void test0571() throws JavaModelException {
-		ASTParser parser = ASTParser.newParser(getJLS3());
+		ASTParser parser = ASTParser.newParser(getJLSFirst());
 		String source = "public class A {public boolean foo() {}}";
 		parser.setSource(source.toCharArray());
 		parser.setProject(getJavaProject("Converter"));
@@ -5167,7 +5167,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 * No binding when there is no unit name set
 	 */
 	public void test0572() throws JavaModelException {
-		ASTParser parser = ASTParser.newParser(getJLS3());
+		ASTParser parser = ASTParser.newParser(getJLSFirst());
 		String source = "public class A {public boolean foo() {}}";
 		parser.setSource(source.toCharArray());
 		parser.setProject(getJavaProject("Converter"));
@@ -5187,7 +5187,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0573", "Z.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		String source = sourceUnit.getSource();
 		int pos = source.indexOf("his.ba");
-		ASTNode result = runConversion(getJLS3(), sourceUnit, pos, true);
+		ASTNode result = runConversion(sourceUnit, pos, true);
 		assertEquals("not a compilation unit", ASTNode.COMPILATION_UNIT, result.getNodeType()); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		ASTNode node = getASTNode(unit, 0, 0, 0);
@@ -5206,7 +5206,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0574() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0574", "X.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertEquals("not a compilation unit", ASTNode.COMPILATION_UNIT, result.getNodeType()); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		final IProblem[] problems = unit.getProblems();
@@ -5235,7 +5235,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0575() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0575", "X.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertEquals("not a compilation unit", ASTNode.COMPILATION_UNIT, result.getNodeType()); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		final IProblem[] problems = unit.getProblems();
@@ -5272,7 +5272,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0578() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0578", "X.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertEquals("not a compilation unit", ASTNode.COMPILATION_UNIT, result.getNodeType()); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		assertProblemsSize(unit, 0);
@@ -6275,7 +6275,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0607() throws JavaModelException {
 		final char[] source = "private static Category[] values = new Category[]{v1, v2, v3};".toCharArray();
-		ASTParser parser = ASTParser.newParser(getJLS3());
+		ASTParser parser = ASTParser.newParser(getJLSFirst());
 		parser.setKind(ASTParser.K_CLASS_BODY_DECLARATIONS);
 		parser.setSource(source);
 		ASTNode root = parser.createAST(null);
@@ -6346,7 +6346,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0610() throws JavaModelException {
 		final ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0610", "X.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		final ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		final ASTNode result = runConversion(sourceUnit, true);
 		assertEquals("not a compilation unit", ASTNode.COMPILATION_UNIT, result.getNodeType()); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		assertProblemsSize(unit, 1, "The type Test is deprecated");
@@ -6582,7 +6582,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 				"}";
 			workingCopy = getWorkingCopy("/Converter/src/X.java", true/*resolve*/);
 			workingCopy.getBuffer().setContents(contents.toCharArray());
-			ASTNode node = runConversion(getJLS3(), workingCopy, true);
+			ASTNode node = runConversion(workingCopy, true);
 			assertEquals("Not a compilation unit", ASTNode.COMPILATION_UNIT, node.getNodeType());
 			CompilationUnit unit = (CompilationUnit) node;
 			assertProblemsSize(unit, 1, "Dead code");
@@ -6617,7 +6617,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 				"}";
 			workingCopy = getWorkingCopy("/Converter/src/X.java", true/*resolve*/);
 			workingCopy.getBuffer().setContents(contents.toCharArray());
-			ASTNode node = runConversion(getJLS3(), workingCopy, true);
+			ASTNode node = runConversion(workingCopy, true);
 			assertEquals("Not a compilation unit", ASTNode.COMPILATION_UNIT, node.getNodeType());
 			CompilationUnit unit = (CompilationUnit) node;
 			String expectedOutput = "Dead code";
@@ -6692,13 +6692,13 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0619() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter", "src", "test0619", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, false);
+		ASTNode result = runConversion(sourceUnit, false);
 		final CompilationUnit unit = (CompilationUnit) result;
 		assertProblemsSize(unit, 0);
 		ASTNode node = getASTNode(unit, 0, 0, 0);
 		assertNotNull("No node", node);
 		ASTNode statement = node;
-		ASTParser parser = ASTParser.newParser(getJLS3());
+		ASTParser parser = ASTParser.newParser(getJLSFirst());
 		parser.setKind(ASTParser.K_STATEMENTS);
 		parser.setSource(source);
 		parser.setSourceRange(statement.getStartPosition(), statement.getLength());
@@ -6965,7 +6965,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 				"	public void foo(int arg) {}\n" +  //$NON-NLS-1$
 				"}").toCharArray(); //$NON-NLS-1$
 		IJavaProject project = getJavaProject("Converter"); //$NON-NLS-1$
-		ASTNode result = runConversion(getJLS3(), source, "Test.java", project); //$NON-NLS-1$
+		ASTNode result = runConversion(source, "Test.java", project); //$NON-NLS-1$
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -6987,7 +6987,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 				"	public void foo(int arg) {}\n" +  //$NON-NLS-1$
 				"}").toCharArray(); //$NON-NLS-1$
 		IJavaProject project = getJavaProject("Converter"); //$NON-NLS-1$
-		ASTNode result = runConversion(getJLS3(), source, "Object.java", project); //$NON-NLS-1$
+		ASTNode result = runConversion(source, "Object.java", project); //$NON-NLS-1$
 		assertNotNull("No compilation unit", result); //$NON-NLS-1$
 		assertTrue("result is not a compilation unit", result instanceof CompilationUnit); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
@@ -7062,7 +7062,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 * http://dev.eclipse.org/bugs/show_bug.cgi?id=125270
 	 */
 	public void test0628() throws JavaModelException {
-		ASTParser parser = ASTParser.newParser(getJLS3());
+		ASTParser parser = ASTParser.newParser(getJLSFirst());
 		parser.setKind(ASTParser.K_EXPRESSION);
 		String source = "{\"red\", \"yellow\"}";
 		parser.setSource(source.toCharArray());
@@ -7083,7 +7083,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0629() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0629", "X.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true, true);
+		ASTNode result = runConversion(sourceUnit, true, true);
 		assertEquals("Not a compilation unit", ASTNode.COMPILATION_UNIT, result.getNodeType()); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
 		String expectedOutput =
@@ -7102,7 +7102,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0630() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0630", "X.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true, true);
+		ASTNode result = runConversion(sourceUnit, true, true);
 		assertEquals("Not a compilation unit", ASTNode.COMPILATION_UNIT, result.getNodeType()); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
 		String expectedOutput =
@@ -7115,7 +7115,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0631() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0631", "X.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true, true);
+		ASTNode result = runConversion(sourceUnit, true, true);
 		assertEquals("Not a compilation unit", ASTNode.COMPILATION_UNIT, result.getNodeType()); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) result;
 		String expectedOutput =
@@ -7176,7 +7176,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0633() {
 		String src = "switch (state) {case 4:double M0,M1;}";
 		char[] source = src.toCharArray();
-		ASTParser parser = ASTParser.newParser(getJLS3());
+		ASTParser parser = ASTParser.newParser(getJLSFirst());
 		parser.setKind (ASTParser.K_STATEMENTS);
 		parser.setSource (source);
 		ASTNode result = parser.createAST (null);
@@ -7220,7 +7220,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 					"}";
 
 			char[] source = src.toCharArray();
-			ASTParser parser = ASTParser.newParser(getJLS3());
+			ASTParser parser = ASTParser.newParser(getJLSFirst());
 			parser.setKind (ASTParser.K_COMPILATION_UNIT);
 			parser.setSource (source);
 			parser.setStatementsRecovery(true);
@@ -7939,7 +7939,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0653() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0653", "X.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertEquals("Not a compilation unit", ASTNode.COMPILATION_UNIT, result.getNodeType());
 		CompilationUnit unit = (CompilationUnit) result;
 
@@ -8086,7 +8086,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 				"        int d;\n" +
 				"    }";
 		char[] source = src.toCharArray();
-		ASTParser parser = ASTParser.newParser(getJLS3());
+		ASTParser parser = ASTParser.newParser(getJLSFirst());
 		parser.setKind (ASTParser.K_STATEMENTS);
 		parser.setStatementsRecovery(true);
 		parser.setSource (source);
@@ -8119,7 +8119,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 				"        int d;\n" +
 				"    }";
 		char[] source = src.toCharArray();
-		ASTParser parser = ASTParser.newParser(getJLS3());
+		ASTParser parser = ASTParser.newParser(getJLSFirst());
 		parser.setKind (ASTParser.K_STATEMENTS);
 		parser.setStatementsRecovery(false);
 		parser.setSource (source);
@@ -8180,7 +8180,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 				"        int d;\n" +
 				"    }";
 		char[] source = src.toCharArray();
-		ASTParser parser = ASTParser.newParser(getJLS3());
+		ASTParser parser = ASTParser.newParser(getJLSFirst());
 		parser.setKind (ASTParser.K_STATEMENTS);
 		parser.setStatementsRecovery(true);
 		parser.setSource (source);
@@ -8207,7 +8207,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0659() throws CoreException, JavaModelException {
 		IJavaProject javaProject = createJavaProject("P659", new String[] { "src" }, new String[0], "bin");
 		try {
-			ASTParser parser = ASTParser.newParser(getJLS3());
+			ASTParser parser = ASTParser.newParser(getJLSFirst());
 			parser.setKind(ASTParser.K_COMPILATION_UNIT);
 			parser.setStatementsRecovery(true);
 			parser.setBindingsRecovery(true);
@@ -8809,7 +8809,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0669() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0669", "UIPerformChangeOperation.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true, true);
+		ASTNode result = runConversion(sourceUnit, true, true);
 		assertNotNull(result);
 	}
 
@@ -8831,7 +8831,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 				"}";
 			workingCopy = getWorkingCopy("/Converter/src/X.java", true/*resolve*/);
 			workingCopy.getBuffer().setContents(contents);
-			ASTNode node = runConversion(getJLS3(), workingCopy, true, true, true);
+			ASTNode node = runConversion(workingCopy, true, true, true);
 			assertEquals("Not a compilation unit", ASTNode.COMPILATION_UNIT, node.getNodeType());
 			CompilationUnit unit = (CompilationUnit) node;
 			String expectedError =
@@ -8874,7 +8874,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 				"}";
 			workingCopy = getWorkingCopy("/Converter/src/X.java", true/*resolve*/);
 			workingCopy.getBuffer().setContents(contents);
-			ASTNode node = runConversion(getJLS3(), workingCopy, true, true, true);
+			ASTNode node = runConversion(workingCopy, true, true, true);
 			assertEquals("Not a compilation unit", ASTNode.COMPILATION_UNIT, node.getNodeType());
 			CompilationUnit unit = (CompilationUnit) node;
 			String expectedError =
@@ -8944,7 +8944,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 				"}";
 			workingCopy = getWorkingCopy("/Converter/src/X.java", true/*resolve*/);
 			workingCopy.getBuffer().setContents(contents);
-			ASTNode node = runConversion(getJLS3(), workingCopy, true, true, true);
+			ASTNode node = runConversion(workingCopy, true, true, true);
 			assertEquals("Not a compilation unit", ASTNode.COMPILATION_UNIT, node.getNodeType());
 			CompilationUnit unit = (CompilationUnit) node;
 			String expectedError =
@@ -9036,7 +9036,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 				"}";
 			workingCopy = getWorkingCopy("/Converter/src/X.java", true/*resolve*/);
 			workingCopy.getBuffer().setContents(contents);
-			ASTNode node = runConversion(getJLS3(), workingCopy, true, true, true);
+			ASTNode node = runConversion(workingCopy, true, true, true);
 			assertEquals("Not a compilation unit", ASTNode.COMPILATION_UNIT, node.getNodeType());
 			CompilationUnit unit = (CompilationUnit) node;
 			assertTrue("no binding recovery", unit.getAST().hasBindingsRecovery());
@@ -9102,7 +9102,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 				"}";
 			workingCopy = getWorkingCopy("/Converter/src/X.java", true/*resolve*/);
 			workingCopy.getBuffer().setContents(contents);
-			ASTNode node = runConversion(getJLS3(), workingCopy, true, true, true);
+			ASTNode node = runConversion(workingCopy, true, true, true);
 			assertEquals("Not a compilation unit", ASTNode.COMPILATION_UNIT, node.getNodeType());
 			CompilationUnit unit = (CompilationUnit) node;
 			assertProblemsSize(unit, 0);
@@ -9142,7 +9142,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 				"}";
 			workingCopy = getWorkingCopy("/Converter/src/X.java", true/*resolve*/);
 			workingCopy.getBuffer().setContents(contents);
-			ASTNode node = runConversion(getJLS3(), workingCopy, true, true, true);
+			ASTNode node = runConversion(workingCopy, true, true, true);
 			assertEquals("Not a compilation unit", ASTNode.COMPILATION_UNIT, node.getNodeType());
 			CompilationUnit unit = (CompilationUnit) node;
 			String expectedError = "Constructor call must be the first statement in a constructor";
@@ -9169,7 +9169,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0676() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0676", "X.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode node = runConversion(getJLS3(), sourceUnit, true, true, true);
+		ASTNode node = runConversion(sourceUnit, true, true, true);
 		assertEquals("Not a compilation unit", ASTNode.COMPILATION_UNIT, node.getNodeType());
 		CompilationUnit unit = (CompilationUnit) node;
 		assertTrue("no binding recovery", unit.getAST().hasBindingsRecovery());
@@ -9223,7 +9223,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0677() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0677", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode node = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode node = runConversion(sourceUnit, true);
 		assertEquals("Not a compilation unit", ASTNode.COMPILATION_UNIT, node.getNodeType()); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) node;
 		node = getASTNode(unit, 0);
@@ -9257,7 +9257,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 				"}";
 			workingCopy = getWorkingCopy("/Converter/src/X.java", true/*resolve*/);
 			workingCopy.getBuffer().setContents(contents.toCharArray());
-			ASTNode node = runConversion(getJLS3(), workingCopy, true);
+			ASTNode node = runConversion(workingCopy, true);
 			assertEquals("Not a compilation unit", ASTNode.COMPILATION_UNIT, node.getNodeType());
 			CompilationUnit unit = (CompilationUnit) node;
 			String expectedOutput = "Dead code";
@@ -9344,7 +9344,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0680() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0680", "SAMPLE_UTF8.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode node = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode node = runConversion(sourceUnit, true);
 		assertTrue("Not a compilation unit", node.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) node;
 		assertProblemsSize(compilationUnit, 0);
@@ -9361,7 +9361,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0681() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "Sample", "Sample.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode node = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode node = runConversion(sourceUnit, true);
 		assertTrue("Not a compilation unit", node.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit compilationUnit = (CompilationUnit) node;
 		assertProblemsSize(compilationUnit, 0);
@@ -9376,7 +9376,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0682() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0682", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode node = runConversion(getJLS3(), sourceUnit, true, true);
+		ASTNode node = runConversion(sourceUnit, true, true);
 		assertTrue("Not a compilation unit", node.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) node;
 		assertProblemsSize(
@@ -9404,7 +9404,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0683() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0683", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode node = runConversion(getJLS3(), sourceUnit, true, true);
+		ASTNode node = runConversion(sourceUnit, true, true);
 		assertTrue("Not a compilation unit", node.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) node;
 		assertProblemsSize(unit, 0);
@@ -9430,7 +9430,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0684() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0684", "X.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode node = runConversion(getJLS3(), sourceUnit, true, true);
+		ASTNode node = runConversion(sourceUnit, true, true);
 		assertTrue("Not a compilation unit", node.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) node;
 		assertProblemsSize(unit, 0);
@@ -9455,7 +9455,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0685() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0685", "C.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode node = runConversion(getJLS3(), sourceUnit, true, true);
+		ASTNode node = runConversion(sourceUnit, true, true);
 		assertTrue("Not a compilation unit", node.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) node;
 		assertProblemsSize(unit, 0);
@@ -9582,7 +9582,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 		IField field = type.getField("i");
 		assertNotNull("No field", field);
 		ISourceRange sourceRange = field.getNameRange();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, sourceRange.getOffset() + sourceRange.getLength() / 2, false);
+		ASTNode result = runConversion(sourceUnit, sourceRange.getOffset() + sourceRange.getLength() / 2, false);
 		assertNotNull(result);
 	}
 	/**
@@ -9607,7 +9607,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 			newClasspathEntries.toArray(newClasspath);
 			project.setRawClasspath(newClasspath, null);
 			ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0689", "X.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-			ASTNode result = runConversion(getJLS3(), sourceUnit, true, true);
+			ASTNode result = runConversion(sourceUnit, true, true);
 			assertNotNull(result);
 			ITypeBinding typeBinding = result.getAST().resolveWellKnownType("java.lang.Boolean");
 			assertNull("Should be null", typeBinding);
@@ -9637,7 +9637,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 			newClasspathEntries.toArray(newClasspath);
 			project.setRawClasspath(newClasspath, null);
 			ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0690", "X.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-			ASTNode result = runConversion(getJLS3(), sourceUnit, true, true, true);
+			ASTNode result = runConversion(sourceUnit, true, true, true);
 			assertNotNull(result);
 			ITypeBinding typeBinding = result.getAST().resolveWellKnownType("java.lang.Boolean");
 			assertNull("Should be null", typeBinding);
@@ -9654,7 +9654,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 		IType type = unit.getType("X");
 		IMethod method = type.getMethod("foo", new String[0]);
 
-		ASTParser parser = ASTParser.newParser(getJLS3());
+		ASTParser parser = ASTParser.newParser(getJLSFirst());
 		parser.setKind(ASTParser.K_CLASS_BODY_DECLARATIONS);
 		parser.setSource(unit);
 		Hashtable options = JavaCore.getOptions();
@@ -9699,7 +9699,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 		ICompilationUnit unit = getCompilationUnit("Converter" , "src", "test0693", "X.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		ICompilationUnit unit2 = getCompilationUnit("Converter" , "src", "test0693", "Y.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 
-		ASTParser parser = ASTParser.newParser(getJLS3());
+		ASTParser parser = ASTParser.newParser(getJLSFirst());
 		ASTRequestor requestor = new ASTRequestor() {};
 		ICompilationUnit[] cus = new ICompilationUnit[2];
 		cus[0] = unit;
@@ -9720,7 +9720,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 		ICompilationUnit unit = getCompilationUnit("Converter" , "src", "test0694", "X.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		ICompilationUnit unit2 = getCompilationUnit("Converter" , "src", "test0694", "Y.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 
-		ASTParser parser = ASTParser.newParser(getJLS3());
+		ASTParser parser = ASTParser.newParser(getJLSFirst());
 		ASTRequestor requestor = new ASTRequestor() {};
 		ICompilationUnit[] cus = new ICompilationUnit[2];
 		cus[0] = unit;
@@ -9740,7 +9740,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0695() throws JavaModelException {
 		ICompilationUnit unit = getCompilationUnit("Converter" , "src", "test0695", "X.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 
-		ASTParser parser = ASTParser.newParser(getJLS3());
+		ASTParser parser = ASTParser.newParser(getJLSFirst());
 		parser.setKind(ASTParser.K_COMPILATION_UNIT);
 		parser.setSource(unit.getSource().toCharArray());
 		Map options = JavaCore.getOptions();
@@ -9765,7 +9765,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0696() throws JavaModelException {
 		ICompilationUnit unit = getCompilationUnit("Converter" , "src", "test0696", "X.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 
-		ASTParser parser = ASTParser.newParser(getJLS3());
+		ASTParser parser = ASTParser.newParser(getJLSFirst());
 		parser.setKind(ASTParser.K_COMPILATION_UNIT);
 		parser.setSource(unit.getSource().toCharArray());
 		Map options = JavaCore.getOptions();
@@ -9883,7 +9883,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 			VariableDeclarationFragment fragment = (VariableDeclarationFragment) buildAST(contents, workingCopy, false, true, true);
 			IVariableBinding variableBinding = fragment.resolveBinding();
 			final String key = variableBinding.getKey();
-			ASTParser parser = ASTParser.newParser(getJLS3());
+			ASTParser parser = ASTParser.newParser(getJLSFirst());
 			parser.setProject(workingCopy.getJavaProject());
 			parser.setResolveBindings(true);
 			parser.setKind(ASTParser.K_COMPILATION_UNIT);
@@ -9925,7 +9925,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 			VariableDeclarationFragment fragment = (VariableDeclarationFragment) buildAST(contents, workingCopy, false, true, true);
 			IVariableBinding variableBinding = fragment.resolveBinding();
 			final String key = variableBinding.getKey();
-			ASTParser parser = ASTParser.newParser(getJLS3());
+			ASTParser parser = ASTParser.newParser(getJLSFirst());
 			parser.setProject(workingCopy.getJavaProject());
 			parser.setResolveBindings(true);
 			parser.setKind(ASTParser.K_COMPILATION_UNIT);
@@ -9968,7 +9968,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 			VariableDeclarationFragment fragment = (VariableDeclarationFragment) buildAST(contents, workingCopy, false, true, true);
 			IVariableBinding variableBinding = fragment.resolveBinding();
 			final String key = variableBinding.getKey();
-			ASTParser parser = ASTParser.newParser(getJLS3());
+			ASTParser parser = ASTParser.newParser(getJLSFirst());
 			parser.setProject(workingCopy.getJavaProject());
 			parser.setResolveBindings(true);
 			parser.setKind(ASTParser.K_COMPILATION_UNIT);
@@ -9999,7 +9999,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 		final char[] source = ("void foo() {\n" +
 				"	Integer I = new ${cursor}\n" +
 				"}").toCharArray();
-		ASTParser parser = ASTParser.newParser(getJLS3());
+		ASTParser parser = ASTParser.newParser(getJLSFirst());
 		parser.setKind(ASTParser.K_CLASS_BODY_DECLARATIONS);
 		parser.setStatementsRecovery(true);
 		parser.setSource(source);
@@ -10023,7 +10023,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 				"		Integer I = new ${cursor}\n" +
 				"	}\n" +
 				"}").toCharArray();
-		ASTParser parser = ASTParser.newParser(getJLS3());
+		ASTParser parser = ASTParser.newParser(getJLSFirst());
 		parser.setKind(ASTParser.K_COMPILATION_UNIT);
 		parser.setStatementsRecovery(true);
 		parser.setSource(source);
@@ -10045,7 +10045,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 		final char[] source = ("{\n" +
 				"	Integer I = new ${cursor}\n" +
 				"}").toCharArray();
-		ASTParser parser = ASTParser.newParser(getJLS3());
+		ASTParser parser = ASTParser.newParser(getJLSFirst());
 		parser.setKind(ASTParser.K_CLASS_BODY_DECLARATIONS);
 		parser.setStatementsRecovery(true);
 		parser.setSource(source);
@@ -10070,7 +10070,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 				"{\n" +
 				"	Integer I = new ${cursor}\n" +
 				"}").toCharArray();
-		ASTParser parser = ASTParser.newParser(getJLS3());
+		ASTParser parser = ASTParser.newParser(getJLSFirst());
 		parser.setKind(ASTParser.K_CLASS_BODY_DECLARATIONS);
 		parser.setStatementsRecovery(true);
 		parser.setSource(source);
@@ -10099,7 +10099,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 				"		Integer I = new ${cursor}\n" +
 				"	};\"\n" +
 				"}").toCharArray();
-		ASTParser parser = ASTParser.newParser(getJLS3());
+		ASTParser parser = ASTParser.newParser(getJLSFirst());
 		parser.setKind(ASTParser.K_COMPILATION_UNIT);
 		parser.setStatementsRecovery(true);
 		parser.setSource(source);
@@ -10116,7 +10116,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 		final char[] source = ("Integer i = new Integer() {\n" +
 				"	Integer I = new ${cursor}\n" +
 				"};").toCharArray();
-		ASTParser parser = ASTParser.newParser(getJLS3());
+		ASTParser parser = ASTParser.newParser(getJLSFirst());
 		parser.setKind(ASTParser.K_CLASS_BODY_DECLARATIONS);
 		parser.setStatementsRecovery(true);
 		parser.setSource(source);
@@ -10130,7 +10130,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0708() throws JavaModelException {
 		final char[] source = ("System.out.println()\nint i;\n").toCharArray();
-		ASTParser parser = ASTParser.newParser(getJLS3());
+		ASTParser parser = ASTParser.newParser(getJLSFirst());
 		parser.setKind(ASTParser.K_STATEMENTS);
 		parser.setStatementsRecovery(true);
 		parser.setSource(source);
@@ -10175,7 +10175,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0710() throws JavaModelException {
 		final char[] source = (";").toCharArray();
-		ASTParser parser = ASTParser.newParser(getJLS3());
+		ASTParser parser = ASTParser.newParser(getJLSFirst());
 		parser.setKind(ASTParser.K_CLASS_BODY_DECLARATIONS);
 		parser.setStatementsRecovery(true);
 		parser.setSource(source);
@@ -10190,7 +10190,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0711() throws JavaModelException {
 		final char[] source = (";void foo() {}").toCharArray();
-		ASTParser parser = ASTParser.newParser(getJLS3());
+		ASTParser parser = ASTParser.newParser(getJLSFirst());
 		parser.setKind(ASTParser.K_CLASS_BODY_DECLARATIONS);
 		parser.setStatementsRecovery(true);
 		parser.setSource(source);
@@ -10205,7 +10205,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0712() throws JavaModelException {
 		final char[] source = (";void foo() {};").toCharArray();
-		ASTParser parser = ASTParser.newParser(getJLS3());
+		ASTParser parser = ASTParser.newParser(getJLSFirst());
 		parser.setKind(ASTParser.K_CLASS_BODY_DECLARATIONS);
 		parser.setStatementsRecovery(true);
 		parser.setSource(source);
@@ -10228,7 +10228,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 				"      if (condition) appendAndExecute(new AddCommand(...));\n" +
 				"    }\n" +
 				"  }").toCharArray();
-		ASTParser parser = ASTParser.newParser(getJLS3());
+		ASTParser parser = ASTParser.newParser(getJLSFirst());
 		parser.setKind(ASTParser.K_CLASS_BODY_DECLARATIONS);
 		parser.setStatementsRecovery(false);
 		parser.setSource(source);
@@ -10277,7 +10277,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 				"      }\n" +
 				"    }\n" +
 				"  }").toCharArray();
-		ASTParser parser = ASTParser.newParser(getJLS3());
+		ASTParser parser = ASTParser.newParser(getJLSFirst());
 		parser.setKind(ASTParser.K_CLASS_BODY_DECLARATIONS);
 		parser.setStatementsRecovery(false);
 		parser.setSource(source);
@@ -10291,7 +10291,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0715() throws JavaModelException {
 		final char[] source = ("System.out.println()\nint i;\n").toCharArray();
-		ASTParser parser = ASTParser.newParser(getJLS3());
+		ASTParser parser = ASTParser.newParser(getJLSFirst());
 		parser.setKind(ASTParser.K_STATEMENTS);
 		parser.setStatementsRecovery(true);
 		parser.setIgnoreMethodBodies(true);
@@ -10308,7 +10308,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0716() {
 		String src = "switch (state) {case 4:double M0,M1;}";
 		char[] source = src.toCharArray();
-		ASTParser parser = ASTParser.newParser(getJLS3());
+		ASTParser parser = ASTParser.newParser(getJLSFirst());
 		parser.setKind (ASTParser.K_STATEMENTS);
 		parser.setIgnoreMethodBodies(true);
 		parser.setSource (source);
@@ -10340,7 +10340,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 				"      if (condition) appendAndExecute(new AddCommand());\n" +
 				"    }\n" +
 				"  }").toCharArray();
-		ASTParser parser = ASTParser.newParser(getJLS3());
+		ASTParser parser = ASTParser.newParser(getJLSFirst());
 		parser.setKind(ASTParser.K_CLASS_BODY_DECLARATIONS);
 		parser.setStatementsRecovery(false);
 		parser.setIgnoreMethodBodies(true);
@@ -10453,7 +10453,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0720() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0720", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		assertEquals("Wrong number of problems", 1, unit.getProblems().length); //$NON-NLS-1$
@@ -10470,7 +10470,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0721() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0721", "A.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 		char[] source = sourceUnit.getSource().toCharArray();
-		ASTNode result = runConversion(getJLS3(), sourceUnit, true);
+		ASTNode result = runConversion(sourceUnit, true);
 		assertTrue("not a compilation unit", result.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) result;
 		ASTNode node = getASTNode(unit, 0);
@@ -10510,7 +10510,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 						"  }\n" +
 						"}\n";
 
-		ASTParser parser = ASTParser.newParser(getJLS3());
+		ASTParser parser = ASTParser.newParser(getJLSFirst());
 		parser.setKind(ASTParser.K_COMPILATION_UNIT);
 		parser.setSource(source.toCharArray());
 		CompilationUnit resultCompilationUnit = (CompilationUnit) parser.createAST(null);
@@ -10523,7 +10523,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	public void test0723() {
 		String src = "super();";
 		char[] source = src.toCharArray();
-		ASTParser parser = ASTParser.newParser(getJLS3());
+		ASTParser parser = ASTParser.newParser(getJLSFirst());
 		parser.setKind (ASTParser.K_STATEMENTS);
 		parser.setIgnoreMethodBodies(true);
 		parser.setSource (source);

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterTestAST4_2.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterTestAST4_2.java
@@ -10357,7 +10357,6 @@ public class ASTConverterTestAST4_2 extends ConverterTestSetup {
 				"public class one {}";
 			workingCopy = getWorkingCopy("/Converter/src/one/two/one.java", true/*resolve*/);
 			CompilationUnit unit = (CompilationUnit) buildAST(
-				getJLS3(),
 				contents,
 				workingCopy,
 				true,

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterTestAST8_2.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterTestAST8_2.java
@@ -10516,7 +10516,6 @@ public class ASTConverterTestAST8_2 extends ConverterTestSetup {
 				"public class one {}";
 			workingCopy = getWorkingCopy("/Converter/src/one/two/one.java", true/*resolve*/);
 			CompilationUnit unit = (CompilationUnit) buildAST(
-				getJLS3(),
 				contents,
 				workingCopy,
 				true,

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTNodeFinderTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTNodeFinderTest.java
@@ -30,7 +30,7 @@ public class ASTNodeFinderTest extends ConverterTestSetup {
 	@Override
 	public void setUpSuite() throws Exception {
 		super.setUpSuite();
-		this.ast = AST.newAST(getJLS3(), false);
+		this.ast = AST.newAST(getJLSFirst(), false);
 	}
 
 	public ASTNodeFinderTest(String name) {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTPositionsTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTPositionsTest.java
@@ -28,7 +28,7 @@ public class ASTPositionsTest extends ConverterTestSetup {
 	@Override
 	public void setUpSuite() throws Exception {
 		super.setUpSuite();
-		this.ast = AST.newAST(getJLS3(), false);
+		this.ast = AST.newAST(getJLSFirst(), false);
 	}
 
 	public ASTPositionsTest(String name) {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ConverterTestSetup.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ConverterTestSetup.java
@@ -31,12 +31,6 @@ import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 
 @SuppressWarnings("rawtypes")
 public abstract class ConverterTestSetup extends AbstractASTTests {
-	/**
-	 * Internal synonym for deprecated constant AST.JSL3
-	 * to alleviate deprecation warnings.
-	 * @deprecated
-	 */
-	/*package*/ static final int JLS3_INTERNAL = AST.JLS3;
 
 	/**
 	 * Internal synonym for deprecated constant AST.JSL4
@@ -52,10 +46,6 @@ public abstract class ConverterTestSetup extends AbstractASTTests {
 	 */
 	/*package*/ static final int JLS8_INTERNAL = AST.JLS8;
 
-	static int getJLS3() {
-		return JLS3_INTERNAL;
-	}
-
 	static int getJLS4() {
 		return JLS4_INTERNAL;
 	}
@@ -63,6 +53,11 @@ public abstract class ConverterTestSetup extends AbstractASTTests {
 	static int getJLS8() {
 		return JLS8_INTERNAL;
 	}
+
+	static int getJLSFirst() {
+		return AST.getAllSupportedVersions().getFirst();
+	}
+
 	protected AST ast;
 	public static List TEST_SUITES = null;
 	public static boolean PROJECT_SETUP = false;
@@ -352,6 +347,19 @@ public abstract class ConverterTestSetup extends AbstractASTTests {
 	}
 
 	public ASTNode runConversion(
+			ICompilationUnit unit,
+			boolean resolveBindings,
+			boolean statementsRecovery,
+			boolean bindingsRecovery) {
+		ASTParser parser = ASTParser.newParser(getJLSFirst());
+		parser.setSource(unit);
+		parser.setResolveBindings(resolveBindings);
+		parser.setStatementsRecovery(statementsRecovery);
+		parser.setBindingsRecovery(bindingsRecovery);
+		return parser.createAST(null);
+	}
+
+	public ASTNode runConversion(
 			int astLevel,
 			ICompilationUnit unit,
 			boolean resolveBindings,
@@ -624,7 +632,7 @@ public abstract class ConverterTestSetup extends AbstractASTTests {
 	public ASTNode runJLS3Conversion(ICompilationUnit unit, boolean resolveBindings, boolean bindingRecovery) {
 
 		// Create parser
-		ASTParser parser = ASTParser.newParser(JLS3_INTERNAL);
+		ASTParser parser = ASTParser.newParser(getJLSFirst());
 		parser.setSource(unit);
 		parser.setResolveBindings(resolveBindings);
 		parser.setBindingsRecovery(bindingRecovery);


### PR DESCRIPTION
AST overrides to JLS8 so this change makes the tests easier to understand.
By using first supported JLS version explicitly (parser creation) or implicitly (calling runConversion without astLevel) tests have less silently overriden parts.
