### PR TITLE
@(javax|jakarta).inject.Inject cannot be used on same element #4072

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ConstructorDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ConstructorDeclaration.java
@@ -326,9 +326,10 @@ boolean isValueProvidedUsingAnnotation(FieldDeclaration fieldDecl) {
 		int length = fieldDecl.annotations.length;
 		for (int i = 0; i < length; i++) {
 			Annotation annotation = fieldDecl.annotations[i];
-			if (annotation.resolvedType.id == TypeIds.T_JavaxInjectInject) {
+			int annotId = annotation.resolvedType.id;
+			if (annotId == TypeIds.T_JavaxInjectInject || annotId == TypeIds.T_JakartaInjectInject) {
 				return true; // no concept of "optional"
-			} else if (annotation.resolvedType.id == TypeIds.T_ComGoogleInjectInject) {
+			} else if (annotId == TypeIds.T_ComGoogleInjectInject) {
 				MemberValuePair[] memberValuePairs = annotation.memberValuePairs();
 				if (memberValuePairs == Annotation.NoValuePairs)
 					return true;
@@ -337,7 +338,7 @@ boolean isValueProvidedUsingAnnotation(FieldDeclaration fieldDecl) {
 					if (CharOperation.equals(memberValuePair.name, TypeConstants.OPTIONAL))
 						return memberValuePair.value instanceof FalseLiteral;
 				}
-			} else if (annotation.resolvedType.id == TypeIds.T_OrgSpringframeworkBeansFactoryAnnotationAutowired) {
+			} else if (annotId == TypeIds.T_OrgSpringframeworkBeansFactoryAnnotationAutowired) {
 				MemberValuePair[] memberValuePairs = annotation.memberValuePairs();
 				if (memberValuePairs == Annotation.NoValuePairs)
 					return true;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
@@ -518,7 +518,7 @@ public void computeId() {
 					switch (packageName[1]) {
 						case 'a':
 							if (CharOperation.equals(TypeConstants.JAKARTA_ANNOTATION_INJECT_INJECT, this.compoundName))
-								this.id = TypeIds.T_JavaxInjectInject;
+								this.id = TypeIds.T_JakartaInjectInject;
 							return;
 					}
 					return;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeIds.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeIds.java
@@ -151,6 +151,9 @@ public interface TypeIds {
 	// Java 14 preview
 	final int T_JavaLangRecord = 93;
 
+	// new in 2025-09 to identify another known @Inject annotation
+	final int T_JakartaInjectInject = 94;
+
 	// If you add new type id, make sure to bump up T_LastWellKnownTypeId if there is a cross over.
 	final int T_LastWellKnownTypeId = 128;
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
@@ -9476,6 +9476,7 @@ private boolean excludeDueToAnnotation(Annotation[] annotations, int problemId) 
 				case TypeIds.T_JavaLangSafeVarargs:
 					break;
 				case TypeIds.T_JavaxInjectInject:
+				case TypeIds.T_JakartaInjectInject:
 				case TypeIds.T_ComGoogleInjectInject:
 				case TypeIds.T_OrgSpringframeworkBeansFactoryAnnotationAutowired:
 					if (problemId != IProblem.UnusedPrivateField)

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractComparableTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractComparableTest.java
@@ -42,7 +42,7 @@ public class AbstractComparableTest extends AbstractRegressionTest {
 
 	protected static final String JAVAX_INJECT_NAME = "javax/inject/Inject.java";
 	protected static final String JAVAX_INJECT_CONTENT =
-		"package jakarta.inject;\n" +
+		"package javax.inject;\n" +
 		"import static java.lang.annotation.ElementType.*;\n" +
 		"import java.lang.annotation.Retention;\n" +
 		"import static java.lang.annotation.RetentionPolicy.RUNTIME;\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AnnotationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AnnotationTest.java
@@ -10517,17 +10517,17 @@ public void testBug376590b() {
 			JAVAX_INJECT_CONTENT,
 			"Example.java",
 			"class Example {\n" +
-			"  private @jakarta.inject.Inject Object o;\n" +
+			"  private @javax.inject.Inject Object o;\n" +
 			"  private Example() {} // also warn here: no @Inject\n" +
 			"  public Example(Object o) { this.o = o; }\n" +
-			"  private @jakarta.inject.Inject void setO(Object o) { this.o = o;}\n" +
+			"  private @javax.inject.Inject void setO(Object o) { this.o = o;}\n" +
 			"}\n"
 		},
 		null, customOptions,
 		"----------\n" +
 		"1. ERROR in Example.java (at line 2)\n" +
-		"	private @jakarta.inject.Inject Object o;\n" +
-		"	                                      ^\n" +
+		"	private @javax.inject.Inject Object o;\n" +
+		"	                                    ^\n" +
 		"The value of the field Example.o is not used\n" +
 		"----------\n" +
 		"2. ERROR in Example.java (at line 3)\n" +
@@ -10551,7 +10551,7 @@ public void testBug376590c() {
 			JAVAX_INJECT_NAME,
 			JAVAX_INJECT_CONTENT,
 			"Example.java",
-			"import jakarta.inject.Inject;\n" +
+			"import javax.inject.Inject;\n" +
 			"class Example {\n" +
 			"  private @Inject @p.NonNull Object o; // do warn, annotations don't signal a read\n" +
 			"  private @Deprecated @Inject String old; // do warn, annotations don't signal a read\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullAnnotationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullAnnotationTest.java
@@ -4581,7 +4581,7 @@ public void test_nonnull_field_17() {
 			JAVAX_INJECT_CONTENT,
 			"X.java",
 			"import org.eclipse.jdt.annotation.*;\n" +
-			"import jakarta.inject.Inject;\n" +
+			"import javax.inject.Inject;\n" +
 			"public class X {\n" +
 			"    @NonNull @Inject static String s; // warn since injection of static field is less reliable\n" + // variation: static field
 			"    @NonNull @Inject @Deprecated Object o;\n" +
@@ -4641,6 +4641,32 @@ public void test_nonnull_field_19() {
 		"1. ERROR in X.java (at line 4)\n" +
 		"	@NonNull @Inject static String s; // warn since injection of static field is less reliable\n" +
 		"	                               ^\n" +
+		"The @NonNull field s may not have been initialized\n" +
+		"----------\n");
+}
+
+//Using jakarta.inject.Inject and javax.inject.Inject
+public void test_nonnull_field_20() {
+	runNegativeTestWithLibs(
+		new String[] {
+			JAVAX_INJECT_NAME,
+			JAVAX_INJECT_CONTENT,
+			JAKARTA_INJECT_NAME,
+			JAKARTA_INJECT_CONTENT,
+			"X.java",
+			"import org.eclipse.jdt.annotation.*;\n" +
+			"import jakarta.inject.Inject;\n" +
+			"public class X {\n" +
+			"    @NonNull @Inject @javax.inject.Inject static String s; // warn since injection of static field is less reliable\n" + // variation: static field
+			"    @NonNull @Inject @javax.inject.Inject @Deprecated Object o;\n" +
+			"    public X() {}\n" + // variation: with explicit constructor
+			"}\n",
+		},
+		null /*customOptions*/,
+		"----------\n" +
+		"1. ERROR in X.java (at line 4)\n" +
+		"	@NonNull @Inject @javax.inject.Inject static String s; // warn since injection of static field is less reliable\n" +
+		"	                                                    ^\n" +
 		"The @NonNull field s may not have been initialized\n" +
 		"----------\n");
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullAnnotationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullAnnotationTest.java
@@ -4571,7 +4571,7 @@ public void test_nonnull_field_16() {
 		"----------\n");
 }
 
-// Using jakarta.inject.Inject, slight variations
+// Using javax.inject.Inject, slight variations
 // [compiler] Null analysis for fields does not take @com.google.inject.Inject into account
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=400421
 public void test_nonnull_field_17() {
@@ -8772,12 +8772,12 @@ public void testBug418236() {
 }
 public void testBug461878() {
 	Map compilerOptions = getCompilerOptions();
-	compilerOptions.put(JavaCore.COMPILER_NONNULL_ANNOTATION_NAME, "jakarta.annotation.Nonnull");
+	compilerOptions.put(JavaCore.COMPILER_NONNULL_ANNOTATION_NAME, "javax.annotation.Nonnull");
 	runNegativeTest(
 		true, /*flush*/
 		new String[] {
-			"jakarta/annotation/Nonnull.java",
-			"package jakarta.annotation;\n" +
+			"javax/annotation/Nonnull.java",
+			"package javax.annotation;\n" +
 			"import java.lang.annotation.Retention;\n" +
 			"import java.lang.annotation.RetentionPolicy;\n" +
 			"@Retention(RetentionPolicy.RUNTIME)\n" +
@@ -8785,7 +8785,7 @@ public void testBug461878() {
 			"}\n",
 			"edu/umd/cs/findbugs/annotations/PossiblyNull.java",
 			"package edu.umd.cs.findbugs.annotations;\n" +
-			"@jakarta.annotation.Nonnull // <-- error!!!\n" +
+			"@javax.annotation.Nonnull // <-- error!!!\n" +
 			"public @interface PossiblyNull {\n" +
 			"}\n"
 		},
@@ -8793,8 +8793,8 @@ public void testBug461878() {
 		compilerOptions,
 		"----------\n" +
 		"1. WARNING in edu\\umd\\cs\\findbugs\\annotations\\PossiblyNull.java (at line 2)\n" +
-		"	@jakarta.annotation.Nonnull // <-- error!!!\n" +
-		"	^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
+		"	@javax.annotation.Nonnull // <-- error!!!\n" +
+		"	^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
 		"The nullness annotation \'Nonnull\' is not applicable at this location\n" +
 		"----------\n",
 		JavacTestOptions.Excuse.EclipseHasSomeMoreWarnings);


### PR DESCRIPTION
assign separate type ids

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4072
