### PR TITLE
NPE: Cannot invoke org.eclipse.jdt.internal.compiler.lookup.TypeBinding.isAnonymousType() because binding.type is null" on hyperlink request

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ResolveTests10.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ResolveTests10.java
@@ -152,4 +152,30 @@ public class ResolveTests10 extends AbstractJavaModelTests {
 		assertEquals(1, selected.length);
 		assertEquals("Number", selected[0].getElementName());
 	}
+
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4216
+	// NPE: Cannot invoke org.eclipse.jdt.internal.compiler.lookup.TypeBinding.isAnonymousType() because binding.type is null" on hyperlink request
+	public void testIssue4216() throws CoreException {
+		this.wc = getWorkingCopy("/Resolve/src/X.java",
+		"""
+		public class Hover {
+
+			private void mat() {
+				var entity/*here*/ = entity.get() == null ? entity : entity.get();
+			}
+		}
+		""");
+		String str = this.wc.getSource();
+		String selection = "entity/*here*/";
+		int start = str.lastIndexOf(selection);
+		int length = selection.length();
+
+		IJavaElement[] selected = this.wc.codeSelect(start, length);
+		assertEquals(1, selected.length);
+		assertElementsEqual(
+				"Unexpected elements",
+				"entity [in mat() [in Hover [in [Working copy] X.java [in <default> [in src [in Resolve]]]]]]",
+				selected
+			);
+	}
 }

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SelectionRequestor.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SelectionRequestor.java
@@ -415,7 +415,7 @@ public void acceptLocalVariable(LocalVariableBinding binding, org.eclipse.jdt.in
 	LocalVariable localVar = null;
 	if(parent != null) {
 		String typeSig = null;
-		if (local.type == null || (local.type.isTypeNameVar(binding.declaringScope) && !binding.type.isAnonymousType())) {
+		if (local.type == null || (local.type.isTypeNameVar(binding.declaringScope) && binding.type != null && !binding.type.isAnonymousType())) {
 			if (local.initialization instanceof CastExpression) {
 				typeSig = Util.typeSignature(((CastExpression) local.initialization).type);
 			} else {


### PR DESCRIPTION
* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4216

