### PR TITLE
Hook compact constructors properly into null & resource analysis under the new Records 2.0 scheme of things

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AbstractMethodDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AbstractMethodDeclaration.java
@@ -131,16 +131,19 @@ public abstract class AbstractMethodDeclaration
 	 * we create the argument binding and resolve annotations in order to compute null annotation tagbits.
 	 */
 	public void createArgumentBindings() {
-		createArgumentBindings(this.arguments, this.binding, this.scope);
+		createArgumentBindings(this.arguments(true), this.binding, this.scope);
 	}
 	// version for invocation from LambdaExpression:
-	static void createArgumentBindings(Argument[] arguments, MethodBinding binding, MethodScope scope) {
+	static void createArgumentBindings(AbstractVariableDeclaration[] arguments, MethodBinding binding, MethodScope scope) {
 		boolean useTypeAnnotations = scope.environment().usesNullTypeAnnotations();
 		if (arguments != null && binding != null) {
-			for (int i = 0, length = arguments.length; i < length; i++) {
-				Argument argument = arguments[i];
-				binding.parameters[i] = argument.createBinding(scope, binding.parameters[i]);
-				long argumentTagBits = argument.binding.tagBits;
+			LocalVariableBinding [] argumentBindings = binding.isCompactConstructor() ? scope.argumentBindings() : new LocalVariableBinding[arguments.length];
+			int length = Math.min(binding.parameters.length, arguments.length);
+			for (int i = 0; i < length; i++) {
+				if (arguments[i] instanceof Argument argument)
+					argumentBindings[i] = argument.createBinding(scope, binding.parameters[i]);
+				binding.parameters[i] = argumentBindings[i].type;
+				long argumentTagBits = argumentBindings[i].tagBits;
 				if ((argumentTagBits & TagBits.AnnotationOwning) != 0) {
 					if (binding.parameterFlowBits == null) {
 						binding.parameterFlowBits = new byte[arguments.length];
@@ -253,15 +256,16 @@ public abstract class AbstractMethodDeclaration
 	 * <li>NotOwning - for resource leak analysis
 	 * </ul>
 	 */
-	static void analyseArguments(LookupEnvironment environment, FlowInfo flowInfo, FlowContext flowContext, Argument[] methodArguments, MethodBinding methodBinding) {
+	static void analyseArguments(LookupEnvironment environment, FlowInfo flowInfo, FlowContext flowContext, AbstractVariableDeclaration[] methodArguments, MethodBinding methodBinding, MethodScope scope) {
 		if (methodArguments != null) {
 			boolean usesNullTypeAnnotations = environment.usesNullTypeAnnotations();
 			boolean usesOwningAnnotations = environment.usesOwningAnnotations();
 
+			LocalVariableBinding [] methodArgumentBindings = scope.argumentBindings();
 			int length = Math.min(methodBinding.parameters.length, methodArguments.length);
 			for (int i = 0; i < length; i++) {
 				TypeBinding parameterBinding = methodBinding.parameters[i];
-				LocalVariableBinding local = methodArguments[i].binding;
+				LocalVariableBinding local = methodArgumentBindings[i];
 				if (usesNullTypeAnnotations) {
 					// leverage null type annotations:
 					long tagBits = parameterBinding.tagBits & TagBits.AnnotationNullMASK;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Argument.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Argument.java
@@ -64,7 +64,7 @@ public class Argument extends LocalDeclaration {
 		return false;
 	}
 
-	public TypeBinding createBinding(MethodScope scope, TypeBinding typeBinding) {
+	public LocalVariableBinding createBinding(MethodScope scope, TypeBinding typeBinding) {
 		if (this.binding == null) {
 			// for default constructors and fake implementation of abstract methods
 			this.binding = new LocalVariableBinding(this, typeBinding, this.modifiers, scope);
@@ -85,7 +85,7 @@ public class Argument extends LocalDeclaration {
 			scope.validateNullAnnotation(this.binding.tagBits, this.type, annots);
 		}
 		this.binding.declaration = this;
-		return this.binding.type; // might have been updated during resolveAnnotations (for typeAnnotations)
+		return this.binding; // type might have been updated during resolveAnnotations (for typeAnnotations)
 	}
 
 	public TypeBinding bind(MethodScope scope, TypeBinding typeBinding, boolean used) {
@@ -93,7 +93,7 @@ public class Argument extends LocalDeclaration {
 			scope.problemReporter().illegalUseOfUnderscoreAsAnIdentifier(this.sourceStart, this.sourceEnd, scope.compilerOptions().sourceLevel > ClassFileConstants.JDK1_8, true);
 		}
 
-		TypeBinding newTypeBinding = createBinding(scope, typeBinding); // basically a no-op if createBinding() was called before
+		TypeBinding newTypeBinding = createBinding(scope, typeBinding).type; // basically a no-op if createBinding() was called before
 
 		// record the resolved type into the type reference
 		Binding existingVariable = scope.getBinding(this.name, Binding.VARIABLE, this, false /*do not resolve hidden field*/);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ConstructorDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ConstructorDeclaration.java
@@ -197,14 +197,7 @@ public void analyseCode(ClassScope classScope, InitializationFlowContext initial
 			}
 
 			// nullity, owning and mark as assigned
-			analyseArguments(classScope.environment(), flowInfo, initializerFlowContext, this.arguments, this.binding);
-
-			if (this.isCompactConstructor()) {
-				for (LocalVariableBinding local : this.scope.locals) {
-					if (local != null && local.isParameter())
-						flowInfo.markAsDefinitelyAssigned(local);
-				}
-			}
+			analyseArguments(classScope.environment(), flowInfo, initializerFlowContext, this.arguments(true), this.binding, this.scope);
 
 			if (JavaFeature.FLEXIBLE_CONSTRUCTOR_BODIES.matchesCompliance(this.scope.compilerOptions())) {
 				this.scope.enterEarlyConstructionContext();

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LambdaExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LambdaExpression.java
@@ -569,7 +569,7 @@ public class LambdaExpression extends FunctionalExpression implements IPolyExpre
 
 		// nullity, owning and mark as assigned
 		MethodBinding methodWithParameterDeclaration = argumentsTypeElided() ? this.descriptor : this.binding;
-		AbstractMethodDeclaration.analyseArguments(currentScope.environment(), lambdaInfo, flowContext, this.arguments, methodWithParameterDeclaration);
+		AbstractMethodDeclaration.analyseArguments(currentScope.environment(), lambdaInfo, flowContext, this.arguments, methodWithParameterDeclaration, this.scope);
 
 		if (this.arguments != null) {
 			for (Argument argument : this.arguments) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/MethodDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/MethodDeclaration.java
@@ -104,7 +104,7 @@ public class MethodDeclaration extends AbstractMethodDeclaration {
 					FlowInfo.DEAD_END);
 
 			// nullity, owning and mark as assigned
-			analyseArguments(classScope.environment(), flowInfo, flowContext, this.arguments, this.binding);
+			analyseArguments(classScope.environment(), flowInfo, flowContext, this.arguments, this.binding, this.scope);
 
 			BiPredicate<TypeBinding, ReferenceBinding> condition = (argType, declClass) -> {
 				ReferenceBinding enclosingType = argType.enclosingType();

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MethodBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MethodBinding.java
@@ -534,7 +534,8 @@ protected void fillInDefaultNonNullness(AbstractMethodDeclaration sourceMethod, 
 				argumentBindings[i].tagBits |= TagBits.AnnotationNonNull;
 			}
 		} else if (sourceMethod != null && (this.parameterFlowBits[i] & PARAM_NONNULL) != 0) {
-			sourceMethod.scope.problemReporter().nullAnnotationIsRedundant(sourceMethod, i);
+			if (!sourceMethod.isCompactConstructor()) // Don't complain about implicit parameter. Also component nullity applies to more than just the parameter.
+				sourceMethod.scope.problemReporter().nullAnnotationIsRedundant(sourceMethod, i);
 		}
 	}
 	if (added)

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SourceTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SourceTypeBinding.java
@@ -2258,6 +2258,7 @@ private MethodBinding resolveTypesWithSuspendedTempErrorHandlingPolicy(MethodBin
 				methodDecl.bits |= ASTNode.HasTypeAnnotations;
 			// bind the implicit argument already.
 			final LocalVariableBinding implicitArgument = new LocalVariableBinding(rcbs[i].name, rcbs[i].type, rcbs[i].modifiers, true);
+			implicitArgument.tagBits |= rcbs[i].tagBits & (TagBits.AnnotationNullMASK | TagBits.AnnotationOwningMASK);
 			methodDecl.scope.addLocalVariable(implicitArgument);
 			List<AnnotationBinding> propagatedAnnotations = new ArrayList<>();
 			ASTNode.getRelevantAnnotations(rcbs[i].sourceRecordComponent().annotations, TagBits.AnnotationForParameter, propagatedAnnotations);

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullAnnotationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullAnnotationTest.java
@@ -11591,4 +11591,166 @@ public void testIssue3971_2() {
 		"----------\n"
 	);
 }
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3971
+// [Records][Null analysis] Verify null analysis plays well with the recent design and implementation changes for Records 2.0
+public void testIssue3971_3() {
+	if (this.complianceLevel < ClassFileConstants.JDK16)
+		return;
+	Map options = getCompilerOptions();
+	options.put(JavaCore.COMPILER_INHERIT_NULL_ANNOTATIONS, JavaCore.ENABLED);
+	runNegativeTestWithLibs(
+		true /* shouldFlush*/,
+		new String[] {
+			"Point.java",
+			"import org.eclipse.jdt.annotation.*;\n" +
+			"@interface PA {}\n" +
+			"@interface PB {}\n" +
+			"public record Point(@NonNull @PA Integer x, @PB Integer y) {\n" +
+			"    public Point { x = null; y = null;}\n" +
+			"}\n",
+		},
+		options,
+		"----------\n" +
+		"1. ERROR in Point.java (at line 5)\n" +
+		"	public Point { x = null; y = null;}\n" +
+		"	                   ^^^^\n" +
+		"Null type mismatch: required '@NonNull Integer' but the provided value is null\n" +
+		"----------\n");
+}
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3971
+// [Records][Null analysis] Verify null analysis plays well with the recent design and implementation changes for Records 2.0
+public void testIssue3971_4() {
+	if (this.complianceLevel < ClassFileConstants.JDK16)
+		return;
+	Map customOptions = getCompilerOptions();
+	customOptions.put(JavaCore.COMPILER_NULLABLE_ANNOTATION_NAME, "annotation.Nullable");
+	customOptions.put(JavaCore.COMPILER_NONNULL_ANNOTATION_NAME, "annotation.NonNull");
+	customOptions.put(JavaCore.COMPILER_NONNULL_BY_DEFAULT_ANNOTATION_NAME, "annotation.NonNullByDefault");
+	customOptions.put(JavaCore.COMPILER_PB_DEAD_CODE, JavaCore.IGNORE);
+	runConformTestWithLibs(
+		new String[] {
+			"annotation/DefaultLocation.java",
+			"package annotation;\n" +
+			"\n" +
+			"public enum DefaultLocation {\n" +
+			"    PARAMETER, RETURN_TYPE, FIELD\n" +
+			"}\n" +
+			"",
+			"annotation/NonNull.java",
+			"package annotation;\n" +
+			"\n" +
+			"public @interface NonNull {\n" +
+			"}\n" +
+			"",
+			"annotation/NonNullByDefault.java",
+			"package annotation;\n" +
+			"\n" +
+			"import static annotation.DefaultLocation.*;\n" +
+			" \n" +
+			"public @interface NonNullByDefault {\n" +
+			"	DefaultLocation[] value() default { PARAMETER, RETURN_TYPE, FIELD };\n" +
+			"}\n" +
+			"",
+			"annotation/Nullable.java",
+			"package annotation;\n" +
+			"\n" +
+			"public @interface Nullable {\n" +
+			"}\n" +
+			"",
+		},
+		customOptions,
+		""
+	);
+	runNegativeTestWithLibs(
+		new String[] {
+				"X.java",
+				"""
+				import annotation.*;
+
+				public record X(@NonNull String component) {
+
+
+					public X {
+						component = null;
+					}
+				}
+				"""
+		},
+		customOptions,
+		"----------\n" +
+		"1. ERROR in X.java (at line 7)\n" +
+		"	component = null;\n" +
+		"	            ^^^^\n" +
+		"Null type mismatch: required '@NonNull String' but the provided value is null\n" +
+		"----------\n"
+	);
+}
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3971
+// [Records][Null analysis] Verify null analysis plays well with the recent design and implementation changes for Records 2.0
+public void testIssue3971_5() {
+	if (this.complianceLevel < ClassFileConstants.JDK16)
+		return;
+	Map customOptions = getCompilerOptions();
+	customOptions.put(JavaCore.COMPILER_NULLABLE_ANNOTATION_NAME, "annotation.Nullable");
+	customOptions.put(JavaCore.COMPILER_NONNULL_ANNOTATION_NAME, "annotation.NonNull");
+	customOptions.put(JavaCore.COMPILER_NONNULL_BY_DEFAULT_ANNOTATION_NAME, "annotation.NonNullByDefault");
+	customOptions.put(JavaCore.COMPILER_PB_DEAD_CODE, JavaCore.IGNORE);
+	runConformTestWithLibs(
+		new String[] {
+			"annotation/DefaultLocation.java",
+			"package annotation;\n" +
+			"\n" +
+			"public enum DefaultLocation {\n" +
+			"    PARAMETER, RETURN_TYPE, FIELD\n" +
+			"}\n" +
+			"",
+			"annotation/NonNull.java",
+			"package annotation;\n" +
+			"\n" +
+			"public @interface NonNull {\n" +
+			"}\n" +
+			"",
+			"annotation/NonNullByDefault.java",
+			"package annotation;\n" +
+			"\n" +
+			"import static annotation.DefaultLocation.*;\n" +
+			" \n" +
+			"public @interface NonNullByDefault {\n" +
+			"	DefaultLocation[] value() default { PARAMETER, RETURN_TYPE, FIELD };\n" +
+			"}\n" +
+			"",
+			"annotation/Nullable.java",
+			"package annotation;\n" +
+			"\n" +
+			"public @interface Nullable {\n" +
+			"}\n" +
+			"",
+		},
+		customOptions,
+		""
+	);
+	runNegativeTestWithLibs(
+		new String[] {
+				"X.java",
+				"""
+				import annotation.*;
+
+				public record X(@NonNull String component) {
+
+					@NonNullByDefault
+					public X {
+						component = null;
+					}
+				}
+				"""
+		},
+		customOptions,
+		"----------\n" +
+		"1. ERROR in X.java (at line 7)\n" +
+		"	component = null;\n" +
+		"	            ^^^^\n" +
+		"Null type mismatch: required '@NonNull String' but the provided value is null\n" +
+		"----------\n"
+	);
+}
 }


### PR DESCRIPTION
Partial fix for https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3971

