### PR TITLE
Failing to compile java file due to Nullpointer #4290

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/LocalTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/LocalTypeBinding.java
@@ -64,6 +64,12 @@ public LocalTypeBinding(LocalTypeBinding prototype) {
 	this.enclosingMethod = prototype.enclosingMethod;
 }
 
+@Override
+public MethodBinding[] methods() {
+	if (this.isRecord())
+		this.scope.collateRecordComponents();
+	return super.methods();
+}
 /* Record a dependency onto a source target type which may be altered
 * by the end of the innerclass emulation. Later on, we will revisit
 * all its dependents so as to update them (see updateInnerEmulationDependents()).

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordsRestrictedClassTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordsRestrictedClassTest.java
@@ -10915,4 +10915,24 @@ public void testIssue4146_3() throws Exception {
 	verifyClassFile(expectedOutput, "Segment.class", ClassFileBytesDisassembler.SYSTEM);
 
 }
+public void testIssue4290_1() throws Exception {
+	this.runConformTest(
+		new String[] {
+					"X.java",
+					"""
+					public class X {
+					    public Object a() {
+					        return new Object() {
+					            static record A(Object  a, Object b) {}
+					        };
+					    }
+					    public static void main(String[] args) {
+							System.out.println("OK");
+						}
+					}
+					""",
+	            },
+				"OK");
+
+}
 }


### PR DESCRIPTION
Load record components for local types on demand.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
Fixes #4290

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
