### PR TITLE
Invalid compilation error when passing a reference to an exception method-reference to a method accepting a functional-interface with generic exception

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceVariable.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceVariable.java
@@ -162,6 +162,11 @@ public class InferenceVariable extends TypeVariableBinding {
 	}
 
 	@Override
+	public boolean isSubtypeOf(TypeBinding other, boolean simulatingBugJDK8026527) {
+		return this.typeParameter.isSubtypeOf(other, simulatingBugJDK8026527);
+	}
+
+	@Override
 	TypeBinding substituteInferenceVariable(InferenceVariable var, TypeBinding substituteType) {
 		if (TypeBinding.equalsEquals(this, var))
 			return substituteType;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/IntersectionTypeBinding18.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/IntersectionTypeBinding18.java
@@ -228,6 +228,20 @@ public class IntersectionTypeBinding18 extends ReferenceBinding {
 	}
 
 	@Override
+	public boolean isProperType(boolean admitCapture18) {
+		enterRecursiveFunction();
+		try {
+			for (ReferenceBinding binding : this.intersectingTypes) {
+				if (!binding.isProperType(admitCapture18))
+					return false;
+			}
+		} finally {
+			exitRecursiveFunction();
+		}
+		return true;
+	}
+
+	@Override
 	public TypeBinding erasure() {
 		int classIdx = -1;
 		for (int i = 0; i < this.intersectingTypes.length; i++) {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest.java
@@ -6766,6 +6766,65 @@ public void testIssue2523() {
             }
         );
 }
+// regression from issue 2523
+public void testGH4306() {
+	runConformTest(
+		new String[] {
+				"Demo.java",
+				"""
+				public class Demo {
+
+				public static void main(String[] args) throws Throwable {
+					run(Demo::close); // Minimal reproducer
+					run(() -> close()); // no error
+
+					// More complex cases closer to the original code
+					ThrowingRunnable<Exception> run = Demo::close; // no error
+					runAll(() -> close()); // no error
+					runAll(Demo::close); // error
+					runAll(Demo::close, () -> close()); // error on first
+					runAll(() -> close(), Demo::close); // error on second
+				}
+
+				@FunctionalInterface
+				interface ThrowingRunnable<E extends Throwable> {
+					void run() throws E;
+				}
+
+				static void close() throws Exception {
+				}
+
+				@SafeVarargs
+				static <E extends Throwable> void runAll(ThrowingRunnable<? extends E>... actions) throws E {
+				}
+
+				static <E extends Throwable> void run(ThrowingRunnable<? extends E> action) throws E {
+				}
+			}
+				"""
+		});
+}
+public void testGH4306b() {
+	runConformTest(new String[] {
+			"Demo.java",
+			"""
+			public class Demo {
+				public static void main(String[] args) {
+					A type = get(A::new);
+				}
+
+				private static <T extends A> T get(SupplierTest<? extends T> supplier) {
+					return null;
+				}
+
+				private static class A {}
+				private interface SupplierTest<T extends A> {
+					T create();
+				}
+			}
+			"""
+	});
+}
 public void testGH4214() {
 	runConformTest(new String[] {
 		"C.java",


### PR DESCRIPTION
1. implement InferenceVariable.isSubtypeOf()
2. improve Scope.isMalformedPair() 
    a. make it symmetric
    b. peel off any InferenceVariable
4. implement IntersectionTypeBinding18.isProperType()

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4306
