### PR TITLE
Provide new ICompilationUnit.updateTimeStamp() API

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/core/ICompilationUnit.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/core/ICompilationUnit.java
@@ -17,6 +17,7 @@ package org.eclipse.jdt.core;
 
 import java.util.Collections;
 import java.util.Map;
+import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTParser;
@@ -845,4 +846,19 @@ CompilationUnit reconcile(int astLevel, int reconcileFlags, WorkingCopyOwner own
  */
 @Override
 void restore() throws JavaModelException;
+
+/**
+ * Can be used to synchronize the internally used modification stamp to its corresponding {@link IResource}s
+ * modification stamp. <br>
+ * Default implementation does nothing.
+ *
+ * @throws JavaModelException
+ *                                can be thrown if the last modification stamp of the corresponding {@link IResource}
+ *                                object isn't set.
+ * @see IResource#getModificationStamp()
+ * @since 3.42
+ */
+default void updateTimeStamp() throws JavaModelException {
+	// does nothing by default
+}
 }

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/CompilationUnit.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/CompilationUnit.java
@@ -1513,6 +1513,11 @@ protected void updateTimeStamp(CompilationUnit original) throws JavaModelExcepti
 }
 
 @Override
+public void updateTimeStamp() throws JavaModelException {
+	updateTimeStamp(this);
+}
+
+@Override
 protected IStatus validateExistence(IResource underlyingResource) {
 	// check if this compilation unit can be opened
 	if (!isWorkingCopy()) { // no check is done on root kind or exclusion pattern for working copies


### PR DESCRIPTION
Provides new `ICompilationUnit.updateTimeStamp() API` required by JDT UI to fix the problem with Java search affected by improper `CompilationUnitDocumentProvider.commitWorkingCopy()` design.

Basically, the JDT Java search has a special case for working copies but the working copies weren't properly updated by UI during "Save" actions...

Fixes the problem described here: https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3918
