### PR TITLE
Treat methods used as method references as implementing

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ReferenceExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ReferenceExpression.java
@@ -715,6 +715,7 @@ public class ReferenceExpression extends FunctionalExpression implements IPolyEx
         MethodBinding someMethod = null;
         if (isMethodReference) {
         	someMethod = scope.getMethod(this.receiverType, this.selector, descriptorParameters, this);
+        	someMethod.modifiers |= ExtraCompilerModifiers.AccImplementing;
         } else {
         	if (this.receiverType instanceof LocalTypeBinding local) {
         		MethodScope enclosingMethodScope = local.scope.enclosingMethodScope();

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ProgrammingProblemsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ProgrammingProblemsTest.java
@@ -4168,4 +4168,45 @@ public void testGH3870() {
 				s.equals(args)""";
 	runner.runConformTest();
 }
+//https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3944
+//Don't report unused parameter for methods implementing a functional interface by method reference
+public void testGH3944() {
+	if (this.complianceLevel < ClassFileConstants.JDK1_8)
+		return;
+	Map customOptions = getCompilerOptions();
+	customOptions.put(CompilerOptions.OPTION_ReportUnusedParameter, CompilerOptions.ERROR);
+	customOptions.put(CompilerOptions.OPTION_ReportUnusedParameterWhenImplementingAbstract, CompilerOptions.DISABLED);
+	this.runConformTest(
+			new String[] {
+					"Showcase.java",
+					"""
+					public class Showcase {
+					    @FunctionalInterface
+					    interface MyFunction {
+					        int apply(int someParam, int someOtherParam);
+					    }
+
+					    public static void main(String[] args) {
+					        test(Showcase::methodImplementation);
+					    }
+
+					    private static void test(MyFunction func) {
+					        int result = func.apply(42, 9001);
+					        System.out.println("Result: " + result);
+					    }
+
+					    // someParam marked as unused, even if "Ignore in overriding and implementing method" is checked
+					    private static int methodImplementation(int someParam, int someOtherParam) {
+					        return someOtherParam;
+					    }
+					}
+					"""
+			},
+			"Result: 9001",
+			null/*classLibraries*/,
+			true/*shouldFlushOutputDirectory*/,
+			null/*vmArguments*/,
+			customOptions,
+			null/*requestor*/);
+}
 }


### PR DESCRIPTION
When method references are used to implement an interface, the implementation might not use all arguments. Marking such methods as implementing removes warnings for unused arguments when "Ignore in overriding and implementing method" is checked.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3944

## What it does
Marks methods used as method references as implementing to remove warnings about unused arguments when "Ignore in overriding and implementing method" is checked.

## How to test
The class in ProgrammingProblemsTest#testGH3944 showcases the issue.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)

I created an account, but could not login with the password. [Ask for a new password](https://accounts.eclipse.org/user/password?destination=/user/login) has not sent me something yet.