### PR TITLE
Method call compiles with javac but not ecj #3457

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
@@ -163,6 +163,8 @@ public class InferenceContext18 {
 	// during reduction we ignore missing types but record that fact here:
 	TypeBinding missingType;
 
+	private static ThreadLocal<InferenceContext18> instance = new ThreadLocal<>();
+
 	public static boolean isSameSite(InvocationSite site1, InvocationSite site2) {
 		if (site1 == site2)
 			return true;
@@ -1023,30 +1025,35 @@ public class InferenceContext18 {
 	 * @throws InferenceFailureException a compile error has been detected during inference
 	 */
 	private /*@Nullable*/ BoundSet solve(boolean inferringApplicability, boolean isRecordPatternTypeInference) throws InferenceFailureException {
+		instance.set(this);
 
-		if (!reduce())
-			return null;
-		if (!this.currentBounds.incorporate(this))
-			return null;
-		if (inferringApplicability)
-			this.b2 = this.currentBounds.copy(); // Preserve the result after reduction, without effects of resolve() for later use in invocation type inference.
+		try {
+			if (!reduce())
+				return null;
+			if (!this.currentBounds.incorporate(this))
+				return null;
+			if (inferringApplicability)
+				this.b2 = this.currentBounds.copy(); // Preserve the result after reduction, without effects of resolve() for later use in invocation type inference.
 
-		BoundSet solution = resolve(this.inferenceVariables, isRecordPatternTypeInference);
+			BoundSet solution = resolve(this.inferenceVariables, isRecordPatternTypeInference);
 
-		/* If inferring applicability make a final pass over the initial constraints preserved as final constraints to make sure they hold true at a macroscopic level.
-		   See https://bugs.eclipse.org/bugs/show_bug.cgi?id=426537#c55 onwards.
-		*/
-		if (inferringApplicability && solution != null && this.finalConstraints != null) {
-			for (ConstraintExpressionFormula constraint: this.finalConstraints) {
-				if (constraint.left.isPolyExpression())
-					continue; // avoid redundant re-inference, inner poly's own constraints get validated in its own context & poly invocation type inference proved compatibility against target.
-				constraint.applySubstitution(solution, this.inferenceVariables);
-				if (!this.currentBounds.reduceOneConstraint(this, constraint)) {
-					return null;
+			/* If inferring applicability make a final pass over the initial constraints preserved as final constraints to make sure they hold true at a macroscopic level.
+			   See https://bugs.eclipse.org/bugs/show_bug.cgi?id=426537#c55 onwards.
+			*/
+			if (inferringApplicability && solution != null && this.finalConstraints != null) {
+				for (ConstraintExpressionFormula constraint: this.finalConstraints) {
+					if (constraint.left.isPolyExpression())
+						continue; // avoid redundant re-inference, inner poly's own constraints get validated in its own context & poly invocation type inference proved compatibility against target.
+					constraint.applySubstitution(solution, this.inferenceVariables);
+					if (!this.currentBounds.reduceOneConstraint(this, constraint)) {
+						return null;
+					}
 				}
 			}
+			return solution;
+		} finally {
+			instance.remove();
 		}
-		return solution;
 	}
 
 	public /*@Nullable*/ BoundSet solve() throws InferenceFailureException {
@@ -2203,5 +2210,13 @@ public class InferenceContext18 {
 			}
 		}
 		return false;
+	}
+	public static TypeBinding maybeCapture(TypeBinding type) {
+		InferenceContext18 inst = instance.get();
+		if (inst != null) {
+			InvocationSite inv = inst.currentInvocation;
+			return type.capture(inst.scope, inv.sourceStart(), inv.sourceEnd());
+		}
+		return type;
 	}
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedTypeBinding.java
@@ -168,6 +168,13 @@ public class ParameterizedTypeBinding extends ReferenceBinding implements Substi
 	public boolean canBeInstantiated() {
 		return ((this.tagBits & TagBits.HasDirectWildcard) == 0) && super.canBeInstantiated(); // cannot instantiate param type with wildcard arguments
 	}
+	@Override
+	public TypeBinding findSuperTypeOriginatingFrom(TypeBinding otherType) {
+		TypeBinding capture = InferenceContext18.maybeCapture(this);
+		if (capture != this) //$IDENTITY-COMPARISON$
+			return capture.findSuperTypeOriginatingFrom(otherType);
+		return super.findSuperTypeOriginatingFrom(otherType);
+	}
 
 	/**
 	 * Perform capture conversion for a parameterized type with wildcard arguments

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
@@ -1725,6 +1725,7 @@ public final boolean isStrictfp() {
  */
 public boolean isSuperclassOf(ReferenceBinding otherType) {
 	while ((otherType = otherType.superclass()) != null) {
+		otherType = (ReferenceBinding) InferenceContext18.maybeCapture(otherType);
 		if (otherType.isEquivalentTo(this)) return true;
 	}
 	return false;

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_1_8.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_1_8.java
@@ -6987,7 +6987,7 @@ public void testBug472851() {
 		"1. ERROR in Test.java (at line 10)\n" +
 		"	test(type);\n" +
 		"	^^^^\n" +
-		"The method test(List<L>) in the type Test is not applicable for the arguments (List<capture#1-of ? extends List<?>>)\n" +
+		"The method test(List<L>) in the type Test is not applicable for the arguments (List<capture#2-of ? extends List<?>>)\n" +
 		"----------\n");
 }
 public void testBug502350() {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
@@ -1049,6 +1049,26 @@ public void testGH3501() {
 			""";
 	runner.runNegativeTest();
 }
+public void testGH3457() {
+	runConformTest(new String[] {
+		"Test.java",
+		"""
+		public class Test {
+			public void test() {
+				this.error(new TypeToken<A2<?>>() {});
+			}
+
+			public <T extends B1> void error(TypeToken<? extends A1<? extends T>> type) {}
+			public static abstract class TypeToken<T> {}
+			public static class A1<T extends B1> {}
+			public static class A2<T extends B2> extends A1<T> {}
+
+			public static class B1 {}
+			public static class B2 extends B1 {}
+		}
+		"""
+	});
+}
 public static Class<GenericsRegressionTest_9> testClass() {
 	return GenericsRegressionTest_9.class;
 }


### PR DESCRIPTION
During inference let InferenceContext18 capture types during
+ PTB.findSuperTypeOriginatingFrom
+ RB.isSuperclassOf()

to comply with JLS §4.10.2

This is an opportunistic fix, in that it only works during type inference.

With a solution based on `ThreadLocal<InferenceContext18>` I'm bypassing the problem of needing to pass a scope and source locations into lots of core functions. For the issue at hand this is sufficient, but significant more work might be needed if similar bugs are reported where no type inference is involved.