### PR TITLE
[25] JEP 512 - Compact Source Files

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ImplicitlyDeclaredClassesTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ImplicitlyDeclaredClassesTest.java
@@ -366,8 +366,8 @@ public class ImplicitlyDeclaredClassesTest extends AbstractRegressionTest9 {
 				"X.java",
 				"""
 				public static void main(String[] args) {
-					println("Hello1");
-					println("Hello2");
+					IO.println("Hello1");
+					IO.println("Hello2");
 				}"""
 		},
 		"Hello1\n" +
@@ -378,8 +378,8 @@ public class ImplicitlyDeclaredClassesTest extends AbstractRegressionTest9 {
 				"X.java",
 				"""
 				public static void main(String[] args) {
-					String str = readln("Enter:");
-					println(str);
+					String str = IO.readln("Enter:");
+					IO.println(str);
 				}
 				"""
 		},
@@ -392,7 +392,7 @@ public class ImplicitlyDeclaredClassesTest extends AbstractRegressionTest9 {
 		runConformTest(new String[] {
 				"Main.java",
 				"""
-				import static java.io.IO.*;
+				import static java.lang.IO.*;
 				public class Main {
 					public static void main(String[] args) {
 						println("Hello");


### PR DESCRIPTION
For testing on 25-ea+25: Adjust to the move of IO to java.lang and withdrawal of auto importing IO.*

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3888