### PR TITLE
Parameters of implicit constructor of record classes reported incorrectly as being unused

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AbstractMethodDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AbstractMethodDeclaration.java
@@ -164,7 +164,7 @@ public abstract class AbstractMethodDeclaration
 				}
 				return;
 			}
-			boolean used = this.binding.isAbstract() || this.binding.isNative();
+			boolean used = this.binding.isAbstract() || this.binding.isNative() || this.binding.isCompactConstructor() || (this.bits & ASTNode.IsImplicit) != 0;
 			AnnotationBinding[][] paramAnnotations = null;
 			for (int i = 0, length = this.arguments.length; i < length; i++) {
 				Argument argument = this.arguments[i];

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordsRestrictedClassTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordsRestrictedClassTest.java
@@ -9719,4 +9719,52 @@ public void testGH3891_preview() {
 		""";
 	runner.runNegativeTest();
 }
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3904
+// Unused parameters warning reported for record components
+public void testIssue3904() {
+	Map<String, String> options = getCompilerOptions();
+	options.put(CompilerOptions.OPTION_ReportUnusedParameter, CompilerOptions.ERROR);
+	this.runNegativeTest(
+	new String[] {
+			"X.java",
+			"class X {\n" +
+			"	public static void main(String[] args) {\n" +
+			"		Pair p = new Pair(\"4\", \"2\");\n" +
+			"		System.out.println(p.fTag() + p.fContent());\n" +
+			"	}\n" +
+			"	public record Pair(String fTag, String fContent) {}\n" + // should NOT warn on implicit constructor
+			"   public void foo(int unused) {\n" + // should warn on unused parameter of non-constructor
+			"   }\n" +
+			"   public record Person(String name, int age) {\n" +
+			"       public Person(String name, int age) {\n" + // Should warn here
+			"           this.name = null; this.age = 0;\n" +
+			"       }\n" +
+			"   }\n" +
+			"   public record Point (int x, int y) {\n" +
+			"       public Point {}\n" + // no warning here
+			"   }\n"+
+			"\n" +
+			"}\n",
+		},
+		"----------\n" +
+		"1. ERROR in X.java (at line 7)\n" +
+		"	public void foo(int unused) {\n" +
+		"	                    ^^^^^^\n" +
+		"The value of the parameter unused is not used\n" +
+		"----------\n" +
+		"2. ERROR in X.java (at line 10)\n" +
+		"	public Person(String name, int age) {\n" +
+		"	                     ^^^^\n" +
+		"The value of the parameter name is not used\n" +
+		"----------\n" +
+		"3. ERROR in X.java (at line 10)\n" +
+		"	public Person(String name, int age) {\n" +
+		"	                               ^^^\n" +
+		"The value of the parameter age is not used\n" +
+		"----------\n",
+		null,
+		true,
+		options
+	);
+}
 }


### PR DESCRIPTION
* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3904

