### PR TITLE
Add multi-release compilation support to JDT

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/core/IClasspathAttribute.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/core/IClasspathAttribute.java
@@ -278,6 +278,20 @@ public interface IClasspathAttribute {
 	String WITHOUT_TEST_CODE = "without_test_code"; //$NON-NLS-1$
 
 	/**
+	 * Constant for the name of the release attribute.
+	 *
+	 * <p>
+	 * The possible values for this attribute are numbers > 8.
+	 * If the value of this attribute is provided, and the classpath entry
+	 * is a source folder, this will enable <a href="https://openjdk.org/jeps/238">Multi-Release</a>
+	 * compilation for this source folder for the given java release.
+	 * </p>
+	 *
+	 * @since 3.42
+	 */
+	String RELEASE = "release"; //$NON-NLS-1$
+
+	/**
 	 * Returns the name of this classpath attribute.
 	 *
 	 * @return the name of this classpath attribute.

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/AbstractImageBuilder.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/AbstractImageBuilder.java
@@ -541,13 +541,26 @@ protected void finishedWith(String sourceLocator, CompilationResult result, char
 }
 
 protected IContainer createFolder(IPath packagePath, IContainer outputFolder) throws CoreException {
-	if (packagePath.isEmpty()) return outputFolder;
+	if (packagePath.isEmpty()) {
+		createFolder(outputFolder);
+		return outputFolder;
+	}
 	IFolder folder = outputFolder.getFolder(packagePath);
 	if (!folder.exists()) {
 		createFolder(packagePath.removeLastSegments(1), outputFolder);
 		folder.create(IResource.FORCE | IResource.DERIVED, true, null);
 	}
 	return folder;
+}
+
+private void createFolder(IContainer container) throws CoreException {
+	if (container.exists()) {
+		return;
+	}
+	if (container instanceof IFolder folder) {
+		createFolder(container.getParent());
+		folder.create(IResource.FORCE | IResource.DERIVED, true, null);
+	}
 }
 
 @Override

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/BatchImageBuilder.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/BatchImageBuilder.java
@@ -160,23 +160,25 @@ protected void cleanOutputFolders(boolean copyBack) throws CoreException {
 				IContainer outputFolder = sourceLocation.binaryFolder;
 				if (!visited.contains(outputFolder)) {
 					visited.add(outputFolder);
-					IResource[] members = outputFolder.members();
-					for (IResource member : members) {
-						if (!member.isDerived()) {
-							member.accept(
-								new IResourceVisitor() {
-									@Override
-									public boolean visit(IResource resource) throws CoreException {
-										resource.setDerived(true, null);
-										return resource.getType() != IResource.FILE;
+					if (outputFolder.exists()) {
+						IResource[] members = outputFolder.members();
+						for (IResource member : members) {
+							if (!member.isDerived()) {
+								member.accept(
+									new IResourceVisitor() {
+										@Override
+										public boolean visit(IResource resource) throws CoreException {
+											resource.setDerived(true, null);
+											return resource.getType() != IResource.FILE;
+										}
 									}
-								}
-							);
-						}
-						try {
-							member.delete(IResource.FORCE, null);
-						} catch(CoreException e) {
-							Util.log(e, "Error occurred while deleting: " + member.getFullPath()); //$NON-NLS-1$
+								);
+							}
+							try {
+								member.delete(IResource.FORCE, null);
+							} catch(CoreException e) {
+								Util.log(e, "Error occurred while deleting: " + member.getFullPath()); //$NON-NLS-1$
+							}
 						}
 					}
 				}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/NameEnvironment.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/NameEnvironment.java
@@ -20,15 +20,7 @@
 package org.eclipse.jdt.internal.core.builder;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.eclipse.core.resources.IContainer;
@@ -41,6 +33,7 @@ import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
+import org.eclipse.jdt.core.IClasspathAttribute;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IModuleDescription;
@@ -203,9 +196,18 @@ private void computeClasspathLocations(
 					}
 					bLocation.patchModuleName = patchedModuleName;
 				} else {
+					IClasspathAttribute[] extraAttributes = entry.getExtraAttributes();
+					Map<String, String> map = Arrays.stream(extraAttributes).collect(Collectors.toMap(IClasspathAttribute::getName, IClasspathAttribute::getValue));
+					String release = map.get(IClasspathAttribute.RELEASE);
+					IContainer finalOutputFolder;
+					if (release == null) {
+						finalOutputFolder = outputFolder;
+					} else {
+						finalOutputFolder = outputFolder.getFolder(new Path(String.format("META-INF/versions/%s", release))); //$NON-NLS-1$
+					}
 					ClasspathLocation sourceLocation = ClasspathLocation.forSourceFolder(
 								(IContainer) target,
-								outputFolder,
+								finalOutputFolder,
 								entry.fullInclusionPatternChars(),
 								entry.fullExclusionPatternChars(),
 								entry.ignoreOptionalProblems(),


### PR DESCRIPTION
Currently JDT (like other IDEs) lacks good support for compilation of so called [multi-release-jar](https://openjdk.org/jeps/238) setups. Maven has quite good support for this by setting a `${release}` property per source folder and [enable an output flag](https://maven.apache.org/plugins/maven-compiler-plugin/compile-mojo.html#multiReleaseOutput) but often needs some ugly workarounds due to missing support in IDEs.

This is an attempt to bring multi-release-compilation to JDT to finally have this feature supported at least in one of the major IDEs and make this powerful feature more widely adopted.

In its current form it does the following:

1. One can set a `release` attribute in the classpath of a source folder, this can look like this:
```
<?xml version="1.0" encoding="UTF-8"?>
<classpath>
	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
		<attributes>
			<attribute name="module" value="true"/>
		</attributes>
	</classpathentry>
	<classpathentry kind="src" path="src"/>
	<classpathentry kind="src" path="src9">
		<attributes>
			<attribute name="release" value="9"/>
		</attributes>
	</classpathentry>
	<classpathentry kind="output" path="bin"/>
</classpath>
```
2. if such attribute is found JDT enables "multi-release-output" as per specification to place the compiled output of this source folder to `<outputfolder>/META-INF/versions/<release>`

The next step would be to further pass the release option to the compiler itself.
