### PR TITLE
TagElement issue in the markdown comments

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/AbstractCommentParser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/AbstractCommentParser.java
@@ -180,6 +180,7 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 			boolean isDomParser = (this.kind & DOM_PARSER) != 0;
 			boolean isFormatterParser = (this.kind & FORMATTER_COMMENT_PARSER) != 0;
 			int lastStarPosition = -1;
+			boolean isTagElementClose = false;
 
 			// Init scanner position
 			this.markdown = this.source[this.javadocStart + 1] == '/';
@@ -348,6 +349,9 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 						// Fix bug 51650
 						this.textStart = -1;
 						this.markdownHelper.resetAtLineEnd();
+						if (this.inlineTagStarted && this.markdown) {
+							isTagElementClose = true;
+						}
 						break;
 					case '}' :
 						if (verifText && this.tagValue == TAG_RETURN_VALUE && this.returnStatement != null) {
@@ -372,7 +376,9 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 							}
 							if (!isFormatterParser && !treatAsText && (!this.inlineReturn || this.inlineReturnOpenBraces <= 0))
 								this.textStart = this.index;
-							setInlineTagStarted(false);
+							if ((!isTagElementClose && this.markdown) || !this.markdown) {  //The comment parser should create a TagElement only if the previous one is closed - markdown.
+								setInlineTagStarted(false);
+							}
 							if (this.inlineReturn) {
 								if (this.inlineReturnOpenBraces > 0) {
 									--this.inlineReturnOpenBraces;

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterMarkdownTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterMarkdownTest.java
@@ -1839,4 +1839,23 @@ public class ASTConverterMarkdownTest extends ConverterTestSetup {
 			}
 		}
 	}
+
+	public void testIllegelTagElement() throws JavaModelException {
+		String source= """
+				///{@link #getValue()
+				///value}
+				class IllegelTagElement {}
+				""";
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy("/Converter_23/src/markdown/gh3761/IllegelTagElement.java", source, null);
+		if (this.docCommentSupport.equals(JavaCore.ENABLED)) {
+			CompilationUnit compilUnit = (CompilationUnit) runConversion(this.workingCopies[0], true);
+			TypeDeclaration typedeclaration =  (TypeDeclaration) compilUnit.types().get(0);
+			Javadoc javadoc = typedeclaration.getJavadoc();
+			List<TagElement> te = javadoc.tags();
+			assertEquals("TagElement length is grater than one", te.size(), 1);
+			List<TagElement> tes = (te.get(0)).fragments();
+			assertEquals("inner TagElement length is grater than one", tes.size(), 1);
+		}
+	}
 }

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterMarkdownTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterMarkdownTest.java
@@ -1840,7 +1840,7 @@ public class ASTConverterMarkdownTest extends ConverterTestSetup {
 		}
 	}
 
-	public void testIllegelTagElement() throws JavaModelException {
+	public void testIllegelTagElement_01() throws JavaModelException {
 		String source= """
 				///{@link #getValue()
 				///value}
@@ -1853,9 +1853,43 @@ public class ASTConverterMarkdownTest extends ConverterTestSetup {
 			TypeDeclaration typedeclaration =  (TypeDeclaration) compilUnit.types().get(0);
 			Javadoc javadoc = typedeclaration.getJavadoc();
 			List<TagElement> te = javadoc.tags();
-			assertEquals("TagElement length is grater than one", te.size(), 1);
+			assertEquals("TagElement length is grater than one", 1, te.size());
 			List<TagElement> tes = (te.get(0)).fragments();
-			assertEquals("inner TagElement length is grater than one", tes.size(), 1);
+			assertEquals("inner TagElement length is grater than one", 1, tes.size());
+			assertEquals("TagName", "@link", tes.get(0).getTagName());
+			List<?> fragments = tes.get(0).fragments();
+			assertEquals("fragments count does not match", 2, fragments.size());
+			assertTrue(fragments.get(0) instanceof MethodRef);
+			assertTrue(fragments.get(1) instanceof TextElement);
+			assertEquals("Incorrect text", "value", fragments.get(1).toString());
+			assertEquals("Incorrect name", "#getValue()", fragments.get(0).toString());
+		}
+	}
+
+	//this is a malfound test. Need to to analysis how it works
+	public void testIllegelTagElement_02() throws JavaModelException {
+		String source= """
+				///{@link #getValue()
+				///value{}}
+				class IllegelTagElement {}
+				""";
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy("/Converter_23/src/markdown/gh3761/IllegelTagElement.java", source, null);
+		if (this.docCommentSupport.equals(JavaCore.ENABLED)) {
+			CompilationUnit compilUnit = (CompilationUnit) runConversion(this.workingCopies[0], true);
+			TypeDeclaration typedeclaration =  (TypeDeclaration) compilUnit.types().get(0);
+			Javadoc javadoc = typedeclaration.getJavadoc();
+			List<TagElement> te = javadoc.tags();
+			assertEquals("TagElement length is grater than one", 1, te.size());
+			List<TagElement> tes = (te.get(0)).fragments();
+			assertEquals("fragments count does not match", 1, tes.size());
+			assertEquals("TagName", "@link", tes.get(0).getTagName());
+			List<?> fragments = tes.get(0).fragments();
+			assertTrue(fragments.get(0) instanceof MethodRef);
+			assertTrue(fragments.get(1) instanceof TextElement);
+			assertEquals("Incorrect text", "value", fragments.get(1).toString());
+			assertEquals("Incorrect name", "#getValue()", fragments.get(0).toString());
+			assertTrue(te.get(0).getLength() < tes.get(0).getLength());
 		}
 	}
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
![image](https://github.com/user-attachments/assets/f2cb88d1-0b0c-4f7b-b2c4-f5b136acbe4c)

If a TagElement spans multiple lines, the comment parser incorrectly creates multiple TagElements instead of a single one, resulting in an invalid start position in MarkDown comments. This issue has already been handled correctly for normal JavaDoc comments.

With this fix, the parser ensures that a TagElement is treated as a single entity, even when placed across multiple lines.

This PR closes #3865

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
