### PR TITLE
[Records 2.0] Alternate generation of synthetic component accessors and record override methods

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ClassFile.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ClassFile.java
@@ -2345,7 +2345,9 @@ public class ClassFile implements TypeConstants, TypeIds {
 			AbstractMethodDeclaration methodDeclaration = binding.sourceMethod();
 			if (methodDeclaration != null) {
 				if ((methodDeclaration.bits & ASTNode.HasTypeAnnotations) != 0) {
-					Argument[] arguments = methodDeclaration.arguments;
+					AbstractVariableDeclaration[] arguments = binding.isCompactConstructor() ?
+							getRecordComponents(binding.declaringClass) : methodDeclaration.arguments;
+
 					if (arguments != null) {
 						completeArgumentAnnotationInfo(arguments, allTypeAnnotationContexts);
 					}
@@ -3758,7 +3760,7 @@ public class ClassFile implements TypeConstants, TypeIds {
 
 		assert type instanceof SourceTypeBinding;
 		SourceTypeBinding sourceType = (SourceTypeBinding) type;
-		FieldBinding[] recordComponents = sourceType.getImplicitComponentFields();
+		RecordComponentBinding[] recordComponents = sourceType.components();
 
 		int numArgs = 2 + recordComponents.length;
 		this.contents[numArgsLocation++] = (byte) (numArgs >> 8);
@@ -3776,10 +3778,10 @@ public class ClassFile implements TypeConstants, TypeIds {
 		if (recordComponents.length * 2 + localContentsOffset >= this.contents.length) {
 			resizeContents(recordComponents.length * 2);
 		}
-		for (FieldBinding field : recordComponents) {
+		for (RecordComponentBinding component : recordComponents) {
 			int methodHandleIndex = this.constantPool.literalIndexForMethodHandleFieldRef(
 					ClassFileConstants.MethodHandleRefKindGetField,
-					recordName, field.name, field.type.signature());
+					recordName, component.name, component.type.signature());
 
 			this.contents[localContentsOffset++] = (byte) (methodHandleIndex >> 8);
 			this.contents[localContentsOffset++] = (byte) methodHandleIndex;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/CodeStream.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/CodeStream.java
@@ -1334,8 +1334,8 @@ public void fdiv() {
 	this.bCodeStream[this.classFileOffset++] = Opcodes.OPC_fdiv;
 }
 
-public void fieldAccess(byte opcode, FieldBinding fieldBinding, TypeBinding declaringClass) {
-	if (declaringClass == null) declaringClass = fieldBinding.declaringClass;
+public void fieldAccess(byte opcode, VariableBinding fieldBinding, TypeBinding declaringClass) {
+	if (declaringClass == null) declaringClass = fieldBinding.getDeclaringClass();
 	if ((declaringClass.tagBits & TagBits.ContainsNestedTypeReferences) != 0) {
 		Util.recordNestedType(this.classFile, declaringClass);
 	}
@@ -2862,7 +2862,7 @@ public void generateSyntheticBodyForEnumInitializationMethod(SyntheticMethodBind
 	return_();
 }
 public void generateSyntheticBodyForFieldReadAccess(SyntheticMethodBinding accessMethod) {
-	FieldBinding fieldBinding = accessMethod.targetReadField;
+	VariableBinding fieldBinding = accessMethod.targetReadField;
 	// target method declaring class may not be accessible (247953);
 	TypeBinding declaringClass = accessMethod.purpose == SyntheticMethodBinding.SuperFieldReadAccess
 			? accessMethod.declaringClass.superclass()
@@ -3025,7 +3025,7 @@ ReferenceBinding findDirectSuperTypeTowards(SyntheticMethodBinding accessMethod,
 public void generateSyntheticBodyForSwitchTable(SyntheticMethodBinding methodBinding) {
 	ClassScope scope = ((SourceTypeBinding)methodBinding.declaringClass).scope;
 	final BranchLabel nullLabel = new BranchLabel(this);
-	FieldBinding syntheticFieldBinding = methodBinding.targetReadField;
+	VariableBinding syntheticFieldBinding = methodBinding.targetReadField;
 	fieldAccess(Opcodes.OPC_getstatic, syntheticFieldBinding, null /* default declaringClass */);
 	dup();
 	ifnull(nullLabel);
@@ -3152,11 +3152,11 @@ public void generateSyntheticBodyForRecordCanonicalConstructor(SyntheticMethodBi
 	aload_0();
 	invoke(Opcodes.OPC_invokespecial, superCons, superClass);
 	int resolvedPosition;
-	FieldBinding[] fields =  declaringClass.getImplicitComponentFields();
+	VariableBinding[] fields =  declaringClass.components();
 	int len = fields != null ? fields.length : 0;
 	resolvedPosition = 1;
 	for (int i = 0;  i < len; ++i) {
-		FieldBinding field = fields[i];
+		VariableBinding field = fields[i];
 		aload_0();
 	    TypeBinding type = field.type;
 		load(type, resolvedPosition);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ClassScope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ClassScope.java
@@ -487,10 +487,6 @@ public class ClassScope extends Scope {
 			if (hasAbstractMethods)
 				problemReporter().abstractMethodInConcreteClass(sourceType);
 		}
-		if (sourceType.isRecord()) {
-			methodBindings = sourceType.checkAndAddSyntheticRecordMethods(methodBindings, count);
-			count = methodBindings.length;
-		}
 		if (count != methodBindings.length)
 			System.arraycopy(methodBindings, 0, methodBindings = new MethodBinding[count], 0, count);
 		sourceType.tagBits &= ~(TagBits.AreMethodsSorted|TagBits.AreMethodsComplete); // in case some static imports reached already into this type

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/FieldBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/FieldBinding.java
@@ -332,15 +332,19 @@ public long getAnnotationTagBits() {
 	return originalField.tagBits;
 }
 
-public final boolean isDefault() {
-	return !isPublic() && !isProtected() && !isPrivate();
+@Override
+public ReferenceBinding getDeclaringClass() {
+	return this.declaringClass;
 }
-/* Answer true if the receiver is a deprecated field
-*/
 
 /* Answer true if the receiver has default visibility
 */
+public final boolean isDefault() {
+	return !isPublic() && !isProtected() && !isPrivate();
+}
 
+/* Answer true if the receiver is a deprecated field
+*/
 public final boolean isDeprecated() {
 	return (this.modifiers & ClassFileConstants.AccDeprecated) != 0;
 }
@@ -370,12 +374,7 @@ public final boolean isProtected() {
 public final boolean isPublic() {
 	return (this.modifiers & ClassFileConstants.AccPublic) != 0;
 }
-/* Answer true if the receiver is a static field
-*/
 
-public final boolean isStatic() {
-	return (this.modifiers & ClassFileConstants.AccStatic) != 0;
-}
 /* Answer true if the receiver is not defined in the source of the declaringClass
 */
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/RecordComponentBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/RecordComponentBinding.java
@@ -98,6 +98,11 @@ public class RecordComponentBinding extends VariableBinding {
 		return originalRecordComponentBinding.tagBits;
 	}
 
+	@Override
+	public ReferenceBinding getDeclaringClass() {
+		return this.declaringRecord;
+	}
+
 	public final boolean isDeprecated() {
 		return (this.modifiers & ClassFileConstants.AccDeprecated) != 0;
 	}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/VariableBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/VariableBinding.java
@@ -55,6 +55,10 @@ public abstract class VariableBinding extends Binding {
 	@Override
 	public abstract AnnotationBinding[] getAnnotations();
 
+	public ReferenceBinding getDeclaringClass() {
+		return null;
+	}
+
 	public final boolean isBlankFinal(){
 		return (this.modifiers & ExtraCompilerModifiers.AccBlankFinal) != 0;
 	}
@@ -65,6 +69,12 @@ public abstract class VariableBinding extends Binding {
 	*/
 	public final boolean isFinal() {
 		return (this.modifiers & ClassFileConstants.AccFinal) != 0;
+	}
+
+	/* Answer true if the receiver is a static field
+	*/
+	public final boolean isStatic() {
+		return (this.modifiers & ClassFileConstants.AccStatic) != 0;
 	}
 
 	public final boolean isEffectivelyFinal() {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LookupTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LookupTest.java
@@ -443,7 +443,7 @@ public void test013() {
 		"	             ^^^^^^\n" +
 		"The type A.aClass must implement the inherited abstract method A.B.C.anotherMethod(int)\n" +
 		"----------\n" +
-		(this.complianceLevel < ClassFileConstants.JDK14
+		(this.complianceLevel < ClassFileConstants.JDK16
 		?
 		"2. ERROR in p1\\A.java (at line 11)\n" +
 		"	public void anotherMethod(int A) {};	\n" +


### PR DESCRIPTION
Avoid generating duplicate methods in the first place rather than generate, detect duplication and delete which is clunky.

* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3901

