### PR TITLE
[LVTI] var type inference - review and reimplementation

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/core/compiler/IProblem.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/core/compiler/IProblem.java
@@ -2356,9 +2356,13 @@ void setSourceStart(int sourceStart);
 	int VarLocalInitializedToVoid = TypeRelated + 1505; // Variable initializer is ''void'' -- cannot infer variable type
 	/** @since 3.14 */
 	int VarLocalCannotBeArrayInitalizers = TypeRelated + 1506; // Array initializer needs an explicit target-type
-	/** @since 3.14 */
+	/** @since 3.14
+	 *  @deprecated no longer issued - will be removed
+	 * */
 	int VarLocalCannotBeLambda = TypeRelated + 1507; // Lambda expression needs an explicit target-type
-	/** @since 3.14 */
+	/** @since 3.14
+	 *  @deprecated no longer issued - will be removed
+	 * */
 	int VarLocalCannotBeMethodReference = TypeRelated + 1508; // Method reference needs an explicit target-type
 	/** @since 3.14 */
 	int VarIsReserved = Syntax + 1509; // ''var'' is not a valid type name

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ASTNode.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ASTNode.java
@@ -159,6 +159,7 @@ public abstract class ASTNode implements TypeConstants, TypeIds {
 	public static final int IsForeachElementVariable = Bit5;
 	public static final int ShadowsOuterLocal = Bit22;
 	public static final int IsAdditionalDeclarator = Bit23;
+	public static final int IsPatternVariable = Bit24;
 
 	// for name refs or local decls
 	public static final int FirstAssignmentToLocal = Bit4;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ForeachStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ForeachStatement.java
@@ -475,21 +475,11 @@ public class ForeachStatement extends Statement {
 
 		// Patch the resolved type
 		if (this.elementVariable.isTypeNameVar(upperScope)) {
-			if (this.elementVariable.type.dimensions() > 0 || this.elementVariable.type.extraDimensions() > 0) {
-				upperScope.problemReporter().varLocalCannotBeArray(this.elementVariable);
-			}
-			if (TypeBinding.equalsEquals(TypeBinding.NULL, collectionType)) {
-				upperScope.problemReporter().varLocalInitializedToNull(this.elementVariable);
-				elementType = collectionType;
-			} else if (TypeBinding.equalsEquals(TypeBinding.VOID, collectionType)) {
-				upperScope.problemReporter().varLocalInitializedToVoid(this.elementVariable);
-				elementType = collectionType;
-			}
-			if ((elementType = getCollectionElementType(this.scope, collectionType)) == null) {
-				elementType = collectionType;
-			} else {
-				elementType = this.elementVariable.patchType(elementType);
-			}
+			if ((elementType = getCollectionElementType(this.scope, collectionType)) == null)
+				elementType = this.scope.getJavaLangObject(); // error reported below.
+			else
+				elementType = this.elementVariable.patchType(this.scope, elementType);
+
 			if (elementType instanceof ReferenceBinding) {
 				ReferenceBinding refBinding = (ReferenceBinding) elementType;
 				if (!elementType.canBeSeenBy(upperScope)) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LocalDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LocalDeclaration.java
@@ -222,63 +222,31 @@ public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext, Fl
 		this.type.resolvedType = newType;
 		if (this.binding != null) {
 			this.binding.type = newType;
-			this.binding.markInitialized();
 		}
 		return this.type.resolvedType;
 	}
 
-	private static Expression findPolyExpression(Expression e) {
-		// This is simpler than using an ASTVisitor, since we only care about a very few select cases.
-		if (e instanceof FunctionalExpression) {
-			return e;
-		}
-		if (e instanceof ConditionalExpression) {
-			ConditionalExpression ce = (ConditionalExpression)e;
-			Expression candidate = findPolyExpression(ce.valueIfTrue);
-			if (candidate == null) {
-				candidate = findPolyExpression(ce.valueIfFalse);
-			}
-			if (candidate != null) return candidate;
-		}
-		if (e instanceof SwitchExpression se) {
-			for (Expression re : se.resultExpressions()) {
-				Expression candidate = findPolyExpression(re);
-				if (candidate != null) return candidate;
-			}
-		}
-		return null;
-	}
-
 	@Override
 	public void resolve(BlockScope scope) {
-		resolve(scope, false);
-	}
-	public void resolve(BlockScope scope, boolean isPatternVariable) {		// prescan NNBD
-		handleNonNullByDefault(scope, this.annotations, this);
 
-		if (!isPatternVariable && (this.bits & ASTNode.IsForeachElementVariable) == 0 && this.initialization == null && this.isUnnamed(scope)) {
-			scope.problemReporter().unnamedVariableMustHaveInitializer(this);
-		}
+		handleNonNullByDefault(scope, this.annotations, this); // prescan NNBD
+
+		final boolean isPatternVariable = (this.bits & ASTNode.IsPatternVariable) != 0;
+		final boolean isForeachElementVariable = (this.bits & ASTNode.IsForeachElementVariable) != 0;
+		final boolean varTypedLocal = isTypeNameVar(scope);
+		final boolean unnamedLocal = isUnnamed(scope);
 
 		TypeBinding variableType = null;
-		boolean variableTypeInferenceError = false;
-		boolean isTypeNameVar = isTypeNameVar(scope);
-		if (isTypeNameVar && !isPatternVariable) {
-			if (this.type.isParameterizedTypeReference()) {
+
+		if (varTypedLocal) {
+			if (this.type.isParameterizedTypeReference())
 				scope.problemReporter().varCannotBeUsedWithTypeArguments(this.type);
-			}
-			if ((this.bits & ASTNode.IsForeachElementVariable) == 0) {
-				// infer a type from the initializer
-				if (this.initialization != null) {
-					variableType = checkInferredLocalVariableInitializer(scope);
-					variableTypeInferenceError = variableType != null;
-				} else {
-					// That's always an error
-					scope.problemReporter().varLocalWithoutInitizalier(this);
-					variableType = scope.getJavaLangObject();
-					variableTypeInferenceError = true;
-				}
-			}
+			if (this.type.dimensions() > 0 || this.type.extraDimensions() > 0)
+				scope.problemReporter().varLocalCannotBeArray(this);
+			if ((this.bits & ASTNode.IsAdditionalDeclarator) != 0)
+				scope.problemReporter().varLocalMultipleDeclarators(this);
+			if (isPatternVariable)
+				variableType = this.type.resolvedType; // set already if this is a component pattern or is problem binding as it should be.
 		} else {
 			variableType = this.type == null ? null : this.type.resolveType(scope, true /* check bounds*/);
 		}
@@ -297,14 +265,14 @@ public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext, Fl
 				}
 			}
 
-		Binding existingVariable = scope.getBinding(this.name, Binding.VARIABLE, this, false /*do not resolve hidden field*/);
-			if (existingVariable != null && existingVariable.isValidBinding() && !this.isUnnamed(scope)) {
+			Binding existingVariable = scope.getBinding(this.name, Binding.VARIABLE, this, false /*do not resolve hidden field*/);
+			if (existingVariable != null && existingVariable.isValidBinding() && !unnamedLocal) {
 				boolean localExists = existingVariable instanceof LocalVariableBinding;
-			if (localExists && (this.bits & ASTNode.ShadowsOuterLocal) != 0 && scope.isLambdaSubscope() && this.hiddenVariableDepth == 0) {
+				if (localExists && (this.bits & ASTNode.ShadowsOuterLocal) != 0 && scope.isLambdaSubscope() && this.hiddenVariableDepth == 0) {
 					scope.problemReporter().lambdaRedeclaresLocal(this);
 				} else if (localExists && this.hiddenVariableDepth == 0) {
 					if (existingVariable.isPatternVariable()) {
-					scope.problemReporter().illegalRedeclarationOfPatternVar((LocalVariableBinding) existingVariable, this);
+						scope.problemReporter().illegalRedeclarationOfPatternVar((LocalVariableBinding) existingVariable, this);
 					} else {
 						scope.problemReporter().redefineLocal(this);
 					}
@@ -313,66 +281,22 @@ public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext, Fl
 				}
 			}
 		}
-		if ((this.modifiers & ClassFileConstants.AccFinal)!= 0 && this.initialization == null) {
+		if ((this.modifiers & ClassFileConstants.AccFinal) != 0 && this.initialization == null) {
 			this.modifiers |= ExtraCompilerModifiers.AccBlankFinal;
 		}
-		if (isTypeNameVar) {
-			// Create binding for the initializer's type
-			// In order to resolve self-referential initializers, we must declare the variable with a placeholder type (j.l.Object), and then patch it later
-			this.binding = new LocalVariableBinding(this, variableType != null ? variableType : scope.getJavaLangObject(), this.modifiers, false) {
-				private boolean isInitialized = false;
-
-				@Override
-				public void markReferenced() {
-					if (! this.isInitialized) {
-						scope.problemReporter().varLocalReferencesItself(LocalDeclaration.this);
-						this.type = null;
-						this.isInitialized = true; // Quell additional type errors
-					}
-				}
-				@Override
-				public void markInitialized() {
-					this.isInitialized = true;
-				}
-			};
-		} else {
-			// create a binding from the specified type
-			this.binding = new LocalVariableBinding(this, variableType, this.modifiers, false /*isArgument*/);
-		}
+		// Create a binding from the specified type; In order to diagnose self-referential initializers,
+		// we must create the binding with jlO as a placeholder type and patch it later
+		this.binding = new LocalVariableBinding(this, varTypedLocal && variableType == null ? scope.getJavaLangObject() : variableType, this.modifiers, false /*isArgument*/);
 		if (isPatternVariable)
 			this.binding.tagBits |= TagBits.IsPatternBinding;
 		scope.addLocalVariable(this.binding);
 		this.binding.setConstant(Constant.NotAConstant);
-		// allow to recursivelly target the binding....
+		// allow to recursively target the binding....
 		// the correct constant is harmed if correctly computed at the end of this method
 
-		if (variableType == null) {
-			if (this.initialization != null) {
-				if (this.initialization instanceof CastExpression) {
-					((CastExpression)this.initialization).setVarTypeDeclaration(true);
-				}
-				this.initialization.resolveType(scope); // want to report all possible errors
-				if (isTypeNameVar && this.initialization.resolvedType != null) {
-					if (TypeBinding.equalsEquals(TypeBinding.NULL, this.initialization.resolvedType)) {
-						scope.problemReporter().varLocalInitializedToNull(this);
-						variableTypeInferenceError = true;
-					} else if (TypeBinding.equalsEquals(TypeBinding.VOID, this.initialization.resolvedType)) {
-						scope.problemReporter().varLocalInitializedToVoid(this);
-						variableTypeInferenceError = true;
-					}
-					variableType = patchType(this.initialization.resolvedType);
-				} else {
-					variableTypeInferenceError = true;
-				}
-			}
-		}
-		this.binding.markInitialized();
-		if (variableTypeInferenceError) {
-			return;
-		}
 		boolean resolveAnnotationsEarly = false;
 		if (scope.environment().usesNullTypeAnnotations()
-				&& !isTypeNameVar // 'var' does not provide a target type
+				&& !varTypedLocal // 'var' does not provide a target type
 				&& variableType != null && variableType.isValidBinding()) {
 			resolveAnnotationsEarly = this.initialization instanceof Invocation
 					|| this.initialization instanceof ConditionalExpression
@@ -387,16 +311,39 @@ public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext, Fl
 		}
 		if (this.initialization != null) {
 			if (this.initialization instanceof ArrayInitializer) {
+				if (varTypedLocal) {
+					scope.problemReporter().varLocalCannotBeArrayInitalizers(this);
+					variableType = scope.createArrayType(scope.getJavaLangObject(), 1); // Treat as array of anything
+				}
 				TypeBinding initializationType = this.initialization.resolveTypeExpecting(scope, variableType);
 				if (initializationType != null) {
 					((ArrayInitializer) this.initialization).binding = (ArrayBinding) initializationType;
 					this.initialization.computeConversion(scope, variableType, initializationType);
 				}
 			} else {
-				this.initialization.setExpressionContext(isTypeNameVar ? VANILLA_CONTEXT : ASSIGNMENT_CONTEXT);
+				if (varTypedLocal) {
+					this.binding.useFlag = LocalVariableBinding.ILLEGAL_SELF_REFERENCE_IF_USED; // hijack analysis phase flag
+					if (this.initialization instanceof CastExpression castExpression)
+						castExpression.setVarTypeDeclaration(true);
+				}
+				this.initialization.setExpressionContext(varTypedLocal ? VANILLA_CONTEXT : ASSIGNMENT_CONTEXT);
 				this.initialization.setExpectedType(variableType);
-				TypeBinding initializationType = this.initialization.resolvedType != null ? this.initialization.resolvedType : this.initialization.resolveType(scope);
+				TypeBinding initializationType = this.initialization.resolveType(scope);
+				if (varTypedLocal)
+					this.binding.useFlag = LocalVariableBinding.UNUSED; // hand-over hijacked flag; let flow analysis do what it does with it.
+
+				if ((variableType == null && !varTypedLocal) || // having waited until any additional errors in initializer are surfaced, bail out
+						(initializationType == null && varTypedLocal)) // fubar, bail out.
+					return;
+
 				if (initializationType != null) {
+					if (varTypedLocal) {
+						if (TypeBinding.equalsEquals(TypeBinding.NULL, this.initialization.resolvedType))
+							scope.problemReporter().varLocalInitializedToNull(this);
+						else if (TypeBinding.equalsEquals(TypeBinding.VOID, this.initialization.resolvedType))
+							scope.problemReporter().varLocalInitializedToVoid(this);
+						variableType = patchType(this.initialization.resolvedType);
+					}
 					if (TypeBinding.notEquals(variableType, initializationType)) // must call before computeConversion() and typeMismatchError()
 						scope.compilationUnitScope().recordTypeConversion(variableType, initializationType);
 					if (this.initialization.isConstantValueOfTypeAssignableToType(initializationType, variableType)
@@ -434,6 +381,11 @@ public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext, Fl
 				this.binding.isFinal()
 					? this.initialization.constant.castTo((variableType.id << 4) + this.initialization.constant.typeID())
 					: Constant.NotAConstant);
+		} else if (!isPatternVariable && !isForeachElementVariable) {
+			if (varTypedLocal)
+				scope.problemReporter().varLocalWithoutInitizalier(this);
+			if (unnamedLocal)
+				scope.problemReporter().unnamedVariableMustHaveInitializer(this);
 		}
 		// if init could be a constant only resolve annotation at the end, for constant to be positioned before (96991)
 		if (!resolveAnnotationsEarly)
@@ -445,37 +397,6 @@ public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext, Fl
 	void validateNullAnnotations(BlockScope scope) {
 		if (!scope.validateNullAnnotation(this.binding.tagBits, this.type, this.annotations))
 			this.binding.tagBits &= ~TagBits.AnnotationNullMASK;
-	}
-
-	/*
-	 * Checks the initializer for simple errors, and reports an error as needed. If error is found,
-	 * returns a reasonable match for further type checking.
-	 */
-	private TypeBinding checkInferredLocalVariableInitializer(BlockScope scope) {
-		TypeBinding errorType = null;
-		if (this.initialization instanceof ArrayInitializer) {
-			scope.problemReporter().varLocalCannotBeArrayInitalizers(this);
-			errorType = scope.createArrayType(scope.getJavaLangObject(), 1); // Treat as array of anything
-		} else {
-			// Catch-22: isPolyExpression() is not reliable BEFORE resolveType, so we need to peek to suppress the errors
-			Expression polyExpression = findPolyExpression(this.initialization);
-			if (polyExpression instanceof ReferenceExpression) {
-				scope.problemReporter().varLocalCannotBeMethodReference(this);
-				errorType = TypeBinding.NULL;
-			} else if (polyExpression != null) { // Should be instanceof LambdaExpression, but this is safer
-				scope.problemReporter().varLocalCannotBeLambda(this);
-				errorType = TypeBinding.NULL;
-			}
-		}
-		if (this.type.dimensions() > 0 || this.type.extraDimensions() > 0) {
-			scope.problemReporter().varLocalCannotBeArray(this);
-			errorType = scope.createArrayType(scope.getJavaLangObject(), 1); // This is just to quell some warnings
-		}
-		if ((this.bits & ASTNode.IsAdditionalDeclarator) != 0) {
-			scope.problemReporter().varLocalMultipleDeclarators(this);
-			errorType = this.initialization.resolveType(scope);
-		}
-		return errorType;
 	}
 
 	@Override

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LocalDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LocalDeclaration.java
@@ -213,7 +213,11 @@ public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext, Fl
 	public boolean isReceiver() {
 		return false;
 	}
-	public TypeBinding patchType(TypeBinding newType) {
+	public TypeBinding patchType(BlockScope scope, TypeBinding newType) {
+		if (TypeBinding.equalsEquals(TypeBinding.NULL, newType))
+			scope.problemReporter().varLocalInitializedToNull(this);
+		else if (TypeBinding.equalsEquals(TypeBinding.VOID, newType))
+			scope.problemReporter().varLocalInitializedToVoid(this);
 		// Perform upwards projection on type wrt mentioned type variables
 		TypeBinding[] mentionedTypeVariables= newType != null ? newType.syntheticTypeVariablesMentioned() : null;
 		if (mentionedTypeVariables != null && mentionedTypeVariables.length > 0) {
@@ -338,11 +342,7 @@ public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext, Fl
 
 				if (initializationType != null) {
 					if (varTypedLocal) {
-						if (TypeBinding.equalsEquals(TypeBinding.NULL, this.initialization.resolvedType))
-							scope.problemReporter().varLocalInitializedToNull(this);
-						else if (TypeBinding.equalsEquals(TypeBinding.VOID, this.initialization.resolvedType))
-							scope.problemReporter().varLocalInitializedToVoid(this);
-						variableType = patchType(this.initialization.resolvedType);
+						variableType = patchType(scope, this.initialization.resolvedType);
 					}
 					if (TypeBinding.notEquals(variableType, initializationType)) // must call before computeConversion() and typeMismatchError()
 						scope.compilationUnitScope().recordTypeConversion(variableType, initializationType);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SingleNameReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SingleNameReference.java
@@ -1003,13 +1003,16 @@ public TypeBinding resolveType(BlockScope scope) {
 		switch (this.bits & ASTNode.RestrictiveFlagMASK) {
 			case Binding.VARIABLE : // =========only variable============
 			case Binding.VARIABLE | Binding.TYPE : //====both variable and type============
-				if (this.binding instanceof VariableBinding) {
-					VariableBinding variable = (VariableBinding) this.binding;
+				if (this.binding instanceof VariableBinding variable) {
 					TypeBinding variableType;
-					if (this.binding instanceof LocalVariableBinding) {
+					if (this.binding instanceof LocalVariableBinding localVariable) {
 						this.bits &= ~ASTNode.RestrictiveFlagMASK;  // clear bits
 						this.bits |= Binding.LOCAL;
-						((LocalVariableBinding) this.binding).markReferenced();
+						if (localVariable.useFlag == LocalVariableBinding.ILLEGAL_SELF_REFERENCE_IF_USED) {
+							scope.problemReporter().varLocalReferencesItself(this);
+							localVariable.type = null;
+							localVariable.useFlag = LocalVariableBinding.UNUSED; // quell further errors.
+						}
 						checkLocalStaticClassVariables(scope, variable);
 						variableType = variable.type;
 						this.constant = (this.bits & ASTNode.IsStrictlyAssigned) == 0 ? variable.constant(scope) : Constant.NotAConstant;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchExpression.java
@@ -124,7 +124,7 @@ public class SwitchExpression extends SwitchStatement implements IPolyExpression
 
 			this.rExpressions.add(rxpression);
 			if (rxpressionType == null) { // tolerate poly-expression resolving to null in the absence of target type.
-				if (!rxpression.isPolyExpression() || ((IPolyExpression) rxpression).expectedType() != null)
+				if (!rxpression.isPolyExpression() || ((IPolyExpression) rxpression).expectedType() != null || SwitchExpression.this.expressionContext == VANILLA_CONTEXT)
 					this.allWellFormed = false;
 			} else if (!rxpressionType.isValidBinding()) {
 				this.allWellFormed = false;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypePattern.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypePattern.java
@@ -206,7 +206,8 @@ public class TypePattern extends Pattern implements IGenerateTypeCheck {
 			return this.resolvedType;
 
 		Pattern enclosingPattern = this.getEnclosingPattern();
-		if (this.local.type == null || this.local.type.isTypeNameVar(scope)) {
+		boolean varTypedLocal = false;
+		if (this.local.type == null || (varTypedLocal = this.local.type.isTypeNameVar(scope))) {
 			if (enclosingPattern instanceof RecordPattern) {
 				// 14.30.1: The type of a pattern variable declared in a nested type pattern is determined as follows ...
 				ReferenceBinding recType = (ReferenceBinding) enclosingPattern.resolvedType;
@@ -223,9 +224,11 @@ public class TypePattern extends Pattern implements IGenerateTypeCheck {
 							this.local.type.resolvedType = this.resolvedType;
 					}
 				}
+			} else if (varTypedLocal) {
+				this.local.type.resolveType(scope, true); // trigger complaint
 			}
 		}
-		this.local.resolve(scope, true);
+		this.local.resolve(scope);
 		if (this.local.binding != null) {
 			this.local.binding.modifiers |= ExtraCompilerModifiers.AccOutOfFlowScope; // start out this way, will be BlockScope.include'd when definitely assigned
 			CompilerOptions compilerOptions = scope.compilerOptions();

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/YieldStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/YieldStatement.java
@@ -141,7 +141,7 @@ public void resolve(BlockScope scope) {
 
 	if (this.switchExpression == null) {
 		this.switchExpression = enclosingSwitchExpression(scope);
-		if (this.switchExpression != null && this.switchExpression.isPolyExpression()) {
+		if (this.switchExpression != null) {
 			this.expression.setExpressionContext(this.switchExpression.expressionContext); // result expressions feature in same context ...
 			this.expression.setExpectedType(this.switchExpression.expectedType);           // ... with the same target type
 		}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/LocalVariableBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/LocalVariableBinding.java
@@ -37,6 +37,7 @@ public class LocalVariableBinding extends VariableBinding {
 	public static final int UNUSED = 0;
 	public static final int USED = 1;
 	public static final int FAKE_USED = 2;
+	public static final int ILLEGAL_SELF_REFERENCE_IF_USED = 3;
 	public int useFlag; // for flow analysis (default is UNUSED), values < 0 indicate the number of compound uses (postIncrement or compoundAssignment)
 
 	public BlockScope declaringScope; // back-pointer to its declaring scope
@@ -325,13 +326,6 @@ public class LocalVariableBinding extends VariableBinding {
 			}
 		}
 		return null;
-	}
-
-	public void markInitialized() {
-		// Signals that the type is correctly set now - This is for extension in subclasses
-	}
-	public void markReferenced() {
-		// Signal that the name is used - This is for extension in subclasses
 	}
 
 	public void checkEffectiveFinality(Scope scope, Expression node) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
@@ -9901,6 +9901,7 @@ protected void consumeTypePattern() {
 
 	LocalDeclaration local = createLocalDeclaration(identifierName, (int) (namePosition >>> 32), (int) namePosition);
 	local.declarationSourceEnd = local.declarationEnd;
+	local.bits |= ASTNode.IsPatternVariable;
 	this.identifierPtr--;
 	this.identifierLengthPtr--;
 
@@ -9932,6 +9933,7 @@ protected void consumeUnnamedPattern() {
 
 	LocalDeclaration local = createLocalDeclaration(identifierName, (int) (namePosition >>> 32), (int) namePosition);
 	local.declarationSourceEnd = local.declarationEnd;
+	local.bits |= ASTNode.IsPatternVariable;
 	local.declarationSourceStart = (int) (namePosition >>> 32);
 	this.identifierPtr--;
 	this.identifierLengthPtr--;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
@@ -9821,13 +9821,13 @@ public void varLocalCannotBeArray(AbstractVariableDeclaration varDecl) {
 		varDecl.sourceStart,
 		varDecl.sourceEnd);
 }
-public void varLocalReferencesItself(AbstractVariableDeclaration varDecl) {
+public void varLocalReferencesItself(SingleNameReference reference) {
 	this.handle(
 		IProblem.VarLocalReferencesItself,
 		NoArgument,
 		NoArgument,
-		varDecl.sourceStart,
-		varDecl.sourceEnd);
+		reference.sourceStart,
+		reference.sourceEnd);
 }
 public void varLocalWithoutInitizalier(AbstractVariableDeclaration varDecl) {
 	this.handle(
@@ -9856,22 +9856,6 @@ public void varLocalInitializedToVoid(AbstractVariableDeclaration varDecl) {
 public void varLocalCannotBeArrayInitalizers(AbstractVariableDeclaration varDecl) {
 	this.handle(
 		IProblem.VarLocalCannotBeArrayInitalizers,
-		NoArgument,
-		NoArgument,
-		varDecl.sourceStart,
-		varDecl.sourceEnd);
-}
-public void varLocalCannotBeLambda(AbstractVariableDeclaration varDecl) {
-	this.handle(
-		IProblem.VarLocalCannotBeLambda,
-		NoArgument,
-		NoArgument,
-		varDecl.sourceStart,
-		varDecl.sourceEnd);
-}
-public void varLocalCannotBeMethodReference(AbstractVariableDeclaration varDecl) {
-	this.handle(
-		IProblem.VarLocalCannotBeMethodReference,
 		NoArgument,
 		NoArgument,
 		varDecl.sourceStart,

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/messages.properties
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/messages.properties
@@ -1013,8 +1013,8 @@
 1504 = Cannot infer type for local variable initialized to 'null'
 1505 = Variable initializer is 'void' -- cannot infer variable type
 1506 = Array initializer needs an explicit target-type
-1507 = Lambda expression needs an explicit target-type
-1508 = Method reference needs an explicit target-type
+###[obsolete] 1507 = Lambda expression needs an explicit target-type
+###[obsolete] 1508 = Method reference needs an explicit target-type
 1509 = 'var' is not a valid type name
 1510 = 'var' should not be used as an type name, since it is a reserved word from source level 10 on
 1511 = 'var' is not allowed here

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JEP286Test.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JEP286Test.java
@@ -379,12 +379,12 @@ public void test0012_self_reference() throws IOException {
 			"----------\n" +
 			"1. ERROR in X.java (at line 3)\n" +
 			"	var a = 42 + a;\n" +
-			"	    ^\n" +
+			"	             ^\n" +
 			"Declaration using 'var' may not contain references to itself\n" +
 			"----------\n" +
 			"2. ERROR in X.java (at line 4)\n" +
 			"	var b = ((java.util.concurrent.Callable<Integer>)(() -> true ? 1 : b)).call();\n" +
-			"	    ^\n" +
+			"	                                                                   ^\n" +
 			"Declaration using 'var' may not contain references to itself\n" +
 			"----------\n" +
 			"3. WARNING in X.java (at line 7)\n" +
@@ -392,7 +392,7 @@ public void test0012_self_reference() throws IOException {
 			"	    ^\n" +
 		    "The local variable c is hiding another local variable defined in an enclosing scope\n" +
 		    	"----------\n"+
-			"3. WARNING in X.java (at line 10)\n" +
+			"4. WARNING in X.java (at line 10)\n" +
 			"	int d = 42;\n" +
 			"	    ^\n" +
 		    "The field new Callable<Integer>(){}.d is hiding another local variable defined in an enclosing scope\n" +
@@ -411,8 +411,8 @@ public void test0013_lambda() throws IOException {
 			"----------\n" +
 			"1. ERROR in X.java (at line 3)\n" +
 			"	var a = (int i) -> 42;\n" +
-			"	    ^\n" +
-			"Lambda expression needs an explicit target-type\n" +
+			"	        ^^^^^^^^^^^^^\n" +
+			"The target type of this expression must be a functional interface\n" +
 			"----------\n");
 }
 public void test0014_method_reference() throws IOException {
@@ -428,11 +428,11 @@ public void test0014_method_reference() throws IOException {
 			"----------\n" +
 			"1. ERROR in X.java (at line 3)\n" +
 			"	var a = X::main;\n" +
-			"	    ^\n" +
-			"Method reference needs an explicit target-type\n" +
+			"	        ^^^^^^^\n" +
+			"The target type of this expression must be a functional interface\n" +
 			"----------\n");
 }
-public void test0015_complain_over_first_poly_encountered() throws Exception {
+public void test0015_complain_over_all_poly_encountered() throws Exception {
 
 	this.runNegativeTest(
 			new String[] {
@@ -446,8 +446,13 @@ public void test0015_complain_over_first_poly_encountered() throws Exception {
 			"----------\n" +
 			"1. ERROR in X.java (at line 3)\n" +
 			"	var a = args.length > 1 ? X::main : (int i) -> 42;\n" +
-			"	    ^\n" +
-			"Method reference needs an explicit target-type\n" +
+			"	                          ^^^^^^^\n" +
+			"The target type of this expression must be a functional interface\n" +
+			"----------\n" +
+			"2. ERROR in X.java (at line 3)\n" +
+			"	var a = args.length > 1 ? X::main : (int i) -> 42;\n" +
+			"	                                    ^^^^^^^^^^^^^\n" +
+			"The target type of this expression must be a functional interface\n" +
 			"----------\n");
 }
 public void test0016_dont_capture_deep_poly_expressions() throws IOException {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JEP286Test.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JEP286Test.java
@@ -696,11 +696,6 @@ public void testBug530879() throws IOException {
 			"----------\n" +
 			"1. ERROR in X.java (at line 4)\n" +
 			"	for (var v : foo()) { }\n" +
-			"	         ^\n" +
-			"Variable initializer is 'void' -- cannot infer variable type\n" +
-			"----------\n" +
-			"2. ERROR in X.java (at line 4)\n" +
-			"	for (var v : foo()) { }\n" +
 			"	             ^^^^^\n" +
 			"Can only iterate over an array or an instance of java.lang.Iterable\n" +
 			"----------\n");
@@ -717,11 +712,6 @@ public void testBug530879a() throws IOException {
 			},
 			"----------\n" +
 			"1. ERROR in X.java (at line 3)\n" +
-			"	for (var v : null) { }\n" +
-			"	         ^\n" +
-			"Cannot infer type for local variable initialized to 'null'\n" +
-			"----------\n" +
-			"2. ERROR in X.java (at line 3)\n" +
 			"	for (var v : null) { }\n" +
 			"	             ^^^^\n" +
 			"Can only iterate over an array or an instance of java.lang.Iterable\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordPatternTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordPatternTest.java
@@ -4969,7 +4969,34 @@ public class RecordPatternTest extends AbstractRegressionTest9 {
 			},
 			"java.lang.IllegalArgumentException: myRecord contained null value\n" +
 			"java.lang.IllegalArgumentException: myRecord contained blank value '  '\n" +
-			"java.lang.IllegalArgumentException: myRecord was null"
-);
+			"java.lang.IllegalArgumentException: myRecord was null");
+	}
+
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4163
+	// [LVTI/var] ECJ accepts illegal array dimensions on type pattern declarations with var type
+	public void testIssue4163() {
+		runNegativeTest(new String[] {
+				"X.java",
+				"""
+				record R (String s) {
+
+				}
+
+				public class X  {
+					public static void main(String[] args) {
+						Object o = new R("Hello");
+						if (o instanceof R(var [][][] s)) {  // you can use any number of [] pairs actually!
+							System.out.println("R");
+						}
+					}
+				}
+				"""
+			},
+			"----------\n" +
+			"1. ERROR in X.java (at line 8)\n" +
+			"	if (o instanceof R(var [][][] s)) {  // you can use any number of [] pairs actually!\n" +
+			"	                              ^\n" +
+			"'var' is not allowed as an element type of an array\n" +
+			"----------\n");
 	}
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchExpressionsYieldTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchExpressionsYieldTest.java
@@ -8479,4 +8479,85 @@ public class SwitchExpressionsYieldTest extends AbstractRegressionTest {
 				},
 				"NPE!");
 	}
+
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4165
+	// [LVTI][Switch Expressions] ECJ crashes with NPE compiling faulty program
+	public void testIssue4165() {
+		this.runConformTest(
+				new String[] {
+						"X.java",
+						"""
+						interface I {
+						    int foo(int x);
+						}
+
+						public class X {
+
+						    static int foo(int x) {
+						        return x;
+						    }
+
+							public static void main(String [] args) {
+
+								for (int integer : new Integer[] { 0, 1 }) {
+									I b = switch (integer) {
+										case 0 -> X::foo;
+										default ->  (int i) -> 42;
+									};
+									System.out.println(b.foo(100));
+								}
+							}
+						}
+						"""
+				},
+				"100\n42");
+	}
+
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4165
+	// [LVTI][Switch Expressions] ECJ crashes with NPE compiling faulty program
+	public void testIssue4165_2() {
+		this.runNegativeTest(
+				new String[] {
+						"X.java",
+						"""
+						interface I {
+						    int foo(int x);
+						}
+
+						public class X {
+
+						    static int foo(int x) {
+						        return x;
+						    }
+
+							public static void main(String [] args) {
+
+								for (int integer : new Integer[] { 0, 1 }) {
+									var b = switch (integer) {
+										case 0 -> X::foo;
+										default ->  (int i) -> 42;
+									};
+									System.out.println(b.foo(100));
+								}
+							}
+						}
+						"""
+				},
+				"----------\n" +
+				"1. ERROR in X.java (at line 15)\r\n" +
+				"	case 0 -> X::foo;\r\n" +
+				"	          ^^^^^^\n" +
+				"The target type of this expression must be a functional interface\n" +
+				"----------\n" +
+				"2. ERROR in X.java (at line 16)\r\n" +
+				"	default ->  (int i) -> 42;\r\n" +
+				"	            ^^^^^^^^^^^^^\n" +
+				"The target type of this expression must be a functional interface\n" +
+				"----------\n" +
+				"3. ERROR in X.java (at line 18)\r\n" +
+				"	System.out.println(b.foo(100));\r\n" +
+				"	                     ^^^\n" +
+				"The method foo(int) is undefined for the type Object\n" +
+				"----------\n");
+	}
 }

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnLocalName.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionOnLocalName.java
@@ -36,12 +36,6 @@ public class CompletionOnLocalName extends LocalDeclaration implements Completio
 	}
 
 	@Override
-	public void resolve(BlockScope scope, boolean isPatternVariable) {
-		super.resolve(scope, isPatternVariable);
-		throw new CompletionNodeFound(this, scope);
-	}
-
-	@Override
 	public StringBuilder printAsExpression(int indent, StringBuilder output) {
 		printIndent(indent, output);
 		output.append("<CompleteOnLocalName:"); //$NON-NLS-1$

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnLocalName.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/select/SelectionOnLocalName.java
@@ -38,13 +38,9 @@ public class SelectionOnLocalName extends LocalDeclaration{
 				TypeBinding collectionType = stat.collection == null ? null : stat.collection.resolveType((BlockScope) scope.parent);
 
 				// Patch the resolved type
-				if (!TypeBinding.equalsEquals(TypeBinding.NULL, collectionType)
-						&& !TypeBinding.equalsEquals(TypeBinding.VOID, collectionType)) {
-					TypeBinding elementType = ForeachStatement.getCollectionElementType(scope, collectionType);
-					if (elementType != null) {
-						this.patchType(elementType);
-					}
-				}
+				TypeBinding elementType = ForeachStatement.getCollectionElementType(scope, collectionType);
+				if (elementType != null)
+					this.patchType(scope, elementType);
 			}
 		}
 		throw new SelectionNodeFound(this.binding);


### PR DESCRIPTION
- Unspaghettify `LocalDeclaration.resolve`
- Alternate way of reporting `IProblem.VarLocalReferencesItself` that reuses existing infrastructure without inventing additional wheels.
- Streamline error handling 

* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4165
* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4163


