### PR TITLE
PR-2107 follow-up: avoid sharing AST nodes

### DIFF
--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionParser.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionParser.java
@@ -697,6 +697,7 @@ protected void attachOrphanCompletionNode(){
 				//  if (a instanceof List l) { l.is| Object // https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2106
 				if (ifStatement.condition instanceof InstanceOfExpression iof && iof.pattern instanceof TypePattern pattern) {
 					this.currentElement.add(pattern.local, 0);
+					iof.pattern = null;
 				}
 				this.currentElement = this.currentElement.add(ifStatement, 0);
 			}


### PR DESCRIPTION
PR 2107 copies a reference to an AST node (local declaration) which implies that the same node will be visited twice for all phases.

Let's play safe and _move_ instead of _copy_ in order to maintain that AST is indeed a tree :)
