### PR TITLE
Streamline error reporting for record classes

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/core/compiler/IProblem.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/core/compiler/IProblem.java
@@ -2541,6 +2541,7 @@ void setSourceStart(int sourceStart);
 	 */
 	int RecordCanonicalConstructorShouldNotBeGeneric = TypeRelated + 1746;
 	/** @since 3.26
+	 *  @deprecated problem no longer generated
 	 */
 	int RecordCanonicalConstructorHasReturnStatement = TypeRelated + 1747;
 	/** @since 3.26
@@ -2550,6 +2551,7 @@ void setSourceStart(int sourceStart);
 	 */
 	int RecordCompactConstructorHasExplicitConstructorCall = TypeRelated + 1749;
 	/** @since 3.26
+	 *  @deprecated problem no longer generated
 	 */
 	int RecordNestedRecordInherentlyStatic = TypeRelated + 1750;
 	/** @since 3.26

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ConstructorDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ConstructorDeclaration.java
@@ -710,24 +710,24 @@ public void resolve(ClassScope upperScope) {
 		RecordComponentBinding[] rcbs = upperScope.referenceContext.binding.components();
 		boolean lastComponentVarargs = rcbs.length > 0 && rcbs[rcbs.length - 1].sourceRecordComponent().isVarArgs();
 		if (this.binding.isVarargs() != lastComponentVarargs)
-			upperScope.problemReporter().recordErasureIncompatibilityInCanonicalConstructor(this.arguments[this.arguments.length - 1].type);
+			upperScope.problemReporter().erasureIncompatibilityInCanonicalConstructor(this.arguments[this.arguments.length - 1].type);
 		for (int i = 0; i < rcbs.length; ++i) {
 			TypeBinding mpt = this.binding.parameters[i];
 			TypeBinding rct = rcbs[i].type;
 			if (TypeBinding.notEquals(mpt, rct))
-				upperScope.problemReporter().recordErasureIncompatibilityInCanonicalConstructor(this.arguments[i].type);
+				upperScope.problemReporter().erasureIncompatibilityInCanonicalConstructor(this.arguments[i].type);
 		}
 
 		if (!this.binding.isAsVisible(this.binding.declaringClass))
-			this.scope.problemReporter().recordCanonicalConstructorVisibilityReduced(this);
+			this.scope.problemReporter().canonicalConstructorVisibilityReduced(this);
 		if (this.typeParameters != null && this.typeParameters.length > 0)
-			this.scope.problemReporter().recordCanonicalConstructorShouldNotBeGeneric(this);
+			this.scope.problemReporter().canonicalConstructorShouldNotBeGeneric(this);
 		if (this.binding.thrownExceptions != null && this.binding.thrownExceptions.length > 0)
-			this.scope.problemReporter().recordCanonicalConstructorHasThrowsClause(this);
+			this.scope.problemReporter().canonicalConstructorHasThrowsClause(this);
 		if (!this.isCompactConstructor()) {
 			for (int i = 0; i < rcbs.length; i++)
 				if (!CharOperation.equals(this.arguments[i].name, rcbs[i].name))
-					this.scope.problemReporter().recordIllegalParameterNameInCanonicalConstructor(rcbs[i], this.arguments[i]);
+					this.scope.problemReporter().mismatchedParameterNameInCanonicalConstructor(rcbs[i], this.arguments[i]);
 		}
 	}
 	super.resolve(upperScope);
@@ -759,7 +759,7 @@ public void resolveStatements() {
 				!this.isCompactConstructor() && // compact constr should be marked as canonical?
 				(this.binding != null && !this.binding.isCanonicalConstructor()) &&
 				this.constructorCall.accessMode != ExplicitConstructorCall.This) {
-			this.scope.problemReporter().recordMissingExplicitConstructorCallInNonCanonicalConstructor(this);
+			this.scope.problemReporter().missingExplicitConstructorCallInNonCanonicalConstructor(this);
 			this.constructorCall = null;
 		} else {
 			ExplicitConstructorCall lateConstructorCall = null;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ExplicitConstructorCall.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ExplicitConstructorCall.java
@@ -521,9 +521,9 @@ public class ExplicitConstructorCall extends Statement implements Invocation {
 		boolean isInsideCCD = methodDecl.isCompactConstructor();
 		if (this.accessMode != ExplicitConstructorCall.ImplicitSuper) {
 			if (isInsideCCD)
-				scope.problemReporter().recordCompactConstructorHasExplicitConstructorCall(this);
+				scope.problemReporter().compactConstructorHasExplicitConstructorCall(this);
 			else
-				scope.problemReporter().recordCanonicalConstructorHasExplicitConstructorCall(this);
+				scope.problemReporter().canonicalConstructorHasExplicitConstructorCall(this);
 			return false;
 		}
 		return true;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/FieldDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/FieldDeclaration.java
@@ -229,7 +229,7 @@ public void resolve(MethodScope initializationScope) {
 	if (classScope != null) {
 		SourceTypeBinding declaringType = classScope.enclosingSourceType();
 		if (declaringType.isRecord() && !this.isStatic())
-			classScope.problemReporter().recordNonStaticFieldDeclarationInRecord(this);
+			classScope.problemReporter().nonStaticFieldDeclarationInRecord(this);
 		checkHiding: {
 			checkHidingSuperField: {
 				if (declaringType.superclass == null) break checkHidingSuperField;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/FieldReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/FieldReference.java
@@ -107,7 +107,7 @@ public FlowInfo analyseAssignment(BlockScope currentScope, FlowContext flowConte
 			flowInfo.markAsDefinitelyAssigned(this.binding);
 		} else {
 			if (currentScope.methodScope().referenceContext instanceof ConstructorDeclaration cd && cd.isCompactConstructor())
-				currentScope.problemReporter().recordIllegalExplicitFinalFieldAssignInCompactConstructor(this.binding, this);
+				currentScope.problemReporter().illegalExplicitAssignmentInCompactConstructor(this.binding, this);
 			else
 			// assigning a final field outside an initializer or constructor or wrong reference
 				currentScope.problemReporter().cannotAssignToFinalField(this.binding, this);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Initializer.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Initializer.java
@@ -144,7 +144,7 @@ public class Initializer extends FieldDeclaration {
 				}
 			} else {
 				if (scope.enclosingSourceType().isRecord())
-					scope.problemReporter().recordInstanceInitializerBlockInRecord(this);
+					scope.problemReporter().instanceInitializerBlockIllegalInRecord(this);
 			}
 			if (this.block != null) this.block.resolve(scope);
 		} finally {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/MethodDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/MethodDeclaration.java
@@ -271,20 +271,20 @@ public class MethodDeclaration extends AbstractMethodDeclaration {
 		RecordComponent recordComponent = getRecordComponent();
 		if (recordComponent != null) {
 			if (this.returnType != null && TypeBinding.notEquals(this.returnType.resolvedType, recordComponent.type.resolvedType))
-				this.scope.problemReporter().recordIllegalAccessorReturnType(this.returnType, recordComponent.type.resolvedType);
+				this.scope.problemReporter().componentAccessorReturnTypeMismatch(this.returnType, recordComponent.type.resolvedType);
 			if (this.typeParameters != null)
-				this.scope.problemReporter().recordAccessorMethodShouldNotBeGeneric(this);
+				this.scope.problemReporter().componentAccessorMethodShouldNotBeGeneric(this);
 			if (this.binding != null) {
 				if (!this.binding.isPublic())
-					this.scope.problemReporter().recordAccessorMethodShouldBePublic(this);
+					this.scope.problemReporter().componentAccessorMethodShouldBePublic(this);
 				if (this.binding.isStatic())
-					this.scope.problemReporter().recordAccessorMethodShouldNotBeStatic(this);
+					this.scope.problemReporter().componentAccessorMethodShouldNotBeStatic(this);
 				if ((this.binding.modifiers & ExtraCompilerModifiers.AccOverriding) == 0) {
-					this.scope.problemReporter().recordAccessorMissingOverrideAnnotation(this);
+					this.scope.problemReporter().componentAccessorMissingOverrideAnnotation(this);
 				}
 			}
 			if (this.thrownExceptions != null)
-				this.scope.problemReporter().recordAccessorMethodHasThrowsClause(this);
+				this.scope.problemReporter().componentAccessorMethodHasThrowsClause(this);
 		}
 		// check if method with constructor name
 		if (CharOperation.equals(this.scope.enclosingSourceType().sourceName, this.selector)) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ReturnStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ReturnStatement.java
@@ -328,7 +328,7 @@ public void resolve(BlockScope scope) {
 	TypeBinding expressionType;
 
 	if (methodBinding != null && methodBinding.isCompactConstructor())
-		scope.problemReporter().recordCompactConstructorHasReturnStatement(this);
+		scope.problemReporter().compactConstructorHasReturnStatement(this);
 
 	if (lambda == null && scope.isInsideEarlyConstructionContext(null, false))
 		scope.problemReporter().errorReturnInEarlyConstructionContext(this);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ClassScope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ClassScope.java
@@ -119,7 +119,7 @@ public class ClassScope extends Scope {
 					anonymousType.tagBits |= TagBits.HierarchyHasProblems;
 					anonymousType.setSuperClass(getJavaLangObject());
 				} else if (supertype.erasure().id == TypeIds.T_JavaLangRecord) {
-					problemReporter().recordCannotExtendRecord(anonymousType, typeReference, supertype);
+					problemReporter().cannotExtendRecord(anonymousType, typeReference, supertype);
 					anonymousType.tagBits |= TagBits.HierarchyHasProblems;
 					anonymousType.setSuperClass(getJavaLangObject());
 				} else if (supertype.isFinal()) {
@@ -1133,7 +1133,7 @@ public class ClassScope extends Scope {
 			} else if (superclass.erasure().id == TypeIds.T_JavaLangEnum) {
 				problemReporter().cannotExtendEnum(sourceType, superclassRef, superclass);
 			} else if (superclass.erasure().id == TypeIds.T_JavaLangRecord) {
-				problemReporter().recordCannotExtendRecord(sourceType, superclassRef, superclass);
+				problemReporter().cannotExtendRecord(sourceType, superclassRef, superclass);
 			} else if (superclass.isSealed() && sourceType.isLocalType()) {
 				sourceType.setSuperClass(superclass);
 				problemReporter().localTypeMayNotBePermittedType(sourceType, superclassRef, superclass);
@@ -1415,9 +1415,9 @@ public class ClassScope extends Scope {
 				if (knownComponents.containsKey(name)) {
 					RecordComponentBinding clash =  knownComponents.get(name);
 					if (clash != null)
-						problemReporter().recordDuplicateComponent(clash.sourceRecordComponent());
+						problemReporter().duplicateRecordComponent(clash.sourceRecordComponent());
 					knownComponents.put(name, null); // ensure that the duplicate field is found & removed
-					problemReporter().recordDuplicateComponent(component);
+					problemReporter().duplicateRecordComponent(component);
 					component.binding = null;
 				} else {
 					knownComponents.put(name, rcb);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MethodScope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MethodScope.java
@@ -259,7 +259,7 @@ private void checkAndSetModifiersForMethod(MethodBinding methodBinding) {
 			}
 		}
 	} else if (declaringClass.isRecord() && methodBinding.isNative()) {
-		problemReporter().recordIllegalNativeModifierInRecord((AbstractMethodDeclaration) this.referenceContext);
+		problemReporter().nativeMethodIllegalInRecord((AbstractMethodDeclaration) this.referenceContext);
 	}
 
 	// check for abnormal modifiers

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SourceTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SourceTypeBinding.java
@@ -929,7 +929,7 @@ public RecordComponentBinding resolveTypeFor(RecordComponentBinding component) {
 		return null;
 	}
 	if (TypeDeclaration.disallowedComponentNames.contains(new String(componentDeclaration.name))) {
-		this.scope.problemReporter().recordIllegalComponentNameInRecord(componentDeclaration, this.scope.referenceContext);
+		this.scope.problemReporter().illegalComponentNameInRecord(componentDeclaration, this.scope.referenceContext);
 		componentDeclaration.binding = null;
 		return null;
 	}
@@ -945,7 +945,7 @@ public RecordComponentBinding resolveTypeFor(RecordComponentBinding component) {
 	}
 	RecordComponent[] recordComponents = this.scope.referenceContext.recordComponents;
 	if (componentDeclaration.isVarArgs() && recordComponents[recordComponents.length - 1] != componentDeclaration)
-		this.scope.problemReporter().recordIllegalVararg(componentDeclaration, this.scope.referenceContext);
+		this.scope.problemReporter().onlyLastRecordComponentMaybeVararg(componentDeclaration, this.scope.referenceContext);
 
 	if (componentType.isArrayType() && ((ArrayBinding) componentType).leafComponentType == TypeBinding.VOID) {
 		this.scope.problemReporter().variableTypeCannotBeVoidArray(componentDeclaration);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
@@ -4228,7 +4228,7 @@ protected void consumeSingleVariableDeclarator(boolean isVarArgs) {
 		}
 	} else if (this.parsingRecordComponents) {
 		if (!this.statementRecoveryActivated && extendedDimensions > 0)
-			problemReporter().recordIllegalExtendedDimensionsForRecordComponent(singleVariable);
+			problemReporter().illegalExtendedDimensionsForRecordComponent(singleVariable);
 	}
 }
 protected Annotation[][] getAnnotationsOnDimensions(int dimensionsCount) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
@@ -1614,7 +1614,7 @@ public void classExtendFinalRecord(SourceTypeBinding type, TypeReference supercl
 		superclass.sourceStart,
 		superclass.sourceEnd);
 }
-public void recordErasureIncompatibilityInCanonicalConstructor(TypeReference type) {
+public void erasureIncompatibilityInCanonicalConstructor(TypeReference type) {
 	String[] arguments = new String[] { new String(type.resolvedType.readableName()) };
 	this.handle(
 		IProblem.RecordErasureIncompatibilityInCanonicalConstructor,
@@ -6671,7 +6671,7 @@ public void missingOverrideAnnotation(AbstractMethodDeclaration method) {
 		method.sourceStart,
 		method.sourceEnd);
 }
-public void recordAccessorMissingOverrideAnnotation(AbstractMethodDeclaration method) {
+public void componentAccessorMissingOverrideAnnotation(AbstractMethodDeclaration method) {
 	int severity = computeSeverity(IProblem.MissingOverrideAnnotation);
 	if (severity == ProblemSeverities.Ignore) return;
 	MethodBinding binding = method.binding;
@@ -11716,7 +11716,7 @@ public void illegalModifierForRecord(SourceTypeBinding type) {
 		type.sourceStart(),
 		type.sourceEnd());
 }
-public void recordNonStaticFieldDeclarationInRecord(FieldDeclaration field) {
+public void nonStaticFieldDeclarationInRecord(FieldDeclaration field) {
 	this.handle(
 		IProblem.RecordNonStaticFieldDeclarationInRecord,
 		new String[] { new String(field.name) },
@@ -11724,7 +11724,7 @@ public void recordNonStaticFieldDeclarationInRecord(FieldDeclaration field) {
 		field.sourceStart,
 		field.sourceEnd);
 }
-public void recordAccessorMethodHasThrowsClause(ASTNode methodDeclaration) {
+public void componentAccessorMethodHasThrowsClause(ASTNode methodDeclaration) {
 	this.handle(
 		IProblem.RecordAccessorMethodHasThrowsClause,
 		NoArgument,
@@ -11732,7 +11732,7 @@ public void recordAccessorMethodHasThrowsClause(ASTNode methodDeclaration) {
 		methodDeclaration.sourceStart,
 		methodDeclaration.sourceEnd);
 }
-public void recordCanonicalConstructorVisibilityReduced(AbstractMethodDeclaration methodDecl) {
+public void canonicalConstructorVisibilityReduced(AbstractMethodDeclaration methodDecl) {
 	this.handle(
 		IProblem.RecordCanonicalConstructorVisibilityReduced,
 		new String[] {
@@ -11744,7 +11744,7 @@ public void recordCanonicalConstructorVisibilityReduced(AbstractMethodDeclaratio
 		methodDecl.sourceStart,
 		methodDecl.sourceEnd);
 }
-public void recordCompactConstructorHasReturnStatement(ReturnStatement stmt) {
+public void compactConstructorHasReturnStatement(ReturnStatement stmt) {
 	this.handle(
 		IProblem.RecordCompactConstructorHasReturnStatement,
 		NoArgument,
@@ -11760,7 +11760,7 @@ public void compactConstructorsOnlyInRecords(AbstractMethodDeclaration ccd) {
 			ccd.sourceStart,
 			ccd.sourceEnd);
 }
-public void recordIllegalComponentNameInRecord(RecordComponent recComp, TypeDeclaration typeDecl) {
+public void illegalComponentNameInRecord(RecordComponent recComp, TypeDeclaration typeDecl) {
 	this.handle(
 		IProblem.RecordIllegalComponentNameInRecord,
 		new String[] {
@@ -11772,7 +11772,7 @@ public void recordIllegalComponentNameInRecord(RecordComponent recComp, TypeDecl
 		recComp.sourceStart,
 		recComp.sourceEnd);
 }
-public void recordDuplicateComponent(RecordComponent recordComponent) {
+public void duplicateRecordComponent(RecordComponent recordComponent) {
 	this.handle(
 		IProblem.RecordDuplicateComponent,
 		new String[] { new String(recordComponent.name)},
@@ -11780,7 +11780,7 @@ public void recordDuplicateComponent(RecordComponent recordComponent) {
 		recordComponent.sourceStart,
 		recordComponent.sourceEnd);
 }
-public void recordIllegalNativeModifierInRecord(AbstractMethodDeclaration method) {
+public void nativeMethodIllegalInRecord(AbstractMethodDeclaration method) {
 	this.handle(
 		IProblem.RecordIllegalNativeModifierInRecord,
 		new String[] { new String(method.selector)},
@@ -11788,7 +11788,7 @@ public void recordIllegalNativeModifierInRecord(AbstractMethodDeclaration method
 		method.sourceStart,
 		method.sourceEnd);
 }
-public void recordInstanceInitializerBlockInRecord(Initializer initializer) {
+public void instanceInitializerBlockIllegalInRecord(Initializer initializer) {
 	this.handle(
 		IProblem.RecordInstanceInitializerBlockInRecord,
 		NoArgument,
@@ -11805,7 +11805,7 @@ public void restrictedTypeName(char[] name, String compliance, int start, int en
 		start,
 		end);
 }
-public void recordIllegalAccessorReturnType(ASTNode returnType, TypeBinding type) {
+public void componentAccessorReturnTypeMismatch(ASTNode returnType, TypeBinding type) {
 	this.handle(
 		IProblem.RecordIllegalAccessorReturnType,
 		new String[] {new String(type.readableName())},
@@ -11813,7 +11813,7 @@ public void recordIllegalAccessorReturnType(ASTNode returnType, TypeBinding type
 		returnType.sourceStart,
 		returnType.sourceEnd);
 }
-public void recordAccessorMethodShouldNotBeGeneric(ASTNode methodDecl) {
+public void componentAccessorMethodShouldNotBeGeneric(ASTNode methodDecl) {
 	this.handle(
 		IProblem.RecordAccessorMethodShouldNotBeGeneric,
 		NoArgument,
@@ -11821,7 +11821,7 @@ public void recordAccessorMethodShouldNotBeGeneric(ASTNode methodDecl) {
 		methodDecl.sourceStart,
 		methodDecl.sourceEnd);
 }
-public void recordAccessorMethodShouldBePublic(ASTNode methodDecl) {
+public void componentAccessorMethodShouldBePublic(ASTNode methodDecl) {
 	this.handle(
 		IProblem.RecordAccessorMethodShouldBePublic,
 		NoArgument,
@@ -11829,7 +11829,7 @@ public void recordAccessorMethodShouldBePublic(ASTNode methodDecl) {
 		methodDecl.sourceStart,
 		methodDecl.sourceEnd);
 }
-public void recordCanonicalConstructorShouldNotBeGeneric(AbstractMethodDeclaration methodDecl) {
+public void canonicalConstructorShouldNotBeGeneric(AbstractMethodDeclaration methodDecl) {
 	this.handle(
 		IProblem.RecordCanonicalConstructorShouldNotBeGeneric,
 		new String[] { new String(methodDecl.selector)},
@@ -11837,7 +11837,7 @@ public void recordCanonicalConstructorShouldNotBeGeneric(AbstractMethodDeclarati
 		methodDecl.sourceStart,
 		methodDecl.sourceEnd);
 }
-public void recordCanonicalConstructorHasThrowsClause(AbstractMethodDeclaration methodDecl) {
+public void canonicalConstructorHasThrowsClause(AbstractMethodDeclaration methodDecl) {
 	this.handle(
 		IProblem.RecordCanonicalConstructorHasThrowsClause,
 		new String[] { new String(methodDecl.selector)},
@@ -11845,15 +11845,7 @@ public void recordCanonicalConstructorHasThrowsClause(AbstractMethodDeclaration 
 		methodDecl.sourceStart,
 		methodDecl.sourceEnd);
 }
-public void recordCanonicalConstructorHasReturnStatement(ASTNode methodDecl) {
-	this.handle(
-		IProblem.RecordCanonicalConstructorHasReturnStatement,
-		NoArgument,
-		NoArgument,
-		methodDecl.sourceStart,
-		methodDecl.sourceEnd);
-}
-public void recordCanonicalConstructorHasExplicitConstructorCall(ASTNode methodDecl) {
+public void canonicalConstructorHasExplicitConstructorCall(ASTNode methodDecl) {
 	this.handle(
 		IProblem.RecordCanonicalConstructorHasExplicitConstructorCall,
 		NoArgument,
@@ -11861,7 +11853,7 @@ public void recordCanonicalConstructorHasExplicitConstructorCall(ASTNode methodD
 		methodDecl.sourceStart,
 		methodDecl.sourceEnd);
 }
-public void recordCompactConstructorHasExplicitConstructorCall(ASTNode methodDecl) {
+public void compactConstructorHasExplicitConstructorCall(ASTNode methodDecl) {
 	this.handle(
 		IProblem.RecordCompactConstructorHasExplicitConstructorCall,
 		NoArgument,
@@ -11869,15 +11861,7 @@ public void recordCompactConstructorHasExplicitConstructorCall(ASTNode methodDec
 		methodDecl.sourceStart,
 		methodDecl.sourceEnd);
 }
-public void recordNestedRecordInherentlyStatic(SourceTypeBinding type) {
-	this.handle(
-		IProblem.RecordNestedRecordInherentlyStatic,
-		NoArgument,
-		NoArgument,
-		type.sourceStart(),
-		type.sourceEnd());
-}
-public void recordAccessorMethodShouldNotBeStatic(ASTNode methodDecl) {
+public void componentAccessorMethodShouldNotBeStatic(ASTNode methodDecl) {
 	this.handle(
 		IProblem.RecordAccessorMethodShouldNotBeStatic,
 		NoArgument,
@@ -11885,7 +11869,7 @@ public void recordAccessorMethodShouldNotBeStatic(ASTNode methodDecl) {
 		methodDecl.sourceStart,
 		methodDecl.sourceEnd);
 }
-public void recordCannotExtendRecord(SourceTypeBinding type, TypeReference superclass, TypeBinding superTypeBinding) {
+public void cannotExtendRecord(SourceTypeBinding type, TypeReference superclass, TypeBinding superTypeBinding) {
 	String name = new String(type.sourceName());
 	String superTypeFullName = new String(superTypeBinding.readableName());
 	String superTypeShortName = new String(superTypeBinding.shortReadableName());
@@ -11906,7 +11890,7 @@ public void recordComponentCannotBeVoid(RecordComponent arg) {
 		arg.sourceStart,
 		arg.sourceEnd);
 }
-public void recordIllegalVararg(RecordComponent argType, TypeDeclaration typeDecl) {
+public void onlyLastRecordComponentMaybeVararg(RecordComponent argType, TypeDeclaration typeDecl) {
 	String[] arguments = new String[] {CharOperation.toString(argType.type.getTypeName()), new String(typeDecl.name)};
 	this.handle(
 		IProblem.RecordIllegalVararg,
@@ -11933,7 +11917,7 @@ public void recordComponentsCannotHaveModifiers(RecordComponent comp) {
 		comp.sourceStart,
 		comp.sourceEnd);
 }
-public void recordIllegalParameterNameInCanonicalConstructor(RecordComponentBinding comp, Argument arg) {
+public void mismatchedParameterNameInCanonicalConstructor(RecordComponentBinding comp, Argument arg) {
 	this.handle(
 		IProblem.RecordIllegalParameterNameInCanonicalConstructor,
 		new String[] {new String(arg.name), new String(comp.name)},
@@ -11941,7 +11925,7 @@ public void recordIllegalParameterNameInCanonicalConstructor(RecordComponentBind
 		arg.sourceStart,
 		arg.sourceEnd);
 }
-public void recordIllegalExplicitFinalFieldAssignInCompactConstructor(FieldBinding field, FieldReference fieldRef) {
+public void illegalExplicitAssignmentInCompactConstructor(FieldBinding field, FieldReference fieldRef) {
 	String[] arguments = new String[] { new String(field.name) };
 	this.handle(
 		IProblem.RecordIllegalExplicitFinalFieldAssignInCompactConstructor,
@@ -11950,7 +11934,7 @@ public void recordIllegalExplicitFinalFieldAssignInCompactConstructor(FieldBindi
 		fieldRef.sourceStart,
 		fieldRef.sourceEnd);
 }
-public void recordMissingExplicitConstructorCallInNonCanonicalConstructor(ASTNode location) {
+public void missingExplicitConstructorCallInNonCanonicalConstructor(ASTNode location) {
 	this.handle(
 		IProblem.RecordMissingExplicitConstructorCallInNonCanonicalConstructor,
 		NoArgument,
@@ -11967,7 +11951,7 @@ public void recordIllegalStaticModifierForLocalClassOrInterface(SourceTypeBindin
 		type.sourceStart(),
 		type.sourceEnd());
 }
-public void recordIllegalExtendedDimensionsForRecordComponent(AbstractVariableDeclaration aVarDecl) {
+public void illegalExtendedDimensionsForRecordComponent(AbstractVariableDeclaration aVarDecl) {
 	this.handle(
 		IProblem.RecordIllegalExtendedDimensionsForRecordComponent,
 		NoArgument,

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/messages.properties
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/messages.properties
@@ -1064,8 +1064,7 @@
 1724 = Return within switch expressions not permitted
 
 
-# Java 15 Preview - begin
-# Records
+# Java 16 -- Records
 1730 = Illegal modifier for the record {0}; only public, private, protected, static, final and strictfp are permitted
 1731 = Illegal modifier for the record {0}; only public, final and strictfp are permitted
 1732 = Illegal component name {0} in record {1};
@@ -1083,10 +1082,10 @@
 1744 = The accessor method must not be generic
 1745 = The accessor method must be declared public
 1746 = Canonical constructor {0} of a record declaration should not be generic
-1747 = The body of a canonical constructor must not contain a return statement
+###[obsolete] 1747 = The body of a canonical constructor must not contain a return statement
 1748 = The body of a canonical constructor must not contain an explicit constructor call
 1749 = The body of a compact constructor must not contain an explicit constructor call
-1750 = Nested Record is (implicitly) static and hence enclosing type should be static
+###[obsolete] 1750 = Nested Record is (implicitly) static and hence enclosing type should be static
 1751 = The accessor method must not be static
 1752 = The type {1} may not subclass {0} explicitly
 1753 = void is an invalid type for the component {0} of a record


### PR DESCRIPTION
- Get rid of unused error messages.
- Simplify problem reporter methods opting for consistent, simpler, direct names eliminating boiler plate (e.g., `recordNonStaticFieldDeclarationInRecord` -> `nonStaticFieldDeclarationInRecord`;  `recordIllegalComponentNameInRecord` -> `illegalComponentNameInRecord` and `recordCompactConstructorHasReturnStatement` -> `compactConstructorHasReturnStatement`  - the prefix record is mind numbing and useless :)