### PR TITLE
Annotation based null analysis with custom annotations leads to misleading info message

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/MessageSend.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/MessageSend.java
@@ -519,7 +519,7 @@ public boolean checkNPE(BlockScope scope, FlowContext flowContext, FlowInfo flow
 			scope.problemReporter().messageSendPotentialNullReference(this.binding, this);
 		}
 	} else if ((this.resolvedType.tagBits & TagBits.AnnotationNonNull) != 0) {
-		NullAnnotationMatching nonNullStatus = NullAnnotationMatching.okNonNullStatus(this);
+		NullAnnotationMatching nonNullStatus = NullAnnotationMatching.okNonNullStatus(this, true);
 		if (nonNullStatus.wantToReport())
 			nonNullStatus.report(scope);
 	}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/NullAnnotationMatching.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/NullAnnotationMatching.java
@@ -222,7 +222,7 @@ public class NullAnnotationMatching {
 			boolean problemAtDetail = false;
 			if (areSameTypes(requiredType, providedType, providedSubstitute)) {
 				if ((requiredType.tagBits & TagBits.AnnotationNonNull) != 0)
-					return okNonNullStatus(providedExpression);
+					return okNonNullStatus(providedExpression, true);
 				return okStatus;
 			}
 			if (requiredType instanceof TypeVariableBinding && substitution != null && (mode == CheckMode.EXACT || mode == CheckMode.COMPATIBLE || mode == CheckMode.BOUND_SUPER_CHECK)) {
@@ -232,7 +232,7 @@ public class NullAnnotationMatching {
 					return NullAnnotationMatching.NULL_ANNOTATIONS_OK;
 				if (areSameTypes(requiredType, providedType, providedSubstitute)) {
 					if ((requiredType.tagBits & TagBits.AnnotationNonNull) != 0)
-						return okNonNullStatus(providedExpression);
+						return okNonNullStatus(providedExpression, true);
 					return okStatus;
 				}
 			}
@@ -329,7 +329,7 @@ public class NullAnnotationMatching {
 					}
 					severity = severity.max(s);
 					if (!severity.isAnyMismatch() && (providedBits & TagBits.AnnotationNullMASK) == TagBits.AnnotationNonNull)
-						okStatus = okNonNullStatus(providedExpression);
+						okStatus = okNonNullStatus(providedExpression, requiredBits == TagBits.AnnotationNonNull);
 				}
 				if (severity != Severity.MISMATCH && nullStatus != FlowInfo.NULL) {  // null value has no details
 					TypeBinding providedSuper = providedType.findSuperTypeOriginatingFrom(requiredType);
@@ -389,13 +389,14 @@ public class NullAnnotationMatching {
 		}
 	}
 
-	public static NullAnnotationMatching okNonNullStatus(final Expression providedExpression) {
+	public static NullAnnotationMatching okNonNullStatus(final Expression providedExpression, boolean isNonNullRequired) {
 		if (providedExpression instanceof MessageSend) {
 			final MethodBinding method = ((MessageSend) providedExpression).binding;
 			if (method != null && method.isValidBinding()) {
 				MethodBinding originalMethod = method.original();
 				TypeBinding originalDeclaringClass = originalMethod.declaringClass;
-				if (originalDeclaringClass instanceof BinaryTypeBinding
+				if (isNonNullRequired
+						&& originalDeclaringClass instanceof BinaryTypeBinding
 						&& ((BinaryTypeBinding) originalDeclaringClass).externalAnnotationStatus.isPotentiallyUnannotatedLib()
 						&& originalMethod.returnType.isTypeVariable()
 						&& (originalMethod.returnType.tagBits & TagBits.AnnotationNullMASK) == 0)

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/NullAnnotationMatching.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/NullAnnotationMatching.java
@@ -237,8 +237,7 @@ public class NullAnnotationMatching {
 			NullAnnotationMatching okStatus = NullAnnotationMatching.NULL_ANNOTATIONS_OK;
 			boolean problemAtDetail = false;
 			if (areSameTypes(requiredType, providedType, providedSubstitute)) {
-				if ((requiredType.tagBits & TagBits.AnnotationNonNull) != 0 // possibly unsafe interpretation of type variable inferred as nonnull, ...
-						&& !requiredType.isTypeVariable())					// but don't warn when both types are the same *type variable*
+				if ((requiredType.tagBits & TagBits.AnnotationNonNull) != 0)
 					return okNonNullStatus(providedExpression, true);
 				return okStatus;
 			}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ReturnStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ReturnStatement.java
@@ -103,7 +103,7 @@ public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext, Fl
 		if (flowInfo.reachMode() == FlowInfo.REACHABLE) {
 			CompilerOptions compilerOptions = currentScope.compilerOptions();
 			if (compilerOptions.isAnnotationBasedNullAnalysisEnabled)
-				checkAgainstNullAnnotation(currentScope, flowContext, flowInfo, this.expression);
+				checkAgainstNullAnnotation(currentScope, flowContext, flowInfo, this.expression, false);
 			if (compilerOptions.analyseResourceLeaks) {
 				long owningTagBits = methodScope.referenceMethodBinding().tagBits & TagBits.AnnotationOwningMASK;
 				flowInfo = anylizeCloseableReturnExpression(this.expression, currentScope, owningTagBits, flowContext, flowInfo);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Statement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Statement.java
@@ -191,7 +191,7 @@ void internalAnalyseOneArgument18(BlockScope currentScope, FlowContext flowConte
 	// here we consume special case information generated in the ctor of ParameterizedGenericMethodBinding (see there):
 	int statusFromAnnotatedNull = expectedNonNullness == Boolean.TRUE ? nullStatus : 0;
 
-	NullAnnotationMatching annotationStatus = NullAnnotationMatching.analyse(expectedType, argument.resolvedType, nullStatus);
+	NullAnnotationMatching annotationStatus = NullAnnotationMatching.analyse(expectedType, argument.resolvedType, null, null, nullStatus, argument, CheckMode.COMPATIBLE, false);
 
 	if (!annotationStatus.isAnyMismatch() && statusFromAnnotatedNull != 0)
 		expectedType = originalExpected; // to avoid reports mentioning '@NonNull null'!
@@ -206,9 +206,11 @@ void internalAnalyseOneArgument18(BlockScope currentScope, FlowContext flowConte
 			expectedType = env.createNonNullAnnotatedType(expectedType);
 		}
 		flowContext.recordNullityMismatch(currentScope, argument, argument.resolvedType, expectedType, flowInfo, nullStatus, annotationStatus);
+	} else if (annotationStatus.wantToReport()) {
+		annotationStatus.report(currentScope);
 	}
 }
-/* package */ void checkAgainstNullAnnotation(BlockScope scope, FlowContext flowContext, FlowInfo flowInfo, Expression expr) {
+/* package */ void checkAgainstNullAnnotation(BlockScope scope, FlowContext flowContext, FlowInfo flowInfo, Expression expr, boolean localFlow) {
 	int nullStatus = expr.nullStatus(flowInfo, flowContext);
 	long tagBits;
 	MethodBinding methodBinding = null;
@@ -222,7 +224,7 @@ void internalAnalyseOneArgument18(BlockScope currentScope, FlowContext flowConte
 		return;
 	}
 	if (useTypeAnnotations) {
-		checkAgainstNullTypeAnnotation(scope, methodBinding.returnType, expr, flowContext, flowInfo);
+		checkAgainstNullTypeAnnotation(scope, methodBinding.returnType, expr, flowContext, flowInfo, localFlow);
 	} else if (nullStatus != FlowInfo.NON_NULL) {
 		// if we can't prove non-null check against declared null-ness of the enclosing method:
 		if ((tagBits & TagBits.AnnotationNonNull) != 0) {
@@ -230,28 +232,30 @@ void internalAnalyseOneArgument18(BlockScope currentScope, FlowContext flowConte
 		}
 	}
 }
-
 protected void checkAgainstNullTypeAnnotation(BlockScope scope, TypeBinding requiredType, Expression expression, FlowContext flowContext, FlowInfo flowInfo) {
+	checkAgainstNullTypeAnnotation(scope, requiredType, expression, flowContext, flowInfo, true);
+}
+protected void checkAgainstNullTypeAnnotation(BlockScope scope, TypeBinding requiredType, Expression expression, FlowContext flowContext, FlowInfo flowInfo, boolean localFlow) {
 	if (expression instanceof ConditionalExpression && expression.isPolyExpression()) {
 		// drill into both branches using existing nullStatus per branch:
 		ConditionalExpression ce = (ConditionalExpression) expression;
-		internalCheckAgainstNullTypeAnnotation(scope, requiredType, ce.valueIfTrue, ce.ifTrueNullStatus, flowContext, flowInfo);
-		internalCheckAgainstNullTypeAnnotation(scope, requiredType, ce.valueIfFalse, ce.ifFalseNullStatus, flowContext, flowInfo);
+		internalCheckAgainstNullTypeAnnotation(scope, requiredType, ce.valueIfTrue, ce.ifTrueNullStatus, flowContext, flowInfo, localFlow);
+		internalCheckAgainstNullTypeAnnotation(scope, requiredType, ce.valueIfFalse, ce.ifFalseNullStatus, flowContext, flowInfo, localFlow);
 		return;
 	} else 	if (expression instanceof SwitchExpression se && se.isPolyExpression()) {
 		for (Expression rExpression : se.resultExpressions()) {
 			internalCheckAgainstNullTypeAnnotation(scope, requiredType,
 					rExpression,
-					rExpression.nullStatus(flowInfo, flowContext), flowContext, flowInfo);
+					rExpression.nullStatus(flowInfo, flowContext), flowContext, flowInfo, localFlow);
 		}
 		return;
 	}
 	int nullStatus = expression.nullStatus(flowInfo, flowContext);
-	internalCheckAgainstNullTypeAnnotation(scope, requiredType, expression, nullStatus, flowContext, flowInfo);
+	internalCheckAgainstNullTypeAnnotation(scope, requiredType, expression, nullStatus, flowContext, flowInfo, localFlow);
 }
 private void internalCheckAgainstNullTypeAnnotation(BlockScope scope, TypeBinding requiredType, Expression expression,
-		int nullStatus, FlowContext flowContext, FlowInfo flowInfo) {
-	NullAnnotationMatching annotationStatus = NullAnnotationMatching.analyse(requiredType, expression.resolvedType, null, null, nullStatus, expression, CheckMode.COMPATIBLE);
+		int nullStatus, FlowContext flowContext, FlowInfo flowInfo, boolean localFlow) {
+	NullAnnotationMatching annotationStatus = NullAnnotationMatching.analyse(requiredType, expression.resolvedType, null, null, nullStatus, expression, CheckMode.COMPATIBLE, localFlow);
 	if (annotationStatus.isDefiniteMismatch()) {
 		scope.problemReporter().nullityMismatchingTypeAnnotation(expression, expression.resolvedType, requiredType, annotationStatus);
 	} else {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullTypeAnnotationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullTypeAnnotationTest.java
@@ -4078,10 +4078,16 @@ public class NullTypeAnnotationTest extends AbstractNullAnnotationTest {
 			"	getAdd(lx);\n" +
 			"	       ^^\n" +
 			"Null type safety (type annotations): The expression of type \'List<capture#of ? extends X>\' needs unchecked conversion to conform to \'List<@NonNull capture#of ? extends X>\'\n" +
+			"----------\n" +
+			"2. INFO in X.java (at line 19)\n" +
+			"	lt.add(lt.get(0));\n" +
+			"	       ^^^^^^^^^\n" +
+			"Unsafe interpretation of method return type as \'@NonNull\' based on the receiver type \'List<@NonNull P>\'. Type \'List<E>\' doesn\'t seem to be designed with null type annotations in mind\n" +
 			"----------\n");
 	}
 	public void testWildcardCapture2() {
-		runConformTestWithLibs(
+		runWarningTestWithLibs(
+			true, // flush
 			new String[] {
 				"X.java",
 				"import java.lang.annotation.ElementType;\n" +
@@ -4107,7 +4113,12 @@ public class NullTypeAnnotationTest extends AbstractNullAnnotationTest {
 				"}\n"
 			},
 			getCompilerOptions(),
-			"");
+			"----------\n" +
+			"1. INFO in X.java (at line 19)\n" +
+			"	lt.add(lt.get(0));\n" +
+			"	       ^^^^^^^^^\n" +
+			"Unsafe interpretation of method return type as \'@NonNull\' based on the receiver type \'List<@NonNull P>\'. Type \'List<E>\' doesn\'t seem to be designed with null type annotations in mind\n" +
+			"----------\n");
 	}
 	public void testWildcardCapture3() {
 		runNegativeTestWithLibs(
@@ -4142,6 +4153,11 @@ public class NullTypeAnnotationTest extends AbstractNullAnnotationTest {
 			"	getAdd(lx);\n" +
 			"	       ^^\n" +
 			"Null type mismatch (type annotations): required \'List<@NonNull capture#of ? extends X>\' but this expression has type \'List<@Nullable capture#of ? extends X>\'\n" +
+			"----------\n" +
+			"2. INFO in X.java (at line 20)\n" +
+			"	lt.add(lt.get(0));\n" +
+			"	       ^^^^^^^^^\n" +
+			"Unsafe interpretation of method return type as \'@NonNull\' based on the receiver type \'List<@NonNull P>\'. Type \'List<E>\' doesn\'t seem to be designed with null type annotations in mind\n" +
 			"----------\n");
 	}
 	public void testLocalArrays() {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullTypeAnnotationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullTypeAnnotationTest.java
@@ -19521,4 +19521,33 @@ public void testGH3461() {
 	runner.classLibraries = this.LIBS;
 	runner.runConformTest();
 }
+public void testGH4011() {
+	Runner runner = new Runner();
+	runner.customOptions = getCompilerOptions();
+	runner.customOptions.put(CompilerOptions.OPTION_ReportNonNullTypeVariableFromLegacyInvocation, CompilerOptions.ERROR);
+	runner.testFiles = new String[] {
+			"X.java",
+			"""
+			import java.util.List;
+			import org.eclipse.jdt.annotation.NonNull;
+			public class X {
+				void m(List<@NonNull String> list) {
+					@NonNull String s1 = list.get(0);
+					String s2 = list.get(1); // don't expect error here
+				}
+			}
+			"""
+	};
+	runner.classLibraries = this.LIBS;
+	runner.expectedCompilerLog =
+			"""
+			----------
+			1. ERROR in X.java (at line 5)
+				@NonNull String s1 = list.get(0);
+				                     ^^^^^^^^^^^
+			Unsafe interpretation of method return type as '@NonNull' based on the receiver type 'List<@NonNull String>'. Type 'List<E>' doesn't seem to be designed with null type annotations in mind
+			----------
+			""";
+	runner.runNegativeTest();
+}
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullTypeAnnotationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullTypeAnnotationTest.java
@@ -9376,23 +9376,45 @@ public void testBug482247() {
 			"		s[0] = null;\n" +
 			"	}\n" +
 			"	@NonNull String test()  {\n" +
-			"		other(new String[0]);\n" + // unchanged semantics
-			"		return first(new String[0]);\n" + // unchanged semantics
+			"		other(new String[1]);\n" + // unchanged semantics
+			"		return first(new String[1]);\n" + // unchanged semantics
 			"	}\n" +
 			"}\n"
 		},
 		getCompilerOptions(),
 		"----------\n" +
 		"1. WARNING in X.java (at line 12)\n" +
-		"	other(new String[0]);\n" +
+		"	other(new String[1]);\n" +
 		"	      ^^^^^^^^^^^^^\n" +
 		"Null type safety (type annotations): The expression of type \'String[]\' needs unchecked conversion to conform to \'@Nullable String []\'\n" +
 		"----------\n" +
 		"2. WARNING in X.java (at line 13)\n" +
-		"	return first(new String[0]);\n" +
+		"	return first(new String[1]);\n" +
 		"	             ^^^^^^^^^^^^^\n" +
 		"Null type safety (type annotations): The expression of type \'String[]\' needs unchecked conversion to conform to \'@NonNull String @NonNull[]\'\n" +
 		"----------\n");
+}
+public void testBug482247_length0() {
+	runConformTestWithLibs(
+		true/*flush*/,
+		new String[] {
+			"X.java",
+			"import org.eclipse.jdt.annotation.*;\n" +
+			"public class X {\n" +
+			"	<T> @NonNull T first(@NonNull T @NonNull[] arr) {\n" +
+			"		return arr[0];\n" +
+			"	}\n" +
+			"	void other(@Nullable String[] s) {\n" +
+			"		s[0] = null;\n" +
+			"	}\n" +
+			"	@NonNull String test()  {\n" +
+			"		other(new String[0]);\n" + // empty array satisfies any requirement on its (absent) elements
+			"		return first(new String[0]);\n" +
+			"	}\n" +
+			"}\n"
+		},
+		getCompilerOptions(),
+		"");
 }
 public void testBug482247_comment5() {
 	runConformTestWithLibs(
@@ -18424,7 +18446,12 @@ public void testBug562347_561280c9() {
 		"	    ^^^^^^^^^^^^^^^^^\n" +
 		"Redundant null check: comparing \'@NonNull String\' against null\n" +
 		"----------\n" +
-		"2. WARNING in Example.java (at line 25)\n" +
+		"2. INFO in Example.java (at line 22)\n" +
+		"	if (f(entry.getKey()) != null) {\n" +
+		"	      ^^^^^^^^^^^^^^\n" +
+		"Unsafe interpretation of method return type as \'@NonNull\' based on the receiver type \'Map.Entry<@NonNull String,@NonNull String>\'. Type \'Map.Entry<K,V>\' doesn\'t seem to be designed with null type annotations in mind\n" +
+		"----------\n" +
+		"3. WARNING in Example.java (at line 25)\n" +
 		"	String x = \"asdf\";\n" +
 		"	^^^^^^^^^^^^^^^^^^\n" +
 		"Dead code\n" +
@@ -19531,10 +19558,26 @@ public void testGH4011() {
 			import java.util.List;
 			import org.eclipse.jdt.annotation.NonNull;
 			public class X {
-				void m(List<@NonNull String> list) {
-					@NonNull String s1 = list.get(0);
-					String s2 = list.get(1); // don't expect error here
+				String f;
+				String m(List<@NonNull String> list) { // in this method don't warn for non-local flows
+					String s1 = list.get(0); // #1 warn on local flows
+					if (list.size() == 2)
+						return list.get(1);
+					f = list.get(2);
+					other(list.get(3));
+					return "";
 				}
+				void other(String s) {}
+				@NonNull String f2 = "";
+				@NonNull String m2(List<@NonNull String> list) {
+					@NonNull String s1 = list.get(0); // #2
+					if (list.size() == 2)
+						return list.get(1); // #3
+					f2 = list.get(2); // #4
+					other2(list.get(3)); // #5
+					return "";
+				}
+				void other2(@NonNull String s) {}
 			}
 			"""
 	};
@@ -19542,9 +19585,29 @@ public void testGH4011() {
 	runner.expectedCompilerLog =
 			"""
 			----------
-			1. ERROR in X.java (at line 5)
-				@NonNull String s1 = list.get(0);
+			1. ERROR in X.java (at line 6)
+				String s1 = list.get(0); // #1 warn on local flows
+				            ^^^^^^^^^^^
+			Unsafe interpretation of method return type as '@NonNull' based on the receiver type 'List<@NonNull String>'. Type 'List<E>' doesn't seem to be designed with null type annotations in mind
+			----------
+			2. ERROR in X.java (at line 16)
+				@NonNull String s1 = list.get(0); // #2
 				                     ^^^^^^^^^^^
+			Unsafe interpretation of method return type as '@NonNull' based on the receiver type 'List<@NonNull String>'. Type 'List<E>' doesn't seem to be designed with null type annotations in mind
+			----------
+			3. ERROR in X.java (at line 18)
+				return list.get(1); // #3
+				       ^^^^^^^^^^^
+			Unsafe interpretation of method return type as '@NonNull' based on the receiver type 'List<@NonNull String>'. Type 'List<E>' doesn't seem to be designed with null type annotations in mind
+			----------
+			4. ERROR in X.java (at line 19)
+				f2 = list.get(2); // #4
+				     ^^^^^^^^^^^
+			Unsafe interpretation of method return type as '@NonNull' based on the receiver type 'List<@NonNull String>'. Type 'List<E>' doesn't seem to be designed with null type annotations in mind
+			----------
+			5. ERROR in X.java (at line 20)
+				other2(list.get(3)); // #5
+				       ^^^^^^^^^^^
 			Unsafe interpretation of method return type as '@NonNull' based on the receiver type 'List<@NonNull String>'. Type 'List<E>' doesn't seem to be designed with null type annotations in mind
 			----------
 			""";


### PR DESCRIPTION
+ Avoid this warning if nonnull is not required

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4011
