### PR TITLE
More efficient, more modern, fast failing version of computation of the abstract contracts of an interface while deriving SAM 

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/IntersectionTypeBinding18.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/IntersectionTypeBinding18.java
@@ -24,6 +24,7 @@
 package org.eclipse.jdt.internal.compiler.lookup;
 
 import java.util.Set;
+import java.util.stream.Stream;
 import org.eclipse.jdt.internal.compiler.ast.Wildcard;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 
@@ -67,22 +68,10 @@ public class IntersectionTypeBinding18 extends ReferenceBinding {
 	}
 
 	@Override
-	protected MethodBinding[] getInterfaceAbstractContracts(Scope scope, boolean replaceWildcards, boolean filterDefaultMethods) throws InvalidBindingException {
-		int typesLength = this.intersectingTypes.length;
-		MethodBinding[][] methods = new MethodBinding[typesLength][];
-		int contractsLength = 0;
-		for (int i = 0; i < typesLength; i++) {
-			methods[i] = this.intersectingTypes[i].getInterfaceAbstractContracts(scope, replaceWildcards, true);
-			contractsLength += methods[i].length;
-		}
-		MethodBinding[] contracts = new MethodBinding[contractsLength];
-		int idx = 0;
-		for (int i = 0; i < typesLength; i++) {
-			int len = methods[i].length;
-			System.arraycopy(methods[i], 0, contracts, idx, len);
-			idx += len;
-		}
-		return contracts;
+	protected Stream<MethodBinding> collateFunctionalInterfaceContracts(Scope scope, boolean replaceWildcards, Set<MethodBinding> contracts) throws DysfunctionalInterfaceException {
+		for (ReferenceBinding intersectingType : this.intersectingTypes)
+			intersectingType.collateFunctionalInterfaceContracts(scope, replaceWildcards, contracts);
+		return contracts.stream();
 	}
 
 	@Override

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/IntersectionTypeBinding18.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/IntersectionTypeBinding18.java
@@ -23,6 +23,7 @@
 
 package org.eclipse.jdt.internal.compiler.lookup;
 
+import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Stream;
 import org.eclipse.jdt.internal.compiler.ast.Wildcard;
@@ -68,10 +69,10 @@ public class IntersectionTypeBinding18 extends ReferenceBinding {
 	}
 
 	@Override
-	protected Stream<MethodBinding> collateFunctionalInterfaceContracts(Scope scope, boolean replaceWildcards, Set<MethodBinding> contracts) throws DysfunctionalInterfaceException {
-		for (ReferenceBinding intersectingType : this.intersectingTypes)
-			intersectingType.collateFunctionalInterfaceContracts(scope, replaceWildcards, contracts);
-		return contracts.stream();
+	protected Stream<MethodBinding> collateFunctionalInterfaceContracts(Scope scope, boolean replaceWildcards) throws DysfunctionalInterfaceException {
+		return Arrays.stream(this.intersectingTypes).flatMap( //
+						intersectingType -> intersectingType.collateFunctionalInterfaceContracts(scope, replaceWildcards) //
+		);
 	}
 
 	@Override

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/IntersectionTypeBinding18.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/IntersectionTypeBinding18.java
@@ -69,9 +69,9 @@ public class IntersectionTypeBinding18 extends ReferenceBinding {
 	}
 
 	@Override
-	protected Stream<MethodBinding> collateFunctionalInterfaceContracts(Scope scope, boolean replaceWildcards) throws DysfunctionalInterfaceException {
+	protected Stream<MethodBinding> collateFunctionalInterfaceContracts(Scope scope, boolean replaceWildcards, Set<ReferenceBinding> visitedInterfaces) throws DysfunctionalInterfaceException {
 		return Arrays.stream(this.intersectingTypes).flatMap( //
-						intersectingType -> intersectingType.collateFunctionalInterfaceContracts(scope, replaceWildcards) //
+						intersectingType -> intersectingType.collateFunctionalInterfaceContracts(scope, replaceWildcards, visitedInterfaces) //
 		);
 	}
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedTypeBinding.java
@@ -53,6 +53,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.internal.compiler.ast.ASTNode;
 import org.eclipse.jdt.internal.compiler.ast.NullAnnotationMatching;
@@ -1724,11 +1725,12 @@ public class ParameterizedTypeBinding extends ReferenceBinding implements Substi
 	}
 
 	@Override
-	protected MethodBinding[] getInterfaceAbstractContracts(Scope scope, boolean replaceWildcards, boolean filterDefaultMethods) throws InvalidBindingException {
+	protected Stream<MethodBinding> collateFunctionalInterfaceContracts(Scope scope, boolean replaceWildcards, Set<MethodBinding> contracts) throws DysfunctionalInterfaceException {
 		if (replaceWildcards) {
 			TypeBinding[] types = getNonWildcardParameters(scope);
 			if (types == null)
-				return new MethodBinding[] { new ProblemMethodBinding(TypeConstants.ANONYMOUS_METHOD, null, ProblemReasons.NotAWellFormedParameterizedType) };
+				throw DYSFUNCTIONAL_INTERFACE_EXCEPTION;
+
 			for (int i = 0; i < types.length; i++) {
 				if (TypeBinding.notEquals(types[i], this.arguments[i])) {
 					// non-wildcard parameterization differs from this, so use it:
@@ -1736,14 +1738,15 @@ public class ParameterizedTypeBinding extends ReferenceBinding implements Substi
 					TypeVariableBinding [] typeParameters = this.type.typeVariables();
 					for (int j = 0, length = typeParameters.length; j < length; j++) {
 						if (!typeParameters[j].boundCheck(declaringType, types[j], scope, null).isOKbyJLS())
-							return new MethodBinding[] { new ProblemMethodBinding(TypeConstants.ANONYMOUS_METHOD, null, ProblemReasons.NotAWellFormedParameterizedType) };
+							throw DYSFUNCTIONAL_INTERFACE_EXCEPTION;
 					}
-					return declaringType.getInterfaceAbstractContracts(scope, replaceWildcards, filterDefaultMethods);
+					return declaringType.collateFunctionalInterfaceContracts(scope, replaceWildcards, contracts);
 				}
 			}
 		}
-		return super.getInterfaceAbstractContracts(scope, replaceWildcards, filterDefaultMethods);
+		return super.collateFunctionalInterfaceContracts(scope, replaceWildcards, contracts);
 	}
+
 	@Override
 	public MethodBinding getSingleAbstractMethod(final Scope scope, boolean replaceWildcards) {
 		return getSingleAbstractMethod(scope, replaceWildcards, -1, -1 /* do not capture */);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedTypeBinding.java
@@ -1725,7 +1725,7 @@ public class ParameterizedTypeBinding extends ReferenceBinding implements Substi
 	}
 
 	@Override
-	protected Stream<MethodBinding> collateFunctionalInterfaceContracts(Scope scope, boolean replaceWildcards) throws DysfunctionalInterfaceException {
+	protected Stream<MethodBinding> collateFunctionalInterfaceContracts(Scope scope, boolean replaceWildcards, Set<ReferenceBinding> visitedInterfaces) throws DysfunctionalInterfaceException {
 		if (replaceWildcards) {
 			TypeBinding[] types = getNonWildcardParameters(scope);
 			if (types == null)
@@ -1740,11 +1740,11 @@ public class ParameterizedTypeBinding extends ReferenceBinding implements Substi
 						if (!typeParameters[j].boundCheck(declaringType, types[j], scope, null).isOKbyJLS())
 							throw DYSFUNCTIONAL_INTERFACE_EXCEPTION;
 					}
-					return declaringType.collateFunctionalInterfaceContracts(scope, replaceWildcards);
+					return declaringType.collateFunctionalInterfaceContracts(scope, replaceWildcards, visitedInterfaces);
 				}
 			}
 		}
-		return super.collateFunctionalInterfaceContracts(scope, replaceWildcards);
+		return super.collateFunctionalInterfaceContracts(scope, replaceWildcards, visitedInterfaces);
 	}
 
 	@Override

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedTypeBinding.java
@@ -1725,7 +1725,7 @@ public class ParameterizedTypeBinding extends ReferenceBinding implements Substi
 	}
 
 	@Override
-	protected Stream<MethodBinding> collateFunctionalInterfaceContracts(Scope scope, boolean replaceWildcards, Set<MethodBinding> contracts) throws DysfunctionalInterfaceException {
+	protected Stream<MethodBinding> collateFunctionalInterfaceContracts(Scope scope, boolean replaceWildcards) throws DysfunctionalInterfaceException {
 		if (replaceWildcards) {
 			TypeBinding[] types = getNonWildcardParameters(scope);
 			if (types == null)
@@ -1740,11 +1740,11 @@ public class ParameterizedTypeBinding extends ReferenceBinding implements Substi
 						if (!typeParameters[j].boundCheck(declaringType, types[j], scope, null).isOKbyJLS())
 							throw DYSFUNCTIONAL_INTERFACE_EXCEPTION;
 					}
-					return declaringType.collateFunctionalInterfaceContracts(scope, replaceWildcards, contracts);
+					return declaringType.collateFunctionalInterfaceContracts(scope, replaceWildcards);
 				}
 			}
 		}
-		return super.collateFunctionalInterfaceContracts(scope, replaceWildcards, contracts);
+		return super.collateFunctionalInterfaceContracts(scope, replaceWildcards);
 	}
 
 	@Override

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
@@ -2341,10 +2341,10 @@ private MethodBinding[] getFunctionalInterfaceAbstractContracts(Scope scope, boo
 		for (int j = i + 1; j < length; j++) {
 			MethodBinding otherMethod = methods[j];
 			if (method.selector.length != otherMethod.selector.length || !CharOperation.equals(method.selector, otherMethod.selector))
-				break; // Skip comparing apple to oranges.
+				break; // Skip comparing apple to oranges (input sorted by selector, so no viable overrides past this point)
 			if (MethodVerifier.doesMethodOverride(otherMethod, method, environment)) {
 				methods[i] = method = null;
-				break; // Skip comparing rotten apple with remaining lot.
+				break; // Skip comparing rotten apple with remaining lot: is overridden already, no use checking if is overridden also by another
 			}
 		}
 		if (method != null && method.isAbstract()) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
@@ -2332,9 +2332,8 @@ private MethodBinding[] getFunctionalInterfaceAbstractContracts(Scope scope, boo
 	boolean isAnnotationBasedNullAnalysisEnabled = environment.globalOptions.isAnnotationBasedNullAnalysisEnabled;
 	MethodBinding samCandidate = null;
 
-	MethodBinding[] methods = collateFunctionalInterfaceContracts(scope, replaceWildcards)
+	MethodBinding[] methods = collateFunctionalInterfaceContracts(scope, replaceWildcards, new HashSet<>())
 		.sorted((m1, m2) -> CharOperation.compareTo(m1.selector, m2.selector))
-		.distinct()
 		.toArray(MethodBinding []::new);
 
 	for (int i = 0, length = methods.length; i < length; i++) {
@@ -2360,7 +2359,7 @@ private MethodBinding[] getFunctionalInterfaceAbstractContracts(Scope scope, boo
 	return Arrays.stream(methods).filter(m -> m != null && m.isAbstract()).toArray(MethodBinding []::new);
 }
 
-protected Stream<MethodBinding> collateFunctionalInterfaceContracts(Scope scope, boolean replaceWildcards) throws DysfunctionalInterfaceException {
+protected Stream<MethodBinding> collateFunctionalInterfaceContracts(Scope scope, boolean replaceWildcards, Set<ReferenceBinding> visitedInterfaces) throws DysfunctionalInterfaceException {
 
 	if (!isInterface() || !isValidBinding())
 		throw DYSFUNCTIONAL_INTERFACE_EXCEPTION;
@@ -2374,7 +2373,7 @@ protected Stream<MethodBinding> collateFunctionalInterfaceContracts(Scope scope,
 	};
 
 	return Stream.concat( //
-			Arrays.stream(superInterfaces()).flatMap(superInterface -> superInterface.collateFunctionalInterfaceContracts(scope, replaceWildcards)), //
+			Arrays.stream(superInterfaces()).filter(iface->visitedInterfaces.add(iface)).flatMap(superInterface -> superInterface.collateFunctionalInterfaceContracts(scope, replaceWildcards, visitedInterfaces)), //
 			Arrays.stream(methods()).filter(isContractual)
 	);
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
@@ -57,9 +57,13 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.internal.compiler.ast.ASTNode;
 import org.eclipse.jdt.internal.compiler.ast.LambdaExpression;
@@ -95,6 +99,8 @@ abstract public class ReferenceBinding extends TypeBinding {
 
 	int typeBits; // additional bits characterizing this type
 	protected MethodBinding [] singleAbstractMethod;
+
+	protected static final DysfunctionalInterfaceException DYSFUNCTIONAL_INTERFACE_EXCEPTION = new DysfunctionalInterfaceException("Not a functional interface"); //$NON-NLS-1$
 
 	public static final ReferenceBinding LUB_GENERIC = new ReferenceBinding() { /* used for lub computation */
 		{ this.id = TypeIds.T_undefined; }
@@ -2322,93 +2328,58 @@ public void detectWrapperResource() {
 	}
 }
 
-protected MethodBinding [] getInterfaceAbstractContracts(Scope scope, boolean replaceWildcards, boolean filterDefaultMethods) throws InvalidBindingException {
-
-	if (!isInterface() || !isValidBinding()) {
-		throw new InvalidBindingException("Not a functional interface"); //$NON-NLS-1$
-	}
-
-	MethodBinding [] methods = methods();
-	MethodBinding [] contracts = new MethodBinding[0];
-	int contractsCount = 0;
-	int contractsLength = 0;
-
-	ReferenceBinding [] superInterfaces = superInterfaces();
-	for (ReferenceBinding superInterface : superInterfaces) {
-		// filterDefaultMethods=false => keep default methods needed to filter out any abstract methods they may override:
-		MethodBinding [] superInterfaceContracts = superInterface.getInterfaceAbstractContracts(scope, replaceWildcards, false);
-		final int superInterfaceContractsLength = superInterfaceContracts == null  ? 0 : superInterfaceContracts.length;
-		if (superInterfaceContractsLength == 0) continue;
-		if (contractsLength < contractsCount + superInterfaceContractsLength) {
-			System.arraycopy(contracts, 0, contracts = new MethodBinding[contractsLength = contractsCount + superInterfaceContractsLength], 0, contractsCount);
-		}
-		System.arraycopy(superInterfaceContracts, 0, contracts, contractsCount,	superInterfaceContractsLength);
-		contractsCount += superInterfaceContractsLength;
-	}
+private MethodBinding[] getFunctionalInterfaceAbstractContracts(Scope scope, boolean replaceWildcards) throws DysfunctionalInterfaceException {
 
 	LookupEnvironment environment = scope.environment();
-	for (int i = 0, length = methods == null ? 0 : methods.length; i < length; i++) {
-		final MethodBinding method = methods[i];
-		if (method == null || method.isStatic() || method.redeclaresPublicObjectMethod(scope) || method.isPrivate())
-			continue;
-		if (!method.isValidBinding())
-			throw new InvalidBindingException("Not a functional interface"); //$NON-NLS-1$
-		for (int j = 0; j < contractsCount;) {
-			if ( contracts[j] != null && MethodVerifier.doesMethodOverride(method, contracts[j], environment)) {
-				contractsCount--;
-				// abstract method from super type overridden by present interface ==> contracts[j] = null;
-				if (j < contractsCount) {
-					System.arraycopy(contracts, j+1, contracts, j, contractsCount - j);
-					continue;
-				}
-			}
-			j++;
-		}
-		if (filterDefaultMethods && method.isDefaultMethod())
-			continue; // skip default method itself
-		if (contractsCount == contractsLength) {
-			System.arraycopy(contracts, 0, contracts = new MethodBinding[contractsLength += 16], 0, contractsCount);
-		}
-		if(environment.globalOptions.isAnnotationBasedNullAnalysisEnabled) {
-			ImplicitNullAnnotationVerifier.ensureNullnessIsKnown(method, scope);
-		}
-		contracts[contractsCount++] = method;
-	}
-	// check mutual overriding of inherited methods (i.e., not from current type):
-	for (int i = 0; i < contractsCount; i++) {
-		MethodBinding contractI = contracts[i];
-		if (TypeBinding.equalsEquals(contractI.declaringClass, this))
-			continue;
-		for (int j = 0; j < contractsCount; j++) {
-			MethodBinding contractJ = contracts[j];
-			if (i == j || TypeBinding.equalsEquals(contractJ.declaringClass, this))
-				continue;
-			if (contractI == contractJ || MethodVerifier.doesMethodOverride(contractI, contractJ, environment)) {
-				contractsCount--;
-				// abstract method from one super type overridden by other super interface ==> contracts[j] = null;
-				if (j < contractsCount) {
-					System.arraycopy(contracts, j+1, contracts, j, contractsCount - j);
-				}
-				j--;
-				if (j < i)
-					i--;
-				continue;
+	boolean isAnnotationBasedNullAnalysisEnabled = environment.globalOptions.isAnnotationBasedNullAnalysisEnabled;
+	MethodBinding samCandidate = null;
+
+	MethodBinding[] methods = collateFunctionalInterfaceContracts(scope, replaceWildcards, new LinkedHashSet<>())
+		.sorted((m1, m2) -> CharOperation.compareTo(m1.selector, m2.selector))
+		.toArray(MethodBinding []::new);
+
+	for (int i = 0, length = methods.length; i < length; i++) {
+		MethodBinding method = methods[i];
+		for (int j = i + 1; j < length; j++) {
+			MethodBinding otherMethod = methods[j];
+			if (method.selector.length != otherMethod.selector.length || !CharOperation.equals(method.selector, otherMethod.selector))
+				break; // Skip comparing apple to oranges.
+			if (MethodVerifier.doesMethodOverride(otherMethod, method, environment)) {
+				methods[i] = method = null;
+				break; // Skip comparing rotten apple with remaining lot.
 			}
 		}
-		if (filterDefaultMethods && contractI.isDefaultMethod()) {
-			contractsCount--;
-			// remove default method after it has eliminated any matching abstract methods from contracts
-			if (i < contractsCount) {
-				System.arraycopy(contracts, i+1, contracts, i, contractsCount - i);
-			}
-			i--;
+		if (method != null && method.isAbstract()) {
+			if (samCandidate == null)
+				samCandidate = method;
+			else if (!CharOperation.equals(samCandidate.selector, method.selector) || samCandidate.parameters.length != method.parameters.length)
+				throw DYSFUNCTIONAL_INTERFACE_EXCEPTION;
+			if (isAnnotationBasedNullAnalysisEnabled)
+				ImplicitNullAnnotationVerifier.ensureNullnessIsKnown(method, scope);
 		}
 	}
-	if (contractsCount < contractsLength) {
-		System.arraycopy(contracts, 0, contracts = new MethodBinding[contractsCount], 0, contractsCount);
-	}
-	return contracts;
+	return Arrays.stream(methods).filter(m -> m != null && m.isAbstract()).toArray(MethodBinding []::new);
 }
+
+protected Stream<MethodBinding> collateFunctionalInterfaceContracts(Scope scope, boolean replaceWildcards, Set<MethodBinding> contracts) throws DysfunctionalInterfaceException {
+
+	if (!isInterface() || !isValidBinding())
+		throw DYSFUNCTIONAL_INTERFACE_EXCEPTION;
+
+	for (ReferenceBinding superInterface : superInterfaces())
+		superInterface.collateFunctionalInterfaceContracts(scope, replaceWildcards, contracts);
+
+	Predicate<MethodBinding> isContractual = m -> { // select valid public abstract || default methods
+									if (m == null || m.isStatic() || m.redeclaresPublicObjectMethod(scope) || m.isPrivate())
+										return false;
+									if (!m.isValidBinding())
+										throw DYSFUNCTIONAL_INTERFACE_EXCEPTION;
+									return true;
+							};
+	contracts.addAll(Arrays.stream(methods()).filter(isContractual).collect(Collectors.toList()));
+	return contracts.stream();
+}
+
 @Override
 public MethodBinding getSingleAbstractMethod(Scope scope, boolean replaceWildcards) {
 
@@ -2426,7 +2397,7 @@ public MethodBinding getSingleAbstractMethod(Scope scope, boolean replaceWildcar
 		scope.compilationUnitScope().recordQualifiedReference(this.compoundName);
 	MethodBinding[] methods = null;
 	try {
-		methods = getInterfaceAbstractContracts(scope, replaceWildcards, true);
+		methods = getFunctionalInterfaceAbstractContracts(scope, replaceWildcards);
 		if (methods == null || methods.length == 0)
 			return this.singleAbstractMethod[index] = samProblemBinding;
 		int contractParameterLength = 0;
@@ -2442,7 +2413,7 @@ public MethodBinding getSingleAbstractMethod(Scope scope, boolean replaceWildcar
 					return this.singleAbstractMethod[index] = samProblemBinding;
 			}
 		}
-	} catch (InvalidBindingException e) {
+	} catch (DysfunctionalInterfaceException e) {
 		return this.singleAbstractMethod[index] = samProblemBinding;
 	}
 	if (methods.length == 1)
@@ -2677,10 +2648,9 @@ public boolean isDisjointFrom(ReferenceBinding that) {
 		}
 	}
 }
-static class InvalidBindingException extends Exception {
+static class DysfunctionalInterfaceException extends RuntimeException {
 	private static final long serialVersionUID = 1L;
-
-	InvalidBindingException(String message) {
+	DysfunctionalInterfaceException(String message) {
 		super(message);
 	}
 }


### PR DESCRIPTION
PR https://github.com/eclipse-jdt/eclipse.jdt.core/pull/4168 raised alert about serious performance bottlenecks during code assist that under the hood attempt to check if a given interface is a functional interface.

The fail fast hacks in the original implementation seem to have withered away with various incremental changes to `getInterfaceAbstractContracts()` and the version we have now seems to work very hard without being smart.

https://github.com/eclipse-jdt/eclipse.jdt.core/pull/4228 implements a very fast failing check that would address _many but not all_ common scenarios. This PR is a follow up to clean up and speed up the implementation of  `getInterfaceAbstractContracts()` for the general case.

**Speed up is achieved by:**

    *  Not visiting an interface more than once
    *  While checking possible overrides, greatly reduce the loop iterations by first soring on selector and checking overrides only between methods with identical selector
    *  Failing fast - if we have seen two distinct abstract methods already, just punt right away.
 
**Cleanup is achieved by**

    * Use of streams and collectors in lieu of low level array management ops.
    * Clarifying intent by opting for method names that clarify that this code is specific to sam computation as opposed to a general purpose hammer (`getInterfaceAbstractContracts()` split and renamed to `getFunctionalInterfaceAbstractContracts()` and `collateFunctionalInterfaceContracts()`) 

**No correctness issue is addressed here, only performance improvement is attempted**

* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4230