### PR TITLE
Individual tuning of @NonNullByDefault for record components

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.compiler.batch/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Main-Class: org.eclipse.jdt.internal.compiler.batch.Main
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse Compiler for Java(TM)
 Bundle-SymbolicName: org.eclipse.jdt.core.compiler.batch
-Bundle-Version: 3.42.50.qualifier
+Bundle-Version: 3.43.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: Eclipse.org
 Automatic-Module-Name: org.eclipse.jdt.core.compiler.batch

--- a/org.eclipse.jdt.core.compiler.batch/pom.xml
+++ b/org.eclipse.jdt.core.compiler.batch/pom.xml
@@ -17,7 +17,7 @@
     <version>4.37.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.eclipse.jdt.core.compiler.batch</artifactId>
-  <version>3.42.50-SNAPSHOT</version>
+  <version>3.43.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/core/compiler/IProblem.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/core/compiler/IProblem.java
@@ -2000,6 +2000,8 @@ void setSourceStart(int sourceStart);
 	int ConstNonNullFieldComparisonYieldsFalse = Internal + 945;
 	/** @since 3.21 */
 	int InheritedParameterLackingNonNullAnnotation = MethodRelated + 946;
+	/** @since 3.43 */
+	int RecordComponentIncompatibleNullnessVsInheritedAccessor = MethodRelated + 947;
 
 	/** @since 3.10 */
 	int ArrayReferencePotentialNullReference = Internal + 951;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MethodBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MethodBinding.java
@@ -1400,7 +1400,7 @@ public ParameterNonNullDefaultProvider hasNonNullDefaultForParameter(AbstractMet
 		return trueFound ? ParameterNonNullDefaultProvider.TRUE_PROVIDER : ParameterNonNullDefaultProvider.FALSE_PROVIDER;
 	}
 //pre: null annotation analysis is enabled
-private boolean hasNonNullDefaultForType(TypeBinding type, int location, AbstractMethodDeclaration srcMethod, int start) {
+protected boolean hasNonNullDefaultForType(TypeBinding type, int location, AbstractMethodDeclaration srcMethod, int start) {
 	if (type != null && !type.acceptsNonNullDefault() && srcMethod != null && srcMethod.scope.environment().usesNullTypeAnnotations())
 		return false;
 	if ((this.modifiers & ExtraCompilerModifiers.AccIsDefaultConstructor) != 0)

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/RecordComponentBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/RecordComponentBinding.java
@@ -15,12 +15,16 @@
 package org.eclipse.jdt.internal.compiler.lookup;
 
 import org.eclipse.jdt.internal.compiler.ast.ASTNode;
+import org.eclipse.jdt.internal.compiler.ast.AbstractVariableDeclaration;
 import org.eclipse.jdt.internal.compiler.ast.RecordComponent;
 import org.eclipse.jdt.internal.compiler.ast.TypeDeclaration;
 
 public class RecordComponentBinding extends VariableBinding {
 
 	public ReferenceBinding declaringRecord;
+
+	// When applying @NNBD to this component, let's remember the explicit type before applying the default.
+	TypeBinding explicitType;
 
 	public RecordComponentBinding(ReferenceBinding declaringRecord, RecordComponent declaration, TypeBinding type, int modifiers) {
 		super(declaration.name, type, modifiers,  null);
@@ -94,6 +98,12 @@ public class RecordComponentBinding extends VariableBinding {
 			}
 		}
 		return originalRecordComponentBinding.tagBits;
+	}
+
+	@Override
+	public void fillInDefaultNonNullness(AbstractVariableDeclaration sourceField, Scope scope) {
+		this.explicitType = this.type;
+		super.fillInDefaultNonNullness(sourceField, scope);
 	}
 
 	@Override

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SyntheticMethodBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SyntheticMethodBinding.java
@@ -718,6 +718,14 @@ public class SyntheticMethodBinding extends MethodBinding {
 		}
 	}
 
+	//pre: null annotation analysis is enabled
+	@Override
+	public boolean hasNonNullDefaultForReturnType(AbstractMethodDeclaration srcMethod) {
+		if (this.purpose == RecordComponentReadAccess)
+			return hasNonNullDefaultForType(this.returnType, Binding.DefaultLocationRecordComponent, srcMethod, srcMethod == null ? -1 : srcMethod.declarationSourceStart);
+		return super.hasNonNullDefaultForReturnType(srcMethod);
+	}
+
 	public void markNonNull(LookupEnvironment environment) {
 		markNonNull(this, this.purpose, environment);
 	}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
@@ -396,6 +396,7 @@ public static int getIrritant(int problemID) {
 		case IProblem.ContradictoryNullAnnotationsInferred:
 		case IProblem.ContradictoryNullAnnotationsInferredFunctionType:
 		case IProblem.IllegalParameterNullityRedefinition:
+		case IProblem.RecordComponentIncompatibleNullnessVsInheritedAccessor:
 			return CompilerOptions.NullSpecViolation;
 
 		case IProblem.NullNotCompatibleToFreeTypeVariable:
@@ -10535,6 +10536,10 @@ public void expressionPotentialNullReference(ASTNode location) {
 }
 
 public void cannotImplementIncompatibleNullness(ReferenceContext context, MethodBinding currentMethod, MethodBinding inheritedMethod, boolean showReturn) {
+	if (currentMethod instanceof SyntheticMethodBinding synth && synth.purpose == SyntheticMethodBinding.RecordComponentReadAccess) {
+		recordComponentOverrideIncompatibleNullness(synth.sourceRecordComponent(), inheritedMethod, currentMethod.declaringClass);
+		return;
+	}
 	int sourceStart = 0, sourceEnd = 0;
 	if (context instanceof TypeDeclaration) {
 		TypeDeclaration type = (TypeDeclaration) context;
@@ -10570,6 +10575,27 @@ public void cannotImplementIncompatibleNullness(ReferenceContext context, Method
 			messageArguments,
 			sourceStart,
 			sourceEnd);
+}
+public void recordComponentOverrideIncompatibleNullness(AbstractVariableDeclaration component, MethodBinding inheritedMethod, ReferenceBinding declaringClass) {
+	Expression type = component.type;
+	if (type.resolvedType == null || inheritedMethod.returnType == null)
+		return;
+	this.handle(
+		IProblem.RecordComponentIncompatibleNullnessVsInheritedAccessor,
+		new String[] {
+				String.valueOf(type.resolvedType.nullAnnotatedReadableName(this.options, false)),
+				String.valueOf(component.name),
+				String.valueOf(inheritedMethod.returnType.nullAnnotatedReadableName(this.options, false)),
+				String.valueOf(inheritedMethod.readableName()),
+				String.valueOf(declaringClass.readableName()) },
+		new String[] {
+				String.valueOf(type.resolvedType.nullAnnotatedReadableName(this.options, true)),
+				String.valueOf(component.name),
+				String.valueOf(inheritedMethod.returnType.nullAnnotatedReadableName(this.options, true)),
+				String.valueOf(inheritedMethod.shortReadableName()),
+				String.valueOf(declaringClass.shortReadableName()) },
+		type.sourceStart,
+		type.sourceEnd);
 }
 
 public void nullAnnotationIsRedundant(AbstractMethodDeclaration sourceMethod, int i) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/messages.properties
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/messages.properties
@@ -833,6 +833,7 @@
 944 = Redundant null check: The field {0} is a nonnull constant
 945 = Null comparison always yields false: The field {0} is a nonnull constant
 946 = Parameter {0} of method {1} lacks a @{3} annotation as specified in type {2}
+947 = Implicit accessor method for ''{0} {1}'' cannot override inherited method ''{2} {3}'' from {4} due to incompatible nullness constraints
 
 
 951 = Potential null pointer access: array element may be null

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/CompilerInvocationTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/CompilerInvocationTests.java
@@ -995,6 +995,7 @@ public void test011_problem_categories() {
 		expectedProblemAttributes.put("PatternSwitchCaseDefaultOnlyAsSecond", new ProblemAttributes(CategorizedProblem.CAT_PREVIEW_RELATED));
 		expectedProblemAttributes.put("RawMemberTypeCannotBeParameterized", new ProblemAttributes(CategorizedProblem.CAT_TYPE));
 		expectedProblemAttributes.put("RawTypeReference", new ProblemAttributes(CategorizedProblem.CAT_UNCHECKED_RAW));
+		expectedProblemAttributes.put("RecordComponentIncompatibleNullnessVsInheritedAccessor", new ProblemAttributes(CategorizedProblem.CAT_POTENTIAL_PROGRAMMING_PROBLEM));
 		expectedProblemAttributes.put("RecursiveConstructorInvocation", new ProblemAttributes(CategorizedProblem.CAT_MEMBER));
 		expectedProblemAttributes.put("RedefinedArgument", new ProblemAttributes(CategorizedProblem.CAT_INTERNAL));
 		expectedProblemAttributes.put("RedefinedLocal", new ProblemAttributes(CategorizedProblem.CAT_INTERNAL));
@@ -2145,6 +2146,7 @@ public void test012_compiler_problems_tuning() {
 		expectedProblemAttributes.put("PatternSwitchCaseDefaultOnlyAsSecond", SKIP);
 		expectedProblemAttributes.put("RawMemberTypeCannotBeParameterized", SKIP);
 		expectedProblemAttributes.put("RawTypeReference", new ProblemAttributes(JavaCore.COMPILER_PB_RAW_TYPE_REFERENCE));
+		expectedProblemAttributes.put("RecordComponentIncompatibleNullnessVsInheritedAccessor", SKIP);
 		expectedProblemAttributes.put("RecursiveConstructorInvocation", SKIP);
 		expectedProblemAttributes.put("RedefinedArgument", SKIP);
 		expectedProblemAttributes.put("RedefinedLocal", SKIP);

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullAnnotationTests9.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullAnnotationTests9.java
@@ -66,13 +66,13 @@ public class NullAnnotationTests9 extends AbstractNullAnnotationTest {
 			int len = defaultLibs.length;
 			this.LIBS = new String[len+1];
 			System.arraycopy(defaultLibs, 0, this.LIBS, 0, len);
-			this.LIBS[len] = createAnnotation_2_2_jar(Util.getOutputDirectory() + File.separator, null);
+			this.LIBS[len] = createAnnotation_2_4_jar(Util.getOutputDirectory() + File.separator, null);
 		}
 	}
 
-	public static String createAnnotation_2_2_jar(String dirName, String jcl9Path) throws IOException {
-		// role our own annotation library as long as o.e.j.annotation is still at BREE 1.8:
-		String jarFileName = dirName + "org.eclipse.jdt.annotation_2.2.0.jar";
+	public static String createAnnotation_2_4_jar(String dirName, String jcl9Path) throws IOException {
+		// role our own annotation library supporting location MODULE whereas o.e.j.annotation is still at BREE 1.8:
+		String jarFileName = dirName + "org.eclipse.jdt.annotation_2.4.0.jar";
 		createJar(new String[] {
 				"module-info.java",
 				"module org.eclipse.jdt.annotation {\n" +
@@ -84,7 +84,7 @@ public class NullAnnotationTests9 extends AbstractNullAnnotationTest {
 				"\n" +
 				"public enum DefaultLocation {\n" +
 				"	\n" +
-				"	PARAMETER, RETURN_TYPE, FIELD, TYPE_PARAMETER, TYPE_BOUND, TYPE_ARGUMENT, ARRAY_CONTENTS\n" +
+				"	PARAMETER, RETURN_TYPE, FIELD, TYPE_PARAMETER, TYPE_BOUND, TYPE_ARGUMENT, ARRAY_CONTENTS, RECORD_COMPONENT\n" +
 				"}\n",
 
 				"org/eclipse/jdt/annotation/NonNullByDefault.java",
@@ -99,7 +99,7 @@ public class NullAnnotationTests9 extends AbstractNullAnnotationTest {
 				"@Retention(RetentionPolicy.CLASS)\n" +
 				"@Target({ ElementType.MODULE, ElementType.PACKAGE, ElementType.TYPE, ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.FIELD, ElementType.LOCAL_VARIABLE })\n" +
 				"public @interface NonNullByDefault {\n" +
-				"	DefaultLocation[] value() default { PARAMETER, RETURN_TYPE, FIELD, TYPE_BOUND, TYPE_ARGUMENT };\n" +
+				"	DefaultLocation[] value() default { PARAMETER, RETURN_TYPE, FIELD, TYPE_BOUND, TYPE_ARGUMENT, RECORD_COMPONENT };\n" +
 				"}",
 
 				"org/eclipse/jdt/annotation/NonNull.java",

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/NullAnnotationModelTests9.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/NullAnnotationModelTests9.java
@@ -56,7 +56,7 @@ public class NullAnnotationModelTests9 extends ReconcilerTests {
 //		Bundle[] bundles = org.eclipse.jdt.core.tests.Activator.getPackageAdmin().getBundles("org.eclipse.jdt.annotation", "[2.2.0,3.0.0)");
 //		File bundleFile = FileLocator.getBundleFile(bundles[0]);
 //		this.ANNOTATION_LIB = bundleFile.isDirectory() ? bundleFile.getPath()+"/bin" : bundleFile.getPath();
-		this.ANNOTATION_LIB = NullAnnotationTests9.createAnnotation_2_2_jar(getExternalPath(), getExternalJCLPathString("9"));
+		this.ANNOTATION_LIB = NullAnnotationTests9.createAnnotation_2_4_jar(getExternalPath(), getExternalJCLPathString("9"));
 	}
 
 	protected String testJarPath(String jarName) throws IOException {


### PR DESCRIPTION
+ Apply correct default on return type of synth record-comp accessor
+ fine tune how `@NNBD` is applied to record components:
  + already applied during STB.resolveTypeFor(FieldBinding)
  + later ImplicitNullAnnotationVerifier still needs it without default
+ fine tune verification of record component against inherited accessor
+ tests: refresh local source of DefaultLocation & NonNullByDefault

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/701
