### PR TITLE
Fix inline return to not flag open braces that are not inline tags

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocTest_16.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocTest_16.java
@@ -162,6 +162,26 @@ public void testInlineReturn3() {
 		}
 	);
 }
+public void testInlineReturn4() {
+	if(this.complianceLevel < ClassFileConstants.JDK16) {
+		return;
+	}
+	this.runConformTest(
+		new String[] {
+			"X.java",
+			"""
+			public class X {
+				/** {@return {true} or
+				 *  {false}}
+				 */
+				public boolean sample() {
+					return false;
+				}
+			}
+			""",
+		}
+	);
+}
 public void testInlineReturn_broken1() {
 	if(this.complianceLevel < ClassFileConstants.JDK16) {
 		return;
@@ -183,7 +203,7 @@ public void testInlineReturn_broken1() {
 		----------
 		1. ERROR in X.java (at line 2)
 			/** {@return with unbalanced brace{} */
-			    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+			    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 		Javadoc: Missing closing brace for inline tag
 		----------
 		""",

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/DocCommentParser.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/DocCommentParser.java
@@ -1400,6 +1400,7 @@ class DocCommentParser extends AbstractCommentParser {
 					}
 				} else {
 					this.inlineReturn= false;
+					this.inlineReturnOpenBraces= 0;
 				}
 			}
 		}


### PR DESCRIPTION
- add additional logic to AbstractCommentParser to allow text with matching open and closing braces
- add new test to JavadocTest_16
- fixes #3879

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
