### PR TITLE
Proper handling of filling in of default nonnullness for compact constructor argument bindings

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AbstractMethodDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AbstractMethodDeclaration.java
@@ -118,6 +118,14 @@ public abstract class AbstractMethodDeclaration
 		return this.arguments; // overridden in compact constructor.
 	}
 
+	public LocalVariableBinding [] argumentBindings() {
+		int length = this.arguments == null ? 0 : this.arguments.length;
+		LocalVariableBinding [] argumentBindings = new LocalVariableBinding[length];
+		for(int i = 0; i < length; i++)
+			argumentBindings[i] = this.arguments[i].binding;
+		return argumentBindings;
+	}
+
 	/**
 	 * When a method is accessed via SourceTypeBinding.resolveTypesFor(MethodBinding)
 	 * we create the argument binding and resolve annotations in order to compute null annotation tagbits.

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ConstructorDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ConstructorDeclaration.java
@@ -301,6 +301,11 @@ public AbstractVariableDeclaration[] arguments(boolean includedElided) {
 	return includedElided && this.isCompactConstructor() ? this.protoArguments : super.arguments(includedElided);
 }
 
+@Override
+public LocalVariableBinding[] argumentBindings() {
+	return this.isCompactConstructor() ? this.scope == null ? Binding.NO_ARGUMENT_BINDINGS : this.scope.argumentBindings() : super.argumentBindings();
+}
+
 protected void doFieldReachAnalysis(FlowInfo flowInfo, FieldBinding[] fields) {
 	for (FieldBinding field : fields) {
 		if (!field.isStatic() && !flowInfo.isDefinitelyAssigned(field)) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/flow/ExceptionHandlingFlowContext.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/flow/ExceptionHandlingFlowContext.java
@@ -60,7 +60,6 @@ public class ExceptionHandlingFlowContext extends FlowContext {
 	// for dealing with anonymous constructor thrown exceptions
 	public List<TypeBinding> extendedExceptions;
 
-	private static final Argument[] NO_ARGUMENTS = new Argument[0];
 	public  Argument [] catchArguments;
 
 	private final int[] exceptionToCatchBlockMap;
@@ -72,7 +71,7 @@ public ExceptionHandlingFlowContext(
 			FlowContext initializationParent,
 			BlockScope scope,
 			UnconditionalFlowInfo flowInfo) {
-	this(parent, associatedNode, handledExceptions, null, NO_ARGUMENTS, initializationParent, scope, flowInfo);
+	this(parent, associatedNode, handledExceptions, null, ASTNode.NO_ARGUMENTS, initializationParent, scope, flowInfo);
 }
 public ExceptionHandlingFlowContext(
 		FlowContext parent,

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Binding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Binding.java
@@ -70,6 +70,8 @@ public abstract class Binding {
 	public static final ElementValuePair[] NO_ELEMENT_VALUE_PAIRS = new ElementValuePair[0];
 	public static final char[][] NO_PARAMETER_NAMES = new char[0][];
 	public static final RecordComponentBinding[] NO_COMPONENTS = new RecordComponentBinding[0];
+	public static final LocalVariableBinding[] NO_ARGUMENT_BINDINGS = new LocalVariableBinding[0];
+
 
 	public static final RecordComponentBinding[] UNINITIALIZED_COMPONENTS = new RecordComponentBinding[0];
 	public static final FieldBinding[] UNINITIALIZED_FIELDS = new FieldBinding[0];

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MethodBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MethodBinding.java
@@ -519,6 +519,7 @@ protected void fillInDefaultNonNullness(AbstractMethodDeclaration sourceMethod, 
 		this.parameterFlowBits = new byte[this.parameters.length];
 	boolean added = false;
 	int length = this.parameterFlowBits.length;
+	LocalVariableBinding [] argumentBindings = sourceMethod == null ? Binding.NO_ARGUMENT_BINDINGS : sourceMethod.argumentBindings();
 	for (int i = 0; i < length; i++) {
 		if(!needToApplyParameterNonNullDefault.hasNonNullDefaultForParam(i)) {
 			continue;
@@ -530,7 +531,7 @@ protected void fillInDefaultNonNullness(AbstractMethodDeclaration sourceMethod, 
 			added = true;
 			this.parameterFlowBits[i] |= PARAM_NONNULL;
 			if (sourceMethod != null) {
-				sourceMethod.arguments[i].binding.tagBits |= TagBits.AnnotationNonNull;
+				argumentBindings[i].tagBits |= TagBits.AnnotationNonNull;
 			}
 		} else if (sourceMethod != null && (this.parameterFlowBits[i] & PARAM_NONNULL) != 0) {
 			sourceMethod.scope.problemReporter().nullAnnotationIsRedundant(sourceMethod, i);
@@ -560,6 +561,7 @@ protected void fillInDefaultNonNullness18(AbstractMethodDeclaration sourceMethod
 	if (hasNonNullDefaultForParameter.hasAnyNonNullDefault()) {
 		boolean added = false;
 		int length = this.parameters.length;
+		LocalVariableBinding [] argumentBindings = sourceMethod == null ? Binding.NO_ARGUMENT_BINDINGS : sourceMethod.argumentBindings();
 		for (int i = 0; i < length; i++) {
 			if (!hasNonNullDefaultForParameter.hasNonNullDefaultForParam(i))
 				continue;
@@ -572,7 +574,7 @@ protected void fillInDefaultNonNullness18(AbstractMethodDeclaration sourceMethod
 				if (!parameter.isBaseType()) {
 					this.parameters[i] = env.createNonNullAnnotatedType(parameter);
 					if (sourceMethod != null)
-						sourceMethod.arguments[i].binding.type = this.parameters[i];
+						argumentBindings[i].type = this.parameters[i];
 				}
 			}
 		}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MethodScope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MethodScope.java
@@ -24,6 +24,7 @@ package org.eclipse.jdt.internal.compiler.lookup;
 
 import static org.eclipse.jdt.internal.compiler.impl.JavaFeature.FLEXIBLE_CONSTRUCTOR_BODIES;
 
+import java.util.Arrays;
 import java.util.Map;
 import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.internal.compiler.ASTVisitor;
@@ -89,6 +90,15 @@ public MethodScope(Scope parent, ReferenceContext context, boolean isStatic) {
 public MethodScope(Scope parent, ReferenceContext context, boolean isStatic, int lastVisibleFieldID) {
 	this(parent, context, isStatic);
 	this.lastVisibleFieldID = lastVisibleFieldID;
+}
+
+public LocalVariableBinding [] argumentBindings() {
+	int i = 0;
+	while (i < this.localIndex) {
+		LocalVariableBinding local = this.locals[i++];
+		if (local == null ||  !local.isParameter()) break; // done with arguments
+	}
+	return Arrays.copyOf(this.locals, i);
 }
 
 @Override


### PR DESCRIPTION
Partial fix for https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3971

