### PR TITLE
Enable Blank Lines Between Different Tags in Markdown Comments via Formatter

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/formatter/FormatterRegressionTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/formatter/FormatterRegressionTests.java
@@ -16490,4 +16490,50 @@ public void testIssue2977() {
 		""",
 		CodeFormatter.K_COMPILATION_UNIT);
 }
+	public void testMarkdownSpacingFormat() throws JavaModelException {
+		setComplianceLevel(CompilerOptions.VERSION_23);
+		String input = """
+				class Mark {
+					/// @param 		param
+					///  @return 			int
+					public int sample(String param) {
+						return 0;
+					}
+				}
+				""";
+		String expected = """
+				class Mark {
+					/// @param param
+					/// @return int
+					public int sample(String param) {
+						return 0;
+					}
+				}
+				""";
+		formatSource(input, expected);
+	}
+	public void testMarkdownEmptyLinesBtwnDiffTags() throws JavaModelException {
+		setComplianceLevel(CompilerOptions.VERSION_23);
+		this.formatterPrefs.comment_insert_empty_line_between_different_tags = true;
+		String input = """
+				class Mark {
+					/// @param param1
+					/// @return int
+					public int sample(String param1) {
+						return 0;
+					}
+				}
+				""";
+		String expected = """
+				class Mark {
+					/// @param param1
+					///\s
+					/// @return int
+					public int sample(String param1) {
+						return 0;
+					}
+				}
+				""";
+		formatSource(input, expected);
+	}
 }

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/Token.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/Token.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2021 Mateusz Matela and others.
+ * Copyright (c) 2014, 2025 Mateusz Matela and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -11,6 +11,7 @@
  * Contributors:
  *     Mateusz Matela <mateusz.matela@gmail.com> - [formatter] Formatter does not format Java code correctly, especially when max line width is set - https://bugs.eclipse.org/303519
  *     Till Brychcy - Java Code Formatter breaks code if single line comments contain unicode escape - https://bugs.eclipse.org/471090
+ *     IBM Corporation - Markdown support
  *******************************************************************************/
 package org.eclipse.jdt.internal.formatter;
 
@@ -323,6 +324,7 @@ public class Token {
 			case TokenNameCOMMENT_BLOCK:
 			case TokenNameCOMMENT_JAVADOC:
 			case TokenNameCOMMENT_LINE:
+			case TokenNameCOMMENT_MARKDOWN:
 				return true;
 			default:
 				return false;

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/linewrap/CommentWrapExecutor.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/linewrap/CommentWrapExecutor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2014, 2018 Mateusz Matela and others.
+ * Copyright (c) 2014, 2025 Mateusz Matela and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -12,11 +12,13 @@
  *     Mateusz Matela <mateusz.matela@gmail.com> - [formatter] Formatter does not format Java code correctly, especially when max line width is set - https://bugs.eclipse.org/303519
  *     Lars Vogel <Lars.Vogel@vogella.com> - Contributions for
  *     						Bug 473178
+ *     IBM Corporation - Markdown support
  *******************************************************************************/
 package org.eclipse.jdt.internal.formatter.linewrap;
 
 import static org.eclipse.jdt.internal.compiler.parser.TerminalToken.TokenNameCOMMENT_JAVADOC;
 import static org.eclipse.jdt.internal.compiler.parser.TerminalToken.TokenNameCOMMENT_LINE;
+import static org.eclipse.jdt.internal.compiler.parser.TerminalToken.TokenNameCOMMENT_MARKDOWN;
 import static org.eclipse.jdt.internal.compiler.parser.TerminalToken.TokenNameNotAToken;
 import static org.eclipse.jdt.internal.compiler.parser.TerminalToken.TokenNameWHITESPACE;
 import static org.eclipse.jdt.internal.formatter.CommentsPreparator.COMMENT_LINE_SEPARATOR_LENGTH;
@@ -70,9 +72,14 @@ public class CommentWrapExecutor extends TokenTraverser {
 		this.simulation = simulate;
 		this.wrapDisabled = noWrap;
 		this.potentialWrapToken = this.potentialWrapTokenSubstitute = null;
-		this.newLinesAtBoundries = commentToken.tokenType == TokenNameCOMMENT_JAVADOC
-				? this.options.comment_new_lines_at_javadoc_boundaries
-				: this.options.comment_new_lines_at_block_boundaries;
+
+		if (commentToken.tokenType != TokenNameCOMMENT_MARKDOWN) {
+			this.newLinesAtBoundries = commentToken.tokenType == TokenNameCOMMENT_JAVADOC
+					? this.options.comment_new_lines_at_javadoc_boundaries
+					: this.options.comment_new_lines_at_block_boundaries;
+		} else {
+			this.newLinesAtBoundries = false;
+		}
 
 		List<Token> structure = commentToken.getInternalStructure();
 		if (structure == null || structure.isEmpty())
@@ -211,7 +218,8 @@ public class CommentWrapExecutor extends TokenTraverser {
 		new TokenTraverser() {
 			@Override
 			protected boolean token(Token token, int index) {
-				if (token.tokenType == TokenNameCOMMENT_JAVADOC && token.getInternalStructure() == null) {
+				if ((token.tokenType == TokenNameCOMMENT_JAVADOC || token.tokenType == TokenNameCOMMENT_MARKDOWN)
+						&& token.getInternalStructure() == null) {
 					if (getLineBreaksBefore() > 0)
 						token.setAlign(token.getAlign() + token.getIndent());
 					token.setIndent(0);

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/linewrap/WrapPreparator.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/linewrap/WrapPreparator.java
@@ -11,6 +11,7 @@
  * Contributors:
  *     Mateusz Matela <mateusz.matela@gmail.com> - [formatter] Formatter does not format Java code correctly, especially when max line width is set - https://bugs.eclipse.org/303519
  *     Mateusz Matela <mateusz.matela@gmail.com> - [formatter] follow up bug for comments - https://bugs.eclipse.org/458208
+ *     IBM Corporation - Markdown support
  *******************************************************************************/
 package org.eclipse.jdt.internal.formatter.linewrap;
 
@@ -1491,7 +1492,8 @@ public class WrapPreparator extends ASTVisitor {
 				if (token.tokenType == TokenNameCOMMENT_LINE) {
 					commentWrapper.wrapLineComment(token, startPosition);
 				} else {
-					assert token.tokenType == TokenNameCOMMENT_BLOCK || token.tokenType == TokenNameCOMMENT_JAVADOC;
+					assert token.tokenType == TokenNameCOMMENT_BLOCK || token.tokenType == TokenNameCOMMENT_JAVADOC
+							|| token.tokenType == TokenNameCOMMENT_MARKDOWN;
 					commentWrapper.wrapMultiLineComment(token, startPosition, false, false);
 				}
 			}


### PR DESCRIPTION
This commit enhances the formatter to correctly tokenize markdown comments and allows the insertion of blank lines between different markdown tags

Fixes : https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4245


https://github.com/user-attachments/assets/740d354b-b6d5-4f1e-b9dd-ce1671d6b904


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Enable the **_Blank lines between different markdown tags_** opt and try formating

```
class Mark {
	/// @param param1
	/// @return int
	public int sample(String param1) {
		return 0;
	}
}

```

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
