### PR TITLE
[Enhanced switch] ECJ allows case null to be followed by a constant where only default is legal

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/CaseStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/CaseStatement.java
@@ -245,8 +245,6 @@ public void resolve(BlockScope scope) {
 			if (this.swich.nullCase == null)
 				this.swich.nullCase = this;
 			nullCaseCount++;
-			if (count > 1 && nullCaseCount < 2)
-				scope.problemReporter().patternSwitchNullOnlyOrFirstWithDefault(e);
 		}
 
 		// tag constant name with enum type for privileged access to its members
@@ -257,6 +255,10 @@ public void resolve(BlockScope scope) {
 		if (e instanceof Pattern p) {
 			this.swich.containsPatterns = this.swich.isNonTraditional =  true;
 			p.setOuterExpressionType(selectorType);
+		} else if (count > 1 && nullCaseCount == 1) {
+			// Under if (!pattern) because we anyway issue ConstantWithPatternIncompatible for mixing patterns & null
+			// Also multiple nulls get reported as duplicates and we don't want to complain again.
+			scope.problemReporter().patternSwitchNullOnlyOrFirstWithDefault(e);
 		}
 
 		TypeBinding	caseType = e.resolveType(scope);

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchPatternTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchPatternTest.java
@@ -9838,4 +9838,36 @@ public class SwitchPatternTest extends AbstractRegressionTest9 {
 		String unexpectedOutput = "checkcast";
 		verifyClassFile(expectedOutput, unexpectedOutput, "X.class", ClassFileBytesDisassembler.SYSTEM);
 	}
+
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4256
+	// [Enhanced switch] ECJ allows case null to be followed by a constant where only default is legal
+	public void testIssue4256() throws Exception {
+		runNegativeTest(
+			new String[] {
+				"X.java",
+				"""
+				public class X {
+
+				  public static enum Any {
+				    One, Two, Three;
+				  }
+
+				  public static void main(final String[] args) {
+				    final Any any = Any.Three;
+				    switch (any) {
+				      case One -> System.out.println("ONE");
+				      case Two -> System.out.println("TWO");
+				      case null, Three -> System.out.println("THREE");
+				    }
+				  }
+				}
+				"""
+			},
+			"----------\n" +
+			"1. ERROR in X.java (at line 12)\n" +
+			"	case null, Three -> System.out.println(\"THREE\");\n" +
+			"	           ^^^^^\n" +
+			"A null case label has to be either the only expression in a case label or the first expression followed only by a default\n" +
+			"----------\n");
+	}
 }


### PR DESCRIPTION


* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4256

