### PR TITLE
[formatter] Fixed infinite loop on wrapping method header with linebreak forced by comment (#4122)

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/formatter/FormatterBugsTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/formatter/FormatterBugsTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -13391,5 +13391,21 @@ public void testIssue1624() {
 			}
 		}
 		""");
+}
+/**
+ * https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4122
+ * Formatting a java class causes a infinite loop
+ */
+public void testIssue4122() {
+	this.formatterPrefs.alignment_for_method_declaration = Alignment.M_COMPACT_SPLIT;
+	String source =
+		"""
+		class A {
+			private void //
+					method() {
+			}
+		}
+		""";
+	formatSource(source);
 }
 }

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/linewrap/WrapPreparator.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/linewrap/WrapPreparator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2024 Mateusz Matela and others.
+ * Copyright (c) 2014, 2025 Mateusz Matela and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -330,9 +330,6 @@ public class WrapPreparator extends ASTVisitor {
 		}
 
 		if (!node.isConstructor()) {
-			this.wrapParentIndex = this.tm.findFirstTokenInLine(this.tm.firstIndexIn(node.getName(), TokenNameInvalid));
-			while (this.tm.get(this.wrapParentIndex).isComment())
-				this.wrapParentIndex++;
 			List<TypeParameter> typeParameters = node.typeParameters();
 			if (!typeParameters.isEmpty())
 				this.wrapIndexes.add(this.tm.firstIndexIn(typeParameters.get(0), TokenNameInvalid));
@@ -343,6 +340,11 @@ public class WrapPreparator extends ASTVisitor {
 			}
 			this.wrapIndexes.add(this.tm.firstIndexIn(node.getName(), TokenNameInvalid));
 			this.wrapGroupEnd = this.tm.lastIndexIn(node.getName(), TokenNameInvalid);
+			this.wrapParentIndex = this.tm.findFirstTokenInLine(this.wrapIndexes.get(0));
+			while (this.tm.get(this.wrapParentIndex).isComment())
+				this.wrapParentIndex++;
+			if (this.wrapParentIndex == this.wrapIndexes.get(0))
+				this.wrapIndexes.remove(0);
 			handleWrap(this.options.alignment_for_method_declaration);
 		}
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes issue #4122

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Junit test included

## Author checklist

- [/] I have thoroughly tested my changes
- [/] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [/] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
