### PR TITLE
Adding a non-language test - issue #3881 and fixing the testall setup

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavaNonLanguageTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavaNonLanguageTests.java
@@ -1,0 +1,217 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.core.tests.compiler.regression;
+
+import java.util.Map;
+import junit.framework.Test;
+import org.eclipse.jdt.internal.compiler.batch.FileSystem;
+import org.eclipse.jdt.internal.compiler.env.INameEnvironment;
+import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
+
+public class JavaNonLanguageTests extends AbstractRegressionTest9 {
+
+	private static final JavacTestOptions JAVAC_OPTIONS = new JavacTestOptions("--enable-preview -source 25");
+	private static final String[] VMARGS = new String[] {"--enable-preview"};
+	static {
+//		TESTS_NUMBERS = new int [] { 1 };
+//		TESTS_RANGE = new int[] { 1, -1 };
+//		TESTS_NAMES = new String[] { "testIssue001" };
+	}
+	private String extraLibPath;
+	public static Class<?> testClass() {
+		return JavaNonLanguageTests.class;
+	}
+	public static Test suite() {
+		return buildMinimalComplianceTestSuite(testClass(), F_25);
+	}
+	public JavaNonLanguageTests(String testName) {
+		super(testName);
+	}
+
+	// ========= OPT-IN to run.javac mode: ===========
+	@Override
+	protected void setUp() throws Exception {
+		this.runJavacOptIn = true;
+		super.setUp();
+	}
+	@Override
+	protected void tearDown() throws Exception {
+		super.tearDown();
+		this.runJavacOptIn = false; // do it last, so super can still clean up
+	}
+	// =================================================
+
+	// Enables the tests to run individually
+	protected Map<String, String> getCompilerOptions(boolean preview) {
+		Map<String, String> defaultOptions = super.getCompilerOptions();
+		defaultOptions.put(CompilerOptions.OPTION_Compliance, CompilerOptions.VERSION_25);
+		defaultOptions.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_25);
+		defaultOptions.put(CompilerOptions.OPTION_TargetPlatform, CompilerOptions.VERSION_25);
+		defaultOptions.put(CompilerOptions.OPTION_EnablePreviews, preview ? CompilerOptions.ENABLED : CompilerOptions.DISABLED);
+		defaultOptions.put(CompilerOptions.OPTION_ReportPreviewFeatures, CompilerOptions.WARNING);
+		return defaultOptions;
+	}
+
+	protected Map<String, String> getCompilerOptions() {
+		return getCompilerOptions(false);
+	}
+	protected String[] getDefaultClassPaths() {
+		String[] libs = DefaultJavaRuntimeEnvironment.getDefaultClassPaths();
+		if (this.extraLibPath != null) {
+			String[] l = new String[libs.length + 1];
+			System.arraycopy(libs, 0, l, 0, libs.length);
+			l[libs.length] = this.extraLibPath;
+			return l;
+		}
+		return libs;
+	}
+	@Override
+	protected INameEnvironment getNameEnvironment(final String[] testFiles, String[] classPaths, Map<String, String> options) {
+		this.classpaths = classPaths == null ? getDefaultClassPaths() : classPaths;
+		INameEnvironment[] classLibs = getClassLibs(false, options);
+		for (INameEnvironment nameEnvironment : classLibs) {
+			((FileSystem) nameEnvironment).scanForModules(createParser());
+		}
+		return new InMemoryNameEnvironment9(testFiles, this.moduleMap, classLibs);
+	}
+	@Override
+	protected void runConformTest(String[] testFiles, String expectedOutput) {
+		runConformTest(testFiles, expectedOutput, getCompilerOptions(true), VMARGS, JAVAC_OPTIONS);
+	}
+	@Override
+	protected void runConformTest(String[] testFiles, String expectedOutput, Map<String, String> customOptions) {
+		if(!isJRE23Plus)
+			return;
+		runConformTest(testFiles, expectedOutput, customOptions, VMARGS, JAVAC_OPTIONS);
+	}
+	protected void runConformTest(
+			String[] testFiles,
+			String expectedOutputString,
+			String[] classLibraries,
+			boolean shouldFlushOutputDirectory,
+			String[] vmArguments) {
+			runTest(
+		 		// test directory preparation
+				shouldFlushOutputDirectory /* should flush output directory */,
+				testFiles /* test files */,
+				// compiler options
+				classLibraries /* class libraries */,
+				null /* no custom options */,
+				false /* do not perform statements recovery */,
+				null /* no custom requestor */,
+				// compiler results
+				false /* expecting no compiler errors */,
+				null /* do not check compiler log */,
+				// runtime options
+				false /* do not force execution */,
+				vmArguments /* vm arguments */,
+				// runtime results
+				expectedOutputString /* expected output string */,
+				null /* do not check error string */,
+				// javac options
+				JavacTestOptions.DEFAULT /* default javac test options */);
+		}
+	protected void runNegativeTest(String[] testFiles, String expectedCompilerLog) {
+		Map<String, String> customOptions = getCompilerOptions(true);
+		Runner runner = new Runner();
+		runner.testFiles = testFiles;
+		runner.expectedCompilerLog = expectedCompilerLog;
+		runner.javacTestOptions = JAVAC_OPTIONS;
+		runner.customOptions = customOptions;
+		runner.expectedJavacOutputString = null;
+		runner.runNegativeTest();
+	}
+	protected void runNegativeTest(
+			String[] testFiles,
+			String expectedCompilerLog,
+			String javacLog,
+			String[] classLibraries,
+			boolean shouldFlushOutputDirectory,
+			Map<String, String> customOptions) {
+		Runner runner = new Runner();
+		runner.testFiles = testFiles;
+		runner.expectedCompilerLog = expectedCompilerLog;
+		runner.javacTestOptions = JAVAC_OPTIONS;
+		runner.customOptions = customOptions;
+		runner.expectedJavacOutputString = javacLog;
+		runner.runNegativeTest();
+	}
+
+	public void testStable_001() {
+		runConformTest(new String[] {
+			"X.java",
+				"""
+					public class X {
+
+						@SuppressWarnings("preview")
+						private final StableValue<Integer> intLog = StableValue.of();
+
+					    public boolean getIntLog() {
+					        return intLog.trySet((Integer) 100);
+					    }
+
+					    public static void main(String[] args) {
+							X x = new X();
+							System.out.println(x.getIntLog());
+							System.out.println(x.getIntLog());
+						}
+					}
+				"""
+			},
+			"true\n" +
+		    "false");
+	}
+	public void testStable_002() {
+		Map<String,String> options = getCompilerOptions(false);
+		String old = options.get(CompilerOptions.OPTION_EnablePreviews);
+		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
+		try {
+			runNegativeTest(new String[] {
+					"X.java",
+						"""
+							public class X {
+
+								@SuppressWarnings("preview")
+								private final StableValue<Integer> intLog = StableValue.of();
+
+							    public boolean getIntLog() {
+							        return intLog.trySet((Integer) 100);
+							    }
+
+							    public static void main(String[] args) {
+									X x = new X();
+									System.out.println(x.getIntLog());
+									System.out.println(x.getIntLog());
+								}
+							}
+						"""
+				},
+				"----------\n" +
+				"1. ERROR in X.java (at line 4)\n" +
+				"	private final StableValue<Integer> intLog = StableValue.of();\n" +
+				"	                                            ^^^^^^^^^^^\n" +
+				"This API is part of the preview feature \'Stable Values\' which is disabled by default. Use --enable-preview to enable\n" +
+				"----------\n",
+				null,
+				false,
+				options);
+		} finally {
+			options.put(CompilerOptions.OPTION_EnablePreviews, old);
+
+		}
+	}
+}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TestAll.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TestAll.java
@@ -258,13 +258,14 @@ public static Test suite() {
 	 since_23.add(MarkdownCommentsTest.class);
 
 	 ArrayList since_24 = new ArrayList();
-	 since_24.add(ModuleImportTests.class);
-	 since_24.add(SuperAfterStatementsTest.class);
-	 since_24.add(ImplicitlyDeclaredClassesTest.class);
-	 since_24.add(PrimitiveInPatternsTest.class);
-	 since_24.add(PrimitiveInPatternsTestSH.class);
 	 since_24.add(PreviewFlagTest.class);
-	 // Add new tests for Java 24 here and/or move preview tests being moved from 23 to 24
+
+	 ArrayList since_25 = new ArrayList();
+	 since_25.add(ModuleImportTests.class);
+	 since_25.add(SuperAfterStatementsTest.class);
+	 since_25.add(ImplicitlyDeclaredClassesTest.class);
+	 since_25.add(PrimitiveInPatternsTest.class);
+	 since_25.add(PrimitiveInPatternsTestSH.class);
 
 	 // Build final test suite
 	TestSuite all = new TestSuite(TestAll.class.getName());
@@ -606,6 +607,7 @@ public static Test suite() {
 		tests_25.addAll(since_22);
 		tests_25.addAll(since_23);
 		tests_25.addAll(since_24);
+		tests_25.addAll(since_25);
 		TestCase.resetForgottenFilters(tests_25);
 		all.addTest(AbstractCompilerTest.buildComplianceTestSuite(
 				ClassFileConstants.getComplianceLevelForJavaVersion(ClassFileConstants.MAJOR_VERSION_25), tests_25));


### PR DESCRIPTION
## What it does
1. A couple of tests added to the non-language preview feature of StableValues of issue #3881 
2. Fixed up the testAll setup

## How to test

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
