### PR TITLE
[formatter] Introduced constant to look for ANY token type instead of TokenNameInvalid

### DIFF
--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/CommentsPreparator.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/CommentsPreparator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2023 Mateusz Matela and others.
+ * Copyright (c) 2014, 2025 Mateusz Matela and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -17,7 +17,16 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.formatter;
 
-import static org.eclipse.jdt.internal.compiler.parser.TerminalToken.*;
+import static org.eclipse.jdt.internal.compiler.parser.TerminalToken.TokenNameCOMMENT_BLOCK;
+import static org.eclipse.jdt.internal.compiler.parser.TerminalToken.TokenNameCOMMENT_JAVADOC;
+import static org.eclipse.jdt.internal.compiler.parser.TerminalToken.TokenNameCOMMENT_LINE;
+import static org.eclipse.jdt.internal.compiler.parser.TerminalToken.TokenNameCOMMENT_MARKDOWN;
+import static org.eclipse.jdt.internal.compiler.parser.TerminalToken.TokenNameNotAToken;
+import static org.eclipse.jdt.internal.compiler.parser.TerminalToken.TokenNameStringLiteral;
+import static org.eclipse.jdt.internal.compiler.parser.TerminalToken.TokenNameTextBlock;
+import static org.eclipse.jdt.internal.compiler.parser.TerminalToken.TokenNameWHITESPACE;
+import static org.eclipse.jdt.internal.compiler.parser.TerminalToken.TokenNamepackage;
+import static org.eclipse.jdt.internal.formatter.TokenManager.ANY;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -637,7 +646,7 @@ public class CommentsPreparator extends ASTVisitor {
 
 		} else if (node.isNested() && (IMMUTABLE_TAGS.contains(tagName) || TagElement.TAG_SNIPPET.equals(tagName))) {
 			int endPos = node.getStartPosition() + node.getLength() - 1;
-			int endIndex = this.ctm.findIndex(endPos, TokenNameInvalid, false);
+			int endIndex = this.ctm.findIndex(endPos, ANY, false);
 			if (this.ctm.get(endIndex).originalEnd > endPos)
 				endIndex = tokenEndingAt(endPos);
 			if (TagElement.TAG_SNIPPET.equals(tagName)) {
@@ -822,7 +831,7 @@ public class CommentsPreparator extends ASTVisitor {
 			}
 			if (this.options.comment_format_html) {
 				if (TagElement.TAG_PARAM.equals(node.getTagName())
-						&& this.ctm.findIndex(startPos, TokenNameInvalid, false) == 1 + this.ctm.firstIndexIn(node, TokenNameInvalid)) {
+						&& this.ctm.findIndex(startPos, ANY, false) == 1 + this.ctm.firstIndexIn(node, ANY)) {
 					continue; // it's a generic class parameter name, not an HTML tag
 				}
 
@@ -896,9 +905,9 @@ public class CommentsPreparator extends ASTVisitor {
 		if (matcher.start(group) == matcher.end(group))
 			return;
 		int startPosition = textStartPosition + matcher.start(group);
-		int startIndex = this.ctm.findIndex(startPosition, TokenNameInvalid, false);
+		int startIndex = this.ctm.findIndex(startPosition, ANY, false);
 		int endPosition = textStartPosition + matcher.end(group) - 1;
-		int endIndex = this.ctm.findIndex(endPosition, TokenNameInvalid, false);
+		int endIndex = this.ctm.findIndex(endPosition, ANY, false);
 		if (startIndex != endIndex) {
 			startIndex = tokenStartingAt(startPosition);
 			endIndex = tokenEndingAt(endPosition);
@@ -1045,7 +1054,7 @@ public class CommentsPreparator extends ASTVisitor {
 				disableFormattingExclusively(this.formatCodeOpenTagEndIndex, startIndex);
 			}
 			this.formatCodeOpenTagEndIndex = -1;
-			this.lastFormatCodeClosingTagIndex = this.ctm.findIndex(startPos, TokenNameInvalid, true);
+			this.lastFormatCodeClosingTagIndex = this.ctm.findIndex(startPos, ANY, true);
 		}
 //		if (!isOpeningTag) {
 //			if (this.options.comment_javadoc_do_not_separate_block_tags) {
@@ -1077,7 +1086,7 @@ public class CommentsPreparator extends ASTVisitor {
 
 		List<ASTNode> fragments = node.fragments();
 		if (isInline && !fragments.isEmpty()) {
-			int openingIndex = this.ctm.firstIndexBefore(fragments.get(0), TokenNameInvalid);
+			int openingIndex = this.ctm.firstIndexBefore(fragments.get(0), ANY);
 			int closingIndex = tokenStartingAt(endToken.originalEnd);
 			this.ctm.get(closingIndex).breakBefore();
 			boolean formatted = (lang == null || lang.matches("['\"]?java['\"]?")) //$NON-NLS-1$
@@ -1160,7 +1169,7 @@ public class CommentsPreparator extends ASTVisitor {
 	}
 
 	private int tokenStartingAt(int start) {
-		int tokenIndex = this.ctm.findIndex(start, TokenNameInvalid, false);
+		int tokenIndex = this.ctm.findIndex(start, ANY, false);
 		Token token = this.ctm.get(tokenIndex);
 		if (token.originalStart == start)
 			return tokenIndex;
@@ -1171,7 +1180,7 @@ public class CommentsPreparator extends ASTVisitor {
 	}
 
 	private int tokenEndingAt(int end) {
-		int tokenIndex = this.ctm.findIndex(end, TokenNameInvalid, true);
+		int tokenIndex = this.ctm.findIndex(end, ANY, true);
 		Token token = this.ctm.get(tokenIndex);
 		if (token.originalEnd == end)
 			return tokenIndex;

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/DefaultCodeFormatter.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/DefaultCodeFormatter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -24,8 +24,8 @@ import static org.eclipse.jdt.internal.compiler.parser.TerminalToken.TokenNameCO
 import static org.eclipse.jdt.internal.compiler.parser.TerminalToken.TokenNameCOMMENT_JAVADOC;
 import static org.eclipse.jdt.internal.compiler.parser.TerminalToken.TokenNameCOMMENT_LINE;
 import static org.eclipse.jdt.internal.compiler.parser.TerminalToken.TokenNameEOF;
-import static org.eclipse.jdt.internal.compiler.parser.TerminalToken.TokenNameInvalid;
 import static org.eclipse.jdt.internal.compiler.parser.TerminalToken.TokenNameNotAToken;
+import static org.eclipse.jdt.internal.formatter.TokenManager.ANY;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -240,7 +240,7 @@ public class DefaultCodeFormatter extends CodeFormatter {
 					: unit.getModule() != null ? unit.getModule()
 					: unit.getPackage();
 			if (firstElement != null) {
-				int headerEndIndex = this.tokenManager.firstIndexIn(firstElement, TokenNameInvalid);
+				int headerEndIndex = this.tokenManager.firstIndexIn(firstElement, ANY);
 				this.tokenManager.setHeaderEndIndex(headerEndIndex);
 			}
 		}

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/LineBreaksPreparator.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/LineBreaksPreparator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2022 Mateusz Matela and others.
+ * Copyright (c) 2014, 2025 Mateusz Matela and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -17,6 +17,7 @@
 package org.eclipse.jdt.internal.formatter;
 
 import static org.eclipse.jdt.internal.compiler.parser.TerminalToken.*;
+import static org.eclipse.jdt.internal.formatter.TokenManager.ANY;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -44,12 +45,12 @@ public class LineBreaksPreparator extends ASTVisitor {
 	@Override
 	public boolean visit(CompilationUnit node) {
 		List<ImportDeclaration> imports = node.imports();
-		if (!imports.isEmpty() && this.tm.firstIndexIn(imports.get(0), TokenNameInvalid) > 0)
+		if (!imports.isEmpty() && this.tm.firstIndexIn(imports.get(0), ANY) > 0)
 			putBlankLinesBefore(imports.get(0), this.options.blank_lines_before_imports);
 
 		for (int i = 1; i < imports.size(); i++) {
-			int from = this.tm.lastIndexIn(imports.get(i - 1), TokenNameInvalid);
-			int to = this.tm.firstIndexIn(imports.get(i), TokenNameInvalid);
+			int from = this.tm.lastIndexIn(imports.get(i - 1), ANY);
+			int to = this.tm.firstIndexIn(imports.get(i), ANY);
 			for (int j = from; j < to; j++) {
 				Token token1 = this.tm.get(j);
 				Token token2 = this.tm.get(j + 1);
@@ -73,11 +74,11 @@ public class LineBreaksPreparator extends ASTVisitor {
 		if (node.getJavadoc() == null) {
 			putBlankLinesBefore(node, this.options.blank_lines_before_package);
 		} else {
-			putBlankLinesAfter(this.tm.lastTokenIn(node.getJavadoc(), TokenNameInvalid), this.options.blank_lines_before_package);
+			putBlankLinesAfter(this.tm.lastTokenIn(node.getJavadoc(), ANY), this.options.blank_lines_before_package);
 		}
 
 		handleAnnotations(node.annotations(), this.options.insert_new_line_after_annotation_on_package);
-		putBlankLinesAfter(this.tm.lastTokenIn(node, TokenNameInvalid), this.options.blank_lines_after_package);
+		putBlankLinesAfter(this.tm.lastTokenIn(node, ANY), this.options.blank_lines_after_package);
 		return true;
 	}
 
@@ -127,7 +128,7 @@ public class LineBreaksPreparator extends ASTVisitor {
 		if (previous != null) {
 			ASTNode parent = previous.getParent();
 			if (!(parent instanceof TypeDeclaration && this.tm.isFake((TypeDeclaration) parent) || parent instanceof ImplicitTypeDeclaration)) {
-				Token lastToken = this.tm.lastTokenIn(parent, TokenNameInvalid);
+				Token lastToken = this.tm.lastTokenIn(parent, ANY);
 				putBlankLinesBefore(lastToken, this.options.blank_lines_after_last_class_body_declaration);
 			}
 		}
@@ -170,7 +171,7 @@ public class LineBreaksPreparator extends ASTVisitor {
 
 		// put breaks after semicolons
 		int index = enumConstants.isEmpty() ? this.tm.firstIndexAfter(node.getName(), TokenNameLBRACE) + 1
-				: this.tm.firstIndexAfter(enumConstants.get(enumConstants.size() - 1), TokenNameInvalid);
+				: this.tm.firstIndexAfter(enumConstants.get(enumConstants.size() - 1), ANY);
 		for (;; index++) {
 			Token token = this.tm.get(index);
 			if (token.isComment())
@@ -281,7 +282,7 @@ public class LineBreaksPreparator extends ASTVisitor {
 			if (blockIndex + 1 < siblings.size() && siblings.get(blockIndex + 1) instanceof EmptyStatement)
 				return;
 		}
-		putBlankLinesAfter(this.tm.lastTokenIn(blockStatement, TokenNameInvalid), this.options.blank_lines_after_code_block);
+		putBlankLinesAfter(this.tm.lastTokenIn(blockStatement, ANY), this.options.blank_lines_after_code_block);
 	}
 
 	@Override
@@ -319,18 +320,18 @@ public class LineBreaksPreparator extends ASTVisitor {
 			for (Statement statement : statements) {
 				boolean isBreaking = isSwitchBreakingStatement(statement);
 				if (isBreaking && !(statement instanceof Block))
-					adjustEmptyLineAfter(this.tm.lastIndexIn(statement, TokenNameInvalid), -1);
+					adjustEmptyLineAfter(this.tm.lastIndexIn(statement, ANY), -1);
 				if (statement instanceof SwitchCase) {
 					if (nonBreakStatementEnd >= 0) {
 						// indent only comments between previous and current statement
 						this.tm.get(nonBreakStatementEnd + 1).indent();
-						this.tm.firstTokenIn(statement, TokenNameInvalid).unindent();
+						this.tm.firstTokenIn(statement, ANY).unindent();
 					}
 				} else if (!(statement instanceof BreakStatement || statement instanceof YieldStatement
 						|| statement instanceof Block)) {
 					indent(statement);
 				}
-				nonBreakStatementEnd = isBreaking ? -1 : this.tm.lastIndexIn(statement, TokenNameInvalid);
+				nonBreakStatementEnd = isBreaking ? -1 : this.tm.lastIndexIn(statement, ANY);
 			}
 			if (nonBreakStatementEnd >= 0) {
 				// indent comments between last statement and closing brace
@@ -472,7 +473,7 @@ public class LineBreaksPreparator extends ASTVisitor {
 			last = (Annotation) modifiers.get(i);
 		}
 		if (last != null && breakAfter) {
-			this.tm.lastTokenIn(last, TokenNameInvalid).breakAfter();
+			this.tm.lastTokenIn(last, ANY).breakAfter();
 		}
 
 		if (i < modifiers.size()) {
@@ -510,7 +511,7 @@ public class LineBreaksPreparator extends ASTVisitor {
 				&& !(body.getParent() instanceof IfStatement))
 			return;
 		breakLineBefore(body);
-		adjustEmptyLineAfter(this.tm.lastIndexIn(body, TokenNameInvalid), -1);
+		adjustEmptyLineAfter(this.tm.lastIndexIn(body, ANY), -1);
 		indent(body);
 	}
 
@@ -624,11 +625,11 @@ public class LineBreaksPreparator extends ASTVisitor {
 	}
 
 	private void breakLineBefore(ASTNode node) {
-		this.tm.firstTokenIn(node, TokenNameInvalid).breakBefore();
+		this.tm.firstTokenIn(node, ANY).breakBefore();
 	}
 
 	private void putBlankLinesBefore(ASTNode node, int linesCount) {
-		int index = this.tm.firstIndexIn(node, TokenNameInvalid);
+		int index = this.tm.firstIndexIn(node, ANY);
 		while (index > 0 && this.tm.get(index - 1).tokenType == TokenNameCOMMENT_JAVADOC)
 			index--;
 		putBlankLinesBefore(this.tm.get(index), linesCount);
@@ -701,11 +702,11 @@ public class LineBreaksPreparator extends ASTVisitor {
 	}
 
 	private void indent(ASTNode node) {
-		int startIndex = this.tm.firstIndexIn(node, TokenNameInvalid);
+		int startIndex = this.tm.firstIndexIn(node, ANY);
 		while (startIndex > 0 && this.tm.get(startIndex - 1).isComment())
 			startIndex--;
 		this.tm.get(startIndex).indent();
-		int lastIndex = this.tm.lastIndexIn(node, TokenNameInvalid);
+		int lastIndex = this.tm.lastIndexIn(node, ANY);
 		if (lastIndex + 1 < this.tm.size())
 			this.tm.get(lastIndex + 1).unindent();
 	}

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/OneLineEnforcer.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/OneLineEnforcer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2022 Mateusz Matela and others.
+ * Copyright (c) 2018, 2025 Mateusz Matela and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -14,10 +14,10 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.formatter;
 
-import static org.eclipse.jdt.internal.compiler.parser.TerminalToken.TokenNameInvalid;
 import static org.eclipse.jdt.internal.compiler.parser.TerminalToken.TokenNameLBRACE;
 import static org.eclipse.jdt.internal.compiler.parser.TerminalToken.TokenNameRBRACE;
 import static org.eclipse.jdt.internal.compiler.parser.TerminalToken.TokenNamewhile;
+import static org.eclipse.jdt.internal.formatter.TokenManager.ANY;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -145,7 +145,7 @@ public class OneLineEnforcer extends ASTVisitor {
 			int openBraceIndex = this.tm.firstIndexIn(node, TokenNameLBRACE);
 			int closeBraceIndex = this.tm.lastIndexIn(node, TokenNameRBRACE);
 			Token whileToken = this.tm.firstTokenAfter(node, TokenNamewhile);
-			int lastIndex = whileToken.getLineBreaksBefore() == 0 ? this.tm.lastIndexIn(parent, TokenNameInvalid) : closeBraceIndex;
+			int lastIndex = whileToken.getLineBreaksBefore() == 0 ? this.tm.lastIndexIn(parent, ANY) : closeBraceIndex;
 			tryKeepOnOneLine(openBraceIndex, closeBraceIndex, lastIndex, statements, oneLineOption);
 			return;
 		} else if (isSwitchCaseWithArrow(node)) {
@@ -193,7 +193,7 @@ public class OneLineEnforcer extends ASTVisitor {
 				&& this.tm.countLineBreaksBetween(this.tm.get(openBraceIndex), this.tm.get(lastIndex)) > 0)
 			return;
 
-		Set<Integer> breakIndexes = items.stream().map(n -> this.tm.firstIndexIn(n, TokenNameInvalid)).collect(Collectors.toSet());
+		Set<Integer> breakIndexes = items.stream().map(n -> this.tm.firstIndexIn(n, ANY)).collect(Collectors.toSet());
 		breakIndexes.add(openBraceIndex + 1);
 		breakIndexes.add(closeBraceIndex);
 		Token prev = this.tm.get(openBraceIndex);

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/SpacePreparator.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/SpacePreparator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2022 Mateusz Matela and others.
+ * Copyright (c) 2014, 2025 Mateusz Matela and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -16,6 +16,7 @@
 package org.eclipse.jdt.internal.formatter;
 
 import static org.eclipse.jdt.internal.compiler.parser.TerminalToken.*;
+import static org.eclipse.jdt.internal.formatter.TokenManager.ANY;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -144,8 +145,8 @@ public class SpacePreparator extends ASTVisitor {
 			// look for empty parenthesis, may not be there
 			int from = this.tm.firstIndexIn(node.getName(), TokenNameIdentifier) + 1;
 			AnonymousClassDeclaration classDeclaration = node.getAnonymousClassDeclaration();
-			int to = classDeclaration != null ? this.tm.firstIndexBefore(classDeclaration, TokenNameInvalid)
-					: this.tm.lastIndexIn(node, TokenNameInvalid);
+			int to = classDeclaration != null ? this.tm.firstIndexBefore(classDeclaration, ANY)
+					: this.tm.lastIndexIn(node, ANY);
 			for (int i = from; i <= to; i++) {
 				if (this.tm.get(i).tokenType == TokenNameLPAREN) {
 					openingParen = this.tm.get(i);
@@ -260,7 +261,7 @@ public class SpacePreparator extends ASTVisitor {
 			this.tm.firstTokenIn(node.getBody(), TokenNameLBRACE).spaceBefore();
 
 		if (node.getReceiverType() != null)
-			this.tm.lastTokenIn(node.getReceiverType(), TokenNameInvalid).spaceAfter();
+			this.tm.lastTokenIn(node.getReceiverType(), ANY).spaceAfter();
 
 		List<Type> thrownExceptionTypes = node.thrownExceptionTypes();
 		if (!thrownExceptionTypes.isEmpty()) {
@@ -335,7 +336,7 @@ public class SpacePreparator extends ASTVisitor {
 			List<Annotation> varargsAnnotations = node.varargsAnnotations();
 			if (!varargsAnnotations.isEmpty()) {
 				this.tm.firstTokenIn(varargsAnnotations.get(0), TokenNameAT).spaceBefore();
-				this.tm.lastTokenIn(varargsAnnotations.get(varargsAnnotations.size() - 1), TokenNameInvalid).clearSpaceAfter();
+				this.tm.lastTokenIn(varargsAnnotations.get(varargsAnnotations.size() - 1), ANY).clearSpaceAfter();
 			}
 		} else {
 			handleToken(node.getName(), TokenNameIdentifier, true, false);
@@ -403,7 +404,7 @@ public class SpacePreparator extends ASTVisitor {
 	@Override
 	public boolean visit(YieldStatement node) {
 		if (node.getExpression() != null && !node.isImplicit()) {
-			this.tm.firstTokenIn(node, TokenNameInvalid).spaceAfter();
+			this.tm.firstTokenIn(node, ANY).spaceAfter();
 		}
 		return true;
 	}
@@ -453,7 +454,7 @@ public class SpacePreparator extends ASTVisitor {
 						this.options.insert_space_after_semicolon_in_try_resources);
 			}
 			// there can be a semicolon after the last resource
-			int index = this.tm.firstIndexAfter(resources.get(resources.size() - 1), TokenNameInvalid);
+			int index = this.tm.firstIndexAfter(resources.get(resources.size() - 1), ANY);
 			while (index < this.tm.size()) {
 				Token token = this.tm.get(index++);
 				if (token.tokenType == TokenNameSEMICOLON) {
@@ -577,7 +578,7 @@ public class SpacePreparator extends ASTVisitor {
 						&& ((AnnotationTypeMemberDeclaration) parent).getDefault() == node)
 				|| parent instanceof ArrayInitializer;
 		if (!skipSpaceAfter)
-			this.tm.lastTokenIn(node, TokenNameInvalid).spaceAfter();
+			this.tm.lastTokenIn(node, ANY).spaceAfter();
 	}
 
 	@Override
@@ -669,7 +670,7 @@ public class SpacePreparator extends ASTVisitor {
 			handleCommas(node.fragments(), this.options.insert_space_before_comma_in_multiple_local_declarations,
 					this.options.insert_space_after_comma_in_multiple_local_declarations);
 		}
-		this.tm.firstTokenAfter(node.getType(), TokenNameInvalid).spaceBefore();
+		this.tm.firstTokenAfter(node.getType(), ANY).spaceBefore();
 		return true;
 	}
 
@@ -808,7 +809,7 @@ public class SpacePreparator extends ASTVisitor {
 	public boolean visit(PostfixExpression node) {
 		if (this.options.insert_space_before_postfix_operator || this.options.insert_space_after_postfix_operator) {
 			String operator = node.getOperator().toString();
-			int i = this.tm.firstIndexAfter(node.getOperand(), TokenNameInvalid);
+			int i = this.tm.firstIndexAfter(node.getOperand(), ANY);
 			while (!operator.equals(this.tm.toString(i))) {
 				i++;
 			}
@@ -820,7 +821,7 @@ public class SpacePreparator extends ASTVisitor {
 
 	private void handleOperator(String operator, ASTNode nodeAfter, boolean spaceBefore, boolean spaceAfter) {
 		if (spaceBefore || spaceAfter) {
-			int i = this.tm.firstIndexBefore(nodeAfter, TokenNameInvalid);
+			int i = this.tm.firstIndexBefore(nodeAfter, ANY);
 			while (!operator.equals(this.tm.toString(i))) {
 				i--;
 			}
@@ -1098,7 +1099,7 @@ public class SpacePreparator extends ASTVisitor {
 	private void handleTokenAfter(ASTNode node, TerminalToken tokenType, boolean spaceBefore, boolean spaceAfter) {
 		if (tokenType == TokenNameGREATER) {
 			// there could be ">>" or ">>>" instead, get rid of them
-			int index = this.tm.lastIndexIn(node, TokenNameInvalid);
+			int index = this.tm.lastIndexIn(node, ANY);
 			for (int i = index; i < index + 2; i++) {
 				Token token = this.tm.get(i);
 				if (token.tokenType == TokenNameRIGHT_SHIFT || token.tokenType == TokenNameUNSIGNED_RIGHT_SHIFT) {
@@ -1145,7 +1146,7 @@ public class SpacePreparator extends ASTVisitor {
 
 	private void handleSemicolon(ASTNode node) {
 		if (this.options.insert_space_before_semicolon) {
-			Token lastToken = this.tm.lastTokenIn(node, TokenNameInvalid);
+			Token lastToken = this.tm.lastTokenIn(node, ANY);
 			if (lastToken.tokenType == TokenNameSEMICOLON)
 				lastToken.spaceBefore();
 		}
@@ -1160,7 +1161,7 @@ public class SpacePreparator extends ASTVisitor {
 
 	private void handleLoopBody(Statement loopBody) {
 		/* space before body statement may be needed if it will stay on the same line */
-		int firstTokenIndex = this.tm.firstIndexIn(loopBody, TokenNameInvalid);
+		int firstTokenIndex = this.tm.firstIndexIn(loopBody, ANY);
 		if (!(loopBody instanceof Block) && !(loopBody instanceof EmptyStatement)
 				&& !this.tm.get(firstTokenIndex - 1).isComment()) {
 			this.tm.get(firstTokenIndex).spaceBefore();

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/TextEditsBuilder.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/TextEditsBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2023 Mateusz Matela and others.
+ * Copyright (c) 2014, 2025 Mateusz Matela and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -17,11 +17,11 @@ import static org.eclipse.jdt.internal.compiler.parser.TerminalToken.TokenNameCO
 import static org.eclipse.jdt.internal.compiler.parser.TerminalToken.TokenNameCOMMENT_JAVADOC;
 import static org.eclipse.jdt.internal.compiler.parser.TerminalToken.TokenNameCOMMENT_LINE;
 import static org.eclipse.jdt.internal.compiler.parser.TerminalToken.TokenNameCOMMENT_MARKDOWN;
-import static org.eclipse.jdt.internal.compiler.parser.TerminalToken.TokenNameInvalid;
 import static org.eclipse.jdt.internal.compiler.parser.TerminalToken.TokenNameNotAToken;
 import static org.eclipse.jdt.internal.compiler.parser.TerminalToken.TokenNameStringLiteral;
 import static org.eclipse.jdt.internal.compiler.parser.TerminalToken.TokenNameTextBlock;
 import static org.eclipse.jdt.internal.compiler.parser.TerminalToken.TokenNameWHITESPACE;
+import static org.eclipse.jdt.internal.formatter.TokenManager.ANY;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -89,7 +89,7 @@ public class TextEditsBuilder extends TokenTraverser {
 			int sourceStart = this.tm.get(0).originalStart;
 
 			if (start > sourceStart) {
-				Token token = this.tm.get(this.tm.findIndex(start, TokenNameInvalid, false));
+				Token token = this.tm.get(this.tm.findIndex(start, ANY, false));
 				if ((token.tokenType == TokenNameCOMMENT_BLOCK || token.tokenType == TokenNameCOMMENT_JAVADOC)
 						&& start <= token.originalEnd) {
 					start = token.originalStart;
@@ -97,7 +97,7 @@ public class TextEditsBuilder extends TokenTraverser {
 			}
 
 			if (end > start && end > sourceStart) {
-				Token token = this.tm.get(this.tm.findIndex(end, TokenNameInvalid, false));
+				Token token = this.tm.get(this.tm.findIndex(end, ANY, false));
 				if ((token.tokenType == TokenNameCOMMENT_BLOCK || token.tokenType == TokenNameCOMMENT_JAVADOC)
 						&& end < token.originalEnd) {
 					end = token.originalEnd;

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/TokenManager.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/TokenManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2023 Mateusz Matela and others.
+ * Copyright (c) 2014, 2025 Mateusz Matela and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -41,6 +41,11 @@ import org.eclipse.jdt.internal.formatter.linewrap.CommentWrapExecutor;
  * It also has some other methods that are useful on multiple stages of formatting.
  */
 public class TokenManager implements Iterable<Token> {
+
+	/**
+	 * This constant can be passed to all the token-finding methods when looking for a token of unspecified (any) type.
+	 */
+	public static final TerminalToken ANY = TerminalToken.TokenNameInvalid;
 
 	private static final Pattern COMMENT_LINE_ANNOTATION_PATTERN = Pattern.compile("^(\\s*\\*?\\s*)(@)"); //$NON-NLS-1$
 
@@ -132,7 +137,7 @@ public class TokenManager implements Iterable<Token> {
 	}
 
 	public int indexOf(Token token) {
-		int index = findIndex(token.originalStart, TerminalToken.TokenNameInvalid, false);
+		int index = findIndex(token.originalStart, ANY, false);
 		if (get(index) != token)
 			return -1;
 		return index;
@@ -169,7 +174,7 @@ public class TokenManager implements Iterable<Token> {
 		if (forward && get(index).originalEnd < positionInSource)
 			index++;
 		Token t;
-		while (tokenType != TerminalToken.TokenNameInvalid && (t = get(index)).tokenType != tokenType) {
+		while (tokenType != ANY && (t = get(index)).tokenType != tokenType) {
 			if (TerminalToken.isRestrictedKeyword(tokenType) && t.tokenType == TerminalToken.TokenNameIdentifier) {
 				if (tokenType == TerminalToken.getRestrictedKeyword(toString(t)))
 					break;

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/linewrap/Aligner.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/linewrap/Aligner.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2024 Mateusz Matela and others.
+ * Copyright (c) 2014, 2025 Mateusz Matela and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -21,7 +21,7 @@ import static org.eclipse.jdt.internal.compiler.parser.TerminalToken.TokenNameCO
 import static org.eclipse.jdt.internal.compiler.parser.TerminalToken.TokenNameCOMMENT_LINE;
 import static org.eclipse.jdt.internal.compiler.parser.TerminalToken.TokenNameEQUAL;
 import static org.eclipse.jdt.internal.compiler.parser.TerminalToken.TokenNameIdentifier;
-import static org.eclipse.jdt.internal.compiler.parser.TerminalToken.TokenNameInvalid;
+import static org.eclipse.jdt.internal.formatter.TokenManager.ANY;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -123,7 +123,7 @@ public class Aligner {
 	}
 
 	private boolean areKeptOnOneLine(List<? extends ASTNode> nodes) {
-		return nodes.stream().allMatch(n -> this.tm.firstTokenIn(n, TokenNameInvalid).getLineBreaksBefore() == 0);
+		return nodes.stream().allMatch(n -> this.tm.firstTokenIn(n, ANY).getLineBreaksBefore() == 0);
 	}
 
 	private void alignDeclarations(List<Statement> statements) {
@@ -148,7 +148,7 @@ public class Aligner {
 
 		AlignIndexFinder<ExpressionStatement> assignFinder = es -> {
 			Assignment a = (Assignment) es.getExpression();
-			int operatorIndex = this.tm.firstIndexBefore(a.getRightHandSide(), TokenNameInvalid);
+			int operatorIndex = this.tm.firstIndexBefore(a.getRightHandSide(), ANY);
 			while (this.tm.get(operatorIndex).isComment())
 				operatorIndex--;
 			return Optional.of(operatorIndex);
@@ -209,8 +209,8 @@ public class Aligner {
 		if (previousNode == null)
 			return true;
 		int totalLineBreaks = 0;
-		int from = this.tm.lastIndexIn(previousNode, TokenNameInvalid);
-		int to = this.tm.firstIndexIn(node, TokenNameInvalid);
+		int from = this.tm.lastIndexIn(previousNode, ANY);
+		int to = this.tm.firstIndexIn(node, ANY);
 		Token previousToken = this.tm.get(from);
 		for (int i = from + 1; i <= to; i++) {
 			Token token = this.tm.get(i);
@@ -246,7 +246,7 @@ public class Aligner {
 			int maxCommentAlign = 0;
 			for (ASTNode node : alignGroup) {
 				int firstIndexInLine = findFirstTokenInLine(node);
-				int lastIndex = this.tm.lastIndexIn(node, TokenNameInvalid) + 1;
+				int lastIndex = this.tm.lastIndexIn(node, ANY) + 1;
 				maxCommentAlign = Math.max(maxCommentAlign,
 						positionCounter.findMaxPosition(firstIndexInLine, lastIndex));
 			}
@@ -254,7 +254,7 @@ public class Aligner {
 
 			for (ASTNode node : alignGroup) {
 				int firstIndexInLine = findFirstTokenInLine(node);
-				int lastIndex = this.tm.lastIndexIn(node, TokenNameInvalid);
+				int lastIndex = this.tm.lastIndexIn(node, ANY);
 				lastIndex = Math.min(lastIndex, this.tm.size() - 2);
 				for (int i = firstIndexInLine; i <= lastIndex; i++) {
 					Token token = this.tm.get(i);
@@ -277,15 +277,15 @@ public class Aligner {
 
 	private int findFirstTokenInLine(ASTNode node) {
 		if (node instanceof FieldDeclaration) {
-			int typeIndex = this.tm.firstIndexIn(((FieldDeclaration) node).getType(), TokenNameInvalid);
+			int typeIndex = this.tm.firstIndexIn(((FieldDeclaration) node).getType(), ANY);
 			return this.tm.findFirstTokenInLine(typeIndex);
 		}
 		if (node instanceof VariableDeclarationStatement) {
-			int typeIndex = this.tm.firstIndexIn(((VariableDeclarationStatement) node).getType(), TokenNameInvalid);
+			int typeIndex = this.tm.firstIndexIn(((VariableDeclarationStatement) node).getType(), ANY);
 			return this.tm.findFirstTokenInLine(typeIndex);
 		}
 		if (node instanceof ExpressionStatement) {
-			return this.tm.firstIndexIn(node, TokenNameInvalid);
+			return this.tm.firstIndexIn(node, ANY);
 		}
 		throw new IllegalArgumentException(node.getClass().getName());
 	}

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/linewrap/WrapPreparator.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/linewrap/WrapPreparator.java
@@ -16,6 +16,7 @@ package org.eclipse.jdt.internal.formatter.linewrap;
 
 import static java.util.stream.Collectors.toList;
 import static org.eclipse.jdt.internal.compiler.parser.TerminalToken.*;
+import static org.eclipse.jdt.internal.formatter.TokenManager.ANY;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -176,7 +177,7 @@ public class WrapPreparator extends ASTVisitor {
 
 		boolean isMalformed = (node.getFlags() & ASTNode.MALFORMED) != 0;
 		if (isMalformed) {
-			this.tm.addDisableFormatTokenPair(this.tm.firstTokenIn(node, TokenNameInvalid), this.tm.lastTokenIn(node, TokenNameInvalid));
+			this.tm.addDisableFormatTokenPair(this.tm.firstTokenIn(node, ANY), this.tm.lastTokenIn(node, ANY));
 		}
 		return !isMalformed;
 	}
@@ -216,27 +217,27 @@ public class WrapPreparator extends ASTVisitor {
 
 		Type superclassType = node.getSuperclassType();
 		if (superclassType != null) {
-			this.wrapParentIndex = this.tm.lastIndexIn(node.getName(), TokenNameInvalid);
-			this.wrapGroupEnd = this.tm.lastIndexIn(superclassType, TokenNameInvalid);
+			this.wrapParentIndex = this.tm.lastIndexIn(node.getName(), ANY);
+			this.wrapGroupEnd = this.tm.lastIndexIn(superclassType, ANY);
 			this.wrapIndexes.add(this.tm.firstIndexBefore(superclassType, TokenNameextends));
-			this.wrapIndexes.add(this.tm.firstIndexIn(superclassType, TokenNameInvalid));
+			this.wrapIndexes.add(this.tm.firstIndexIn(superclassType, ANY));
 			handleWrap(this.options.alignment_for_superclass_in_type_declaration, PREFERRED);
 		}
 
 		List<Type> superInterfaceTypes = node.superInterfaceTypes();
 		if (!superInterfaceTypes.isEmpty()) {
 			TerminalToken implementsToken = node.isInterface() ? TokenNameextends : TokenNameimplements;
-			this.wrapParentIndex = this.tm.lastIndexIn(node.getName(), TokenNameInvalid);
+			this.wrapParentIndex = this.tm.lastIndexIn(node.getName(), ANY);
 			this.wrapIndexes.add(this.tm.firstIndexBefore(superInterfaceTypes.get(0), implementsToken));
-			prepareElementsList(superInterfaceTypes, TokenNameCOMMA, TokenNameInvalid);
+			prepareElementsList(superInterfaceTypes, TokenNameCOMMA, ANY);
 			handleWrap(this.options.alignment_for_superinterfaces_in_type_declaration, PREFERRED);
 		}
 
 		List<Type> permittedTypes = node.permittedTypes();
 		if (!permittedTypes.isEmpty()) {
-			this.wrapParentIndex = this.tm.lastIndexIn(node.getName(), TokenNameInvalid);
+			this.wrapParentIndex = this.tm.lastIndexIn(node.getName(), ANY);
 			this.wrapIndexes.add(this.tm.firstIndexBefore(permittedTypes.get(0), TokenNameRestrictedIdentifierpermits));
-			prepareElementsList(permittedTypes, TokenNameCOMMA, TokenNameInvalid);
+			prepareElementsList(permittedTypes, TokenNameCOMMA, ANY);
 			handleWrap(this.options.alignment_for_permitted_types_in_type_declaration, PREFERRED);
 		}
 
@@ -279,15 +280,15 @@ public class WrapPreparator extends ASTVisitor {
 
 		if (!components.isEmpty()) {
 			int wrappingOption = this.options.alignment_for_record_components;
-			this.wrapGroupEnd = this.tm.lastIndexIn(components.get(components.size() - 1), TokenNameInvalid);
+			this.wrapGroupEnd = this.tm.lastIndexIn(components.get(components.size() - 1), ANY);
 			handleArguments(components, wrappingOption);
 		}
 
 		List<Type> superInterfaceTypes = node.superInterfaceTypes();
 		if (!superInterfaceTypes.isEmpty()) {
-			this.wrapParentIndex = this.tm.lastIndexIn(node.getName(), TokenNameInvalid);
+			this.wrapParentIndex = this.tm.lastIndexIn(node.getName(), ANY);
 			this.wrapIndexes.add(this.tm.firstIndexBefore(superInterfaceTypes.get(0), TokenNameimplements));
-			prepareElementsList(superInterfaceTypes, TokenNameCOMMA, TokenNameInvalid);
+			prepareElementsList(superInterfaceTypes, TokenNameCOMMA, ANY);
 			handleWrap(this.options.alignment_for_superinterfaces_in_record_declaration, PREFERRED);
 		}
 		return true;
@@ -308,11 +309,11 @@ public class WrapPreparator extends ASTVisitor {
 		Type receiverType = node.getReceiverType();
 		if (!parameters.isEmpty() || receiverType != null) {
 			if (receiverType != null)
-				this.wrapIndexes.add(this.tm.firstIndexIn(receiverType, TokenNameInvalid));
+				this.wrapIndexes.add(this.tm.firstIndexIn(receiverType, ANY));
 			int wrappingOption = node.isConstructor() ? this.options.alignment_for_parameters_in_constructor_declaration
 					: this.options.alignment_for_parameters_in_method_declaration;
 			this.wrapGroupEnd = this.tm.lastIndexIn(
-					parameters.isEmpty() ? receiverType : parameters.get(parameters.size() - 1), TokenNameInvalid);
+					parameters.isEmpty() ? receiverType : parameters.get(parameters.size() - 1), ANY);
 			handleArguments(parameters, wrappingOption);
 		}
 
@@ -332,14 +333,14 @@ public class WrapPreparator extends ASTVisitor {
 		if (!node.isConstructor()) {
 			List<TypeParameter> typeParameters = node.typeParameters();
 			if (!typeParameters.isEmpty())
-				this.wrapIndexes.add(this.tm.firstIndexIn(typeParameters.get(0), TokenNameInvalid));
+				this.wrapIndexes.add(this.tm.firstIndexIn(typeParameters.get(0), ANY));
 			if (node.getReturnType2() != null) {
-				int returTypeIndex = this.tm.firstIndexIn(node.getReturnType2(), TokenNameInvalid);
+				int returTypeIndex = this.tm.firstIndexIn(node.getReturnType2(), ANY);
 				if (returTypeIndex != this.wrapParentIndex)
 					this.wrapIndexes.add(returTypeIndex);
 			}
-			this.wrapIndexes.add(this.tm.firstIndexIn(node.getName(), TokenNameInvalid));
-			this.wrapGroupEnd = this.tm.lastIndexIn(node.getName(), TokenNameInvalid);
+			this.wrapIndexes.add(this.tm.firstIndexIn(node.getName(), ANY));
+			this.wrapGroupEnd = this.tm.lastIndexIn(node.getName(), ANY);
 			this.wrapParentIndex = this.tm.findFirstTokenInLine(this.wrapIndexes.get(0));
 			while (this.tm.get(this.wrapParentIndex).isComment())
 				this.wrapParentIndex++;
@@ -362,11 +363,11 @@ public class WrapPreparator extends ASTVisitor {
 		int constantsEnd = -1;
 		if (!enumConstants.isEmpty()) {
 			for (EnumConstantDeclaration constant : enumConstants)
-				this.wrapIndexes.add(this.tm.firstIndexIn(constant, TokenNameInvalid));
+				this.wrapIndexes.add(this.tm.firstIndexIn(constant, ANY));
 			this.wrapParentIndex = (this.options.alignment_for_enum_constants & Alignment.M_INDENT_ON_COLUMN) > 0
 					? this.tm.firstIndexBefore(enumConstants.get(0), TokenNameLBRACE)
 					: this.tm.firstIndexIn(node, TokenNameenum);
-			this.wrapGroupEnd = constantsEnd = this.tm.lastIndexIn(enumConstants.get(enumConstants.size() - 1), TokenNameInvalid);
+			this.wrapGroupEnd = constantsEnd = this.tm.lastIndexIn(enumConstants.get(enumConstants.size() - 1), ANY);
 			handleWrap(this.options.alignment_for_enum_constants, node);
 		}
 
@@ -392,9 +393,9 @@ public class WrapPreparator extends ASTVisitor {
 
 		List<Type> superInterfaceTypes = node.superInterfaceTypes();
 		if (!superInterfaceTypes.isEmpty()) {
-			this.wrapParentIndex = this.tm.lastIndexIn(node.getName(), TokenNameInvalid);
+			this.wrapParentIndex = this.tm.lastIndexIn(node.getName(), ANY);
 			this.wrapIndexes.add(this.tm.firstIndexBefore(superInterfaceTypes.get(0), TokenNameimplements));
-			prepareElementsList(superInterfaceTypes, TokenNameCOMMA, TokenNameInvalid);
+			prepareElementsList(superInterfaceTypes, TokenNameCOMMA, ANY);
 			handleWrap(this.options.alignment_for_superinterfaces_in_enum_declaration, PREFERRED);
 		}
 
@@ -407,7 +408,7 @@ public class WrapPreparator extends ASTVisitor {
 	public boolean visit(EnumConstantDeclaration node) {
 		handleAnnotations(node.modifiers(), this.options.alignment_for_annotations_on_enum_constant);
 
-		int lParen = this.tm.firstIndexAfter(node.getName(), TokenNameInvalid);
+		int lParen = this.tm.firstIndexAfter(node.getName(), ANY);
 		while (this.tm.get(lParen).isComment())
 			lParen++;
 		if (this.tm.get(lParen).tokenType == TokenNameLPAREN) {
@@ -419,7 +420,7 @@ public class WrapPreparator extends ASTVisitor {
 		handleArguments(node.arguments(), this.options.alignment_for_arguments_in_enum_constant);
 		AnonymousClassDeclaration anonymousClass = node.getAnonymousClassDeclaration();
 		if (anonymousClass != null) {
-			forceContinuousWrapping(anonymousClass, this.tm.firstIndexIn(node.getName(), TokenNameInvalid));
+			forceContinuousWrapping(anonymousClass, this.tm.firstIndexIn(node.getName(), ANY));
 		}
 		return true;
 	}
@@ -455,12 +456,12 @@ public class WrapPreparator extends ASTVisitor {
 			Collections.reverse(this.wrapIndexes);
 			if (expression == null)
 				expression = invocation;
-			this.wrapParentIndex = this.tm.lastIndexIn(expression, TokenNameInvalid);
+			this.wrapParentIndex = this.tm.lastIndexIn(expression, ANY);
 			if (this.options.align_selector_in_method_invocation_on_expression_first_line
 					&& (this.options.alignment_for_selector_in_method_invocation & Alignment.M_INDENT_ON_COLUMN) == 0) {
-				this.wrapParentIndex = this.tm.firstIndexIn(expression, TokenNameInvalid);
+				this.wrapParentIndex = this.tm.firstIndexIn(expression, ANY);
 			}
-			this.wrapGroupEnd = this.tm.lastIndexIn(node, TokenNameInvalid);
+			this.wrapGroupEnd = this.tm.lastIndexIn(node, ANY);
 			handleWrap(this.options.alignment_for_selector_in_method_invocation);
 		}
 		return true;
@@ -557,7 +558,7 @@ public class WrapPreparator extends ASTVisitor {
 			access = new FieldAccessAdapter(expression);
 			int nameIndex = access.getIdentifierIndex(this.tm);
 			// find a dot preceding the name, may not be there
-			for (int i = nameIndex - 1; i > this.tm.firstIndexIn(node, TokenNameInvalid); i--) {
+			for (int i = nameIndex - 1; i > this.tm.firstIndexIn(node, ANY); i--) {
 				Token t = this.tm.get(i);
 				if (t.tokenType == TokenNameDOT) {
 					this.wrapIndexes.add(i);
@@ -569,10 +570,10 @@ public class WrapPreparator extends ASTVisitor {
 			expression = access.getExpression();
 		}
 		Collections.reverse(this.wrapIndexes);
-		this.wrapParentIndex = this.tm.lastIndexIn(expression != null ? expression : access.accessExpression, TokenNameInvalid);
+		this.wrapParentIndex = this.tm.lastIndexIn(expression != null ? expression : access.accessExpression, ANY);
 		boolean isFollowedByInvocation = node.getParent() instanceof MethodInvocation
 				&& node.getLocationInParent() == MethodInvocation.EXPRESSION_PROPERTY;
-		this.wrapGroupEnd = isFollowedByInvocation ? this.tm.lastIndexIn(node.getParent(), TokenNameInvalid)
+		this.wrapGroupEnd = isFollowedByInvocation ? this.tm.lastIndexIn(node.getParent(), ANY)
 				: new FieldAccessAdapter(node).getIdentifierIndex(this.tm);
 		// TODO need configuration for this, now only handles line breaks that cannot be removed
 		handleWrap(Alignment.M_NO_ALIGNMENT);
@@ -596,7 +597,7 @@ public class WrapPreparator extends ASTVisitor {
 
 		findTokensToWrap(node, wrapBeforeOperator, 0);
 		this.wrapParentIndex = this.wrapIndexes.remove(0);
-		this.wrapGroupEnd = this.tm.lastIndexIn(node, TokenNameInvalid);
+		this.wrapGroupEnd = this.tm.lastIndexIn(node, ANY);
 		if ((wrappingOption & Alignment.M_INDENT_ON_COLUMN) != 0 && this.wrapParentIndex > 0)
 			this.wrapParentIndex--;
 		for (int i = this.wrapParentIndex; i >= 0; i--) {
@@ -615,7 +616,7 @@ public class WrapPreparator extends ASTVisitor {
 			findTokensToWrap((InfixExpression) left, wrapBeforeOperator, depth + 1);
 		} else if (this.wrapIndexes.isEmpty() // always add first operand, it will be taken as wrap parent
 				|| !wrapBeforeOperator) {
-			this.wrapIndexes.add(this.tm.firstIndexIn(left, TokenNameInvalid));
+			this.wrapIndexes.add(this.tm.firstIndexIn(left, ANY));
 		}
 
 		Expression right = node.getRightOperand();
@@ -625,11 +626,11 @@ public class WrapPreparator extends ASTVisitor {
 			if (operand instanceof InfixExpression && samePrecedence(node, (InfixExpression) operand)) {
 				findTokensToWrap((InfixExpression) operand, wrapBeforeOperator, depth + 1);
 			}
-			int indexBefore = this.tm.firstIndexBefore(operand, TokenNameInvalid);
+			int indexBefore = this.tm.firstIndexBefore(operand, ANY);
 			while (this.tm.get(indexBefore).isComment())
 				indexBefore--;
 			assert node.getOperator().toString().equals(this.tm.toString(indexBefore));
-			int indexAfter = this.tm.firstIndexIn(operand, TokenNameInvalid);
+			int indexAfter = this.tm.firstIndexIn(operand, ANY);
 			this.wrapIndexes.add(wrapBeforeOperator ? indexBefore : indexAfter);
 			this.secondaryWrapIndexes.add(wrapBeforeOperator ? indexAfter : indexBefore);
 
@@ -667,10 +668,10 @@ public class WrapPreparator extends ASTVisitor {
 		if (!chainsMatter || (!isFirstInChain && !isNextInChain)) {
 			before.add(this.tm.firstIndexAfter(node.getExpression(), TokenNameQUESTION));
 			before.add(this.tm.firstIndexAfter(node.getThenExpression(), TokenNameCOLON));
-			after.add(this.tm.firstIndexIn(node.getThenExpression(), TokenNameInvalid));
-			after.add(this.tm.firstIndexIn(node.getElseExpression(), TokenNameInvalid));
-			this.wrapParentIndex = this.tm.lastIndexIn(node.getExpression(), TokenNameInvalid);
-			this.wrapGroupEnd = this.tm.lastIndexIn(node, TokenNameInvalid);
+			after.add(this.tm.firstIndexIn(node.getThenExpression(), ANY));
+			after.add(this.tm.firstIndexIn(node.getElseExpression(), ANY));
+			this.wrapParentIndex = this.tm.lastIndexIn(node.getExpression(), ANY);
+			this.wrapGroupEnd = this.tm.lastIndexIn(node, ANY);
 			handleWrap(this.options.alignment_for_conditional_expression);
 
 		} else if (isFirstInChain) {
@@ -684,18 +685,18 @@ public class WrapPreparator extends ASTVisitor {
 
 			for (ConditionalExpression conditional : chain) {
 				before.add(this.tm.firstIndexAfter(conditional.getThenExpression(), TokenNameCOLON));
-				after.add(this.tm.firstIndexIn(conditional.getElseExpression(), TokenNameInvalid));
+				after.add(this.tm.firstIndexIn(conditional.getElseExpression(), ANY));
 			}
-			this.wrapParentIndex = this.tm.firstIndexIn(node.getExpression(), TokenNameInvalid);
-			this.wrapGroupEnd = this.tm.lastIndexIn(node, TokenNameInvalid);
+			this.wrapParentIndex = this.tm.firstIndexIn(node.getExpression(), ANY);
+			this.wrapGroupEnd = this.tm.lastIndexIn(node, ANY);
 			handleWrap(this.options.alignment_for_conditional_expression_chain);
 
 			this.currentDepth++;
 			for (ConditionalExpression conditional : chain) {
 				before.add(this.tm.firstIndexAfter(conditional.getExpression(), TokenNameQUESTION));
-				after.add(this.tm.firstIndexIn(conditional.getThenExpression(), TokenNameInvalid));
-				this.wrapParentIndex = this.tm.firstIndexIn(conditional.getExpression(), TokenNameInvalid);
-				this.wrapGroupEnd = this.tm.lastIndexIn(conditional.getThenExpression(), TokenNameInvalid);
+				after.add(this.tm.firstIndexIn(conditional.getThenExpression(), ANY));
+				this.wrapParentIndex = this.tm.firstIndexIn(conditional.getExpression(), ANY);
+				this.wrapGroupEnd = this.tm.lastIndexIn(conditional.getThenExpression(), ANY);
 				handleWrap(this.options.alignment_for_conditional_expression);
 			}
 			this.currentDepth--;
@@ -729,7 +730,7 @@ public class WrapPreparator extends ASTVisitor {
 		if (this.options.brace_position_for_array_initializer.equals(DefaultCodeFormatterConstants.NEXT_LINE_SHIFTED)
 				&& openingBrace.getWrapPolicy() == null && (node.getParent() instanceof SingleMemberAnnotation
 						|| node.getParent() instanceof MemberValuePair)) {
-			int parentIndex = this.tm.firstIndexIn(node.getParent(), TokenNameInvalid);
+			int parentIndex = this.tm.firstIndexIn(node.getParent(), ANY);
 			int indent = this.options.indentation_size;
 			openingBrace.setWrapPolicy(new WrapPolicy(WrapMode.BLOCK_INDENT, parentIndex, indent));
 		}
@@ -738,11 +739,11 @@ public class WrapPreparator extends ASTVisitor {
 
 	@Override
 	public boolean visit(Assignment node) {
-		int rightSideIndex = this.tm.firstIndexIn(node.getRightHandSide(), TokenNameInvalid);
+		int rightSideIndex = this.tm.firstIndexIn(node.getRightHandSide(), ANY);
 		if (this.tm.get(rightSideIndex).getLineBreaksBefore() > 0)
 			return true; // must be an array initializer in new line because of brace_position_for_array_initializer
 
-		int operatorIndex = this.tm.firstIndexBefore(node.getRightHandSide(), TokenNameInvalid);
+		int operatorIndex = this.tm.firstIndexBefore(node.getRightHandSide(), ANY);
 		while (this.tm.get(operatorIndex).isComment())
 			operatorIndex--;
 		assert node.getOperator().toString().equals(this.tm.toString(operatorIndex));
@@ -750,7 +751,7 @@ public class WrapPreparator extends ASTVisitor {
 		this.wrapIndexes.add(this.options.wrap_before_assignment_operator ? operatorIndex : rightSideIndex);
 		this.secondaryWrapIndexes.add(this.options.wrap_before_assignment_operator ? rightSideIndex : operatorIndex);
 		this.wrapParentIndex = operatorIndex - 1;
-		this.wrapGroupEnd = this.tm.lastIndexIn(node.getRightHandSide(), TokenNameInvalid);
+		this.wrapGroupEnd = this.tm.lastIndexIn(node.getRightHandSide(), ANY);
 		handleWrap(this.options.alignment_for_assignment);
 		return true;
 	}
@@ -759,7 +760,7 @@ public class WrapPreparator extends ASTVisitor {
 	public boolean visit(VariableDeclarationFragment node) {
 		if (node.getInitializer() == null)
 			return true;
-		int rightSideIndex = this.tm.firstIndexIn(node.getInitializer(), TokenNameInvalid);
+		int rightSideIndex = this.tm.firstIndexIn(node.getInitializer(), ANY);
 		if (this.tm.get(rightSideIndex).getLineBreaksBefore() > 0)
 			return true; // must be an array initializer in new line because of brace_position_for_array_initializer
 		int equalIndex = this.tm.firstIndexBefore(node.getInitializer(), TokenNameEQUAL);
@@ -767,7 +768,7 @@ public class WrapPreparator extends ASTVisitor {
 		this.wrapIndexes.add(this.options.wrap_before_assignment_operator ? equalIndex : rightSideIndex);
 		this.secondaryWrapIndexes.add(this.options.wrap_before_assignment_operator ? rightSideIndex : equalIndex);
 		this.wrapParentIndex = equalIndex - 1;
-		this.wrapGroupEnd = this.tm.lastIndexIn(node.getInitializer(), TokenNameInvalid);
+		this.wrapGroupEnd = this.tm.lastIndexIn(node.getInitializer(), ANY);
 		handleWrap(this.options.alignment_for_assignment);
 		return true;
 	}
@@ -797,12 +798,12 @@ public class WrapPreparator extends ASTVisitor {
 
 		List<Expression> initializers = node.initializers();
 		if (!initializers.isEmpty())
-			this.wrapIndexes.add(this.tm.firstIndexIn(initializers.get(0), TokenNameInvalid));
+			this.wrapIndexes.add(this.tm.firstIndexIn(initializers.get(0), ANY));
 		if (node.getExpression() != null)
-			this.wrapIndexes.add(this.tm.firstIndexIn(node.getExpression(), TokenNameInvalid));
+			this.wrapIndexes.add(this.tm.firstIndexIn(node.getExpression(), ANY));
 		List<Expression> updaters = node.updaters();
 		if (!updaters.isEmpty())
-			this.wrapIndexes.add(this.tm.firstIndexIn(updaters.get(0), TokenNameInvalid));
+			this.wrapIndexes.add(this.tm.firstIndexIn(updaters.get(0), ANY));
 		if (!this.wrapIndexes.isEmpty()) {
 			this.wrapParentIndex = lParen;
 			this.wrapGroupEnd = rParen;
@@ -837,15 +838,15 @@ public class WrapPreparator extends ASTVisitor {
 
 	private void handleSimpleLoop(Statement body, int wrappingOption) {
 		if (!(body instanceof Block)) {
-			this.wrapIndexes.add(this.tm.firstIndexIn(body, TokenNameInvalid));
+			this.wrapIndexes.add(this.tm.firstIndexIn(body, ANY));
 			this.wrapParentIndex = this.tm.firstIndexBefore(body, TokenNameRPAREN);
-			this.wrapGroupEnd = this.tm.lastIndexIn(body, TokenNameInvalid);
+			this.wrapGroupEnd = this.tm.lastIndexIn(body, ANY);
 			handleWrap(wrappingOption, body.getParent());
 
 			body.accept(new ASTVisitor() {
 				@Override
 				public boolean visit(Block node) {
-					forceContinuousWrapping(node, WrapPreparator.this.tm.firstIndexIn(node, TokenNameInvalid));
+					forceContinuousWrapping(node, WrapPreparator.this.tm.firstIndexIn(node, ANY));
 					return false;
 				}
 			});
@@ -857,11 +858,11 @@ public class WrapPreparator extends ASTVisitor {
 		if (this.options.keep_simple_do_while_body_on_same_line && !(node.getBody() instanceof Block)) {
 			int whileIndex = this.tm.firstIndexAfter(node.getBody(), TokenNamewhile);
 			this.wrapIndexes.add(whileIndex);
-			this.wrapParentIndex = this.tm.lastIndexIn(node.getBody(), TokenNameInvalid);
-			this.wrapGroupEnd = this.tm.lastIndexIn(node, TokenNameInvalid);
+			this.wrapParentIndex = this.tm.lastIndexIn(node.getBody(), ANY);
+			this.wrapGroupEnd = this.tm.lastIndexIn(node, ANY);
 
 			int alignment = this.options.alignment_for_compact_loop;
-			for (int i = this.tm.firstIndexIn(node, TokenNameInvalid) + 1; i < whileIndex; i++) {
+			for (int i = this.tm.firstIndexIn(node, ANY) + 1; i < whileIndex; i++) {
 				Token token = this.tm.get(i);
 				if (token.getLineBreaksBefore() > 0 || token.getLineBreaksAfter() > 0)
 					alignment |= Alignment.M_FORCE;
@@ -890,16 +891,16 @@ public class WrapPreparator extends ASTVisitor {
 		if (this.options.wrap_before_or_operator_multicatch) {
 			for (Type type : types) {
 				if (this.wrapIndexes.isEmpty()) {
-					this.wrapIndexes.add(this.tm.firstIndexIn(type, TokenNameInvalid));
+					this.wrapIndexes.add(this.tm.firstIndexIn(type, ANY));
 				} else {
 					this.wrapIndexes.add(this.tm.firstIndexBefore(type, TokenNameOR));
-					this.secondaryWrapIndexes.add(this.tm.firstIndexIn(type, TokenNameInvalid));
+					this.secondaryWrapIndexes.add(this.tm.firstIndexIn(type, ANY));
 				}
 			}
-			this.wrapParentIndex = this.tm.firstIndexBefore(node, TokenNameInvalid);
+			this.wrapParentIndex = this.tm.firstIndexBefore(node, ANY);
 			while (this.tm.get(this.wrapParentIndex).isComment())
 				this.wrapParentIndex--;
-			this.wrapGroupEnd = this.tm.lastIndexIn(types.get(types.size() - 1), TokenNameInvalid);
+			this.wrapGroupEnd = this.tm.lastIndexIn(types.get(types.size() - 1), ANY);
 			handleWrap(this.options.alignment_for_union_type_in_multicatch);
 		} else {
 			prepareElementsList(types, TokenNameOR, TokenNameLPAREN);
@@ -910,13 +911,13 @@ public class WrapPreparator extends ASTVisitor {
 
 	@Override
 	public boolean visit(LambdaExpression node) {
-		int lParen = this.tm.firstIndexIn(node, TokenNameInvalid);
+		int lParen = this.tm.firstIndexIn(node, ANY);
 		if (this.tm.get(lParen).tokenType == TokenNameLPAREN) {
 			int rParen = this.tm.firstIndexBefore(node.getBody(), TokenNameRPAREN);
 			handleParenthesesPositions(lParen, rParen, this.options.parenthesis_positions_in_lambda_declaration);
 		}
 		if (node.getBody() instanceof Block) {
-			forceContinuousWrapping(node.getBody(), this.tm.firstIndexIn(node, TokenNameInvalid));
+			forceContinuousWrapping(node.getBody(), this.tm.firstIndexIn(node, ANY));
 			handleOneLineEnforced(node, ((Block) node.getBody()).statements());
 		}
 		if (node.hasParentheses()) {
@@ -936,7 +937,7 @@ public class WrapPreparator extends ASTVisitor {
 		int closeBraceIndex = this.tm.firstIndexAfter(statements.get(statements.size() - 1), TokenNameRBRACE);
 		if (areKeptOnOneLine(openBraceIndex, closeBraceIndex)) {
 			for (Statement statement : statements)
-				this.wrapIndexes.add(this.tm.firstIndexIn(statement, TokenNameInvalid));
+				this.wrapIndexes.add(this.tm.firstIndexIn(statement, ANY));
 			this.wrapParentIndex = openBraceIndex;
 			this.wrapGroupEnd = closeBraceIndex;
 			this.currentDepth++;
@@ -1044,7 +1045,7 @@ public class WrapPreparator extends ASTVisitor {
 		int joiningTokenIndex = this.tm.firstIndexBefore(names.get(0), joiningTokenType);
 		this.wrapParentIndex = this.tm.firstIndexBefore(names.get(0), TokenNameIdentifier);
 		this.wrapIndexes.add(joiningTokenIndex);
-		prepareElementsList(names, TokenNameCOMMA, TokenNameInvalid);
+		prepareElementsList(names, TokenNameCOMMA, ANY);
 		handleWrap(this.options.alignment_for_module_statements, PREFERRED);
 	}
 
@@ -1097,15 +1098,15 @@ public class WrapPreparator extends ASTVisitor {
 					? ((SwitchStatement) node.getParent()).statements()
 					: ((SwitchExpression) node.getParent()).statements();
 			Statement nextStatement = siblings.get(siblings.indexOf(node) + 1);
-			if (!(nextStatement instanceof Block) || areKeptOnOneLine(this.tm.firstIndexIn(nextStatement, TokenNameInvalid),
-					this.tm.lastIndexIn(nextStatement, TokenNameInvalid))) {
+			if (!(nextStatement instanceof Block) || areKeptOnOneLine(this.tm.firstIndexIn(nextStatement, ANY),
+					this.tm.lastIndexIn(nextStatement, ANY))) {
 				int atArrow = this.tm.lastIndexIn(node, TokenNameARROW);
-				int afterArrow = this.tm.firstIndexIn(nextStatement, TokenNameInvalid);
+				int afterArrow = this.tm.firstIndexIn(nextStatement, ANY);
 				boolean wrapBefore = this.options.wrap_before_switch_case_arrow_operator;
 				this.wrapIndexes.add(wrapBefore? atArrow : afterArrow);
 				this.secondaryWrapIndexes.add(wrapBefore ? afterArrow : atArrow);
-				this.wrapParentIndex = this.tm.firstIndexIn(node,  TokenNameInvalid);
-				this.wrapGroupEnd = this.tm.lastIndexIn(nextStatement, TokenNameInvalid);
+				this.wrapParentIndex = this.tm.firstIndexIn(node,  ANY);
+				this.wrapGroupEnd = this.tm.lastIndexIn(nextStatement, ANY);
 				handleWrap(this.options.alignment_for_switch_case_with_arrow);
 			}
 		}
@@ -1129,12 +1130,12 @@ public class WrapPreparator extends ASTVisitor {
 		Expression message = node.getMessage();
 		if (message != null) {
 			int atColon = this.tm.firstIndexBefore(message, TokenNameCOLON);
-			int afterColon = this.tm.firstIndexIn(message, TokenNameInvalid);
+			int afterColon = this.tm.firstIndexIn(message, ANY);
 			boolean wrapBefore = this.options.wrap_before_assertion_message_operator;
 			this.wrapIndexes.add(wrapBefore? atColon : afterColon);
 			this.secondaryWrapIndexes.add(wrapBefore ? afterColon : atColon);
-			this.wrapParentIndex = this.tm.firstIndexIn(node,  TokenNameInvalid);
-			this.wrapGroupEnd = this.tm.lastIndexIn(node, TokenNameInvalid);
+			this.wrapParentIndex = this.tm.firstIndexIn(node,  ANY);
+			this.wrapGroupEnd = this.tm.lastIndexIn(node, ANY);
 			handleWrap(this.options.alignment_for_assertion_message);
 		}
 		return true;
@@ -1157,8 +1158,8 @@ public class WrapPreparator extends ASTVisitor {
 		}
 
 		Token previous = null;
-		int from = this.tm.firstIndexIn(node, TokenNameInvalid);
-		int to = this.tm.lastIndexIn(node, TokenNameInvalid);
+		int from = this.tm.firstIndexIn(node, ANY);
+		int to = this.tm.lastIndexIn(node, ANY);
 		for (int i = from; i <= to; i++) {
 			Token token = this.tm.get(i);
 			if ((token.getLineBreaksBefore() > 0 || (previous != null && previous.getLineBreaksAfter() > 0))
@@ -1173,8 +1174,8 @@ public class WrapPreparator extends ASTVisitor {
 
 	private void handleVariableDeclarations(List<VariableDeclarationFragment> fragments) {
 		if (fragments.size() > 1) {
-			this.wrapParentIndex = this.tm.firstIndexIn(fragments.get(0), TokenNameInvalid);
-			prepareElementsList(fragments, TokenNameCOMMA, TokenNameInvalid);
+			this.wrapParentIndex = this.tm.firstIndexIn(fragments.get(0), ANY);
+			prepareElementsList(fragments, TokenNameCOMMA, ANY);
 			this.wrapIndexes.remove(0);
 			handleWrap(this.options.alignment_for_multiple_fields);
 		}
@@ -1194,10 +1195,10 @@ public class WrapPreparator extends ASTVisitor {
 				break;
 			Annotation annotation = (Annotation) modifiers.get(i);
 			if (i == 0) {
-				this.wrapParentIndex = this.tm.firstIndexIn(annotation, TokenNameInvalid);
+				this.wrapParentIndex = this.tm.firstIndexIn(annotation, ANY);
 			} else {
-				this.wrapIndexes.add(this.tm.firstIndexIn(annotation, TokenNameInvalid));
-				this.wrapGroupEnd = this.tm.lastIndexIn(annotation, TokenNameInvalid);
+				this.wrapIndexes.add(this.tm.firstIndexIn(annotation, ANY));
+				this.wrapGroupEnd = this.tm.lastIndexIn(annotation, ANY);
 			}
 			last = annotation;
 		}
@@ -1212,7 +1213,7 @@ public class WrapPreparator extends ASTVisitor {
 	private void prepareElementsList(List<? extends ASTNode> elements, TerminalToken separatorType, TerminalToken wrapParentType) {
 		for (int i = 0; i < elements.size(); i++) {
 			ASTNode element = elements.get(i);
-			this.wrapIndexes.add(this.tm.firstIndexIn(element, TokenNameInvalid));
+			this.wrapIndexes.add(this.tm.firstIndexIn(element, ANY));
 			if (i > 0)
 				this.secondaryWrapIndexes.add(this.tm.firstIndexBefore(element, separatorType));
 		}
@@ -1222,7 +1223,7 @@ public class WrapPreparator extends ASTVisitor {
 			if (this.wrapParentIndex < 0)
 				this.wrapParentIndex = this.tm.findIndex(firstToken.originalStart - 1, wrapParentType, false);
 			if (!elements.isEmpty() && this.wrapGroupEnd < 0)
-				this.wrapGroupEnd = this.tm.lastIndexIn(elements.get(elements.size() - 1), TokenNameInvalid);
+				this.wrapGroupEnd = this.tm.lastIndexIn(elements.get(elements.size() - 1), ANY);
 		}
 	}
 
@@ -1337,10 +1338,10 @@ public class WrapPreparator extends ASTVisitor {
 		} else if (parentNode instanceof IfStatement || parentNode instanceof ForStatement
 				|| parentNode instanceof EnhancedForStatement || parentNode instanceof WhileStatement) {
 			extraIndent = 1;
-			this.wrapParentIndex = this.tm.firstIndexIn(parentNode, TokenNameInvalid); // only if !indoentOnColumn
+			this.wrapParentIndex = this.tm.firstIndexIn(parentNode, ANY); // only if !indoentOnColumn
 		} else if (parentNode instanceof DoStatement) {
 			extraIndent = 0;
-			this.wrapParentIndex = this.tm.firstIndexIn(parentNode, TokenNameInvalid); // only if !indoentOnColumn
+			this.wrapParentIndex = this.tm.firstIndexIn(parentNode, ANY); // only if !indoentOnColumn
 		} else if (parentNode instanceof LambdaExpression) {
 			extraIndent = 1;
 		} else if ((wrappingOption & Alignment.M_INDENT_BY_ONE) != 0) {
@@ -1453,7 +1454,7 @@ public class WrapPreparator extends ASTVisitor {
 		String source = this.tm.getSource();
 		int previousRegionEnd = 0;
 		for (IRegion region : regions) {
-			int index = this.tm.findIndex(previousRegionEnd, TokenNameInvalid, true);
+			int index = this.tm.findIndex(previousRegionEnd, ANY, true);
 			Token token = this.tm.get(index);
 			if (this.tm.countLineBreaksBetween(source, previousRegionEnd,
 					Math.min(token.originalStart, region.getOffset())) > 0)
@@ -1504,7 +1505,7 @@ public class WrapPreparator extends ASTVisitor {
 
 				@Override
 				public boolean visit(EnumConstantDeclaration node) {
-					WrapPreparator.this.tm.firstTokenIn(node, TokenNameInvalid).setWrapPolicy(null);
+					WrapPreparator.this.tm.firstTokenIn(node, ANY).setWrapPolicy(null);
 					return true;
 				}
 			});


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
#3772 changed the token type from int to enum with value of `TokenNameInvalid` in place of `-1`. The formatter's token manager was using `-1` in token-finding methods to mark ANY type of token, so now all these places can be confusing, looking like searching for some invalid tokens. Thus a new constant for ANY token type will improve readability.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Just a simple refactoring, no testing necessary

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
