### PR TITLE
Add API to check if an `IMethod` is `<clinit>`

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/core/IMethod.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/core/IMethod.java
@@ -247,6 +247,15 @@ ITypeParameter getTypeParameter(String name);
 boolean isConstructor() throws JavaModelException;
 
 /**
+ * Returns whether this method is a class initializer.
+ *
+ * @return true if this element is a class initialize, false otherwise
+ * @throws JavaModelException
+ * @since 3.42
+ */
+boolean isClinit() throws JavaModelException;
+
+/**
  * Returns whether this method is a main method.
  * It is a main method if:
  * <ul>

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/core/IType.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/core/IType.java
@@ -43,6 +43,10 @@ import org.eclipse.core.runtime.IProgressMonitor;
  * nested types. However, the {@link #getParent() parent} of such a nested binary type is
  * <em>not</em> the enclosing type, but that nested type's {@link IClassFile}!
  * </p>
+ * <p>
+ * Another Caveat: The {@link #getChildren() children} of a {@link #isBinary() binary} type may
+ * include an <code>IMethod</code> representing <code>&lt;clinit&gt;</code>.
+ * </p>
  *
  * @noimplement This interface is not intended to be implemented by clients.
  */

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/BinaryMethod.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/BinaryMethod.java
@@ -619,6 +619,13 @@ public boolean isConstructor() throws JavaModelException {
 	IBinaryMethod info = (IBinaryMethod) getElementInfo();
 	return info.isConstructor();
 }
+@Override
+public boolean isClinit() throws JavaModelException {
+	if ("<clinit>".equals(getElementName())) {
+		return true;
+	}
+	return false;
+}
 /*
  * @see IMethod#isMainMethod()
  */

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SourceMethod.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SourceMethod.java
@@ -243,6 +243,10 @@ public boolean isConstructor() throws JavaModelException {
 	SourceMethodElementInfo info = (SourceMethodElementInfo) getElementInfo();
 	return info.isConstructor();
 }
+@Override
+public boolean isClinit() throws JavaModelException {
+	return false;
+}
 /**
  * @see IMethod#isMainMethod()
  */


### PR DESCRIPTION
## What it does
- Adds a new API method to check if an `IMethod` is a `<clinit>`.
- Document in `IType` that `getChildren()` may return an `IMethod` that's a `<clinit>`

Fixes #3966

## How to test
- [ ] I should add some integration tests

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
