### PR TITLE
Do not suggest `import` keyword before package declaration

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests.java
@@ -9177,7 +9177,7 @@ public void testCompletionKeywordImport7() throws JavaModelException {
 		cu.codeComplete(cursorLocation, requestor);
 
 		assertEquals(
-			"element:import    completion:import    relevance:"+(R_DEFAULT + R_RESOLVED + R_INTERESTING + R_CASE+ R_NON_RESTRICTED),
+			"",
 			requestor.getResults());
 }
 public void testCompletionKeywordImport8() throws JavaModelException {

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/CompletionEngine.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/CompletionEngine.java
@@ -2164,9 +2164,12 @@ public final class CompletionEngine
 							contextAccepted = true;
 							buildContext(importReference, null, parsedUnit, null, null);
 							if(!this.requestor.isIgnored(CompletionProposal.KEYWORD)) {
-								setSourceAndTokenRange(importReference.sourceStart, importReference.sourceEnd);
-								CompletionOnKeyword keyword = (CompletionOnKeyword)importReference;
-								findKeywords(keyword.getToken(), keyword.getPossibleKeywords(), false, parsedUnit.currentPackage != null);
+								// do not suggest `import` or `package` keywords if the cursor is before an existing package declaration
+								if (parsedUnit.currentPackage == null || importReference.sourceStart >= parsedUnit.currentPackage.sourceStart) {
+									setSourceAndTokenRange(importReference.sourceStart, importReference.sourceEnd);
+									CompletionOnKeyword keyword = (CompletionOnKeyword)importReference;
+									findKeywords(keyword.getToken(), keyword.getPossibleKeywords(), false, parsedUnit.currentPackage != null);
+								}
 							}
 							debugPrintf();
 							return;


### PR DESCRIPTION
## What it does
eg. `import` should not be suggested as a completion at the `|`:

```java
imp|

package dev.datho7561.utils;

public class HelloWorld {

}
```

Fixes #3799

## How to test
Try completion with the code snippet above.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
