### PR TITLE
Index expect the full type name for member declarations

### DIFF
--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/DOMToIndexVisitor.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/DOMToIndexVisitor.java
@@ -133,11 +133,13 @@ class DOMToIndexVisitor extends ASTVisitor {
 			.filter(SingleVariableDeclaration.class::isInstance)
 			.map(SingleVariableDeclaration.class::cast)
 			.map(SingleVariableDeclaration::getType)
-			.map(this::name)
+			.map(Type::toString)
+			.map(String::toCharArray)
 			.toArray(char[][]::new);
-		char[] returnType = name(method.getReturnType2());
+		char[] returnType = method.getReturnType2() == null ? null : method.getReturnType2().toString().toCharArray();
 		char[][] exceptionTypes = ((List<Type>)method.thrownExceptionTypes()).stream()
-			.map(this::name)
+			.map(Type::toString)
+			.map(String::toCharArray)
 			.toArray(char[][]::new);
 		char[][] parameterNames = ((List<VariableDeclaration>)method.parameters()).stream()
 				.map(VariableDeclaration::getName)
@@ -183,7 +185,7 @@ class DOMToIndexVisitor extends ASTVisitor {
 
 	@Override
 	public boolean visit(FieldDeclaration field) {
-		char[] typeName = name(field.getType());
+		char[] typeName = field.getType() == null ? null : field.getType().toString().toCharArray();
 		for (VariableDeclarationFragment fragment: (List<VariableDeclarationFragment>)field.fragments()) {
 			this.sourceIndexer.addFieldDeclaration(typeName, fragment.getName().getIdentifier().toCharArray());
 		}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does

Fixes the DOMToIndexVisitor to mimic SourceIndexRequestor and pass the parameter name (`toString()`) instead of the simple name.

## How to test

Run `JavaSearchBugsTests2.testBug478042_0004()` with and without this patch, with `-DSourceIndexer.DOM_BASED_INDEXER=true`

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
