### PR TITLE
Prevent double contains check for set and failure on non existent output

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/BatchImageBuilder.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/BatchImageBuilder.java
@@ -158,25 +158,26 @@ protected void cleanOutputFolders(boolean copyBack) throws CoreException {
 			this.notifier.subTask(Messages.bind(Messages.build_cleaningOutput, this.javaBuilder.currentProject.getName()));
 			if (sourceLocation.hasIndependentOutputFolder) {
 				IContainer outputFolder = sourceLocation.binaryFolder;
-				if (!visited.contains(outputFolder)) {
-					visited.add(outputFolder);
-					IResource[] members = outputFolder.members();
-					for (IResource member : members) {
-						if (!member.isDerived()) {
-							member.accept(
-								new IResourceVisitor() {
-									@Override
-									public boolean visit(IResource resource) throws CoreException {
-										resource.setDerived(true, null);
-										return resource.getType() != IResource.FILE;
+				if (visited.add(outputFolder)) {
+					if (outputFolder.exists()) {
+						IResource[] members = outputFolder.members();
+						for (IResource member : members) {
+							if (!member.isDerived()) {
+								member.accept(
+									new IResourceVisitor() {
+										@Override
+										public boolean visit(IResource resource) throws CoreException {
+											resource.setDerived(true, null);
+											return resource.getType() != IResource.FILE;
+										}
 									}
-								}
-							);
-						}
-						try {
-							member.delete(IResource.FORCE, null);
-						} catch(CoreException e) {
-							Util.log(e, "Error occurred while deleting: " + member.getFullPath()); //$NON-NLS-1$
+								);
+							}
+							try {
+								member.delete(IResource.FORCE, null);
+							} catch(CoreException e) {
+								Util.log(e, "Error occurred while deleting: " + member.getFullPath()); //$NON-NLS-1$
+							}
 						}
 					}
 				}


### PR DESCRIPTION
Currently there is a check if the output folder is contained in a set and if not it is added. The Set#add method already performs the check and return false in case the item was not added.

This now combines the check and adds an additional check if the folder exits because otherwise the IContainer#members() throw an exception in some cases (e.g. output folder is deleted by an external process in the meanwhile).