### PR TITLE
[markdown doc] Wrong interpretation of array reference

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/AbstractCommentParser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/AbstractCommentParser.java
@@ -254,7 +254,7 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 					case '@' :
 						// Start tag parsing only if we are on line beginning or at inline tag beginning
 						// https://bugs.eclipse.org/bugs/show_bug.cgi?id=206345: ignore all tags when inside @literal or @code tags
-						if (considerTagAsPlainText || this.markdownHelper.isInCodeBlock()) {
+						if (considerTagAsPlainText || this.markdownHelper.isInCode()) {
 							// new tag found
 							if (!this.lineStarted) {
 								// we may want to report invalid syntax when no closing brace found,
@@ -462,7 +462,7 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 						// $FALL-THROUGH$ - fall through default case
 					default :
 						if (this.markdown) {
-							if (nextCharacter == '[') {
+							if (nextCharacter == '[' && !this.markdownHelper.isInCode()) {
 								if (this.textStart != -1) {
 									if (this.textStart < textEndPosition) {
 										pushText(this.textStart, textEndPosition);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/IMarkdownCommentHelper.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/IMarkdownCommentHelper.java
@@ -33,7 +33,7 @@ public interface IMarkdownCommentHelper {
 
 	void recordText();
 
-	boolean isInCodeBlock();
+	boolean isInCode();
 
 	/** Retrieve the start of the current text, possibly including significant leading whitespace. */
 	int getTextStart(int textStart);
@@ -76,7 +76,7 @@ class NullMarkdownHelper implements IMarkdownCommentHelper {
 		// nop
 	}
 	@Override
-	public boolean isInCodeBlock() {
+	public boolean isInCode() {
 		return false;
 	}
 	@Override
@@ -105,6 +105,7 @@ class MarkdownCommentHelper implements IMarkdownCommentHelper {
 	int fenceLength;
 	boolean isBlankLine = true;
 	boolean previousIsBlankLine = true;
+	boolean inInlineCode = false;
 
 	public MarkdownCommentHelper(int lineStart, int commonIndent) {
 		this.markdownLineStart = lineStart;
@@ -127,8 +128,11 @@ class MarkdownCommentHelper implements IMarkdownCommentHelper {
 			return;
 		}
 		if (this.fenceCharCount == 0) {
-			if (lineStarted)
+			if (lineStarted) {
+				if (next == '`')
+					this.inInlineCode ^= true;
 				return;
+			}
 			this.fenceChar = next;
 			this.fenceCharCount = 1;
 			return;
@@ -163,8 +167,8 @@ class MarkdownCommentHelper implements IMarkdownCommentHelper {
 	}
 
 	@Override
-	public boolean isInCodeBlock() {
-		return this.insideIndentedCodeBlock || this.insideFencedCodeBlock;
+	public boolean isInCode() {
+		return this.insideIndentedCodeBlock || this.insideFencedCodeBlock || this.inInlineCode;
 	}
 
 	@Override

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/RunConverterTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/RunConverterTests.java
@@ -67,7 +67,7 @@ public static Class[] getAllTestClasses() {
 		ASTConverterSuperAfterStatements.class,
 		ASTConverterEitherOrMultiPatternTest.class,
 		CompilationUnitResolverDiscoveryTest.class,
-		//ASTConverterMarkdownTest.class
+		ASTConverterMarkdownTest.class
 	};
 }
 public static Test suite() {


### PR DESCRIPTION
+ avoid creating links inside code (inline or block)
+ activate ASTConverterMarkdownTest
  + remove setting preview flag (which is now illegal at 23)

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3761

