### PR TITLE
Use AST.getAllSupportedVersions in tests

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTTest.java
@@ -9550,12 +9550,8 @@ public class ASTTest extends org.eclipse.jdt.core.tests.junit.extension.TestCase
 		assertEquals("node types missing in test", Collections.EMPTY_SET, declaredNodeTypes);
 	}
 
-	@SuppressWarnings("deprecation")
 	public void testASTLevels() throws Exception {
-		int[] apilLevels = {AST.JLS2, AST.JLS3, AST.JLS4, AST.JLS8, AST.JLS9, AST.JLS10, AST.JLS11,
-				AST.JLS12, AST.JLS13, AST.JLS14, AST.JLS15, AST.JLS16, AST.JLS17,AST.JLS18, AST.JLS19,
-				AST.JLS20, AST.JLS21, AST.JLS22, AST.JLS23};
-		for (int level : apilLevels) {
+		for (int level : AST.getAllVersions()) {
 			try {
 				DOMASTUtil.checkASTLevel(level);
 			} catch (IllegalArgumentException e) {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/rewrite/describing/ASTRewritingTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/rewrite/describing/ASTRewritingTest.java
@@ -47,46 +47,6 @@ import org.eclipse.text.edits.TextEdit;
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class ASTRewritingTest extends AbstractJavaModelTests {
 
-	/** @deprecated using deprecated code */
-	private final static int JLS8_INTERNAL = AST.JLS8;
-
-	/** @deprecated using deprecated code */
-	private final static int JLS9_INTERNAL = AST.JLS9;
-
-	/** @deprecated using deprecated code */
-	private final static int JLS10_INTERNAL = AST.JLS10;
-
-	/** @deprecated using deprecated code */
-	private final static int JLS14_INTERNAL = AST.JLS14;
-
-	/** @deprecated using deprecated code */
-	private final static int JLS15_INTERNAL = AST.JLS15;
-
-	/** @deprecated using deprecated code */
-	private final static int JLS16_INTERNAL = AST.JLS16;
-
-	/** @deprecated using deprecated code */
-	private final static int JLS17_INTERNAL = AST.JLS17;
-
-	/** @deprecated using deprecated code */
-	private final static int JLS18_INTERNAL = AST.JLS18;
-
-	/** @deprecated using deprecated code */
-	private final static int JLS19_INTERNAL = AST.JLS19;
-
-	/** @deprecated using deprecated code */
-	private final static int JLS20_INTERNAL = AST.JLS20;
-
-	/** @deprecated using deprecated code */
-	private final static int JLS21_INTERNAL = AST.JLS21;
-
-	private final static int JLS22_INTERNAL = AST.JLS22;
-	private final static int JLS23_INTERNAL = AST.JLS23;
-
-	private final static int[] JLS_LEVELS = { JLS8_INTERNAL, JLS9_INTERNAL,
-			JLS10_INTERNAL, JLS14_INTERNAL, JLS15_INTERNAL, JLS16_INTERNAL, JLS17_INTERNAL, JLS18_INTERNAL,
-			JLS19_INTERNAL, JLS20_INTERNAL, JLS21_INTERNAL , JLS22_INTERNAL, JLS23_INTERNAL};
-
 	private static final String ONLY_AST_STRING = "_only";
 	private static final String SINCE_AST_STRING = "_since";
 	private static final String STRING_ = "_";
@@ -201,8 +161,7 @@ public class ASTRewritingTest extends AbstractJavaModelTests {
 							String suffix = name.substring(index + SINCE_AST_STRING.length() + 1);
 							since = Integer.parseInt(suffix);
 						}
-						for (int j= 0; j < JLS_LEVELS.length; j++) {
-							int level = JLS_LEVELS[j];
+						for (int level :AST.getAllSupportedVersions()) {
 							if (level >= since && level >= classSince) {
 								suite.addTest((Test) cons.newInstance(new Object[]{name, Integer.valueOf(level)}));
 							}


### PR DESCRIPTION
Manually listing "all" ast versions to test is too error prone and leads to cases where JLS 11 (an LTS version) is not tested but JLS 9 is. Simplifies the code and reduces places to add support for new Java versions.
