### PR TITLE
APT: Fix cancel build during annotation processing #3317

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/BuildNotifier.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/BuildNotifier.java
@@ -86,9 +86,9 @@ public void begin() {
 }
 
 /**
- * Check whether the build has been canceled.
+ * Check whether the build has been canceled. Throws OperationCanceledException when canceled.
  */
-public void checkCancel() {
+public void checkCancel() throws OperationCanceledException{
 	if (this.cancelling) {
 		throw new OperationCanceledException();
 	}
@@ -121,20 +121,22 @@ private long getBuildDurationInMs() {
 }
 
 /**
- * Check whether the build has been canceled.
+ * Check whether the build has been canceled. Throws AbortCompilation when canceled.
  * Must use this call instead of checkCancel() when within the compiler.
  */
-public void checkCancelWithinCompiler() {
-	if (!this.cancelling) {
-		try {
-			checkCancel();
-		} catch (OperationCanceledException cancelRequest) {
-			// Once the compiler has been canceled, don't check again.
-			setCancelling(true);
-			// Only AbortCompilation can stop the compiler cleanly.
-			// We check cancelation again following the call to compile.
-			throw new AbortCompilation(true, null);
-		}
+public void checkCancelWithinCompiler() throws AbortCompilation {
+	if (this.cancelling) {
+		// when annotation processor catched already thrown AbortCompilation away throw it again
+		throw new AbortCompilation(true, null);
+	}
+	try {
+		checkCancel();
+	} catch (OperationCanceledException cancelRequest) {
+		// Once the compiler has been canceled, don't check again.
+		setCancelling(true);
+		// Only AbortCompilation can stop the compiler cleanly.
+		// We check cancelation again following the call to compile.
+		throw new AbortCompilation(true, null);
 	}
 }
 


### PR DESCRIPTION
When user canceled build during annotation processing the AbortCompilation exception was catched away and not rethrown. The BuildNotifier even remembered that the AbortCompilation was already thrown and did not throw it again such that any further cancel even after annotation processing was suppressed.

fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3317
