### PR TITLE
Check for thread interruption in Parser::parse

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
@@ -11605,6 +11605,11 @@ protected void parse() {
 try {
 	this.scanner.setActiveParser(this);
 	ProcessTerminals : for (;;) {
+		if (Thread.currentThread().isInterrupted()) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("[" + Thread.currentThread().getName() + "] Task interrupted", new InterruptedException()); //$NON-NLS-1$ //$NON-NLS-2$
+        }
+
 		int stackLength = this.stack.length;
 		if (++this.stateStackTop >= stackLength) {
 			System.arraycopy(


### PR DESCRIPTION
## What it does
Regularly checks for the interrupted state of the current thread and correspondingly aborts execution by setting the interrupted state again and throwing an exception

## How to test
- Start the completion proposal that requires an expensive AST calculation (or add a 100ms delay in the very same `for`-loop I modified in this PR to simulate the expensive calculation)
- Cancel the completion proposals by clicking outside of the proposal pop-up window

**Expected result**
- `AsyncCompletionProposalPopup` signals the cancellation (requires https://github.com/eclipse-platform/eclipse.platform.ui/pull/3157)
- The parsing is aborted and the exception is propagated (this PR)
- No exception is logged (requires https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/2425)