### PR TITLE
[javac] some differences ecj <-> javac regarding 'recent' features

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/InnerEmulationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/InnerEmulationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2006, 2024 IBM Corporation and others.
+ * Copyright (c) 2006, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -42,6 +42,21 @@ static {
 public InnerEmulationTest(String name) {
 	super(name);
 }
+
+// ========= OPT-IN to run.javac mode: ===========
+@Override
+protected void setUp() throws Exception {
+	if (this.complianceLevel >= ClassFileConstants.JDK25)
+		this.runJavacOptIn = true;
+	super.setUp();
+}
+@Override
+protected void tearDown() throws Exception {
+	super.tearDown();
+	this.runJavacOptIn = false; // do it last, so super can still clean up
+}
+// =================================================
+
 @Override
 protected Map getCompilerOptions() {
 	Map options = super.getCompilerOptions();


### PR DESCRIPTION
InnerEmulationTest opts in to run.javac at 25+

Relates to https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2959