### PR TITLE
Defect fixes for 4.37 

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ClassFile.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ClassFile.java
@@ -6679,6 +6679,7 @@ public class ClassFile implements TypeConstants, TypeIds {
 			if (hasExceptionMarkers && exceptionMarker.pc == currentPC) {
 				frame.numberOfStackItems = 0;
 				frame.addStackItem(new VerificationTypeInfo(exceptionMarker.getBinding()));
+				frame.adoptStackShape = true; // good to go.
 				indexInExceptionMarkers++;
 				if (indexInExceptionMarkers < exceptionsMarkersLength) {
 					exceptionMarker = exceptionMarkers[indexInExceptionMarkers];
@@ -6714,6 +6715,7 @@ public class ClassFile implements TypeConstants, TypeIds {
 			}
 			byte opcode = (byte) u1At(bytecodes, 0, pc);
 			inspectFrame(currentPC, frame);
+			frame.adoptStackShape = true;
 			switch (opcode) {
 				case Opcodes.OPC_nop:
 					pc++;
@@ -7270,6 +7272,7 @@ public class ClassFile implements TypeConstants, TypeIds {
 					addRealJumpTarget(realJumpTarget, jumpPC, frames, createNewFrame(jumpPC, frame, isClinit, methodBinding), scope);
 					pc += 3;
 					addRealJumpTarget(realJumpTarget, pc - codeOffset);
+					frame.adoptStackShape = false;
 					break;
 				case Opcodes.OPC_tableswitch:
 					frame.numberOfStackItems--;
@@ -7292,6 +7295,7 @@ public class ClassFile implements TypeConstants, TypeIds {
 						addRealJumpTarget(realJumpTarget, jumpPC, frames, createNewFrame(jumpPC, frame, isClinit, methodBinding), scope);
 						pc += 4;
 					}
+					frame.adoptStackShape = false;
 					break;
 				case Opcodes.OPC_lookupswitch:
 					frame.numberOfStackItems--;
@@ -7311,6 +7315,7 @@ public class ClassFile implements TypeConstants, TypeIds {
 						addRealJumpTarget(realJumpTarget, jumpPC, frames, createNewFrame(jumpPC, frame, isClinit, methodBinding), scope);
 						pc += 4;
 					}
+					frame.adoptStackShape = false;
 					break;
 				case Opcodes.OPC_ireturn:
 				case Opcodes.OPC_lreturn:
@@ -7320,10 +7325,12 @@ public class ClassFile implements TypeConstants, TypeIds {
 					frame.numberOfStackItems--;
 					pc++;
 					addRealJumpTarget(realJumpTarget, pc - codeOffset);
+					frame.adoptStackShape = false;
 					break;
 				case Opcodes.OPC_return:
 					pc++;
 					addRealJumpTarget(realJumpTarget, pc - codeOffset);
+					frame.adoptStackShape = false;
 					break;
 				case Opcodes.OPC_getstatic:
 					index = u2At(bytecodes, 1, pc);
@@ -7561,6 +7568,7 @@ public class ClassFile implements TypeConstants, TypeIds {
 					frame.numberOfStackItems--;
 					pc++;
 					addRealJumpTarget(realJumpTarget, pc - codeOffset);
+					frame.adoptStackShape = false;
 					break;
 				case Opcodes.OPC_checkcast:
 					index = u2At(bytecodes, 1, pc);
@@ -7665,6 +7673,7 @@ public class ClassFile implements TypeConstants, TypeIds {
 					addRealJumpTarget(realJumpTarget, jumpPC, frames, createNewFrame(jumpPC, frame, isClinit, methodBinding), scope);
 					pc += 5;
 					addRealJumpTarget(realJumpTarget, pc - codeOffset); // handle infinite loop
+					frame.adoptStackShape = false;
 					break;
 				default: // should not occur
 					if (this.codeStream.methodDeclaration != null) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ClassFile.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ClassFile.java
@@ -5871,16 +5871,18 @@ public class ClassFile implements TypeConstants, TypeIds {
 					}
 				}
 			} else {
+				if (methodBinding instanceof SyntheticMethodBinding smb && smb.purpose == SyntheticMethodBinding.DeserializeLambda) {
+					// For the branching complexities in the generated $deserializeLambda$ we need the local variable
+					LocalVariableBinding lvb = new LocalVariableBinding(" synthetic0".toCharArray(), this.referenceBinding.scope.getJavaLangInvokeSerializedLambda(), 0, true); //$NON-NLS-1$
+					lvb.resolvedPosition = 0;
+					this.codeStream.record(lvb);
+					lvb.recordInitializationStartPC(0);
+					lvb.recordInitializationEndPC(codeLength);
+				}
 				TypeBinding[] arguments;
 				if ((arguments = methodBinding.parameters) != null) {
 					for (int i = 0, max = arguments.length; i < max; i++) {
 						final TypeBinding typeBinding = arguments[i];
-						// For the branching complexities in the generated $deserializeLambda$ we need the local variable
-						LocalVariableBinding localVariableBinding = new LocalVariableBinding((" synthetic"+i).toCharArray(), typeBinding, 0, true); //$NON-NLS-1$
-						localVariableBinding.resolvedPosition = i;
-						this.codeStream.record(localVariableBinding);
-						localVariableBinding.recordInitializationStartPC(0);
-						localVariableBinding.recordInitializationEndPC(codeLength);
 						frame.putLocal(resolvedPosition,
 								new VerificationTypeInfo(typeBinding));
 						switch (typeBinding.id) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/CastExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/CastExpression.java
@@ -458,9 +458,37 @@ public static boolean checkUnsafeCast(Expression expression, Scope scope, TypeBi
 						expression.bits |= ASTNode.UnsafeCast; // upcast since castType is known to be bound paramType
 						return true;
 					default :
-						if (isNarrowing){
-							// match is not parameterized or raw, then any other subtype of match will erase  to |T|
-							expression.bits |= ASTNode.UnsafeCast;
+						if (isNarrowing) {
+							/* So we have a cast `(G<T1, ... Tn>) match` where at least one of the type arguments is NOT an unbounded wildcard
+							   as castType would have been reifiable otherwise and we won't be here. Since `match` is not parameterized or raw,
+							   should the runtime checkcast succeed, match will amount to G<?, ... ?> and so the question distills to whether
+							   the cast `(G<T1, ... Tn>) G<?,...?>` is unsafe
+
+							   JLS 5.1.6.2 states:
+									• A narrowing reference conversion from a type S to a parameterized class or
+									interface type T is unchecked, unless at least one of the following is true:
+									– All of the type arguments of T are unbounded wildcards.
+									– T <: S, and S has no subtype X other than T where the type arguments of X are
+									not contained in the type arguments of T.
+							*/
+
+							ParameterizedTypeBinding ParameterizedCastType = (ParameterizedTypeBinding) castType;
+							TypeBinding [] typeArguments = ParameterizedCastType.typeArgumentsIncludingEnclosing();
+							TypeVariableBinding [] typeVariables = ParameterizedCastType.genericType().typeVariablesIncludingEnclosing();
+
+							if (typeArguments.length != typeVariables.length) { // broken type.
+								expression.bits |= ASTNode.UnsafeCast;
+								return true;
+							}
+							for (int i = 0, length = typeArguments.length; i < length; i++) {
+								TypeVariableBinding tvb = typeVariables[i];
+								TypeBinding checkedTopOfStackTypeArgument =
+										scope.environment().createWildcard((ReferenceBinding) tvb.declaringElement, tvb.rank, null, null, Wildcard.UNBOUND);
+								if (checkedTopOfStackTypeArgument.isTypeArgumentContainedBy(typeArguments[i]))
+									continue;
+								expression.bits |= ASTNode.UnsafeCast;
+								break;
+							}
 							return true;
 						}
 						break;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/EitherOrMultiPattern.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/EitherOrMultiPattern.java
@@ -79,17 +79,6 @@ public class EitherOrMultiPattern extends Pattern {
 	}
 
 	@Override
-	public boolean matchFailurePossible() {
-		if (!isUnguarded())
-			return true;
-		for (Pattern p : this.patterns) {
-			if (p.matchFailurePossible())
-				return true;
-		}
-		return false;
-	}
-
-	@Override
 	public void generateCode(BlockScope currentScope, CodeStream codeStream, BranchLabel patternMatchLabel, BranchLabel matchFailLabel) {
 		/* JVM Stack on entry - [expression] // && expression instanceof _one of the_ EitherOrMultiPattern, we don't know which one
 		   JVM stack on exit with successful pattern match or failed match -> []

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/GuardedPattern.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/GuardedPattern.java
@@ -61,11 +61,6 @@ public class GuardedPattern extends Pattern {
 	}
 
 	@Override
-	public boolean matchFailurePossible() {
-		return !isUnguarded() || this.primaryPattern.matchFailurePossible();
-	}
-
-	@Override
 	public boolean isUnguarded() {
 		Constant cst = this.condition.optimizedBooleanConstant();
 		return cst != null && cst != Constant.NotAConstant && cst.booleanValue() == true;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LocalDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LocalDeclaration.java
@@ -140,7 +140,7 @@ public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext, Fl
 			//AccAlternateModifierProblem -> duplicate modifier
 			//AccModifierProblem | AccAlternateModifierProblem -> visibility problem"
 
-			this.modifiers = (this.modifiers & ~ExtraCompilerModifiers.AccAlternateModifierProblem) | ExtraCompilerModifiers.AccModifierProblem;
+			this.modifiers &= ~ExtraCompilerModifiers.AccAlternateModifierProblem;
 	}
 
 	/**

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Pattern.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Pattern.java
@@ -110,11 +110,6 @@ public abstract class Pattern extends Expression {
 		return false;
 	}
 
-	// Given a non-null instance of same type, would the pattern always match ?
-	public boolean matchFailurePossible() {
-		return false;
-	}
-
 	public boolean isUnconditional(TypeBinding t, Scope scope) {
 		return false;
 	}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Pattern.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Pattern.java
@@ -30,7 +30,7 @@ public abstract class Pattern extends Expression {
 
 	boolean isTotalTypeNode = false;
 
-	private Pattern enclosingPattern;
+	private RecordPattern enclosingPattern;
 
 	protected MethodBinding accessorMethod;
 
@@ -58,7 +58,7 @@ public abstract class Pattern extends Expression {
 
 	record TestContextRecord(TypeBinding left, TypeBinding right, PrimitiveConversionRoute route) {}
 
-	public Pattern getEnclosingPattern() {
+	public RecordPattern getEnclosingPattern() {
 		return this.enclosingPattern;
 	}
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/RecordComponent.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/RecordComponent.java
@@ -21,8 +21,6 @@ import org.eclipse.jdt.internal.compiler.codegen.CodeStream;
 import org.eclipse.jdt.internal.compiler.lookup.Binding;
 import org.eclipse.jdt.internal.compiler.lookup.BlockScope;
 import org.eclipse.jdt.internal.compiler.lookup.RecordComponentBinding;
-import org.eclipse.jdt.internal.compiler.lookup.TagBits;
-import org.eclipse.jdt.internal.compiler.lookup.TypeBinding;
 
 public class RecordComponent extends AbstractVariableDeclaration {
 
@@ -78,21 +76,6 @@ public class RecordComponent extends AbstractVariableDeclaration {
 	@Override
 	public boolean isVarArgs() {
 		return this.type != null &&  (this.type.bits & IsVarArgs) != 0;
-	}
-
-	@Override
-	public void resolve(BlockScope scope) {
-		resolveAnnotations(scope, this.annotations, this.binding);
-		// Check if this declaration should now have the type annotations bit set
-		if (this.annotations != null) {
-			for (Annotation annotation : this.annotations) {
-				TypeBinding resolvedAnnotationType = annotation.resolvedType;
-				if (resolvedAnnotationType != null && (resolvedAnnotationType.getAnnotationTagBits() & TagBits.AnnotationForTypeUse) != 0) {
-					this.bits |= ASTNode.HasTypeAnnotations;
-					break;
-				}
-			}
-		}
 	}
 
 	@Override

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/RecordPattern.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/RecordPattern.java
@@ -175,11 +175,6 @@ public class RecordPattern extends Pattern {
 	}
 
 	@Override
-	public boolean matchFailurePossible() {
-		return this.patterns.length != 0; // if no deconstruction is involved, no failure is possible.
-	}
-
-	@Override
 	public boolean dominates(Pattern p) {
 		/* 14.30.3: A record pattern with type R and pattern list L dominates another record pattern
 		   with type S and pattern list M if (i) R and S name the same record class, and (ii)

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/RecordPattern.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/RecordPattern.java
@@ -260,7 +260,7 @@ public class RecordPattern extends Pattern {
 					if (current.index != outer.patterns.length - 1)
 						pops++;
 					current = outer;
-					outer = outer.getEnclosingPattern() instanceof RecordPattern rp ? rp : null;
+					outer = outer.getEnclosingPattern();
 				}
 				while (pops > 1) {
 					codeStream.pop2();

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ReferenceExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ReferenceExpression.java
@@ -265,9 +265,30 @@ public class ReferenceExpression extends FunctionalExpression implements IPolyEx
 		return (this.binding.isVarargs() ||
 				(isConstructorReference() && (this.receiverType.syntheticOuterLocalVariables() != null || this.shouldCaptureInstance)) ||
 				this.requiresBridges() || // bridges.
+				descriptorEncodesIntersectionType() ||
 				!isDirectCodeGenPossible());
 		// To fix: We should opt for direct code generation wherever possible.
 	}
+
+	private boolean descriptorEncodesIntersectionType() {
+		if (this.descriptor == null || this.descriptor.parameters == null || this.descriptor.parameters.length == 0)
+			return false;
+		for (TypeBinding parameter : this.descriptor.parameters) {
+			if (isIntersectionType(parameter))
+				return true;
+		}
+		return false;
+	}
+
+	private boolean isIntersectionType(TypeBinding parameter) {
+		if (parameter.isIntersectionType() || parameter.isIntersectionType18())
+			return true;
+		if (parameter instanceof TypeVariableBinding tvb) {
+			return isIntersectionType(tvb.upperBound());
+		}
+		return false;
+	}
+
 	private boolean isDirectCodeGenPossible() {
 		if (this.binding != null) {
 			if (isMethodReference() && this.syntheticAccessor == null) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypePattern.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypePattern.java
@@ -69,7 +69,8 @@ public class TypePattern extends Pattern implements IGenerateTypeCheck {
 			return patternInfo; // exclude anonymous blokes from flow analysis.
 
 		patternInfo.markAsDefinitelyAssigned(this.local.binding);
-		patternInfo.markAsDefinitelyNonNull(this.local.binding);
+		if (this.getEnclosingPattern() == null)
+			patternInfo.markAsDefinitelyNonNull(this.local.binding); // can't say the same for members of a record being deconstructed.
 		return patternInfo;
 	}
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/ClassFileConstants.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/ClassFileConstants.java
@@ -223,7 +223,6 @@ public interface ClassFileConstants {
 	int ATTR_LINES = 0x2; // LineNumberAttribute
 	int ATTR_VARS = 0x4; // LocalVariableTableAttribute
 	int ATTR_STACK_MAP_TABLE = 0x8; // Stack map table attribute
-	int ATTR_STACK_MAP = 0x10; // Stack map attribute: cldc
 	int ATTR_TYPE_ANNOTATION = 0x20; // type annotation attribute (jsr 308)
 	int ATTR_METHOD_PARAMETERS = 0x40; // method parameters attribute (jep 118)
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/BranchLabel.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/BranchLabel.java
@@ -277,21 +277,21 @@ public void place() { // Currently lacking wide support.
 					this.codeStream.lastEntryPC = this.position;
 				}
 				// end of new code
-				if ((this.codeStream.generateAttributes & (ClassFileConstants.ATTR_VARS | ClassFileConstants.ATTR_STACK_MAP_TABLE | ClassFileConstants.ATTR_STACK_MAP)) != 0) {
-					LocalVariableBinding locals[] = this.codeStream.locals;
-					for (LocalVariableBinding local : locals) {
-						if ((local != null) && (local.initializationCount > 0)) {
-							if (local.initializationPCs[((local.initializationCount - 1) << 1) + 1] == oldPosition) {
-								// we want to prevent interval of size 0 to have a negative size.
-								// see PR 1GIRQLA: ITPJCORE:ALL - ClassFormatError for local variable attribute
-								local.initializationPCs[((local.initializationCount - 1) << 1) + 1] = this.position;
-							}
-							if (local.initializationPCs[(local.initializationCount - 1) << 1] == oldPosition) {
-								local.initializationPCs[(local.initializationCount - 1) << 1] = this.position;
-							}
+
+				LocalVariableBinding locals[] = this.codeStream.locals;
+				for (LocalVariableBinding local : locals) {
+					if ((local != null) && (local.initializationCount > 0)) {
+						if (local.initializationPCs[((local.initializationCount - 1) << 1) + 1] == oldPosition) {
+							// we want to prevent interval of size 0 to have a negative size.
+							// see PR 1GIRQLA: ITPJCORE:ALL - ClassFormatError for local variable attribute
+							local.initializationPCs[((local.initializationCount - 1) << 1) + 1] = this.position;
+						}
+						if (local.initializationPCs[(local.initializationCount - 1) << 1] == oldPosition) {
+							local.initializationPCs[(local.initializationCount - 1) << 1] = this.position;
 						}
 					}
 				}
+
 				if ((this.codeStream.generateAttributes & ClassFileConstants.ATTR_LINES) != 0) {
 					// we need to remove all entries that is beyond this.position inside the pcToSourcerMap table
 					this.codeStream.removeUnusedPcToSourceMapEntries();

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/CodeStream.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/CodeStream.java
@@ -246,10 +246,6 @@ public void aconst_null() {
 
 public void addDefinitelyAssignedVariables(Scope scope, int initStateIndex) {
 	// Required to fix 1PR0XVS: LFRE:WINNT - Compiler: variable table for method appears incorrect
-	if ((this.generateAttributes & (ClassFileConstants.ATTR_VARS
-			| ClassFileConstants.ATTR_STACK_MAP_TABLE
-			| ClassFileConstants.ATTR_STACK_MAP)) == 0)
-		return;
 	for (int i = 0; i < this.visibleLocalsCount; i++) {
 		LocalVariableBinding localBinding = this.visibleLocals[i];
 		if (localBinding != null) {
@@ -283,11 +279,6 @@ public void addVariable(LocalVariableBinding localBinding) {
 }
 
 public void addVisibleLocalVariable(LocalVariableBinding localBinding) {
-	if ((this.generateAttributes & (ClassFileConstants.ATTR_VARS
-			| ClassFileConstants.ATTR_STACK_MAP_TABLE
-			| ClassFileConstants.ATTR_STACK_MAP)) == 0)
-		return;
-
 	if (this.visibleLocalsCount >= this.visibleLocals.length)
 		System.arraycopy(this.visibleLocals, 0, this.visibleLocals = new LocalVariableBinding[this.visibleLocalsCount * 2], 0, this.visibleLocalsCount);
 	this.visibleLocals[this.visibleLocalsCount++] = localBinding;
@@ -1157,10 +1148,6 @@ public void dup2_x2() {
 
 public void exitUserScope(BlockScope currentScope, Predicate<LocalVariableBinding> condition) {
 	// mark all the scope's locals as losing their definite assignment
-	if ((this.generateAttributes & (ClassFileConstants.ATTR_VARS
-			| ClassFileConstants.ATTR_STACK_MAP_TABLE
-			| ClassFileConstants.ATTR_STACK_MAP)) == 0)
-		return;
 	int index = this.visibleLocalsCount - 1;
 	while (index >= 0) {
 		LocalVariableBinding visibleLocal = this.visibleLocals[index];
@@ -6612,10 +6599,6 @@ public void pushOnStack(TypeBinding binding) {
 }
 
 public void record(LocalVariableBinding local) {
-	if ((this.generateAttributes & (ClassFileConstants.ATTR_VARS
-			| ClassFileConstants.ATTR_STACK_MAP_TABLE
-			| ClassFileConstants.ATTR_STACK_MAP)) == 0)
-		return;
 	if (this.allLocalsCounter == this.locals.length) {
 		// resize the collection
 		System.arraycopy(this.locals, 0, this.locals = new LocalVariableBinding[this.allLocalsCounter + LOCALS_INCREMENT], 0, this.allLocalsCounter);
@@ -6783,10 +6766,6 @@ public void registerExceptionHandler(ExceptionLabel anExceptionLabel) {
 public void removeNotDefinitelyAssignedVariables(Scope scope, int initStateIndex) {
 	// given some flow info, make sure we did not loose some variables initialization
 	// if this happens, then we must update their pc entries to reflect it in debug attributes
-	if ((this.generateAttributes & (ClassFileConstants.ATTR_VARS
-			| ClassFileConstants.ATTR_STACK_MAP_TABLE
-			| ClassFileConstants.ATTR_STACK_MAP)) == 0)
-		return;
 	for (int i = 0; i < this.visibleLocalsCount; i++) {
 		LocalVariableBinding localBinding = this.visibleLocals[i];
 		if (localBinding != null && !isDefinitelyAssigned(scope, initStateIndex, localBinding) && localBinding.initializationCount > 0) {
@@ -6857,12 +6836,6 @@ public void reset(AbstractMethodDeclaration referenceMethod, ClassFile targetCla
 }
 
 private OperandStack createOperandStack(CompilerOptions compilerOptions) {
-	if ((this.generateAttributes & (ClassFileConstants.ATTR_VARS
-			| ClassFileConstants.ATTR_STACK_MAP_TABLE
-			| ClassFileConstants.ATTR_STACK_MAP)) == 0) {
-		return new OperandStack.NullStack();
-	}
-
 	return JavaFeature.SWITCH_EXPRESSIONS.isSupported(compilerOptions.sourceLevel, compilerOptions.enablePreviewFeatures) ?
 										new OperandStack(this.classFile) : new OperandStack.NullStack();
 }
@@ -7390,11 +7363,6 @@ public TypeBinding retrieveLocalType(int currentPC, int resolvedPosition) {
 
 	if (this.operandStack instanceof OperandStack.NullStack)
 		return null;
-
-	if ((this.generateAttributes & (ClassFileConstants.ATTR_VARS
-			| ClassFileConstants.ATTR_STACK_MAP_TABLE
-			| ClassFileConstants.ATTR_STACK_MAP)) == 0)
-		return null; // can't retrieve what we didn't record.
 
 	for (int i = this.allLocalsCounter  - 1 ; i >= 0; i--) {
 		LocalVariableBinding localVariable = this.locals[i];

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/StackMapFrame.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/StackMapFrame.java
@@ -38,6 +38,12 @@ public class StackMapFrame {
 	private int numberOfDifferentLocals = -1;
 	public int tagBits;
 
+	/* Should the `next` frame (i.e., frame starting at the next bci after the last instruction of `this` frame)
+	   start out congruent to `this` ? If `this` completes abruptly and there are no forward references to `next`
+	   it should not!
+	*/
+	public boolean adoptStackShape = true;
+
 	public StackMapFrame(int initialLocalSize) {
 		this.locals = new VerificationTypeInfo[initialLocalSize];
 		this.numberOfLocals = -1;
@@ -94,7 +100,9 @@ public class StackMapFrame {
 		result.numberOfLocals = -1;
 		result.numberOfDifferentLocals = -1;
 		result.pc = this.pc;
-		result.numberOfStackItems = this.numberOfStackItems;
+
+		// If control doesn't flow into the new frame from `this` do not inherit the stack shape from `this`
+		result.numberOfStackItems = this.adoptStackShape ? this.numberOfStackItems : 0;
 
 		if (length != 0) {
 			result.locals = new VerificationTypeInfo[length];
@@ -103,7 +111,7 @@ public class StackMapFrame {
 				result.locals[i] = getCachedValue(cache, verificationTypeInfo);
 			}
 		}
-		length = this.numberOfStackItems;
+		length = result.numberOfStackItems;
 		if (length != 0) {
 			result.stackItems = new VerificationTypeInfo[length];
 			for (int i = 0; i < length; i++) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/StackMapFrameCodeStream.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/StackMapFrameCodeStream.java
@@ -21,7 +21,6 @@ import java.util.Set;
 import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.internal.compiler.ClassFile;
 import org.eclipse.jdt.internal.compiler.ast.ASTNode;
-import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 import org.eclipse.jdt.internal.compiler.lookup.Binding;
 import org.eclipse.jdt.internal.compiler.lookup.LocalVariableBinding;
 import org.eclipse.jdt.internal.compiler.lookup.MethodBinding;
@@ -87,7 +86,6 @@ public class StackMapFrameCodeStream extends CodeStream {
 
 	public StackMapFrameCodeStream(ClassFile givenClassFile) {
 		super(givenClassFile);
-		this.generateAttributes |= ClassFileConstants.ATTR_STACK_MAP;
 	}
 
 	@Override

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BinaryTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BinaryTypeBinding.java
@@ -592,6 +592,7 @@ private void cachePartsFrom2(IBinaryType binaryType, boolean needFieldsAndMethod
 				iComponents = binaryType.getRecordComponents();
 				if (iComponents != null) {
 					createFields(iComponents, binaryType, sourceLevel, missingTypeNames, RECORD_INITIALIZATION);
+					this.tagBits |= TagBits.HasUnresolvedComponents;
 				}
 			}
 			IBinaryField[] iFields = binaryType.getFields();
@@ -1281,13 +1282,13 @@ public RecordComponentBinding[] components() {
 	if (!isPrototype()) {
 		return this.components = this.prototype.components();
 	}
-	if ((this.extendedTagBits & ExtendedTagBits.AreRecordComponentsComplete) != 0)
+	if ((this.tagBits & TagBits.HasUnresolvedComponents) == 0)
 		return this.components;
 
 	for (int i = this.components.length; --i >= 0;) {
 		resolveTypeFor(this.components[i]);
 	}
-	this.extendedTagBits |= ExtendedTagBits.AreRecordComponentsComplete;
+	this.tagBits &= ~TagBits.HasUnresolvedComponents;
 	return this.components;
 }
 // NOTE: the type of each field of a binary type is resolved when needed
@@ -1833,7 +1834,8 @@ public MethodBinding getRecordComponentAccessor(char[] name) {
 	if (isRecord()) {
 		for (MethodBinding m : this.getMethods(name)) {
 			if (CharOperation.equals(m.selector, name)) {
-				return m;
+				if (m.parameters == null || m.parameters.length == 0)
+					return m;
 			}
 		}
 	}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Binding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Binding.java
@@ -72,8 +72,6 @@ public abstract class Binding {
 	public static final RecordComponentBinding[] NO_COMPONENTS = new RecordComponentBinding[0];
 	public static final LocalVariableBinding[] NO_ARGUMENT_BINDINGS = new LocalVariableBinding[0];
 
-
-	public static final RecordComponentBinding[] UNINITIALIZED_COMPONENTS = new RecordComponentBinding[0];
 	public static final FieldBinding[] UNINITIALIZED_FIELDS = new FieldBinding[0];
 	public static final MethodBinding[] UNINITIALIZED_METHODS = new MethodBinding[0];
 	public static final ReferenceBinding[] UNINITIALIZED_REFERENCE_TYPES = new ReferenceBinding[0];

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/CompilationUnitScope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/CompilationUnitScope.java
@@ -412,6 +412,11 @@ void sealTypeHierarchy() {
 		sourceType.scope.connectPermittedTypes();
 	}
 }
+void collateRecordComponents() {
+	for (SourceTypeBinding sourceType : this.topLevelTypes) {
+		sourceType.scope.collateRecordComponents();
+	}
+}
 void integrateAnnotationsInHierarchy() {
 	// Only now that all hierarchy information is built we're ready for ...
 	// ... integrating annotations

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ExtendedTagBits.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ExtendedTagBits.java
@@ -17,7 +17,6 @@ import org.eclipse.jdt.internal.compiler.ast.ASTNode;
 
 public interface ExtendedTagBits {
 
-	int AreRecordComponentsComplete = ASTNode.Bit1; // type
 	int HasUnresolvedPermittedSubtypes = ASTNode.Bit2;
 
 	/** From Java 16

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ExtraCompilerModifiers.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ExtraCompilerModifiers.java
@@ -39,7 +39,6 @@ public interface ExtraCompilerModifiers { // modifier constant
 	// bit21 - use by ClassFileConstants.AccDeprecated
 	final int AccDeprecatedImplicitly = ASTNode.Bit22; // record whether deprecated itself or contained by a deprecated type
 	final int AccAlternateModifierProblem = ASTNode.Bit23;
-	final int AccModifierProblem = ASTNode.Bit24;
 	final int AccSemicolonBody = ASTNode.Bit25;
 	final int AccRecord = ASTNode.Bit25;
 	final int AccUnresolved = ASTNode.Bit26;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/LookupEnvironment.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/LookupEnvironment.java
@@ -159,6 +159,7 @@ public class LookupEnvironment implements ProblemReasons, TypeConstants {
 		CHECK_AND_SET_IMPORTS,
 		CONNECT_TYPE_HIERARCHY,
 		SEAL_TYPE_HIERARCHY,
+		COLLATE_RECORD_COMPONENTS,
 		BUILD_FIELDS_AND_METHODS,
 		INTEGRATE_ANNOTATIONS_IN_HIERARCHY,
 		CHECK_PARAMETERIZED_TYPES;
@@ -188,6 +189,7 @@ public class LookupEnvironment implements ProblemReasons, TypeConstants {
 				case CHECK_AND_SET_IMPORTS -> scope.checkAndSetImports();
 				case CONNECT_TYPE_HIERARCHY -> scope.connectTypeHierarchy();
 				case SEAL_TYPE_HIERARCHY -> scope.sealTypeHierarchy();
+				case COLLATE_RECORD_COMPONENTS -> scope.collateRecordComponents();
 				case BUILD_FIELDS_AND_METHODS -> scope.buildFieldsAndMethods();
 				case INTEGRATE_ANNOTATIONS_IN_HIERARCHY -> scope.integrateAnnotationsInHierarchy();
 				case CHECK_PARAMETERIZED_TYPES -> scope.checkParameterizedTypes();

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedTypeBinding.java
@@ -120,24 +120,14 @@ public class ParameterizedTypeBinding extends ReferenceBinding implements Substi
 	}
 	@Override
 	public RecordComponentBinding[] components() {
-		if ((this.extendedTagBits & ExtendedTagBits.AreRecordComponentsComplete) != 0)
-			return this.components;
-
-		try {
-			RecordComponentBinding[] originalRecordComponents = this.type.components();
-			int length = originalRecordComponents.length;
-			RecordComponentBinding[] parameterizedRecordComponents = new RecordComponentBinding[length];
+		if (this.isRecord() && this.components == null) {
+			RecordComponentBinding[] originalComponents = this.type.components();
+			int length = originalComponents.length;
+			this.components = new RecordComponentBinding[length];
 			for (int i = 0; i < length; i++)
-				// substitute all record components, so as to get updated declaring class at least
-				parameterizedRecordComponents[i] = new ParameterizedRecordComponentBinding(this, originalRecordComponents[i]);
-			this.components = parameterizedRecordComponents;
-		} finally {
-			// if the original record components cannot be retrieved (ex. AbortCompilation), then assume we do not have any record components
-			if (this.components == null)
-				this.components = Binding.NO_COMPONENTS;
-			this.extendedTagBits |= ExtendedTagBits.AreRecordComponentsComplete;
+				this.components[i] = new ParameterizedRecordComponentBinding(this, originalComponents[i]);
 		}
-		return this.components;
+		return this.components != null ? this.components : (this.components = Binding.NO_COMPONENTS);
 	}
 	/**
 	 * Iterate type arguments, and validate them according to corresponding variable bounds.

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
@@ -1814,6 +1814,60 @@ public final ReferenceBinding outermostEnclosingType() {
 	}
 }
 
+/** return all type variables involved left to right */
+public TypeVariableBinding [] typeVariablesIncludingEnclosing() {
+
+	ReferenceBinding enclosingType = enclosingType();
+	TypeVariableBinding [] ownVariables = typeVariables();
+	TypeVariableBinding [] outerVariables = hasEnclosingInstanceContext() && enclosingType != null ? enclosingType.typeVariablesIncludingEnclosing() : Binding.NO_TYPE_VARIABLES;
+
+	if (outerVariables == null || outerVariables == Binding.NO_TYPE_VARIABLES)
+		return ownVariables == null ? Binding.NO_TYPE_VARIABLES : ownVariables;
+
+	if (ownVariables == null || ownVariables == Binding.NO_TYPE_VARIABLES)
+		return outerVariables;
+
+	int outerVariablesCount = outerVariables.length;
+	TypeVariableBinding [] allVariables;
+	System.arraycopy(outerVariables,
+			            0,
+			            allVariables = new TypeVariableBinding[outerVariablesCount + ownVariables.length],
+			            0,
+			         outerVariablesCount);
+	System.arraycopy(ownVariables,
+                         0,
+                         allVariables,
+                 outerVariablesCount,
+              ownVariables.length);
+	return allVariables;
+}
+
+public TypeBinding[] typeArgumentsIncludingEnclosing() {
+	ReferenceBinding enclosingType = enclosingType();
+	TypeBinding [] ownArguments = typeArguments();
+	TypeBinding [] outerArguments = hasEnclosingInstanceContext() && enclosingType != null ? enclosingType.typeArguments() : Binding.NO_TYPES;
+
+	if (outerArguments == null || outerArguments == Binding.NO_TYPES)
+		return ownArguments == null ? Binding.NO_TYPES : ownArguments;
+
+	if (ownArguments == null || ownArguments == Binding.NO_TYPES)
+		return outerArguments;
+
+	int outerArgumentsCount = outerArguments.length;
+	TypeBinding [] allArguments;
+	System.arraycopy(outerArguments,
+			            0,
+			            allArguments = new TypeBinding[outerArgumentsCount + ownArguments.length],
+			            0,
+			            outerArgumentsCount);
+	System.arraycopy(ownArguments,
+                         0,
+                         allArguments,
+                         outerArgumentsCount,
+              ownArguments.length);
+	return allArguments;
+}
+
 /**
  * Answer the source name for the type.
  * In the case of member types, as the qualified name from its top level type.

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TagBits.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TagBits.java
@@ -97,6 +97,7 @@ public interface TagBits {
 	long HasUnresolvedSuperinterfaces = ASTNode.Bit27;
 	long HasUnresolvedEnclosingType = ASTNode.Bit28;
 	long HasUnresolvedMemberTypes = ASTNode.Bit29;  // Also in use at STB.
+	long HasUnresolvedComponents = ASTNode.Bit34L;
 
 	long HasTypeVariable = ASTNode.Bit30; // set either for type variables (direct) or parameterized types indirectly referencing type variables
 	long HasDirectWildcard = ASTNode.Bit31; // set for parameterized types directly referencing wildcards
@@ -105,7 +106,7 @@ public interface TagBits {
 	long BeginAnnotationCheck = ASTNode.Bit32L;
 	long EndAnnotationCheck = ASTNode.Bit33L;
 
-	// currently unused: ASTNode.Bit34L, ASTNode.Bit34L
+	// currently unused: ASTNode.Bit35L
 
 	// standard annotations
 	// 9-bits for targets

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
@@ -7207,7 +7207,7 @@ public void notCompatibleTypesError(ASTNode location, TypeBinding leftType, Type
 		rightShortName = rightName;
 	}
 	int problemId = IProblem.IncompatibleTypesInEqualityOperator;
-	if (location instanceof Pattern p && p.getEnclosingPattern() instanceof RecordPattern) {
+	if (location instanceof Pattern p && p.getEnclosingPattern() != null) {
 		problemId = IProblem.PatternTypeMismatch;
 	} else if (location instanceof InstanceOfExpression) {
 		problemId = IProblem.IncompatibleTypesInConditionalOperator;

--- a/org.eclipse.jdt.core.tests.compiler/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.tests.compiler/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.core.tests.compiler;singleton:=true
-Bundle-Version: 3.13.800.qualifier
+Bundle-Version: 3.13.900.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jdt.core.tests.compiler,

--- a/org.eclipse.jdt.core.tests.compiler/pom.xml
+++ b/org.eclipse.jdt.core.tests.compiler/pom.xml
@@ -19,7 +19,7 @@
     <relativePath>../tests-pom/</relativePath>
   </parent>
   <artifactId>org.eclipse.jdt.core.tests.compiler</artifactId>
-  <version>3.13.800-SNAPSHOT</version>
+  <version>3.13.900-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericTypeTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericTypeTest.java
@@ -35879,7 +35879,7 @@ public void test1078() {
 			"  }\n" +
 			"}", // =================,
 		},
-		// unchecked warnings on [4][5][8][9][10][11][12]
+		// unchecked warnings on [4][8][9][10][11][12]
 		"----------\n" +
 		"1. WARNING in X.java (at line 10)\n" +
 		"	List list = (List)object;//[1]\n" +
@@ -35901,42 +35901,32 @@ public void test1078() {
 		"	    ^^^^^^^^^^^^^^^^^^^^\n" +
 		"Type safety: Unchecked cast from Object to List<Object>\n" +
 		"----------\n" +
-		"5. WARNING in X.java (at line 15)\n" +
-		"	foo((List<? extends Object>)object);//[5]\n" +
-		"	    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
-		"Type safety: Unchecked cast from Object to List<? extends Object>\n" +
-		"----------\n" +
-		"6. WARNING in X.java (at line 17)\n" +
+		"5. WARNING in X.java (at line 17)\n" +
 		"	foo((Map)object);//[6]\n" +
 		"	     ^^^\n" +
 		"Map is a raw type. References to generic type Map<K,V> should be parameterized\n" +
 		"----------\n" +
-		"7. WARNING in X.java (at line 19)\n" +
+		"6. WARNING in X.java (at line 19)\n" +
 		"	foo((Map<Object, ?>)object);//[8]unchecked cast\n" +
 		"	    ^^^^^^^^^^^^^^^^^^^^^^\n" +
 		"Type safety: Unchecked cast from Object to Map<Object,?>\n" +
 		"----------\n" +
-		"8. WARNING in X.java (at line 20)\n" +
+		"7. WARNING in X.java (at line 20)\n" +
 		"	foo((Map<?, Object>)object);//[9]unchecked cast\n" +
 		"	    ^^^^^^^^^^^^^^^^^^^^^^\n" +
 		"Type safety: Unchecked cast from Object to Map<?,Object>\n" +
 		"----------\n" +
-		"9. WARNING in X.java (at line 21)\n" +
+		"8. WARNING in X.java (at line 21)\n" +
 		"	foo((Map<Object, Object>)object);//[10]unchecked cast\n" +
 		"	    ^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
 		"Type safety: Unchecked cast from Object to Map<Object,Object>\n" +
 		"----------\n" +
-		"10. WARNING in X.java (at line 22)\n" +
+		"9. WARNING in X.java (at line 22)\n" +
 		"	foo((Map<? extends Object, Object>)object);//[11]unchecked cast\n" +
 		"	    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
 		"Type safety: Unchecked cast from Object to Map<? extends Object,Object>\n" +
 		"----------\n" +
-		"11. WARNING in X.java (at line 23)\n" +
-		"	foo((Map<? extends Object, ? extends Object>)object);//[12]\n" +
-		"	    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
-		"Type safety: Unchecked cast from Object to Map<? extends Object,? extends Object>\n" +
-		"----------\n" +
-		"12. ERROR in X.java (at line 24)\n" +
+		"10. ERROR in X.java (at line 24)\n" +
 		"	Zork z;\n" +
 		"	^^^^\n" +
 		"Zork cannot be resolved to a type\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest.java
@@ -6688,5 +6688,54 @@ public void testIssue3624() {
 			}
 		);
 }
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3897
+// Compilation error on ECJ but not with JavaC
+public void testIssue3897() {
+		this.runNegativeTest(
+			new String[] {
+				"X.java",
+				"""
+				public class X<T> {
+				    T value;
+
+				    public void set(T val) {
+				        this.value = val;
+				    }
+
+				    public T get() {
+				        return value;
+				    }
+
+				    public void unsafePut(Object obj) {
+				        this.set(((X<T>) obj).get()); // <-- unchecked cast - causes ClassCastException further down
+				    }
+
+				    public static void main(String[] args) {
+				        X<String> xStr = new X<>();
+				        xStr.set("hello");
+
+				        X<Integer> xInt = new X<>();
+				        xInt.set(42);
+
+				        xStr.unsafePut(xInt);
+				        System.out.println(xStr.get()); // 🚨 ClassCastException at runtime
+				        Zork z;
+				    }
+				}
+				"""
+			},
+			"----------\n" +
+			"1. WARNING in X.java (at line 13)\n" +
+			"	this.set(((X<T>) obj).get()); // <-- unchecked cast - causes ClassCastException further down\n" +
+			"	         ^^^^^^^^^^^^\n" +
+			"Type safety: Unchecked cast from Object to X<T>\n" +
+			"----------\n" +
+			"2. ERROR in X.java (at line 25)\n" +
+			"	Zork z;\n" +
+			"	^^^^\n" +
+			"Zork cannot be resolved to a type\n" +
+			"----------\n"
+		);
+}
 }
 

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/InstanceofPrimaryPatternTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/InstanceofPrimaryPatternTest.java
@@ -753,4 +753,235 @@ public class InstanceofPrimaryPatternTest extends AbstractRegressionTest {
 			},
 			"42");
 	}
+
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3897
+	// Compilation error on ECJ but not with JavaC
+	public void testIssue3897() {
+		runConformTest(
+			new String[] {
+				"X.java",
+				"""
+				import java.util.ArrayList;
+
+				public class X {
+
+					public static void main(String[] args) {
+						var o = new Object();
+						if (o instanceof ListInteger<? extends Integer> list) {
+							System.out.println("List");
+						}
+						System.out.println("Not List");
+					}
+
+					class ListInteger<T extends Integer> extends ArrayList<T> {
+
+					}
+				}
+				"""
+			},
+			"Not List");
+	}
+
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3897
+	// Compilation error on ECJ but not with JavaC
+	public void testIssue3897_2() {
+		runNegativeTest(
+			new String[] {
+				"X.java",
+				"""
+				import java.util.ArrayList;
+
+				interface I {}
+
+				class A implements I {}
+				class B implements I {}
+
+				public class X {
+
+					public void main(String[] args) {
+				        ListInteger<? extends B> li = (ListInteger<? extends B>) new Object();
+				        ListInteger<? extends A> li2 = (ListInteger<? extends A>) new Object();
+				        ArrayList<String> as = (ArrayList<String>) new Object();
+				        Zork z;
+					}
+
+					class ListInteger<T extends I> extends ArrayList<T> {
+
+					}
+				}
+				"""
+			},
+			"----------\n" +
+			"1. WARNING in X.java (at line 11)\n" +
+			"	ListInteger<? extends B> li = (ListInteger<? extends B>) new Object();\n" +
+			"	                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
+			"Type safety: Unchecked cast from Object to X.ListInteger<? extends B>\n" +
+			"----------\n" +
+			"2. WARNING in X.java (at line 12)\n" +
+			"	ListInteger<? extends A> li2 = (ListInteger<? extends A>) new Object();\n" +
+			"	                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
+			"Type safety: Unchecked cast from Object to X.ListInteger<? extends A>\n" +
+			"----------\n" +
+			"3. WARNING in X.java (at line 13)\n" +
+			"	ArrayList<String> as = (ArrayList<String>) new Object();\n" +
+			"	                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
+			"Type safety: Unchecked cast from Object to ArrayList<String>\n" +
+			"----------\n" +
+			"4. ERROR in X.java (at line 14)\n" +
+			"	Zork z;\n" +
+			"	^^^^\n" +
+			"Zork cannot be resolved to a type\n" +
+			"----------\n" +
+			"5. WARNING in X.java (at line 17)\n" +
+			"	class ListInteger<T extends I> extends ArrayList<T> {\n" +
+			"	      ^^^^^^^^^^^\n" +
+			"The serializable class ListInteger does not declare a static final serialVersionUID field of type long\n" +
+			"----------\n");
+	}
+
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3897
+	// Compilation error on ECJ but not with JavaC
+	public void testIssue3897_3() {
+		runNegativeTest(
+			new String[] {
+				"X.java",
+				"""
+				import java.util.ArrayList;
+
+				class Base {}
+
+				class A extends Base {}
+				class B extends Base {}
+
+				public class X {
+
+					public void main(String[] args) {
+				        ListInteger<? extends B> li = (ListInteger<? extends B>) new Object();
+				        ListInteger<? extends A> li2 = (ListInteger<? extends A>) new Object();
+				        ArrayList<String> as = (ArrayList<String>) new Object();
+				        Zork z;
+					}
+
+					class ListInteger<T extends Base> extends ArrayList<T> {
+
+					}
+				}
+				"""
+			},
+			"----------\n" +
+			"1. WARNING in X.java (at line 11)\n" +
+			"	ListInteger<? extends B> li = (ListInteger<? extends B>) new Object();\n" +
+			"	                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
+			"Type safety: Unchecked cast from Object to X.ListInteger<? extends B>\n" +
+			"----------\n" +
+			"2. WARNING in X.java (at line 12)\n" +
+			"	ListInteger<? extends A> li2 = (ListInteger<? extends A>) new Object();\n" +
+			"	                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
+			"Type safety: Unchecked cast from Object to X.ListInteger<? extends A>\n" +
+			"----------\n" +
+			"3. WARNING in X.java (at line 13)\n" +
+			"	ArrayList<String> as = (ArrayList<String>) new Object();\n" +
+			"	                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
+			"Type safety: Unchecked cast from Object to ArrayList<String>\n" +
+			"----------\n" +
+			"4. ERROR in X.java (at line 14)\n" +
+			"	Zork z;\n" +
+			"	^^^^\n" +
+			"Zork cannot be resolved to a type\n" +
+			"----------\n" +
+			"5. WARNING in X.java (at line 17)\n" +
+			"	class ListInteger<T extends Base> extends ArrayList<T> {\n" +
+			"	      ^^^^^^^^^^^\n" +
+			"The serializable class ListInteger does not declare a static final serialVersionUID field of type long\n" +
+			"----------\n");
+	}
+
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3897
+	// Compilation error on ECJ but not with JavaC
+	public void testIssue3897_4() {
+		runNegativeTest(
+			new String[] {
+				"X.java",
+				"""
+				interface I {}
+
+				class A<T extends I> {
+				    T i;
+				}
+
+				public class X {
+				    public static void main(String[] args) {
+				        Object o = new A<>();
+
+				        // 1. No warning in Javac; "Unchecked cast" warning in ECJ, even if the cast can never fail.
+				        A<? extends I> a = (A<? extends I>) o;
+				        // 2. No warning in either Javac or ECJ.
+				        A<? extends I> b = (A<?>) o;
+
+				        // 3. Works in Javac; error in ECJ.
+				        if (o instanceof A<? extends I> c) {
+				            I i = c.i;
+				            System.out.println(i);
+				        }
+
+				        // 4. Works in both Javac and ECJ.
+				        if (o instanceof A<?> c) {
+				            // Type checks in ECJ and Javac. Both considers b.i to have type I.
+				            I i = c.i;
+				            System.out.println(i);
+				        }
+
+				        System.out.println(o);
+				        System.out.println(a);
+				        Zork z;
+				    }
+				}
+				"""
+			},
+			"----------\n" +
+			"1. ERROR in X.java (at line 31)\n" +
+			"	Zork z;\n" +
+			"	^^^^\n" +
+			"Zork cannot be resolved to a type\n" +
+			"----------\n");
+	}
+
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3897
+	// Compilation error on ECJ but not with JavaC
+	public void testIssue3897_5() {
+		runNegativeTest(
+			new String[] {
+				"X.java",
+				"""
+				import java.util.ArrayList;
+				import java.util.List;
+
+				class Test2 {
+					public static void main(String[] args) {
+						List<Integer> x = new ArrayList<Integer>();
+						if (x instanceof ArrayList<Integer>) { // OK
+							System.out.println("ArrayList of Integers");
+						}
+						if (x instanceof ArrayList<String>) { // error
+							System.out.println("ArrayList of Strings");
+						}
+						if (x instanceof ArrayList<Object>) { // error
+							System.out.println("ArrayList of Objects");
+						}
+					}
+				}
+				"""
+			},
+			"----------\n" +
+			"1. ERROR in X.java (at line 10)\n" +
+			"	if (x instanceof ArrayList<String>) { // error\n" +
+			"	    ^\n" +
+			"Type List<Integer> cannot be safely cast to ArrayList<String>\n" +
+			"----------\n" +
+			"2. ERROR in X.java (at line 13)\n" +
+			"	if (x instanceof ArrayList<Object>) { // error\n" +
+			"	    ^\n" +
+			"Type List<Integer> cannot be safely cast to ArrayList<Object>\n" +
+			"----------\n");
+	}
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LambdaExpressionsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LambdaExpressionsTest.java
@@ -8608,6 +8608,61 @@ public void testGHIssue2096() {
     		"----------\n");
 }
 
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3798
+// BootstrapMethodError / LambdaConversionException using ECJ
+public void testIssue3798() {
+	this.runConformTest(
+         new String[] {
+             "X.java",
+             """
+			import java.util.Optional;
+			import java.util.stream.Stream;
+
+			public class X {
+			    private static interface Value1 {
+			        int getValue1();
+			    }
+
+			    private static interface Value2 {
+			        String getValue2();
+			    }
+
+			    private static class ObjectA implements Value1, Value2 {
+			        @Override
+			        public String getValue2() {
+			            return "A2";
+			        }
+
+			        @Override
+			        public int getValue1() {
+			            return 'A' + 1;
+			        }
+			    }
+
+			    private static class ObjectB implements Value1, Value2 {
+			        @Override
+			        public String getValue2() {
+			            return "B2";
+			        }
+
+			        @Override
+			        public int getValue1() {
+			            return 'B' + 1;
+			        }
+			    }
+
+			    public static void main(String[] args) {
+			        Stream.of(Optional.<ObjectA>empty(), Optional.of(new ObjectA()), Optional.of(new ObjectB()))
+			                .filter(Optional::isPresent)
+			                .map(Optional::get)
+			                .map(Value2::getValue2)
+			                .forEach(System.out::println);
+			    }
+			}
+             """},
+         "A2\nB2");
+}
+
 public static Class testClass() {
 	return LambdaExpressionsTest.class;
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordPatternTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordPatternTest.java
@@ -4921,4 +4921,55 @@ public class RecordPatternTest extends AbstractRegressionTest9 {
 			},
 			"012012345678");
 	}
+
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4065
+	// [Null][Record] Invalid "dead code" warning for record pattern with null-guard on component
+	public void testIssue4065() {
+		runConformTest(new String[] {
+				"InvalidDeadCodeWarning.java",
+				"""
+				public class InvalidDeadCodeWarning {
+
+				    public static void main(String[] args) {
+				        try {
+				            new InvalidDeadCodeWarning(new MyRecord(null));
+				        } catch (IllegalArgumentException e) {
+				            System.out.println(e);
+				        }
+
+				        try {
+				            new InvalidDeadCodeWarning(new MyRecord("  "));
+				        } catch (IllegalArgumentException e) {
+				            System.out.println(e);
+				        }
+
+				        try {
+				            new InvalidDeadCodeWarning(null);
+				        } catch (IllegalArgumentException e) {
+				            System.out.println(e);
+				        }
+				    }
+
+
+				    record MyRecord(String value) {
+				    }
+
+				    final MyRecord myRecord;
+
+				    InvalidDeadCodeWarning(MyRecord myRecord) {
+				        this.myRecord = switch (myRecord) {
+				            case MyRecord(var value) when value == null -> throw new IllegalArgumentException("myRecord contained null value"); // "Dead code" warning
+				            case MyRecord(var value) when value.isBlank() -> throw new IllegalArgumentException("myRecord contained blank value '" + value + "'");
+				            case null -> throw new IllegalArgumentException("myRecord was null");
+				            default -> myRecord;
+				        };
+				    }
+				}
+				"""
+			},
+			"java.lang.IllegalArgumentException: myRecord contained null value\n" +
+			"java.lang.IllegalArgumentException: myRecord contained blank value '  '\n" +
+			"java.lang.IllegalArgumentException: myRecord was null"
+);
+	}
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchPatternTest22.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchPatternTest22.java
@@ -1099,4 +1099,111 @@ public class SwitchPatternTest22 extends AbstractBatchCompilerTest {
 				},
 			"First guard\nSecond guard\nDefault");
 	}
+
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4038
+	// [Record patterns] Verify error with record patterns
+	public void testIssue4038() {
+		runConformTest(new String[] {
+				"Problem.java",
+				"""
+				public class Problem {
+
+				    record R(Object o)  {}
+
+				    static void execute(R stmt) {
+				        switch (stmt) {
+				            case R(var _) -> {
+				                while (cond(null)) {
+				                    execute(null);
+				                }
+				            }
+				        }
+				    }
+
+				    static boolean cond(Object object) {
+				        return true;
+				    }
+
+				    public static void main(String[] args) {
+				    	System.out.println("012012345678");
+				    }
+				}
+				"""
+			},
+			"012012345678");
+	}
+
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4038
+	// [Record patterns] Verify error with record patterns
+	public void testIssue4038_2() {
+		runConformTest(new String[] {
+				"Problem.java",
+				"""
+				public class Problem {
+
+				    record R(Object o)  {}
+
+				    static void execute(R stmt) {
+				        switch (stmt) {
+				            case R(Object _) -> {
+				                while (cond(null)) {
+				                    execute(null);
+				                }
+				            }
+				        }
+				    }
+
+				    static boolean cond(Object object) {
+				        return true;
+				    }
+
+				    public static void main(String[] args) {
+				    	System.out.println("012012345678");
+				    }
+				}
+				"""
+			},
+			"012012345678");
+	}
+
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4038
+	// [Record patterns] Verify error with record patterns
+	public void testIssue4038_3() {
+		runConformTest(new String[] {
+				"Problem.java",
+				"""
+				public class Problem {
+
+				    record R(Object o)  {}
+
+				    static int execute(R stmt) {
+				    	int retVal = -1;
+				        switch (stmt) {
+				            case R(String _) -> {
+				            	try {
+					                while (cond(null)) {
+					                    execute(null);
+					                }
+				                } catch(NullPointerException npe) {
+				                    retVal = 654321;
+			                    }
+			                    return retVal;
+				            }
+				            default -> { return 123456; }
+				        }
+				    }
+
+				    static boolean cond(Object object) {
+				        return true;
+				    }
+
+				    public static void main(String[] args) {
+				    	System.out.println(execute(new R("Hello")));
+				    	System.out.println(execute(new R(new Problem())));
+				    }
+				}
+				"""
+			},
+			"654321\n123456");
+	}
 }


### PR DESCRIPTION
* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4038
[Record patterns] Verify error with record patterns when case body starts with while loop

* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4058
 [Cleanup] Vestiges of CLDC support still remain in ECJ 

* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3798
BootstrapMethodError / LambdaConversionException using ECJ

* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3895
Reclaim unused bit-flag ExtraCompilerModifiers.AccModifierProblem


* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3897
Compilation error on ECJ but not with JavaC 

* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4065
[Null][Record] Invalid "dead code" warning for record pattern with null-guard on component

* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4055
[Internal][cleanup] org.eclipse.jdt.internal.compiler.ClassFile.initializeDefaultLocals has some weird code in it. 

* Hoist record component discovery into a separate step under `CompleteTypeBindingsSteps` in order to disentangle the design