### PR TITLE
An attempt to fix classpath entries encoding on Windows

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaIndexTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaIndexTests.java
@@ -24,6 +24,7 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.URIUtil;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.jdt.core.ClasspathContainerInitializer;
@@ -181,7 +182,8 @@ public class JavaIndexTests extends AbstractJavaSearchTests  {
 	public void testUseIndexInternalJarAfterRestart() throws IOException, CoreException {
 		String indexFilePath = getExternalResourcePath("Test.index");
 		String jarFilePath = "/P/Test.jar";
-		String fullJarPath = getWorkspacePath() + jarFilePath;
+		String workspacePath = getWorkspacePath();
+		String fullJarPath = Paths.get(workspacePath, jarFilePath).toString();
 		try {
 			IJavaProject p = createJavaProject("P");
 			createJar(new String[] {
@@ -779,7 +781,7 @@ public class JavaIndexTests extends AbstractJavaSearchTests  {
 	}
 
 	// Test that it works if the index file is in the jar file
-	public void testIndexInJar() throws IOException, CoreException {
+	public void testIndexInJar() throws Exception {
 		String indexFilePath = getExternalResourcePath("Test.index");
 		String jarFilePath = getExternalResourcePath("Test.jar");
 		String indexZipPath =  getExternalResourcePath("TestIndex.zip");
@@ -804,7 +806,7 @@ public class JavaIndexTests extends AbstractJavaSearchTests  {
 
 			IndexManager indexManager = JavaModelManager.getIndexManager();
 			Index index = indexManager.getIndex(libPath, false, false);
-			assertEquals(url, index.getIndexLocation().getUrl().toString());
+			assertEquals(URIUtil.fromString(url).toURL().toString(), index.getIndexLocation().getUrl().toString());
 
 			search("Test", TYPE, DECLARATIONS, EXACT_RULE, SearchEngine.createJavaSearchScope(new IJavaElement[]{p}));
 			assertSearchResults(getExternalPath() + "Test.jar pkg.Test");
@@ -815,7 +817,7 @@ public class JavaIndexTests extends AbstractJavaSearchTests  {
 
 			this.resultCollector = new JavaSearchResultCollector();
 			index = indexManager.getIndex(libPath, false, false);
-			assertEquals(url, index.getIndexLocation().getUrl().toString());
+			assertEquals(URIUtil.fromString(url).toURL().toString(), index.getIndexLocation().getUrl().toString());
 			search("Test", TYPE, DECLARATIONS, EXACT_RULE, SearchEngine.createJavaSearchScope(new IJavaElement[]{p}));
 			assertSearchResults(getExternalPath() + "Test.jar pkg.Test");
 		} finally {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ClasspathEntry.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ClasspathEntry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2019 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -54,6 +54,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.URIUtil;
 import org.eclipse.jdt.core.*;
 import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.core.compiler.IProblem;
@@ -1782,8 +1783,10 @@ public class ClasspathEntry implements IClasspathEntry {
 			if (IClasspathAttribute.INDEX_LOCATION_ATTRIBUTE_NAME.equals(attrib.getName())) {
 				String value = attrib.getValue();
 				try {
-					return (new URI(value)).toURL();
+					URI uri = URIUtil.fromString(value);
+					return uri.toURL();
 				} catch (MalformedURLException | URISyntaxException e) {
+					Util.log(e);
 					return null;
 				}
 			}

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/IndexManager.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/IndexManager.java
@@ -40,6 +40,7 @@ import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.SubMonitor;
+import org.eclipse.core.runtime.URIUtil;
 import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
@@ -1311,9 +1312,12 @@ private void readIndexMap() {
 			if (savedSignature.equals(new String(names[0]))) {
 				for (int i = 1, l = names.length-1 ; i < l ; i+=2) {
 					IndexLocation indexPath = null;
+					String name = new String(names[i]);
 					try {
-						indexPath = IndexLocation.createIndexLocation((new URI(new String(names[i])).toURL()));
+						URI uri = URIUtil.fromString(name);
+						indexPath = IndexLocation.createIndexLocation(uri.toURL());
 					} catch (URISyntaxException e) {
+						Util.log(e, "Failed to create index name '" + name + "' for " + this.indexNamesMapFile); //$NON-NLS-1$ //$NON-NLS-2$
 						// Ignore the null path and continue
 					}
 					if (indexPath == null) continue;


### PR DESCRIPTION
On Windows, passing raw paths to URI constructor results in such errors below:

```
!ENTRY org.eclipse.jdt.core 4 0 2025-06-30 15:11:54.640
!MESSAGE Unexpected internal error
!STACK 0
java.net.URISyntaxException: Illegal character in path at index 10:
file:///C:\workspaces\Test.index
	at java.base/java.net.URI$Parser.fail(URI.java:2995)
	at java.base/java.net.URI$Parser.checkChars(URI.java:3166)
	at java.base/java.net.URI$Parser.parseHierarchical(URI.java:3248)
	at java.base/java.net.URI$Parser.parse(URI.java:3196)
	at java.base/java.net.URI.<init>(URI.java:645)
	at org.eclipse.jdt.internal.core.ClasspathEntry.getLibraryIndexLocation(ClasspathEntry.java:1785)
	at org.eclipse.jdt.internal.core.ClasspathChange.requestIndexing(ClasspathChange.java:552)
	at org.eclipse.jdt.internal.core.DeltaProcessor.resourceChanged(DeltaProcessor.java:2124)
	at org.eclipse.jdt.internal.core.DeltaProcessingState.resourceChanged(DeltaProcessingState.java:490)
	at org.eclipse.core.internal.events.NotificationManager$1.run(NotificationManager.java:321)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:47)
	at org.eclipse.core.internal.events.NotificationManager.notify(NotificationManager.java:311)
	at org.eclipse.core.internal.events.NotificationManager.broadcastChanges(NotificationManager.java:174)
	at org.eclipse.core.internal.resources.Workspace.broadcastPostChange(Workspace.java:465)
	at org.eclipse.core.internal.resources.Workspace.endOperation(Workspace.java:1593)
	at org.eclipse.core.internal.resources.Workspace.run(Workspace.java:2471)
	at org.eclipse.core.internal.resources.Workspace.run(Workspace.java:2482)
	at org.eclipse.jdt.internal.core.JavaModelOperation.runOperation(JavaModelOperation.java:821)
	at org.eclipse.jdt.internal.core.JavaProject.setRawClasspath(JavaProject.java:3526)
	at org.eclipse.jdt.internal.core.JavaProject.setRawClasspath(JavaProject.java:3486)
	at org.eclipse.jdt.internal.core.JavaProject.setRawClasspath(JavaProject.java:3542)
	at org.eclipse.jdt.core.tests.model.AbstractJavaModelTests.setClasspath(AbstractJavaModelTests.java:3325)
	at org.eclipse.jdt.core.tests.model.JavaIndexTests.testChangeClasspath(JavaIndexTests.java:587)
```

This patch tries to fix regression from commit
bda8ab24c7e1b7ab32703b94e13b23aa1641ec22.

Still open: failure in
`testUseIndexInternalJarAfterRestart(org.eclipse.jdt.core.tests.model.JavaIndexTests)`

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4124
