### PR TITLE
ecj doesn't properly apply the comb rule from 15.12.1

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractRegressionTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractRegressionTest.java
@@ -575,6 +575,8 @@ static class JavacCompiler {
 			switch(rawVersion) {
 				case "24-ea", "24-beta", "24":
 					return 0000;
+				case "24.0.1":
+					return 0100;
 			}
 		}
 		throw new RuntimeException("unknown raw javac version: " + rawVersion);

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/InnerEmulationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/InnerEmulationTest.java
@@ -5994,29 +5994,30 @@ public void test172() throws Exception {
 		this.runNegativeTest(
 				files,
 				"----------\n" +
-				"1. WARNING in X.java (at line 8)\n" +
+				"1. ERROR in X.java (at line 8)\n" +
+				"	a(null);\n" +
+				"	^\n" +
+				"The method a() in the type X is not applicable for the arguments (null)\n" +
+				"----------\n" +
+				"2. WARNING in X.java (at line 14)\n" +
 				"	a(null);\n" +
 				"	^^^^^^^\n" +
 				"Access to enclosing method a(String) from the type X is emulated by a synthetic accessor method\n" +
 				"----------\n" +
-				"2. WARNING in X.java (at line 9)\n" +
-				"	c(null);\n" +
-				"	^^^^^^^\n" +
-				"Access to enclosing method c(String) from the type X is emulated by a synthetic accessor method\n" +
-				"----------\n" +
-				"3. WARNING in X.java (at line 14)\n" +
-				"	a(null);\n" +
-				"	^^^^^^^\n" +
-				"Access to enclosing method a(String) from the type X is emulated by a synthetic accessor method\n" +
-				"----------\n" +
-				"4. WARNING in X.java (at line 15)\n" +
+				"3. WARNING in X.java (at line 15)\n" +
 				"	c(null);\n" +
 				"	^^^^^^^\n" +
 				"Access to enclosing method c(String) from the type X is emulated by a synthetic accessor method\n" +
 				"----------\n"
 				);
 	} else {
-		this.runConformTest(files, "");
+		this.runNegativeTest(files,
+				"----------\n" +
+				"1. ERROR in X.java (at line 8)\n" +
+				"	a(null);\n" +
+				"	^\n" +
+				"The method a() in the type X is not applicable for the arguments (null)\n" +
+				"----------\n");
 	}
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=308245

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocTestForMethod.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocTestForMethod.java
@@ -4130,7 +4130,7 @@ public class JavadocTestForMethod extends JavadocTest {
 				+ "1. ERROR in test\\X.java (at line 6)\n"
 				+ "	* @see Visibility#avm_private(int) Invalid ref: non-applicable inherited method\n"
 				+ "	                  ^^^^^^^^^^^\n"
-				+ "Javadoc: The method avm_private() in the type AbstractVisibility is not applicable for the arguments (int)\n"
+				+ "Javadoc: The method avm_private() from the type AbstractVisibility is not visible\n"
 				+ "----------\n"
 				+ "2. ERROR in test\\X.java (at line 7)\n"
 				+ "	* @see Visibility#avm_public(String) Invalid ref: non-applicable inherited method\n"


### PR DESCRIPTION
+ don't find private methods from super types
  + unless there is only one private method, to be reported as invisible

+ support running with run.javac on JDK 24.0.1

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4081
