### PR TITLE
NPE: Cannot invoke org.eclipse.jdt.internal.compiler.lookup.BlockScope.getBinding() because scope is null" on hyperlink request

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ResolveTests10.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ResolveTests10.java
@@ -178,4 +178,49 @@ public class ResolveTests10 extends AbstractJavaModelTests {
 				selected
 			);
 	}
+
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4217
+	// NPE: Cannot invoke org.eclipse.jdt.internal.compiler.lookup.BlockScope.getBinding(char[], int, org.eclipse.jdt.internal.compiler.lookup.InvocationSite, boolean) because scope is null" on hyperlink request 
+	public void testIssue4217() throws CoreException {
+		this.wc = getWorkingCopy("/Resolve/src/X.java",
+		"""
+		import java.util.concurrent.Callable;
+
+		public class Test {
+
+			public static <T> void createObjectBinding(final Callable<T> func) {
+				return;
+			}
+
+			sealed interface Index {
+				enum SS implements Index {}
+				enum TS implements Index {}
+			}
+
+			public abstract sealed class Entity<S extends Index> permits Struct, Time {}
+
+			final class Struct extends Entity<Index.SS> {}
+
+			final class Time extends Entity<Index.TS> {
+				Struct getStruct() {
+					return null;
+				}
+			}
+
+			private void setMaterials(Time entity) {
+				ObjectBinding<Entity<?>> selfIllumImage = Bindings.<Entity<?>>createObjectBinding(() -> {
+					var entity2/*here*/ = entity.getStruct() == null ? entity : entity.getStruct();
+					return createSlefIlluminationMap(entity.getSpells());
+				});
+			}
+		}
+		""");
+		String str = this.wc.getSource();
+		String selection = "entity2/*here*/";
+		int start = str.lastIndexOf(selection);
+		int length = selection.length();
+
+		IJavaElement[] selected = this.wc.codeSelect(start, length);
+		assertEquals(0, selected.length);
+	}
 }

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/SelectionEngine.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/SelectionEngine.java
@@ -1410,6 +1410,9 @@ public final class SelectionEngine extends Engine implements ISearchRequestor {
 			public boolean visit(
 		    		LocalDeclaration localDeclaration, BlockScope scope) {
 				if(localDeclaration instanceof SelectionOnLocalName) {
+					if (scope == null) {
+						return false;
+					}
 					localDeclaration.resolve(scope);
 				}
 				if (localDeclaration.type instanceof SingleTypeReference && ((SingleTypeReference)localDeclaration.type).token == assistIdentifier) {


### PR DESCRIPTION
…e.getBinding() because scope is null" on hyperlink request (#4217)

* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4217

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
