### PR TITLE
[23][Primitive type patterns] ECJ rejects boolean type pattern with default case

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/CaseStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/CaseStatement.java
@@ -24,6 +24,7 @@ import org.eclipse.jdt.internal.compiler.codegen.BranchLabel;
 import org.eclipse.jdt.internal.compiler.codegen.CodeStream;
 import org.eclipse.jdt.internal.compiler.flow.FlowContext;
 import org.eclipse.jdt.internal.compiler.flow.FlowInfo;
+import org.eclipse.jdt.internal.compiler.impl.BooleanConstant;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jdt.internal.compiler.impl.Constant;
 import org.eclipse.jdt.internal.compiler.impl.IntConstant;
@@ -382,5 +383,15 @@ public void traverse(ASTVisitor visitor, 	BlockScope blockScope) {
 			e.traverse(visitor, blockScope);
 	}
 	visitor.endVisit(this, blockScope);
+}
+
+public Boolean getBooleanConstantValue() {
+	if (this.constantExpressions != null) {
+		for (Expression expression : this.constantExpressions) {
+			if (expression.constant instanceof BooleanConstant bc)
+				return bc.booleanValue();
+		}
+	}
+	return null;
 }
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
@@ -583,11 +583,17 @@ public class SwitchStatement extends Expression {
 			if (this.statements != null) {
 				preprocess(); // make a pass over the switch block and allocate vectors.
 				LocalVariableBinding[] patternVariables = NO_VARIABLES;
+				boolean trueSeen = false, falseSeen = false;
 				for (final Statement statement : this.statements) {
 					if (statement instanceof CaseStatement caseStatement) {
 						caseStatement.swich = this;
 						caseStatement.resolve(this.scope);
 						patternVariables = caseStatement.bindingsWhenTrue();
+						Boolean booleanConstant = caseStatement.getBooleanConstantValue();
+						if (booleanConstant == Boolean.TRUE)
+							trueSeen = true;
+						else if (booleanConstant == Boolean.FALSE)
+							falseSeen = true;
 					} else {
 						statement.resolveWithBindings(patternVariables, this.scope);
 						patternVariables = LocalVariableBinding.merge(patternVariables, statement.bindingsWhenComplete());
@@ -595,7 +601,7 @@ public class SwitchStatement extends Expression {
 				}
 				if (expressionType != null
 						&& (expressionType.id == TypeIds.T_boolean || expressionType.id == TypeIds.T_JavaLangBoolean)
-						&& this.defaultCase != null  && isExhaustive()) {
+						&& this.defaultCase != null  && trueSeen && falseSeen) {
 					upperScope.problemReporter().caseDefaultPlusTrueAndFalse(this);
 				}
 				if (this.labelExpressions.length != this.labelExpressionIndex)


### PR DESCRIPTION
+ explicitly detect 'true' and 'false' constants

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3128
