### PR TITLE
Switch expression and type inference generates wrong/unsecure bytecode which fails to verify

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchExpression.java
@@ -73,7 +73,7 @@ public class SwitchExpression extends SwitchStatement implements IPolyExpression
 				TypeBinding uniformType = null;
 				for (Expression rExpression : this.rExpressions)
 					uniformType = uniformType == null ? rExpression.resolvedType : NullAnnotationMatching.moreDangerousType(uniformType, rExpression.resolvedType);
-				return uniformType;
+				return resolveAsType(uniformType);
 			}
 
 			if (this.allBoolean)

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchExpressionsYieldTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchExpressionsYieldTest.java
@@ -8432,4 +8432,30 @@ public class SwitchExpressionsYieldTest extends AbstractRegressionTest {
 				"The method state() is undefined for the type X\n" +
 				"----------\n");
 	}
+
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3920
+	// Java 24 switch expression and type inference generates wrong/unsecure bytecode
+	public void testIssue3920() {
+		this.runConformTest(
+				new String[] {
+				"X.java",
+				"""
+				import java.util.List;
+				import java.util.stream.Collectors;
+
+				public class X {
+					public static void main(String[] args) {
+						var l = List.of("A","B");
+						int i = 12;
+						var t = switch(i) {
+						case 1 -> l.stream().collect(Collectors.joining(" "));
+						default -> "Fixed!";
+						};
+						System.out.println(t);
+					}
+				}
+				"""
+				},
+				"Fixed!");
+	}
 }


### PR DESCRIPTION
* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3920

