### PR TITLE
Avoid duplicate calls in ReferenceBinding::superInterfaces #3601

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LambdaExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LambdaExpression.java
@@ -1438,7 +1438,7 @@ public class LambdaExpression extends FunctionalExpression implements IPolyExpre
 				return LambdaExpression.this.scope.getJavaLangObject();
 			}
 			@Override
-			public ReferenceBinding[] superInterfaces() {
+			protected ReferenceBinding[] superInterfacesRecursive(Map<ReferenceBinding, Object> visited) {
 				return new ReferenceBinding[] { (ReferenceBinding) LambdaExpression.this.resolvedType };
 			}
 			@Override

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceVariable.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceVariable.java
@@ -174,7 +174,7 @@ public class InferenceVariable extends TypeVariableBinding {
 	}
 
 	@Override
-	public ReferenceBinding[] superInterfaces() {
+	protected ReferenceBinding[] superInterfacesRecursive(Map<ReferenceBinding, Object> visited) {
 		return Binding.NO_SUPERINTERFACES;
 	}
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/IntersectionTypeBinding18.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/IntersectionTypeBinding18.java
@@ -23,6 +23,7 @@
 
 package org.eclipse.jdt.internal.compiler.lookup;
 
+import java.util.Map;
 import java.util.Set;
 import org.eclipse.jdt.internal.compiler.ast.Wildcard;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
@@ -153,7 +154,7 @@ public class IntersectionTypeBinding18 extends ReferenceBinding {
 	}
 
 	@Override
-	public ReferenceBinding [] superInterfaces() {
+	protected ReferenceBinding[] superInterfacesRecursive(Map<ReferenceBinding, Object> visited) {
 		if (this.intersectingTypes[0].isClass()) {
 			ReferenceBinding [] superInterfaces = new ReferenceBinding[this.length - 1];
 			System.arraycopy(this.intersectingTypes, 1, superInterfaces, 0, this.length - 1);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedTypeBinding.java
@@ -1551,11 +1551,12 @@ public class ParameterizedTypeBinding extends ReferenceBinding implements Substi
 	 * @see org.eclipse.jdt.internal.compiler.lookup.ReferenceBinding#superInterfaces()
 	 */
 	@Override
-	public ReferenceBinding[] superInterfaces() {
-	    if (this.superInterfaces == null) {
+	protected ReferenceBinding[] superInterfacesRecursive(Map<ReferenceBinding, Object> visited) {
+		// TODO (visjee) protect from duplicated calls
+	    if (this.superInterfaces == null && visited.put(this, this) == null) {
     		if (this.type.isHierarchyBeingConnected())
     			return Binding.NO_SUPERINTERFACES; // prevent superinterfaces from being assigned before they are connected
-    		this.superInterfaces = Scope.substitute(this, this.type.superInterfaces());
+    		this.superInterfaces = Scope.substitute(this, this.type.superInterfacesRecursive(visited));
     		if (this.superInterfaces != null) {
 	    		for (int i = this.superInterfaces.length; --i >= 0;) {
 	    			this.typeBits |= (this.superInterfaces[i].typeBits & TypeIds.InheritableBits);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ProblemReferenceBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ProblemReferenceBinding.java
@@ -15,6 +15,7 @@
 package org.eclipse.jdt.internal.compiler.lookup;
 
 import java.lang.reflect.Field;
+import java.util.Map;
 import org.eclipse.jdt.core.compiler.CharOperation;
 
 @SuppressWarnings("rawtypes")
@@ -60,10 +61,10 @@ public ReferenceBinding superclass() {
 }
 
 @Override
-public ReferenceBinding[] superInterfaces() {
+protected ReferenceBinding[] superInterfacesRecursive(Map<ReferenceBinding, Object> visited) {
 	if (this.closestMatch != null)
-		return this.closestMatch.superInterfaces();
-	return super.superInterfaces();
+		return this.closestMatch.superInterfacesRecursive(visited); // TODO (visjee) protect from duplicated calls
+	return super.superInterfacesRecursive(visited);
 }
 
 @Override

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
@@ -57,6 +57,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -2098,7 +2099,11 @@ public ReferenceBinding superclass() {
 }
 
 @Override
-public ReferenceBinding[] superInterfaces() {
+public final ReferenceBinding[] superInterfaces() {
+	return superInterfacesRecursive(new IdentityHashMap<>());
+}
+
+protected ReferenceBinding[] superInterfacesRecursive(Map<ReferenceBinding, Object> visited) {
 	return Binding.NO_SUPERINTERFACES;
 }
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SourceTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SourceTypeBinding.java
@@ -3178,9 +3178,9 @@ public ReferenceBinding superclass() {
 }
 
 @Override
-public ReferenceBinding[] superInterfaces() {
-	if (!isPrototype())
-		return this.superInterfaces = this.prototype.superInterfaces();
+protected ReferenceBinding[] superInterfacesRecursive(Map<ReferenceBinding, Object> visited) {
+	if (!isPrototype() && visited.put(this, this) == null)
+		return this.superInterfaces = this.prototype.superInterfacesRecursive(visited); // TODO (visjee) protect from duplicated calls
 	return this.superInterfaces != null ? this.superInterfaces : isAnnotationType() ? this.superInterfaces = new ReferenceBinding [] { this.scope.getJavaLangAnnotationAnnotation() } : null;
 }
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeVariableBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeVariableBinding.java
@@ -45,16 +45,17 @@ package org.eclipse.jdt.internal.compiler.lookup;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.internal.compiler.ast.ASTNode;
 import org.eclipse.jdt.internal.compiler.ast.Annotation;
 import org.eclipse.jdt.internal.compiler.ast.NullAnnotationMatching;
+import org.eclipse.jdt.internal.compiler.ast.NullAnnotationMatching.CheckMode;
 import org.eclipse.jdt.internal.compiler.ast.TypeParameter;
 import org.eclipse.jdt.internal.compiler.ast.TypeReference;
 import org.eclipse.jdt.internal.compiler.ast.Wildcard;
-import org.eclipse.jdt.internal.compiler.ast.NullAnnotationMatching.CheckMode;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jdt.internal.compiler.lookup.TypeConstants.BoundCheckStatus;
@@ -935,7 +936,7 @@ public class TypeVariableBinding extends ReferenceBinding {
 	}
 
 	@Override
-	public ReferenceBinding[] superInterfaces() {
+	protected ReferenceBinding[] superInterfacesRecursive(Map<ReferenceBinding, Object> visited) {
 		return this.superInterfaces;
 	}
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/WildcardBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/WildcardBinding.java
@@ -28,6 +28,7 @@
 package org.eclipse.jdt.internal.compiler.lookup;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.internal.compiler.ast.Annotation;
@@ -927,10 +928,10 @@ public class WildcardBinding extends ReferenceBinding implements HotSwappable{
     }
 
     @Override
-	public ReferenceBinding[] superInterfaces() {
-        if (this.superInterfaces == null) {
+    protected ReferenceBinding[] superInterfacesRecursive(Map<ReferenceBinding, Object> visited) {
+        if (this.superInterfaces == null && visited.put(this, this) == null) {
         	if (typeVariable() != null) {
-        		this.superInterfaces = this.typeVariable.superInterfaces();
+        		this.superInterfaces = this.typeVariable.superInterfacesRecursive(visited);// TODO (visjee) protect from duplicated calls
         	} else {
         		this.superInterfaces = Binding.NO_SUPERINTERFACES;
         	}


### PR DESCRIPTION
- Make the method final

- Add new recursive method ReferenceBinding.superInterfacesRecursive that takes an IndentityHashMap to keep the visited types
 
Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3601

Supersedes #3622