### PR TITLE
Compiler runs into a stack overflow when dealing with nested generics #4214

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
@@ -164,6 +164,7 @@ public class InferenceContext18 {
 	TypeBinding missingType;
 
 	private static ThreadLocal<InferenceContext18> instance = new ThreadLocal<>();
+	private boolean isCaptureInProcess = false;
 
 	public static boolean isSameSite(InvocationSite site1, InvocationSite site2) {
 		if (site1 == site2)
@@ -2213,9 +2214,14 @@ public class InferenceContext18 {
 	}
 	public static TypeBinding maybeCapture(TypeBinding type) {
 		InferenceContext18 inst = instance.get();
-		if (inst != null) {
-			InvocationSite inv = inst.currentInvocation;
-			return type.capture(inst.scope, inv.sourceStart(), inv.sourceEnd());
+		if (inst != null && !inst.isCaptureInProcess) {
+			try {
+				InvocationSite inv = inst.currentInvocation;
+				inst.isCaptureInProcess = true;
+				return type.capture(inst.scope, inv.sourceStart(), inv.sourceEnd());
+			} finally {
+				inst.isCaptureInProcess = false;
+			}
 		}
 		return type;
 	}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest.java
@@ -6766,5 +6766,21 @@ public void testIssue2523() {
             }
         );
 }
+public void testGH4214() {
+	runConformTest(new String[] {
+		"C.java",
+		"""
+		class C {
+			class A<T> {}
+			public class B<T extends B<? extends A<?>>> extends A<T> {
+				void foo() {
+					bar((T)this);
+				}
+			}
+			<T extends B<?>> void bar(T t) {}
+		}
+		"""
+	});
+}
 }
 


### PR DESCRIPTION
Avoid re-entrance of IC18.maybeCapture()

https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4214
