### PR TITLE
Avoid unnecessary downcast in `CompletionTests2.testBug397070`

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests2.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests2.java
@@ -32,7 +32,6 @@ import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.jdt.core.*;
 import org.eclipse.jdt.core.tests.util.Util;
-import org.eclipse.jdt.internal.codeassist.InternalCompletionContext;
 import org.eclipse.jdt.internal.codeassist.RelevanceConstants;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jdt.internal.core.SourceType;
@@ -5618,12 +5617,9 @@ public void testBug397070() throws JavaModelException {
 		SourceType type = null;
 		public void acceptContext(CompletionContext con) {
 			this.type = null;
-			if (con instanceof InternalCompletionContext) {
-				InternalCompletionContext context = (InternalCompletionContext) con;
-				IJavaElement element = context.getEnclosingElement();
-				if (element instanceof org.eclipse.jdt.internal.core.SourceType) {
-					this.type = (SourceType) element;
-				}
+			IJavaElement element = con.getEnclosingElement();
+			if (element instanceof org.eclipse.jdt.internal.core.SourceType) {
+				this.type = (SourceType) element;
 			}
 		}
 		public boolean isExtendedContextRequired() {


### PR DESCRIPTION
## What it does
Fixes #3817

## How to test
Run the test suite, confirm it still compiles and passes.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
