### PR TITLE
Fix relevance for completion of receiver of varargs method invocation

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests.java
@@ -26145,11 +26145,11 @@ public void testBug574982() throws JavaModelException {
 	int cursorLocation = str.lastIndexOf(completeBehind) + completeBehind.length();
 	this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner);
 	assertResults(
-			"ABC[TYPE_REF]{p1.ABC, p1, Lp1.ABC;, null, null, 69}\n" +
-			"ABC[TYPE_REF]{p2.ABC, p2, Lp2.ABC;, null, null, 69}\n" +
-			"A3[TYPE_REF]{A3, , LA3;, null, null, 72}\n" +
-			"ArrayTest[TYPE_REF]{ArrayTest, , LArrayTest;, null, null, 72}\n" +
-			"A[TYPE_REF]{A, , LA;, null, null, 76}",
+			"ABC[TYPE_REF]{p1.ABC, p1, Lp1.ABC;, null, null, 49}\n" +
+			"ABC[TYPE_REF]{p2.ABC, p2, Lp2.ABC;, null, null, 49}\n" +
+			"A3[TYPE_REF]{A3, , LA3;, null, null, 52}\n" +
+			"ArrayTest[TYPE_REF]{ArrayTest, , LArrayTest;, null, null, 52}\n" +
+			"A[TYPE_REF]{A, , LA;, null, null, 56}",
 			requestor.getResults());
 }
 /**

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/CompletionEngine.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/CompletionEngine.java
@@ -3887,7 +3887,7 @@ public final class CompletionEngine
 			checkCancel();
 
 			// see if we can find argument type at position in case if we are at a vararg.
-			checkForVarargExpectedTypes(astNodeParent, scope);
+			checkForVarargExpectedTypes(astNodeParent, astNode, scope);
 			findVariablesAndMethods(this.completionToken, scope, singleNameReference, scope, insideTypeAnnotation,
 					singleNameReference.isInsideAnnotationAttribute, true, new ObjectVector());
 
@@ -3923,8 +3923,11 @@ public final class CompletionEngine
 		}
 	}
 
-	private void checkForVarargExpectedTypes(ASTNode astNodeParent, Scope scope) {
-		if (astNodeParent instanceof MessageSend m && this.expectedTypesPtr == -1) {
+	private void checkForVarargExpectedTypes(ASTNode astNodeParent, ASTNode astNode, Scope scope) {
+		if (astNodeParent instanceof MessageSend m
+				&& m.arguments() != null
+				&& Stream.of(m.arguments()).anyMatch(astNode::equals)
+				&& this.expectedTypesPtr == -1) {
 			final ObjectVector methodsToSearchOn = new ObjectVector();
 			final CompletionRequestor actual = this.requestor;
 			this.requestor = new CompletionRequestor(true) {


### PR DESCRIPTION
## What it does
Fixes #4247 by fixing the bug in `CompletionEngine.checkForVarargExpectedTypes`

## How to test
There's an existing test case that I've updated

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
