### PR TITLE
Method call compiles with javac but not ecj

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
@@ -2219,4 +2219,12 @@ public class InferenceContext18 {
 		}
 		return type;
 	}
+
+	public static TypeBinding maybeUncapture(CaptureBinding capture) {
+		InferenceContext18 inst = instance.get();
+		if (inst != null) {
+			return capture.uncapture(inst.scope);
+		}
+		return capture;
+	}
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeBinding.java
@@ -1392,6 +1392,8 @@ public boolean isTypeArgumentContainedBy(TypeBinding otherType) {
 						for (TypeBinding intersectingType : intersectingTypes)
 							if (TypeBinding.equalsEquals(intersectingType, this))
 								return true;
+					} else if (otherBound instanceof CaptureBinding capture) {
+						otherBound = InferenceContext18.maybeUncapture(capture); // not backed by JLS
 					}
 					if (TypeBinding.equalsEquals(otherBound, this))
 						return true; // ? extends T  <=  ? extends ? extends T
@@ -1400,7 +1402,7 @@ public boolean isTypeArgumentContainedBy(TypeBinding otherType) {
 					TypeBinding match = upperBound.findSuperTypeOriginatingFrom(otherBound);
 					if (match != null && (match = match.leafComponentType()).isRawType()) {
 						return TypeBinding.equalsEquals(match, otherBound.leafComponentType()); // forbide: Collection <=  ? extends Collection<?>
-																												// forbide: Collection[] <=  ? extends Collection<?>[]
+																								// forbide: Collection[] <=  ? extends Collection<?>[]
 					}
 					return upperBound.isCompatibleWith(otherBound);
 

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
@@ -1069,6 +1069,29 @@ public void testGH3457() {
 		"""
 	});
 }
+public void testGH3457b() {
+	runConformTest(new String[] {
+		"QueryUtil.java",
+		"""
+		import java.util.ArrayList;
+		import java.util.Collection;
+
+		interface IQuery<T> { }
+
+		public class QueryUtil {
+			public static <T> IQuery<T> createCompoundQuery(IQuery<? extends T> query1, IQuery<T> query2, boolean and) {
+				ArrayList<IQuery<? extends T>> queries = new ArrayList<>(2);
+				queries.add(query1);
+				queries.add(query2);
+				return createCompoundQuery(queries, and);
+			}
+			public static <T> IQuery<T> createCompoundQuery(Collection<? extends IQuery<? extends T>> queries, boolean and) {
+				return null;
+			}
+		}
+		"""
+	});
+}
 public static Class<GenericsRegressionTest_9> testClass() {
 	return GenericsRegressionTest_9.class;
 }


### PR DESCRIPTION
Regression fix:
+ uncapture in a situation that previously didn't capture in the 1.place

Re-fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3457
