### PR TITLE
The method public static KeySetView<K,java.lang.Boolean> newKeySet() is wrongly tagged as containing missing types

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/core/compiler/IProblem.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/core/compiler/IProblem.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -2777,4 +2777,7 @@ void setSourceStart(int sourceStart);
 	 * @noreference preview feature
 	 */
 	int DefaultTrueAndFalseCases = PreviewRelated + 2102;
+
+	/** @since 3.41 */
+	int MissingTypeForInference = Internal + 2103;
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ConstraintExceptionFormula.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ConstraintExceptionFormula.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2015 GK Software AG.
+ * Copyright (c) 2013, 2025 GK Software AG.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -44,7 +44,7 @@ public class ConstraintExceptionFormula extends ConstraintFormula {
 	@Override
 	public Object reduce(InferenceContext18 inferenceContext) {
 		if ((this.right.tagBits & TagBits.HasMissingType) != 0) {
-			inferenceContext.hasIgnoredMissingType = true;
+			inferenceContext.missingType = this.right;
 			return TRUE;
 		}
 		// JLS 18.2.5

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ConstraintExpressionFormula.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ConstraintExpressionFormula.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2022 GK Software AG.
+ * Copyright (c) 2013, 2025 GK Software AG.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -50,7 +50,7 @@ class ConstraintExpressionFormula extends ConstraintFormula {
 	@Override
 	public Object reduce(InferenceContext18 inferenceContext) throws InferenceFailureException {
 		if ((this.right.tagBits & TagBits.HasMissingType) != 0) {
-			inferenceContext.hasIgnoredMissingType = true;
+			inferenceContext.missingType = this.right;
 			return TRUE;
 		}
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ConstraintTypeFormula.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ConstraintTypeFormula.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2018 GK Software AG, and others
+ * Copyright (c) 2013, 2025 GK Software AG, and others
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -62,8 +62,12 @@ class ConstraintTypeFormula extends ConstraintFormula {
 	// return: ReductionResult or ConstraintFormula[]
 	@Override
 	public Object reduce(InferenceContext18 inferenceContext) {
-		if ((this.left.tagBits & TagBits.HasMissingType) != 0 || (this.right.tagBits & TagBits.HasMissingType) != 0) {
-			inferenceContext.hasIgnoredMissingType = true;
+		if ((this.left.tagBits & TagBits.HasMissingType) != 0) {
+			inferenceContext.missingType = this.left;
+			return TRUE;
+		}
+		if ((this.right.tagBits & TagBits.HasMissingType) != 0) {
+			inferenceContext.missingType = this.right;
 			return TRUE;
 		}
 		switch (this.relation) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2022 GK Software AG, and others.
+ * Copyright (c) 2013, 2025 GK Software AG, and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -161,7 +161,7 @@ public class InferenceContext18 {
 	private boolean isInexactVarargsInference = false;
 	boolean prematureOverloadResolution = false;
 	// during reduction we ignore missing types but record that fact here:
-	boolean hasIgnoredMissingType;
+	TypeBinding missingType;
 
 	public static boolean isSameSite(InvocationSite site1, InvocationSite site2) {
 		if (site1 == site2)

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedGenericMethodBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedGenericMethodBinding.java
@@ -307,7 +307,10 @@ public class ParameterizedGenericMethodBinding extends ParameterizedMethodBindin
 					if (invocationSite instanceof Invocation && allArgumentsAreProper && (expectedType == null || expectedType.isProperType(true)))
 						infCtx18.forwardResults(result, (Invocation) invocationSite, methodSubstitute, expectedType);
 					try {
-						if (infCtx18.hasIgnoredMissingType) {
+						if (infCtx18.hasIgnoredMissingType
+								&& (expectedType == null
+									|| (expectedType.tagBits & TagBits.HasMissingType) == 0)) // don't blame the method, when it's the expected type having problems
+						{
 							return new ProblemMethodBinding(originalMethod, originalMethod.selector, parameters, ProblemReasons.MissingTypeInSignature);
 						}
 						if (hasReturnProblem) { // illegally working from the provisional result?

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedGenericMethodBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedGenericMethodBinding.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -307,11 +307,12 @@ public class ParameterizedGenericMethodBinding extends ParameterizedMethodBindin
 					if (invocationSite instanceof Invocation && allArgumentsAreProper && (expectedType == null || expectedType.isProperType(true)))
 						infCtx18.forwardResults(result, (Invocation) invocationSite, methodSubstitute, expectedType);
 					try {
-						if (infCtx18.hasIgnoredMissingType
+						if (infCtx18.missingType != null
 								&& (expectedType == null
-									|| (expectedType.tagBits & TagBits.HasMissingType) == 0)) // don't blame the method, when it's the expected type having problems
-						{
-							return new ProblemMethodBinding(originalMethod, originalMethod.selector, parameters, ProblemReasons.MissingTypeInSignature);
+									|| (expectedType.tagBits & TagBits.HasMissingType) == 0)) { // here the context will have reported an error already, so keep quiet
+							ProblemMethodBinding problemMethod = new ProblemMethodBinding(originalMethod, originalMethod.selector, parameters, ProblemReasons.MissingTypeInSignature);
+							problemMethod.missingType = infCtx18.missingType;
+							return problemMethod;
 						}
 						if (hasReturnProblem) { // illegally working from the provisional result?
 							MethodBinding problemMethod = infCtx18.getReturnProblemMethodIfNeeded(expectedType, methodSubstitute);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ProblemMethodBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ProblemMethodBinding.java
@@ -16,11 +16,14 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.compiler.lookup;
 
+import java.util.List;
+
 public class ProblemMethodBinding extends MethodBinding {
 
 	private final int problemReason;
 	public MethodBinding closestMatch; // TODO (philippe) should rename into #alternateMatch
 	public InferenceContext18 inferenceContext; // inference context may help to coordinate error reporting
+	public TypeBinding missingType;
 
 public ProblemMethodBinding(char[] selector, TypeBinding[] args, int problemReason) {
 	this.selector = selector;
@@ -95,5 +98,11 @@ public boolean isParameterizedGeneric() {
 @Override
 public final int problemId() {
 	return this.problemReason;
+}
+@Override
+public List<TypeBinding> collectMissingTypes(List<TypeBinding> missingTypes, boolean considerReturnType) {
+	if (this.closestMatch != null)
+		return this.closestMatch.collectMissingTypes(missingTypes, considerReturnType);
+	return super.collectMissingTypes(missingTypes, considerReturnType);
 }
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
@@ -6921,7 +6921,7 @@ public void missingSynchronizedOnInheritedMethod(MethodBinding currentMethod, Me
 public void missingTypeInConstructor(ASTNode location, MethodBinding constructor) {
 	List<TypeBinding> missingTypes = constructor.collectMissingTypes(null, true);
 	if (missingTypes == null) {
-		System.err.println("The constructor " + constructor + " is wrongly tagged as containing missing types"); //$NON-NLS-1$ //$NON-NLS-2$
+		assert false : "The constructor " + constructor + " is wrongly tagged as containing missing types"; //$NON-NLS-1$ //$NON-NLS-2$
 		return;
 	}
 	TypeBinding missingType = missingTypes.get(0);
@@ -6954,7 +6954,7 @@ public void missingTypeInLambda(LambdaExpression lambda, MethodBinding method) {
 	int nameSourceEnd = lambda.diagnosticsSourceEnd();
 	List<TypeBinding> missingTypes = method.collectMissingTypes(null, true);
 	if (missingTypes == null) {
-		System.err.println("The lambda expression " + method + " is wrongly tagged as containing missing types"); //$NON-NLS-1$ //$NON-NLS-2$
+		assert false : "The lambda expression " + method + " is wrongly tagged as containing missing types"; //$NON-NLS-1$ //$NON-NLS-2$
 		return;
 	}
 	TypeBinding missingType = missingTypes.get(0);
@@ -6981,7 +6981,7 @@ public void missingTypeInMethod(ASTNode astNode, MethodBinding method) {
 	}
 	List<TypeBinding> missingTypes = method.collectMissingTypes(null, true);
 	if (missingTypes == null) {
-		System.err.println("The method " + method + " is wrongly tagged as containing missing types"); //$NON-NLS-1$ //$NON-NLS-2$
+		assert false : "The method " + method + " is wrongly tagged as containing missing types"; //$NON-NLS-1$ //$NON-NLS-2$
 		return;
 	}
 	TypeBinding missingType = missingTypes.get(0);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/messages.properties
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/messages.properties
@@ -1208,6 +1208,8 @@
 2101 = Case constant of type {0} is incompatible with switch selector type {1}
 2102 = Switch cannot have both boolean values and a default label
 
+2103 = Inference for this invocation of method {1}({2}) from the type {0} refers to the missing type {3}
+
 ### ELABORATIONS
 ## Access restrictions
 78592 = The type ''{1}'' is not API (restriction on classpath entry ''{0}'')

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/CompilerInvocationTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/CompilerInvocationTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2024 IBM Corporation and others.
+ * Copyright (c) 2006, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -847,6 +847,7 @@ public void test011_problem_categories() {
 		expectedProblemAttributes.put("MissingSynchronizedModifierInInheritedMethod", new ProblemAttributes(CategorizedProblem.CAT_POTENTIAL_PROGRAMMING_PROBLEM));
 		expectedProblemAttributes.put("MissingTypeInConstructor", new ProblemAttributes(CategorizedProblem.CAT_MEMBER));
 		expectedProblemAttributes.put("MissingTypeInLambda", new ProblemAttributes(CategorizedProblem.CAT_MEMBER));
+		expectedProblemAttributes.put("MissingTypeForInference", new ProblemAttributes(CategorizedProblem.CAT_INTERNAL));
 		expectedProblemAttributes.put("UnterminatedTextBlock", new ProblemAttributes(CategorizedProblem.CAT_PREVIEW_RELATED));
 		expectedProblemAttributes.put("MissingTypeInMethod", new ProblemAttributes(CategorizedProblem.CAT_MEMBER));
 		expectedProblemAttributes.put("MissingValueForAnnotationMember", new ProblemAttributes(CategorizedProblem.CAT_TYPE));
@@ -1989,6 +1990,7 @@ public void test012_compiler_problems_tuning() {
 		expectedProblemAttributes.put("MissingTypeInLambda", SKIP);
 		expectedProblemAttributes.put("UnterminatedTextBlock", SKIP);
 		expectedProblemAttributes.put("MissingTypeInMethod", SKIP);
+		expectedProblemAttributes.put("MissingTypeForInference", SKIP);
 		expectedProblemAttributes.put("MissingValueForAnnotationMember", SKIP);
 		expectedProblemAttributes.put("MissingValueFromLambda", SKIP);
 		expectedProblemAttributes.put("ModuleNotRead", SKIP);

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2021 IBM Corporation.
+ * Copyright (c) 2016, 2025 IBM Corporation.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -1024,6 +1024,30 @@ public void testGH2817() {
 			"""
 		};
 	runner.runConformTest();
+}
+public void testGH3501() {
+	Runner runner = new Runner();
+	runner.testFiles = new String[] {
+			"X.java",
+			"""
+			import java.util.Collections;
+			public class X {
+				void test() {
+					Zork v = Collections.singleton("1");
+				}
+			}
+			"""
+		};
+	runner.expectedCompilerLog =
+			"""
+			----------
+			1. ERROR in X.java (at line 4)
+				Zork v = Collections.singleton("1");
+				^^^^
+			Zork cannot be resolved to a type
+			----------
+			""";
+	runner.runNegativeTest();
 }
 public static Class<GenericsRegressionTest_9> testClass() {
 	return GenericsRegressionTest_9.class;

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NegativeLambdaExpressionsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NegativeLambdaExpressionsTest.java
@@ -4995,6 +4995,40 @@ this.runNegativeTest(
 				"The type of foo() from the type X is Zork, this is incompatible with the descriptor\'s return type: int[]\n" +
 				"----------\n");
 }
+// reference to missing type occurs during type inference involving a reference expression:
+public void testGH3501() {
+	runNegativeTest(new String[] {
+			"X.java",
+			"""
+			interface I<T> { void doit(T t); }
+			public class X {
+				void foo(Zork z) { }
+				<U> void acceptI(I<U> i) { }
+				void test() {
+					acceptI(this::foo);
+				}
+			}
+			"""
+		},
+		"""
+		----------
+		1. ERROR in X.java (at line 3)
+			void foo(Zork z) { }
+			         ^^^^
+		Zork cannot be resolved to a type
+		----------
+		2. ERROR in X.java (at line 6)
+			acceptI(this::foo);
+			^^^^^^^
+		Inference for this invocation of method acceptI(I<U>) from the type X refers to the missing type Zork
+		----------
+		3. ERROR in X.java (at line 6)
+			acceptI(this::foo);
+			        ^^^^^^^^^
+		The type X does not define foo(U) that is applicable here
+		----------
+		""");
+}
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=401610, [1.8][compiler] Allow lambda/reference expressions in non-overloaded method invocation contexts
 public void test401610() {
 this.runConformTest(
@@ -6584,9 +6618,9 @@ public void test406588() {
 				"}\n"
 			},
 			"----------\n" +
-			"1. ERROR in X.java (at line 10)\n" + 
-			"	this(Z::new);\n" + 
-			"	     ^^^^^^\n" + 
+			"1. ERROR in X.java (at line 10)\n" +
+			"	this(Z::new);\n" +
+			"	     ^^^^^^\n" +
 			"No enclosing instance of type X.Y is available due to some intermediate constructor invocation\n" +
 			"----------\n");
 }


### PR DESCRIPTION
Avoid tagging the method, when the target type has a missing type

Tentatively turn the syserrs into assert false : "message"

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3501
