### PR TITLE
Fix tests after no longer using JLS3 contstants

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterJavadocTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterJavadocTest.java
@@ -90,8 +90,7 @@ public class ASTConverterJavadocTest extends ConverterTestSetup {
 	protected boolean resolveBinding = true;
 	protected boolean packageBinding = true;
 	// AST Level
-	/** @deprecated using deprecated code */
-	protected int astLevel = AST.JLS2;
+	protected int astLevel = AST.getAllSupportedVersions().getFirst();
 	protected int savedLevel;
 	// Debug
 	protected String prefix = "";
@@ -1200,8 +1199,6 @@ public class ASTConverterJavadocTest extends ConverterTestSetup {
 
 		// Create DOM AST nodes hierarchy
 		List unitComments = null;
-		String sourceLevel = null;
-		String complianceLevel = null;
 		CompilationUnit compilUnit = (CompilationUnit) runConversion(testedSource, fileName, this.currentProject, options);
 		if (this.compilerOption.equals(JavaCore.ERROR)) {
 			assumeEquals(this.prefix+"Unexpected problems", 0, compilUnit.getProblems().length); //$NON-NLS-1$
@@ -1257,10 +1254,6 @@ public class ASTConverterJavadocTest extends ConverterTestSetup {
 		}
 		*/
 
-		if (sourceLevel != null) {
-			this.currentProject.setOption(JavaCore.COMPILER_COMPLIANCE, complianceLevel);
-			this.currentProject.setOption(JavaCore.COMPILER_SOURCE, sourceLevel);
-		}
 		// Return compilation unit for possible further verifications
 		return compilUnit;
 	}

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterRecoveryTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterRecoveryTest.java
@@ -53,7 +53,7 @@ public class ASTConverterRecoveryTest extends ConverterTestSetup {
 			"}\n");
 
 		char[] source = this.workingCopies[0].getSource().toCharArray();
-		ASTNode result = runConversion(this.workingCopies[0], true, true);
+		ASTNode result = runConversion(this.workingCopies[0], true, true, true);
 
 		assertASTNodeEquals(
 			"package test;\n" +
@@ -120,7 +120,7 @@ public class ASTConverterRecoveryTest extends ConverterTestSetup {
 			"}\n");
 
 		char[] source = this.workingCopies[0].getSource().toCharArray();
-		ASTNode result = runConversion(this.workingCopies[0], true, true);
+		ASTNode result = runConversion(this.workingCopies[0], true, true, true);
 
 		assertASTNodeEquals(
 			"package test;\n" +
@@ -188,7 +188,7 @@ public class ASTConverterRecoveryTest extends ConverterTestSetup {
 			"}\n");
 
 		char[] source = this.workingCopies[0].getSource().toCharArray();
-		ASTNode result = runConversion(this.workingCopies[0], true, true);
+		ASTNode result = runConversion(this.workingCopies[0], true, true, true);
 
 		assertASTNodeEquals(
 			"package test;\n" +
@@ -256,7 +256,7 @@ public class ASTConverterRecoveryTest extends ConverterTestSetup {
 			"}\n");
 
 		char[] source = this.workingCopies[0].getSource().toCharArray();
-		ASTNode result = runConversion(this.workingCopies[0], true, true);
+		ASTNode result = runConversion(this.workingCopies[0], true, true, true);
 
 		assertASTNodeEquals(
 			"package test;\n" +
@@ -298,7 +298,7 @@ public class ASTConverterRecoveryTest extends ConverterTestSetup {
 			"}\n");
 
 		char[] source = this.workingCopies[0].getSource().toCharArray();
-		ASTNode result = runConversion(this.workingCopies[0], true, true);
+		ASTNode result = runConversion(this.workingCopies[0], true, true, true);
 
 		assertASTNodeEquals(
 			"package test;\n" +
@@ -355,7 +355,7 @@ public class ASTConverterRecoveryTest extends ConverterTestSetup {
 			"}\n");
 
 		char[] source = this.workingCopies[0].getSource().toCharArray();
-		ASTNode result = runConversion(this.workingCopies[0], true, true);
+		ASTNode result = runConversion(this.workingCopies[0], true, true, true);
 
 		assertASTNodeEquals(
 			"package test;\n" +
@@ -401,7 +401,7 @@ public class ASTConverterRecoveryTest extends ConverterTestSetup {
 			"}\n");
 
 		char[] source = this.workingCopies[0].getSource().toCharArray();
-		ASTNode result = runConversion(this.workingCopies[0], true, true);
+		ASTNode result = runConversion(this.workingCopies[0], true, true, true);
 
 		assertASTNodeEquals(
 			"package test;\n" +
@@ -454,7 +454,7 @@ public class ASTConverterRecoveryTest extends ConverterTestSetup {
 			"}\n");
 
 		char[] source = this.workingCopies[0].getSource().toCharArray();
-		ASTNode result = runConversion(this.workingCopies[0], true, true);
+		ASTNode result = runConversion(this.workingCopies[0], true, true, true);
 
 		assertASTNodeEquals(
 			"package test;\n" +
@@ -516,7 +516,7 @@ public class ASTConverterRecoveryTest extends ConverterTestSetup {
 			"}\n");
 
 		char[] source = this.workingCopies[0].getSource().toCharArray();
-		ASTNode result = runConversion(this.workingCopies[0], true, true);
+		ASTNode result = runConversion(this.workingCopies[0], true, true, true);
 
 		assertASTNodeEquals(
 			"package test;\n" +
@@ -569,7 +569,7 @@ public class ASTConverterRecoveryTest extends ConverterTestSetup {
 			"}\n");
 
 		char[] source = this.workingCopies[0].getSource().toCharArray();
-		ASTNode result = runConversion(this.workingCopies[0], true, true);
+		ASTNode result = runConversion(this.workingCopies[0], true, true, true);
 
 		assertASTNodeEquals(
 			"package test;\n" +
@@ -622,7 +622,7 @@ public class ASTConverterRecoveryTest extends ConverterTestSetup {
 			"}\n");
 
 		char[] source = this.workingCopies[0].getSource().toCharArray();
-		ASTNode result = runConversion(this.workingCopies[0], true, true);
+		ASTNode result = runConversion(this.workingCopies[0], true, true, true);
 
 		assertASTNodeEquals(
 			"package test;\n" +
@@ -675,7 +675,7 @@ public class ASTConverterRecoveryTest extends ConverterTestSetup {
 			"}\n");
 
 		char[] source = this.workingCopies[0].getSource().toCharArray();
-		ASTNode result = runConversion(this.workingCopies[0], true, true);
+		ASTNode result = runConversion(this.workingCopies[0], true, true, true);
 
 		assertASTNodeEquals(
 			"package test;\n" +
@@ -721,7 +721,7 @@ public class ASTConverterRecoveryTest extends ConverterTestSetup {
 			"}\n");
 
 		char[] source = this.workingCopies[0].getSource().toCharArray();
-		ASTNode result = runConversion(this.workingCopies[0], true, true);
+		ASTNode result = runConversion(this.workingCopies[0], true, true, true);
 
 		assertASTNodeEquals(
 			"package test;\n" +
@@ -816,7 +816,7 @@ public class ASTConverterRecoveryTest extends ConverterTestSetup {
 			"}\n");
 
 		char[] source = this.workingCopies[0].getSource().toCharArray();
-		ASTNode result = runConversion(this.workingCopies[0], true, true);
+		ASTNode result = runConversion(this.workingCopies[0], true, true, true);
 
 		assertASTNodeEquals(
 			"package test;\n" +
@@ -861,7 +861,7 @@ public class ASTConverterRecoveryTest extends ConverterTestSetup {
 			"}\n");
 
 		char[] source = this.workingCopies[0].getSource().toCharArray();
-		ASTNode result = runConversion(this.workingCopies[0], true, true);
+		ASTNode result = runConversion(this.workingCopies[0], true, true, true);
 
 		assertASTNodeEquals(
 			"package test;\n" +
@@ -905,7 +905,7 @@ public class ASTConverterRecoveryTest extends ConverterTestSetup {
 			"}\n");
 
 		char[] source = this.workingCopies[0].getSource().toCharArray();
-		ASTNode result = runConversion(this.workingCopies[0], true, true);
+		ASTNode result = runConversion(this.workingCopies[0], true, true, true);
 
 		assertASTNodeEquals(
 			"package test;\n" +
@@ -984,7 +984,7 @@ public class ASTConverterRecoveryTest extends ConverterTestSetup {
 			"}\n");
 
 		char[] source = this.workingCopies[0].getSource().toCharArray();
-		ASTNode result = runConversion(this.workingCopies[0], true, true);
+		ASTNode result = runConversion(this.workingCopies[0], true, true, true);
 
 		assertASTNodeEquals(
 			"package test;\n" +
@@ -1024,7 +1024,7 @@ public class ASTConverterRecoveryTest extends ConverterTestSetup {
 			"}\n");
 
 		char[] source = this.workingCopies[0].getSource().toCharArray();
-		ASTNode result = runConversion(this.workingCopies[0], true, true);
+		ASTNode result = runConversion(this.workingCopies[0], true, true, true);
 
 		assertASTNodeEquals(
 			"package test;\n" +

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterTestAST3_2.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterTestAST3_2.java
@@ -9376,7 +9376,7 @@ public class ASTConverterTestAST3_2 extends ConverterTestSetup {
 	 */
 	public void test0682() throws JavaModelException {
 		ICompilationUnit sourceUnit = getCompilationUnit("Converter" , "src", "test0682", "Test.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
-		ASTNode node = runConversion(sourceUnit, true, true);
+		ASTNode node = runConversion(sourceUnit, true, true, true);
 		assertTrue("Not a compilation unit", node.getNodeType() == ASTNode.COMPILATION_UNIT); //$NON-NLS-1$
 		CompilationUnit unit = (CompilationUnit) node;
 		assertProblemsSize(


### PR DESCRIPTION
Jenkins build didn't kick in for
https://github.com/eclipse-jdt/eclipse.jdt.core/pull/3673 for some reason thus failing tests been missed. The problem was using wrong runConversion method that didn't recover statements.