### PR TITLE
DefaultBindingResolver cannot resolve module imports

### DIFF
--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/DefaultBindingResolver.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/DefaultBindingResolver.java
@@ -804,12 +804,12 @@ class DefaultBindingResolver extends BindingResolver {
 								}
 								return packageBinding;
 							} else {
-								// if it is not a package, it has to be a type
-								ITypeBinding typeBinding = this.getTypeBinding((org.eclipse.jdt.internal.compiler.lookup.TypeBinding) binding);
-								if (typeBinding == null) {
-									return null;
+								if (binding instanceof org.eclipse.jdt.internal.compiler.lookup.ModuleBinding) {
+								    return getModuleBinding((org.eclipse.jdt.internal.compiler.lookup.ModuleBinding) binding);
+								} else if (binding instanceof org.eclipse.jdt.internal.compiler.lookup.TypeBinding) {
+								    return getTypeBinding((org.eclipse.jdt.internal.compiler.lookup.TypeBinding) binding);
 								}
-								return typeBinding;
+								return null;
 							}
 						}
 					}


### PR DESCRIPTION
A ClassCastException occurred because DefaultBindingResolver cannot resolve module imports.

Fixes: https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4121

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
