### PR TITLE
Fix ASTMatcher match for TypePattern

### DIFF
--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ASTMatcher.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ASTMatcher.java
@@ -2954,7 +2954,11 @@ public class ASTMatcher {
 			return false;
 		}
 		TypePattern o = (TypePattern) other;
-		return safeSubtreeMatch(node.getPatternVariable(), o.getPatternVariable());
+		int level = node.getAST().apiLevel;
+		if (level < AST.JLS22_INTERNAL) {
+			return safeSubtreeMatch(node.getPatternVariable(), o.getPatternVariable());
+		}
+		return safeSubtreeMatch(node.getPatternVariable2(), o.getPatternVariable2());
 	}
 
 	/**


### PR DESCRIPTION
- fixes #4303

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes ASTMatcher comparing TypePatterns when JLS is 22 or greater.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
