### PR TITLE
Set unitName when resolving DOM

### DIFF
--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/SourceIndexer.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/SourceIndexer.java
@@ -203,6 +203,7 @@ public class SourceIndexer extends AbstractIndexer implements ITypeRequestor, Su
 		try {
 			ASTParser astParser = ASTParser.newParser(AST.getJLSLatest()); // we don't seek exact compilation the more tolerant the better here
 			astParser.setSource(unit); // configure projects and so on
+			astParser.setUnitName(unit.getElementName());
 			astParser.setSource(reducedDOM.toCharArray()); // trimmed contents
 			astParser.setStatementsRecovery(true);
 			astParser.setResolveBindings(true);


### PR DESCRIPTION
otherwise document doesn't get resolved and index is not populated with lambda or method references

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does

Make SourceIndexer.resolveDocument() actually resolve bindings

## How to test

Setting `-DSourceIndexer.DOM_BASED_INDEXER=true`, ensure that an index entry is created for a lambda.
Without this patch, the lambda or method reference is ignored

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
