### PR TITLE
Fix null-status of token enums (#3303)

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
@@ -167,7 +167,7 @@ public class Parser implements ParserBasicInformation, ConflictedParser, Operato
 	private static final short TYPE_CLASS = 1;
 
 	public Scanner scanner;
-	public TerminalToken currentToken;
+	public TerminalToken currentToken = TokenNameNotAToken;
 
 	static {
 		try{
@@ -819,7 +819,7 @@ public class Parser implements ParserBasicInformation, ConflictedParser, Operato
 	protected int expressionPtr;
 	protected Expression[] expressionStack = new Expression[ExpressionStackIncrement];
 	protected int rBracketPosition;
-	public TerminalToken firstToken ; // handle for multiple parsing goals
+	public TerminalToken firstToken = TokenNameNotAToken; // handle for multiple parsing goals
 
 	/* jsr308 -- Type annotation management, we now maintain type annotations in a separate stack
 	   as otherwise they get interspersed with other expressions and some of the code is not prepared
@@ -864,7 +864,7 @@ public class Parser implements ParserBasicInformation, ConflictedParser, Operato
 	protected int lastCheckPoint;
 	protected int lastErrorEndPosition;
 	protected int lastErrorEndPositionBeforeRecovery = -1;
-	protected TerminalToken lastIgnoredToken, nextIgnoredToken;
+	protected TerminalToken lastIgnoredToken = TokenNameNotAToken, nextIgnoredToken = TokenNameNotAToken;
 
 	protected int listLength; // for recovering some incomplete list (interfaces, throws or parameters)
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/RecoveredAnnotation.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/RecoveredAnnotation.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.compiler.parser;
 
+import static org.eclipse.jdt.internal.compiler.parser.TerminalToken.TokenNameNotAToken;
+
 import org.eclipse.jdt.internal.compiler.ast.*;
 
 public class RecoveredAnnotation extends RecoveredElement {
@@ -27,7 +29,7 @@ public class RecoveredAnnotation extends RecoveredElement {
 	public boolean hasPendingMemberValueName;
 	public int memberValuPairEqualEnd = -1;
 	public Annotation annotation;
-	public TerminalToken errorToken;
+	public TerminalToken errorToken = TokenNameNotAToken;
 
 	public RecoveredAnnotation(int identifierPtr, int identifierLengthPtr, int sourceStart, RecoveredElement parent, int bracketBalance) {
 		super(parent, bracketBalance);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/RecoveredType.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/RecoveredType.java
@@ -789,21 +789,19 @@ public RecoveredElement updateOnOpeningBrace(int braceStart, int braceEnd){
 				!= parser.scanner.searchLineNumber(braceEnd)){
 		 */
 		Parser parser = parser();
-		if (parser.lastIgnoredToken != null){
-			switch(parser.lastIgnoredToken){
-				case TokenNameInvalid :
-				case TokenNameextends :
-				case TokenNameimplements :
-				case TokenNameRestrictedIdentifierpermits:
-				case TokenNameGREATER :
-				case TokenNameRIGHT_SHIFT :
-				case TokenNameUNSIGNED_RIGHT_SHIFT :
-					if (parser.recoveredStaticInitializerStart == 0) break;
-				//$FALL-THROUGH$
-				default:
-					this.foundOpeningBrace = true;
-					this.bracketBalance = 1; // pretend the brace was already there
-			}
+		switch(parser.lastIgnoredToken){
+			case TokenNameInvalid :
+			case TokenNameextends :
+			case TokenNameimplements :
+			case TokenNameRestrictedIdentifierpermits:
+			case TokenNameGREATER :
+			case TokenNameRIGHT_SHIFT :
+			case TokenNameUNSIGNED_RIGHT_SHIFT :
+				if (parser.recoveredStaticInitializerStart == 0) break;
+			//$FALL-THROUGH$
+			default:
+				this.foundOpeningBrace = true;
+				this.bracketBalance = 1; // pretend the brace was already there
 		}
 	}
 	// might be an initializer

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Scanner.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Scanner.java
@@ -5033,9 +5033,9 @@ private static final class VanguardScanner extends Scanner {
 
 private static class Goal {
 
-	TerminalToken first;      // steer the parser towards a single minded pursuit.
-	TerminalToken [] follow;  // the definite terminal symbols that signal the successful reduction to goal.
-	int[] rules;
+	final TerminalToken first;      // steer the parser towards a single minded pursuit.
+	final TerminalToken [] follow;  // the definite terminal symbols that signal the successful reduction to goal.
+	final int[] rules;
 
 	static int LambdaParameterListRule = 0;
 	static int IntersectionCastRule = 0;

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/impl/AssistParser.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/impl/AssistParser.java
@@ -46,7 +46,7 @@ public abstract class AssistParser extends Parser {
 	int[] blockStarts = new int[30];
 
 	// the previous token read by the scanner
-	protected TerminalToken previousToken;
+	protected TerminalToken previousToken = TokenNameNotAToken;
 
 	// the index in the identifier stack of the previous identifier
 	protected int previousIdentifierPtr;


### PR DESCRIPTION
## What it does

With the change from using an int to using an enum to represent a token, the default value of a
token-holding variable has changed from `0` (meaning TokenNameNotAToken, and works like that in a switch) to `null` which is bad in a switch statement.

This was largely ignored in the recent patch, and not found in testing.

This patch rectifies this omission. I've checked every field initialization and local variable holding a `TerminalToken`, and initialized the ones where they appeared to be missing. I also put in 

And by the way: Is there a good reason not to use JDT's null-checking for ECJ itself?

## How to test
Since the existing `null`-handling didn't trigger any errors in the suite run by CI, I don't expect it to be easy to to trigger an error scenario.

I didn't do fuzz-testing, but did run this change through ECJ's null-analysis.

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
