### PR TITLE
eclipse/ecj 4.36: flexible constructor bodies in record as inner class does not compile (java 24 preview enabled) #4193

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ConstructorDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ConstructorDeclaration.java
@@ -761,12 +761,6 @@ public void resolveStatements() {
 				this.scope.problemReporter().cannotUseSuperInJavaLangObject(this.constructorCall);
 			}
 			this.constructorCall = null;
-		} else if (sourceType.isRecord() &&
-				!this.isCompactConstructor() && // compact constr should be marked as canonical?
-				(this.binding != null && !this.binding.isCanonicalConstructor()) &&
-				this.constructorCall.accessMode != ExplicitConstructorCall.This) {
-			this.scope.problemReporter().missingExplicitConstructorCallInNonCanonicalConstructor(this);
-			this.constructorCall = null;
 		} else {
 			this.scope.enterEarlyConstructionContext(); // even if no late ctor call to also capture arguments of ctor call as 1st stmt
 			if (getLateConstructorCall() != null) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypeOrLambda.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypeOrLambda.java
@@ -53,6 +53,8 @@ public interface TypeOrLambda {
 						ensureSyntheticOuterAccess(cs.referenceContext.binding);
 					}
 					earlySeen = cs.insideEarlyConstructionContext;
+					if (cs.referenceContext.binding != null && cs.referenceContext.binding.isStatic())
+						break;
 				}
 				outerScope = outerScope.parent;
 				if (outerScope instanceof MethodScope ms && ms.isStatic)

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
@@ -11922,7 +11922,7 @@ public void illegalExplicitAssignmentInCompactConstructor(FieldBinding field, Fi
 		fieldRef.sourceStart,
 		fieldRef.sourceEnd);
 }
-public void missingExplicitConstructorCallInNonCanonicalConstructor(ASTNode location) {
+public void missingThisCallInNonCanonicalConstructor(ASTNode location) {
 	this.handle(
 		IProblem.RecordMissingExplicitConstructorCallInNonCanonicalConstructor,
 		NoArgument,

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/messages.properties
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/messages.properties
@@ -1095,7 +1095,7 @@
 1757 = A record component {0} cannot have modifiers
 1758 = Illegal parameter name {0} in canonical constructor, expected {1}, the corresponding component name
 1759 = Illegal explicit assignment of a final field {0} in compact constructor
-1760 = A non-canonical constructor must start with an explicit invocation to a constructor
+1760 = A non-canonical constructor must invoke another constructor of the same class
 1761 = A local class or interface {0} is implicitly static; cannot have explicit static declaration
 1762 = Illegal modifier for the local record {0}; only final and strictfp are permitted
 1763 = Extended dimensions are illegal for a record component

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordsRestrictedClassTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordsRestrictedClassTest.java
@@ -1312,7 +1312,7 @@ public class RecordsRestrictedClassTest extends AbstractRegressionTest {
 			"2. ERROR in X.java (at line 12)\n" +
 			"	public Point(Integer myInt) {}\n" +
 			"	       ^^^^^^^^^^^^^^^^^^^^\n" +
-			"A non-canonical constructor must start with an explicit invocation to a constructor\n" +
+			"A non-canonical constructor must invoke another constructor of the same class\n" +
 			"----------\n");
 	}
 	public void testBug553152_016() {
@@ -4566,7 +4566,7 @@ public void testBug562637_001() {
 			"1. ERROR in X.java (at line 2)\n" +
 			"	public X() {\n" +
 			"	       ^^^\n" +
-			"A non-canonical constructor must start with an explicit invocation to a constructor\n" +
+			"A non-canonical constructor must invoke another constructor of the same class\n" +
 			"----------\n");
 	}
 	public void testBug564146_002() {
@@ -4581,10 +4581,10 @@ public void testBug562637_001() {
 				"}",
 			},
 			"----------\n" +
-			"1. ERROR in X.java (at line 2)\n" +
-			"	public X() {\n" +
-			"	       ^^^\n" +
-			"A non-canonical constructor must start with an explicit invocation to a constructor\n" +
+			"1. ERROR in X.java (at line 3)\n" +
+			"	super();\n" +
+			"	^^^^^^^^\n" +
+			"A non-canonical constructor must invoke another constructor of the same class\n" +
 			"----------\n");
 	}
 	public void testBug564146_003() {
@@ -8146,7 +8146,7 @@ public void testBug571015_002() {
 			"1. ERROR in X.java (at line 2)\n" +
 			"	R(I<X> ... t) {}\n" +
 			"	^^^^^^^^^^^^^\n" +
-			"A non-canonical constructor must start with an explicit invocation to a constructor\n" +
+			"A non-canonical constructor must invoke another constructor of the same class\n" +
 			"----------\n" +
 			"2. WARNING in X.java (at line 2)\n" +
 			"	R(I<X> ... t) {}\n" +


### PR DESCRIPTION
Fix bug 1:
+ don't assume access to outer this in static nested class/record

Fix bug 2:
+ move analysis of this case to ExplicitConstructorCall
  + by this move the analysis is independent of early/late contexts

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4193
