### PR TITLE
[25] JEP 513 - Flexible Constructor Bodies

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ASTNode.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ASTNode.java
@@ -8,6 +8,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Matt McCutchen - partial fix for https://bugs.eclipse.org/bugs/show_bug.cgi?id=122995
@@ -206,7 +210,7 @@ public abstract class ASTNode implements TypeConstants, TypeIds {
 	public static final int IgnoreNoEffectAssignCheck = Bit30;
 
 	// for references on lhs of assignment
-	public static final int IsStrictlyAssigned = Bit14; // set only for true assignments, as opposed to compound ones. Used also for JEP 482 to allow assignment, but not read
+	public static final int IsStrictlyAssigned = Bit14; // set only for true assignments, as opposed to compound ones. Used also for JEP 513 to allow assignment, but not read
 	public static final int IsCompoundAssigned = Bit17; // set only for compound assignments, as opposed to other ones
 
 	// for explicit constructor call

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AllocationExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AllocationExpression.java
@@ -8,6 +8,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Stephan Herrmann - Contributions for
@@ -559,7 +563,7 @@ protected void checkEarlyConstructionContext(BlockScope scope) {
 		if (uninitialized != null)
 			scope.problemReporter().allocationInEarlyConstructionContext(this, this.resolvedType, uninitialized);
 	}
-	// if JEP 482 is not enabled, problems will be detected when looking for enclosing instance(s)
+	// if JEP 513 is not enabled, problems will be detected when looking for enclosing instance(s)
 }
 protected boolean isMissingTypeRelevant() {
 	if (this.binding != null && this.binding.isVarargs()) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LambdaExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LambdaExpression.java
@@ -8,6 +8,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Jesper S Moller - Contributions for
@@ -1259,7 +1263,7 @@ public class LambdaExpression extends FunctionalExpression implements IPolyExpre
 		}
 		codeStream.pushPatternAccessTrapScope(this.scope);
 		if (this.scopesInEarlyConstruction != null) {
-			// JEP 482: restore early construction context info into scopes:
+			// JEP 513: restore early construction context info into scopes:
 			for (ClassScope classScope : this.scopesInEarlyConstruction)
 				classScope.insideEarlyConstructionContext = true;
 		}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/QualifiedThisReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/QualifiedThisReference.java
@@ -8,6 +8,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Stephan Herrmann - Contribution for
@@ -126,7 +130,7 @@ public class QualifiedThisReference extends ThisReference {
 		// Ensure one cannot write code like: B() { super(B.this); }
 		if (depth == 0 || JavaFeature.FLEXIBLE_CONSTRUCTOR_BODIES.isSupported(scope.compilerOptions())) {
 			checkAccess(scope, null);
-		} // if depth>0, prior to JEP 482: path emulation will diagnose bad scenarii
+		} // if depth>0, prior to JEP 513: path emulation will diagnose bad scenarii
 		else if (scope.compilerOptions().complianceLevel >= ClassFileConstants.JDK16) {
 			MethodScope ms = scope.methodScope();
 			if (ms.isStatic)

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Reference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Reference.java
@@ -8,6 +8,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Stephan Herrmann <stephan@cs.tu-berlin.de> - Contributions for
@@ -187,9 +191,9 @@ void reportOnlyUselesslyReadPrivateField(BlockScope currentScope, FieldBinding f
 }
 
 protected void checkFieldAccessInEarlyConstructionContext(BlockScope scope, char[] token, FieldBinding fieldBinding, TypeBinding actualReceiverType) {
-	if (actualReceiverType != null && JavaFeature.FLEXIBLE_CONSTRUCTOR_BODIES.matchesCompliance(scope.compilerOptions())) {
+	if (actualReceiverType != null) {
 		if (scope.isInsideEarlyConstructionContext(actualReceiverType, false)) {
-			// §6.5.6.1 (JEP 482):
+			// §6.5.6.1 (JEP 513):
 			// If the declaration denotes an instance variable of a class C ... then .. or a compile time occurs:
 			// - [...]
 			// - If the expression name appears in an early construction context of C (8.8.7.1),
@@ -218,7 +222,7 @@ protected void checkFieldAccessInEarlyConstructionContext(BlockScope scope, char
 					return;
 				}
 			}
-			// otherwise legal if JEP 482 is enabled
+			// otherwise legal if JEP 513 is enabled
 			scope.problemReporter().validateJavaFeatureSupport(JavaFeature.FLEXIBLE_CONSTRUCTOR_BODIES, this.sourceStart, this.sourceEnd);
 		}
 	}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ThisReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ThisReference.java
@@ -8,6 +8,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Stephan Herrmann - Contribution for
@@ -60,7 +64,7 @@ public class ThisReference extends Reference {
 			if (JavaFeature.FLEXIBLE_CONSTRUCTOR_BODIES.isSupported(scope.compilerOptions())) {
 				if (!this.inFieldReference  // this.f is also covered in Reference.checkFieldAccessInEarlyConstructionContext()
 						&& scope.isInsideEarlyConstructionContext(this.resolvedType, false)) {
-					// JEP 482 message
+					// JEP 513 message
 					scope.problemReporter().errorExpressionInEarlyConstructionContext(this);
 					return false;
 				}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypeOrLambda.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypeOrLambda.java
@@ -8,6 +8,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
  * Contributors:
  *     Stephan Herrmann - initial API and implementation
  *******************************************************************************/
@@ -36,7 +40,7 @@ public interface TypeOrLambda {
 	 */
 	default void addSyntheticArgumentsBeyondEarlyConstructionContext(boolean earlySeen, Scope outerScope) {
 		if (outerScope != null && JavaFeature.FLEXIBLE_CONSTRUCTOR_BODIES.isSupported(outerScope.compilerOptions())) {
-			// JEP 482 / 492:
+			// JEP 513:
 			// This is the central location for organizing synthetic arguments and fields
 			// to serve far outer instances even in inner early construction context.
 			// Locations MethodBinding.computeSignature() and BlockScope.getEmulationPath() will faithfully

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/impl/JavaFeature.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/impl/JavaFeature.java
@@ -79,13 +79,14 @@ public enum JavaFeature {
 			new char[][] {},
 			true),
 	/**
-	 * JEP 482. Some locations only check if compliance is sufficient to use this feature,
-	 * to leave checking for actual enablement for later. This is done so we can report
-	 * that a preview feature could potentially kick in even when it is disabled.
+	 * JEP 513.
+	 * As this feature graduated to a standard feature, we optimistically perform analysis using the
+	 * rules of this JEP even below 25. This is done so we can report when certain code will become
+	 * legal when adopting version 25.
 	 * <dl>
 	 * <dt>Initial check in ConstructorDeclaration.resolveStatements();
-	 * <dd>At 23 we always call enterEarlyConstructionContext() to enable many downstream analyses.<br>
-	 * Check actual support only when a "late constructor" has been found.<br>
+	 * <dd>we always call enterEarlyConstructionContext() to enable many downstream analyses.<br>
+	 * Check actual support only when the feature is actually used.<br>
 	 * Similar for analyseCode() and generateCode().
 	 * <dt>Differentiate error messages based on enablement:
 	 * <dd><ul>
@@ -97,7 +98,7 @@ public enum JavaFeature {
 	 * <dd>applies all strategy variants from above
 	 * <dt>Individual exceptions from old rules
 	 * <dd><ul><li>MethodScope.findField()<li>Scope.getBinding(char[], int, InvocationSite, boolean)</ul>
-	 * <dt>Main code gen change in TypeDeclaration.manageEnclosingInstanceAccessIfNecessary()
+	 * <dt>Main code gen addition in TypeDeclaration.addSyntheticArgumentsBeyondEarlyConstructionContext()
 	 * <dd>Only if feature is actually supported, we will generate special synthetic args and fields<br>
 	 * Uses some feature-specific help from BlockScope.getEmulationPath()
 	 * </dl>
@@ -105,7 +106,7 @@ public enum JavaFeature {
 	FLEXIBLE_CONSTRUCTOR_BODIES(ClassFileConstants.JDK25,
 			Messages.bind(Messages.flexible_constructor_bodies),
 			new char[][] {},
-			true),
+			false),
 	PRIMITIVES_IN_PATTERNS(ClassFileConstants.JDK25,
 			Messages.bind(Messages.primitives_in_patterns),
 			new char[][] {},

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BlockScope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BlockScope.java
@@ -8,6 +8,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Stephan Herrmann - Contributions for
@@ -941,7 +945,7 @@ public Object[] getEmulationPath(ReferenceBinding targetEnclosingType, boolean o
 	Object[] path = new Object[2]; // probably at least 2 of them
 	ReferenceBinding currentType = sourceType.enclosingType();
 	if ((methodScope().referenceContext instanceof ConstructorDeclaration) && JavaFeature.FLEXIBLE_CONSTRUCTOR_BODIES.matchesCompliance(compilerOptions())) {
-		// JEP 482: find the outermost arg up-to the target depth, available as a synthetic argument
+		// JEP 513: find the outermost arg up-to the target depth, available as a synthetic argument
 		// this allows us to "skip over" any intermediate early construction context not having an enclosing instance
 		ReferenceBinding outer = currentType;
 		while (outer != null && outer.depth() >= targetEnclosingType.depth()) {
@@ -994,7 +998,7 @@ public Object[] getEmulationPath(ReferenceBinding targetEnclosingType, boolean o
 				}
 			}
 
-			// TODO JEP 482: do we need a search for far outer starting at currentType, like in the above JEP 482 section?
+			// TODO JEP 513: do we need a search for far outer starting at currentType, like in the above JEP 513 section?
 			syntheticField = ((NestedTypeBinding) currentType).getSyntheticField(currentEnclosingType, onlyExactMatch);
 			if (syntheticField == null) break;
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ClassScope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ClassScope.java
@@ -8,6 +8,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Stephan Herrmann <stephan@cs.tu-berlin.de> - Contributions for
@@ -54,7 +58,7 @@ public class ClassScope extends Scope {
 	java.util.ArrayList<TypeReference> deferredBoundChecks;
 	public boolean resolvingPolyExpressionArguments = false;
 	/**
-	 * This is the primary flag for detection of early construction contexts (JEP 482).
+	 * This is the primary flag for detection of early construction contexts (JEP 513).
 	 * It is temporarily set on the scope of a class while processing statements of this class's
 	 * early construction context (during resolveType(), analyseCode() and generateCode())
 	 * <p>Main access is via {@link Scope#enterEarlyConstructionContext()}, {@link Scope#leaveEarlyConstructionContext()}
@@ -63,7 +67,7 @@ public class ClassScope extends Scope {
 	 * into {@code scopesInEarlyConstruction}, for use during generateCode(), which doesn't have the
 	 * context of the lambda declaration.
 	 * </p>
-	 * <p>All this is always active at compliance 23, see {@link JavaFeature#FLEXIBLE_CONSTRUCTOR_BODIES}
+	 * <p>All this is always active at compliance 23+, see {@link JavaFeature#FLEXIBLE_CONSTRUCTOR_BODIES}
 	 * for details on where enablement is actually checked.</p>
 	 */
 	public boolean insideEarlyConstructionContext = false;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MethodScope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MethodScope.java
@@ -8,6 +8,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
  *     IBM Corporation - initial API and implementation
  *     Stephan Herrmann - Contributions for
  *								bug 349326 - [1.7] new warning for missing try-with-resources
@@ -500,13 +504,12 @@ public FieldBinding findField(TypeBinding receiverType, char[] fieldName, Invoca
 		return field; // static fields are always accessible
 
 	if (this.isConstructorCall) {
-		// JEP 482 exception to old rules.
+		// JEP 513 exception to old rules.
 		// 'this.field' is already detected when FieldReference triggers ThisReference.resolveType() -> checkAccess()
 		// hence here we only handle single name references:
 		if (invocationSite instanceof SingleNameReference nameRef
 				&& (nameRef.bits & ASTNode.IsStrictlyAssigned) != 0
-				&& FLEXIBLE_CONSTRUCTOR_BODIES.matchesCompliance(compilerOptions())) {
-			problemReporter().validateJavaFeatureSupport(FLEXIBLE_CONSTRUCTOR_BODIES, invocationSite.sourceStart(), invocationSite.sourceEnd());
+				&& FLEXIBLE_CONSTRUCTOR_BODIES.isSupported(compilerOptions())) {
 			return field;
 		}
 	} else {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
@@ -8,6 +8,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Stephan Herrmann - Contributions for
@@ -2509,7 +2513,7 @@ public ModuleBinding module() {
 }
 
 public boolean hasEnclosingInstanceContext() {
-	// This method intentionally disregards early construction contexts (JEP 482).
+	// This method intentionally disregards early construction contexts (JEP 513).
 	// Details of how each outer level is handled are coordinated in
 	// TypeDeclaration.manageEnclosingInstanceAccessIfNecessary().
 	if (isStatic())

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Scope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Scope.java
@@ -8,6 +8,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Stephan Herrmann - Contributions for
@@ -2119,11 +2123,8 @@ public abstract class Scope {
 									if (fieldBinding.isValidBinding()) {
 										if (!fieldBinding.isStatic()) {
 											if (insideConstructorCall) {
-												if (invocationSite instanceof ASTNode node
-														&& (node.bits & ASTNode.IsStrictlyAssigned) != 0
-														&& JavaFeature.FLEXIBLE_CONSTRUCTOR_BODIES.matchesCompliance(compilerOptions())) {
-													// enablement check for assignment deferred to Reference.checkFieldAccessInEarlyConstructionContext()
-												} else if (!JavaFeature.FLEXIBLE_CONSTRUCTOR_BODIES.isSupported(compilerOptions())) {
+												// in 25+ check for assignment legality is deferred to Reference.checkFieldAccessInEarlyConstructionContext()
+												if (!JavaFeature.FLEXIBLE_CONSTRUCTOR_BODIES.isSupported(compilerOptions())) {
 													insideProblem =
 														new ProblemFieldBinding(
 															fieldBinding, // closest match

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/FlowAnalysisTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/FlowAnalysisTest.java
@@ -8,6 +8,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Stephan Herrmann - Contributions for
@@ -1058,15 +1062,14 @@ public void test032() {
 			"	}\n" +
 			"}\n", // =================
 		},
+		JavaFeature.FLEXIBLE_CONSTRUCTOR_BODIES.isSupported(this.complianceLevel, false) ?
+		""
+		:
 		"----------\n" +
 		"1. ERROR in X.java (at line 14)\n" +
 		"	super(blank = 0);\n" +
 		"	      ^^^^^\n" +
-		(this.complianceLevel == JavaFeature.FLEXIBLE_CONSTRUCTOR_BODIES.getCompliance() ?
-		"Flexible Constructor Bodies is a preview feature and disabled by default. Use --enable-preview to enable\n"
-		:
-		"Cannot refer to an instance field blank while explicitly invoking a constructor\n"
-		) +
+		"Cannot refer to an instance field blank while explicitly invoking a constructor\n" +
 		"----------\n");
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=155423 - variation

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericTypeTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericTypeTest.java
@@ -47,6 +47,7 @@ import org.eclipse.jdt.core.tests.util.Util;
 import org.eclipse.jdt.core.util.ClassFileBytesDisassembler;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
+import org.eclipse.jdt.internal.compiler.impl.JavaFeature;
 
 @SuppressWarnings({ "unchecked", "rawtypes" })
 public class GenericTypeTest extends AbstractComparableTest {
@@ -37458,9 +37459,6 @@ public void test1119() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=166963
 public void test1120() {
-	String msg = (this.complianceLevel < ClassFileConstants.JDK25) ?
-						"Constructor call must be the first statement in a constructor\n" :
-							"Flexible Constructor Bodies is a preview feature and disabled by default. Use --enable-preview to enable\n";
 	this.runNegativeTest(
 		new String[] {
 			"X.java",
@@ -37473,37 +37471,68 @@ public void test1120() {
 			"	}\n" +
 			"}", // =================
 		},
-		"----------\n" +
-		"1. ERROR in X.java (at line 4)\n" +
-		"	this(zork);\n" +
-		"	^^^^^^^^^^^\n" +
-		msg +
-		"----------\n" +
-		"2. ERROR in X.java (at line 4)\n" +
-		"	this(zork);\n" +
-		"	     ^^^^\n" +
-		"zork cannot be resolved to a variable\n" +
-		"----------\n" +
-		"3. ERROR in X.java (at line 5)\n" +
-		"	Zork.this.this();\n" +
-		"	^^^^^^^^^^^^^^^^^\n" +
-		"Constructor call must be the first statement in a constructor\n" +
-		"----------\n" +
-		"4. ERROR in X.java (at line 5)\n" +
-		"	Zork.this.this();\n" +
-		"	^^^^\n" +
-		"Zork cannot be resolved to a type\n" +
-		"----------\n" +
-		"5. ERROR in X.java (at line 6)\n" +
-		"	<Zork>this();\n" +
-		"	 ^^^^\n" +
-		"Zork cannot be resolved to a type\n" +
-		"----------\n" +
-		"6. ERROR in X.java (at line 6)\n" +
-		"	<Zork>this();\n" +
-		"	      ^^^^^^^\n" +
-		"Constructor call must be the first statement in a constructor\n" +
-		"----------\n");
+		(!JavaFeature.FLEXIBLE_CONSTRUCTOR_BODIES.isSupported(this.complianceLevel, false)
+		?
+			"----------\n" +
+			"1. ERROR in X.java (at line 4)\n" +
+			"	this(zork);\n" +
+			"	^^^^^^^^^^^\n" +
+			"The Java feature 'Flexible Constructor Bodies' is only available with source level 25 and above\n" +
+			"----------\n" +
+			"2. ERROR in X.java (at line 4)\n" +
+			"	this(zork);\n" +
+			"	     ^^^^\n" +
+			"zork cannot be resolved to a variable\n" +
+			"----------\n" +
+			"3. ERROR in X.java (at line 5)\n" +
+			"	Zork.this.this();\n" +
+			"	^^^^^^^^^^^^^^^^^\n" +
+			"The Java feature 'Flexible Constructor Bodies' is only available with source level 25 and above\n" +
+			"----------\n" +
+			"4. ERROR in X.java (at line 5)\n" +
+			"	Zork.this.this();\n" +
+			"	^^^^\n" +
+			"Zork cannot be resolved to a type\n" +
+			"----------\n" +
+			"5. ERROR in X.java (at line 6)\n" +
+			"	<Zork>this();\n" +
+			"	 ^^^^\n" +
+			"Zork cannot be resolved to a type\n" +
+			"----------\n" +
+			"6. ERROR in X.java (at line 6)\n" +
+			"	<Zork>this();\n" +
+			"	      ^^^^^^^\n" +
+			"The Java feature 'Flexible Constructor Bodies' is only available with source level 25 and above\n" +
+			"----------\n"
+		:
+			"""
+			----------
+			1. ERROR in X.java (at line 4)
+				this(zork);
+				     ^^^^
+			zork cannot be resolved to a variable
+			----------
+			2. ERROR in X.java (at line 5)
+				Zork.this.this();
+				^^^^^^^^^^^^^^^^^
+			Constructor cannot have more than one explicit constructor call
+			----------
+			3. ERROR in X.java (at line 5)
+				Zork.this.this();
+				^^^^
+			Zork cannot be resolved to a type
+			----------
+			4. ERROR in X.java (at line 6)
+				<Zork>this();
+				 ^^^^
+			Zork cannot be resolved to a type
+			----------
+			5. ERROR in X.java (at line 6)
+				<Zork>this();
+				      ^^^^^^^
+			Constructor cannot have more than one explicit constructor call
+			----------
+			"""));
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=181270
 public void test1121() {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/InnerEmulationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/InnerEmulationTest.java
@@ -8,6 +8,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Stephan Herrmann - Contribution for
@@ -26,6 +30,7 @@ import org.eclipse.jdt.core.util.ClassFileBytesDisassembler;
 import org.eclipse.jdt.core.util.IClassFileReader;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
+import org.eclipse.jdt.internal.compiler.impl.JavaFeature;
 
 @SuppressWarnings({ "unchecked", "rawtypes" })
 public class InnerEmulationTest extends AbstractRegressionTest {
@@ -133,7 +138,9 @@ public void test002() {
 		"1. ERROR in A.java (at line 10)\n" +
 		"	this(new C()); \n" +
 		"	     ^^^^^^^\n" +
-		"No enclosing instance of type A is available due to some intermediate constructor invocation\n" +
+		(JavaFeature.FLEXIBLE_CONSTRUCTOR_BODIES.isSupported(this.complianceLevel, false)
+		? "Cannot instantiate class A.C in an early construction context of class A\n"
+		: "No enclosing instance of type A is available due to some intermediate constructor invocation\n" )+
 		"----------\n"
 
 	);
@@ -147,7 +154,9 @@ public void test003() {
 			"1. ERROR in A.java (at line 8)\n" +
 			"	super(getRunnable(), new B().toString()); \n" +
 			"	                     ^^^^^^^\n" +
-			"No enclosing instance of type A is available due to some intermediate constructor invocation\n" +
+			(JavaFeature.FLEXIBLE_CONSTRUCTOR_BODIES.isSupported(this.complianceLevel, false)
+			? "Cannot instantiate class A.B in an early construction context of class A\n"
+			: "No enclosing instance of type A is available due to some intermediate constructor invocation\n") +
 			"----------\n"
 			:
 			"----------\n" +
@@ -3578,7 +3587,9 @@ public void test099() {
 		"	               ^^^^^^^^\n" +
 		"The nested type Y$1Local cannot be referenced using its binary name\n" +
 		"----------\n",
-		JavacTestOptions.JavacHasABug.JavacBug4094180);
+		JavacTestOptions.SKIP);
+		// before 24 this was JavacHasABug.JavacBug4094180
+		// at 24+ javac is raising a wrong error: "an enclosing instance that contains Local is required"
 }
 
 /*
@@ -3709,7 +3720,9 @@ public void test107() {
 		"1. ERROR in X.java (at line 11)\n" +
 		"	super(B.this); \n" +
 		"	      ^^^^^^\n" +
-		"Cannot refer to \'this\' nor \'super\' while explicitly invoking a constructor\n" +
+		(JavaFeature.FLEXIBLE_CONSTRUCTOR_BODIES.isSupported(this.complianceLevel, false)
+		? "Cannot use 'B.this' in an early construction context\n"
+		: "Cannot refer to 'this' nor 'super' while explicitly invoking a constructor\n" )+
 		"----------\n");
 }
 
@@ -3876,7 +3889,9 @@ public void test114() {
 		"1. ERROR in X.java (at line 9)\n" +
 		"	super(s);\n" +
 		"	      ^\n" +
-		"Cannot refer to an instance field s while explicitly invoking a constructor\n" +
+		(JavaFeature.FLEXIBLE_CONSTRUCTOR_BODIES.isSupported(this.complianceLevel, false)
+		? "Cannot read field s in an early construction context\n"
+		: "Cannot refer to an instance field s while explicitly invoking a constructor\n") +
 		"----------\n");
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=58606
@@ -4061,7 +4076,8 @@ public void test119() {
 		"<foo:0><foo:3><bar:3>");
 }
 public void test120() {
-	this.runNegativeTest(
+	Runner runner = new Runner();
+	runner.testFiles =
 		new String[] {
 			"X.java",
 			"public class X {\n" +
@@ -4098,13 +4114,19 @@ public void test120() {
 			"		}\n" +
 			"	}\n" +
 			"}\n",
-		},
-		"----------\n" +
-		"1. ERROR in X.java (at line 10)\n" +
-		"	foo(); //1\n" +
-		"	^^^^^\n" +
-		"No enclosing instance of the type X is accessible in scope\n" +
-		"----------\n");
+		};
+	if (JavaFeature.FLEXIBLE_CONSTRUCTOR_BODIES.isSupported(this.complianceLevel, false)) {
+		runner.runConformTest();
+	} else {
+		runner.expectedCompilerLog =
+	 		"----------\n" +
+			"1. ERROR in X.java (at line 10)\n" +
+			"	foo(); //1\n" +
+			"	^^^^^\n" +
+			"No enclosing instance of the type X is accessible in scope\n" +
+			"----------\n";
+		runner.runNegativeTest();
+	}
 }
 public void test121() {
 	this.runConformTest(


### PR DESCRIPTION
feature is graduating
+ more optimistically use new code
  - if things go wrong report feature disabled, rather than old error
+ avoid some old errors that would be "duplicates" of new ones

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3887