### PR TITLE
Regression in generics type inferral

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/CaptureBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/CaptureBinding.java
@@ -598,6 +598,13 @@ public class CaptureBinding extends TypeVariableBinding {
 	}
 
 	@Override
+	public int typeArgumentDepth() {
+		if (this.wildcard != null)
+			return this.wildcard.typeArgumentDepth();
+		return 1;
+	}
+
+	@Override
 	public String toString() {
 		if (this.wildcard != null) {
 			StringBuilder buffer = new StringBuilder(10);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/CapturingContext.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/CapturingContext.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2025 GK Software, and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Stephan Herrmann - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.internal.compiler.lookup;
+
+/**
+ * Global registry of active contexts to be used for capturing
+ * in situations that have no AST location nor Scope at hand.
+ */
+public class CapturingContext {
+
+	/** Global reference to an active context per thread. */
+	private static ThreadLocal<CapturingContext> activeContexts = new ThreadLocal<>();
+
+	/** Position to use for capturing: */
+	private int start, end;
+	/** Scope to use for capturing: */
+	private Scope scope;
+	/** implements a linked stack */
+	private CapturingContext previous;
+
+	/** Prevent recursive capturing */
+	private boolean isCaptureInProgress;
+
+	private CapturingContext(int start, int end, Scope scope, CapturingContext previous) {
+		this.start = start;
+		this.end = end;
+		this.scope = scope;
+		this.previous = previous;
+	}
+
+	public static void enter(int start, int end, Scope scope) {
+		activeContexts.set(new CapturingContext(start, end, scope, activeContexts.get()));
+	}
+
+	public static void leave() {
+		CapturingContext inst = activeContexts.get();
+		activeContexts.remove();
+		if (inst != null && inst.previous != null)
+			activeContexts.set(inst.previous);
+	}
+
+	public static ReferenceBinding maybeCapture(ReferenceBinding type) {
+		if (type instanceof ParameterizedTypeBinding ptb) {
+			CapturingContext inst = activeContexts.get();
+			if (inst != null && !inst.isCaptureInProgress) {
+				try {
+					inst.isCaptureInProgress = true;
+					return ptb.capture(inst.scope, inst.start, inst.end);
+				} finally {
+					inst.isCaptureInProgress = false;
+				}
+			}
+		}
+		return type;
+	}
+}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
@@ -163,9 +163,6 @@ public class InferenceContext18 {
 	// during reduction we ignore missing types but record that fact here:
 	TypeBinding missingType;
 
-	private static ThreadLocal<InferenceContext18> instance = new ThreadLocal<>();
-	private boolean isCaptureInProcess = false;
-
 	public static boolean isSameSite(InvocationSite site1, InvocationSite site2) {
 		if (site1 == site2)
 			return true;
@@ -1017,16 +1014,20 @@ public class InferenceContext18 {
 	 * @throws InferenceFailureException a compile error has been detected during inference
 	 */
 	public /*@Nullable*/ BoundSet solve(boolean inferringApplicability) throws InferenceFailureException {
-		return solve(inferringApplicability, false);
+		return solve(inferringApplicability, (ASTNode) this.currentInvocation);
 	}
 	/**
 	 * Try to solve the inference problem defined by constraints and bounds previously registered.
-	 * @param isRecordPatternTypeInference see 18_5_5_item_5 for Record Type Inference
+	 * @param inferringApplicability toggles between 18.5.1 and 18.5.2
+	 * @param location the current invocation (18.5.1 - 18.5.5) or record pattern (18.5.5, see item 5)
 	 * @return a bound set representing the solution, or null if inference failed
 	 * @throws InferenceFailureException a compile error has been detected during inference
 	 */
-	private /*@Nullable*/ BoundSet solve(boolean inferringApplicability, boolean isRecordPatternTypeInference) throws InferenceFailureException {
-		instance.set(this);
+	private /*@Nullable*/ BoundSet solve(boolean inferringApplicability, ASTNode location)
+			throws InferenceFailureException
+	{
+		CapturingContext.enter(location.sourceStart(), location.sourceEnd(), this.scope);
+		boolean isRecordPatternTypeInference = location instanceof RecordPattern;
 
 		try {
 			if (!reduce())
@@ -1053,7 +1054,7 @@ public class InferenceContext18 {
 			}
 			return solution;
 		} finally {
-			instance.remove();
+			CapturingContext.leave();
 		}
 	}
 
@@ -1994,7 +1995,7 @@ public class InferenceContext18 {
 		 */
 		BoundSet solution = null;
 		try {
-			solution = solve(false, true /* isRecordPatternTypeInference */);
+			solution = solve(false, recordPattern);
 		} catch (InferenceFailureException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
@@ -2211,18 +2212,5 @@ public class InferenceContext18 {
 			}
 		}
 		return false;
-	}
-	public static TypeBinding maybeCapture(TypeBinding type) {
-		InferenceContext18 inst = instance.get();
-		if (inst != null && !inst.isCaptureInProcess) {
-			try {
-				InvocationSite inv = inst.currentInvocation;
-				inst.isCaptureInProcess = true;
-				return type.capture(inst.scope, inv.sourceStart(), inv.sourceEnd());
-			} finally {
-				inst.isCaptureInProcess = false;
-			}
-		}
-		return type;
 	}
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
@@ -734,7 +734,7 @@ public class InferenceContext18 {
 
 
 	protected int getInferenceKind(MethodBinding nonGenericMethod, TypeBinding[] argumentTypes) {
-		switch (this.scope.parameterCompatibilityLevel(nonGenericMethod, argumentTypes)) {
+		switch (this.scope.parameterCompatibilityLevel(nonGenericMethod, argumentTypes, false, this.currentInvocation)) {
 			case Scope.AUTOBOX_COMPATIBLE:
 			case Scope.COMPATIBLE_IGNORING_MISSING_TYPE: // if in doubt the method with missing types should be accepted to signal its relevance for resolution
 				return CHECK_LOOSE;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/LookupEnvironment.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/LookupEnvironment.java
@@ -1485,6 +1485,7 @@ public WildcardBinding createWildcard(ReferenceBinding genericType, int rank, Ty
 }
 
 public CaptureBinding createCapturedWildcard(WildcardBinding wildcard, ReferenceBinding contextType, int start, int end, ASTNode cud, Supplier<Integer> idSupplier) {
+	wildcard = normalizeWildcard(wildcard);
 	return this.typeSystem.getCapturedWildcard(wildcard, contextType, start, end, cud, idSupplier);
 }
 
@@ -1500,6 +1501,13 @@ private TypeBinding normalizeWildcardBound(TypeBinding bound, int boundKind) {
 			return capture.firstBound;
 	}
 	return bound;
+}
+private WildcardBinding normalizeWildcard(WildcardBinding wildcard) {
+	if (wildcard.boundKind == Wildcard.EXTENDS
+			&& wildcard.bound instanceof CaptureBinding wildCap
+			&& wildCap.wildcard != null) // null happens for CaptureBinding18
+		return wildCap.wildcard;
+	return wildcard;
 }
 
 /**

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
@@ -1758,7 +1758,7 @@ public final boolean isStrictfp() {
  */
 public boolean isSuperclassOf(ReferenceBinding otherType) {
 	while ((otherType = otherType.superclass()) != null) {
-		otherType = (ReferenceBinding) InferenceContext18.maybeCapture(otherType);
+		otherType = CapturingContext.maybeCapture(otherType);
 		if (otherType.isEquivalentTo(this)) return true;
 	}
 	return false;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Scope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Scope.java
@@ -4936,9 +4936,6 @@ public abstract class Scope {
 		return parameterCompatibilityLevel(method, arguments, false, site);
 	}
 
-	public int parameterCompatibilityLevel(MethodBinding method, TypeBinding[] arguments) {
-		return parameterCompatibilityLevel(method, arguments, false, null);
-	}
 	public int parameterCompatibilityLevel(MethodBinding method, TypeBinding[] arguments, boolean tiebreakingVarargsMethods, InvocationSite site) {
 		TypeBinding[] parameters = method.parameters;
 		int paramLength = parameters.length;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Scope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Scope.java
@@ -822,7 +822,7 @@ public abstract class Scope {
 			}
 		}
 
-		int level = parameterCompatibilityLevel(method, arguments, tiebreakingVarargsMethods);
+		int level = parameterCompatibilityLevel(method, arguments, tiebreakingVarargsMethods, invocationSite);
 		if (level > NOT_COMPATIBLE) {
 			if (method.hasPolymorphicSignature(this)) {
 				// generate polymorphic method and set polymorphic tagbits as well
@@ -3809,8 +3809,8 @@ public abstract class Scope {
 			for (int i = (oneParamsLength > twoParamsLength ? twoParamsLength : oneParamsLength) - 2; i >= 0; i--)
 				if (TypeBinding.notEquals(oneParams[i], twoParams[i]) && !oneParams[i].isCompatibleWith(twoParams[i]))
 					return false;
-			if (parameterCompatibilityLevel(one, twoParams, true) == NOT_COMPATIBLE
-					&& parameterCompatibilityLevel(two, oneParams, true) == VARARGS_COMPATIBLE)
+			if (parameterCompatibilityLevel(one, twoParams, true, null) == NOT_COMPATIBLE
+					&& parameterCompatibilityLevel(two, oneParams, true, null) == VARARGS_COMPATIBLE)
 				return true;
 		}
 		return false;
@@ -4933,13 +4933,13 @@ public abstract class Scope {
 					break;
 				}
 		}
-		return parameterCompatibilityLevel(method, arguments, false);
+		return parameterCompatibilityLevel(method, arguments, false, site);
 	}
 
 	public int parameterCompatibilityLevel(MethodBinding method, TypeBinding[] arguments) {
-		return parameterCompatibilityLevel(method, arguments, false);
+		return parameterCompatibilityLevel(method, arguments, false, null);
 	}
-	public int parameterCompatibilityLevel(MethodBinding method, TypeBinding[] arguments, boolean tiebreakingVarargsMethods) {
+	public int parameterCompatibilityLevel(MethodBinding method, TypeBinding[] arguments, boolean tiebreakingVarargsMethods, InvocationSite site) {
 		TypeBinding[] parameters = method.parameters;
 		int paramLength = parameters.length;
 		int argLength = arguments.length;
@@ -4989,7 +4989,17 @@ public abstract class Scope {
 			TypeBinding param = parameters[i];
 			TypeBinding arg = (tiebreakingVarargsMethods && (i == (argLength - 1))) ? ((ArrayBinding)arguments[i]).elementsType() : arguments[i];
 			if (TypeBinding.notEquals(arg,param)) {
-				int newLevel = parameterCompatibilityLevel(arg, param, env, tiebreakingVarargsMethods, method);
+				if (site instanceof Invocation invocation) {
+					Expression[] invArgs = invocation.arguments();
+					int idx = i < invArgs.length ? i : invArgs.length - 1;
+					CapturingContext.enter(invArgs[idx].sourceStart, invArgs[idx].sourceEnd, this);
+				}
+				int newLevel;
+				try {
+					newLevel = parameterCompatibilityLevel(arg, param, env, tiebreakingVarargsMethods, method);
+				} finally {
+					CapturingContext.leave();
+				}
 				if (newLevel == NOT_COMPATIBLE) {
 					return NOT_COMPATIBLE;
 				} else if (newLevel == COMPATIBLE_IGNORING_MISSING_TYPE) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeBinding.java
@@ -289,6 +289,10 @@ public int depth() {
 	return 0;
 }
 
+public int typeArgumentDepth() {
+	return 1;
+}
+
 /* Answer the receiver's enclosing method ... null if the receiver is not a local type.
  */
 public MethodBinding enclosingMethod() {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/WildcardBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/WildcardBinding.java
@@ -1000,6 +1000,25 @@ public class WildcardBinding extends ReferenceBinding implements HotSwappable{
 			    return new String(CharOperation.concat(TypeConstants.WILDCARD_NAME, TypeConstants.WILDCARD_SUPER, this.bound.debugName().toCharArray()));
         }
 	}
+
+	@Override
+	public int typeArgumentDepth() {
+		int max = 0;
+		if (enterRecursiveFunction()) {
+			try {
+				if (this.bound != null)
+					max = this.bound.typeArgumentDepth();
+				if (this.otherBounds != null) {
+					for (TypeBinding otherBound : this.otherBounds)
+						max = Math.max(max, otherBound.typeArgumentDepth());
+				}
+			} finally {
+				exitRecursiveFunction();
+			}
+		}
+		return max;
+	}
+
 	/**
 	 * Returns associated type variable, or null in case of inconsistency
 	 */

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericTypeTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericTypeTest.java
@@ -28971,7 +28971,7 @@ public void test0909() {
 
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=127583
 public void test0910() {
-	int[] capIds = new int[]{ 1, 2, 3, 4, 8};
+	int[] capIds = new int[]{ 1, 3, 4, 6, 13};
 	this.runNegativeTest(
 		new String[] {
 			"X.java",

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest.java
@@ -6871,5 +6871,27 @@ public void testGH4235() {
 			"""
 		});
 }
+public void testGH4236() {
+	if (this.complianceLevel < ClassFileConstants.JDK16)
+		return; // uses records
+	runConformTest(new String[]{
+			"A.java",
+			"""
+			import java.io.Serializable;
+			public record A(DR<? extends TI<?>> effective) {
+			  A(DR<? extends TI<?>> effective, Object x) {
+			    this(effective);
+			  }
+			}
+
+			class DR<T extends Comparable<? super T> & Serializable> {
+			}
+
+			abstract class TI<M> implements Comparable<TI<M>>, Serializable {
+			  private static final long serialVersionUID = 1L;
+			}
+			"""
+		});
+}
 }
 

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_1_8.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_1_8.java
@@ -6986,7 +6986,7 @@ public void testBug472851() {
 		"1. ERROR in Test.java (at line 10)\n" +
 		"	test(type);\n" +
 		"	^^^^\n" +
-		"The method test(List<L>) in the type Test is not applicable for the arguments (List<capture#2-of ? extends List<?>>)\n" +
+		"The method test(List<L>) in the type Test is not applicable for the arguments (List<capture#1-of ? extends List<?>>)\n" +
 		"----------\n");
 }
 public void testBug502350() {


### PR DESCRIPTION
Capture in more situations:
+ register context for capturing using new class CapturingContext
  + consolidate with previous IC18.maybeCapture()
+ enter/leave from:
  + PTB.capture() - context for glb-computation during initializeBounds
  + Scope.parameterCompatibilityLevel() - context for isCompatibleWith()

Apply normalization like #4041 also during wildcard creation:
  + normalize "? extends cap-of ? extends X" to "? extends X"

Measures to avoid infinite recursion:
+ guard with CapturingContext.isCaptureInProgress
+ don't expand types that already have deeper structure than otherType
  + impl. as typeArgumentDepth(), use in findSuperTypeOriginatingFrom()

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4236
