### PR TITLE
Compile error involving wildcards

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedTypeBinding.java
@@ -169,6 +169,9 @@ public class ParameterizedTypeBinding extends ReferenceBinding implements Substi
 	}
 	@Override
 	public TypeBinding findSuperTypeOriginatingFrom(TypeBinding otherType) {
+		if (otherType instanceof ReferenceBinding otherRef && TypeBinding.equalsEquals(this.type, otherRef.actualType()))
+			return this;
+
 		TypeBinding capture = InferenceContext18.maybeCapture(this);
 		if (capture != this) //$IDENTITY-COMPARISON$
 			return capture.findSuperTypeOriginatingFrom(otherType);

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_1_8.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_1_8.java
@@ -6986,7 +6986,7 @@ public void testBug472851() {
 		"1. ERROR in Test.java (at line 10)\n" +
 		"	test(type);\n" +
 		"	^^^^\n" +
-		"The method test(List<L>) in the type Test is not applicable for the arguments (List<capture#2-of ? extends List<?>>)\n" +
+		"The method test(List<L>) in the type Test is not applicable for the arguments (List<capture#1-of ? extends List<?>>)\n" +
 		"----------\n");
 }
 public void testBug502350() {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
@@ -1097,7 +1097,7 @@ public void testGH3457b() {
 	});
 }
 public void testGH3948() {
-	runNegativeTest(new String[] {
+	runConformTest(new String[] {
 			"Foo.java",
 			"""
 			import java.util.Collections;
@@ -1127,25 +1127,64 @@ public void testGH3948() {
 			    public static interface Bar{}
 			}
 			"""
-		},
-		"""
-		----------
-		1. ERROR in Foo.java (at line 18)
-			test(Foo::get, Foo::set);
-			^^^^
-		The method test(Function<Foo,List<U>>, BiConsumer<Foo,List<? extends U>>) in the type Foo is not applicable for the arguments (Foo::get, Foo::set)
-		----------
-		2. ERROR in Foo.java (at line 18)
-			test(Foo::get, Foo::set);
-			     ^^^^^^^^
-		The type of get() from the type Foo is List<Foo.Bar>, this is incompatible with the descriptor's return type: List<U>
-		----------
-		3. ERROR in Foo.java (at line 18)
-			test(Foo::get, Foo::set);
-			               ^^^^^^^^
-		The type Foo does not define set(Foo, List<capture#5-of ? extends U>) that is applicable here
-		----------
-		""");
+		});
+}
+public void testGH4022a() {
+	runConformTest(new String[] {
+			"Bug.java",
+			"""
+			import java.util.Collection;
+			import java.util.Set;
+
+			public abstract class Bug {
+				// real code uses some guava method, so method signature  cannot be changed
+				public abstract <T2> Collection<T2> toCollection(Iterable<? extends T2> elements);
+
+				public abstract <T> Set<Class<? extends T>> getSubTypesAsSet(Class<T> type);
+
+				public <T> Collection<Class<? extends T>> getSubTypesAsCollection(Class<T> superclassOrInterface)    {
+					// compiles on older eclipse and javac 21
+					// fails since d9d550f8ddeda45cf4d1b803a99afbd73abf57e4
+					return toCollection(getSubTypesAsSet(superclassOrInterface));
+				}
+
+				public <T> Collection<Class<? extends T>> getSubTypesAsCollectionFixed(Class<T> superclassOrInterface) {
+					// type as suggested by eclipse when using "extract local variable"
+					Set<Class<? extends T>> subTypesAsSet = getSubTypesAsSet(superclassOrInterface);
+
+					// compiles
+					return toCollection(subTypesAsSet);
+				}
+			}
+			"""
+		});
+}
+public void testGH4022b() {
+	runConformTest(new String[] {
+			"OtherExample.java",
+			"""
+			import java.util.Set;
+			import java.util.function.Function;
+
+			interface TaskDefinition {
+				public Set<String> getLabels();
+			}
+
+			abstract class FluentIterable<E> implements Iterable<E> {
+				public abstract <T> FluentIterable<T> transformAndConcat(
+						Function<? super E, ? extends Iterable<? extends T>> function);
+
+				public abstract Set<E> toSet();
+			}
+
+			public abstract class OtherExample {
+				public Set<String> getAllLabels(FluentIterable<TaskDefinition> from) {
+			                // doesn't compile since d9d550f8ddeda45cf4d1b803a99afbd73abf57e4
+					return from.transformAndConcat((TaskDefinition input) -> input.getLabels()).toSet();
+				}
+			}
+			"""
+		});
 }
 public static Class<GenericsRegressionTest_9> testClass() {
 	return GenericsRegressionTest_9.class;

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NegativeLambdaExpressionsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NegativeLambdaExpressionsTest.java
@@ -37,7 +37,7 @@ import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 public class NegativeLambdaExpressionsTest extends AbstractRegressionTest {
 
 static {
-	TESTS_NAMES = new String[] { "testIssue3956"};
+//	TESTS_NAMES = new String[] { "testIssue3956"};
 //	TESTS_NUMBERS = new int[] { 50 };
 //	TESTS_RANGE = new int[] { 11, -1 };
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NegativeLambdaExpressionsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NegativeLambdaExpressionsTest.java
@@ -37,7 +37,7 @@ import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 public class NegativeLambdaExpressionsTest extends AbstractRegressionTest {
 
 static {
-//	TESTS_NAMES = new String[] { "test404657_loop"};
+	TESTS_NAMES = new String[] { "testIssue3956"};
 //	TESTS_NUMBERS = new int[] { 50 };
 //	TESTS_RANGE = new int[] { 11, -1 };
 }


### PR DESCRIPTION
PTB.findSuperTypeOriginatingFrom() should capture only when actually performing supertype navigation.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4022
