### PR TITLE
[25] JEP 507 - Primitive Type in patterns, instanceof, and switch (Third Preview)

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractRegressionTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractRegressionTest.java
@@ -1180,7 +1180,7 @@ protected static class JavacTestOptions {
 			JavacBug8348928 = // https://bugs.openjdk.org/browse/JDK-8348928
 					new JavacHasABug(MismatchType.EclipseErrorsJavacWarnings),
 			JavacBug8348410 = // https://bugs.openjdk.org/browse/JDK-8348410
-					new JavacHasABug(MismatchType.EclipseErrorsJavacNone);
+					new JavacHasABug(MismatchType.EclipseErrorsJavacNone, ClassFileConstants.JDK25, 0000);
 
 
 		// bugs that have been fixed but that we've not identified

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PrimitiveInPatternsTestSH.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PrimitiveInPatternsTestSH.java
@@ -2661,6 +2661,7 @@ public class PrimitiveInPatternsTestSH extends AbstractRegressionTest9 {
 				}
 				"""
 			};
+		runner.javacTestOptions = JAVAC_OPTIONS;
 		runner.vmArguments = VMARGS;
 		runner.expectedOutputString = "1";
 		runner.runConformTest();


### PR DESCRIPTION
+ https://bugs.openjdk.org/browse/JDK-8348410 has been fixed
  - define upper limit for excuse JavacBug8348410
  - actually pass --enable-preview to javac in one more test

Relates to https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3889