### PR TITLE
Resolve symlinks in macOS tmp-directory for placeholders in tests.

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/util/Util.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/util/Util.java
@@ -149,6 +149,12 @@ public class Util {
         if (Character.isLowerCase(container.charAt(0)) && container.charAt(1) == ':') {
             container = Character.toUpperCase(container.charAt(0)) + container.substring(1);
         }
+
+        try {
+            container = Path.of(container).normalize().toRealPath().toString();
+        } catch (IOException e) {
+            throw new RuntimeException("output_directory container cannot resolve to real path: " + container);
+        }
         File dir = new File(new File(container), "comptest");
 
         // If root directory already exists, clean it


### PR DESCRIPTION
## What it does

On macOS, the path returned by `System.getProperty("java.io.tmpdir")` apparently involves symbolic links, which makes the string replacement for `---OUTPUT_DIR_PLACEHOLDER---` non-functional. This leads to confusing false positives for a number of test cases, if executed on macOS.

This has possibly been a problem since macOS Catalina (2019).

Example: `System.getProperty("java.io.tmpdir")` returned `/var/folders/cj/v4s2fp2n6rs6656g10yzc19c0000gn/T/`.
This represents a real path of `/private/var/folders/cj/v4s2fp2n6rs6656g10yzc19c0000gn/T`, which `EclipseFileManager` will resolve and is subsequently used in the output.

## How to test
Run a test like `BatchCompilerTest` on recent macOS. Without this patch, it will fail 158 tests. E.g. on `BatchCompilerTest.test008`, it will fail with comparison of the expected output:

```
----------\n
1. ERROR in ---OUTPUT_DIR_PLACEHOLDER---/X.java (at line 11)\n
	Zork z;\n
	^^^^\n
Zork cannot be resolved to a type\n
----------\n
1 problem (1 error)\n

```

which differs from the real output:

```
----------\n
1. ERROR in /private/var/folders/cj/v4s2fp2n6rs6656g10yzc19c0000gn/T/comptest/run.1742128243046/regression/X.java (at line 11)\n
	Zork z;\n
	^^^^\n
Zork cannot be resolved to a type\n
----------\n
1 problem (1 error)\n

```

The cause is that the real output prints a path which was canocalized in `org.eclipse.jdt.internal.compiler.batch.Main.getCompilationUnits()`, using `File.getCanonicalPath`, with no matching canocalization in the test harness. This is fixed by this PR.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
