### PR TITLE
extends ICompilerFactory by CompilationProgress #3370

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/apt/dispatch/BaseAnnotationProcessorManager.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/apt/dispatch/BaseAnnotationProcessorManager.java
@@ -18,6 +18,7 @@ package org.eclipse.jdt.internal.compiler.apt.dispatch;
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.List;
+import org.eclipse.jdt.core.compiler.CompilationProgress;
 import org.eclipse.jdt.internal.compiler.AbstractAnnotationProcessorManager;
 import org.eclipse.jdt.internal.compiler.Compiler;
 import org.eclipse.jdt.internal.compiler.ast.CompilationUnitDeclaration;
@@ -100,6 +101,11 @@ public abstract class BaseAnnotationProcessorManager extends AbstractAnnotationP
 	@Override
 	public void reset() {
 		this._processingEnv.reset();
+	}
+
+	@Override
+	public CompilationProgress getCompilationProgress() {
+		return this._processingEnv.getCompilationProgress();
 	}
 
 	/* (non-Javadoc)

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/apt/dispatch/BaseProcessingEnvImpl.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/apt/dispatch/BaseProcessingEnvImpl.java
@@ -25,6 +25,7 @@ import javax.lang.model.SourceVersion;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 import javax.tools.JavaFileManager;
+import org.eclipse.jdt.core.compiler.CompilationProgress;
 import org.eclipse.jdt.internal.compiler.Compiler;
 import org.eclipse.jdt.internal.compiler.apt.model.ElementsImpl;
 import org.eclipse.jdt.internal.compiler.apt.model.Factory;
@@ -218,6 +219,10 @@ public abstract class BaseProcessingEnvImpl implements ProcessingEnvironment {
 
 	public JavaFileManager getFileManager() {
 		return null;
+	}
+
+	CompilationProgress getCompilationProgress() {
+		return this._compiler.progress;
 	}
 
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/apt/dispatch/IProcessorProvider.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/apt/dispatch/IProcessorProvider.java
@@ -17,6 +17,7 @@ package org.eclipse.jdt.internal.compiler.apt.dispatch;
 
 import java.util.List;
 import javax.annotation.processing.Processor;
+import org.eclipse.jdt.core.compiler.CompilationProgress;
 
 /**
  * Implementors know how to discover annotation processors, and maintain a list of processors that
@@ -45,4 +46,6 @@ public interface IProcessorProvider {
 	 * @param p the processor, if known, or null if not.
 	 */
 	void reportProcessorException(Processor p, Exception e);
+
+	CompilationProgress getCompilationProgress();
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/messages.properties
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/messages.properties
@@ -14,6 +14,7 @@
 ### compiler messages.
 
 ### compilation
+apt_processing=Processing annotations with: {0}
 compilation_unresolvedProblem =  Unresolved compilation problem: \n
 compilation_unresolvedProblems = Unresolved compilation problems: \n
 compilation_request    = [parsing    {2} - #{0}/{1}]

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/util/Messages.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/util/Messages.java
@@ -79,6 +79,7 @@ public final class Messages {
 		// Do not instantiate
 	}
 
+	public static String apt_processing;
 	public static String compilation_unresolvedProblem;
 	public static String compilation_unresolvedProblems;
 	public static String compilation_request;

--- a/org.eclipse.jdt.core.tests.builder.mockcompiler/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.tests.builder.mockcompiler/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.core.tests.builder.mockcompiler; singleton:=true
-Bundle-Version: 1.0.100.qualifier
+Bundle-Version: 1.0.200.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Fragment-Host: org.eclipse.jdt.core

--- a/org.eclipse.jdt.core.tests.builder.mockcompiler/pom.xml
+++ b/org.eclipse.jdt.core.tests.builder.mockcompiler/pom.xml
@@ -20,6 +20,6 @@
     <relativePath>../tests-pom/</relativePath>
   </parent>
   <artifactId>org.eclipse.jdt.core.tests.builder.mockcompiler</artifactId>
-  <version>1.0.100-SNAPSHOT</version>
+  <version>1.0.200-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.eclipse.jdt.core.tests.builder.mockcompiler/src/org/eclipse/jdt/core/tests/builder/mockcompiler/MockCompilerFactory.java
+++ b/org.eclipse.jdt.core.tests.builder.mockcompiler/src/org/eclipse/jdt/core/tests/builder/mockcompiler/MockCompilerFactory.java
@@ -17,6 +17,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Consumer;
 import org.eclipse.jdt.core.compiler.CategorizedProblem;
+import org.eclipse.jdt.core.compiler.CompilationProgress;
 import org.eclipse.jdt.internal.compiler.CompilationResult;
 import org.eclipse.jdt.internal.compiler.Compiler;
 import org.eclipse.jdt.internal.compiler.CompilerConfiguration;
@@ -34,7 +35,7 @@ public class MockCompilerFactory implements ICompilerFactory {
 
 	@Override
 	public Compiler newCompiler(INameEnvironment environment, IErrorHandlingPolicy policy,
-			CompilerConfiguration compilerConfig, ICompilerRequestor requestor, IProblemFactory problemFactory) {
+			CompilerConfiguration compilerConfig, ICompilerRequestor requestor, IProblemFactory problemFactory, CompilationProgress progress) {
 		Compiler compiler = new MockCompiler(environment, policy, compilerConfig, requestor, problemFactory);
 		for (Consumer<Compiler> listener : listeners) {
 			listener.accept(compiler);

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/compiler/DefaultCompilerFactory.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/compiler/DefaultCompilerFactory.java
@@ -13,14 +13,16 @@
 
 package org.eclipse.jdt.internal.compiler;
 
+import org.eclipse.jdt.core.compiler.CompilationProgress;
 import org.eclipse.jdt.internal.compiler.env.INameEnvironment;
 
 public class DefaultCompilerFactory implements ICompilerFactory {
 
 	@Override
 	public Compiler newCompiler(INameEnvironment environment, IErrorHandlingPolicy policy,
-			CompilerConfiguration compilerConfig, ICompilerRequestor requestor, IProblemFactory problemFactory) {
-		return new Compiler(environment, policy, compilerConfig.compilerOptions(),
-				requestor, problemFactory);
+			CompilerConfiguration compilerConfig, ICompilerRequestor requestor, IProblemFactory problemFactory,
+			CompilationProgress compilationProgress) {
+		return new Compiler(environment, policy, compilerConfig.compilerOptions(), requestor, problemFactory,
+				null /* printwriter */, compilationProgress);
 	}
 }

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/compiler/ICompilerFactory.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/compiler/ICompilerFactory.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.jdt.internal.compiler;
 
+import org.eclipse.jdt.core.compiler.CompilationProgress;
 import org.eclipse.jdt.internal.compiler.env.INameEnvironment;
 
 /**
@@ -28,11 +29,15 @@ public interface ICompilerFactory {
 	 * @param compilerConfig - the configuration to control the compiler behavior
 	 * @param requestor - the requestor to receive and persist compilation results
 	 * @param problemFactory - the factory to create problem descriptors
+	 * @param compilationProgress - the CompilationProgress to be used
 	 * @return the new compiler instance
+	 * @see CompilationProgress
 	 */
-	public Compiler newCompiler(final INameEnvironment environment,
-			final IErrorHandlingPolicy policy,
-			final CompilerConfiguration compilerConfig,
-			final ICompilerRequestor requestor,
-			final IProblemFactory problemFactory);
+	public Compiler newCompiler(INameEnvironment environment,
+			IErrorHandlingPolicy policy,
+			CompilerConfiguration compilerConfig,
+			ICompilerRequestor requestor,
+			IProblemFactory problemFactory,
+			CompilationProgress compilationProgress
+			);
 }

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/AbstractImageBuilder.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/AbstractImageBuilder.java
@@ -48,6 +48,7 @@ import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.compiler.CategorizedProblem;
 import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.core.compiler.CompilationParticipant;
+import org.eclipse.jdt.core.compiler.CompilationProgress;
 import org.eclipse.jdt.core.compiler.IProblem;
 import org.eclipse.jdt.internal.compiler.AbstractAnnotationProcessorManager;
 import org.eclipse.jdt.internal.compiler.ClassFile;
@@ -621,13 +622,37 @@ protected Compiler newCompiler() {
 	if (compilerFactory == null) {
 		compilerFactory = new DefaultCompilerFactory();
 	}
+	CompilationProgress compilationProgress= new CompilationProgress() {
 
-	Compiler newCompiler = compilerFactory.newCompiler(
-			this.nameEnvironment,
-			DefaultErrorHandlingPolicies.proceedWithAllProblems(),
-			prepareCompilerConfiguration(compilerOptions),
-			this,
-			ProblemFactory.getProblemFactory(Locale.getDefault()));
+		@Override
+		public void begin(int remainingWork) {
+			// ignore
+		}
+
+		@Override
+		public void done() {
+			// ignore
+		}
+
+		@Override
+		public boolean isCanceled() {
+			return AbstractImageBuilder.this.notifier.cancelling;
+		}
+
+		@Override
+		public void setTaskName(String name) {
+			AbstractImageBuilder.this.notifier.subTask(name);
+		}
+
+		@Override
+		public void worked(int workIncrement, int remainingWork) {
+			// ignore
+		}
+
+	};
+	Compiler newCompiler = compilerFactory.newCompiler(this.nameEnvironment,
+			DefaultErrorHandlingPolicies.proceedWithAllProblems(), prepareCompilerConfiguration(compilerOptions), this,
+			ProblemFactory.getProblemFactory(Locale.getDefault()), compilationProgress);
 
 	CompilerOptions options = newCompiler.options;
 	// temporary code to allow the compiler to revert to a single thread

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/BuildNotifier.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/BuildNotifier.java
@@ -144,8 +144,7 @@ public void checkCancelWithinCompiler() throws AbortCompilation {
  * Notification while within a compile that a unit has finished being compiled.
  */
 public void compiled(SourceFile unit) {
-	String message = Messages.bind(Messages.build_compiling, unit.resource.getFullPath().removeLastSegments(1).makeRelative().toString());
-	subTask(message);
+	// no subTask message, as this would interfere with progress status from compiler
 	updateProgressDelta(this.progressPerCompilationUnit);
 	checkCancelWithinCompiler();
 }


### PR DESCRIPTION
- Allows compiler implementations to check for cancel and to report progress.
- Implements progress report and explicit cancel check before progressing AnnotationProcessor

implements https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3370
![image](https://github.com/user-attachments/assets/9c062a53-8c32-400f-a3a8-68ee4237648d)
