### PR TITLE
Fix `CompletionTests.testBug343342`

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests.java
@@ -22242,7 +22242,7 @@ public void testBug343342() throws JavaModelException {
 	CompletionTestsRequestor2 requestor = new CompletionTestsRequestor2(true);
 	requestor.allowAllRequiredProposals();
 	String str = this.workingCopies[0].getSource();
-	String completeBehind = "case xy*/";
+	String completeBehind = "case xy";
 	int cursorLocation = str.lastIndexOf(completeBehind) + completeBehind.length();
 	this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner);
 	assertResults(


### PR DESCRIPTION
## What it does
Fixes #3781 by setting the proper completion location for `CompletionTests.testBug343342`.

## How to test
Debug the test suite. Confirm that the `cursorLocation` is at the right location (should be ~120) rather than at the beginning of the file.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
