### PR TITLE
fix for null analysis issue for conditional expressions 

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.compiler.batch/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Main-Class: org.eclipse.jdt.internal.compiler.batch.Main
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse Compiler for Java(TM)
 Bundle-SymbolicName: org.eclipse.jdt.core.compiler.batch
-Bundle-Version: 3.42.50.qualifier
+Bundle-Version: 3.43.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: Eclipse.org
 Automatic-Module-Name: org.eclipse.jdt.core.compiler.batch

--- a/org.eclipse.jdt.core.compiler.batch/pom.xml
+++ b/org.eclipse.jdt.core.compiler.batch/pom.xml
@@ -17,7 +17,7 @@
     <version>4.37.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.eclipse.jdt.core.compiler.batch</artifactId>
-  <version>3.42.50-SNAPSHOT</version>
+  <version>3.43.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/core/compiler/IProblem.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/core/compiler/IProblem.java
@@ -2089,6 +2089,8 @@ void setSourceStart(int sourceStart);
 	/** @since 3.41 */
 	int FieldWithUnresolvedOwningAnnotation = Internal + 989;
 
+	/** @since 3.42 */
+	int RedundantNullCheckNullValueExpression = Internal + 990;
 
 	// Java 8 work
 	/** @since 3.10 */

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/core/compiler/IProblem.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/core/compiler/IProblem.java
@@ -2089,7 +2089,7 @@ void setSourceStart(int sourceStart);
 	/** @since 3.41 */
 	int FieldWithUnresolvedOwningAnnotation = Internal + 989;
 
-	/** @since 3.42 */
+	/** @since 3.43 */
 	int RedundantNullCheckNullValueExpression = Internal + 990;
 
 	// Java 8 work

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/EqualExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/EqualExpression.java
@@ -199,8 +199,8 @@ public class EqualExpression extends BinaryExpression {
 				break;
 			case FlowInfo.NON_NULL :
 				if (((this.bits & OperatorMASK) >> OperatorSHIFT) == EQUAL_EQUAL) {
-					flowContext.recordNullConditional(scope, conditionalExpression,
-							FlowContext.CAN_ONLY_NULL_NON_NULL | FlowContext.IN_COMPARISON_NON_NULL, flowInfo);
+//					flowContext.recordNullConditional(scope, conditionalExpression,
+//							FlowContext.CAN_ONLY_NULL_NON_NULL | FlowContext.IN_COMPARISON_NON_NULL, flowInfo);
 				} else {
 					flowContext.recordNullConditional(scope, conditionalExpression,
 							FlowContext.CAN_ONLY_NULL_NON_NULL | FlowContext.IN_COMPARISON_NULL, flowInfo);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/EqualExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/EqualExpression.java
@@ -32,7 +32,6 @@ import org.eclipse.jdt.internal.compiler.lookup.Binding;
 import org.eclipse.jdt.internal.compiler.lookup.BlockScope;
 import org.eclipse.jdt.internal.compiler.lookup.FieldBinding;
 import org.eclipse.jdt.internal.compiler.lookup.LocalVariableBinding;
-import org.eclipse.jdt.internal.compiler.lookup.NullTypeBinding;
 import org.eclipse.jdt.internal.compiler.lookup.Scope;
 import org.eclipse.jdt.internal.compiler.lookup.TagBits;
 import org.eclipse.jdt.internal.compiler.lookup.TypeBinding;
@@ -82,9 +81,7 @@ public class EqualExpression extends BinaryExpression {
 					flowContext.recordNullCheckedFieldReference((Reference) this.left, 1);
 				}
 			} else if (this.left instanceof ConditionalExpression ce) {
-				if ((ce.resolvedType.tagBits & TagBits.IsBaseType) == 0 || ce.resolvedType instanceof NullTypeBinding) {
-					checkConditionalExpressionComparison(scope, flowContext, flowInfo, rightStatus, this.left);
-				}
+				checkConditionalExpressionComparison(scope, flowContext, flowInfo, rightStatus, ce);
 			}
 		}
 		if (!rightNonNullChecked) {
@@ -102,9 +99,7 @@ public class EqualExpression extends BinaryExpression {
 					flowContext.recordNullCheckedFieldReference((Reference) this.right, 1);
 				}
 			} else if (this.right instanceof ConditionalExpression ce) {
-				if ((ce.resolvedType.tagBits & TagBits.IsBaseType) == 0 || ce.resolvedType instanceof NullTypeBinding) {
-					checkConditionalExpressionComparison(scope, flowContext, flowInfo, leftStatus, this.right);
-				}
+				checkConditionalExpressionComparison(scope, flowContext, flowInfo, leftStatus, ce);
 			}
 		}
 
@@ -186,25 +181,28 @@ public class EqualExpression extends BinaryExpression {
 	}
 	private void checkConditionalExpressionComparison(BlockScope scope,
 			FlowContext flowContext, FlowInfo flowInfo,
-			int nullStatus, Expression reference) {
+			int nullStatus, ConditionalExpression conditionalExpression) {
+
+//		if (conditionalExpression.nullStatus(flowInfo, flowContext) != FlowInfo.NULL)
+//			return;
 
 
 		switch (nullStatus) {
 			case FlowInfo.NULL :
 				if (((this.bits & OperatorMASK) >> OperatorSHIFT) == EQUAL_EQUAL) {
-					flowContext.flagConditional(scope, reference,
+					flowContext.recordNullConditional(scope, conditionalExpression,
 							FlowContext.CAN_ONLY_NULL | FlowContext.IN_COMPARISON_NULL, flowInfo);
 				} else {
-					flowContext.flagConditional(scope, reference,
+					flowContext.recordNullConditional(scope, conditionalExpression,
 							FlowContext.CAN_ONLY_NULL | FlowContext.IN_COMPARISON_NON_NULL, flowInfo);
 				}
 				break;
 			case FlowInfo.NON_NULL :
 				if (((this.bits & OperatorMASK) >> OperatorSHIFT) == EQUAL_EQUAL) {
-					flowContext.flagConditional(scope, reference,
+					flowContext.recordNullConditional(scope, conditionalExpression,
 							FlowContext.CAN_ONLY_NULL_NON_NULL | FlowContext.IN_COMPARISON_NON_NULL, flowInfo);
 				} else {
-					flowContext.flagConditional(scope, reference,
+					flowContext.recordNullConditional(scope, conditionalExpression,
 							FlowContext.CAN_ONLY_NULL_NON_NULL | FlowContext.IN_COMPARISON_NULL, flowInfo);
 				}
 				break;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/flow/FlowContext.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/flow/FlowContext.java
@@ -1035,17 +1035,9 @@ public void recordNullConditional(Scope scope, Expression conditionalExpression,
 	int checkTypeWithoutHideNullWarning = checkType & ~FlowContext.HIDE_NULL_COMPARISON_WARNING_MASK;
 	switch (checkTypeWithoutHideNullWarning) {
 		case FlowContext.CAN_ONLY_NULL_NON_NULL | FlowContext.IN_COMPARISON_NULL:
-		case FlowContext.CAN_ONLY_NULL_NON_NULL | FlowContext.IN_COMPARISON_NON_NULL:
 			if (conditionalExpression.nullStatus(flowInfo, this) == FlowInfo.NON_NULL ) {
-				if (checkTypeWithoutHideNullWarning == (CAN_ONLY_NULL_NON_NULL | IN_COMPARISON_NON_NULL)) {
-					if ((checkType & HIDE_NULL_COMPARISON_WARNING) == 0) {
-						scope.problemReporter().expressionRedundantNullComparison(conditionalExpression, /* isExpressionNull */false );
-					}
-					flowInfo.initsWhenFalse().setReachMode(FlowInfo.UNREACHABLE_BY_NULLANALYSIS);
-				} else {
-					scope.problemReporter().expressionRedundantNullComparison(conditionalExpression, /* isExpressionNull */false );
-					flowInfo.initsWhenTrue().setReachMode(FlowInfo.UNREACHABLE_BY_NULLANALYSIS);
-				}
+				scope.problemReporter().expressionRedundantNullComparison(conditionalExpression, /* isExpressionNull */false );
+				flowInfo.initsWhenTrue().setReachMode(FlowInfo.UNREACHABLE_BY_NULLANALYSIS);
 			}
 			break;
 		case FlowContext.CAN_ONLY_NULL | FlowContext.IN_COMPARISON_NULL:

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/flow/FlowContext.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/flow/FlowContext.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -1020,6 +1020,41 @@ public void recordUsingNullReference(Scope scope, LocalVariableBinding local,
 	if (this.parent != null) {
 		this.parent.recordUsingNullReference(scope, local, location, checkType,
 				flowInfo);
+	}
+}
+
+public void flagConditional(Scope scope, Expression conditionalExpression,
+		 int checkType, FlowInfo flowInfo) {
+
+	// if inside an assert, we will not raise redundant null check warnings
+	checkType |= (this.tagBits & FlowContext.HIDE_NULL_COMPARISON_WARNING);
+	int checkTypeWithoutHideNullWarning = checkType & ~FlowContext.HIDE_NULL_COMPARISON_WARNING_MASK;
+	switch (checkTypeWithoutHideNullWarning) {
+		case FlowContext.CAN_ONLY_NULL_NON_NULL | FlowContext.IN_COMPARISON_NULL:
+			if ((checkType & FlowContext.HIDE_NULL_COMPARISON_WARNING) == 0) {
+				scope.problemReporter().expressionRedundantNullComparison(conditionalExpression, /* isExpressionNull */false );
+			}
+			flowInfo.initsWhenTrue().setReachMode(FlowInfo.UNREACHABLE_BY_NULLANALYSIS);
+			break;
+		case FlowContext.CAN_ONLY_NULL_NON_NULL | FlowContext.IN_COMPARISON_NON_NULL:
+			if ((checkType & FlowContext.HIDE_NULL_COMPARISON_WARNING) == 0) {
+				scope.problemReporter().expressionRedundantNullComparison(conditionalExpression, /* isExpressionNull */false);
+			}
+			flowInfo.initsWhenFalse().setReachMode(FlowInfo.UNREACHABLE_BY_NULLANALYSIS);
+			break;
+
+		case FlowContext.CAN_ONLY_NULL | FlowContext.IN_COMPARISON_NULL:
+			if ((checkType & FlowContext.HIDE_NULL_COMPARISON_WARNING) == 0) {
+				scope.problemReporter().expressionRedundantNullComparison(conditionalExpression, /* isExpressionNull */true);
+			}
+			flowInfo.initsWhenFalse().setReachMode(FlowInfo.UNREACHABLE_BY_NULLANALYSIS);
+			break;
+		case FlowContext.CAN_ONLY_NULL | FlowContext.IN_COMPARISON_NON_NULL:
+			if ((checkType & FlowContext.HIDE_NULL_COMPARISON_WARNING) == 0) {
+				scope.problemReporter().expressionRedundantNullComparison(conditionalExpression, /* isExpressionNull */true);
+			}
+			flowInfo.initsWhenTrue().setReachMode(FlowInfo.UNREACHABLE_BY_NULLANALYSIS);
+			break;
 	}
 }
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
@@ -6059,6 +6059,30 @@ public void localVariableNullComparedToNonNull(LocalVariableBinding local, ASTNo
 }
 
 /**
+ * @param expr expression being compared for null or non-null
+ * @param isExpressionNull true if flow info shows null, false if flow info is non-null
+ */
+
+public void expressionRedundantNullComparison(Expression expr, boolean isExpressionNull) {
+	if (expr.resolvedType == null)
+		return;
+
+	int problemId = isExpressionNull ? IProblem.RedundantNullCheckNullValueExpression
+			: IProblem.RedundantNullCheckOnNonNullExpression;
+	int severity = computeSeverity(problemId);
+	if (severity == ProblemSeverities.Ignore) return;
+	String[] arguments = new String[] {new String(expr.toString())};
+	this.handle(
+		problemId,
+		arguments,
+		arguments,
+		severity,
+		nodeSourceStart(expr),
+		nodeSourceEnd(expr));
+}
+
+
+/**
  * @param expr expression being compared for null or nonnull
  * @param checkForNull true if checking for null, false if checking for nonnull
  */

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
@@ -371,6 +371,7 @@ public static int getIrritant(int problemID) {
 		case IProblem.ConstNonNullFieldComparisonYieldsFalse:
 		case IProblem.FieldComparisonYieldsFalse:
 		case IProblem.UnnecessaryNullCaseInSwitchOverNonNull:
+		case IProblem.RedundantNullCheckNullValueExpression:
 			return CompilerOptions.RedundantNullCheck;
 
 		case IProblem.RequiredNonNullButProvidedNull:

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/messages.properties
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/messages.properties
@@ -876,6 +876,9 @@
 988 = Parameter ''{0}'' of method ''{1}'' has an unresolved annotation ''{2}'' that could be relevant for static analysis
 989 = Field ''{0}'' has an unresolved annotation ''{1}'' that could be relevant for static analysis
 
+# null analysis for conditional expressions
+990 = Redundant null check: this expression can only be null
+
 # Java 8
 1001 = Syntax error, modifiers and annotations are not allowed for the lambda parameter {0} as its type is elided
 1002 = Syntax error, modifiers are not allowed here

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AssignmentTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AssignmentTest.java
@@ -2485,6 +2485,11 @@ public void testIssue3990_5() {
 					return ret;
 				}
 
+				public int  foo4(boolean pred, Integer x)
+				{
+					boolean willFail = (x == (pred ? 0 : 1)); // wrong if non-null error flagged
+					return willFail ? 0 : 1;
+				}
 				boolean test() {
 					return true;
 				}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AssignmentTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AssignmentTest.java
@@ -41,7 +41,7 @@ protected Map getCompilerOptions() {
 // Static initializer to specify tests subset using TESTS_* static variables
 // All specified tests which does not belong to the class are skipped...
 static {
-//	TESTS_NAMES = new String[] { "test000" };
+//	TESTS_NAMES = new String[] { "testIssue3990" };
 //	TESTS_NUMBERS = new int[] { 69 };
 //	TESTS_RANGE = new int[] { 11, -1 };
 }
@@ -2107,6 +2107,355 @@ public void testBug486908_B() {
 			"}\n"
 	});
 }
+public void testIssue3990_1() {
+	Map options = getCompilerOptions();
+	options.put(CompilerOptions.OPTION_ReportDeadCode, CompilerOptions.ERROR);
+	this.runNegativeTest(
+		new String[] {
+			"X.java",
+			"""
+				public class X {
+
+					boolean test() {
+						return true;
+					}
+
+					int foo0() {
+						if ((test() ? null : null) == null)
+							return 1;
+						return 0;
+					}
+
+					int foo1() {
+						if ((test() ? null : null) != null)
+							return 1;
+						return 0;
+					}
+
+					// more complex
+					int bar0() {
+						X s = null;
+						if ((test() ? s : null) == null)
+							return 1;
+						return 0;
+					}
+
+					int bar1() {
+						X s = null;
+						if ((test() ? s : null) != null)
+							return 1;
+						return 0;
+					}
+				}
+			""",
+		},
+		"----------\n" +
+		"1. ERROR in X.java (at line 8)\n" +
+		"	if ((test() ? null : null) == null)\n" +
+		"	    ^^^^^^^^^^^^^^^^^^^^^^\n" +
+		"Redundant null check: this expression can only be null\n" +
+		"----------\n" +
+		"2. ERROR in X.java (at line 10)\n" +
+		"	return 0;\n" +
+		"	^^^^^^^^^\n" +
+		"Dead code\n" +
+		"----------\n" +
+		"3. ERROR in X.java (at line 14)\n" +
+		"	if ((test() ? null : null) != null)\n" +
+		"	    ^^^^^^^^^^^^^^^^^^^^^^\n" +
+		"Redundant null check: this expression can only be null\n" +
+		"----------\n" +
+		"4. ERROR in X.java (at line 15)\n" +
+		"	return 1;\n" +
+		"	^^^^^^^^^\n" +
+		"Dead code\n" +
+		"----------\n" +
+		"5. ERROR in X.java (at line 22)\n" +
+		"	if ((test() ? s : null) == null)\n" +
+		"	    ^^^^^^^^^^^^^^^^^^^\n" +
+		"Redundant null check: this expression can only be null\n" +
+		"----------\n" +
+		"6. ERROR in X.java (at line 24)\n" +
+		"	return 0;\n" +
+		"	^^^^^^^^^\n" +
+		"Dead code\n" +
+		"----------\n" +
+		"7. ERROR in X.java (at line 29)\n" +
+		"	if ((test() ? s : null) != null)\n" +
+		"	    ^^^^^^^^^^^^^^^^^^^\n" +
+		"Redundant null check: this expression can only be null\n" +
+		"----------\n" +
+		"8. ERROR in X.java (at line 30)\n" +
+		"	return 1;\n" +
+		"	^^^^^^^^^\n" +
+		"Dead code\n" +
+		"----------\n",
+		null/*classLibs*/,
+		true/*shouldFlush*/,
+		options);
+}
+public void testIssue3990_2() {
+	Map options = getCompilerOptions();
+	options.put(CompilerOptions.OPTION_ReportDeadCode, CompilerOptions.ERROR);
+	this.runNegativeTest(
+		new String[] {
+			"X.java",
+			"""
+				public class X {
+
+					boolean test() {
+						return true;
+					}
+
+					int foo0() {
+						if ((test() ? this : this) == null)
+							return 1;
+						return 0;
+					}
+
+					int foo1() {
+						if ((test() ? this : this) != null)
+							return 1;
+						return 0;
+					}
+
+					// more complex
+					int bar0() {
+						X s = this;
+						if ((test() ? s : this) == null)
+							return 1;
+						return 0;
+					}
+
+					int bar1() {
+						X s = this;
+						if ((test() ? s : this) != null)
+							return 1;
+						return 0;
+					}
+				}
+			""",
+		},
+		"----------\n" +
+		"1. ERROR in X.java (at line 8)\n" +
+		"	if ((test() ? this : this) == null)\n" +
+		"	    ^^^^^^^^^^^^^^^^^^^^^^\n" +
+		"Null comparison always yields false: this expression cannot be null\n" +
+		"----------\n" +
+		"2. ERROR in X.java (at line 9)\n" +
+		"	return 1;\n" +
+		"	^^^^^^^^^\n" +
+		"Dead code\n" +
+		"----------\n" +
+		"3. ERROR in X.java (at line 14)\n" +
+		"	if ((test() ? this : this) != null)\n" +
+		"	    ^^^^^^^^^^^^^^^^^^^^^^\n" +
+		"Redundant null check: this expression cannot be null\n" +
+		"----------\n" +
+		"4. ERROR in X.java (at line 16)\n" +
+		"	return 0;\n" +
+		"	^^^^^^^^^\n" +
+		"Dead code\n" +
+		"----------\n" +
+		"5. ERROR in X.java (at line 22)\n" +
+		"	if ((test() ? s : this) == null)\n" +
+		"	    ^^^^^^^^^^^^^^^^^^^\n" +
+		"Null comparison always yields false: this expression cannot be null\n" +
+		"----------\n" +
+		"6. ERROR in X.java (at line 23)\n" +
+		"	return 1;\n" +
+		"	^^^^^^^^^\n" +
+		"Dead code\n" +
+		"----------\n" +
+		"7. ERROR in X.java (at line 29)\n" +
+		"	if ((test() ? s : this) != null)\n" +
+		"	    ^^^^^^^^^^^^^^^^^^^\n" +
+		"Redundant null check: this expression cannot be null\n" +
+		"----------\n" +
+		"8. ERROR in X.java (at line 31)\n" +
+		"	return 0;\n" +
+		"	^^^^^^^^^\n" +
+		"Dead code\n" +
+		"----------\n",
+		null/*classLibs*/,
+		true/*shouldFlush*/,
+		options);
+}
+public void testIssue3990_3() {
+	Map options = getCompilerOptions();
+	options.put(CompilerOptions.OPTION_ReportDeadCode, CompilerOptions.ERROR);
+	this.runNegativeTest(
+		new String[] {
+			"X.java",
+			"""
+				public class X {
+
+					boolean test() {
+						return true;
+					}
+
+					int foo0() {
+						if (null == (test() ? null : null))
+							return 1;
+						return 0;
+					}
+
+					int foo1() {
+						if (null != (test() ? null : null))
+							return 1;
+						return 0;
+					}
+
+					// more complex
+					int bar0() {
+						X s = null;
+						if (null == (test() ? s : null))
+							return 1;
+						return 0;
+					}
+
+					int bar1() {
+						X s = null;
+						if (null != (test() ? s : null))
+							return 1;
+						return 0;
+					}
+				}
+			""",
+		},
+		"----------\n" +
+		"1. ERROR in X.java (at line 8)\n" +
+		"	if (null == (test() ? null : null))\n" +
+		"	            ^^^^^^^^^^^^^^^^^^^^^^\n" +
+		"Redundant null check: this expression can only be null\n" +
+		"----------\n" +
+		"2. ERROR in X.java (at line 10)\n" +
+		"	return 0;\n" +
+		"	^^^^^^^^^\n" +
+		"Dead code\n" +
+		"----------\n" +
+		"3. ERROR in X.java (at line 14)\n" +
+		"	if (null != (test() ? null : null))\n" +
+		"	            ^^^^^^^^^^^^^^^^^^^^^^\n" +
+		"Redundant null check: this expression can only be null\n" +
+		"----------\n" +
+		"4. ERROR in X.java (at line 15)\n" +
+		"	return 1;\n" +
+		"	^^^^^^^^^\n" +
+		"Dead code\n" +
+		"----------\n" +
+		"5. ERROR in X.java (at line 22)\n" +
+		"	if (null == (test() ? s : null))\n" +
+		"	            ^^^^^^^^^^^^^^^^^^^\n" +
+		"Redundant null check: this expression can only be null\n" +
+		"----------\n" +
+		"6. ERROR in X.java (at line 24)\n" +
+		"	return 0;\n" +
+		"	^^^^^^^^^\n" +
+		"Dead code\n" +
+		"----------\n" +
+		"7. ERROR in X.java (at line 29)\n" +
+		"	if (null != (test() ? s : null))\n" +
+		"	            ^^^^^^^^^^^^^^^^^^^\n" +
+		"Redundant null check: this expression can only be null\n" +
+		"----------\n" +
+		"8. ERROR in X.java (at line 30)\n" +
+		"	return 1;\n" +
+		"	^^^^^^^^^\n" +
+		"Dead code\n" +
+		"----------\n",
+		null/*classLibs*/,
+		true/*shouldFlush*/,
+		options);
+}
+public void testIssue3990_4() {
+	Map options = getCompilerOptions();
+	options.put(CompilerOptions.OPTION_ReportDeadCode, CompilerOptions.ERROR);
+	this.runNegativeTest(
+		new String[] {
+			"X.java",
+			"""
+				public class X {
+
+					boolean test() {
+						return true;
+					}
+
+					int foo0() {
+						if ((test() ? this : this) == null)
+							return 1;
+						return 0;
+					}
+
+					int foo1() {
+						if ((test() ? this : this) != null)
+							return 1;
+						return 0;
+					}
+
+					// more complex
+					int bar0() {
+						X s = this;
+						if ((test() ? s : this) == null)
+							return 1;
+						return 0;
+					}
+
+					int bar1() {
+						X s = this;
+						if ((test() ? s : this) != null)
+							return 1;
+						return 0;
+					}
+				}
+			""",
+		},
+		"----------\n" +
+		"1. ERROR in X.java (at line 8)\n" +
+		"	if ((test() ? this : this) == null)\n" +
+		"	    ^^^^^^^^^^^^^^^^^^^^^^\n" +
+		"Null comparison always yields false: this expression cannot be null\n" +
+		"----------\n" +
+		"2. ERROR in X.java (at line 9)\n" +
+		"	return 1;\n" +
+		"	^^^^^^^^^\n" +
+		"Dead code\n" +
+		"----------\n" +
+		"3. ERROR in X.java (at line 14)\n" +
+		"	if ((test() ? this : this) != null)\n" +
+		"	    ^^^^^^^^^^^^^^^^^^^^^^\n" +
+		"Redundant null check: this expression cannot be null\n" +
+		"----------\n" +
+		"4. ERROR in X.java (at line 16)\n" +
+		"	return 0;\n" +
+		"	^^^^^^^^^\n" +
+		"Dead code\n" +
+		"----------\n" +
+		"5. ERROR in X.java (at line 22)\n" +
+		"	if ((test() ? s : this) == null)\n" +
+		"	    ^^^^^^^^^^^^^^^^^^^\n" +
+		"Null comparison always yields false: this expression cannot be null\n" +
+		"----------\n" +
+		"6. ERROR in X.java (at line 23)\n" +
+		"	return 1;\n" +
+		"	^^^^^^^^^\n" +
+		"Dead code\n" +
+		"----------\n" +
+		"7. ERROR in X.java (at line 29)\n" +
+		"	if ((test() ? s : this) != null)\n" +
+		"	    ^^^^^^^^^^^^^^^^^^^\n" +
+		"Redundant null check: this expression cannot be null\n" +
+		"----------\n" +
+		"8. ERROR in X.java (at line 31)\n" +
+		"	return 0;\n" +
+		"	^^^^^^^^^\n" +
+		"Dead code\n" +
+		"----------\n",
+		null/*classLibs*/,
+		true/*shouldFlush*/,
+		options);
+}
+
 public static Class testClass() {
 	return AssignmentTest.class;
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AssignmentTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AssignmentTest.java
@@ -2456,6 +2456,97 @@ public void testIssue3990_4() {
 		options);
 }
 
+public void testIssue3990_5() {
+	Map options = getCompilerOptions();
+	options.put(CompilerOptions.OPTION_ReportDeadCode, CompilerOptions.ERROR);
+	this.runNegativeTest(
+		new String[] {
+			"X.java",
+			"""
+			public class X {
+				int foo0() {
+					int ret = 0;
+
+					for (int i = 0; i < 2; i++) {
+						if ((test() ? null : null) ==  null) // Error here
+							ret = 1;
+					}
+					return ret;
+				}
+				int foo1() {
+					int ret = 0;
+					String s = null;
+
+					for (int i = 0; i < 2; i++) {
+						if ((test() ? s : null) ==  null) // No Error here
+							ret = 1;
+						s = "hello";
+					}
+					return ret;
+				}
+
+				boolean test() {
+					return true;
+				}
+			}
+			""",
+		},
+		"----------\n" +
+		"1. ERROR in X.java (at line 6)\n" +
+		"	if ((test() ? null : null) ==  null) // Error here\n" +
+		"	    ^^^^^^^^^^^^^^^^^^^^^^\n" +
+		"Redundant null check: this expression can only be null\n" +
+		"----------\n",
+		null/*classLibs*/,
+		true/*shouldFlush*/,
+		options);
+}
+
+public void _testIssue3990_6() {
+	Map options = getCompilerOptions();
+	options.put(CompilerOptions.OPTION_ReportDeadCode, CompilerOptions.ERROR);
+	this.runNegativeTest(
+		new String[] {
+			"X.java",
+			"""
+			public class X {
+				int foo3() {
+					int ret = 0;
+					String s = null;
+
+					for (int i = 0; i < 2; i++) {
+						if ((test() ? s : null) ==  null) // Flag null error
+							ret = 1;
+
+						if (s == null) // Flag null error
+							ret = 2;
+
+
+					}
+					return ret;
+				}
+
+				boolean test() {
+					return true;
+				}
+			}
+			""",
+		},
+		"----------\n" +
+		"1. ERROR in X.java (at line 6)\n" +
+		"	if ((test() ? null : null) ==  null) // Flag null error\n" +
+		"	    ^^^^^^^^^^^^^^^^^^^^^^\n" +
+		"Redundant null check: this expression can only be null\n" +
+		"----------\n" +
+		"2. ERROR in X.java (at line 10)\n" +
+		"	if (s == null) // Flag null error\n" +
+		"	    ^\n" +
+		"Redundant null check: The variable s can only be null at this location\n" +
+		"----------\n",
+		null/*classLibs*/,
+		true/*shouldFlush*/,
+		options);
+}
 public static Class testClass() {
 	return AssignmentTest.class;
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/CompilerInvocationTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/CompilerInvocationTests.java
@@ -1004,6 +1004,7 @@ public void test011_problem_categories() {
 		expectedProblemAttributes.put("RedundantNullCheckAgainstNonNullType", new ProblemAttributes(CategorizedProblem.CAT_POTENTIAL_PROGRAMMING_PROBLEM));
 		expectedProblemAttributes.put("RedundantNullCheckOnConstNonNullField", new ProblemAttributes(CategorizedProblem.CAT_POTENTIAL_PROGRAMMING_PROBLEM));
 		expectedProblemAttributes.put("RedundantNullCheckOnField", new ProblemAttributes(CategorizedProblem.CAT_POTENTIAL_PROGRAMMING_PROBLEM));
+		expectedProblemAttributes.put("RedundantNullCheckNullValueExpression", new ProblemAttributes(CategorizedProblem.CAT_POTENTIAL_PROGRAMMING_PROBLEM));
 		expectedProblemAttributes.put("RedundantNullCheckOnNonNullExpression", new ProblemAttributes(CategorizedProblem.CAT_POTENTIAL_PROGRAMMING_PROBLEM));
 		expectedProblemAttributes.put("RedundantNullCheckOnNonNullSpecdField", new ProblemAttributes(CategorizedProblem.CAT_POTENTIAL_PROGRAMMING_PROBLEM));
 		expectedProblemAttributes.put("RedundantNullCheckOnNonNullLocalVariable", new ProblemAttributes(CategorizedProblem.CAT_POTENTIAL_PROGRAMMING_PROBLEM));
@@ -2154,6 +2155,7 @@ public void test012_compiler_problems_tuning() {
 		expectedProblemAttributes.put("RedundantNullCheckAgainstNonNullType", new ProblemAttributes(JavaCore.COMPILER_PB_REDUNDANT_NULL_CHECK));
 		expectedProblemAttributes.put("RedundantNullCheckOnConstNonNullField", new ProblemAttributes(JavaCore.COMPILER_PB_REDUNDANT_NULL_CHECK));
 		expectedProblemAttributes.put("RedundantNullCheckOnField", new ProblemAttributes(JavaCore.COMPILER_PB_REDUNDANT_NULL_CHECK));
+		expectedProblemAttributes.put("RedundantNullCheckNullValueExpression", new ProblemAttributes(JavaCore.COMPILER_PB_REDUNDANT_NULL_CHECK));
 		expectedProblemAttributes.put("RedundantNullCheckOnNonNullExpression", new ProblemAttributes(JavaCore.COMPILER_PB_REDUNDANT_NULL_CHECK));
 		expectedProblemAttributes.put("RedundantNullCheckOnNonNullSpecdField", new ProblemAttributes(JavaCore.COMPILER_PB_REDUNDANT_NULL_CHECK));
 		expectedProblemAttributes.put("RedundantNullCheckOnNonNullLocalVariable", new ProblemAttributes(JavaCore.COMPILER_PB_REDUNDANT_NULL_CHECK));


### PR DESCRIPTION
## What it does
fixes #3990 

Null in Conditional Expressions are now reported with this fix. 
General algorithm:
At EqualExpression, check for conditional expression in checkNullComparison and then the logic followed is similar to the flow analysis of checkVariableComparison. Additional error code of 990 error code [IProblem.RedundantNullCheckNullValueExpression] is introduced - see below as well.

A few points:

- 671 [IProblem.RedundantNullCheckOnNonNullExpression] has been reused in the fix but could not use 672 as it meant NullExpressionReference though the error message is similar to the newly introduced 990 error code [IProblem.RedundantNullCheckNullValueExpression]
- Have not optimised the code - or done much common method refactorings - atleast for the first round of PR for the sake of clarity.

## How to test
Test cases are part of the PR

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
