### PR TITLE
ECJ compile error: "Bound mismatch: The generic method ... is not applicable for the arguments"

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
@@ -165,6 +165,13 @@ public class InferenceContext18 {
 
 	private static ThreadLocal<InferenceContext18> instance = new ThreadLocal<>();
 
+	void enter() {
+		instance.set(this);
+	}
+	static void leave() {
+		instance.remove();
+	}
+
 	public static boolean isSameSite(InvocationSite site1, InvocationSite site2) {
 		if (site1 == site2)
 			return true;
@@ -863,9 +870,12 @@ public class InferenceContext18 {
 				if (!reduceAndIncorporate(ConstraintTypeFormula.create(skplus1, tkplus1, ReductionResult.SUBTYPE)))
 					return false;
 			}
+			enter();
 			return solve() != null;
 		} catch (InferenceFailureException e) {
 			return false;
+		} finally {
+			leave();
 		}
 	}
 
@@ -1025,35 +1035,29 @@ public class InferenceContext18 {
 	 * @throws InferenceFailureException a compile error has been detected during inference
 	 */
 	private /*@Nullable*/ BoundSet solve(boolean inferringApplicability, boolean isRecordPatternTypeInference) throws InferenceFailureException {
-		instance.set(this);
+		if (!reduce())
+			return null;
+		if (!this.currentBounds.incorporate(this))
+			return null;
+		if (inferringApplicability)
+			this.b2 = this.currentBounds.copy(); // Preserve the result after reduction, without effects of resolve() for later use in invocation type inference.
 
-		try {
-			if (!reduce())
-				return null;
-			if (!this.currentBounds.incorporate(this))
-				return null;
-			if (inferringApplicability)
-				this.b2 = this.currentBounds.copy(); // Preserve the result after reduction, without effects of resolve() for later use in invocation type inference.
+		BoundSet solution = resolve(this.inferenceVariables, isRecordPatternTypeInference);
 
-			BoundSet solution = resolve(this.inferenceVariables, isRecordPatternTypeInference);
-
-			/* If inferring applicability make a final pass over the initial constraints preserved as final constraints to make sure they hold true at a macroscopic level.
-			   See https://bugs.eclipse.org/bugs/show_bug.cgi?id=426537#c55 onwards.
-			*/
-			if (inferringApplicability && solution != null && this.finalConstraints != null) {
-				for (ConstraintExpressionFormula constraint: this.finalConstraints) {
-					if (constraint.left.isPolyExpression())
-						continue; // avoid redundant re-inference, inner poly's own constraints get validated in its own context & poly invocation type inference proved compatibility against target.
-					constraint.applySubstitution(solution, this.inferenceVariables);
-					if (!this.currentBounds.reduceOneConstraint(this, constraint)) {
-						return null;
-					}
+		/* If inferring applicability make a final pass over the initial constraints preserved as final constraints to make sure they hold true at a macroscopic level.
+		   See https://bugs.eclipse.org/bugs/show_bug.cgi?id=426537#c55 onwards.
+		*/
+		if (inferringApplicability && solution != null && this.finalConstraints != null) {
+			for (ConstraintExpressionFormula constraint: this.finalConstraints) {
+				if (constraint.left.isPolyExpression())
+					continue; // avoid redundant re-inference, inner poly's own constraints get validated in its own context & poly invocation type inference proved compatibility against target.
+				constraint.applySubstitution(solution, this.inferenceVariables);
+				if (!this.currentBounds.reduceOneConstraint(this, constraint)) {
+					return null;
 				}
 			}
-			return solution;
-		} finally {
-			instance.remove();
 		}
+		return solution;
 	}
 
 	public /*@Nullable*/ BoundSet solve() throws InferenceFailureException {
@@ -1993,10 +1997,13 @@ public class InferenceContext18 {
 		 */
 		BoundSet solution = null;
 		try {
+			enter();
 			solution = solve(false, true /* isRecordPatternTypeInference */);
 		} catch (InferenceFailureException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
+		} finally {
+			leave();
 		}
 		if (solution == null)
 			return null;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedGenericMethodBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedGenericMethodBinding.java
@@ -183,6 +183,7 @@ public class ParameterizedGenericMethodBinding extends ParameterizedMethodBindin
 				if (InferenceContext18.DEBUG) {
 					System.out.println("Infer applicability for "+invocationSite+":\n"+infCtx18); //$NON-NLS-1$ //$NON-NLS-2$
 				}
+				infCtx18.enter();
 				result = infCtx18.solve(true);
 				if (InferenceContext18.DEBUG) {
 					System.out.println("Result=\n"+result); //$NON-NLS-1$
@@ -288,6 +289,7 @@ public class ParameterizedGenericMethodBinding extends ParameterizedMethodBindin
 			return null;
 		} finally {
 			environment.currentInferenceContext = previousContext;
+			InferenceContext18.leave();
 		}
 	}
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Scope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Scope.java
@@ -651,6 +651,8 @@ public abstract class Scope {
 				    				}
 				    			}
 				        	}
+							if (substitutedBound instanceof CaptureBinding capture && wildcard.boundKind == Wildcard.EXTENDS)
+								substitutedBound = InferenceContext18.maybeUncapture(capture);
 			        		return wildcard.environment.createWildcard(wildcard.genericType, wildcard.rank, substitutedBound, substitutedOtherBounds, wildcard.boundKind, wildcard.getTypeAnnotations());
 				        }
 			        }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/WildcardBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/WildcardBinding.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2017 IBM Corporation and others.
+ * Copyright (c) 2005, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -754,6 +754,8 @@ public class WildcardBinding extends ReferenceBinding implements HotSwappable{
 		}
 		haveSubstitution |= currentOtherBounds != null;
 		if (haveSubstitution) {
+			if (currentBound instanceof CaptureBinding capture && this.boundKind == Wildcard.EXTENDS)
+				currentBound = InferenceContext18.maybeUncapture(capture);
 			WildcardBinding wildcard = this.environment.createWildcard(this.genericType, this.rank, currentBound, currentOtherBounds, this.boundKind);
 			return propagateNonConflictingNullAnnotations(wildcard);
 		}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
@@ -1186,6 +1186,31 @@ public void testGH4022b() {
 			"""
 		});
 }
+public void testGH4033() {
+	runConformTest(new String[] {
+			"Snippet.java",
+			"""
+			import java.util.Collection;
+			import java.util.Iterator;
+			
+			public class Snippet {
+				interface Apple {}
+				interface Banana<T1, T2> {}
+				interface Smoothie<T extends Apple, M extends Apple> extends Banana<T, String> {}
+			
+				public static void main(String[] args) {
+					Collection<Smoothie<? extends Apple, ? extends Apple>> c = null;
+					method(c);
+				}
+			
+				static final <S extends Banana<? extends T, ?>, T> Iterator<T> method(
+						Collection<S> c) {
+					return null;
+				}
+			}
+			"""
+		});
+}
 public static Class<GenericsRegressionTest_9> testClass() {
 	return GenericsRegressionTest_9.class;
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NegativeLambdaExpressionsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NegativeLambdaExpressionsTest.java
@@ -9931,7 +9931,14 @@ public void test432759() {
 			"	}\n" +
 			"}\n"
 	},
-	"");
+	"""
+	----------
+	1. ERROR in X.java (at line 16)
+		BinaryOperator<Subsumer<? super T>> attempt_X_3 = Subsumer::andThe3;
+		                                                  ^^^^^^^^^^^^^^^^^
+	The type Subsumer does not define andThe3(Subsumer<capture#7-of ? super T>, Subsumer<capture#7-of ? super T>) that is applicable here
+	----------
+	""");
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=437444#c36,  NPE in broken code
 public void test437444() {
@@ -10548,12 +10555,12 @@ public void testIssue3956() {
 			"2. ERROR in TestMe.java (at line 19)\n" +
 			"	return update().handleAsync(() -> recording.process());\n" +
 			"	                ^^^^^^^^^^^\n" +
-			"The method handleAsync(BiFunction<? super capture#1-of ?,Throwable,? extends U>) in the type CompletableFuture<capture#1-of ?> is not applicable for the arguments (() -> {})\n" +
+			"The method handleAsync(BiFunction<? super ?,Throwable,? extends U>) in the type CompletableFuture<capture#1-of ?> is not applicable for the arguments (() -> {})\n" +
 			"----------\n" +
 			"3. ERROR in TestMe.java (at line 19)\n" +
 			"	return update().handleAsync(() -> recording.process());\n" +
 			"	                            ^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
-			"Lambda expression's signature does not match the signature of the functional interface method apply(? super capture#1-of ?, Throwable)\n" +
+			"Lambda expression's signature does not match the signature of the functional interface method apply(? super ?, Throwable)\n" +
 			"----------\n" +
 			"4. ERROR in TestMe.java (at line 19)\n" +
 			"	return update().handleAsync(() -> recording.process());\n" +


### PR DESCRIPTION
+ "normalize" `? extends capture#1-of X` to `? extends X` by uncapture
+ extend the scope of when IC18 is "active" for (un)capture
+ test adjustments:
  - adjust type display in test expectations
  - expect one more error (also reported by javac)

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4033
