### PR TITLE
"Type mismatch" regression since 4.29 with generics and null-analysis

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ASTNode.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ASTNode.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -808,15 +808,15 @@ public abstract class ASTNode implements TypeConstants, TypeIds {
 				case Binding.FIELD :
 				case Binding.RECORD_COMPONENT :
 				case Binding.LOCAL :
-					if ((recipient.tagBits & TagBits.AnnotationResolved) != 0) return annotations;
-					recipient.tagBits |= (TagBits.AnnotationResolved | TagBits.DeprecatedAnnotationResolved);
+					if ((recipient.extendedTagBits & ExtendedTagBits.AnnotationResolved) != 0) return annotations;
+					recipient.extendedTagBits |= (ExtendedTagBits.AnnotationResolved | ExtendedTagBits.DeprecatedAnnotationResolved);
 					if (length > 0) {
 						annotations = new AnnotationBinding[length];
 						recipient.setAnnotations(annotations, scope, false);
 					}
 					break;
 				case Binding.TYPE_PARAMETER :
-					recipient.tagBits |= TagBits.AnnotationResolved;
+					recipient.extendedTagBits |= ExtendedTagBits.AnnotationResolved;
 					//$FALL-THROUGH$
 				case Binding.TYPE_USE :
 					// for TYPE_USE we deliberately don't set the annotation resolved tagbits,
@@ -1317,7 +1317,7 @@ public static void resolveDeprecatedAnnotations(BlockScope scope, Annotation[] a
 		if (annotations != null) {
 			int length;
 			if ((length = annotations.length) >= 0) {
-				if ((recipient.tagBits & TagBits.DeprecatedAnnotationResolved) != 0)
+				if ((recipient.extendedTagBits & ExtendedTagBits.DeprecatedAnnotationResolved) != 0)
 					return;
 				for (int i = 0; i < length; i++) {
 					TypeReference annotationTypeRef = annotations[i].type;
@@ -1325,7 +1325,7 @@ public static void resolveDeprecatedAnnotations(BlockScope scope, Annotation[] a
 					if (!CharOperation.equals(TypeConstants.JAVA_LANG_DEPRECATED[2], annotationTypeRef.getLastToken())) continue;
 					TypeBinding annotationType = annotations[i].type.resolveType(scope);
 					if(annotationType != null && annotationType.isValidBinding() && annotationType.id == TypeIds.T_JavaLangDeprecated) {
-						long deprecationTagBits = TagBits.AnnotationDeprecated | TagBits.DeprecatedAnnotationResolved;
+						long deprecationTagBits = TagBits.AnnotationDeprecated;
 						if (scope.compilerOptions().complianceLevel >= ClassFileConstants.JDK9) {
 							for (MemberValuePair memberValuePair : annotations[i].memberValuePairs()) {
 								if (CharOperation.equals(memberValuePair.name, TypeConstants.FOR_REMOVAL)) {
@@ -1339,7 +1339,7 @@ public static void resolveDeprecatedAnnotations(BlockScope scope, Annotation[] a
 					}
 				}
 			}
-			recipient.tagBits |= TagBits.DeprecatedAnnotationResolved;
+			recipient.extendedTagBits |= ExtendedTagBits.DeprecatedAnnotationResolved;
 		}
 	}
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Argument.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Argument.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -77,7 +77,7 @@ public class Argument extends LocalDeclaration {
 				}
 			}
 		}
-		if ((this.binding.tagBits & TagBits.AnnotationResolved) == 0) {
+		if ((this.binding.extendedTagBits & ExtendedTagBits.AnnotationResolved) == 0) {
 			Annotation[] annots = this.annotations;
 			long sourceLevel = scope.compilerOptions().sourceLevel;
 			if (sourceLevel >= ClassFileConstants.JDK14 && annots == null) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypeParameter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypeParameter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -163,7 +163,7 @@ public class TypeParameter extends AbstractVariableDeclaration {
 				}
 			}
 			if (this.binding != null)
-				this.binding.tagBits |= TagBits.AnnotationResolved;
+				this.binding.extendedTagBits |= ExtendedTagBits.AnnotationResolved;
 		}
 	}
 
@@ -234,7 +234,7 @@ public class TypeParameter extends AbstractVariableDeclaration {
 	}
 
 	public void updateWithAnnotations(ClassScope scope) {
-		if (this.binding == null || (this.binding.tagBits & TagBits.AnnotationResolved) != 0)
+		if (this.binding == null || (this.binding.extendedTagBits & ExtendedTagBits.AnnotationResolved) != 0)
 			return;
 		if (this.type != null) {
 			TypeBinding prevType = this.type.resolvedType;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Binding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Binding.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -123,6 +123,10 @@ public abstract class Binding {
 			NULL_UNSPECIFIED_BY_DEFAULT | // included to terminate search up the parent chain
 			DefaultLocationParameter | DefaultLocationReturnType | DefaultLocationField |
 			DefaultLocationTypeArgument | DefaultLocationTypeParameter | DefaultLocationTypeBound | DefaultLocationArrayContents;
+
+
+	public long tagBits = 0; // See values in the interface TagBits
+	public int extendedTagBits; // See values in the interface ExtendedTagBits
 
 	/*
 	* Answer the receiver's binding type from Binding.BindingID.

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ExtendedTagBits.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ExtendedTagBits.java
@@ -36,5 +36,6 @@ public interface ExtendedTagBits {
 
 	int AnnotationResolved = ASTNode.Bit6;
 	int DeprecatedAnnotationResolved = ASTNode.Bit7;
-
+	int NullDefaultAnnotationResolved = ASTNode.Bit8; // package, type, method or variable
+	int AllAnnotationsResolved = ExtendedTagBits.AnnotationResolved | ExtendedTagBits.DeprecatedAnnotationResolved | ExtendedTagBits.NullDefaultAnnotationResolved;
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ExtendedTagBits.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ExtendedTagBits.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 IBM Corporation and others.
+ * Copyright (c) 2020, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -33,4 +33,8 @@ public interface ExtendedTagBits {
 	int IsClosingMethod = ASTNode.Bit1; // method
 
 	int HasMissingOwningAnnotation = ASTNode.Bit2; // method/ctor or field
+
+	int AnnotationResolved = ASTNode.Bit6;
+	int DeprecatedAnnotationResolved = ASTNode.Bit7;
+
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/FieldBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/FieldBinding.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -307,10 +307,10 @@ public AnnotationBinding[] getAnnotations() {
 @Override
 public long getAnnotationTagBits() {
 	FieldBinding originalField = original();
-	if ((originalField.tagBits & TagBits.AnnotationResolved) == 0 && originalField.declaringClass instanceof SourceTypeBinding) {
+	if ((originalField.extendedTagBits & ExtendedTagBits.AnnotationResolved) == 0 && originalField.declaringClass instanceof SourceTypeBinding) {
 		ClassScope scope = ((SourceTypeBinding) originalField.declaringClass).scope;
 		if (scope == null) { // synthetic fields do not have a scope nor any annotations
-			this.tagBits |= (TagBits.AnnotationResolved | TagBits.DeprecatedAnnotationResolved);
+			this.extendedTagBits |= (ExtendedTagBits.AnnotationResolved | ExtendedTagBits.DeprecatedAnnotationResolved);
 			return 0;
 		}
 		TypeDeclaration typeDecl = scope.referenceContext;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/FieldBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/FieldBinding.java
@@ -39,7 +39,6 @@ public class FieldBinding extends VariableBinding {
 	public int compoundUseFlag = 0; // number or accesses via postIncrement or compoundAssignment
 
 	public FakedTrackingVariable closeTracker;
-	public long extendedTagBits;
 	public IBinaryAnnotation binaryPreviewAnnotation; // captures the exact preview feature of a preview API
 
 protected FieldBinding() {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/FieldBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/FieldBinding.java
@@ -310,7 +310,7 @@ public long getAnnotationTagBits() {
 	if ((originalField.extendedTagBits & ExtendedTagBits.AnnotationResolved) == 0 && originalField.declaringClass instanceof SourceTypeBinding) {
 		ClassScope scope = ((SourceTypeBinding) originalField.declaringClass).scope;
 		if (scope == null) { // synthetic fields do not have a scope nor any annotations
-			this.extendedTagBits |= (ExtendedTagBits.AnnotationResolved | ExtendedTagBits.DeprecatedAnnotationResolved);
+			this.extendedTagBits |= ExtendedTagBits.AllAnnotationsResolved;
 			return 0;
 		}
 		TypeDeclaration typeDecl = scope.referenceContext;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/LocalVariableBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/LocalVariableBinding.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2018 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -176,7 +176,7 @@ public class LocalVariableBinding extends VariableBinding {
 	@Override
 	public AnnotationBinding[] getAnnotations() {
 		if (this.declaringScope == null) {
-			if ((this.tagBits & TagBits.AnnotationResolved) != 0) {
+			if ((this.extendedTagBits & ExtendedTagBits.AnnotationResolved) != 0) {
 				// annotation are already resolved
 				if (this.declaration == null) {
 					return Binding.NO_ANNOTATIONS;
@@ -201,7 +201,7 @@ public class LocalVariableBinding extends VariableBinding {
 		if (sourceType == null)
 			return Binding.NO_ANNOTATIONS;
 
-		if ((this.tagBits & TagBits.AnnotationResolved) == 0) {
+		if ((this.extendedTagBits & ExtendedTagBits.AnnotationResolved) == 0) {
 			if (((this.tagBits & TagBits.IsArgument) != 0) && this.declaration != null) {
 				Annotation[] annotationNodes = this.declaration.annotations;
 				if (annotationNodes != null) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/LookupEnvironment.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/LookupEnvironment.java
@@ -1653,6 +1653,19 @@ int getAnalysisAnnotationBit(char[][] qualifiedTypeName) {
 	Integer typeBit = this.allAnalysisAnnotations.get(qualifiedTypeString);
 	return typeBit == null ? 0 : typeBit;
 }
+
+public boolean isNonNullByDefaultSimpleName(char[] simpleName) {
+	char[][] qualified = this.globalOptions.nonNullByDefaultAnnotationName;
+	if (CharOperation.equals(qualified[qualified.length-1], simpleName))
+		return true;
+	String tail = '.'+String.valueOf(simpleName);
+	for (String qualifiedString : this.globalOptions.nonNullByDefaultAnnotationSecondaryNames) {
+		if (qualifiedString.endsWith(tail))
+			return true;
+	}
+	return false;
+}
+
 /**
  * Check if the given type is a missing type that could be relevant for static analysis.
  * @return A bit from {@link ExtendedTagBits} encoding the check result, or {@code 0}.

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MemberTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MemberTypeBinding.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -70,7 +70,7 @@ public void initializeDeprecatedAnnotationTagBits() {
 		this.prototype.initializeDeprecatedAnnotationTagBits();
 		return;
 	}
-	if ((this.tagBits & TagBits.DeprecatedAnnotationResolved) == 0) {
+	if ((this.extendedTagBits & ExtendedTagBits.DeprecatedAnnotationResolved) == 0) {
 		super.initializeDeprecatedAnnotationTagBits();
 		if ((this.tagBits & TagBits.AnnotationDeprecated) == 0) {
 			// check enclosing type
@@ -81,7 +81,7 @@ public void initializeDeprecatedAnnotationTagBits() {
 
 public void updateDeprecationFromEnclosing() {
 	ReferenceBinding enclosing = enclosingType();
-	if ((enclosing.tagBits & TagBits.DeprecatedAnnotationResolved) == 0) {
+	if ((enclosing.extendedTagBits & ExtendedTagBits.DeprecatedAnnotationResolved) == 0) {
 		enclosing.initializeDeprecatedAnnotationTagBits();
 	}
 	if (enclosing.isViewedAsDeprecated()) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MethodBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MethodBinding.java
@@ -64,8 +64,6 @@ public class MethodBinding extends Binding {
 	public ReferenceBinding declaringClass;
 	public TypeVariableBinding[] typeVariables = Binding.NO_TYPE_VARIABLES;
 	char[] signature;
-	public long tagBits;
-	public int extendedTagBits = 0; // See values in the interface ExtendedTagBits
 	public IBinaryAnnotation binaryPreviewAnnotation; // captures the exact preview feature of a preview API
 	// Used only for constructors
 	protected AnnotationBinding [] typeAnnotations = Binding.NO_ANNOTATIONS;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MethodBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MethodBinding.java
@@ -669,7 +669,7 @@ public AnnotationBinding[] getAnnotations() {
 @Override
 public long getAnnotationTagBits() {
 	MethodBinding originalMethod = original();
-	if ((originalMethod.tagBits & TagBits.AnnotationResolved) == 0 && originalMethod.declaringClass instanceof SourceTypeBinding) {
+	if ((originalMethod.extendedTagBits & ExtendedTagBits.AnnotationResolved) == 0 && originalMethod.declaringClass instanceof SourceTypeBinding) {
 		ClassScope scope = ((SourceTypeBinding) originalMethod.declaringClass).scope;
 		if (scope != null) {
 			TypeDeclaration typeDecl = scope.referenceContext;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ModuleBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ModuleBinding.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2024 IBM Corporation and others.
+ * Copyright (c) 2016, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -144,7 +144,6 @@ public class ModuleBinding extends Binding implements IUpdatableModule {
 	private SimpleSetOfCharArray packageNames;
 	public int modifiers;
 	public LookupEnvironment environment;
-	public long tagBits;
 	public int defaultNullness = NO_NULL_DEFAULT;
 	ModuleBinding[] requiredModules = null;
 	boolean isAuto = false;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/PackageBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/PackageBinding.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -25,7 +25,6 @@ import org.eclipse.jdt.internal.compiler.util.HashtableOfPackage;
 import org.eclipse.jdt.internal.compiler.util.HashtableOfType;
 
 public abstract class PackageBinding extends Binding implements TypeConstants {
-	public long tagBits = 0; // See values in the interface TagBits below
 
 	public char[][] compoundName;
 	PackageBinding parent;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/PackageBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/PackageBinding.java
@@ -306,8 +306,8 @@ public Binding getTypeOrPackage(char[] name, ModuleBinding mod, boolean splitPac
 	return problemBinding;
 }
 public final boolean isViewedAsDeprecated() {
-	if ((this.tagBits & TagBits.DeprecatedAnnotationResolved) == 0) {
-		this.tagBits |= TagBits.DeprecatedAnnotationResolved;
+	if ((this.extendedTagBits & ExtendedTagBits.DeprecatedAnnotationResolved) == 0) {
+		this.extendedTagBits |= ExtendedTagBits.DeprecatedAnnotationResolved;
 		if (this.compoundName != CharOperation.NO_CHAR_CHAR) {
 			ReferenceBinding packageInfo = this.getType(TypeConstants.PACKAGE_INFO_NAME, this.enclosingModule);
 			if (packageInfo != null) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/RecordComponentBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/RecordComponentBinding.java
@@ -86,7 +86,7 @@ public class RecordComponentBinding extends VariableBinding {
 				originalRecordComponentBinding.declaringRecord instanceof SourceTypeBinding) {
 			ClassScope scope = ((SourceTypeBinding) originalRecordComponentBinding.declaringRecord).scope;
 			if (scope == null) {// should not be true - but safety net
-				this.extendedTagBits |= (ExtendedTagBits.AnnotationResolved | ExtendedTagBits.DeprecatedAnnotationResolved);
+				this.extendedTagBits |= ExtendedTagBits.AllAnnotationsResolved;
 				return 0;
 			}
 			TypeDeclaration typeDecl = scope.referenceContext;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/RecordComponentBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/RecordComponentBinding.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2020, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -82,11 +82,11 @@ public class RecordComponentBinding extends VariableBinding {
 	@Override
 	public long getAnnotationTagBits() {
 		RecordComponentBinding originalRecordComponentBinding = original();
-		if ((originalRecordComponentBinding.tagBits & TagBits.AnnotationResolved) == 0 &&
+		if ((originalRecordComponentBinding.extendedTagBits & ExtendedTagBits.AnnotationResolved) == 0 &&
 				originalRecordComponentBinding.declaringRecord instanceof SourceTypeBinding) {
 			ClassScope scope = ((SourceTypeBinding) originalRecordComponentBinding.declaringRecord).scope;
 			if (scope == null) {// should not be true - but safety net
-				this.tagBits |= (TagBits.AnnotationResolved | TagBits.DeprecatedAnnotationResolved);
+				this.extendedTagBits |= (ExtendedTagBits.AnnotationResolved | ExtendedTagBits.DeprecatedAnnotationResolved);
 				return 0;
 			}
 			TypeDeclaration typeDecl = scope.referenceContext;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SourceModuleBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SourceModuleBinding.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 GK Software AG, and others.
+ * Copyright (c) 2017, 2025 GK Software AG, and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -137,14 +137,14 @@ public class SourceModuleBinding extends ModuleBinding {
 		return this.tagBits;
 	}
 	protected void ensureAnnotationsResolved() {
-		if ((this.tagBits & TagBits.AnnotationResolved) == 0 && this.scope != null) {
+		if ((this.extendedTagBits & ExtendedTagBits.AnnotationResolved) == 0 && this.scope != null) {
 			ModuleDeclaration module = this.scope.referenceContext.moduleDeclaration;
 			ASTNode.resolveAnnotations(module.scope, module.annotations, this);
 			if ((this.tagBits & TagBits.AnnotationDeprecated) != 0) {
 				this.modifiers |= ClassFileConstants.AccDeprecated;
-				this.tagBits |= TagBits.DeprecatedAnnotationResolved;
+				this.extendedTagBits |= ExtendedTagBits.DeprecatedAnnotationResolved;
 			}
-			this.tagBits |= TagBits.AnnotationResolved;
+			this.extendedTagBits |= ExtendedTagBits.AnnotationResolved;
 		}
 	}
 	@Override

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SourceModuleBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SourceModuleBinding.java
@@ -142,9 +142,8 @@ public class SourceModuleBinding extends ModuleBinding {
 			ASTNode.resolveAnnotations(module.scope, module.annotations, this);
 			if ((this.tagBits & TagBits.AnnotationDeprecated) != 0) {
 				this.modifiers |= ClassFileConstants.AccDeprecated;
-				this.extendedTagBits |= ExtendedTagBits.DeprecatedAnnotationResolved;
 			}
-			this.extendedTagBits |= ExtendedTagBits.AnnotationResolved;
+			this.extendedTagBits |= ExtendedTagBits.AllAnnotationsResolved;
 		}
 	}
 	@Override

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SourceTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SourceTypeBinding.java
@@ -1359,6 +1359,23 @@ public long getAnnotationTagBits() {
 	}
 	return this.tagBits;
 }
+void initializeNullDefaultAnnotation() {
+	if (!isPrototype()) {
+		this.prototype.initializeNullDefaultAnnotation();
+		return;
+	}
+	if ((this.extendedTagBits & ExtendedTagBits.NullDefaultAnnotationResolved) == 0 && this.scope != null) {
+		TypeDeclaration typeDecl = this.scope.referenceContext;
+		boolean old = typeDecl.staticInitializerScope.insideTypeAnnotation;
+		try {
+			typeDecl.staticInitializerScope.insideTypeAnnotation = true;
+			ASTNode.resolveNullDefaultAnnotations(typeDecl.staticInitializerScope, typeDecl.annotations, this);
+			evaluateNullAnnotations();
+		} finally {
+			typeDecl.staticInitializerScope.insideTypeAnnotation = old;
+		}
+	}
+}
 @Override
 public boolean isReadyForAnnotations() {
 	if ((this.extendedTagBits & ExtendedTagBits.AnnotationResolved) != 0)
@@ -1793,7 +1810,7 @@ int getNullDefault() {
 	// ensure nullness defaults are initialized at all enclosing levels:
 	switch (this.nullnessDefaultInitialized) {
 	case 0:
-		getAnnotationTagBits(); // initialize
+		initializeNullDefaultAnnotation();
 		//$FALL-THROUGH$
 	case 1:
 		getPackage().isViewedAsDeprecated(); // initialize annotations

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SourceTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SourceTypeBinding.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -1345,7 +1345,7 @@ public long getAnnotationTagBits() {
 	if (!isPrototype())
 		return this.prototype.getAnnotationTagBits();
 
-	if ((this.tagBits & TagBits.AnnotationResolved) == 0 && this.scope != null) {
+	if ((this.extendedTagBits & ExtendedTagBits.AnnotationResolved) == 0 && this.scope != null) {
 		TypeDeclaration typeDecl = this.scope.referenceContext;
 		boolean old = typeDecl.staticInitializerScope.insideTypeAnnotation;
 		try {
@@ -1361,7 +1361,7 @@ public long getAnnotationTagBits() {
 }
 @Override
 public boolean isReadyForAnnotations() {
-	if ((this.tagBits & TagBits.AnnotationResolved) != 0)
+	if ((this.extendedTagBits & ExtendedTagBits.AnnotationResolved) != 0)
 		return true;
 	TypeDeclaration type;
 	if (this.scope != null && (type = this.scope.referenceType()) != null) {
@@ -1751,13 +1751,13 @@ public void initializeDeprecatedAnnotationTagBits() {
 		this.prototype.initializeDeprecatedAnnotationTagBits();
 		return;
 	}
-	if ((this.tagBits & TagBits.DeprecatedAnnotationResolved) == 0) {
+	if ((this.extendedTagBits & ExtendedTagBits.DeprecatedAnnotationResolved) == 0) {
 		TypeDeclaration typeDecl = this.scope.referenceContext;
 		boolean old = typeDecl.staticInitializerScope.insideTypeAnnotation;
 		try {
 			typeDecl.staticInitializerScope.insideTypeAnnotation = true;
 			ASTNode.resolveDeprecatedAnnotations(typeDecl.staticInitializerScope, typeDecl.annotations, this);
-			this.tagBits |= TagBits.DeprecatedAnnotationResolved;
+			this.extendedTagBits |= ExtendedTagBits.DeprecatedAnnotationResolved;
 		} finally {
 			typeDecl.staticInitializerScope.insideTypeAnnotation = old;
 		}
@@ -2722,7 +2722,7 @@ private void maybeMarkTypeParametersNonNull() {
 		for (int i = 0; i < this.typeVariables.length; i++) {
 			TypeVariableBinding tvb = this.typeVariables[i];
 			TypeParameter typeParameter = this.scope.referenceContext.typeParameters[i];
-			if (typeParameter.annotations != null && (tvb.tagBits & TagBits.AnnotationResolved) == 0)
+			if (typeParameter.annotations != null && (tvb.extendedTagBits & ExtendedTagBits.AnnotationResolved) == 0)
 				continue; // not yet ready
 			if ((tvb.tagBits & TagBits.AnnotationNullMASK) == 0)
 				this.typeVariables[i] = (TypeVariableBinding) this.environment.createAnnotatedType(tvb, annots);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SyntheticFieldBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SyntheticFieldBinding.java
@@ -19,6 +19,6 @@ public class SyntheticFieldBinding extends FieldBinding {
 
 	public SyntheticFieldBinding(char[] name, TypeBinding type, int modifiers, ReferenceBinding declaringClass, Constant constant) {
 		super(name, type, modifiers, declaringClass, constant);
-		this.extendedTagBits |= (ExtendedTagBits.AnnotationResolved | ExtendedTagBits.DeprecatedAnnotationResolved);
+		this.extendedTagBits |= ExtendedTagBits.AllAnnotationsResolved;
 	}
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SyntheticFieldBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SyntheticFieldBinding.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2009 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -19,6 +19,6 @@ public class SyntheticFieldBinding extends FieldBinding {
 
 	public SyntheticFieldBinding(char[] name, TypeBinding type, int modifiers, ReferenceBinding declaringClass, Constant constant) {
 		super(name, type, modifiers, declaringClass, constant);
-		this.tagBits |= (TagBits.AnnotationResolved | TagBits.DeprecatedAnnotationResolved);
+		this.extendedTagBits |= (ExtendedTagBits.AnnotationResolved | ExtendedTagBits.DeprecatedAnnotationResolved);
 	}
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SyntheticMethodBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SyntheticMethodBinding.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -84,7 +84,7 @@ public class SyntheticMethodBinding extends MethodBinding {
 
 	public SyntheticMethodBinding(FieldBinding targetField, boolean isReadAccess, boolean isSuperAccess, ReferenceBinding declaringClass) {
 		this.modifiers = ClassFileConstants.AccDefault | ClassFileConstants.AccStatic | ClassFileConstants.AccSynthetic;
-		this.tagBits |= (TagBits.AnnotationResolved | TagBits.DeprecatedAnnotationResolved);
+		this.extendedTagBits |= (ExtendedTagBits.AnnotationResolved | ExtendedTagBits.DeprecatedAnnotationResolved);
 		SourceTypeBinding declaringSourceType = (SourceTypeBinding) declaringClass;
 		SyntheticMethodBinding[] knownAccessMethods = declaringSourceType.syntheticMethods();
 		int methodId = knownAccessMethods == null ? 0 : knownAccessMethods[knownAccessMethods.length - 1].index + 1; //index may miss some numbers in between. get the highest index and assign next number.;
@@ -187,7 +187,7 @@ public class SyntheticMethodBinding extends MethodBinding {
 
 	public SyntheticMethodBinding(FieldBinding targetField, ReferenceBinding declaringClass, TypeBinding enumBinding, char[] selector,  SwitchStatement switchStatement) {
 		this.modifiers = (declaringClass.isInterface() ? ClassFileConstants.AccPublic : ClassFileConstants.AccDefault) | ClassFileConstants.AccStatic | ClassFileConstants.AccSynthetic;
-		this.tagBits |= (TagBits.AnnotationResolved | TagBits.DeprecatedAnnotationResolved);
+		this.extendedTagBits |= (ExtendedTagBits.AnnotationResolved | ExtendedTagBits.DeprecatedAnnotationResolved);
 		SourceTypeBinding declaringSourceType = (SourceTypeBinding) declaringClass;
 		SyntheticMethodBinding[] knownAccessMethods = declaringSourceType.syntheticMethods();
 		int methodId = knownAccessMethods == null ? 0 : knownAccessMethods[knownAccessMethods.length - 1].index + 1; //index may miss some numbers in between. get the highest index and assign next number.;
@@ -268,7 +268,7 @@ public class SyntheticMethodBinding extends MethodBinding {
 	    // amongst other, clear the AccGenericSignature, so as to ensure no remains of original inherited persist (101794)
 	    // also use the modifiers from the target method, as opposed to inherited one (147690)
 	    this.modifiers = (targetMethod.modifiers | ClassFileConstants.AccBridge | ClassFileConstants.AccSynthetic) & ~(ClassFileConstants.AccSynchronized | ClassFileConstants.AccAbstract | ClassFileConstants.AccNative  | ClassFileConstants.AccFinal | ExtraCompilerModifiers.AccGenericSignature);
-		this.tagBits |= (TagBits.AnnotationResolved | TagBits.DeprecatedAnnotationResolved);
+		this.extendedTagBits |= (ExtendedTagBits.AnnotationResolved | ExtendedTagBits.DeprecatedAnnotationResolved);
 	    this.returnType = overridenMethodToBridge.returnType;
 	    this.parameters = overridenMethodToBridge.parameters;
 	    this.thrownExceptions = overridenMethodToBridge.thrownExceptions;
@@ -284,7 +284,7 @@ public class SyntheticMethodBinding extends MethodBinding {
 	    this.declaringClass = declaringEnum;
 	    this.selector = selector;
 	    this.modifiers = ClassFileConstants.AccPublic | ClassFileConstants.AccStatic;
-		this.tagBits |= (TagBits.AnnotationResolved | TagBits.DeprecatedAnnotationResolved);
+		this.extendedTagBits |= (ExtendedTagBits.AnnotationResolved | ExtendedTagBits.DeprecatedAnnotationResolved);
 		LookupEnvironment environment = declaringEnum.scope.environment();
 	    this.thrownExceptions = Binding.NO_EXCEPTIONS;
 		if (selector == TypeConstants.VALUES) {
@@ -315,7 +315,7 @@ public class SyntheticMethodBinding extends MethodBinding {
 		this.declaringClass = declaringClass;
 		this.selector = TypeConstants.DESERIALIZE_LAMBDA;
 		this.modifiers = ClassFileConstants.AccPrivate | ClassFileConstants.AccStatic | ClassFileConstants.AccSynthetic;
-		this.tagBits |= (TagBits.AnnotationResolved | TagBits.DeprecatedAnnotationResolved);
+		this.extendedTagBits |= (ExtendedTagBits.AnnotationResolved | ExtendedTagBits.DeprecatedAnnotationResolved);
 		this.thrownExceptions = Binding.NO_EXCEPTIONS;
 		this.returnType = declaringClass.scope.getJavaLangObject();
 	    this.parameters = new TypeBinding[]{declaringClass.scope.getJavaLangInvokeSerializedLambda()};
@@ -333,7 +333,7 @@ public class SyntheticMethodBinding extends MethodBinding {
 		buffer.append(TypeConstants.SYNTHETIC_ENUM_CONSTANT_INITIALIZATION_METHOD_PREFIX).append(this.index);
 		this.selector = String.valueOf(buffer).toCharArray();
 		this.modifiers = ClassFileConstants.AccPrivate | ClassFileConstants.AccStatic;
-		this.tagBits |= (TagBits.AnnotationResolved | TagBits.DeprecatedAnnotationResolved);
+		this.extendedTagBits |= (ExtendedTagBits.AnnotationResolved | ExtendedTagBits.DeprecatedAnnotationResolved);
 		this.purpose = SyntheticMethodBinding.TooManyEnumsConstants;
 		this.thrownExceptions = Binding.NO_EXCEPTIONS;
 		this.returnType = TypeBinding.VOID;
@@ -353,7 +353,7 @@ public class SyntheticMethodBinding extends MethodBinding {
 	    this.selector = overridenMethodToBridge.selector;
 	    // amongst other, clear the AccGenericSignature, so as to ensure no remains of original inherited persist (101794)
 	    this.modifiers = (overridenMethodToBridge.modifiers | ClassFileConstants.AccBridge | ClassFileConstants.AccSynthetic) & ~(ClassFileConstants.AccSynchronized | ClassFileConstants.AccAbstract | ClassFileConstants.AccNative  | ClassFileConstants.AccFinal | ExtraCompilerModifiers.AccGenericSignature);
-		this.tagBits |= (TagBits.AnnotationResolved | TagBits.DeprecatedAnnotationResolved);
+		this.extendedTagBits |= (ExtendedTagBits.AnnotationResolved | ExtendedTagBits.DeprecatedAnnotationResolved);
 	    this.returnType = overridenMethodToBridge.returnType;
 	    this.parameters = overridenMethodToBridge.parameters;
 	    this.thrownExceptions = overridenMethodToBridge.thrownExceptions;
@@ -366,7 +366,7 @@ public class SyntheticMethodBinding extends MethodBinding {
 	    this.declaringClass = declaringClass;
 	    this.selector = selector;
 	    this.modifiers = ClassFileConstants.AccSynthetic | ClassFileConstants.AccPrivate | ClassFileConstants.AccStatic;
-		this.tagBits |= (TagBits.AnnotationResolved | TagBits.DeprecatedAnnotationResolved);
+		this.extendedTagBits |= (ExtendedTagBits.AnnotationResolved | ExtendedTagBits.DeprecatedAnnotationResolved);
 	    this.returnType = arrayType;
 	    LookupEnvironment environment = declaringClass.environment;
 		if (environment.globalOptions.isAnnotationBasedNullAnalysisEnabled) {
@@ -387,7 +387,8 @@ public class SyntheticMethodBinding extends MethodBinding {
 	    this.declaringClass = declaringClass;
 	    this.selector = lambdaName;
 	    this.modifiers = lambda.binding.modifiers;
-		this.tagBits |= (TagBits.AnnotationResolved | TagBits.DeprecatedAnnotationResolved) | (lambda.binding.tagBits & TagBits.HasParameterAnnotations);
+	    this.tagBits |=  (lambda.binding.tagBits & TagBits.HasParameterAnnotations);
+		this.extendedTagBits |= (ExtendedTagBits.AnnotationResolved | ExtendedTagBits.DeprecatedAnnotationResolved);
 	    this.returnType = lambda.binding.returnType;
 	    this.parameters = lambda.binding.parameters;
         if (this.returnType.isNonDenotable() || Stream.of(this.parameters).anyMatch(TypeBinding::isNonDenotable)) {
@@ -406,7 +407,8 @@ public class SyntheticMethodBinding extends MethodBinding {
 	    this.declaringClass = declaringClass;
 	    this.selector = ref.binding.selector;
 	    this.modifiers = ref.binding.modifiers;
-		this.tagBits |= (TagBits.AnnotationResolved | TagBits.DeprecatedAnnotationResolved) | (ref.binding.tagBits & TagBits.HasParameterAnnotations);
+		this.extendedTagBits |= (ExtendedTagBits.AnnotationResolved | ExtendedTagBits.DeprecatedAnnotationResolved);
+		this.tagBits |= (ref.binding.tagBits & TagBits.HasParameterAnnotations);
 	    this.returnType = ref.binding.returnType;
 	    this.parameters = ref.binding.parameters;
 	    this.thrownExceptions = ref.binding.thrownExceptions;
@@ -418,7 +420,7 @@ public class SyntheticMethodBinding extends MethodBinding {
 	    this.declaringClass = declaringClass;
 	    this.selector = selector;
 	    this.modifiers = ClassFileConstants.AccSynthetic | ClassFileConstants.AccPrivate | ClassFileConstants.AccStatic;
-		this.tagBits |= (TagBits.AnnotationResolved | TagBits.DeprecatedAnnotationResolved);
+		this.extendedTagBits |= (ExtendedTagBits.AnnotationResolved | ExtendedTagBits.DeprecatedAnnotationResolved);
 	    this.returnType = publicConstructor.declaringClass;
 
 	    int realParametersLength = privateConstructor.parameters.length;
@@ -442,7 +444,7 @@ public class SyntheticMethodBinding extends MethodBinding {
 		this.modifiers = declaringClass.modifiers & (ClassFileConstants.AccPublic|ClassFileConstants.AccPrivate|ClassFileConstants.AccProtected);
 		if (this.declaringClass.isStrictfp())
 			this.modifiers |= ClassFileConstants.AccStrictfp;
-		this.tagBits |= (TagBits.AnnotationResolved | TagBits.DeprecatedAnnotationResolved);
+		this.extendedTagBits |= (ExtendedTagBits.AnnotationResolved | ExtendedTagBits.DeprecatedAnnotationResolved);
 		this.extendedTagBits |= ExtendedTagBits.IsCanonicalConstructor;
 		this.extendedTagBits |= ExtendedTagBits.isImplicit;
 		this.parameters = rcb.length == 0 ? Binding.NO_PARAMETERS : new TypeBinding[rcb.length];
@@ -465,7 +467,7 @@ public class SyntheticMethodBinding extends MethodBinding {
 //			this.modifiers |= ExtraCompilerModifiers.AccGenericSignature;
 		if (this.declaringClass.isStrictfp())
 			this.modifiers |= ClassFileConstants.AccStrictfp;
-		this.tagBits |= (TagBits.AnnotationResolved | TagBits.DeprecatedAnnotationResolved);
+		this.extendedTagBits |= (ExtendedTagBits.AnnotationResolved | ExtendedTagBits.DeprecatedAnnotationResolved);
 		this.parameters = Binding.NO_PARAMETERS;
 //		this.returnType = rcb.type; Not resolved yet - to be filled in later
 		this.selector = rcb.name;
@@ -484,7 +486,7 @@ public class SyntheticMethodBinding extends MethodBinding {
 		this.modifiers = ClassFileConstants.AccPublic | ClassFileConstants.AccFinal;
 		if (this.declaringClass.isStrictfp())
 				this.modifiers |= ClassFileConstants.AccStrictfp;
-		this.tagBits |= (TagBits.AnnotationResolved | TagBits.DeprecatedAnnotationResolved);
+		this.extendedTagBits |= (ExtendedTagBits.AnnotationResolved | ExtendedTagBits.DeprecatedAnnotationResolved);
 	    this.selector = selector;
 	    this.thrownExceptions = Binding.NO_EXCEPTIONS;
 		if (selector == TypeConstants.TOSTRING) {
@@ -510,7 +512,7 @@ public class SyntheticMethodBinding extends MethodBinding {
 
 		this.targetMethod = accessedConstructor;
 		this.modifiers = ClassFileConstants.AccDefault | ClassFileConstants.AccSynthetic;
-		this.tagBits |= (TagBits.AnnotationResolved | TagBits.DeprecatedAnnotationResolved);
+		this.extendedTagBits |= (ExtendedTagBits.AnnotationResolved | ExtendedTagBits.DeprecatedAnnotationResolved);
 		SourceTypeBinding sourceType = (SourceTypeBinding) accessedConstructor.declaringClass;
 		SyntheticMethodBinding[] knownSyntheticMethods = sourceType.syntheticMethods();   // returns synthetic methods sorted with index.
 		this.index = knownSyntheticMethods == null ? 0 : knownSyntheticMethods[knownSyntheticMethods.length - 1].index + 1; //index may miss some numbers in between. get the highest index and assign next number.
@@ -595,7 +597,7 @@ public class SyntheticMethodBinding extends MethodBinding {
 			else
 				this.modifiers = ClassFileConstants.AccDefault | ClassFileConstants.AccStatic | ClassFileConstants.AccSynthetic;
 		}
-		this.tagBits |= (TagBits.AnnotationResolved | TagBits.DeprecatedAnnotationResolved);
+		this.extendedTagBits |= (ExtendedTagBits.AnnotationResolved | ExtendedTagBits.DeprecatedAnnotationResolved);
 		SourceTypeBinding declaringSourceType = (SourceTypeBinding) receiverType;
 		SyntheticMethodBinding[] knownAccessMethods = declaringSourceType.syntheticMethods();
 		int methodId = knownAccessMethods == null ? 0 : knownAccessMethods[knownAccessMethods.length - 1].index + 1; //index may miss some numbers in between. get the highest index and assign next number.

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SyntheticMethodBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SyntheticMethodBinding.java
@@ -84,7 +84,7 @@ public class SyntheticMethodBinding extends MethodBinding {
 
 	public SyntheticMethodBinding(FieldBinding targetField, boolean isReadAccess, boolean isSuperAccess, ReferenceBinding declaringClass) {
 		this.modifiers = ClassFileConstants.AccDefault | ClassFileConstants.AccStatic | ClassFileConstants.AccSynthetic;
-		this.extendedTagBits |= (ExtendedTagBits.AnnotationResolved | ExtendedTagBits.DeprecatedAnnotationResolved);
+		this.extendedTagBits |= ExtendedTagBits.AllAnnotationsResolved;
 		SourceTypeBinding declaringSourceType = (SourceTypeBinding) declaringClass;
 		SyntheticMethodBinding[] knownAccessMethods = declaringSourceType.syntheticMethods();
 		int methodId = knownAccessMethods == null ? 0 : knownAccessMethods[knownAccessMethods.length - 1].index + 1; //index may miss some numbers in between. get the highest index and assign next number.;
@@ -187,7 +187,7 @@ public class SyntheticMethodBinding extends MethodBinding {
 
 	public SyntheticMethodBinding(FieldBinding targetField, ReferenceBinding declaringClass, TypeBinding enumBinding, char[] selector,  SwitchStatement switchStatement) {
 		this.modifiers = (declaringClass.isInterface() ? ClassFileConstants.AccPublic : ClassFileConstants.AccDefault) | ClassFileConstants.AccStatic | ClassFileConstants.AccSynthetic;
-		this.extendedTagBits |= (ExtendedTagBits.AnnotationResolved | ExtendedTagBits.DeprecatedAnnotationResolved);
+		this.extendedTagBits |= ExtendedTagBits.AllAnnotationsResolved;
 		SourceTypeBinding declaringSourceType = (SourceTypeBinding) declaringClass;
 		SyntheticMethodBinding[] knownAccessMethods = declaringSourceType.syntheticMethods();
 		int methodId = knownAccessMethods == null ? 0 : knownAccessMethods[knownAccessMethods.length - 1].index + 1; //index may miss some numbers in between. get the highest index and assign next number.;
@@ -268,7 +268,7 @@ public class SyntheticMethodBinding extends MethodBinding {
 	    // amongst other, clear the AccGenericSignature, so as to ensure no remains of original inherited persist (101794)
 	    // also use the modifiers from the target method, as opposed to inherited one (147690)
 	    this.modifiers = (targetMethod.modifiers | ClassFileConstants.AccBridge | ClassFileConstants.AccSynthetic) & ~(ClassFileConstants.AccSynchronized | ClassFileConstants.AccAbstract | ClassFileConstants.AccNative  | ClassFileConstants.AccFinal | ExtraCompilerModifiers.AccGenericSignature);
-		this.extendedTagBits |= (ExtendedTagBits.AnnotationResolved | ExtendedTagBits.DeprecatedAnnotationResolved);
+		this.extendedTagBits |= ExtendedTagBits.AllAnnotationsResolved;
 	    this.returnType = overridenMethodToBridge.returnType;
 	    this.parameters = overridenMethodToBridge.parameters;
 	    this.thrownExceptions = overridenMethodToBridge.thrownExceptions;
@@ -284,7 +284,7 @@ public class SyntheticMethodBinding extends MethodBinding {
 	    this.declaringClass = declaringEnum;
 	    this.selector = selector;
 	    this.modifiers = ClassFileConstants.AccPublic | ClassFileConstants.AccStatic;
-		this.extendedTagBits |= (ExtendedTagBits.AnnotationResolved | ExtendedTagBits.DeprecatedAnnotationResolved);
+		this.extendedTagBits |= ExtendedTagBits.AllAnnotationsResolved;
 		LookupEnvironment environment = declaringEnum.scope.environment();
 	    this.thrownExceptions = Binding.NO_EXCEPTIONS;
 		if (selector == TypeConstants.VALUES) {
@@ -315,7 +315,7 @@ public class SyntheticMethodBinding extends MethodBinding {
 		this.declaringClass = declaringClass;
 		this.selector = TypeConstants.DESERIALIZE_LAMBDA;
 		this.modifiers = ClassFileConstants.AccPrivate | ClassFileConstants.AccStatic | ClassFileConstants.AccSynthetic;
-		this.extendedTagBits |= (ExtendedTagBits.AnnotationResolved | ExtendedTagBits.DeprecatedAnnotationResolved);
+		this.extendedTagBits |= ExtendedTagBits.AllAnnotationsResolved;
 		this.thrownExceptions = Binding.NO_EXCEPTIONS;
 		this.returnType = declaringClass.scope.getJavaLangObject();
 	    this.parameters = new TypeBinding[]{declaringClass.scope.getJavaLangInvokeSerializedLambda()};
@@ -333,7 +333,7 @@ public class SyntheticMethodBinding extends MethodBinding {
 		buffer.append(TypeConstants.SYNTHETIC_ENUM_CONSTANT_INITIALIZATION_METHOD_PREFIX).append(this.index);
 		this.selector = String.valueOf(buffer).toCharArray();
 		this.modifiers = ClassFileConstants.AccPrivate | ClassFileConstants.AccStatic;
-		this.extendedTagBits |= (ExtendedTagBits.AnnotationResolved | ExtendedTagBits.DeprecatedAnnotationResolved);
+		this.extendedTagBits |= ExtendedTagBits.AllAnnotationsResolved;
 		this.purpose = SyntheticMethodBinding.TooManyEnumsConstants;
 		this.thrownExceptions = Binding.NO_EXCEPTIONS;
 		this.returnType = TypeBinding.VOID;
@@ -353,7 +353,7 @@ public class SyntheticMethodBinding extends MethodBinding {
 	    this.selector = overridenMethodToBridge.selector;
 	    // amongst other, clear the AccGenericSignature, so as to ensure no remains of original inherited persist (101794)
 	    this.modifiers = (overridenMethodToBridge.modifiers | ClassFileConstants.AccBridge | ClassFileConstants.AccSynthetic) & ~(ClassFileConstants.AccSynchronized | ClassFileConstants.AccAbstract | ClassFileConstants.AccNative  | ClassFileConstants.AccFinal | ExtraCompilerModifiers.AccGenericSignature);
-		this.extendedTagBits |= (ExtendedTagBits.AnnotationResolved | ExtendedTagBits.DeprecatedAnnotationResolved);
+		this.extendedTagBits |= ExtendedTagBits.AllAnnotationsResolved;
 	    this.returnType = overridenMethodToBridge.returnType;
 	    this.parameters = overridenMethodToBridge.parameters;
 	    this.thrownExceptions = overridenMethodToBridge.thrownExceptions;
@@ -366,7 +366,7 @@ public class SyntheticMethodBinding extends MethodBinding {
 	    this.declaringClass = declaringClass;
 	    this.selector = selector;
 	    this.modifiers = ClassFileConstants.AccSynthetic | ClassFileConstants.AccPrivate | ClassFileConstants.AccStatic;
-		this.extendedTagBits |= (ExtendedTagBits.AnnotationResolved | ExtendedTagBits.DeprecatedAnnotationResolved);
+		this.extendedTagBits |= ExtendedTagBits.AllAnnotationsResolved;
 	    this.returnType = arrayType;
 	    LookupEnvironment environment = declaringClass.environment;
 		if (environment.globalOptions.isAnnotationBasedNullAnalysisEnabled) {
@@ -388,7 +388,7 @@ public class SyntheticMethodBinding extends MethodBinding {
 	    this.selector = lambdaName;
 	    this.modifiers = lambda.binding.modifiers;
 	    this.tagBits |=  (lambda.binding.tagBits & TagBits.HasParameterAnnotations);
-		this.extendedTagBits |= (ExtendedTagBits.AnnotationResolved | ExtendedTagBits.DeprecatedAnnotationResolved);
+		this.extendedTagBits |= ExtendedTagBits.AllAnnotationsResolved;
 	    this.returnType = lambda.binding.returnType;
 	    this.parameters = lambda.binding.parameters;
         if (this.returnType.isNonDenotable() || Stream.of(this.parameters).anyMatch(TypeBinding::isNonDenotable)) {
@@ -407,7 +407,7 @@ public class SyntheticMethodBinding extends MethodBinding {
 	    this.declaringClass = declaringClass;
 	    this.selector = ref.binding.selector;
 	    this.modifiers = ref.binding.modifiers;
-		this.extendedTagBits |= (ExtendedTagBits.AnnotationResolved | ExtendedTagBits.DeprecatedAnnotationResolved);
+		this.extendedTagBits |= ExtendedTagBits.AllAnnotationsResolved;
 		this.tagBits |= (ref.binding.tagBits & TagBits.HasParameterAnnotations);
 	    this.returnType = ref.binding.returnType;
 	    this.parameters = ref.binding.parameters;
@@ -420,7 +420,7 @@ public class SyntheticMethodBinding extends MethodBinding {
 	    this.declaringClass = declaringClass;
 	    this.selector = selector;
 	    this.modifiers = ClassFileConstants.AccSynthetic | ClassFileConstants.AccPrivate | ClassFileConstants.AccStatic;
-		this.extendedTagBits |= (ExtendedTagBits.AnnotationResolved | ExtendedTagBits.DeprecatedAnnotationResolved);
+		this.extendedTagBits |= ExtendedTagBits.AllAnnotationsResolved;
 	    this.returnType = publicConstructor.declaringClass;
 
 	    int realParametersLength = privateConstructor.parameters.length;
@@ -444,7 +444,7 @@ public class SyntheticMethodBinding extends MethodBinding {
 		this.modifiers = declaringClass.modifiers & (ClassFileConstants.AccPublic|ClassFileConstants.AccPrivate|ClassFileConstants.AccProtected);
 		if (this.declaringClass.isStrictfp())
 			this.modifiers |= ClassFileConstants.AccStrictfp;
-		this.extendedTagBits |= (ExtendedTagBits.AnnotationResolved | ExtendedTagBits.DeprecatedAnnotationResolved);
+		this.extendedTagBits |= ExtendedTagBits.AllAnnotationsResolved;
 		this.extendedTagBits |= ExtendedTagBits.IsCanonicalConstructor;
 		this.extendedTagBits |= ExtendedTagBits.isImplicit;
 		this.parameters = rcb.length == 0 ? Binding.NO_PARAMETERS : new TypeBinding[rcb.length];
@@ -467,7 +467,7 @@ public class SyntheticMethodBinding extends MethodBinding {
 //			this.modifiers |= ExtraCompilerModifiers.AccGenericSignature;
 		if (this.declaringClass.isStrictfp())
 			this.modifiers |= ClassFileConstants.AccStrictfp;
-		this.extendedTagBits |= (ExtendedTagBits.AnnotationResolved | ExtendedTagBits.DeprecatedAnnotationResolved);
+		this.extendedTagBits |= ExtendedTagBits.AllAnnotationsResolved;
 		this.parameters = Binding.NO_PARAMETERS;
 //		this.returnType = rcb.type; Not resolved yet - to be filled in later
 		this.selector = rcb.name;
@@ -486,7 +486,7 @@ public class SyntheticMethodBinding extends MethodBinding {
 		this.modifiers = ClassFileConstants.AccPublic | ClassFileConstants.AccFinal;
 		if (this.declaringClass.isStrictfp())
 				this.modifiers |= ClassFileConstants.AccStrictfp;
-		this.extendedTagBits |= (ExtendedTagBits.AnnotationResolved | ExtendedTagBits.DeprecatedAnnotationResolved);
+		this.extendedTagBits |= ExtendedTagBits.AllAnnotationsResolved;
 	    this.selector = selector;
 	    this.thrownExceptions = Binding.NO_EXCEPTIONS;
 		if (selector == TypeConstants.TOSTRING) {
@@ -512,7 +512,7 @@ public class SyntheticMethodBinding extends MethodBinding {
 
 		this.targetMethod = accessedConstructor;
 		this.modifiers = ClassFileConstants.AccDefault | ClassFileConstants.AccSynthetic;
-		this.extendedTagBits |= (ExtendedTagBits.AnnotationResolved | ExtendedTagBits.DeprecatedAnnotationResolved);
+		this.extendedTagBits |= ExtendedTagBits.AllAnnotationsResolved;
 		SourceTypeBinding sourceType = (SourceTypeBinding) accessedConstructor.declaringClass;
 		SyntheticMethodBinding[] knownSyntheticMethods = sourceType.syntheticMethods();   // returns synthetic methods sorted with index.
 		this.index = knownSyntheticMethods == null ? 0 : knownSyntheticMethods[knownSyntheticMethods.length - 1].index + 1; //index may miss some numbers in between. get the highest index and assign next number.
@@ -597,7 +597,7 @@ public class SyntheticMethodBinding extends MethodBinding {
 			else
 				this.modifiers = ClassFileConstants.AccDefault | ClassFileConstants.AccStatic | ClassFileConstants.AccSynthetic;
 		}
-		this.extendedTagBits |= (ExtendedTagBits.AnnotationResolved | ExtendedTagBits.DeprecatedAnnotationResolved);
+		this.extendedTagBits |= ExtendedTagBits.AllAnnotationsResolved;
 		SourceTypeBinding declaringSourceType = (SourceTypeBinding) receiverType;
 		SyntheticMethodBinding[] knownAccessMethods = declaringSourceType.syntheticMethods();
 		int methodId = knownAccessMethods == null ? 0 : knownAccessMethods[knownAccessMethods.length - 1].index + 1; //index may miss some numbers in between. get the highest index and assign next number.

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TagBits.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TagBits.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2021 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -108,10 +108,10 @@ public interface TagBits {
 	long BeginAnnotationCheck = ASTNode.Bit32L;
 	long EndAnnotationCheck = ASTNode.Bit33L;
 
+	// currently unused: ASTNode.Bit34L, ASTNode.Bit34L
+
 	// standard annotations
 	// 9-bits for targets
-	long AnnotationResolved = ASTNode.Bit34L;
-	long DeprecatedAnnotationResolved = ASTNode.Bit35L;
 	long AnnotationTarget = ASTNode.Bit36L; // @Target({}) only sets this bit
 	long AnnotationForType = ASTNode.Bit37L;
 	long AnnotationForField = ASTNode.Bit38L;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeBinding.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -59,8 +59,6 @@ import org.eclipse.jdt.internal.compiler.tool.EclipseCompiler;
 abstract public class TypeBinding extends Binding {
 
 	public int id = TypeIds.NoId;
-	public long tagBits = 0; // See values in the interface TagBits below
-	public int extendedTagBits = 0; // See values in the interface ExtendedTagBits
 
 	protected AnnotationBinding [] typeAnnotations = Binding.NO_ANNOTATIONS;
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/VariableBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/VariableBinding.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -29,7 +29,6 @@ public abstract class VariableBinding extends Binding {
 	public char[] name;
 	protected Constant constant;
 	public int id; // for flow-analysis (position in flowInfo bit vector)
-	public long tagBits;
 
 	public VariableBinding(char[] name, TypeBinding type, int modifiers, Constant constant) {
 		this.name = name;

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullTypeAnnotationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullTypeAnnotationTest.java
@@ -19482,4 +19482,43 @@ public void testErrorPosition() {
 		----------
 		""");
 }
+public void testGH3461() {
+	Runner runner = new Runner();
+	runner.customOptions = getCompilerOptions();
+	runner.testFiles = new String[] {
+			"AbstractClassInAnnotation.java",
+			"""
+			public abstract class AbstractClassInAnnotation { }
+			""",
+			"AnnotationWithClassType.java",
+			"""
+			import java.lang.annotation.ElementType;
+			import java.lang.annotation.Retention;
+			import java.lang.annotation.RetentionPolicy;
+			import java.lang.annotation.Target;
+
+			@Target({ ElementType.TYPE })
+			@Retention(RetentionPolicy.RUNTIME)
+			public @interface AnnotationWithClassType {
+			            Class<? extends AbstractClassInAnnotation> value();
+			}
+			""",
+			"AnotherType.java",
+			"""
+			class AnotherType { }
+			""",
+			"ErrorClass.java",
+			"""
+			@AnnotationWithClassType(ImplementationClass.class)
+			abstract class ErrorClass<A extends AnotherType> { // notice: removing "<A extends AnotherType>" makes the error also disappear
+			}
+			""",
+			"ImplementationClass.java",
+			"""
+			public final class ImplementationClass extends AbstractClassInAnnotation { }
+			"""
+	};
+	runner.classLibraries = this.LIBS;
+	runner.runConformTest();
+}
 }


### PR DESCRIPTION
+ when looking for @NNBD only do a selective search for annotations
  (the current bug happens because this search triggers resolving
   of unrelated annotations with member value pairs that aren't ready)
+ implement specific resolving similar to resolveDeprecatedAnnotations()

Includes two preparatory commits to restructure the code ahead of the actual fix.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3461

