### PR TITLE
Remove obsolete, disabled tests #2758

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericTypeTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericTypeTest.java
@@ -15327,52 +15327,6 @@ public class GenericTypeTest extends AbstractComparableTest {
 			"Zork cannot be resolved to a type\n" +
 			"----------\n");
 	}
-
-// https://bugs.eclipse.org/bugs/show_bug.cgi?id=84743 - variation in -source 1.4 mode but 1.5 compliance (ignore covariance)
-public void _2551_test0498(){
-	Map customOptions = getCompilerOptions();
-	customOptions.put(CompilerOptions.OPTION_Source, CompilerOptions.getFirstSupportedJavaVersion());
-	runNegativeTest(
-		// test directory preparation
-		true /* flush output directory */,
-		new String[] { /* test files */
-			"X.java",
-			"interface I {\n" +
-			"   String foo();\n" +
-			"}\n" +
-			"interface J {\n" +
-			"   Object foo();\n" +
-			"}\n" +
-			" \n" +
-			"public class X implements I {\n" +
-			"   public String foo() {\n" +
-			" 	return \"\";\n" +
-			"   }\n" +
-			"   public static void main(String[] args) {\n" +
-			"         I i = new X();\n" +
-			"         try {\n" +
-			"	        J j = (J) i;\n" +
-			"         } catch(ClassCastException e) {\n" +
-			"	        System.out.println(\"SUCCESS\");\n" +
-			"         }\n" +
-			"  }\n" +
-			"}\n"
-		},
-		// compiler options
-		null /* no class libraries */,
-		customOptions /* custom options */,
-		// compiler results
-		"----------\n" + /* expected compiler log */
-		"1. ERROR in X.java (at line 15)\n" +
-		"	J j = (J) i;\n" +
-		"	      ^^^^^\n" +
-		"Cannot cast from I to J\n" +
-		"----------\n",
-		// javac options
-		RUN_JAVAC ? /* javac test options */
-			new JavacTestOptions("-source " + CompilerOptions.getFirstSupportedJavaVersion()) :
-			JavacTestOptions.DEFAULT );
-}
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=85157
 public void test0499(){
 	this.runNegativeTest(
@@ -29209,32 +29163,6 @@ public void test0885() {
 		"	                                               ^^^^^^^^^^\n" +
 		"Cannot specify any additional bound Comparable<C> when first bound is a type parameter\n" +
 		"----------\n");
-}
-//https://bugs.eclipse.org/bugs/show_bug.cgi?id=124943
-public void _2551_test0886() {
-	Map customOptions= getCompilerOptions();
-	customOptions.put(CompilerOptions.OPTION_Source, CompilerOptions.getFirstSupportedJavaVersion());
-	runConformTest(
-		// test directory preparation
-		true /* flush output directory */,
-		new String[] { /* test files */
-			"X.java", // =================
-			"public class X {\n" +
-			"	void test() {\n" +
-			"		\"Hello\".compareTo((Object) \"Hello\");\n" +
-			"	}\n" +
-			"}\n" ,
-		},
-		// compiler options
-		null /* no class libraries */,
-		customOptions /* custom options */,
-		// compiler results
-		"" /* expected compiler log */,
-		// runtime results
-		"" /* expected output string */,
-		null /* do not check error string */,
-		// javac options
-		new JavacTestOptions("-source " + CompilerOptions.getFirstSupportedJavaVersion() + " -Xlint:-options") /* javac test options */);
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=122775
 public void test0887() {


### PR DESCRIPTION
## What it does
Remove two tests which are no longer relevant for ECJ's relevant target Java versions.

 * test0498 no longer valid, shown cast should be allowed
 * test0887 no longer valid test, String.compareTo(Object) axed in JDK 5

## How to test
Less is more...

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
