### PR TITLE
[25] JavaSearchBugs16Tests.testAIOOBEForRecordClassGh790() throws AssertionError

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SplitPackageBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SplitPackageBinding.java
@@ -80,12 +80,26 @@ public class SplitPackageBinding extends PackageBinding {
 							split.add(packageBinding);
 					}
 				}
-				if (split.incarnations.size() == 1) // we don't want singleton SplitPackageBinding
-					return split.incarnations.iterator().next(); // simply peel the only incarnation
-				return split;
+				return split.reduce();
 			}
 		}
 		return null;
+	}
+	private PackageBinding reduce() {
+		switch (this.incarnations.size()) {
+			case 1:  // we don't want singleton SplitPackageBinding
+				return this.incarnations.iterator().next(); // simply peel the only incarnation
+			case 2: // also a pair of packages from Source and Binary variants of the same module is not a split package
+				Iterator<PlainPackageBinding> iterator = this.incarnations.iterator();
+				PlainPackageBinding pack1 = iterator.next();
+				PlainPackageBinding pack2 = iterator.next();
+				ModuleBinding mod1 = pack1.enclosingModule;
+				ModuleBinding mod2 = pack2.enclosingModule;
+				if (mod1.getClass() != mod2.getClass() && CharOperation.equals(mod1.name(), mod2.name())) {
+					return pack1;
+				}
+		}
+		return this;
 	}
 	private static int RANK_VALID = 3;
 	private static int rank(PackageBinding candidate) {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchBugs16Tests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchBugs16Tests.java
@@ -631,7 +631,6 @@ public class JavaSearchBugs16Tests extends AbstractJavaSearchTests {
 	 * https://github.com/eclipse-jdt/eclipse.jdt.core/issues/790
 	 */
 	public void testAIOOBEForRecordClassGh790() throws Exception {
-		if (isJRE25) return; // FIXME see https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3976
 		String testProjectName = "gh790AIOOBEForRecordClass";
 		try {
 			IJavaProject project = createJava16Project(testProjectName, new String[] {"src"});
@@ -653,9 +652,14 @@ public class JavaSearchBugs16Tests extends AbstractJavaSearchTests {
 			IType type = project.findType("test.Test");
 			IField field = type.getField("internal");
 			search(field, REFERENCES, EXACT_RULE, SearchEngine.createWorkspaceScope(), this.resultCollector);
-			assertSearchResults(
+			String expectedMatches =
 					"src/test/Test.java test.Test() [internal] EXACT_MATCH\n" +
-					"src/test/Test.java test.Test() [internal] EXACT_MATCH");
+					"src/test/Test.java test.Test() [internal] EXACT_MATCH";
+			if (isJRE25) {
+				expectedMatches += "\n" +
+						System.getProperty("java.home")+"/lib/jrt-fs.jar java.security.PrivateKey sun.security.pkcs.PKCS8Key.parseKey(byte[]) POTENTIAL_MATCH";
+			}
+			assertSearchResults( expectedMatches);
 		} finally {
 			deleteProject(testProjectName);
 		}


### PR DESCRIPTION
+ boldly reduce split package from source & binary versions of the same module to just one constituent.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3976

