### PR TITLE
Address folder and package mismatch in completion tests

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests.java
@@ -25123,6 +25123,7 @@ public void testBug402812a() throws Exception {
 
 		this.workingCopies[0] = getWorkingCopy(
 				"/Completion/src/test/Test.java",
+				"package test;\n" +
 				"interface Test { \n" +
 				"static void staticMethod() {}" +
 				"    default void defaultMethod() {" +
@@ -25162,6 +25163,7 @@ public void testBug402812b() throws Exception {
 
 		this.workingCopies[0] = getWorkingCopy(
 				"/Completion/src/test/Test.java",
+				"package test;\n" +
 				"interface I { \n" +
 				"    static void staticMethod() {}" +
 				"    default void defaultMethod() {}" +
@@ -25207,6 +25209,7 @@ public void testBug402812c() throws Exception {
 
 		this.workingCopies[0] = getWorkingCopy(
 				"/Completion/src/test/Test.java",
+				"package test;\n" +
 				"interface I { \n" +
 				"static void staticMethod() {}" +
 				"    default void defaultMethod() {" +
@@ -25253,6 +25256,7 @@ public void testBug402812d() throws Exception {
 
 		this.workingCopies[0] = getWorkingCopy(
 				"/Completion/src/test/Test.java",
+				"package test;\n" +
 				"interface I { \n" +
 				"    static void staticMethod() {}" +
 				"    default void defaultMethod() {}" +
@@ -25338,6 +25342,7 @@ public void testBug406468a() throws JavaModelException {
 		this.workingCopies = new ICompilationUnit[1];
 		this.workingCopies[0] = getWorkingCopy(
 				"/Completion/src/test/X.java",
+				"package test;\n" +
 				"interface I {\n" +
 				"	X [][][] copy (int x);\n" +
 				"}\n" +
@@ -25380,6 +25385,7 @@ public void testBug406468b() throws JavaModelException {
 		this.workingCopies = new ICompilationUnit[1];
 		this.workingCopies[0] = getWorkingCopy(
 				"/Completion/src/test/X.java",
+				"package test;\n" +
 				"interface I {\n" +
 				"	X<java.lang.String> copy ();\n" +
 				"}\n" +
@@ -25756,8 +25762,8 @@ public void testBug533740d() throws JavaModelException {
 public void testBug496354() throws Exception {
 	this.workingCopies = new ICompilationUnit[1];
 	this.workingCopies[0] = getWorkingCopy(
-			"Completion/src/Foo.java",
-			"package test;\n" +
+			"Completion/src/test/Foo.java",
+			"package test;\n"+
 			"import java.io.IOException;\n" +
 			"import java.lang.annotation.ElementType;\n" +
 			"import java.lang.annotation.Target;\n" +
@@ -25790,7 +25796,7 @@ public void testBug496354() throws Exception {
 public void testBug573632() throws Exception {
 	this.workingCopies = new ICompilationUnit[1];
 	this.workingCopies[0] = getWorkingCopy(
-			"Completion/src/Foo.java",
+			"Completion/src/test/Foo.java",
 			"package test;\n" +
 			"public class Foo {\n" +
 			"	Foo f;\n" +
@@ -25811,9 +25817,9 @@ public void testBug573632() throws Exception {
 	assertResults(
 			"clone[METHOD_REF]{clone(), Ljava.lang.Object;, ()Ljava.lang.Object;, clone, null, 60}\n" +
 			"equals[METHOD_REF]{equals(), Ljava.lang.Object;, (Ljava.lang.Object;)Z, equals, (obj), 60}\n" +
-			"f[FIELD_REF]{f, LFoo;, LFoo;, f, null, 60}\n" +
+			"f[FIELD_REF]{f, Ltest.Foo;, Ltest.Foo;, f, null, 60}\n" +
 			"finalize[METHOD_REF]{finalize(), Ljava.lang.Object;, ()V, finalize, null, 60}\n" +
-			"foo[METHOD_REF]{foo(), LFoo;, ()V, foo, null, 60}\n" +
+			"foo[METHOD_REF]{foo(), Ltest.Foo;, ()V, foo, null, 60}\n" +
 			"getClass[METHOD_REF]{getClass(), Ljava.lang.Object;, ()Ljava.lang.Class;, getClass, null, 60}\n" +
 			"hashCode[METHOD_REF]{hashCode(), Ljava.lang.Object;, ()I, hashCode, null, 60}\n" +
 			"notify[METHOD_REF]{notify(), Ljava.lang.Object;, ()V, notify, null, 60}\n" +
@@ -25828,7 +25834,7 @@ public void testBug573632a() throws Exception {
 	// variation: nested ifs
 	this.workingCopies = new ICompilationUnit[1];
 	this.workingCopies[0] = getWorkingCopy(
-			"Completion/src/Foo.java",
+			"Completion/src/test/Foo.java",
 			"package test;\n" +
 			"public class Foo {\n" +
 			"	Foo f;\n" +
@@ -25851,9 +25857,9 @@ public void testBug573632a() throws Exception {
 	assertResults(
 			"clone[METHOD_REF]{clone(), Ljava.lang.Object;, ()Ljava.lang.Object;, clone, null, 60}\n" +
 			"equals[METHOD_REF]{equals(), Ljava.lang.Object;, (Ljava.lang.Object;)Z, equals, (obj), 60}\n" +
-			"f[FIELD_REF]{f, LFoo;, LFoo;, f, null, 60}\n" +
+			"f[FIELD_REF]{f, Ltest.Foo;, Ltest.Foo;, f, null, 60}\n" +
 			"finalize[METHOD_REF]{finalize(), Ljava.lang.Object;, ()V, finalize, null, 60}\n" +
-			"foo[METHOD_REF]{foo(), LFoo;, ()V, foo, null, 60}\n" +
+			"foo[METHOD_REF]{foo(), Ltest.Foo;, ()V, foo, null, 60}\n" +
 			"getClass[METHOD_REF]{getClass(), Ljava.lang.Object;, ()Ljava.lang.Class;, getClass, null, 60}\n" +
 			"hashCode[METHOD_REF]{hashCode(), Ljava.lang.Object;, ()I, hashCode, null, 60}\n" +
 			"notify[METHOD_REF]{notify(), Ljava.lang.Object;, ()V, notify, null, 60}\n" +
@@ -25868,7 +25874,7 @@ public void testBug573632b() throws Exception {
 	// variation: for
 	this.workingCopies = new ICompilationUnit[1];
 	this.workingCopies[0] = getWorkingCopy(
-			"Completion/src/Foo.java",
+			"Completion/src/test/Foo.java",
 			"package test;\n" +
 			"public class Foo {\n" +
 			"	Foo f;\n" +
@@ -25889,9 +25895,9 @@ public void testBug573632b() throws Exception {
 	assertResults(
 			"clone[METHOD_REF]{clone(), Ljava.lang.Object;, ()Ljava.lang.Object;, clone, null, 60}\n" +
 			"equals[METHOD_REF]{equals(), Ljava.lang.Object;, (Ljava.lang.Object;)Z, equals, (obj), 60}\n" +
-			"f[FIELD_REF]{f, LFoo;, LFoo;, f, null, 60}\n" +
+			"f[FIELD_REF]{f, Ltest.Foo;, Ltest.Foo;, f, null, 60}\n" +
 			"finalize[METHOD_REF]{finalize(), Ljava.lang.Object;, ()V, finalize, null, 60}\n" +
-			"foo[METHOD_REF]{foo(), LFoo;, ()V, foo, null, 60}\n" +
+			"foo[METHOD_REF]{foo(), Ltest.Foo;, ()V, foo, null, 60}\n" +
 			"getClass[METHOD_REF]{getClass(), Ljava.lang.Object;, ()Ljava.lang.Class;, getClass, null, 60}\n" +
 			"hashCode[METHOD_REF]{hashCode(), Ljava.lang.Object;, ()I, hashCode, null, 60}\n" +
 			"notify[METHOD_REF]{notify(), Ljava.lang.Object;, ()V, notify, null, 60}\n" +
@@ -25906,7 +25912,7 @@ public void testBug573632c() throws Exception {
 	// variation: while
 	this.workingCopies = new ICompilationUnit[1];
 	this.workingCopies[0] = getWorkingCopy(
-			"Completion/src/Foo.java",
+			"Completion/src/test/Foo.java",
 			"package test;\n" +
 			"public class Foo {\n" +
 			"	Foo f;\n" +
@@ -25927,9 +25933,9 @@ public void testBug573632c() throws Exception {
 	assertResults(
 			"clone[METHOD_REF]{clone(), Ljava.lang.Object;, ()Ljava.lang.Object;, clone, null, 60}\n" +
 			"equals[METHOD_REF]{equals(), Ljava.lang.Object;, (Ljava.lang.Object;)Z, equals, (obj), 60}\n" +
-			"f[FIELD_REF]{f, LFoo;, LFoo;, f, null, 60}\n" +
+			"f[FIELD_REF]{f, Ltest.Foo;, Ltest.Foo;, f, null, 60}\n" +
 			"finalize[METHOD_REF]{finalize(), Ljava.lang.Object;, ()V, finalize, null, 60}\n" +
-			"foo[METHOD_REF]{foo(), LFoo;, ()V, foo, null, 60}\n" +
+			"foo[METHOD_REF]{foo(), Ltest.Foo;, ()V, foo, null, 60}\n" +
 			"getClass[METHOD_REF]{getClass(), Ljava.lang.Object;, ()Ljava.lang.Class;, getClass, null, 60}\n" +
 			"hashCode[METHOD_REF]{hashCode(), Ljava.lang.Object;, ()I, hashCode, null, 60}\n" +
 			"notify[METHOD_REF]{notify(), Ljava.lang.Object;, ()V, notify, null, 60}\n" +


### PR DESCRIPTION
## What it does
Some completion tests use test files that have mismatching package declarations and folder locations.

These tests aren't testing for how mismatching the package declaration and folder location affects the completion results, so I think it would be helpful to make the declared package and folder match.

## How to test
I've updated the existing test cases.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
