### PR TITLE
Content Assist doesn't work for record type names in some contexts

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests16.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests16.java
@@ -14,6 +14,7 @@
 package org.eclipse.jdt.core.tests.model;
 
 import junit.framework.Test;
+import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
@@ -1178,6 +1179,201 @@ public class CompletionTests16 extends AbstractJavaModelCompletionTests {
 				"name[FIELD_REF]{this.name, LR;, Ljava.lang.String;, name, null, 49}\n" +
 				"name[LOCAL_VARIABLE_REF]{name, null, Ljava.lang.String;, name, null, 52}\n" +
 				"name[METHOD_REF]{name(), LR;, ()Ljava.lang.String;, name, null, 52}",
+				requestor.getResults());
+
+	}
+
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4215
+	// Content Assist doesn't work for record type names in some contexts
+	public void testIssue4215() throws JavaModelException {
+		this.workingCopies = new ICompilationUnit[2];
+
+		this.workingCopies[1] = getWorkingCopy(
+				"/Completion/src/p/Point.java",
+				"""
+				package p;
+				public record Point(int x, int y) {
+					void foo() {
+						System.out.println(this.x);
+						System.out.println(x());
+					}
+				}
+
+				class X {
+					X x = new X();
+				}
+				"""
+				);
+		this.workingCopies[0] = getWorkingCopy(
+				"/Completion/src/X.java",
+				"""
+				public class X {
+					public static void main(String[] args) {
+						new Poi
+					}
+				}
+				"""
+				);
+		this.workingCopies[0].getJavaProject(); //assuming single project for all working copies
+		CompletionTestsRequestor2 requestor = new CompletionTestsRequestor2(true);
+		requestor.allowAllRequiredProposals();
+		String str = this.workingCopies[0].getSource();
+		String completeBehind = "new Poi";
+		int cursorLocation = str.lastIndexOf(completeBehind) + completeBehind.length();
+		this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner, new NullProgressMonitor());
+		assertResults(
+				"Point[CONSTRUCTOR_INVOCATION]{(), Lp.Point;, (II)V, Point, (x, y), 52}",
+				requestor.getResults());
+
+	}
+
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4215
+	// Content Assist doesn't work for record type names in some contexts
+	public void testIssue4215_2() throws JavaModelException {
+		this.workingCopies = new ICompilationUnit[2];
+
+		this.workingCopies[1] = getWorkingCopy(
+				"/Completion/src/p/Point.java",
+				"""
+				package p;
+				public record Point(int x, int y) {
+					public Point {
+						x = 0;
+						y = 0;
+					}
+
+					void foo() {
+						System.out.println(this.x);
+						System.out.println(x());
+					}
+				}
+
+				class X {
+					X x = new X();
+				}
+				"""
+				);
+		this.workingCopies[0] = getWorkingCopy(
+				"/Completion/src/X.java",
+				"""
+				public class X {
+					public static void main(String[] args) {
+						new Poi
+					}
+				}
+				"""
+				);
+		this.workingCopies[0].getJavaProject(); //assuming single project for all working copies
+		CompletionTestsRequestor2 requestor = new CompletionTestsRequestor2(true);
+		requestor.allowAllRequiredProposals();
+		String str = this.workingCopies[0].getSource();
+		String completeBehind = "new Poi";
+		int cursorLocation = str.lastIndexOf(completeBehind) + completeBehind.length();
+		this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner, new NullProgressMonitor());
+		assertResults(
+				"Point[CONSTRUCTOR_INVOCATION]{(), Lp.Point;, (II)V, Point, (x, y), 52}",
+				requestor.getResults());
+
+	}
+
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4215
+	// Content Assist doesn't work for record type names in some contexts
+	public void testIssue4215_3() throws JavaModelException {
+		this.workingCopies = new ICompilationUnit[2];
+
+		this.workingCopies[1] = getWorkingCopy(
+				"/Completion/src/p/Point.java",
+				"""
+				package p;
+				public record Point(int x, int y) {
+					public Point() {
+						this(0, 0);
+					}
+
+					void foo() {
+						System.out.println(this.x);
+						System.out.println(x());
+					}
+				}
+
+				class X {
+					X x = new X();
+				}
+				"""
+				);
+		this.workingCopies[0] = getWorkingCopy(
+				"/Completion/src/X.java",
+				"""
+				public class X {
+					public static void main(String[] args) {
+						new Poi
+					}
+				}
+				"""
+				);
+		this.workingCopies[0].getJavaProject(); //assuming single project for all working copies
+		CompletionTestsRequestor2 requestor = new CompletionTestsRequestor2(true);
+		requestor.allowAllRequiredProposals();
+		String str = this.workingCopies[0].getSource();
+		String completeBehind = "new Poi";
+		int cursorLocation = str.lastIndexOf(completeBehind) + completeBehind.length();
+		this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner, new NullProgressMonitor());
+		assertResults(
+				"Point[CONSTRUCTOR_INVOCATION]{(), Lp.Point;, ()V, Point, null, 52}\n" +
+				"Point[CONSTRUCTOR_INVOCATION]{(), Lp.Point;, (II)V, Point, (x, y), 52}",
+				requestor.getResults());
+
+	}
+
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4215
+	// Content Assist doesn't work for record type names in some contexts
+	public void testIssue4215_4() throws JavaModelException {
+		this.workingCopies = new ICompilationUnit[2];
+
+		this.workingCopies[1] = getWorkingCopy(
+				"/Completion/src/p/Point.java",
+				"""
+				package p;
+				public record Point(int x, int y) {
+					public Point() {
+						this(0, 0);
+					}
+					public Point (int x, int y) {
+						this.x = x;
+						this.y = y;
+					}
+					void foo() {
+						System.out.println(this.x);
+						System.out.println(x());
+					}
+				}
+
+				class X {
+					X x = new X();
+				}
+				"""
+				);
+		this.workingCopies[0] = getWorkingCopy(
+				"/Completion/src/X.java",
+				"""
+				public class X {
+					public static void main(String[] args) {
+						new Poi
+					}
+				}
+				"""
+				);
+		this.workingCopies[0].getJavaProject(); //assuming single project for all working copies
+		CompletionTestsRequestor2 requestor = new CompletionTestsRequestor2(true);
+		requestor.allowAllRequiredProposals();
+		String str = this.workingCopies[0].getSource();
+		String completeBehind = "new Poi";
+		int cursorLocation = str.lastIndexOf(completeBehind) + completeBehind.length();
+		this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner, new NullProgressMonitor());
+		assertResults(
+				"Point[CONSTRUCTOR_INVOCATION]{(), Lp.Point;, ()V, Point, null, 52}\n" +
+				"Point[CONSTRUCTOR_INVOCATION]{(), Lp.Point;, (II)V, Point, (x, y), 52}\n" +
+				"Point[CONSTRUCTOR_INVOCATION]{(), Lp.Point;, (II)V, Point, (x, y), 52}", // duplicated: see https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4222
 				requestor.getResults());
 
 	}

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/CompletionEngine.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/CompletionEngine.java
@@ -6340,6 +6340,16 @@ public final class CompletionEngine
 		}
 	}
 
+	private boolean argumentMismatch(AbstractVariableDeclaration[] arguments, char[][] parameterTypes) {
+		int argumentsLength = arguments == null ? 0 : arguments.length;
+		if (parameterTypes.length != argumentsLength)
+			return true;
+		for (int j = 0; j < argumentsLength; j++)
+			if (!CharOperation.equals(getTypeName(arguments[j].type), parameterTypes[j]))
+				return true;
+		return false;
+	}
+
 	private char[] getResolvedSignature(char[][] parameterTypes, char[] fullyQualifiedTypeName, int parameterCount, Scope scope) {
 		char[][] cn = CharOperation.splitOn('.', fullyQualifiedTypeName);
 
@@ -6381,24 +6391,19 @@ public final class CompletionEngine
 						return null;
 
 					next : for (AbstractMethodDeclaration method : methods) {
-						if (!method.isConstructor()) continue next;
-
-						AbstractVariableDeclaration[] arguments = method.arguments(true);
-						int argumentsLength = arguments == null ? 0 : arguments.length;
-
-						if (parameterCount != argumentsLength) continue next;
-
-						for (int j = 0; j < argumentsLength; j++) {
-							char[] argumentTypeName = getTypeName(arguments[j].type);
-
-							if (!CharOperation.equals(argumentTypeName, parameterTypes[j])) {
-								continue next;
-							}
-						}
-
+						if (!method.isConstructor() || argumentMismatch(method.arguments(true), parameterTypes))
+							continue next;
 						refBinding.resolveTypesFor(method.binding); // force resolution
 						if (method.binding == null) continue next;
 						return getSignature(method.binding);
+					}
+					if (typeDeclaration.isRecord() && !argumentMismatch(typeDeclaration.recordComponents, parameterTypes)) {
+						MethodBinding [] constructors = refBinding.getMethods(TypeConstants.INIT, parameterTypes.length);
+						if (constructors != null) {
+							for (MethodBinding constructor : constructors)
+								if (constructor instanceof SyntheticMethodBinding)
+									return getSignature(constructor);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4215

