### PR TITLE
[Build] Add missing version of maven-enforcer-plugin

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/pom.xml
+++ b/org.eclipse.jdt.core.compiler.batch/pom.xml
@@ -116,6 +116,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.6.1</version>
         <executions>
           <execution>
             <id>no-tabs-in-compiler-messages</id>


### PR DESCRIPTION
## What it does
Add missing version of maven-enforcer-plugin.
Currently there is a warning in the (I-) build because of this.

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
