### PR TITLE
Make InnerClassInfo thread-safe

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/ClassFileStruct.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/ClassFileStruct.java
@@ -16,7 +16,7 @@ package org.eclipse.jdt.internal.compiler.classfmt;
 abstract public class ClassFileStruct {
 	byte[] reference;
 	int[] constantPoolOffsets;
-	int structOffset;
+	final int structOffset;
 public ClassFileStruct(byte[] classFileBytes, int[] offsets, int offset) {
 	this.reference = classFileBytes;
 	this.constantPoolOffsets = offsets;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/InnerClassInfo.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/InnerClassInfo.java
@@ -22,16 +22,16 @@ import org.eclipse.jdt.internal.compiler.util.CharDeduplication;
  */
 
 public class InnerClassInfo extends ClassFileStruct implements IBinaryNestedType {
-	int innerClassNameIndex = -1;
-	int outerClassNameIndex = -1;
-	int innerNameIndex = -1;
-	private char[] innerClassName;
-	private char[] outerClassName;
-	private char[] innerName;
-	private int accessFlags = -1;
-	private boolean readInnerClassName;
-	private boolean readOuterClassName;
-	private boolean readInnerName;
+	final int innerClassNameIndex;
+	final int outerClassNameIndex;
+	final int innerNameIndex;
+	private volatile char[] innerClassName;
+	private volatile char[] outerClassName;
+	private volatile char[] innerName;
+	private volatile int accessFlags = -1;
+	private volatile boolean readInnerClassName;
+	private volatile boolean readOuterClassName;
+	private volatile boolean readInnerName;
 
 public InnerClassInfo(byte classFileBytes[], int offsets[], int offset) {
 	super(classFileBytes, offsets, offset);


### PR DESCRIPTION
This change adjusts fields in InnerClassInfo to be volatile, if those fields can cause concurrency problems. In particular, the following methods result in issues when ran with Java 25 in a multi-threade environment:

* getEnclosingTypeName
* getName
* getSourceName

They follow the pattern of checking whether some value is initialized with a boolean variable, then setting the value if its not initialized yet. When those methods are invoked from multiple threads on the same object, there is no guarantee that the initialized value will be read by all threads. By making both the flag and the value fields are volatile, threads will read the correct value; the value could still be initialized multiple times, but we assume that all threads will be setting the same value.

This change additionally makes some fields final, to make the code easier to read and analyze.

Fixes: #4199

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
