### PR TITLE
Method call compiles with javac but not ecj with upper bound of type variable

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/RawTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/RawTypeBinding.java
@@ -218,6 +218,8 @@ public class RawTypeBinding extends ParameterizedTypeBinding {
 	public boolean isSubtypeOf(TypeBinding right, boolean simulatingBugJDK8026527) {
     	if (simulatingBugJDK8026527) {
     		right = this.environment.convertToRawType(right.erasure(), false);
+    	} else if (!right.isRawType() && TypeBinding.equalsEquals(this.type, right.erasure())) {
+			return false; // outside the scope of JDK-8026527 T#RAW should not be seen as subtype of T<X> nor T<?>
     	}
     	return super.isSubtypeOf(right, simulatingBugJDK8026527);
     }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Scope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Scope.java
@@ -422,7 +422,7 @@ public abstract class Scope {
 				if (isMalformedPair(iType, jType, scope)) {
 					return null;
 				}
-				if (iType.isCompatibleWith(jType, scope)) { // if Vi <: Vj, Vj is removed
+				if (iType.isSubtypeOf(jType, false)) { // if Vi <: Vj, Vj is removed
 					if (result == types) { // defensive copy
 						System.arraycopy(result, 0, result = new TypeBinding[length], 0, length);
 					}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest.java
@@ -6737,5 +6737,29 @@ public void testIssue3897() {
 			"----------\n"
 		);
 }
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2523
+// Compilation error on ecj but not javac due to usage of incorrect super interface
+public void testIssue2523() {
+        this.runConformTest(
+            new String[] {
+                "X.java",
+                """
+                public class X {
+                    public void test() {
+                        C<? extends D> c = null;
+                        optional(c, null);
+                    }
+
+                    private <I extends F, T extends E<I>> void optional(C<T> l, I i) {}
+
+                    public static interface C<T extends E<?>> {}
+                    public static class D implements E<F> {}
+                    public static interface E<I extends F> {}
+                    public static class F {}
+                }
+                """
+            }
+        );
+}
 }
 


### PR DESCRIPTION
Fix CaptureBinding.initializeBounds() by more closely adhering to JLS

Fix a bug in glb concerning T#RAW vs T<X> or T<?>
+ this fix includes making RawTypeBinding.isSubtypeOf() stricter

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2523
