### PR TITLE
[False Positive] unlikely-arg-type

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/UnlikelyArgumentCheck.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/UnlikelyArgumentCheck.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2017 GK Software AG and others.
+ * Copyright (c) 2015, 2025 GK Software SE and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -14,11 +14,15 @@
 
 package org.eclipse.jdt.internal.compiler.ast;
 
+import java.util.HashSet;
+import java.util.Set;
 import org.eclipse.jdt.internal.compiler.lookup.BlockScope;
+import org.eclipse.jdt.internal.compiler.lookup.MethodBinding;
 import org.eclipse.jdt.internal.compiler.lookup.ParameterizedTypeBinding;
 import org.eclipse.jdt.internal.compiler.lookup.ReferenceBinding;
 import org.eclipse.jdt.internal.compiler.lookup.Scope;
 import org.eclipse.jdt.internal.compiler.lookup.TypeBinding;
+import org.eclipse.jdt.internal.compiler.lookup.TypeConstants;
 import org.eclipse.jdt.internal.compiler.lookup.TypeConstants.DangerousMethod;
 import org.eclipse.jdt.internal.compiler.lookup.TypeIds;
 
@@ -63,8 +67,34 @@ public class UnlikelyArgumentCheck {
 			typeToCheck2 = typeToCheck2.erasure();
 			expectedType2 = expectedType2.erasure();
 		}
-		return !typeToCheck2.isCompatibleWith(expectedType2, currentScope)
+		boolean potentiallyDangerous = !typeToCheck2.isCompatibleWith(expectedType2, currentScope)
 				&& !expectedType2.isCompatibleWith(typeToCheck2, currentScope);
+		if (potentiallyDangerous
+				&& this.dangerousMethod == DangerousMethod.Equals
+				&& hasEqualsMethodInCommonSuperType(this.expectedType, this.typeToCheck, new HashSet<>())) {
+			return false;
+		}
+		return potentiallyDangerous;
+	}
+
+	private boolean hasEqualsMethodInCommonSuperType(TypeBinding type1, TypeBinding type2, Set<TypeBinding> visited) {
+		if (type1.id == TypeIds.T_JavaLangObject || type2.id == TypeIds.T_JavaLangObject)
+			return false;
+		if (!visited.add(type1))
+			return false;
+		if (type2.isCompatibleWith(type1)) {
+			// found a common super type
+			for (MethodBinding equalsMethod : type1.getMethods(TypeConstants.EQUALS))
+				if (equalsMethod.parameters.length == 1 && equalsMethod.parameters[0].id == TypeIds.T_JavaLangObject)
+					return true;
+		}
+		if (hasEqualsMethodInCommonSuperType(type1.superclass(), type2, visited))
+			return true;
+		for (ReferenceBinding ifc : type1.superInterfaces()) {
+			if (hasEqualsMethodInCommonSuperType(ifc, type2, visited))
+				return true;
+		}
+		return false;
 	}
 
 	/**

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ProgrammingProblemsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ProgrammingProblemsTest.java
@@ -4063,4 +4063,26 @@ public void testIssue3054_5() {
 			true/*shouldFlushOutputDirectory*/,
 			customOptions);
 }
+public void testGH3660() {
+	Runner runner = new Runner();
+	runner.customOptions = getCompilerOptions();
+	runner.customOptions.put(JavaCore.COMPILER_PB_UNLIKELY_EQUALS_ARGUMENT_TYPE, JavaCore.ERROR);
+	runner.testFiles = new String[] {
+			"Snippet.java",
+			"""
+			import java.util.HashMap;
+			import java.util.concurrent.ConcurrentHashMap;
+
+			public class Snippet {
+				public static void main(String[] args) {
+					HashMap<Integer, Integer> map1 = new HashMap<>();
+					ConcurrentHashMap<Integer, Integer> map2 = new ConcurrentHashMap<>();
+					System.out.print(map1.equals(map2)); // true but unlikely-arg-type
+					System.out.print(map2.equals(map1)); // true but unlikely-arg-type
+				}
+			}
+			"""};
+	runner.expectedOutputString = "truetrue";
+	runner.runConformTest();
+}
 }


### PR DESCRIPTION
keep quiet if a common supertype has a custom equals() method

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3660
