### PR TITLE
ECJ Compile error: "The method ... from the type ... is not visible"

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Scope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Scope.java
@@ -1786,10 +1786,8 @@ public abstract class Scope {
 					case ProblemReasons.TypeParameterArityMismatch :
 						return problemMethod;
 				}
-			} else if (foundSize == 0 && singlePrivateMethod != null) {
-				// if there is only one private method, we want to report that it is not visible.
-				return new ProblemMethodBinding(singlePrivateMethod, selector, singlePrivateMethod.parameters, ProblemReasons.NotVisible);
 			}
+
 			// abstract classes may get a match in interfaces; for non abstract
 			// classes, reduces secondary errors since missing interface method
 			// error is already reported
@@ -1809,7 +1807,13 @@ public abstract class Scope {
 				}
 				return interfaceMethod;
 			}
-			if (found.size == 0) return null;
+			if (found.size == 0) {
+				if (singlePrivateMethod != null) {
+					// if there is only one private method, we want to report that it is not visible.
+					return new ProblemMethodBinding(singlePrivateMethod, selector, singlePrivateMethod.parameters, ProblemReasons.NotVisible);
+				}
+				return null;
+			}
 			if (problemMethod != null) return problemMethod;
 
 			// still no match; try to find a close match when the parameter

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/InnerEmulationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/InnerEmulationTest.java
@@ -6106,6 +6106,27 @@ public void test172c() throws Exception {
 		----------
 		""");
 }
+// regression from https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4081
+public void testGH4149() {
+	runConformTest(new String[] {
+			"ReproducerDiamondMethod.java",
+			"""
+			public class ReproducerDiamondMethod extends A implements B {
+				void callIt() {
+					init();
+				}
+			}
+
+			class A {
+				private void init() {};
+			}
+
+			interface B {
+				default void init() {};
+			}
+			"""
+	});
+}
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=308245
 public void test173() throws Exception {
 	this.runConformTest(


### PR DESCRIPTION
defer returning invisible private method until after interfaces lookup

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4149
