### PR TITLE
ecj complains about intermediate constructor invocation inside lambda

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LambdaExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LambdaExpression.java
@@ -82,7 +82,7 @@ import org.eclipse.jdt.internal.compiler.problem.AbortMethod;
 import org.eclipse.jdt.internal.compiler.problem.AbortType;
 import org.eclipse.jdt.internal.compiler.problem.ProblemSeverities;
 
-public class LambdaExpression extends FunctionalExpression implements IPolyExpression, ReferenceContext, ProblemSeverities {
+public class LambdaExpression extends FunctionalExpression implements IPolyExpression, ReferenceContext, ProblemSeverities, TypeOrLambda {
 	public Argument [] arguments;
 	private TypeBinding [] argumentTypes;
 	public int arrowPosition;
@@ -558,6 +558,8 @@ public class LambdaExpression extends FunctionalExpression implements IPolyExpre
 
 		if (this.ignoreFurtherInvestigation)
 			return flowInfo;
+
+		addSyntheticArgumentsBeyondEarlyConstructionContext(false, this.enclosingScope);
 
 		FlowInfo lambdaInfo = flowInfo.copy(); // what happens in vegas, stays in vegas ...
 		ExceptionHandlingFlowContext methodContext =
@@ -1366,6 +1368,11 @@ public class LambdaExpression extends FunctionalExpression implements IPolyExpre
 				break;
 		}
 		return syntheticLocal;
+	}
+
+	@Override
+	public void ensureSyntheticOuterAccess(SourceTypeBinding targetEnclosing) {
+		this.mapSyntheticEnclosingTypes.computeIfAbsent(targetEnclosing, this::addSyntheticArgument);
 	}
 
 	private SyntheticArgumentBinding getActualOuterLocalFromEnclosingScope(ReferenceBinding enclosingType) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypeDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypeDeclaration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -63,7 +63,7 @@ import org.eclipse.jdt.internal.compiler.problem.ProblemSeverities;
 import org.eclipse.jdt.internal.compiler.util.SimpleSetOfCharArray;
 import org.eclipse.jdt.internal.compiler.util.Util;
 
-public class TypeDeclaration extends Statement implements ProblemSeverities, ReferenceContext {
+public class TypeDeclaration extends Statement implements ProblemSeverities, ReferenceContext, TypeOrLambda {
 	// Type decl kinds
 	public static final int CLASS_DECL = 1;
 	public static final int INTERFACE_DECL = 2;
@@ -1105,7 +1105,7 @@ public void manageEnclosingInstanceAccessIfNecessary(BlockScope currentScope, Fl
 			outerScope = outerScope.enclosingInstanceScope();
 			earlySeen = methodScope.isInsideEarlyConstructionContext(nestedType.enclosingType(), false);
 		}
-		addSyntheticArgumentsBeyondEarlyConstructionContext(nestedType, earlySeen, outerScope);
+		addSyntheticArgumentsBeyondEarlyConstructionContext(earlySeen, outerScope);
 	}
 	// add superclass enclosing instance arg for anonymous types (if necessary)
 	if (nestedType.isAnonymousType()) {
@@ -1156,30 +1156,13 @@ public void manageEnclosingInstanceAccessIfNecessary(ClassScope currentScope, Fl
 		NestedTypeBinding nestedType = (NestedTypeBinding) this.binding;
 		nestedType.addSyntheticArgumentAndField(this.binding.enclosingType());
 		boolean earlySeen = this.scope.insideEarlyConstructionContext;
-		addSyntheticArgumentsBeyondEarlyConstructionContext(nestedType, earlySeen, currentScope);
+		addSyntheticArgumentsBeyondEarlyConstructionContext(earlySeen, currentScope);
 	}
 }
 
-private void addSyntheticArgumentsBeyondEarlyConstructionContext(NestedTypeBinding nestedType, boolean earlySeen, Scope outerScope) {
-	if (outerScope != null && JavaFeature.FLEXIBLE_CONSTRUCTOR_BODIES.isSupported(outerScope.compilerOptions())) {
-		// JEP 482: this is the central location for organizing synthetic arguments and fields
-		// to serve far outer instances even in inner early construction context.
-		// Locations MethodBinding.computeSignature() and BlockScope.getEmulationPath() will faithfully
-		// use the information generated here, to decide about signature and call sequence.
-		while (outerScope != null) {
-			if (outerScope instanceof ClassScope cs) {
-				if (earlySeen && !cs.insideEarlyConstructionContext) {
-					// a direct outer beyond an early construction context disrupts
-					// the chain of fields, supply a local copy instead (arg & field):
-					nestedType.addSyntheticArgumentAndField(cs.referenceContext.binding);
-				}
-				earlySeen = cs.insideEarlyConstructionContext;
-			}
-			outerScope = outerScope.parent;
-			if (outerScope instanceof MethodScope ms && ms.isStatic)
-				break;
-		}
-	}
+@Override
+public void ensureSyntheticOuterAccess(SourceTypeBinding targetEnclosing) {
+	((NestedTypeBinding) this.binding).addSyntheticArgumentAndField(targetEnclosing);
 }
 
 /**

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypeOrLambda.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypeOrLambda.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2025 GK Software SE, and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
+ * Contributors:
+ *     Stephan Herrmann - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.internal.compiler.ast;
+
+import org.eclipse.jdt.internal.compiler.impl.JavaFeature;
+import org.eclipse.jdt.internal.compiler.lookup.ClassScope;
+import org.eclipse.jdt.internal.compiler.lookup.MethodScope;
+import org.eclipse.jdt.internal.compiler.lookup.Scope;
+import org.eclipse.jdt.internal.compiler.lookup.SourceTypeBinding;
+
+/**
+ * Common properties of type declarations and lambda expressions.
+ * <p>
+ * In terms of access to enclosing instances both type declarations and lambda expressions
+ * are barriers which need to be bridged with synthetic arguments (and fields in the case of types).
+ * </p>
+ */
+public interface TypeOrLambda {
+
+	/**
+	 * If the current type or lambda is within some early construction context, then next enclosing
+	 * instance may need to be managed via a synthetic argument (and field in the case of types).
+	 * @param earlySeen are we already looking from an early construction context?
+	 * @param outerScope where to search for enclosing types to be managed
+	 */
+	default void addSyntheticArgumentsBeyondEarlyConstructionContext(boolean earlySeen, Scope outerScope) {
+		if (outerScope != null && JavaFeature.FLEXIBLE_CONSTRUCTOR_BODIES.isSupported(outerScope.compilerOptions())) {
+			// JEP 482 / 492:
+			// This is the central location for organizing synthetic arguments and fields
+			// to serve far outer instances even in inner early construction context.
+			// Locations MethodBinding.computeSignature() and BlockScope.getEmulationPath() will faithfully
+			// use the information generated here, to decide about signature and call sequence.
+			while (outerScope != null) {
+				if (outerScope instanceof ClassScope cs) {
+					if (earlySeen && !cs.insideEarlyConstructionContext) {
+						// a direct outer beyond an early construction context disrupts
+						// the chain of fields, supply a local copy instead (arg & field):
+						ensureSyntheticOuterAccess(cs.referenceContext.binding);
+					}
+					earlySeen = cs.insideEarlyConstructionContext;
+				}
+				outerScope = outerScope.parent;
+				if (outerScope instanceof MethodScope ms && ms.isStatic)
+					break;
+			}
+		}
+	}
+
+	void ensureSyntheticOuterAccess(SourceTypeBinding targetEnclosing);
+}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Scope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Scope.java
@@ -5697,7 +5697,7 @@ public abstract class Scope {
 					ReferenceBinding tmp = lambdaEnclosingType;
 					while ((tmp = tmp.enclosingType()) != null) {
 						if (!TypeBinding.equalsEquals(enclosingType, tmp)) continue;
-						lambda.mapSyntheticEnclosingTypes.computeIfAbsent((SourceTypeBinding) enclosingType, lambda::addSyntheticArgument);
+						lambda.ensureSyntheticOuterAccess((SourceTypeBinding) enclosingType);
 						lambda.hasOuterClassMemberReference = true; // ref to Outer class members allowed - interpreting 8.8.7.1
 						break;
 					}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SuperAfterStatementsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SuperAfterStatementsTest.java
@@ -3099,4 +3099,42 @@ public class SuperAfterStatementsTest extends AbstractRegressionTest9 {
 			},
 			"10");
 	}
+	public void testGH3700() {
+		// test case from https://bugs.openjdk.org/browse/JDK-8333313
+		runConformTest(new String[] {
+				"Main.java",
+				"""
+				interface Foo {
+					void foo();
+				}
+
+				public class Main {
+					static int check = 0;
+
+					class Test {
+						Test() {}
+						Test(int a) {
+							class InnerLocal {
+								int a = 1;
+							}
+							Foo lmb = () -> {
+								Main.check = new InnerLocal() {
+										public int a() {
+											return this.a;
+										}
+									}.a();
+							};
+							lmb.foo();
+							this();
+						}
+					}
+					public static void main(String... args) {
+						new Main().new Test(3);
+						System.out.print(check);
+					}
+				}
+				"""
+		},
+		"1");
+	}
 }


### PR DESCRIPTION
Shy start to unify type declaration and lambda in some respect:
+ both need to manage access to enclosing instances
+ hook the pulled-up method into LE.analyseCode() to fix the bug

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3700
