### PR TITLE
Resource closure analysis triggers NPE with compact constructors

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/FakedTrackingVariable.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/FakedTrackingVariable.java
@@ -265,7 +265,13 @@ public class FakedTrackingVariable extends LocalDeclaration {
 					return null;
 				// tracking var doesn't yet exist. This happens in finally block
 				// which is analyzed before the corresponding try block
-				Statement location = local.declaration;
+				ASTNode location = local.declaration;
+				if (location == null && local.isParameter() && local.declaringScope != null) {
+					if (local.declaringScope.referenceContext() instanceof ConstructorDeclaration cd && cd.isCompactConstructor()) {
+						TypeDeclaration referenceType = local.declaringScope.referenceType();
+						location = referenceType.binding.getRecordComponent(local.name);
+					}
+				}
 				local.closeTracker = new FakedTrackingVariable(local, location, flowInfo, flowContext, FlowInfo.UNKNOWN, useAnnotations);
 				if (local.isParameter()) {
 					local.closeTracker.globalClosingState |= OWNED_BY_OUTSIDE;

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordsRestrictedClassTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordsRestrictedClassTest.java
@@ -10601,4 +10601,58 @@ public void testIssue4106() {
 	"----------\n",
 	JavacTestOptions.SKIP);
 }
+
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4118
+// Record with compact ctor - Internal compiler error: java.lang.RuntimeException: Internal Error compiling
+public void testIssue4118() {
+	this.runConformTest(
+		new String[] {
+					"RecordCompactWithReader.java",
+					"""
+					import java.io.Reader;
+					import java.time.Instant;
+					import java.util.Objects;
+
+					public record RecordCompactWithReader(Instant modified, Reader reader) {
+					    public RecordCompactWithReader {
+					        Objects.requireNonNull(modified);
+					        Objects.requireNonNull(reader);
+					    }
+					    public static void main(String [] args) {
+					    	System.out.println("OK!");
+					    }
+					}
+					""",
+	            },
+		"OK!"
+		);
+}
+
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4070
+// Resource closure analysis triggers NPE with compact constructors
+public void testIssue4070() {
+	this.runConformTest(
+		new String[] {
+					"Config.java",
+					"""
+					import java.net.URI;
+					import java.net.http.HttpClient;
+					import java.util.Objects;
+
+					public record Config(HttpClient httpClient, URI base, String defaultContentType) {
+
+						  @SuppressWarnings("resource")
+						  public Config {
+						    Objects.requireNonNull(httpClient, "httpClient");
+						  }
+
+						  public static void main(String [] args) {
+					    	System.out.println("OK!");
+					    }
+					}
+					""",
+	            },
+		"OK!"
+		);
+}
 }


### PR DESCRIPTION
* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4070
* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4118

