### PR TITLE
Do not ask for unchecked conversion if return type is Object

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ReturnStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ReturnStatement.java
@@ -387,7 +387,7 @@ public void resolve(BlockScope scope) {
 			|| expressionType.isCompatibleWith(methodType, scope)) {
 
 		this.expression.computeConversion(scope, methodType, expressionType);
-		if (expressionType.needsUncheckedConversion(methodType)) {
+		if (!scope.getJavaLangObject().equals(methodType) && expressionType.needsUncheckedConversion(methodType)) {
 		    scope.problemReporter().unsafeTypeConversion(this.expression, expressionType, methodType);
 		}
 		if (this.expression instanceof CastExpression) {


### PR DESCRIPTION
Currently ReturnStatement.resolve(BlockScope) checks if the type requires an unchecked conversion, it can trigger an errors when the type is not found, but in case of the return type is object what can always be used this check is undesired.

This now first check if the return type is object and then omit the check for unchecked conversion to prevent this situation.

Fix https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4231

This would then help in fixing the problem observed here:
- https://github.com/eclipse-equinox/equinox/pull/1084#issuecomment-3093458618