### PR TITLE
[23] Flow analysis fails to recognize initialization in an instance initializer block

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ExplicitConstructorCall.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ExplicitConstructorCall.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -7,6 +7,10 @@
  * https://www.eclipse.org/legal/epl-2.0/
  *
  * SPDX-License-Identifier: EPL-2.0
+ *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
@@ -42,6 +46,7 @@ import org.eclipse.jdt.internal.compiler.codegen.CodeStream;
 import org.eclipse.jdt.internal.compiler.codegen.Opcodes;
 import org.eclipse.jdt.internal.compiler.flow.FlowContext;
 import org.eclipse.jdt.internal.compiler.flow.FlowInfo;
+import org.eclipse.jdt.internal.compiler.impl.Constant;
 import org.eclipse.jdt.internal.compiler.impl.JavaFeature;
 import org.eclipse.jdt.internal.compiler.lookup.*;
 
@@ -122,6 +127,20 @@ public class ExplicitConstructorCall extends Statement implements Invocation {
 			((MethodScope) currentScope).isConstructorCall = false;
 			currentScope.leaveEarlyConstructionContext();
 		}
+	}
+
+	public boolean hasArgumentNeedingAnalysis() {
+		if (this.arguments != null) {
+			for (Expression arg : this.arguments) {
+				if (arg.constant != Constant.NotAConstant)
+					continue;
+				if (arg instanceof SingleNameReference ref
+						&& ref.binding != null && ref.binding.isParameter())
+					continue;
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SuperAfterStatementsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SuperAfterStatementsTest.java
@@ -3137,4 +3137,87 @@ public class SuperAfterStatementsTest extends AbstractRegressionTest9 {
 		},
 		"1");
 	}
+
+	public void testGH3748a() {
+		runNegativeTest(new String[] {
+				"X.java",
+				"""
+				public class X {
+					final int fin1, fin2;
+					{
+						fin1 = 0;
+						fin2 = 1;
+					}
+					X() {
+						int abc = 0; // Commenting out this line brings out the error
+						this(fin1 = 10);
+						fin2 = 11;
+					}
+					X(int x) {}
+				}
+				"""
+			},
+			"""
+			----------
+			1. ERROR in X.java (at line 4)
+				fin1 = 0;
+				^^^^
+			The final field fin1 may already have been assigned
+			----------
+			2. WARNING in X.java (at line 9)
+				this(fin1 = 10);
+				^^^^^^^^^^^^^^^^
+			You are using a preview language feature that may or may not be supported in a future release
+			----------
+			3. WARNING in X.java (at line 9)
+				this(fin1 = 10);
+				     ^^^^
+			You are using a preview language feature that may or may not be supported in a future release
+			----------
+			4. ERROR in X.java (at line 10)
+				fin2 = 11;
+				^^^^
+			The final field fin2 may already have been assigned
+			----------
+			""");
+	}
+
+	public void testGH3748b() {
+		runNegativeTest(new String[] {
+				"X.java",
+				"""
+				public class X {
+					final int fin1;
+					final int fin2;
+					{
+						fin1 = 0;
+						fin2 = 1;
+					}
+					X() {
+						this(fin1 = 10);
+						fin2 = 11;
+					}
+					X(int x) {}
+				}
+				"""
+			},
+			"""
+			----------
+			1. ERROR in X.java (at line 5)
+				fin1 = 0;
+				^^^^
+			The final field fin1 may already have been assigned
+			----------
+			2. WARNING in X.java (at line 9)
+				this(fin1 = 10);
+				     ^^^^
+			You are using a preview language feature that may or may not be supported in a future release
+			----------
+			3. ERROR in X.java (at line 10)
+				fin2 = 11;
+				^^^^
+			The final field fin2 may already have been assigned
+			----------
+			""");
+	}
 }


### PR DESCRIPTION
+ arguments to explicit constructor call are prologue
  - if they are relevant don't skip prologue analysis
+ fine tune creation and usage of flow prologueInfo

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3748

