### PR TITLE
Fix super interfaces for captures using interfaces from the type variable when the super class has more specific interfaces

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/CaptureBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/CaptureBinding.java
@@ -247,6 +247,23 @@ public class CaptureBinding extends TypeVariableBinding {
 						// TODO: there are cases were we need to compute glb(capturedWildcardBound, substitutedVariableSuperclass)
 						//       but then when glb (perhaps triggered inside setFirstBound()) fails, how to report the error??
 					}
+					if (this.superclass.id != TypeIds.T_JavaLangObject) {
+						int length = substitutedVariableInterfaces.length;
+						ReferenceBinding[] superTypes = new ReferenceBinding[length + 1];
+						System.arraycopy(substitutedVariableInterfaces, 0, superTypes, 1, length);
+						superTypes[0] = this.superclass;
+						superTypes = Scope.greaterLowerBound(superTypes);
+						substitutedVariableInterfaces = new ReferenceBinding[superTypes.length - 1];
+						boolean foundSuper = false;
+						for (int i = 0; i < superTypes.length; i++) {
+							ReferenceBinding current = superTypes[i];
+							if (current.isInterface()) {
+								substitutedVariableInterfaces[i - (foundSuper ? 1 : 0)] = superTypes[i];
+							} else {
+								foundSuper = true;
+							}
+						}
+					}
 					this.setSuperInterfaces(substitutedVariableInterfaces);
 				}
 				this.setFirstBound(capturedWildcardBound);

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest.java
@@ -6737,5 +6737,29 @@ public void testIssue3897() {
 			"----------\n"
 		);
 }
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2523
+// Compilation error on ecj but not javac due to usage of incorrect super interface
+public void testIssue2523() {
+        this.runConformTest(
+            new String[] {
+                "X.java",
+                """
+                public class X {
+                    public void test() {
+                        C<? extends D> c = null;
+                        optional(c, null);
+                    }
+
+                    private <I extends F, T extends E<I>> void optional(C<T> l, I i) {}
+
+                    public static interface C<T extends E<?>> {}
+                    public static class D implements E<F> {}
+                    public static interface E<I extends F> {}
+                    public static class F {}
+                }
+                """
+            }
+        );
+}
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
Fixes #2523 by only setting super interfaces that aren't already an interface of the super class.

## How to test
Attempt to compile the test case.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
