### PR TITLE
Completion within markdown should escape array brackets #3773

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AbstractJavaModelCompletionTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AbstractJavaModelCompletionTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -37,6 +37,7 @@ public abstract class AbstractJavaModelCompletionTests extends AbstractJavaModel
 	public static List COMPLETION_SUITES = null;
 	protected static IJavaProject COMPLETION_PROJECT;
 	protected static class CompletionResult {
+		public String proposalDisplays;
 		public String proposals;
 		public String context;
 		public int cursorLocation;
@@ -108,6 +109,7 @@ protected CompletionResult complete(String path, String source, boolean showPosi
 
 	CompletionResult result =  new CompletionResult();
 	result.proposals = requestor.getResults();
+	result.proposalDisplays = requestor.getDisplayResults();
 	result.context = requestor.getContext();
 	result.cursorLocation = cursorLocation;
 	result.tokenStart = tokenStart;
@@ -149,6 +151,7 @@ protected CompletionResult contextComplete0(
 
 	CompletionResult result =  new CompletionResult();
 	result.proposals = requestor.getResults();
+	result.proposalDisplays = requestor.getDisplayResults();
 	result.context = requestor.getContext();
 	result.cursorLocation = cursorLocation;
 	return result;
@@ -164,6 +167,7 @@ protected CompletionResult snippetContextComplete(
 
 	CompletionResult result =  new CompletionResult();
 	result.proposals = requestor.getResults();
+	result.proposalDisplays = requestor.getDisplayResults();
 	result.context = requestor.getContext();
 	result.cursorLocation = cursorLocation;
 	return result;

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavadocCompletionContextTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavadocCompletionContextTests.java
@@ -1643,10 +1643,9 @@ public void test0056() throws JavaModelException {
 		result.context);
 }
 public void test0057() throws JavaModelException {
-	String preview = COMPLETION_PROJECT.getOption(CompilerOptions.OPTION_EnablePreviews, false);
+	String source = COMPLETION_PROJECT.getOption(CompilerOptions.OPTION_Source, false);
 	try {
 		COMPLETION_PROJECT.setOption(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_24);
-		COMPLETION_PROJECT.setOption(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.ENABLED);
 
 		this.workingCopies = new ICompilationUnit[1];
 		this.workingCopies[0] = getWorkingCopy(
@@ -1668,8 +1667,7 @@ public void test0057() throws JavaModelException {
 				"main[METHOD_REF]{main(String\\[\\]), Ltest0057.X;, ([Ljava.lang.String;)V, main, (args), 49}",
 					result.proposals);
 	} finally {
-		COMPLETION_PROJECT.setOption(CompilerOptions.OPTION_Source, CompilerOptions.getFirstSupportedJavaVersion());
-		COMPLETION_PROJECT.setOption(CompilerOptions.OPTION_EnablePreviews, preview);
+		COMPLETION_PROJECT.setOption(CompilerOptions.OPTION_Source, source);
 	}
 }
 public void test0058() throws JavaModelException {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavadocCompletionContextTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavadocCompletionContextTests.java
@@ -1664,6 +1664,9 @@ public void test0057() throws JavaModelException {
 
 		CompletionResult result = contextComplete(this.workingCopies[0], cursorLocation);
 		assertResults(
+				"main[METHOD_REF]{main(String[]), Ltest0057.X;, ([Ljava.lang.String;)V, main, (args), 49}",
+					result.proposalDisplays);
+		assertResults(
 				"main[METHOD_REF]{main(String\\[\\]), Ltest0057.X;, ([Ljava.lang.String;)V, main, (args), 49}",
 					result.proposals);
 	} finally {
@@ -1671,10 +1674,9 @@ public void test0057() throws JavaModelException {
 	}
 }
 public void test0058() throws JavaModelException {
-	String preview = COMPLETION_PROJECT.getOption(CompilerOptions.OPTION_EnablePreviews, false);
+	String source = COMPLETION_PROJECT.getOption(CompilerOptions.OPTION_Source, false);
 	try {
 		COMPLETION_PROJECT.setOption(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_24);
-		COMPLETION_PROJECT.setOption(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.ENABLED);
 
 		this.workingCopies = new ICompilationUnit[1];
 		this.workingCopies[0] = getWorkingCopy(
@@ -1694,10 +1696,12 @@ public void test0058() throws JavaModelException {
 		CompletionResult result = contextComplete(this.workingCopies[0], cursorLocation);
 		assertResults(
 				"main[JAVADOC_METHOD_REF]{{@link #main(String[])}, Ltest0057.X;, ([Ljava.lang.String;)V, main, (args), 80}",
+					result.proposalDisplays);
+		assertResults(
+				"main[JAVADOC_METHOD_REF]{{@link #main(String[])}, Ltest0057.X;, ([Ljava.lang.String;)V, main, (args), 80}",
 					result.proposals);
 	} finally {
-		COMPLETION_PROJECT.setOption(CompilerOptions.OPTION_Source, CompilerOptions.getFirstSupportedJavaVersion());
-		COMPLETION_PROJECT.setOption(CompilerOptions.OPTION_EnablePreviews, preview);
+		COMPLETION_PROJECT.setOption(CompilerOptions.OPTION_Source, source);
 	}
 }
 }

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavadocCompletionContextTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavadocCompletionContextTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2009 IBM Corporation and others.
+ * Copyright (c) 2005, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -20,6 +20,9 @@ import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 
 public class JavadocCompletionContextTests extends AbstractJavaModelCompletionTests {
 
+	static {
+		//TESTS_NAMES = new String[] {"test0058", "test0057"};
+	}
 public JavadocCompletionContextTests(String name) {
 	super(name);
 }
@@ -1638,5 +1641,65 @@ public void test0056() throws JavaModelException {
 		"expectedTypesKeys=null\n"+
 		"completion token location=UNKNOWN",
 		result.context);
+}
+public void test0057() throws JavaModelException {
+	String preview = COMPLETION_PROJECT.getOption(CompilerOptions.OPTION_EnablePreviews, false);
+	try {
+		COMPLETION_PROJECT.setOption(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_24);
+		COMPLETION_PROJECT.setOption(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.ENABLED);
+
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy(
+				"/Completion/src3/test0057/X.java",
+				"""
+				///
+				/// see method [#ma
+				///
+				public class X {
+					public static void main(String[] args) {}
+				}"""
+				);
+
+		String str = this.workingCopies[0].getSource();
+		int cursorLocation = str.lastIndexOf("#ma") + "#ma".length();
+
+		CompletionResult result = contextComplete(this.workingCopies[0], cursorLocation);
+		assertResults(
+				"main[METHOD_REF]{main(String\\[\\]), Ltest0057.X;, ([Ljava.lang.String;)V, main, (args), 49}",
+					result.proposals);
+	} finally {
+		COMPLETION_PROJECT.setOption(CompilerOptions.OPTION_Source, CompilerOptions.getFirstSupportedJavaVersion());
+		COMPLETION_PROJECT.setOption(CompilerOptions.OPTION_EnablePreviews, preview);
+	}
+}
+public void test0058() throws JavaModelException {
+	String preview = COMPLETION_PROJECT.getOption(CompilerOptions.OPTION_EnablePreviews, false);
+	try {
+		COMPLETION_PROJECT.setOption(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_24);
+		COMPLETION_PROJECT.setOption(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.ENABLED);
+
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy(
+				"/Completion/src3/test0057/X.java",
+				"""
+				/**
+				 * see [#ma
+				 */
+				public class X {
+					public static void main(String[] args) {}
+				}"""
+				);
+
+		String str = this.workingCopies[0].getSource();
+		int cursorLocation = str.lastIndexOf("#ma") + "#ma".length();
+
+		CompletionResult result = contextComplete(this.workingCopies[0], cursorLocation);
+		assertResults(
+				"main[JAVADOC_METHOD_REF]{{@link #main(String[])}, Ltest0057.X;, ([Ljava.lang.String;)V, main, (args), 80}",
+					result.proposals);
+	} finally {
+		COMPLETION_PROJECT.setOption(CompilerOptions.OPTION_Source, CompilerOptions.getFirstSupportedJavaVersion());
+		COMPLETION_PROJECT.setOption(CompilerOptions.OPTION_EnablePreviews, preview);
+	}
 }
 }

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/CompletionEngine.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/CompletionEngine.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -5309,8 +5309,13 @@ public final class CompletionEngine
 			case Binding.ARRAY_TYPE :
 				createType(type.leafComponentType(), scope, completion);
 				int dim = type.dimensions();
+				boolean markdown = this.parser.assistNodeParent instanceof Javadoc docComment && docComment.isMarkdown;
 				for (int i = 0; i < dim; i++) {
+					if (markdown)
+						completion.append('\\');
 					completion.append('[');
+					if (markdown)
+						completion.append('\\');
 					completion.append(']');
 				}
 				break;

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/CompletionEngine.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/CompletionEngine.java
@@ -5309,13 +5309,8 @@ public final class CompletionEngine
 			case Binding.ARRAY_TYPE :
 				createType(type.leafComponentType(), scope, completion);
 				int dim = type.dimensions();
-				boolean markdown = this.parser.assistNodeParent instanceof Javadoc docComment && docComment.isMarkdown;
 				for (int i = 0; i < dim; i++) {
-					if (markdown)
-						completion.append('\\');
 					completion.append('[');
-					if (markdown)
-						completion.append('\\');
 					completion.append(']');
 				}
 				break;
@@ -9620,7 +9615,13 @@ public final class CompletionEngine
 						}
 						proposal.setRequiredProposals(subProposals);
 					}
-					proposal.setCompletion(completion);
+
+					if (this.parser.assistNodeParent instanceof Javadoc jdoc && jdoc.isMarkdown) {
+						proposal.displayString = completion;
+						proposal.setCompletion(CharOperation.replace(completion, "[]".toCharArray(), "\\[\\]".toCharArray()));  //$NON-NLS-1$//$NON-NLS-2$
+					} else {
+						proposal.setCompletion(completion);
+					}
 					proposal.setFlags(method.modifiers);
 					proposal.setReplaceRange(this.startPosition - this.offset, this.endPosition - this.offset);
 					proposal.setTokenRange(this.tokenStart - this.offset, this.tokenEnd - this.offset);

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/InternalCompletionProposal.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/InternalCompletionProposal.java
@@ -89,7 +89,7 @@ public class InternalCompletionProposal extends CompletionProposal {
 	/**
 	 * Completion display string; defaults to empty string.
 	 */
-	public char[] displayString = CharOperation.NO_CHAR;
+	public char[] displayString = null;
 	/**
 	 * Start position (inclusive) of source range in original buffer
 	 * to be replaced by completion string;
@@ -539,7 +539,9 @@ public class InternalCompletionProposal extends CompletionProposal {
 
 	@Override
 	public char[] getDisplayString() {
-		return this.displayString;
+		if  (this.displayString != null)
+			return this.displayString;
+		return getCompletion();
 	}
 
 	@Override

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/InternalCompletionProposal.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/InternalCompletionProposal.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2018 IBM Corporation and others.
+ * Copyright (c) 2004, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -86,6 +86,10 @@ public class InternalCompletionProposal extends CompletionProposal {
 	 */
 	private char[] completion = CharOperation.NO_CHAR;
 
+	/**
+	 * Completion display string; defaults to empty string.
+	 */
+	public char[] displayString = CharOperation.NO_CHAR;
 	/**
 	 * Start position (inclusive) of source range in original buffer
 	 * to be replaced by completion string;
@@ -531,6 +535,11 @@ public class InternalCompletionProposal extends CompletionProposal {
 		}
 		this.tokenStart = startIndex;
 		this.tokenEnd = endIndex;
+	}
+
+	@Override
+	public char[] getDisplayString() {
+		return this.displayString;
 	}
 
 	@Override

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/core/CompletionProposal.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/core/CompletionProposal.java
@@ -1064,6 +1064,22 @@ public class CompletionProposal {
 	}
 
 	/**
+	 * Returns the proposed sequence of characters to be displayed. In most cases,
+	 * this will be same as {@link #getCompletion()}. In certain scenarios where the
+	 * code to be inserted cannot be displayed as is, for e.g. aesthetic reasons,
+	 * the implementor of this API may choose to return a different value. The other
+	 * characteristics of the {@link #getCompletion()} also apply here.
+	 * <p>
+	 * The client must not modify the array returned.
+	 * </p>
+	 *
+	 * @return the completion string to be displayed in a pretty form
+	 * @since 3.41
+	 */
+	public char[] getDisplayString() {
+		return null;
+	}
+	/**
 	 * Sets the proposed sequence of characters to insert into the
 	 * source file buffer, replacing the characters at the specified
 	 * source range. The string can be arbitrary; for example, it might

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/core/CompletionProposal.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/core/CompletionProposal.java
@@ -1064,17 +1064,16 @@ public class CompletionProposal {
 	}
 
 	/**
-	 * Returns the proposed sequence of characters to be displayed. In most cases,
-	 * this will be same as {@link #getCompletion()}. In certain scenarios where the
-	 * code to be inserted cannot be displayed as is, for e.g. aesthetic reasons,
-	 * the implementor of this API may choose to return a different value. The other
-	 * characteristics of the {@link #getCompletion()} also apply here.
+	 * Returns the proposed sequence of characters to be displayed. In certain scenarios
+	 * where the code to be inserted cannot be displayed as is, for e.g. aesthetic reasons,
+	 * the implementor of this API may choose to return a different value other than {@link #getCompletion()}.
+	 * The other characteristics of the {@link #getCompletion()} also apply here.
 	 * <p>
 	 * The client must not modify the array returned.
 	 * </p>
 	 *
 	 * @return the completion string to be displayed in a pretty form
-	 * @since 3.41
+	 * @since 3.42
 	 */
 	public char[] getDisplayString() {
 		return null;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
Fixes #3773

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
