### PR TITLE
Stabilize ModuleBuilderTests.testBug540904() after PR 4270

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ModuleBuilderTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ModuleBuilderTests.java
@@ -7266,6 +7266,7 @@ public class ModuleBuilderTests extends ModifyingResourceTests {
 			addLibraryEntry(p2, file.getFullPath(), false);
 			getWorkspace().build(IncrementalProjectBuilder.FULL_BUILD, null);
 			IMarker[] markers = p2.getProject().findMarkers(null, true, IResource.DEPTH_INFINITE);
+			sortMarkers(markers);
 			assertMarkers(
 					"Should see one marker for missing jar",
 					"""


### PR DESCRIPTION
After #4270 test ModuleBuilderTests.testBug540904() is unstable, see e.g. https://ci.eclipse.org/jdt/job/eclipse.jdt.core-Github/job/PR-4278/3/testReport/org.eclipse.jdt.core.tests.model/ModuleBuilderTests/testBug540904/

see https://github.com/eclipse-jdt/eclipse.jdt.core/pull/4270

