### PR TITLE
[LVTI/var] ECJ allows type arguments to be specified with the reserved type name var

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LocalDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LocalDeclaration.java
@@ -243,10 +243,6 @@ public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext, Fl
 		TypeBinding variableType = null;
 
 		if (varTypedLocal) {
-			if (this.type.isParameterizedTypeReference())
-				scope.problemReporter().varCannotBeUsedWithTypeArguments(this.type);
-			if (this.type.dimensions() > 0 || this.type.extraDimensions() > 0)
-				scope.problemReporter().varLocalCannotBeArray(this);
 			if ((this.bits & ASTNode.IsAdditionalDeclarator) != 0)
 				scope.problemReporter().varLocalMultipleDeclarators(this);
 			if (isPatternVariable)

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SingleTypeReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SingleTypeReference.java
@@ -29,7 +29,7 @@ public class SingleTypeReference extends TypeReference {
 		this.token = source;
 		this.sourceStart = start;
 		this.sourceEnd = end;
-}
+	}
 	public SingleTypeReference(char[] source, long pos) {
 			this.token = source;
 			this.sourceStart = (int) (pos>>>32);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
@@ -9813,7 +9813,7 @@ public void varLocalMultipleDeclarators(AbstractVariableDeclaration varDecl) {
 		varDecl.sourceStart,
 		varDecl.sourceEnd);
 }
-public void varLocalCannotBeArray(AbstractVariableDeclaration varDecl) {
+public void varLocalCannotBeArray(ASTNode varDecl) {
 	this.handle(
 		IProblem.VarLocalCannotBeArray,
 		NoArgument,

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JEP286Test.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JEP286Test.java
@@ -341,12 +341,12 @@ public void test0011_array_type() throws IOException {
 			"----------\n" +
 			"1. ERROR in X.java (at line 3)\n" +
 			"	var myArray[] = new int[42];\n" +
-			"	    ^^^^^^^\n" +
+			"	^^^\n" +
 			"'var' is not allowed as an element type of an array\n" +
 			"----------\n" +
 			"2. ERROR in X.java (at line 4)\n" +
 			"	var[] moreArray = new int[1337];\n" +
-			"	      ^^^^^^^^^\n" +
+			"	^^^^^\n" +
 			"'var' is not allowed as an element type of an array\n" +
 			"----------\n");
 }
@@ -678,7 +678,7 @@ public void testBug531832() throws IOException {
 			"----------\n" +
 			"1. ERROR in X.java (at line 3)\n" +
 			"	for (var[] v : args) { }\n" +
-			"	           ^\n" +
+			"	     ^^^^^\n" +
 			"'var' is not allowed as an element type of an array\n" +
 			"----------\n");
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JEP323VarLambdaParamsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JEP323VarLambdaParamsTest.java
@@ -208,7 +208,7 @@ public void testBug534787_negative_004() throws IOException {
 			"----------\n" +
 			"1. ERROR in X.java (at line 3)\n" +
 			"	I lam = (var  x, var y, var...s) -> {System.out.println(\"SUCCESS \" + x);};\n" +
-			"	                              ^\n" +
+			"	                        ^^^\n" +
 			"'var' is not allowed as an element type of an array\n" +
 			"----------\n");
 }
@@ -234,7 +234,7 @@ public void testBug534787_negative_005() throws IOException {
 			"----------\n" +
 			"2. ERROR in X.java (at line 3)\n" +
 			"	I lam = (var  x, Integer y, var...s) -> {System.out.println(\"SUCCESS \" + x);};\n" +
-			"	                                  ^\n" +
+			"	                            ^^^\n" +
 			"'var' is not allowed as an element type of an array\n" +
 			"----------\n");
 }
@@ -313,8 +313,8 @@ public void testBug536159_04() throws IOException {
 			"----------\n" +
 			"1. ERROR in X.java (at line 3)\n" +
 			"	FI x = (var i []) -> 5;\n" +
-			"	            ^\n" +
-			"\'var\' is not allowed as an element type of an array\n" +
+			"	        ^^^\n" +
+			"'var' is not allowed as an element type of an array\n" +
 			"----------\n");
 }
 public void testBug541532_01() throws IOException {
@@ -341,5 +341,29 @@ public void testBug541532_01() throws IOException {
 			"}\n"
 		},
 		"hello\nworld");
+}
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4159
+// [LVTI/var] ECJ allows type arguments to be specified with the reserved type name var
+public void testIssue4159() throws IOException {
+	runNegativeTest(new String[] {
+			"X.java",
+			"""
+			interface I {
+				void doit(int x);
+			}
+
+			public class X  {
+				public static void main(String[] args) {
+					I i = (var<String> x ) -> {};
+				}
+			}
+			"""
+			},
+			"----------\n" +
+			"1. ERROR in X.java (at line 7)\n" +
+			"	I i = (var<String> x ) -> {};\n" +
+			"	       ^^^\n" +
+			"'var' cannot be used with type arguments\n" +
+			"----------\n");
 }
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordPatternTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordPatternTest.java
@@ -4995,7 +4995,7 @@ public class RecordPatternTest extends AbstractRegressionTest9 {
 			"----------\n" +
 			"1. ERROR in X.java (at line 8)\n" +
 			"	if (o instanceof R(var [][][] s)) {  // you can use any number of [] pairs actually!\n" +
-			"	                              ^\n" +
+			"	                   ^^^^^^^^^^\n" +
 			"'var' is not allowed as an element type of an array\n" +
 			"----------\n");
 	}

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/impl/AssistParser.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/impl/AssistParser.java
@@ -1484,13 +1484,13 @@ protected void flushElementStack() {
  * Build specific type reference nodes in case the cursor is located inside the type reference
  */
 @Override
-protected TypeReference getTypeReference(int dim) {
+protected TypeReference constructTypeReference(int dim) {
 
 	int index;
 
 	/* no need to take action if not inside completed identifiers */
 	if ((index = indexOfAssistIdentifier(true)) < 0) {
-		return super.getTypeReference(dim);
+		return super.constructTypeReference(dim);
 	}
 	int length = this.identifierLengthStack[this.identifierLengthPtr];
 	TypeReference reference;

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/compiler/SourceElementParser.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/compiler/SourceElementParser.java
@@ -753,7 +753,7 @@ protected CompilationUnitDeclaration endParse(int act) {
 	}
 }
 @Override
-public TypeReference getTypeReference(int dim) {
+public TypeReference constructTypeReference(int dim) {
 	/* build a Reference on a variable that may be qualified or not
 	 * This variable is a type reference and dim will be its dimensions
 	 */

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/MatchLocatorParser.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/MatchLocatorParser.java
@@ -971,8 +971,8 @@ protected TypeReference augmentTypeWithAdditionalDimensions(TypeReference typeRe
 	return result;
 }
 @Override
-protected TypeReference getTypeReference(int dim) {
-	TypeReference typeRef = super.getTypeReference(dim);
+protected TypeReference constructTypeReference(int dim) {
+	TypeReference typeRef = super.constructTypeReference(dim);
 	if (this.patternFineGrain == 0) {
 		this.patternLocator.match(typeRef, this.nodeSet); // NB: Don't check container since type reference can happen anywhere
 	}


### PR DESCRIPTION
* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4159

