### PR TITLE
Revert "Fix various indent issues in cleanups/quick fixes in unformat…

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/rewrite/describing/ASTRewritingExpressionsTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/rewrite/describing/ASTRewritingExpressionsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2015 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -2384,7 +2384,7 @@ public class ASTRewritingExpressionsTest extends ASTRewritingTest {
 				"         Serializable o = ((Serializable & I & @Marker3 J) () -> {});\n" +
 				"    	  Serializable oo = (@Marker1 I & @Marker2 J & @Marker3 Serializable) obj;\n" +
 				"         Serializable ooo = (@Marker1 I & @Marker2 Serializable) obj;\n" +
-				"         return (@Marker1 I & @Marker2 Serializable) obj;\n" +
+				"        return (@Marker1 I & @Marker2 Serializable) obj;\n" +
 				"      }\n" +
 				"}\n" +
 				"interface I {\n" +

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/ASTRewriteAnalyzer.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/ASTRewriteAnalyzer.java
@@ -348,10 +348,6 @@ public final class ASTRewriteAnalyzer extends ASTVisitor {
 	    return this.formatter.createIndentString(indent);
 	}
 
-	final String createIndentString(int indent, int minimumIndentInSpaces) {
-		return this.formatter.createIndentString(indent, minimumIndentInSpaces);
-	}
-
 	final private String getIndentOfLine(int pos) {
 		int line= getLineInformation().getLineOfOffset(pos);
 		if (line >= 0) {
@@ -366,14 +362,6 @@ public final class ASTRewriteAnalyzer extends ASTVisitor {
 		return Util.EMPTY_STRING;
 	}
 
-	final private String getIndentString(String line, int minimumIndentInSpaces) {
-		String indent= this.formatter.getIndentString(line);
-		int indentInSpaces= this.formatter.computeIndentInSpaces(indent);
-		if (indentInSpaces < minimumIndentInSpaces) {
-			indent= indent + " ".repeat(minimumIndentInSpaces - indentInSpaces); //$NON-NLS-1$
-		}
-		return indent;
-	}
 
 	final String getIndentAtOffset(int pos) {
 		return this.formatter.getIndentString(getIndentOfLine(pos));
@@ -543,10 +531,6 @@ public final class ASTRewriteAnalyzer extends ASTVisitor {
 			return getIndent(this.startPos);
 		}
 
-		protected int getInitialIndentInSpaces() {
-			return getIndentInSpaces(this.startPos);
-		}
-
 		protected int getNodeIndent(int nodeIndex) {
 			ASTNode node= getOriginalNode(nodeIndex);
 			if (node == null) {
@@ -559,20 +543,6 @@ public final class ASTRewriteAnalyzer extends ASTVisitor {
 				return getInitialIndent();
 			}
 			return getIndent(node.getStartPosition());
-		}
-
-		protected int getNodeIndentInSpaces(int nodeIndex) {
-			ASTNode node= getOriginalNode(nodeIndex);
-			if (node == null) {
-				for (int i= nodeIndex - 1; i>= 0; i--) {
-					ASTNode curr= getOriginalNode(i);
-					if (curr != null) {
-						return getIndentInSpaces(curr.getStartPosition());
-					}
-				}
-				return getInitialIndentInSpaces();
-			}
-			return getIndentInSpaces(node.getStartPosition());
 		}
 
 		protected int getStartOfNextNode(int nextIndex, int defaultPos) {
@@ -629,12 +599,6 @@ public final class ASTRewriteAnalyzer extends ASTVisitor {
 			this.startPos= offset;
 			this.list= getEvent(parent, property).getChildren();
 
-			boolean maintainMinimumIndent= false;
-			if (property == Block.STATEMENTS_PROPERTY ||
-					property == SwitchStatement.STATEMENTS_PROPERTY ||
-					property == SwitchExpression.STATEMENTS_PROPERTY) {
-				maintainMinimumIndent= true;
-			}
 			int total= this.list.length;
 			if (total == 0) {
 				return this.startPos;
@@ -690,17 +654,12 @@ public final class ASTRewriteAnalyzer extends ASTVisitor {
 					if (separatorState == NONE) { // element after last existing element (but not first)
 						doTextInsert(currPos, getSeparatorString(i - 1), editGroup); // insert separator
 						separatorState= NEW;
-						maintainMinimumIndent= false;
 					}
 					if (separatorState == NEW || insertAfterSeparator(node)) {
 						if (separatorState == EXISTING) {
 							updateIndent(prevMark, currPos, i, editGroup);
 						}
-						if (maintainMinimumIndent && separatorState != EXISTING) {
-							doTextInsert(currPos, node, getNodeIndent(i), true, getNodeIndentInSpaces(i), editGroup); // insert node
-						} else {
-							doTextInsert(currPos, node, getNodeIndent(i), true, editGroup); // insert node
-						}
+						doTextInsert(currPos, node, getNodeIndent(i), true, editGroup); // insert node
 
 						separatorState= NEW;
 						if (i != lastNonDelete) {
@@ -712,11 +671,7 @@ public final class ASTRewriteAnalyzer extends ASTVisitor {
 						}
 					} else { // EXISTING && insert before separator
 						doTextInsert(prevEnd, getSeparatorString(i - 1), editGroup);
-						if (maintainMinimumIndent) {
-							doTextInsert(prevEnd, node, getNodeIndent(i), true, getNodeIndentInSpaces(i), editGroup);
-						} else {
-							doTextInsert(prevEnd, node, getNodeIndent(i), true, editGroup);
-						}
+						doTextInsert(prevEnd, node, getNodeIndent(i), true, editGroup);
 					}
 					if (insertNew && i == lastNonDelete) {
 						if (endKeyword != null && endKeyword.length() > 0) {
@@ -839,11 +794,7 @@ public final class ASTRewriteAnalyzer extends ASTVisitor {
 							// ignore
 						}
 						doTextRemoveAndVisit(currPos, currEnd - currPos, node, editGroup);
-						if (maintainMinimumIndent && separatorState != EXISTING) {
-							doTextInsert(currPos, changed, getNodeIndent(i), true, getNodeIndentInSpaces(i), editGroup);
-						} else {
-							doTextInsert(currPos, changed, getNodeIndent(i), true, editGroup);
-						}
+						doTextInsert(currPos, changed, getNodeIndent(i), true, editGroup);
 
 						prevEnd= currEnd;
 					} else { // is unchanged
@@ -1040,8 +991,7 @@ public final class ASTRewriteAnalyzer extends ASTVisitor {
 						// prefix contains a new line: update the indent to the one used in the prefix
 						indent= this.formatter.computeIndentUnits(prefix.substring(lineStart));
 					}
-					int minimumIndent= this.formatter.computeIndentInSpaces(getIndentOfLine(parent.getStartPosition()));
-					doTextInsert(offset, replacingNode, indent, true, minimumIndent, editGroup);
+					doTextInsert(offset, replacingNode, indent, true, editGroup);
 					doTextInsert(offset, strings[1], editGroup);
 					return endPos;
 				}
@@ -1191,7 +1141,7 @@ public final class ASTRewriteAnalyzer extends ASTVisitor {
 			for (int i= 0; i < newLines; i++) {
 				buf.append(lineDelim);
 			}
-			buf.append(createIndentString(getNodeIndent(nextNodeIndex), getNodeIndentInSpaces(nextNodeIndex)));
+			buf.append(createIndentString(getNodeIndent(nextNodeIndex)));
 			return buf.toString();
 		}
 
@@ -1517,18 +1467,11 @@ public final class ASTRewriteAnalyzer extends ASTVisitor {
 		return this.formatter.computeIndentUnits(getIndentOfLine(offset));
 	}
 
-	final int getIndentInSpaces(int offset) {
-		return this.formatter.computeIndentInSpaces(getIndentOfLine(offset));
-	}
-
 	final void doTextInsert(int insertOffset, ASTNode node, int initialIndentLevel, boolean removeLeadingIndent, TextEditGroup editGroup) {
-		doTextInsert(insertOffset, node, initialIndentLevel, removeLeadingIndent, 0, editGroup);
-	}
-
-	final void doTextInsert(int insertOffset, ASTNode node, int initialIndentLevel, boolean removeLeadingIndent,
-			int minimumIndentInSpaces, TextEditGroup editGroup) {
 		ArrayList markers= new ArrayList();
-		String formatted= this.formatter.getFormattedResult(node, initialIndentLevel, minimumIndentInSpaces, markers);
+		String formatted= this.formatter.getFormattedResult(node, initialIndentLevel, markers);
+
+
 		int currPos= 0;
 		if (removeLeadingIndent) {
 			while (currPos < formatted.length() && ScannerHelper.isWhitespace(formatted.charAt(currPos))) {
@@ -1541,11 +1484,6 @@ public final class ASTRewriteAnalyzer extends ASTVisitor {
 			int offset= curr.offset;
 			if (offset >= currPos) {
 				String insertStr= formatted.substring(currPos, offset);
-				int indentInSpaces= this.formatter.computeIndentInSpaces(insertStr);
-				if (indentInSpaces < minimumIndentInSpaces && !removeLeadingIndent) {
-					insertStr= reindent(insertStr, minimumIndentInSpaces);
-				}
-				removeLeadingIndent= false;
 				doTextInsert(insertOffset, insertStr, editGroup); // insert until the marker's begin
 			} else {
 				// already processed
@@ -1574,8 +1512,8 @@ public final class ASTRewriteAnalyzer extends ASTVisitor {
 				// proper indentation - see https://bugs.eclipse.org/bugs/show_bug.cgi?id=350285
 				int lineOffset = getCurrentLineStart(formatted, offset);
 				String destIndentString = (lineOffset == 0)
-						? createIndentString(initialIndentLevel, minimumIndentInSpaces)
-						: getIndentString(formatted.substring(lineOffset, offset), minimumIndentInSpaces);
+						? this.formatter.createIndentString(initialIndentLevel)
+						: this.formatter.getIndentString(formatted.substring(lineOffset, offset));
 				if (data instanceof CopyPlaceholderData) { // replace with a copy/move target
 					CopySourceInfo copySource= ((CopyPlaceholderData) data).copySource;
 					int srcIndentLevel= getIndent(copySource.getNode().getStartPosition());
@@ -1596,35 +1534,9 @@ public final class ASTRewriteAnalyzer extends ASTVisitor {
 		}
 		if (currPos < formatted.length()) {
 			String insertStr= formatted.substring(currPos);
-			String[] lines= insertStr.split("\n"); //$NON-NLS-1$
-			boolean mustReformInsert= false;
-			for (int i= 0; i < lines.length; ++i) {
-				if (!lines[i].isEmpty()) {
-					int indentInSpaces= this.formatter.computeIndentInSpaces(lines[i]) + this.formatter.getIndentWidth() * initialIndentLevel;
-					if (indentInSpaces < minimumIndentInSpaces) {
-						lines[i]= reindent(lines[i], minimumIndentInSpaces);
-						mustReformInsert= true;
-					}
-				}
-			}
-			if (mustReformInsert) {
-				StringBuilder s= new StringBuilder();
-				for (int i= 0; i < lines.length - 1; ++i) {
-					s.append(lines[i] + "\n"); //$NON-NLS-1$
-				}
-				s.append(lines[lines.length - 1]);
-				insertStr= s.toString();
-			}
 			doTextInsert(insertOffset, insertStr, editGroup);
 		}
 	}
-
-	private String reindent(String line, int minimumIndentInSpaces) {
-		String originalIndent= this.formatter.getIndentString(line);
-		String newIndent= getIndentString(line, minimumIndentInSpaces);
-		return newIndent + line.substring(originalIndent.length());
-	}
-
 	private boolean needsNewLineForLineComment(ASTNode node, String formatted, int offset) {
 		if (!this.lineCommentEndOffsets.isEndOfLineComment(getExtendedEnd(node), this.content)) {
 			return false;
@@ -3900,29 +3812,6 @@ public final class ASTRewriteAnalyzer extends ASTVisitor {
 			return indent;
 		}
 
-		@Override
-		protected int getNodeIndentInSpaces(int nodeIndex) {
-			int indent= getInitialIndentInSpaces();
-			if (this.indentSwitchStatementsCompareToCases) {
-				RewriteEvent event = this.list[nodeIndex];
-				int changeKind = event.getChangeKind();
-				ASTNode node;
-				if (changeKind == RewriteEvent.INSERTED || changeKind == RewriteEvent.REPLACED) {
-					node= (ASTNode)event.getNewValue();
-				} else {
-					node= (ASTNode)event.getOriginalValue();
-				}
-				if (node.getNodeType() != ASTNode.SWITCH_CASE) {
-					ASTNode prevNode = getNode(nodeIndex -1);
-					if (prevNode.getNodeType() == ASTNode.SWITCH_CASE && ((SwitchCase)prevNode).isSwitchLabeledRule()) {
-						return 0;
-					} else {
-						indent= indent + ASTRewriteAnalyzer.this.formatter.getIndentWidth();					}
-				}
-			}
-			return indent;
-		}
-
 		private boolean isSwitchLabeledRule(int nodeIndex, int nextNodeIndex) {
 			ASTNode curr= getNode(nodeIndex);
 			ASTNode next= getNode(nodeIndex +1);
@@ -3961,38 +3850,6 @@ public final class ASTRewriteAnalyzer extends ASTVisitor {
 
 				if (node.getNodeType() != ASTNode.SWITCH_CASE) {
 					indent++;
-				}
-			}
-			return indent;
-		}
-
-		@Override
-		protected int getNodeIndentInSpaces(int nodeIndex) {
-			int indent= getInitialIndentInSpaces();
-
-			if (this.indentSwitchStatementsCompareToCases) {
-				RewriteEvent event = this.list[nodeIndex];
-				int changeKind = event.getChangeKind();
-
-				ASTNode node;
-				if (changeKind == RewriteEvent.INSERTED || changeKind == RewriteEvent.REPLACED) {
-					node= (ASTNode)event.getNewValue();
-				} else {
-					node= (ASTNode)event.getOriginalValue();
-				}
-
-				if (node.getNodeType() != ASTNode.SWITCH_CASE) {
-					for (int i= 0; i < this.list.length; ++i) {
-						RewriteEvent nodeEvent = this.list[i];
-						int nodeChangeKind= nodeEvent.getChangeKind();
-						if (nodeChangeKind == RewriteEvent.UNCHANGED || nodeChangeKind == RewriteEvent.REPLACED) {
-							node= (ASTNode)nodeEvent.getOriginalValue();
-							if (node.getNodeType() != ASTNode.SWITCH_CASE) {
-								return getIndentInSpaces(node.getStartPosition());
-							}
-						}
-					}
-					indent+= ASTRewriteAnalyzer.this.formatter.getIndentWidth();
 				}
 			}
 			return indent;

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/ASTRewriteFormatter.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/ASTRewriteFormatter.java
@@ -168,11 +168,10 @@ public final class ASTRewriteFormatter {
 	 *
 	 * @param node The node to flatten.
 	 * @param initialIndentationLevel The initial indentation level.
-	 * @param minimumIndentInSpaces The minimum indent to use in spaces
 	 * @param resultingMarkers Resulting the updated NodeMarkers.
 	 * @return Returns the serialized and formatted code.
 	 */
-	public String getFormattedResult(ASTNode node, int initialIndentationLevel, int minimumIndentInSpaces, Collection resultingMarkers) {
+	public String getFormattedResult(ASTNode node, int initialIndentationLevel, Collection resultingMarkers) {
 
 		ExtendedFlattener flattener= new ExtendedFlattener(this.eventStore);
 		node.accept(flattener);
@@ -181,15 +180,11 @@ public final class ASTRewriteFormatter {
 		Collections.addAll(resultingMarkers, markers);
 
 		String unformatted= flattener.getResult();
-		TextEdit edit= formatNode(node, unformatted, initialIndentationLevel, minimumIndentInSpaces);
+		TextEdit edit= formatNode(node, unformatted, initialIndentationLevel);
 		if (edit == null) {
 		    if (initialIndentationLevel > 0) {
 		        // at least correct the indent
 		        String indentString = createIndentString(initialIndentationLevel);
-		        int indentInSpaces= computeIndentInSpaces(indentString);
-		        if (indentInSpaces < minimumIndentInSpaces) {
-		        	indentString = " ".repeat(minimumIndentInSpaces - indentInSpaces) + indentString; //$NON-NLS-1$
-		        }
 				ReplaceEdit[] edits = IndentManipulation.getChangeIndentEdits(unformatted, 0, this.tabWidth, this.indentWidth, indentString);
 				edit= new MultiTextEdit();
 				edit.addChild(new InsertEdit(0, indentString));
@@ -205,16 +200,7 @@ public final class ASTRewriteFormatter {
     	return ToolFactory.createCodeFormatter(this.options).createIndentationString(indentationUnits);
     }
 
-    public String createIndentString(int indentationUnits, int minimumIndentInSpaces) {
-    	String indent= ToolFactory.createCodeFormatter(this.options).createIndentationString(indentationUnits);
-    	int indentInSpaces= computeIndentInSpaces(indent);
-    	if (indentInSpaces < minimumIndentInSpaces) {
-    		indent= indent + " ".repeat(minimumIndentInSpaces - indentInSpaces); //$NON-NLS-1$
-    	}
-    	return indent;
-    }
-
-    public String getIndentString(String currentLine) {
+	public String getIndentString(String currentLine) {
 		return IndentManipulation.extractIndentString(currentLine, this.tabWidth, this.indentWidth);
 	}
 
@@ -251,7 +237,7 @@ public final class ASTRewriteFormatter {
 			return doc.get();
 		} catch (BadLocationException e) {
 			//JavaPlugin.log(e); // bug in the formatter
-			Assert.isTrue(false, "Formatter created edits with wrong positions: " + e.getMessage()); //$NON-NLS-1$
+			Assert.isTrue(false, "Fromatter created edits with wrong positions: " + e.getMessage()); //$NON-NLS-1$
 		}
 		return null;
 	}
@@ -264,13 +250,11 @@ public final class ASTRewriteFormatter {
 	 * Creates edits that describe how to format the given string. Returns <code>null</code> if the code could not be formatted for the given kind.
 	 * @param node Node describing the type of the string
 	 * @param str The unformatted string
-	 * @param indentationLevel Indentation level in tab widths
-	 * @param minimumIndentInSpaces Minimum indent of item in spaces
 	 * @return Returns the edit representing the result of the formatter
 	 * @throws IllegalArgumentException If the offset and length are not inside the string, a
 	 *  IllegalArgumentException is thrown.
 	 */
-	private TextEdit formatNode(ASTNode node, String str, int indentationLevel, int minimumIndentInSpaces) {
+	private TextEdit formatNode(ASTNode node, String str, int indentationLevel) {
 		int code;
 		String prefix= ""; //$NON-NLS-1$
 		String suffix= ""; //$NON-NLS-1$


### PR DESCRIPTION
…ted file (#3685)"

This reverts commit 20001efc0e643f1d0b1166a41bc314d25a84e01a.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
