### PR TITLE
ECJ doesn't compile on Collections.unmodifiableSet(Set<? super Integer>) but javac does

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
@@ -2219,12 +2219,4 @@ public class InferenceContext18 {
 		}
 		return type;
 	}
-
-	public static TypeBinding maybeUncapture(CaptureBinding capture) {
-		InferenceContext18 inst = instance.get();
-		if (inst != null) {
-			return capture.uncapture(inst.scope);
-		}
-		return capture;
-	}
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedTypeBinding.java
@@ -1514,6 +1514,7 @@ public class ParameterizedTypeBinding extends ReferenceBinding implements Substi
 	        ReferenceBinding genericSuperclass = this.type.superclass();
 	        if (genericSuperclass == null) return null; // e.g. interfaces
 		    this.superclass = (ReferenceBinding) Scope.substitute(this, genericSuperclass);
+		    this.superclass = (ReferenceBinding) InferenceContext18.maybeCapture(this.superclass);
 			this.typeBits |= (this.superclass.typeBits & TypeIds.InheritableBits);
 			if ((this.typeBits & (TypeIds.BitAutoCloseable|TypeIds.BitCloseable)) != 0) // avoid the side-effects of hasTypeBit()!
 				this.typeBits |= applyCloseableWhitelists(this.environment.globalOptions);
@@ -1532,6 +1533,7 @@ public class ParameterizedTypeBinding extends ReferenceBinding implements Substi
     		this.superInterfaces = Scope.substitute(this, this.type.superInterfaces());
     		if (this.superInterfaces != null) {
 	    		for (int i = this.superInterfaces.length; --i >= 0;) {
+	    			this.superInterfaces[i] = (ReferenceBinding) InferenceContext18.maybeCapture(this.superInterfaces[i]);
 	    			this.typeBits |= (this.superInterfaces[i].typeBits & TypeIds.InheritableBits);
 	    			if ((this.typeBits & (TypeIds.BitAutoCloseable|TypeIds.BitCloseable)) != 0) // avoid the side-effects of hasTypeBit()!
 	    				this.typeBits |= applyCloseableWhitelists(this.environment.globalOptions);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeBinding.java
@@ -1390,8 +1390,6 @@ public boolean isTypeArgumentContainedBy(TypeBinding otherType) {
 						for (TypeBinding intersectingType : intersectingTypes)
 							if (TypeBinding.equalsEquals(intersectingType, this))
 								return true;
-					} else if (otherBound instanceof CaptureBinding capture) {
-						otherBound = InferenceContext18.maybeUncapture(capture); // not backed by JLS
 					}
 					if (TypeBinding.equalsEquals(otherBound, this))
 						return true; // ? extends T  <=  ? extends ? extends T

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
@@ -1096,6 +1096,30 @@ public void testGH3457b() {
 		"""
 	});
 }
+public void testGH3457c() {
+	runConformTest(new String[] {
+		"QueryUtil.java",
+		"""
+		import java.util.ArrayList;
+		import java.util.Collection;
+		import java.util.List;
+
+		interface IQuery<T> extends List<T> { }
+
+		public class QueryUtil {
+			public static <T> IQuery<T> createCompoundQuery(IQuery<? extends T> query1, IQuery<T> query2, boolean and) {
+				ArrayList<IQuery<? extends T>> queries = new ArrayList<>(2);
+				queries.add(query1);
+				queries.add(query2);
+				return createCompoundQuery(queries, and);
+			}
+			public static <T> IQuery<T> createCompoundQuery(Collection<? extends List<? extends T>> queries, boolean and) {
+				return null;
+			}
+		}
+		"""
+	});
+}
 public void testGH3948() {
 	runConformTest(new String[] {
 			"Foo.java",
@@ -1292,6 +1316,25 @@ public void testGH4003() {
 		"""
 	});
 }
+
+public void testGH4098() {
+	runConformTest(new String[] {
+		"ClassA.java",
+		"""
+		import java.util.Collections;
+		import java.util.HashSet;
+		import java.util.Set;
+
+		public class ClassA {
+		  public static void main(String[] args) {
+		    Set<? super Integer> set = new HashSet<>(Set.of(1, 5));
+		    System.out.println(Collections.unmodifiableSet(set));
+		  }
+		}
+		"""
+	});
+}
+
 public static Class<GenericsRegressionTest_9> testClass() {
 	return GenericsRegressionTest_9.class;
 }


### PR DESCRIPTION
+ remove bogus uncapture from #3915 as suggested by coehlrich
+ fix variant test case by more capturing of PTB super types

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4098
