### PR TITLE
Properly index `import module` from DOM

### DIFF
--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/DOMToIndexVisitor.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/DOMToIndexVisitor.java
@@ -173,7 +173,9 @@ class DOMToIndexVisitor extends ASTVisitor {
 	public boolean visit(ImportDeclaration node) {
 		if (node.isStatic() && !node.isOnDemand()) {
 			this.sourceIndexer.addMethodReference(simpleName(node.getName()), 0);
-		} else if (!node.isOnDemand()) {
+		} else if (Modifier.isModule(node.getModifiers())) {
+			this.sourceIndexer.addModuleReference(node.getName().getFullyQualifiedName().toCharArray());
+		} if (!node.isOnDemand()) {
 			this.sourceIndexer.addTypeReference(node.getName().getFullyQualifiedName().toCharArray());
 		}
 		return true;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does

Make that the name on `import module` get indexed as a module reference instead of a type

## How to test

Setting `-DSourceIndexer.DOM_BASED_INDEXER=true`, try JavaSearchModuleImportTest

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
