### PR TITLE
The workaround for new JIT bug into eclipse.ini generates new output on every run of Eclipse (#4075)

### DIFF
--- a/org.eclipse.jdt.core/META-INF/p2.inf
+++ b/org.eclipse.jdt.core/META-INF/p2.inf
@@ -1,7 +1,7 @@
 instructions.install = \
-	addJvmArg(jvmArg:-XX:CompileCommand=exclude org.eclipse.jdt.internal.core.dom.rewrite.ASTRewriteAnalyzer::getExtendedRange); \
-	addJvmArg(jvmArg:-XX:CompileCommand=quiet);
+	addJvmArg(jvmArg:-XX:CompileCommand=quiet); \
+	addJvmArg(jvmArg:-XX:CompileCommand=exclude org.eclipse.jdt.internal.core.dom.rewrite.ASTRewriteAnalyzer::getExtendedRange);
 instructions.uninstall = \
-	removeJvmArg(jvmArg:-XX:CompileCommand=exclude org.eclipse.jdt.internal.core.dom.rewrite.ASTRewriteAnalyzer::getExtendedRange); \
-	removeJvmArg(jvmArg:-XX:CompileCommand=quiet);
+	removeJvmArg(jvmArg:-XX:CompileCommand=quiet); \
+	removeJvmArg(jvmArg:-XX:CompileCommand=exclude org.eclipse.jdt.internal.core.dom.rewrite.ASTRewriteAnalyzer::getExtendedRange);
 


### PR DESCRIPTION
Fix order of vmargs

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3312
