### PR TITLE
Compilation error on full build but not on incremental build due to @Deprecated

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ASTNode.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ASTNode.java
@@ -1338,6 +1338,8 @@ public abstract class ASTNode implements TypeConstants, TypeIds {
 										break;
 									}
 								}
+								annotations[i].recipient = recipient;
+								annotations[i].resolveType(scope); // allow downstream access to since & forRemoval
 							}
 							recipient.tagBits |= deprecationTagBits;
 						}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedTypeBinding.java
@@ -708,6 +708,10 @@ public class ParameterizedTypeBinding extends ReferenceBinding implements Substi
 	public AnnotationBinding[] getAnnotations() {
 		return this.type.getAnnotations();
 	}
+	@Override
+	public AnnotationBinding[] getAnnotations(long requestedInitialization) {
+		return this.type.getAnnotations(requestedInitialization);
+	}
 
 	@Override
 	public long getAnnotationTagBits() {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
@@ -1083,7 +1083,15 @@ public final int getAccessFlags() {
 public AnnotationBinding[] getAnnotations() {
 	return retrieveAnnotations(prototype());
 }
-
+/**
+ * Get annotations, but request initialization only for specific ones
+ * @param requestedInitialization uses the bits from {@link ExtendedTagBits#DeprecatedAnnotationResolved}
+ *  or {@link ExtendedTagBits#AllAnnotationsResolved} to request initialization of specific annotations
+ *  (with option to select others in the future).
+ */
+public AnnotationBinding[] getAnnotations(long requestedInitialization) {
+	return getAnnotations();
+}
 /**
  * @see org.eclipse.jdt.internal.compiler.lookup.Binding#getAnnotationTagBits()
  */

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SourceTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SourceTypeBinding.java
@@ -2378,13 +2378,25 @@ protected boolean hasMethodWithNumArgs(char[] selector, int numArgs) {
 	}
 	return false;
 }
+@Override
+public AnnotationBinding[] getAnnotations(long requestedInitialization) {
+	AnnotationHolder holder = retrieveAnnotationHolder(prototype(), requestedInitialization);
+	return holder == null ? Binding.NO_ANNOTATIONS : holder.getAnnotations();
+}
 
 @Override
 public AnnotationHolder retrieveAnnotationHolder(Binding binding, boolean forceInitialization) {
+	return retrieveAnnotationHolder(binding, ExtendedTagBits.AllAnnotationsResolved);
+}
+private AnnotationHolder retrieveAnnotationHolder(Binding binding, long requestedInitialization) {
 	if (!isPrototype())
-		return this.prototype.retrieveAnnotationHolder(binding, forceInitialization);
-	if (forceInitialization)
-		binding.getAnnotationTagBits(); // ensure annotations are up to date
+		return this.prototype.retrieveAnnotationHolder(binding, requestedInitialization);
+	if (requestedInitialization == ExtendedTagBits.AllAnnotationsResolved) {
+		binding.getAnnotationTagBits(); // ensure all annotations are up to date
+	} else {
+		if ((requestedInitialization & ExtendedTagBits.DeprecatedAnnotationResolved) != 0)
+			binding.initializeDeprecatedAnnotationTagBits(); // selective initialization
+	}
 	return super.retrieveAnnotationHolder(binding, false);
 }
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
@@ -1916,7 +1916,7 @@ public void deprecatedType(TypeBinding type, ASTNode location) {
 // a deprecated type in a qualified reference (see bug 292510)
 public void deprecatedType(TypeBinding type, ASTNode location, int index) {
 	if (location == null) return; // 1G828DN - no type ref for synthetic arguments
-	final TypeBinding leafType = type.leafComponentType();
+	final ReferenceBinding leafType = (ReferenceBinding) type.leafComponentType();
 	if (!leafType.isReadyForAnnotations() && scheduleProblemForContext(() -> deprecatedType(type, location, index)))
 		return;
 	int sourceStart = -1;
@@ -1926,7 +1926,7 @@ public void deprecatedType(TypeBinding type, ASTNode location, int index) {
 			sourceStart = (int) (ref.sourcePositions[index] >> 32);
 		}
 	}
-	String sinceValue = deprecatedSinceValue(() -> leafType.getAnnotations());
+	String sinceValue = deprecatedSinceValue(() -> leafType.getAnnotations(ExtendedTagBits.DeprecatedAnnotationResolved));
 	if (sinceValue != null) {
 		this.handle(
 			((leafType.tagBits & TagBits.AnnotationTerminallyDeprecated) == 0) ? IProblem.UsingDeprecatedSinceVersionType : IProblem.UsingTerminallyDeprecatedSinceVersionType,

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
@@ -1335,6 +1335,91 @@ public void testGH4098() {
 	});
 }
 
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3907
+// Compilation error on full build but not on incremental build due to @deprecated
+public void testIssue3907() {
+	runConformTest(new String[] {
+		"LoadExtension.java",
+		"""
+		public class LoadExtension extends AbstractLoad<Integer> {
+		}
+		""",
+		"TestIntegrationExtension.java",
+		"""
+		public final class TestIntegrationExtension implements Extension {
+
+		}
+
+		@ExtendWith(TestIntegrationExtension.class)
+		@interface TestIntegration {
+		}
+
+		@interface ExtendWith {
+			Class<? extends Extension>[] value();
+		}
+
+		interface Extension {
+		}
+
+
+		/**
+		 * @deprecated
+		 */
+		@TestIntegration()
+		@Deprecated
+		abstract class AbstractLoad<T extends Number> {
+
+		}
+		"""
+	});
+}
+public void testIssue3907_since() {
+	Runner runner = new Runner();
+	runner.testFiles = new String[] {
+		"LoadExtension.java",
+		"""
+		public class LoadExtension extends AbstractLoad<Integer> {
+		}
+		""",
+		"TestIntegrationExtension.java",
+		"""
+		public final class TestIntegrationExtension implements Extension {
+
+		}
+
+		@ExtendWith(TestIntegrationExtension.class)
+		@interface TestIntegration {
+		}
+
+		@interface ExtendWith {
+			Class<? extends Extension>[] value();
+		}
+
+		interface Extension {
+		}
+
+
+		/**
+		 * @deprecated
+		 */
+		@TestIntegration()
+		@Deprecated(since="13")
+		abstract class AbstractLoad<T extends Number> {
+
+		}
+		"""
+	};
+	runner.expectedCompilerLog =
+			"""
+			----------
+			1. WARNING in LoadExtension.java (at line 1)
+				public class LoadExtension extends AbstractLoad<Integer> {
+				                                   ^^^^^^^^^^^^
+			The type AbstractLoad<Integer> is deprecated since version 13
+			----------
+			""";
+	runner.runWarningTest();
+}
 public static Class<GenericsRegressionTest_9> testClass() {
 	return GenericsRegressionTest_9.class;
 }


### PR DESCRIPTION
+ when error reporting needs the since value, don't resolve all annots
  - this prevents that membervalue pairs of sibling annotations are prematurely type checked (before hierarchy linked)
+ during initialization of deprecated annotation store it for later use

https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3907
