### PR TITLE
[24] ECJ allows local enclosing instance before invocation of super()

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BlockScope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BlockScope.java
@@ -877,7 +877,8 @@ public Object[] getEmulationPath(ReferenceBinding targetEnclosingType, boolean o
 	SourceTypeBinding sourceType = currentMethodScope.enclosingSourceType();
 
 	// use 'this' if possible
-	if (!currentMethodScope.isStatic && !currentMethodScope.isConstructorCall) {
+	if (!currentMethodScope.isStatic && !currentMethodScope.isConstructorCall
+			&& !isInsideEarlyConstructionContext(targetEnclosingType, true)) {
 		if (TypeBinding.equalsEquals(sourceType, targetEnclosingType) || (!onlyExactMatch && sourceType.findSuperTypeOriginatingFrom(targetEnclosingType) != null)) {
 			return BlockScope.EmulationPathToImplicitThis; // implicit this is good enough
 		}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
@@ -7375,12 +7375,18 @@ public void noSuchEnclosingInstance(TypeBinding targetType, ASTNode location, bo
 		id = IProblem.IncorrectEnclosingInstanceReference;
 	}
 
+	int end = location.sourceEnd;
+	if (location instanceof LambdaExpression lambda)
+		end = lambda.diagnosticsSourceEnd();
+	else if (location instanceof QualifiedAllocationExpression qae && qae.anonymousType != null)
+		end = qae.anonymousType.sourceEnd;
+
 	this.handle(
 		id,
 		new String[] { new String(targetType.readableName())},
 		new String[] { new String(targetType.shortReadableName())},
 		location.sourceStart,
-		location instanceof LambdaExpression ? ((LambdaExpression)location).diagnosticsSourceEnd() : location.sourceEnd);
+		end);
 }
 public void notCompatibleTypesError(ASTNode location, TypeBinding leftType, TypeBinding rightType) {
 	String leftName = new String(leftType.readableName());

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/InnerEmulationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/InnerEmulationTest.java
@@ -1456,7 +1456,7 @@ public void test033() {
 			"----------\n" +
 			"1. ERROR in p1\\A2.java (at line 20)\n" +
 			"	(new D.E(null, null, null, new F(get()) {}) {}).execute();	\n" +
-			"	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
+			"	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
 			"No enclosing instance of type D is accessible. Must qualify the allocation with an enclosing instance of type D (e.g. x.new A() where x is an instance of D).\n" +
 			"----------\n"
 			:
@@ -1468,7 +1468,7 @@ public void test033() {
 			"----------\n" +
 			"2. ERROR in p1\\A2.java (at line 20)\n" +
 			"	(new D.E(null, null, null, new F(get()) {}) {}).execute();	\n" +
-			"	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
+			"	^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
 			"No enclosing instance of type D is accessible. Must qualify the allocation with an enclosing instance of type D (e.g. x.new A() where x is an instance of D).\n" +
 			"----------\n";
 	this.runNegativeTest(
@@ -2264,7 +2264,7 @@ public void test056() {
 		"----------\n" +
 		"1. ERROR in p1\\X.java (at line 9)\n" +
 		"	new L1.LM1(){};	//ko\n" +
-		"	^^^^^^^^^^^^^^\n" +
+		"	^^^^^^^^^^^^\n" +
 		"No enclosing instance of type L1 is accessible. Must qualify the allocation with an enclosing instance of type L1 (e.g. x.new A() where x is an instance of L1).\n" +
 		"----------\n"
 	);

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SuperAfterStatementsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SuperAfterStatementsTest.java
@@ -3323,4 +3323,45 @@ public class SuperAfterStatementsTest extends AbstractRegressionTest9 {
 				"Cannot instantiate local class \'SuperClass\' in a static context\n" +
 				"----------\n");
 	}
+	public void testGH3753() {
+		runNegativeTest(new String[] {
+				"X.java",
+				"""
+				public class X {
+					static int value = 0;
+					public static void main(String[] argv) {
+						class Local {
+							class Inner {}
+							Local(int a) {
+								X.value = new Inner() { // This is reported by Javac
+									public int foo() {
+										return 1;
+									}
+								}.foo();
+								super();
+							}
+						}
+					}
+				}
+				"""
+		},
+		"""
+		----------
+		1. WARNING in X.java (at line 4)
+			class Local {
+			      ^^^^^
+		The type Local is never used locally
+		----------
+		2. ERROR in X.java (at line 7)
+			X.value = new Inner() { // This is reported by Javac
+			          ^^^^^^^^^^^
+		No enclosing instance of type Local is accessible. Must qualify the allocation with an enclosing instance of type Local (e.g. x.new A() where x is an instance of Local).
+		----------
+		3. WARNING in X.java (at line 12)
+			super();
+			^^^^^^^^
+		You are using a preview language feature that may or may not be supported in a future release
+		----------
+		""");
+	}
 }


### PR DESCRIPTION
+ check for early construction context in one more location
+ improve location of error message (avoid marking an entire block)

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3753
