### PR TITLE
Implement a fail fast mechanism for org.eclipse.jdt.internal.compiler.lookup.ReferenceBinding.isFunctionalInterface(Scope)

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MethodBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MethodBinding.java
@@ -1418,17 +1418,14 @@ private boolean hasNonNullDefaultForType(TypeBinding type, int location, Abstrac
 }
 
 public boolean redeclaresPublicObjectMethod(Scope scope) {
-	ReferenceBinding javaLangObject = scope.getJavaLangObject();
-	MethodBinding [] methods = javaLangObject.getMethods(this.selector);
-	for (int i = 0, length = methods == null ? 0 : methods.length; i < length; i++) {
-		final MethodBinding method = methods[i];
-		if (!method.isPublic() || method.isStatic() || method.parameters.length != this.parameters.length)
-			continue;
-		if (MethodVerifier.doesMethodOverride(this, method, scope.environment()))
-			return true;
-	}
-	return false;
+	 if (this.selector[0] == 'h')
+		 return this.parameters.length == 0 && this.selector.length == 8 && CharOperation.equals(this.selector, TypeConstants.HASHCODE);
+	 if (this.selector[0] == 't')
+		 return this.parameters.length == 0 && this.selector.length == 8 && CharOperation.equals(this.selector, TypeConstants.TOSTRING);
+	 return this.selector[0] == 'e' && this.parameters.length == 1 && this.selector.length == 6
+						&& CharOperation.equals(this.selector, TypeConstants.EQUALS) && TypeBinding.equalsEquals(this.parameters[0], scope.getJavaLangObject());
 }
+
 public boolean isVoidMethod() {
 	return this.returnType == TypeBinding.VOID;
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
@@ -1680,6 +1680,22 @@ public boolean isInterface() {
 	return (this.modifiers & ClassFileConstants.AccInterface) != 0;
 }
 
+private boolean isPatentlyDysfunctional(Scope scope) {
+	if (!isInterface() || isSealed() || isAnnotationType())
+		return true;
+	MethodBinding samCandidate = null;
+	for (MethodBinding method : methods()) {
+		if (method.isAbstract() && !method.redeclaresPublicObjectMethod(scope)) {
+			if (samCandidate == null) {
+				samCandidate = method;
+			} else if (!CharOperation.equals(samCandidate.selector, method.selector) ||
+						samCandidate.parameters.length != method.parameters.length) {
+				return true;
+			}
+		}
+	}
+	return false;
+}
 @Override
 public boolean isFunctionalInterface(Scope scope) {
 	MethodBinding method;
@@ -2399,11 +2415,11 @@ public MethodBinding getSingleAbstractMethod(Scope scope, boolean replaceWildcar
 	int index = replaceWildcards ? 0 : 1;
 	if (this.singleAbstractMethod != null) {
 		if (this.singleAbstractMethod[index] != null)
-		return this.singleAbstractMethod[index];
+			return this.singleAbstractMethod[index];
 	} else {
 		this.singleAbstractMethod = new MethodBinding[2];
-		if (this.isSealed())
-			return this.singleAbstractMethod[index] = samProblemBinding; // JLS 9.8
+		if (isPatentlyDysfunctional(scope))
+			return this.singleAbstractMethod[0] = this.singleAbstractMethod[1] = samProblemBinding;
 	}
 
 	if (this.compoundName != null)

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NegativeLambdaExpressionsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NegativeLambdaExpressionsTest.java
@@ -10679,6 +10679,26 @@ this.runNegativeTest(
 		"----------\n");
 }
 
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4227
+// ECJ fails to complain about misapplication of @FunctionalInterface annotation on annotation types
+public void testIssue4227() {
+this.runNegativeTest(
+		new String[] {
+			"X.java",
+			"""
+			@FunctionalInterface
+			@interface X {
+			}
+			"""
+		},
+		"----------\n" +
+		"1. ERROR in X.java (at line 2)\n" +
+		"	@interface X {\n" +
+		"	           ^\n" +
+		"Invalid '@FunctionalInterface' annotation; X is not a functional interface\n" +
+		"----------\n");
+}
+
 public static Class testClass() {
 	return NegativeLambdaExpressionsTest.class;
 }


### PR DESCRIPTION
* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4227