### PR TITLE
Don't warn about readonly model by default, only during debug

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/DeltaProcessor.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/DeltaProcessor.java
@@ -2022,7 +2022,7 @@ public class DeltaProcessor {
 	 * Registers the given delta with this delta processor.
 	 */
 	public void registerJavaModelDelta(IJavaElementDelta delta) {
-		if (JavaModelManager.isReadOnly()) {
+		if (VERBOSE && JavaModelManager.isReadOnly()) {
 			ILog.get().warn("JavaModel change during read only operation", new IllegalStateException( //$NON-NLS-1$
 					"JavaModel modified during 'read only' operation. Consider to report this warning to https://github.com/eclipse-jdt/eclipse.jdt.core/issues. delta=" //$NON-NLS-1$
 							+ delta));


### PR DESCRIPTION
Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2315