### PR TITLE
Completion does not offer record components from Javadoc

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Javadoc.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Javadoc.java
@@ -16,6 +16,7 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.compiler.ast;
 
+import java.util.function.Function;
 import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.internal.compiler.ASTVisitor;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
@@ -241,6 +242,7 @@ public class Javadoc extends ASTNode {
 			JavadocSingleNameReference param = this.paramReferences[i];
 			scope.problemReporter().javadocUnexpectedTag(param.tagSourceStart, param.tagSourceEnd);
 		}
+		resolveParamTags(scope, true);
 		resolveTypeParameterTags(scope, true);
 
 		// @return tags
@@ -542,9 +544,35 @@ public class Javadoc extends ASTNode {
 			scope.problemReporter().javadocInvalidReference(reference.sourceStart, reference.sourceEnd);
 		}
 	}
-
 	/*
-	 * Resolve @param tags while method scope
+	 * Resolve @param tags for records
+	 */
+	private void resolveParamTags(ClassScope scope, boolean reportMissing) {
+		TypeDeclaration typeDecl = scope.referenceContext;
+		if (!typeDecl.isRecord())
+			return;
+		Function<JavadocSingleNameReference, Binding>  resolveNameRef =
+						(nameRef) -> {
+							nameRef.resolve(scope);
+							return nameRef.binding;
+						};
+		Function<AbstractVariableDeclaration, Binding>  resolveArgumentOrComponent =
+						(arg) -> {
+							if (arg instanceof RecordComponent) {
+								return typeDecl.binding.getField(arg.name, false);
+							}
+							return (VariableBinding) arg.getBinding();
+						};
+		resolveParamTags(typeDecl.initializerScope,
+				reportMissing,
+				typeDecl.recordComponents,
+				true,
+				typeDecl.modifiers, // not used
+				resolveNameRef,
+				resolveArgumentOrComponent);
+	}
+	/*
+	 * Resolve @param tags for methods
 	 */
 	private void resolveParamTags(MethodScope scope, boolean reportMissing, boolean considerParamRefAsUsage) {
 		AbstractMethodDeclaration methodDecl = scope.referenceMethod();
@@ -558,36 +586,62 @@ public class Javadoc extends ASTNode {
 			}
 			return;
 		}
+		Function<JavadocSingleNameReference, Binding>  resolveNameRef =
+						(nameRef) -> {
+							nameRef.resolve(scope, true, considerParamRefAsUsage);
+							return nameRef.binding;
+						};
+		Function<AbstractVariableDeclaration, Binding>  resolveArgumentOrComponent =
+						(arg) -> {
+							return arg instanceof Argument argument ? argument.binding : scope.findVariable(arg.name);
+						};
+		resolveParamTags(scope,
+				reportMissing,
+				methodDecl.arguments(),
+				!methodDecl.isCompactConstructor(),
+				methodDecl.binding.modifiers,
+				resolveNameRef,
+				resolveArgumentOrComponent);
+	}
+	private void resolveParamTags(MethodScope scope,
+			boolean reportMissing,
+			AbstractVariableDeclaration[] arguments,
+			boolean reportAllUndocumented,
+			int modifiers,
+			Function<JavadocSingleNameReference, Binding>  resolveNameRef,
+			Function<AbstractVariableDeclaration, Binding>  resolveArgumentOrComponent) {
 
+		int paramTagsSize = this.paramReferences == null ? 0 : this.paramReferences.length;
 		// If no param tags then report a problem for each method argument
-		AbstractVariableDeclaration [] arguments = methodDecl.arguments(true);
 		int argumentsSize = arguments == null ? 0 : arguments.length;
 		if (paramTagsSize == 0) {
-			if (reportMissing && !methodDecl.isCompactConstructor()) {
+			if (reportMissing && reportAllUndocumented) {
 				for (int i = 0; i < argumentsSize; i++) {
 					AbstractVariableDeclaration arg = arguments[i];
-					scope.problemReporter().javadocMissingParamTag(arg.name, arg.sourceStart, arg.sourceEnd, methodDecl.binding.modifiers);
+					scope.problemReporter().javadocMissingParamTag(arg.name, arg.sourceStart, arg.sourceEnd, modifiers);
 				}
 			}
+			return;
 		} else {
-			LocalVariableBinding[] bindings = new LocalVariableBinding[paramTagsSize];
+			VariableBinding[] bindings = new VariableBinding[paramTagsSize];
 			int maxBindings = 0;
 
 			// Scan all @param tags
 			for (int i = 0; i < paramTagsSize; i++) {
 				JavadocSingleNameReference param = this.paramReferences[i];
-				param.resolve(scope, true, considerParamRefAsUsage);
-				if (param.binding != null && param.binding.isValidBinding()) {
+
+				Binding lBinding = resolveNameRef.apply(param);
+				if (lBinding instanceof VariableBinding varBinding) {
 					// Verify duplicated tags
 					boolean found = false;
 					for (int j = 0; j < maxBindings && !found; j++) {
 						if (bindings[j] == param.binding) {
-							scope.problemReporter().javadocDuplicatedParamTag(param.token, param.sourceStart, param.sourceEnd, methodDecl.binding.modifiers);
+							scope.problemReporter().javadocDuplicatedParamTag(param.token, param.sourceStart, param.sourceEnd, modifiers);
 							found = true;
 						}
 					}
 					if (!found) {
-						bindings[maxBindings++] = (LocalVariableBinding) param.binding;
+						bindings[maxBindings++] = varBinding;
 					}
 				}
 			}
@@ -596,17 +650,19 @@ public class Javadoc extends ASTNode {
 			if (reportMissing) {
 				for (int i = 0; i < argumentsSize; i++) {
 					AbstractVariableDeclaration arg = arguments[i];
-					LocalVariableBinding argBinding = arg instanceof Argument argument ? argument.binding : scope.findVariable(arg.name);
-					boolean found = false;
-					for (int j = 0; j < maxBindings; j++) {
-						LocalVariableBinding binding = bindings[j];
-						if (argBinding == binding) {
-							found = true;
-							break;
+					Binding lBinding = resolveArgumentOrComponent.apply(arg);
+					if (lBinding instanceof VariableBinding argBinding) {
+						boolean found = false;
+						for (int j = 0; j < maxBindings; j++) {
+							VariableBinding binding = bindings[j];
+							if (argBinding == binding) {
+								found = true;
+								break;
+							}
 						}
-					}
-					if (!found) {
-						scope.problemReporter().javadocMissingParamTag(arg.name, arg.sourceStart, arg.sourceEnd, methodDecl.binding.modifiers);
+						if (!found) {
+							scope.problemReporter().javadocMissingParamTag(arg.name, arg.sourceStart, arg.sourceEnd, modifiers);
+						}
 					}
 				}
 			}
@@ -760,12 +816,10 @@ public class Javadoc extends ASTNode {
 	 */
 	private void resolveTypeParameterTags(Scope scope, boolean reportMissing) {
 		int paramTypeParamLength = this.paramTypeParameters == null ? 0 : this.paramTypeParameters.length;
-		int paramReferencesLength = this.paramReferences == null ? 0 : this.paramReferences.length;
 
 		// Get declaration infos
 		TypeParameter[] parameters = null;
 		TypeVariableBinding[] typeVariables = null;
-		RecordComponent[] recordParameters = null;
 		int modifiers = -1;
 		switch (scope.kind) {
 			case Scope.METHOD_SCOPE:
@@ -787,81 +841,17 @@ public class Javadoc extends ASTNode {
 				parameters = typeDeclaration.typeParameters;
 				typeVariables = typeDeclaration.binding.typeVariables;
 				modifiers = typeDeclaration.binding.modifiers;
-				recordParameters = typeDeclaration.recordComponents;
 				break;
 		}
 
 		// If no type variables then report a problem for each param type parameter tag
-		if ((recordParameters == null || recordParameters.length == 0)
-				&& (typeVariables == null || typeVariables.length == 0)) {
+		if ((typeVariables == null || typeVariables.length == 0)) {
 			for (int i = 0; i < paramTypeParamLength; i++) {
 				JavadocSingleTypeReference param = this.paramTypeParameters[i];
 				scope.problemReporter().javadocUnexpectedTag(param.tagSourceStart, param.tagSourceEnd);
 			}
 			return;
 		}
-
-		// If no param tags then report a problem for each record parameter
-		if (recordParameters != null) {
-			int recordParametersLength = recordParameters.length;
-			String argNames[] = new String[paramReferencesLength];
-			if (paramReferencesLength == 0) {
-				if (reportMissing) {
-					for (int i = 0, l=recordParametersLength; i<l; i++) {
-						scope.problemReporter().javadocMissingParamTag(recordParameters[i].name, recordParameters[i].sourceStart, recordParameters[i].sourceEnd, modifiers);
-					}
-				}
-			} else {
-				// Otherwise verify that all param tags match record args
-				// Scan all @param tags
-				for (int i = 0; i < paramReferencesLength; ++i) {
-					JavadocSingleNameReference param = this.paramReferences[i];
-					String paramName = new String(param.getName()[0]);
-					// Verify duplicated tags
-					boolean duplicate = false;
-					for (int j = 0; j < i && !duplicate; j++) {
-						if (paramName.equals(argNames[j])) {
-							scope.problemReporter().javadocDuplicatedParamTag(param.token, param.sourceStart, param.sourceEnd, modifiers);
-							duplicate = true;
-						}
-					}
-					if (!duplicate) {
-						argNames[i] = paramName;
-					}
-				}
-				// Look for undocumented arguments
-				if (reportMissing) {
-					for (RecordComponent component : recordParameters) {
-						boolean found = false;
-						for (int j = 0; j < paramReferencesLength && !found; j++) {
-							JavadocSingleNameReference param = this.paramReferences[j];
-							String paramName = new String(param.getName()[0]);
-							if (paramName.equals(new String(component.name))) {
-								found = true;
-							}
-						}
-						if (!found) {
-							scope.problemReporter().javadocMissingParamTag(component.name, component.sourceStart, component.sourceEnd, modifiers);
-						}
-					}
-				}
-				// Look for param tags that specify non-existent arguments
-				for (int i = 0; i < paramReferencesLength; i++) {
-					JavadocSingleNameReference param = this.paramReferences[i];
-					String paramName = new String(param.getName()[0]);
-					boolean found = false;
-					for (RecordComponent component : recordParameters) {
-						if (paramName.equals(new String(component.name))) {
-							found = true;
-						}
-					}
-					if (!found) {
-						scope.problemReporter().javadocInvalidParamTagName(param.sourceStart, param.sourceEnd);
-					}
-				}
-			}
-		}
-
 		// If no param tags then report a problem for each declaration type parameter
 		if (parameters != null) {
 			int typeParametersLength = parameters.length;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Javadoc.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Javadoc.java
@@ -561,7 +561,7 @@ public class Javadoc extends ASTNode {
 							if (arg instanceof RecordComponent) {
 								return typeDecl.binding.getField(arg.name, false);
 							}
-							return (VariableBinding) arg.getBinding();
+							return arg.getBinding();
 						};
 		resolveParamTags(typeDecl.initializerScope,
 				reportMissing,

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Javadoc.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Javadoc.java
@@ -558,10 +558,7 @@ public class Javadoc extends ASTNode {
 						};
 		Function<AbstractVariableDeclaration, Binding>  resolveArgumentOrComponent =
 						(arg) -> {
-							if (arg instanceof RecordComponent) {
-								return typeDecl.binding.getField(arg.name, false);
-							}
-							return arg.getBinding();
+							return typeDecl.binding.getField(arg.name, false);
 						};
 		resolveParamTags(typeDecl.initializerScope,
 				reportMissing,

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocTestForRecord.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocTestForRecord.java
@@ -14,7 +14,6 @@ package org.eclipse.jdt.core.tests.compiler.regression;
 
 import java.util.Map;
 import junit.framework.Test;
-import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 
 public class JavadocTestForRecord extends JavadocTest {
@@ -118,7 +117,6 @@ public class JavadocTestForRecord extends JavadocTest {
 		Runner runner = new Runner();
 		runner.testFiles = testFiles;
 		runner.expectedOutputString = expectedOutput;
-		runner.vmArguments = new String[] { "--enable-preview" };
 		runner.customOptions = customOptions;
 		runner.javacTestOptions = JavacTestOptions.forReleaseWithPreview("16");
 		runner.runConformTest();
@@ -138,9 +136,6 @@ public class JavadocTestForRecord extends JavadocTest {
 	}
 
 	public void test001() {
-		if (this.complianceLevel < ClassFileConstants.JDK14) {
-			return;
-		}
 		this.runNegativeTest(new String[] { "X.java", "public record X() {\n" + "}\n" },
 				"----------\n" + "1. ERROR in X.java (at line 1)\n" + "	public record X() {\n" + "	              ^\n"
 						+ "Javadoc: Missing comment for public declaration\n" + "----------\n",
@@ -148,9 +143,6 @@ public class JavadocTestForRecord extends JavadocTest {
 	}
 
 	public void test002() {
-		if (this.complianceLevel < ClassFileConstants.JDK14) {
-			return;
-		}
 		this.runNegativeTest(
 				new String[] { "X.java",
 						"	/**\n" + "	 * @param radius radius of X\n" + "	 */\n" + "public record X(int radius) {\n"
@@ -161,9 +153,6 @@ public class JavadocTestForRecord extends JavadocTest {
 	}
 
 	public void test003() {
-		if (this.complianceLevel < ClassFileConstants.JDK14) {
-			return;
-		}
 		runConformTest(new String[] { "X.java",
 				"		/**  \n" + "		 *   \n" + "		 */  \n" + "public record X() {\n" + "		/**  \n"
 						+ "		 *   @param args \n" + "		 */  \n" + "  public static void main(String[] args){\n"
@@ -172,9 +161,6 @@ public class JavadocTestForRecord extends JavadocTest {
 	}
 
 	public void test004() {
-		if (this.complianceLevel < ClassFileConstants.JDK14) {
-			return;
-		}
 		runConformTest(new String[] { "X.java",
 				"		/**  \n" +
 				"		 * @param a\n" +
@@ -190,9 +176,6 @@ public class JavadocTestForRecord extends JavadocTest {
 	}
 
 	public void test005() {
-		if (this.complianceLevel < ClassFileConstants.JDK14) {
-			return;
-		}
 		runNegativeTest(new String[] { "X.java",
 				"		/**  \n" +
 				"		 */  \n" +
@@ -214,9 +197,6 @@ public class JavadocTestForRecord extends JavadocTest {
 	}
 
 	public void test006() {
-		if (this.complianceLevel < ClassFileConstants.JDK14) {
-			return;
-		}
 		runNegativeTest(new String[] { "X.java",
 				"		/**  \n" +
 				"		 * @param a\n" +
@@ -240,9 +220,6 @@ public class JavadocTestForRecord extends JavadocTest {
 	}
 
 	public void test007() {
-		if (this.complianceLevel < ClassFileConstants.JDK14) {
-			return;
-		}
 		runNegativeTest(new String[] { "X.java",
 				"		/**  \n" +
 				"		 * @param a\n" +
@@ -265,10 +242,6 @@ public class JavadocTestForRecord extends JavadocTest {
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 	public void test_bug572367() {
-		if (this.complianceLevel < ClassFileConstants.JDK14) {
-			return;
-		}
-
 		this.reportMissingJavadocCommentsVisibility = CompilerOptions.PRIVATE;
 		runConformTest(new String[] { "X.java",
 				"		/**  \n" +
@@ -284,9 +257,6 @@ public class JavadocTestForRecord extends JavadocTest {
 				"0");
 	}
 	public void testGHIssue4158_1() {
-		if (this.complianceLevel < ClassFileConstants.JDK16) {
-			return;
-		}
 		runNegativeTest(new String[] { "X.java",
 				"""
 					/**
@@ -322,9 +292,6 @@ public class JavadocTestForRecord extends JavadocTest {
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 	public void testGHIssue4158_2() {
-		if (this.complianceLevel < ClassFileConstants.JDK16) {
-			return;
-		}
 		runNegativeTest(new String[] { "X.java",
 					"""
 					/**

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocTestForRecord.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocTestForRecord.java
@@ -138,7 +138,7 @@ public class JavadocTestForRecord extends JavadocTest {
 	}
 
 	public void test001() {
-		if(this.complianceLevel < ClassFileConstants.JDK14) {
+		if (this.complianceLevel < ClassFileConstants.JDK14) {
 			return;
 		}
 		this.runNegativeTest(new String[] { "X.java", "public record X() {\n" + "}\n" },
@@ -148,7 +148,7 @@ public class JavadocTestForRecord extends JavadocTest {
 	}
 
 	public void test002() {
-		if(this.complianceLevel < ClassFileConstants.JDK14) {
+		if (this.complianceLevel < ClassFileConstants.JDK14) {
 			return;
 		}
 		this.runNegativeTest(
@@ -161,7 +161,7 @@ public class JavadocTestForRecord extends JavadocTest {
 	}
 
 	public void test003() {
-		if(this.complianceLevel < ClassFileConstants.JDK14) {
+		if (this.complianceLevel < ClassFileConstants.JDK14) {
 			return;
 		}
 		runConformTest(new String[] { "X.java",
@@ -172,7 +172,7 @@ public class JavadocTestForRecord extends JavadocTest {
 	}
 
 	public void test004() {
-		if(this.complianceLevel < ClassFileConstants.JDK14) {
+		if (this.complianceLevel < ClassFileConstants.JDK14) {
 			return;
 		}
 		runConformTest(new String[] { "X.java",
@@ -190,7 +190,7 @@ public class JavadocTestForRecord extends JavadocTest {
 	}
 
 	public void test005() {
-		if(this.complianceLevel < ClassFileConstants.JDK14) {
+		if (this.complianceLevel < ClassFileConstants.JDK14) {
 			return;
 		}
 		runNegativeTest(new String[] { "X.java",
@@ -214,7 +214,7 @@ public class JavadocTestForRecord extends JavadocTest {
 	}
 
 	public void test006() {
-		if(this.complianceLevel < ClassFileConstants.JDK14) {
+		if (this.complianceLevel < ClassFileConstants.JDK14) {
 			return;
 		}
 		runNegativeTest(new String[] { "X.java",
@@ -240,7 +240,7 @@ public class JavadocTestForRecord extends JavadocTest {
 	}
 
 	public void test007() {
-		if(this.complianceLevel < ClassFileConstants.JDK14) {
+		if (this.complianceLevel < ClassFileConstants.JDK14) {
 			return;
 		}
 		runNegativeTest(new String[] { "X.java",
@@ -265,7 +265,7 @@ public class JavadocTestForRecord extends JavadocTest {
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 	public void test_bug572367() {
-		if(this.complianceLevel < ClassFileConstants.JDK14) {
+		if (this.complianceLevel < ClassFileConstants.JDK14) {
 			return;
 		}
 
@@ -284,7 +284,7 @@ public class JavadocTestForRecord extends JavadocTest {
 				"0");
 	}
 	public void testGHIssue4158_1() {
-		if(this.complianceLevel < ClassFileConstants.JDK14) {
+		if (this.complianceLevel < ClassFileConstants.JDK16) {
 			return;
 		}
 		runNegativeTest(new String[] { "X.java",
@@ -322,7 +322,7 @@ public class JavadocTestForRecord extends JavadocTest {
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
 	public void testGHIssue4158_2() {
-		if(this.complianceLevel < ClassFileConstants.JDK14) {
+		if (this.complianceLevel < ClassFileConstants.JDK16) {
 			return;
 		}
 		runNegativeTest(new String[] { "X.java",

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocTestForRecord.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocTestForRecord.java
@@ -39,8 +39,7 @@ public class JavadocTestForRecord extends JavadocTest {
 	String reportMissingJavadocComments = CompilerOptions.ERROR;
 	String reportMissingJavadocCommentsVisibility = CompilerOptions.PROTECTED;
 
-	@SuppressWarnings("rawtypes")
-	public static Class testClass() {
+	public static Class<JavadocTestForRecord> testClass() {
 		return JavadocTestForRecord.class;
 	}
 
@@ -57,9 +56,8 @@ public class JavadocTestForRecord extends JavadocTest {
 		return buildMinimalComplianceTestSuite(testClass(), F_16);
 	}
 
-	@SuppressWarnings({ "unchecked", "rawtypes" })
-	protected Map getCompilerOptions() {
-		Map options = super.getCompilerOptions();
+	protected Map<String, String> getCompilerOptions() {
+		Map<String, String> options = super.getCompilerOptions();
 		options.put(CompilerOptions.OPTION_DocCommentSupport, this.docCommentSupport);
 		options.put(CompilerOptions.OPTION_ReportInvalidJavadoc, this.reportInvalidJavadoc);
 		if (!CompilerOptions.IGNORE.equals(this.reportInvalidJavadoc)) {
@@ -115,9 +113,8 @@ public class JavadocTestForRecord extends JavadocTest {
 		runConformTest(testFiles, expectedOutput, getCompilerOptions());
 	}
 
-	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@Override
-	protected void runConformTest(String[] testFiles, String expectedOutput, Map customOptions) {
+	protected void runConformTest(String[] testFiles, String expectedOutput, Map<String, String> customOptions) {
 		Runner runner = new Runner();
 		runner.testFiles = testFiles;
 		runner.expectedOutputString = expectedOutput;
@@ -263,7 +260,7 @@ public class JavadocTestForRecord extends JavadocTest {
 				"1. ERROR in X.java (at line 3)\n" +
 				"	* @param b\n" +
 				"	         ^\n" +
-				"Javadoc: Invalid param tag name\n" +
+				"Javadoc: Parameter b is not declared\n" +
 				"----------\n",
 				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
 	}
@@ -286,5 +283,84 @@ public class JavadocTestForRecord extends JavadocTest {
 				"		}" },
 				"0");
 	}
-
+	public void testGHIssue4158_1() {
+		if(this.complianceLevel < ClassFileConstants.JDK14) {
+			return;
+		}
+		runNegativeTest(new String[] { "X.java",
+				"""
+					/**
+					 * @param abc
+					 * @param abc
+					 * @param def
+					 * @param xyz
+					 * @return no return
+					 */
+					public record X(int abc, int def) {}
+					""" },
+				"----------\n" +
+				"1. ERROR in X.java (at line 3)\n" +
+				"	* @param abc\n" +
+				"	         ^^^\n" +
+				"Javadoc: Duplicate tag for parameter\n" +
+				"----------\n" +
+				"2. ERROR in X.java (at line 3)\n" +
+				"	* @param abc\n" +
+				"	         ^^^\n" +
+				"Javadoc: Duplicate tag for parameter\n" +
+				"----------\n" +
+				"3. ERROR in X.java (at line 5)\n" +
+				"	* @param xyz\n" +
+				"	         ^^^\n" +
+				"Javadoc: Parameter xyz is not declared\n" +
+				"----------\n" +
+				"4. ERROR in X.java (at line 6)\n" +
+				"	* @return no return\n" +
+				"	   ^^^^^^\n" +
+				"Javadoc: Unexpected tag\n" +
+				"----------\n",
+				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
+	}
+	public void testGHIssue4158_2() {
+		if(this.complianceLevel < ClassFileConstants.JDK14) {
+			return;
+		}
+		runNegativeTest(new String[] { "X.java",
+					"""
+					/**
+					 * @param <T> a type param
+					 * @param <S> a type param
+					 * @param abc first
+					 * Javadoc with missing param tags
+					 */
+					public record X<U, V>(int abc, int def) {}
+					""" },
+				"----------\n" +
+				"1. ERROR in X.java (at line 2)\n" +
+				"	* @param <T> a type param\n" +
+				"	          ^\n" +
+				"Javadoc: T cannot be resolved to a type\n" +
+				"----------\n" +
+				"2. ERROR in X.java (at line 3)\n" +
+				"	* @param <S> a type param\n" +
+				"	          ^\n" +
+				"Javadoc: S cannot be resolved to a type\n" +
+				"----------\n" +
+				"3. ERROR in X.java (at line 7)\n" +
+				"	public record X<U, V>(int abc, int def) {}\n" +
+				"	                ^\n" +
+				"Javadoc: Missing tag for parameter U\n" +
+				"----------\n" +
+				"4. ERROR in X.java (at line 7)\n" +
+				"	public record X<U, V>(int abc, int def) {}\n" +
+				"	                   ^\n" +
+				"Javadoc: Missing tag for parameter V\n" +
+				"----------\n" +
+				"5. ERROR in X.java (at line 7)\n" +
+				"	public record X<U, V>(int abc, int def) {}\n" +
+				"	                                   ^^^\n" +
+				"Javadoc: Missing tag for parameter def\n" +
+				"----------\n",
+				JavacTestOptions.Excuse.EclipseWarningConfiguredAsError);
+	}
 }

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests16_2.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests16_2.java
@@ -652,7 +652,7 @@ public class CompletionTests16_2 extends AbstractJavaModelCompletionTests {
 				 * A foo bar.
 				 * @param foo The foo.
 				 * @param bar the bar 1
-				 * @param ba
+				 * @param bar
 				 */
 				public record FooBar(String foo, String bar, String bar2, String bar3) {}
 			""");
@@ -660,7 +660,7 @@ public class CompletionTests16_2 extends AbstractJavaModelCompletionTests {
 		requestor.allowAllRequiredProposals();
 		NullProgressMonitor monitor = new NullProgressMonitor();
 		String str = this.workingCopies[0].getSource();
-		String completeBehind = "@param b";
+		String completeBehind = "@param bar";
 		int cursorLocation = str.lastIndexOf(completeBehind) + completeBehind.length();
 		this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner, monitor);
 

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests16_2.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests16_2.java
@@ -674,11 +674,38 @@ public class CompletionTests16_2 extends AbstractJavaModelCompletionTests {
 		this.workingCopies[0] = getWorkingCopy(
 			"/Completion/src/test/FooBar.java",
 			"""
+				package test;
+				/**
+				 * A foo bar.
+				 * @param foo The foo.
+				 * @param bar
+				 */
+				public record FooBar(String foo, String bar, String bar2, String bar3) {}
+			""");
+		CompletionTestsRequestor2 requestor = new CompletionTestsRequestor2(true, false, false, true, true);
+		requestor.allowAllRequiredProposals();
+		NullProgressMonitor monitor = new NullProgressMonitor();
+		String str = this.workingCopies[0].getSource();
+		String completeBehind = "@param bar";
+		int cursorLocation = str.lastIndexOf(completeBehind) + completeBehind.length();
+		this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner, monitor);
+
+		assertResults(
+				"bar3[JAVADOC_PARAM_REF]{bar3, null, null, bar3, null, 43}\n"
+				+ "bar2[JAVADOC_PARAM_REF]{bar2, null, null, bar2, null, 44}\n"
+				+ "bar[JAVADOC_PARAM_REF]{bar, null, null, bar, null, 45}",
+				requestor.getResults());
+	}
+	public void testGHIssue4158_3() throws JavaModelException {
+		this.workingCopies = new ICompilationUnit[2];
+		this.workingCopies[0] = getWorkingCopy(
+			"/Completion/src/test/FooBar.java",
+			"""
 				/**
 				 *
 				 * @param <X
 				 */
-				public record X<XYZ>(int abc, int XYZ) {
+				public record X<XTZ>(int abc, int XPZ) {
 				}
 			""");
 		CompletionTestsRequestor2 requestor = new CompletionTestsRequestor2(true, false, false, true, true);
@@ -690,10 +717,10 @@ public class CompletionTests16_2 extends AbstractJavaModelCompletionTests {
 		this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner, monitor);
 
 		assertResults(
-				"XYZ[JAVADOC_PARAM_REF]{<XYZ>, null, null, XYZ, null, 38}",
+				"XTZ[JAVADOC_PARAM_REF]{<XTZ>, null, null, XTZ, null, 38}",
 				requestor.getResults());
 	}
-	public void testGHIssue4158_3() throws JavaModelException {
+	public void testGHIssue4158_4() throws JavaModelException {
 		this.workingCopies = new ICompilationUnit[2];
 		this.workingCopies[0] = getWorkingCopy(
 			"/Completion/src/test/FooBar.java",
@@ -702,7 +729,7 @@ public class CompletionTests16_2 extends AbstractJavaModelCompletionTests {
 				 *
 				 * @param X
 				 */
-				public record X<XYZ>(int abc, int XYZ) {
+				public record X<XTZ>(int abc, int XPZ) {
 				}
 			""");
 		CompletionTestsRequestor2 requestor = new CompletionTestsRequestor2(true, false, false, true, true);
@@ -714,7 +741,7 @@ public class CompletionTests16_2 extends AbstractJavaModelCompletionTests {
 		this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner, monitor);
 
 		assertResults(
-				"XYZ[JAVADOC_PARAM_REF]{XYZ, null, null, XYZ, null, 44}",
+				"XPZ[JAVADOC_PARAM_REF]{XPZ, null, null, XPZ, null, 44}",
 				requestor.getResults());
 	}
 }

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests16_2.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests16_2.java
@@ -642,4 +642,79 @@ public class CompletionTests16_2 extends AbstractJavaModelCompletionTests {
 				+ "wait[METHOD_REF]{wait(), Ljava.lang.Object;, (JI)V, wait, (millis, nanos), 60}",
 				requestor.getResults());
 	}
+	public void testGHIssue4158_1() throws JavaModelException {
+		this.workingCopies = new ICompilationUnit[2];
+		this.workingCopies[0] = getWorkingCopy(
+			"/Completion/src/test/FooBar.java",
+			"""
+				package test;
+				/**
+				 * A foo bar.
+				 * @param foo The foo.
+				 * @param bar the bar 1
+				 * @param ba
+				 */
+				public record FooBar(String foo, String bar, String bar2, String bar3) {}
+			""");
+		CompletionTestsRequestor2 requestor = new CompletionTestsRequestor2(true, false, false, true, true);
+		requestor.allowAllRequiredProposals();
+		NullProgressMonitor monitor = new NullProgressMonitor();
+		String str = this.workingCopies[0].getSource();
+		String completeBehind = "@param b";
+		int cursorLocation = str.lastIndexOf(completeBehind) + completeBehind.length();
+		this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner, monitor);
+
+		assertResults(
+				"bar3[JAVADOC_PARAM_REF]{bar3, null, null, bar3, null, 43}\n"
+				+ "bar2[JAVADOC_PARAM_REF]{bar2, null, null, bar2, null, 44}",
+				requestor.getResults());
+	}
+	public void testGHIssue4158_2() throws JavaModelException {
+		this.workingCopies = new ICompilationUnit[2];
+		this.workingCopies[0] = getWorkingCopy(
+			"/Completion/src/test/FooBar.java",
+			"""
+				/**
+				 *
+				 * @param <X
+				 */
+				public record X<XYZ>(int abc, int XYZ) {
+				}
+			""");
+		CompletionTestsRequestor2 requestor = new CompletionTestsRequestor2(true, false, false, true, true);
+		requestor.allowAllRequiredProposals();
+		NullProgressMonitor monitor = new NullProgressMonitor();
+		String str = this.workingCopies[0].getSource();
+		String completeBehind = "@param <X";
+		int cursorLocation = str.lastIndexOf(completeBehind) + completeBehind.length();
+		this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner, monitor);
+
+		assertResults(
+				"XYZ[JAVADOC_PARAM_REF]{<XYZ>, null, null, XYZ, null, 38}",
+				requestor.getResults());
+	}
+	public void testGHIssue4158_3() throws JavaModelException {
+		this.workingCopies = new ICompilationUnit[2];
+		this.workingCopies[0] = getWorkingCopy(
+			"/Completion/src/test/FooBar.java",
+			"""
+				/**
+				 *
+				 * @param X
+				 */
+				public record X<XYZ>(int abc, int XYZ) {
+				}
+			""");
+		CompletionTestsRequestor2 requestor = new CompletionTestsRequestor2(true, false, false, true, true);
+		requestor.allowAllRequiredProposals();
+		NullProgressMonitor monitor = new NullProgressMonitor();
+		String str = this.workingCopies[0].getSource();
+		String completeBehind = "@param X";
+		int cursorLocation = str.lastIndexOf(completeBehind) + completeBehind.length();
+		this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner, monitor);
+
+		assertResults(
+				"XYZ[JAVADOC_PARAM_REF]{XYZ, null, null, XYZ, null, 44}",
+				requestor.getResults());
+	}
 }

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionJavadoc.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionJavadoc.java
@@ -19,6 +19,7 @@ import org.eclipse.jdt.internal.compiler.ast.Expression;
 import org.eclipse.jdt.internal.compiler.ast.Javadoc;
 import org.eclipse.jdt.internal.compiler.ast.JavadocSingleNameReference;
 import org.eclipse.jdt.internal.compiler.ast.JavadocSingleTypeReference;
+import org.eclipse.jdt.internal.compiler.ast.RecordComponent;
 import org.eclipse.jdt.internal.compiler.ast.TypeDeclaration;
 import org.eclipse.jdt.internal.compiler.ast.TypeParameter;
 import org.eclipse.jdt.internal.compiler.ast.TypeReference;
@@ -29,6 +30,7 @@ import org.eclipse.jdt.internal.compiler.lookup.MethodScope;
 import org.eclipse.jdt.internal.compiler.lookup.Scope;
 import org.eclipse.jdt.internal.compiler.lookup.TypeBinding;
 import org.eclipse.jdt.internal.compiler.lookup.TypeVariableBinding;
+import org.eclipse.jdt.internal.compiler.lookup.VariableBinding;
 
 /**
  * Node representing a Javadoc comment including code selection.
@@ -77,6 +79,8 @@ public class CompletionJavadoc extends Javadoc {
 					CompletionOnJavadocParamNameReference paramNameReference = (CompletionOnJavadocParamNameReference) this.completionNode;
 					if (scope.kind == Scope.METHOD_SCOPE) {
 						paramNameReference.missingParams = missingParamTags(paramNameReference.binding, (MethodScope)scope);
+					} else if (scope.kind == Scope.CLASS_SCOPE) {
+						paramNameReference.missingParams = missingRecordComponentNames(paramNameReference.binding, (ClassScope)scope);
 					}
 					if (paramNameReference.token == null || paramNameReference.token.length == 0) {
 						paramNameReference.missingTypeParams = missingTypeParameterTags(paramNameReference.binding, scope);
@@ -196,6 +200,58 @@ public class CompletionJavadoc extends Javadoc {
 		internalResolve(scope);
 	}
 
+	/*
+	 * Look for missing record component @param tags
+	 */
+	private char[][] missingRecordComponentNames(Binding paramNameRefBinding, ClassScope scope) {
+		TypeDeclaration type = scope.referenceContext;
+		if (type == null || !type.isRecord()) {
+			return null;
+		}
+		// Verify if there's some possible param tag
+		RecordComponent[] components = type.recordComponents;
+		int componentSize = components == null ? 0 : components.length;
+		if (componentSize == 0) return null;
+		int paramTagsSize = this.paramReferences == null ? 0 : this.paramReferences.length;
+
+		char[][] missingComponents = new char[componentSize][];
+		if (paramTagsSize == 0) {
+			for (int i = 0; i < componentSize; i++) {
+				missingComponents[i] = components[i].name;
+			}
+			return missingComponents;
+		}
+
+		missingComponents = new char[componentSize][];
+		int size = 0;
+		for (int i = 0; i < componentSize; i++) {
+			RecordComponent arg = components[i];
+			boolean found = false;
+			int paramNameRefCount = 0;
+			for (int j = 0; j < paramTagsSize && !found; j++) {
+				JavadocSingleNameReference param = this.paramReferences[j];
+				VariableBinding field = type.binding.getField(arg.name, false);
+				if (field == param.binding) {
+					if (param.binding == paramNameRefBinding) { // do not count first occurrence of component name reference
+						paramNameRefCount++;
+						found = paramNameRefCount > 1;
+					} else {
+						found = true;
+					}
+				}
+			}
+			if (!found) {
+				missingComponents[size++] = arg.name;
+			}
+		}
+		if (size > 0) {
+			if (size != componentSize) {
+				System.arraycopy(missingComponents, 0, missingComponents = new char[size][], 0, size);
+			}
+			return missingComponents;
+		}
+		return null;
+	}
 	/*
 	 * Look for missing method @param tags
 	 */

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionJavadoc.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionJavadoc.java
@@ -68,7 +68,12 @@ public class CompletionJavadoc extends Javadoc {
 				if (resolve) {
 					switch (scope.kind) {
 						case Scope.CLASS_SCOPE:
-							this.completionNode.resolveType((ClassScope)scope);
+							if (scope.referenceContext() instanceof TypeDeclaration type && type.isRecord()) {
+								this.completionNode.resolveType(type.initializerScope);
+							}
+							else {
+								this.completionNode.resolveType((ClassScope)scope);
+							}
 							break;
 						case Scope.METHOD_SCOPE:
 							this.completionNode.resolveType((MethodScope) scope);


### PR DESCRIPTION
Add missing resolution and completion code for records inside Javadoc

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
Fixes #4158

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
