### PR TITLE
[24] Local instantiation in static context allowed by ECJ

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ExplicitConstructorCall.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ExplicitConstructorCall.java
@@ -378,6 +378,14 @@ public class ExplicitConstructorCall extends Statement implements Invocation {
 						&& receiverType.erasure().id == TypeIds.T_JavaLangEnum) {
 					scope.problemReporter().cannotInvokeSuperConstructorInEnum(this, methodScope.referenceMethod().binding);
 				}
+				if (!receiverType.isEnum() &&
+						this.accessMode <= ExplicitConstructorCall.Super &&
+						receiverType instanceof LocalTypeBinding local) {
+					MethodScope allocationStaticEnclosing = scope.parent.nearestEnclosingStaticScope(); // Constructor scope already has static, start from parent scope
+					MethodScope typesEnclosingStaticScope = local.scope.nearestEnclosingStaticScope();
+					if (allocationStaticEnclosing != null && typesEnclosingStaticScope != null && allocationStaticEnclosing != typesEnclosingStaticScope)
+						scope.problemReporter().allocationInStaticContext(this, local);
+				}
 				// qualification should be from the type of the enclosingType
 				if (this.qualification != null) {
 					if (this.accessMode != ExplicitConstructorCall.Super) {


### PR DESCRIPTION
Similar checks and reporting should be done in ExplicitConstructorCall as well.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
Fixes more scenarios of #3687

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
