### PR TITLE
ECJ eats a class annotation if null analysis is performed

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ASTNode.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ASTNode.java
@@ -810,7 +810,7 @@ public abstract class ASTNode implements TypeConstants, TypeIds {
 				case Binding.FIELD :
 				case Binding.RECORD_COMPONENT :
 				case Binding.LOCAL :
-					if ((recipient.extendedTagBits & ExtendedTagBits.AnnotationResolved) != 0) return annotations;
+					if (ExtendedTagBits.areAllAnnotationsResolved(recipient.extendedTagBits)) return annotations;
 					recipient.extendedTagBits |= ExtendedTagBits.AllAnnotationsResolved;
 					if (length > 0) {
 						annotations = new AnnotationBinding[length];
@@ -849,7 +849,7 @@ public abstract class ASTNode implements TypeConstants, TypeIds {
 								annotations[j] = annot.getCompilerAnnotation();
 							}
 						}
-						break;
+						return annotations;
 					case Binding.LOCAL :
 						LocalVariableBinding local = (LocalVariableBinding) recipient;
 						// Note for JDK>=14, this could be LVB or RCB, hence typecasting to VB
@@ -890,9 +890,10 @@ public abstract class ASTNode implements TypeConstants, TypeIds {
 						// copy the se8 annotations.
 						if (annotationRecipient instanceof RecordComponentBinding && copySE8AnnotationsToType)
 							copySE8AnnotationsToType(scope, recipient, sourceAnnotations, false);
-						break;
+						return annotations;
+					default:
+						annotations[i] = annotation.compilerAnnotation;
 				}
-				return annotations;
 			} else {
 				annotation.recipient = recipient;
 				annotation.resolveType(scope);
@@ -1354,7 +1355,7 @@ public abstract class ASTNode implements TypeConstants, TypeIds {
 			if (annotations != null) {
 				int length;
 				if ((length = annotations.length) >= 0) {
-					if ((recipient.tagBits & ExtendedTagBits.NullDefaultAnnotationResolved) != 0) return;
+					if ((recipient.extendedTagBits & ExtendedTagBits.NullDefaultAnnotationResolved) != 0) return;
 					for (int i = 0; i < length; i++) {
 						TypeReference annotationTypeRef = annotations[i].type;
 						// only resolve type name if 'NonNullByDefault' last token (or corresponding configured annotation name)

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ExtendedTagBits.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ExtendedTagBits.java
@@ -36,4 +36,7 @@ public interface ExtendedTagBits {
 	int DeprecatedAnnotationResolved = ASTNode.Bit7;
 	int NullDefaultAnnotationResolved = ASTNode.Bit8; // package, type, method or variable
 	int AllAnnotationsResolved = ExtendedTagBits.AnnotationResolved | ExtendedTagBits.DeprecatedAnnotationResolved | ExtendedTagBits.NullDefaultAnnotationResolved;
+	static boolean areAllAnnotationsResolved(long extendedTagBits) {
+		return (extendedTagBits & AllAnnotationsResolved) == AllAnnotationsResolved;
+	}
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SourceTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SourceTypeBinding.java
@@ -1135,7 +1135,7 @@ public long getAnnotationTagBits() {
 	if (!isPrototype())
 		return this.prototype.getAnnotationTagBits();
 
-	if ((this.extendedTagBits & ExtendedTagBits.AnnotationResolved) == 0 && this.scope != null) {
+	if (!ExtendedTagBits.areAllAnnotationsResolved(this.extendedTagBits) && this.scope != null) {
 		TypeDeclaration typeDecl = this.scope.referenceContext;
 		boolean old = typeDecl.staticInitializerScope.insideTypeAnnotation;
 		try {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AnnotationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AnnotationTest.java
@@ -12057,4 +12057,61 @@ public void testIssue4107() {
 			null,
 			true);
 }
+public void testGH4243() throws Exception {
+	Runner runner = new Runner();
+	runner.customOptions = getCompilerOptions();
+	runner.customOptions.put(JavaCore.COMPILER_ANNOTATION_NULL_ANALYSIS, JavaCore.ENABLED);
+	runner.customOptions.put(JavaCore.COMPILER_NONNULL_BY_DEFAULT_ANNOTATION_NAME, "p.nonnullbydefault");
+	runner.testFiles = new String[] {
+			"p/Main.java",
+			"""
+			package p;
+			import java.lang.annotation.*;
+
+			@nonnullbydefault
+			@Main.NeededAnnotation
+			public final class Main {
+
+			   public static void main(String[] args) {
+			      for (Annotation anno : Main.class.getAnnotations()) {
+			         System.out.println(anno);
+			      }
+			   }
+
+			   public record Foo(String needed) {}
+
+			   @Retention(RetentionPolicy.RUNTIME)
+			   @interface NeededAnnotation {}
+			}
+			""",
+			"p/nonnullbydefault.java",
+			"""
+			package p;
+			public @interface nonnullbydefault {}
+			""",
+		};
+	runner.expectedOutputString = "@p.Main.NeededAnnotation()"; // the other annotation is not runtime visible
+	runner.runConformTest();
+
+	ClassFileBytesDisassembler disassembler = ToolFactory.createDefaultClassFileBytesDisassembler();
+	byte[] classFileBytes = org.eclipse.jdt.internal.compiler.util.Util.getFileByteContent(
+			new File(OUTPUT_DIR + File.separator  + "p"+ File.separator + "Main.class"));
+	String actualOutput =
+		disassembler.disassemble(
+			classFileBytes,
+			"\n",
+			ClassFileBytesDisassembler.DETAILED);
+
+	String expectedOutput =
+		"""
+		@p.nonnullbydefault
+		@p.Main.NeededAnnotation
+		public final class p.Main {
+		""";
+
+	if (actualOutput.indexOf(expectedOutput) == -1) {
+		System.out.println(org.eclipse.jdt.core.tests.util.Util.displayString(actualOutput, 2));
+	}
+	assertTrue("unexpected bytecode sequence", actualOutput.indexOf(expectedOutput) != -1);
+}
 }


### PR DESCRIPTION
+ fix confusion tagBits vs. extendedTagTypes
+ don't skip annotation resolution when only some have been resolved
+ don't return incompletely initialized annotations array

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4243
