### PR TITLE
[23] Folding a markdown region hides the first line of subsequent Java

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Scanner.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Scanner.java
@@ -1946,6 +1946,7 @@ protected int getNextToken0() throws InvalidInputException {
 										}
 									}
 									if (!lineBeginsWithMarkdown()) {
+										this.currentPosition--;
 										break;
 									}
 								}
@@ -2842,6 +2843,7 @@ public final void jumpOverMethodBody() {
 										}
 									}
 									if (!lineBeginsWithMarkdown()) {
+										this.currentPosition--;
 										break;
 									}
 								}
@@ -2875,6 +2877,7 @@ public final void jumpOverMethodBody() {
 											}
 										}
 										if (!lineBeginsWithMarkdown()) {
+											this.currentPosition--;
 											break;
 										}
 									}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/MarkdownCommentsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/MarkdownCommentsTest.java
@@ -348,7 +348,7 @@ public class MarkdownCommentsTest extends JavadocTest {
 					"""
 					public class X {
 						/// Some text here without the necessary tags for main method
-						/// @param arguments
+						/// @param arguments\s 
 
 						// This line will be ignored and the previous block will be considered as the Javadoc
 						public static void main(String[] arguments) {
@@ -358,7 +358,7 @@ public class MarkdownCommentsTest extends JavadocTest {
 					""", },
 					"----------\n" +
 					"1. WARNING in X.java (at line 3)\n" +
-					"	/// @param arguments\n" +
+					"	/// @param arguments \n" +
 					"	           ^^^^^^^^^\n" +
 					"Javadoc: Description expected after this reference\n" +
 					"----------\n");


### PR DESCRIPTION
Reduced fix from PR 2943

Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1615
