### PR TITLE
[23][Primitive type patterns] ECJ rejects boolean type pattern with default case

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PrimitiveInPatternsTestSH.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PrimitiveInPatternsTestSH.java
@@ -2665,6 +2665,25 @@ public class PrimitiveInPatternsTestSH extends AbstractRegressionTest9 {
 		runner.expectedOutputString = "1";
 		runner.runConformTest();
 	}
+	public void testGH3128() {
+		runConformTest(new String[] {
+				"X.java",
+				"""
+				class X {
+					public void foo(Boolean boxed) {
+						switch (boxed) {
+							case boolean b -> { System.out.print(b); }
+							default -> {}
+						}
+					}
+					public static void main(String... args) {
+						new X().foo(true);
+					}
+				}
+				"""
+			},
+			"true");
+	}
 	public void testJDK8348901() {
 		// according to https://bugs.openjdk.org/browse/JDK-8348901 the null type is to be admitted when case null is present
 		runConformTest(new String[] {


### PR DESCRIPTION
Testcase

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3128
