### PR TITLE
ecj-javac difference when var hits diamond with capture

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordPatternTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordPatternTest.java
@@ -28,7 +28,7 @@ public class RecordPatternTest extends AbstractRegressionTest9 {
 	static {
 //		TESTS_NUMBERS = new int [] { 40 };
 //		TESTS_RANGE = new int[] { 1, -1 };
-//		TESTS_NAMES = new String[] { "testRecPatExhaust018" };
+//		TESTS_NAMES = new String[] { "testRecPatTypeInfer_001" };
 	}
 	private String extraLibPath;
 	public static Class<?> testClass() {
@@ -4920,5 +4920,30 @@ public class RecordPatternTest extends AbstractRegressionTest9 {
 				"""
 			},
 			"012012345678");
+	}
+	public void testRecPatTypeInfer_001() {
+		runConformTest(new String[] {
+				"X.java",
+				"""
+				interface I<T> {}
+				record R<T>(T t) {}
+
+				public class X  {
+
+				    static <T> boolean foo(R<T> y) {
+				       if (y.t() instanceof R(var v)) {
+				            var t = new R<>(v);
+				            R<Object> r = t;
+				            return true;
+				        }
+				        return false;
+				    }
+				    public static void main(String argv[]) {
+				        System.out.println(foo(new R<R<Object>>(new R<>(new X()))));
+				    }
+				}
+				"""
+				},
+				"true");
 	}
 }


### PR DESCRIPTION
WIP - DRAFT

				interface I<T> {}
				record R<T>(T t) {}

				public class X  {

				    static <T> boolean foo(R<T> y) {
				       if (y.t() instanceof R(var v)) {
				            var t = new R<>(v);
				            R<Object> r = t; //error  shown [Type mismatch: cannot convert from R<capture#2-of ?> to R<Object>]
				            return true;
				        }
				        return false;
				    }
				    public static void main(String argv[]) {
				        System.out.println(foo(new R<R<Object>>(new R<>(new X()))));
				    }
				}

## What it does
Test case that shows difference between javac and ecj behaviour.  javac compiles and prints true while running while ecj gives the following error:
"Type mismatch: cannot convert from R<capture#2-of ?> to R<Object>"

## How to test
The code above is a reproducible testcase. Currently the fix is in the works. The patch contains the test case only as of now.

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
