### PR TITLE
remove unused left overs from 1.7 tiebreak strategy

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/impl/CompilerOptions.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/impl/CompilerOptions.java
@@ -571,13 +571,6 @@ public class CompilerOptions {
 	/** When checking for unlikely argument types of of Map.get() et al, perform strict analysis against the expected type */
 	public boolean reportUnlikelyCollectionMethodArgumentTypeStrict;
 
-	/** Should the compiler tolerate illegal ambiguous varargs invocation in {@code compliance < 1.7}
-	 * to be bug compatible with javac? (bug 383780) */
-	public static boolean tolerateIllegalAmbiguousVarargsInvocation;
-	{
-		String tolerateIllegalAmbiguousVarargs = System.getProperty("tolerateIllegalAmbiguousVarargsInvocation"); //$NON-NLS-1$
-		tolerateIllegalAmbiguousVarargsInvocation = tolerateIllegalAmbiguousVarargs != null && tolerateIllegalAmbiguousVarargs.equalsIgnoreCase("true"); //$NON-NLS-1$
-	}
 	/** Should null annotations of overridden methods be inherited? */
 	public boolean inheritNullAnnotations;
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
@@ -734,7 +734,7 @@ public class InferenceContext18 {
 
 
 	protected int getInferenceKind(MethodBinding nonGenericMethod, TypeBinding[] argumentTypes) {
-		switch (this.scope.parameterCompatibilityLevel(nonGenericMethod, argumentTypes, false, this.currentInvocation)) {
+		switch (this.scope.parameterCompatibilityLevel(nonGenericMethod, argumentTypes, this.currentInvocation)) {
 			case Scope.AUTOBOX_COMPATIBLE:
 			case Scope.COMPATIBLE_IGNORING_MISSING_TYPE: // if in doubt the method with missing types should be accepted to signal its relevance for resolution
 				return CHECK_LOOSE;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MethodBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MethodBinding.java
@@ -1284,13 +1284,6 @@ public final int sourceStart() {
 	return method.sourceStart;
 }
 
-/**
- * Returns the method to use during tiebreak (usually the method itself).
- * For generic method invocations, tiebreak needs to use generic method with erasure substitutes.
- */
-public MethodBinding tiebreakMethod() {
-	return this;
-}
 @Override
 public String toString() {
 	StringBuilder output = new StringBuilder(10);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedGenericMethodBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedGenericMethodBinding.java
@@ -50,7 +50,6 @@ public class ParameterizedGenericMethodBinding extends ParameterizedMethodBindin
     public boolean inferredReturnType;
     public boolean wasInferred; // only set to true for instances resulting from method invocation inferrence
     public boolean isRaw; // set to true for method behaving as raw for substitution purpose
-    private MethodBinding tiebreakMethod;
 	public boolean inferredWithUncheckedConversion;
 	public TypeBinding targetType; // used to distinguish different PGMB created for different target types (needed because inference contexts are remembered per PGMB)
 
@@ -558,15 +557,6 @@ public class ParameterizedGenericMethodBinding extends ParameterizedMethodBindin
         	return originalVariable.combineTypeAnnotations(substitute);
         }
 	    return originalVariable;
-	}
-	/**
-	 * @see org.eclipse.jdt.internal.compiler.lookup.MethodBinding#tiebreakMethod()
-	 */
-	@Override
-	public MethodBinding tiebreakMethod() {
-		if (this.tiebreakMethod == null)
-			this.tiebreakMethod = this.originalMethod.asRawMethod(this.environment);
-		return this.tiebreakMethod;
 	}
 
 	@Override

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ProblemMethodBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ProblemMethodBinding.java
@@ -78,10 +78,6 @@ public MethodBinding shallowOriginal() {
 	return this.closestMatch == null ? this : this.closestMatch.shallowOriginal();
 }
 @Override
-public MethodBinding tiebreakMethod() {
-	return this.closestMatch == null ? this : this.closestMatch.tiebreakMethod();
-}
-@Override
 public boolean hasSubstitutedParameters() {
 	if (this.closestMatch != null)
 		return this.closestMatch.hasSubstitutedParameters();


### PR DESCRIPTION
This code has been unused probably since the big removal of compliance 1.7-