### PR TITLE
Add fallback to unnamed module if INameEnvironment is used

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/env/ICompilationUnit.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/env/ICompilationUnit.java
@@ -65,7 +65,7 @@ default ModuleBinding module(LookupEnvironment environment) {
 		char[] moduleName = modEnv.isOnModulePath(this) ? getModuleName() : ModuleBinding.UNNAMED;
 		return environment.getModule(moduleName);
 	}
-	return null;
+	return environment.getModule(ModuleBinding.UNNAMED);
 }
 /**
  * Returns the name of the module to which this compilation unit is associated.


### PR DESCRIPTION
## What it does

If an ICompilationUnit is compiled with a plain INameEnvironment, a NullPointerException is thrown when the source code is also in an unnamed module.

In such a case, the ICompilationUnit should return the unnamed module, rather than null, thus restoring the previous behavior that was changed as part of 681dc0aff701f3bfe3109d43b838b0894c6d2cdd.

Closes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4006

## How to test

Execute the following snippet:
```java
package test;

import java.util.HashMap;
import java.util.Locale;
import java.util.Map;

import org.eclipse.jdt.internal.compiler.Compiler;
import org.eclipse.jdt.internal.compiler.DefaultErrorHandlingPolicies;
import org.eclipse.jdt.internal.compiler.ICompilerRequestor;
import org.eclipse.jdt.internal.compiler.IErrorHandlingPolicy;
import org.eclipse.jdt.internal.compiler.IProblemFactory;
import org.eclipse.jdt.internal.compiler.env.ICompilationUnit;
import org.eclipse.jdt.internal.compiler.env.INameEnvironment;
import org.eclipse.jdt.internal.compiler.env.NameEnvironmentAnswer;
import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
import org.eclipse.jdt.internal.compiler.problem.DefaultProblemFactory;

public class Test {
	private static String content = """
			public class Foo {
			}
			""";
	
	public static void main(String[] args) {
		ICompilationUnit cu = new CompilationUnit(content, "Foo.java");
		final INameEnvironment nameEnvironment = new NameEnvironmentStub();
		final IErrorHandlingPolicy policy = DefaultErrorHandlingPolicies.proceedWithAllProblems();
		Map<String, String> defaultSettings = new HashMap<>();
		defaultSettings.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_17);
		defaultSettings.put(CompilerOptions.OPTION_Compliance, CompilerOptions.VERSION_17);
		final CompilerOptions compilerOptions = new CompilerOptions(defaultSettings);
		final ICompilerRequestor compilerRequestor = e -> {};
		final IProblemFactory problemFactory = new DefaultProblemFactory(Locale.getDefault());
		
		Compiler c = new Compiler(nameEnvironment, policy, compilerOptions, compilerRequestor, problemFactory);
		c.compile(new ICompilationUnit[] {cu});
	}
	
	private static class CompilationUnit implements ICompilationUnit {
		private String contents;
		private String fileName;
		
		public CompilationUnit(String contents, String fileName) {
			this.contents = contents;
			this.fileName = fileName;
		}

		@Override
		public char[] getFileName() {
			return fileName.toCharArray();
		}

		@Override
		public char[] getContents() {
			return contents.toCharArray();
		}

		@Override
		public char[] getMainTypeName() {
			return fileName.substring(0, fileName.indexOf('.')).toCharArray();
		}

		@Override
		public char[][] getPackageName() {
			return null;
		}
		
	}
	
	private static class NameEnvironmentStub implements INameEnvironment {
		@Override
		public NameEnvironmentAnswer findType(char[][] compoundTypeName) {
			return null;
		}

		@Override
		public NameEnvironmentAnswer findType(char[] typeName, char[][] packageName) {
			return null;
		}

		@Override
		public boolean isPackage(char[][] parentPackageName, char[] packageName) {
			return false;
		}

		@Override
		public void cleanup() {
		}
	}
}
```

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
