### PR TITLE
[Records] Record component by name equals with an explicit accessor leads to ClassFormatError

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SourceTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SourceTypeBinding.java
@@ -1898,7 +1898,7 @@ nextMethod:
 		if (CharOperation.equals(method.selector, TypeConstants.EQUALS)) {
 			if (method.parameters != null && method.parameters.length == 1 && TypeBinding.equalsEquals(method.parameters[0], this.scope.getJavaLangObject()))
 				needEquals = false;
-			continue;
+			// fall through and check if method is an accessor; Unlike toString and hashCode, equals is a valid component name.
 		}
 
 		for (int j = 0; j < rcLength; j++) {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordsRestrictedClassTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordsRestrictedClassTest.java
@@ -10502,4 +10502,25 @@ public void testIssue4015_4() {
 
 		"ARecord[]");
 }
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4025
+// [Records] Record component by name equals with an explicit accessor leads to ClassFormatError
+public void testIssue4025() {
+	this.runConformTest(
+		new String[] {
+					"X.java",
+					"""
+					public record X(boolean equals)  {
+					    public boolean equals() {
+					        return equals;
+					    }
+
+					    public static void main(String argv[]) {
+					        System.out.println("Ok!");
+					    }
+					}
+					""",
+	            },
+
+		"Ok!");
+}
 }


### PR DESCRIPTION
* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4025

