### PR TITLE
Reduce explicit JLS3 references in tests

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/APIDocumentationTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/APIDocumentationTests.java
@@ -77,13 +77,6 @@ public class APIDocumentationTests extends AbstractASTTests {
 //		TESTS_RANGE = new int[] { 83304, -1 };
 		}
 
-	/**
-	 * Internal synonym for deprecated constant AST.JSL3
-	 * to alleviate deprecation warnings.
-	 * @deprecated
-	 */
-	/*package*/ static final int JLS3_INTERNAL = AST.JLS3;
-
 /**
  * Helper class able to analyze JavaCore options javadocs.
  */
@@ -196,7 +189,7 @@ public void testJavaCoreAPI() throws CoreException, IllegalArgumentException, Il
 	// fetch default option values
 	Hashtable<String, String> realDefaultValues = JavaCore.getDefaultOptions();
 	// load documented values in a map
-	ASTParser parser = ASTParser.newParser(JLS3_INTERNAL);
+	ASTParser parser = ASTParser.newParser(AST.getAllSupportedVersions().getFirst());
 	parser.setSource(sourceChars);
 	ASTNode rootNode = parser.createAST(null);
 	final JavaCoreJavadocAnalyzer analyzer = new JavaCoreJavadocAnalyzer();

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTModelBridgeTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTModelBridgeTests.java
@@ -44,13 +44,6 @@ public class ASTModelBridgeTests extends AbstractASTTests {
 
 	ICompilationUnit workingCopy;
 
-	/**
-	 * Internal synonym for deprecated constant AST.JSL3
-	 * to alleviate deprecation warnings.
-	 * @deprecated
-	 */
-	/*package*/ static final int JLS3_INTERNAL = AST.JLS3;
-
 	protected void checkSourceRange(int start, int length, String expectedContents, String source) {
 		assertTrue("length == 0", length != 0); //$NON-NLS-1$ //$NON-NLS-2$
 		assertTrue("start == -1", start != -1); //$NON-NLS-1$
@@ -119,7 +112,7 @@ public class ASTModelBridgeTests extends AbstractASTTests {
 	private IBinding[] createBindings(String contents, IJavaElement element, boolean recoverBindings) throws JavaModelException {
 		this.workingCopy.getBuffer().setContents(contents);
 		this.workingCopy.makeConsistent(null);
-		ASTParser parser = ASTParser.newParser(JLS3_INTERNAL);
+		ASTParser parser = ASTParser.newParser(AST.getAllSupportedVersions().getFirst());
 		parser.setProject(getJavaProject("P"));
 		parser.setBindingsRecovery(recoverBindings);
 		IJavaElement[] elements = new IJavaElement[] {element};
@@ -128,7 +121,7 @@ public class ASTModelBridgeTests extends AbstractASTTests {
 
 	private IBinding[] createBinaryBindings(String contents, IJavaElement element) throws CoreException {
 		createClassFile("/P/lib", "A.class", contents);
-		ASTParser parser = ASTParser.newParser(JLS3_INTERNAL);
+		ASTParser parser = ASTParser.newParser(AST.getAllSupportedVersions().getFirst());
 		parser.setProject(getJavaProject("P"));
 		IJavaElement[] elements = new IJavaElement[] {element};
 		return parser.createBindings(elements, null);
@@ -813,7 +806,7 @@ public class ASTModelBridgeTests extends AbstractASTTests {
 	 * (test several kinds of elements)
 	 */
 	public void testCreateBindings01() throws JavaModelException {
-		ASTParser parser = ASTParser.newParser(JLS3_INTERNAL);
+		ASTParser parser = ASTParser.newParser(AST.getAllSupportedVersions().getFirst());
 		parser.setResolveBindings(true);
 		parser.setProject(getJavaProject("P"));
 		WorkingCopyOwner owner = new WorkingCopyOwner() {};
@@ -864,7 +857,7 @@ public class ASTModelBridgeTests extends AbstractASTTests {
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=297757
 	 */
 	public void testCreateBindings23() throws JavaModelException {
-		ASTParser parser = ASTParser.newParser(JLS3_INTERNAL);
+		ASTParser parser = ASTParser.newParser(AST.getAllSupportedVersions().getFirst());
 		parser.setProject(getJavaProject("P"));
 		WorkingCopyOwner owner = new WorkingCopyOwner() {};
 		this.workingCopies = new ICompilationUnit[3];
@@ -1319,7 +1312,7 @@ public class ASTModelBridgeTests extends AbstractASTTests {
 		IJavaProject javaProject = getJavaProject("P");
 		IPackageFragment pack = javaProject.findPackageFragment(new Path("/P/lib/pack"));
 		IType type = pack.getOrdinaryClassFile("package-info.class").getType();
-		ASTParser parser = ASTParser.newParser(JLS3_INTERNAL);
+		ASTParser parser = ASTParser.newParser(AST.getAllSupportedVersions().getFirst());
 		parser.setProject(javaProject);
 		IJavaElement[] elements = new IJavaElement[] {type};
 		IBinding[] bindings = parser.createBindings(elements, null);
@@ -2599,7 +2592,7 @@ public class ASTModelBridgeTests extends AbstractASTTests {
 	public void testTypeParameter2() throws CoreException {
 		ICompilationUnit cu = null;
 		try {
-			ASTParser parser = ASTParser.newParser(JLS3_INTERNAL);
+			ASTParser parser = ASTParser.newParser(AST.getAllSupportedVersions().getFirst());
 			parser.setResolveBindings(true);
 			parser.setProject(getJavaProject("P"));
 			createFolder("/P/src/p");

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/BatchASTCreationTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/BatchASTCreationTests.java
@@ -31,13 +31,6 @@ import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class BatchASTCreationTests extends AbstractASTTests {
 
-	/**
-	 * Internal synonym for deprecated constant AST.JSL3
-	 * to alleviate deprecation warnings.
-	 * @deprecated
-	 */
-	/*package*/ static final int JLS3_INTERNAL = AST.JLS3;
-
 	public static class TestASTRequestor extends ASTRequestor {
 		public ArrayList asts = new ArrayList();
 		public void acceptAST(ICompilationUnit source, CompilationUnit ast) {
@@ -210,7 +203,7 @@ public class BatchASTCreationTests extends AbstractASTTests {
 	}
 
 	private void createASTs(ICompilationUnit[] cus, TestASTRequestor requestor) {
-		ASTParser parser = ASTParser.newParser(JLS3_INTERNAL);
+		ASTParser parser = ASTParser.newParser(AST.getAllSupportedVersions().getFirst());
 		parser.createASTs(cus, new String[] {}, requestor, null);
 	}
 
@@ -1742,7 +1735,7 @@ public void test073() throws CoreException, IOException {
 			"    return this.m.equals(p);\n" +
 			"  }\n" +
 			"}");
-		ASTParser parser = ASTParser.newParser(JLS3_INTERNAL);
+		ASTParser parser = ASTParser.newParser(AST.getAllSupportedVersions().getFirst());
 		parser.setResolveBindings(true);
 		parser.setProject(project);
 		class Requestor extends ASTRequestor {
@@ -1889,7 +1882,7 @@ public void test078() throws CoreException, IOException {
 			"            }\n" +
 			"        }\n" +
 			"}");
-		ASTParser parser = ASTParser.newParser(JLS3_INTERNAL);
+		ASTParser parser = ASTParser.newParser(AST.getAllSupportedVersions().getFirst());
 		parser.setResolveBindings(true);
 		parser.setProject(project);
        	final IBinding[] bindings = new IBinding[1];
@@ -1945,7 +1938,7 @@ public void test079() throws CoreException, IOException {
 				"}");
 		ICompilationUnit compilationUnits[] = new ICompilationUnit[1];
 		compilationUnits[0] = getCompilationUnit("P079", "src", "test", "Test.java");
-		ASTParser parser = ASTParser.newParser(JLS3_INTERNAL);
+		ASTParser parser = ASTParser.newParser(AST.getAllSupportedVersions().getFirst());
 		parser.setResolveBindings(true);
 		parser.setProject(project);
 		final IBinding[] bindings = new IBinding[1];
@@ -2003,7 +1996,7 @@ public void test080() throws CoreException, IOException {
 				"}");
 		ICompilationUnit compilationUnits[] = new ICompilationUnit[1];
 		compilationUnits[0] = getCompilationUnit(projectName, "src", "test", "Test.java");
-		ASTParser parser = ASTParser.newParser(JLS3_INTERNAL);
+		ASTParser parser = ASTParser.newParser(AST.getAllSupportedVersions().getFirst());
 		parser.setResolveBindings(true);
 		parser.setProject(project);
        	final IBinding[] bindings = new IBinding[1];
@@ -2051,7 +2044,7 @@ public void test081() throws CoreException, IOException {
 			BindingKey.createTypeBindingKey(typeName)
 		};
 		final BindingRequestor requestor = new BindingRequestor();
-		final ASTParser parser = ASTParser.newParser(JLS3_INTERNAL);
+		final ASTParser parser = ASTParser.newParser(AST.getAllSupportedVersions().getFirst());
 		parser.setResolveBindings(true);
 		parser.setProject(javaProject);
 		// this doesn't really do a parse; it's a type lookup
@@ -2080,7 +2073,7 @@ public void test082() throws CoreException, IOException {
 			BindingKey.createTypeBindingKey(typeName)
 		};
 		final BindingRequestor requestor = new BindingRequestor();
-		final ASTParser parser = ASTParser.newParser(JLS3_INTERNAL);
+		final ASTParser parser = ASTParser.newParser(AST.getAllSupportedVersions().getFirst());
 		parser.setResolveBindings(true);
 		parser.setProject(javaProject);
 		// this doesn't really do a parse; it's a type lookup
@@ -2231,7 +2224,7 @@ public void test082() throws CoreException, IOException {
 				"}",
 			});
 			TestASTRequestor requestor = new TestASTRequestor();
-			ASTParser parser = ASTParser.newParser(JLS3_INTERNAL);
+			ASTParser parser = ASTParser.newParser(AST.getAllSupportedVersions().getFirst());
 			parser.setIgnoreMethodBodies(true);
 			parser.createASTs(this.workingCopies, new String[] {}, requestor, null);
 			// statement declaring i should not be in the AST
@@ -2263,7 +2256,7 @@ public void test082() throws CoreException, IOException {
 				"}",
 			});
 			TestASTRequestor requestor = new TestASTRequestor();
-			ASTParser parser = ASTParser.newParser(JLS3_INTERNAL);
+			ASTParser parser = ASTParser.newParser(AST.getAllSupportedVersions().getFirst());
 			parser.setIgnoreMethodBodies(true);
 			parser.setResolveBindings(true);
 			parser.setProject(getJavaProject("P"));

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ClassNameTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ClassNameTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2012 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -56,13 +56,6 @@ public static Test suite() {
 	TESTS_COUNT = suite.countTestCases();
 	return suite;
 }
-
-/**
- * Internal synonym for deprecated constant AST.JSL3
- * to alleviate deprecation warnings.
- * @deprecated
- */
-/*package*/ static final int JLS3_INTERNAL = AST.JLS3;
 
 /* (non-Javadoc)
  * @see org.eclipse.jdt.core.tests.model.AbstractJavaModelTests#setUp()
@@ -1222,7 +1215,7 @@ public void testBug152841() throws Exception{
 		"}";
 		ICompilationUnit cu= pack.createCompilationUnit("Test.java", source, true, null);
 
-		ASTParser parser= ASTParser.newParser(JLS3_INTERNAL);
+		ASTParser parser= ASTParser.newParser(AST.getAllSupportedVersions().getFirst());
 		parser.setSource(cu);
 		parser.setResolveBindings(true);
 		parser.createAST(null);

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompilationUnitTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompilationUnitTests.java
@@ -52,12 +52,6 @@ public class CompilationUnitTests extends ModifyingResourceTests {
 public CompilationUnitTests(String name) {
 	super(name);
 }
-/**
- * Internal synonym for deprecated constant AST.JSL3
- * to alleviate deprecation warnings.
- * @deprecated
- */
-/*package*/ static final int JLS3_INTERNAL = AST.JLS3;
 
 @Override
 public void setUpSuite() throws Exception {
@@ -533,7 +527,7 @@ public void testDeprecatedFlag10() throws CoreException {
 				"public class D extends p2.C {}\n");
 		ICompilationUnit cuD = getCompilationUnit("/P/src/p/D.java");
 
-		ASTParser parser = ASTParser.newParser(JLS3_INTERNAL);
+		ASTParser parser = ASTParser.newParser(AST.getAllSupportedVersions().getFirst());
 		parser.setProject(this.testProject);
 		parser.setSource(cuD);
 		parser.setResolveBindings(true);
@@ -584,7 +578,7 @@ public void testDeprecatedFlag11() throws CoreException {
 				"public class D extends p2.C {}\n");
 		ICompilationUnit cuD = getCompilationUnit("/P/src/p/D.java");
 
-		ASTParser parser = ASTParser.newParser(JLS3_INTERNAL);
+		ASTParser parser = ASTParser.newParser(AST.getAllSupportedVersions().getFirst());
 		parser.setWorkingCopyOwner(myWCOwner);
 		parser.setProject(this.testProject);
 		parser.setSource(cuD);

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/IgnoreOptionalProblemsFromSourceFoldersTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/IgnoreOptionalProblemsFromSourceFoldersTests.java
@@ -40,13 +40,6 @@ public class IgnoreOptionalProblemsFromSourceFoldersTests extends ModifyingResou
 		super(name);
 	}
 
-	/**
-	 * Internal synonym for deprecated constant AST.JSL3
-	 * to alleviate deprecation warnings.
-	 * @deprecated
-	 */
-	/*package*/ static final int JLS3_INTERNAL = AST.JLS3;
-
 	// ignore optional errors
 	public void test001() throws CoreException {
 		ICompilationUnit unit = null;
@@ -327,7 +320,7 @@ public class IgnoreOptionalProblemsFromSourceFoldersTests extends ModifyingResou
 					"}");
 			ICompilationUnit unit = (ICompilationUnit) JavaCore.create(file);
 
-			ASTParser parser = ASTParser.newParser(JLS3_INTERNAL);
+			ASTParser parser = ASTParser.newParser(AST.getAllSupportedVersions().getFirst());
 			parser.setProject(project);
 			parser.setSource(unit);
 			parser.setResolveBindings(true);

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ReconcilerStatementsRecoveryTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ReconcilerStatementsRecoveryTests.java
@@ -76,13 +76,6 @@ public static Test suite() {
 	return buildModelTestSuite(ReconcilerStatementsRecoveryTests.class);
 }
 
-/**
- * Internal synonym for deprecated constant AST.JSL3
- * to alleviate deprecation warnings.
- * @deprecated
- */
-/*package*/ static final int JLS3_INTERNAL = AST.JLS3;
-
 protected void assertProblems(String message, String expected) {
 	assertProblems(message, expected, this.problemRequestor);
 }
@@ -97,7 +90,7 @@ protected void assertNoProblem(char[] source, ICompilationUnit unit) throws Inte
 		// Reconcile again to see if error goes away
 		this.problemRequestor.initialize(source);
 		unit.getBuffer().setContents(source); // need to set contents again to be sure that following reconcile will be really done
-		unit.reconcile(JLS3_INTERNAL,
+		unit.reconcile(AST.getAllSupportedVersions().getFirst(),
 			true, // force problem detection to see errors if any
 			null,	// do not use working copy owner to not use working copies in name lookup
 			null);
@@ -278,7 +271,7 @@ public void testStatementsRecovery02() throws CoreException {
 		"     UnknownType name\n" +
 		"  }\n" +
 		"}");
-	this.workingCopy.reconcile(JLS3_INTERNAL, false, false, null, null);
+	this.workingCopy.reconcile(AST.getAllSupportedVersions().getFirst(), false, false, null, null);
 	assertWorkingCopyDeltas(
 		"Unexpected delta after syntax error",
 		"[Working copy] X.java[*]: {CONTENT | FINE GRAINED | AST AFFECTED}"
@@ -343,7 +336,7 @@ public void testStatementsRecovery04() throws CoreException {
 		"     UnknownType name\n" +
 		"  }\n" +
 		"}");
-	this.workingCopy.reconcile(JLS3_INTERNAL, false, true, null, null);
+	this.workingCopy.reconcile(AST.getAllSupportedVersions().getFirst(), false, true, null, null);
 	assertWorkingCopyDeltas(
 		"Unexpected delta after syntax error",
 		"[Working copy] X.java[*]: {CONTENT | FINE GRAINED | AST AFFECTED}"

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/WorkingCopyOwnerTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/WorkingCopyOwnerTests.java
@@ -39,13 +39,6 @@ import org.eclipse.jdt.internal.core.util.Util;
 @SuppressWarnings("rawtypes")
 public class WorkingCopyOwnerTests extends ModifyingResourceTests {
 
-	/**
-	 * Internal synonym for deprecated constant AST.JSL3
-	 * to alleviate deprecation warnings.
-	 * @deprecated
-	 */
-	/*package*/ static final int JLS3_INTERNAL = AST.JLS3;
-
 	ICompilationUnit workingCopy = null;
 
 	public static class TestWorkingCopyOwner extends WorkingCopyOwner {
@@ -101,7 +94,7 @@ public class WorkingCopyOwnerTests extends ModifyingResourceTests {
 
 	private void assertProblems(String expectedProblems, String path, String source, WorkingCopyOwner owner) throws JavaModelException {
 		this.workingCopy = getWorkingCopy(path, source);
-		ASTParser parser = ASTParser.newParser(JLS3_INTERNAL);
+		ASTParser parser = ASTParser.newParser(AST.getAllSupportedVersions().getFirst());
 		parser.setSource(this.workingCopy);
 		parser.setResolveBindings(true);
 		parser.setWorkingCopyOwner(owner);
@@ -1078,7 +1071,7 @@ public class WorkingCopyOwnerTests extends ModifyingResourceTests {
 			"  int field;\n" +
 			"}"
 		);
-		CompilationUnit ast = this.workingCopy.reconcile(JLS3_INTERNAL, false, null, null);
+		CompilationUnit ast = this.workingCopy.reconcile(AST.getAllSupportedVersions().getFirst(), false, null, null);
 		assertASTNodeEquals(
 			"Unexpected AST",
 			"public class X {\n" +
@@ -1101,7 +1094,7 @@ public class WorkingCopyOwnerTests extends ModifyingResourceTests {
 			"  int field;\n" +
 			"}"
 		);
-		CompilationUnit ast = this.workingCopy.reconcile(JLS3_INTERNAL, true/*force resolution*/, null, null);
+		CompilationUnit ast = this.workingCopy.reconcile(AST.getAllSupportedVersions().getFirst(), true/*force resolution*/, null, null);
 		TypeDeclaration type = (TypeDeclaration) ast.types().get(0);
 		assertNull("Unexpected binding", type.resolveBinding());
 	}

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/rewrite/describing/ImportRewriteTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/rewrite/describing/ImportRewriteTest.java
@@ -54,13 +54,6 @@ import org.osgi.service.prefs.BackingStoreException;
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class ImportRewriteTest extends AbstractJavaModelTests {
 
-	/**
-	 * Internal synonym for deprecated constant AST.JSL3
-	 * to alleviate deprecation warnings.
-	 * @deprecated
-	 */
-	/*package*/ static final int JLS3_INTERNAL = AST.JLS3;
-
 	private static final Class THIS= ImportRewriteTest.class;
 
 	protected IPackageFragmentRoot sourceFolder;
@@ -2063,7 +2056,7 @@ public class ImportRewriteTest extends AbstractJavaModelTests {
 		buf.append("}\n");
 		ICompilationUnit cuT= test1.createCompilationUnit("T.java", buf.toString(), false, null);
 
-		ASTParser parser= ASTParser.newParser(JLS3_INTERNAL);
+		ASTParser parser= ASTParser.newParser(AST.getAllSupportedVersions().getFirst());
 		parser.setSource(cuT);
 		parser.setResolveBindings(true);
 		CompilationUnit astRoot= (CompilationUnit) parser.createAST(null);
@@ -2585,7 +2578,7 @@ public class ImportRewriteTest extends AbstractJavaModelTests {
 
 		String[] order= new String[] { "java.util", "java.io", "java.net" };
 		int threshold= 99;
-		AST ast= AST.newAST(JLS3_INTERNAL, false);
+		AST ast= AST.newAST(AST.getAllSupportedVersions().getFirst(), false);
 		ImportRewrite importsRewrite= newImportsRewrite(cu2, order, threshold, threshold, true);
 		{
 			IJavaElement[] elements= cu1.codeSelect(content.indexOf("IOException"), "IOException".length());
@@ -2658,7 +2651,7 @@ public class ImportRewriteTest extends AbstractJavaModelTests {
 
 		String[] order= new String[] { "java.util", "java.io", "java.net" };
 		int threshold= 99;
-		AST ast= AST.newAST(JLS3_INTERNAL, false);
+		AST ast= AST.newAST(AST.getAllSupportedVersions().getFirst(), false);
 		ImportRewrite importsRewrite= newImportsRewrite(cu2, order, threshold, threshold, true);
 		{
 			IJavaElement[] elements= cu1.codeSelect(content.indexOf("Map"), "Map".length());


### PR DESCRIPTION
Makes it clear what the tests are actually testing as JLS 3 is no longer supported.
