### PR TITLE
Do not emit restriction warning on inherited method

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/MessageSend.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/MessageSend.java
@@ -71,6 +71,7 @@ import static org.eclipse.jdt.internal.compiler.ast.ExpressionContext.VANILLA_CO
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.BiConsumer;
 import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.internal.compiler.ASTVisitor;
@@ -1002,7 +1003,10 @@ public TypeBinding resolveType(BlockScope scope) {
 		}
 		// abstract private methods cannot occur nor abstract static............
 	}
-	if (isMethodUseDeprecated(this.binding, scope, true, this))
+	TypeBinding declared = this.binding.declaringClass.erasure();
+	TypeBinding actual = this.actualReceiverType.erasure();
+	boolean isExplicitUse = Objects.equals( declared, actual);
+	if (isMethodUseDeprecated(this.binding, scope, isExplicitUse, this))
 		scope.problemReporter().deprecatedMethod(this.binding, this);
 
 	TypeBinding returnType;


### PR DESCRIPTION
Currently when we have a type `A` and it is accessible from package `p1`, but extends a type `B` (that is not accessible in package `p2`) calling any inherited method `A.M` triggers a restriction warning.

This is undesired because as a caller I never access any restricted code here as `A` is inherit all public methods from `B`.

A good example can be found here:
- https://github.com/eclipse-equinox/equinox/pull/1080

in this example the code in `HttpServerManager` has a local variable of type `Server` and calls method `stop()` on this.

```
Server server = servers.remove(pid);
if (server != null) {
	try {
		server.stop();
	} catch (Exception e) {
	}
	File contextWorkDir = new File(workDir, DIR_PREFIX + pid.hashCode());
	deleteDirectory(contextWorkDir);
}
```

this causes the following errors:

```
Description	Resource	Path	Location	Type
Access restriction: The method 'AbstractLifeCycle.stop()' is not API (restriction on required library 'org.eclipse.jetty.util_12.0.23.jar')	HttpServerManager.java	/org.eclipse.equinox.http.jetty/src/org/eclipse/equinox/http/jetty/internal	line 77	Java Problem
```

it does not emit such warnings if the method itself is overridden (an example would be `server.dump(null, "")` that overrides a method in `ContainerLifeCycle` from the same package) because then the method binding equals the actual binding.

To mitigate this, the class `MessageSend` now checks if there is an implicit call and sets `isExplicitUse=false` like it is already done for implicit super constructor calls.

@stephan-herrmann What do you think? Any flaws in my analysis?

