### PR TITLE
Revert APT progress report - fixes #3718

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/AbstractImageBuilder.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/AbstractImageBuilder.java
@@ -641,7 +641,11 @@ protected Compiler newCompiler() {
 
 		@Override
 		public void setTaskName(String name) {
-			AbstractImageBuilder.this.notifier.subTask(name);
+			// ignore
+
+			// idea was to use
+			// AbstractImageBuilder.this.notifier.subTask(name);
+			// but that only works in SWT thread while compile can run in any thread.
 		}
 
 		@Override

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/BuildNotifier.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/BuildNotifier.java
@@ -144,7 +144,8 @@ public void checkCancelWithinCompiler() throws AbortCompilation {
  * Notification while within a compile that a unit has finished being compiled.
  */
 public void compiled(SourceFile unit) {
-	// no subTask message, as this would interfere with progress status from compiler
+	String message = Messages.bind(Messages.build_compiling, unit.resource.getFullPath().removeLastSegments(1).makeRelative().toString());
+	subTask(message);
 	updateProgressDelta(this.progressPerCompilationUnit);
 	checkCancelWithinCompiler();
 }


### PR DESCRIPTION
ProgressMonitor can only be called in SWT Thread.

partial revert of 20b7abdcb7df40ff172fcf799114eac502fc6e32 Keeping the CompilationProgress.isCanceled()

https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3718
