### PR TITLE
Add import module support to ImportRewrite

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/rewrite/describing/ASTRewritingTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/rewrite/describing/ASTRewritingTest.java
@@ -114,6 +114,7 @@ public class ASTRewritingTest extends AbstractJavaModelTests {
 		  suite.addTest(SourceModifierTest.suite());
 		  suite.addTest(ImportRewriteTest.suite());
 		  suite.addTest(ImportRewrite18Test.suite());
+		  suite.addTest(ImportRewrite25Test.suite());
 		  suite.addTest(ImportRewrite_RecordTest.suite());
 		  suite.addTest(ASTRewritingSuperAfterStatementsTest.suite());
 		  suite.addTest(ASTRewritingEitherOrMultiPatternNodeTest.suite());

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/rewrite/describing/ImportRewrite25Test.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/rewrite/describing/ImportRewrite25Test.java
@@ -13,7 +13,8 @@
  *******************************************************************************/
 package org.eclipse.jdt.core.tests.rewrite.describing;
 
-import java.io.IOException;
+import static org.eclipse.jdt.core.tests.rewrite.describing.StringAsserts.assertEqualStringIgnoreDelim;
+
 import java.lang.reflect.Method;
 import java.util.List;
 import junit.framework.Test;
@@ -170,10 +171,6 @@ public class ImportRewrite25Test extends AbstractJavaModelTests {
 		assertTrue(actualType.isParameterizedType());
 		apply(rewrite);
 		assertEqualStringIgnoreDelim(cu.getSource(), contents);
-	}
-
-	private void assertEqualStringIgnoreDelim(String actual, String expected) throws IOException {
-		StringAsserts.assertEqualStringIgnoreDelim(actual, expected);
 	}
 
 	private ImportRewrite newImportsRewrite(ICompilationUnit cu, String[] order, int normalThreshold, int staticThreshold, boolean restoreExistingImports) throws CoreException, BackingStoreException {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/rewrite/describing/ImportRewrite25Test.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/rewrite/describing/ImportRewrite25Test.java
@@ -1,0 +1,205 @@
+/*******************************************************************************
+ * Copyright (c) 2014, 2025 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *		IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.core.tests.rewrite.describing;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.util.List;
+import junit.framework.Test;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jdt.core.ITypeRoot;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.dom.AST;
+import org.eclipse.jdt.core.dom.ASTParser;
+import org.eclipse.jdt.core.dom.CompilationUnit;
+import org.eclipse.jdt.core.dom.FieldDeclaration;
+import org.eclipse.jdt.core.dom.ITypeBinding;
+import org.eclipse.jdt.core.dom.IVariableBinding;
+import org.eclipse.jdt.core.dom.Type;
+import org.eclipse.jdt.core.dom.TypeDeclaration;
+import org.eclipse.jdt.core.dom.VariableDeclarationFragment;
+import org.eclipse.jdt.core.dom.rewrite.ImportRewrite;
+import org.eclipse.jdt.core.formatter.DefaultCodeFormatterConstants;
+import org.eclipse.jdt.core.tests.model.AbstractJavaModelTests;
+import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
+import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.Document;
+import org.eclipse.text.edits.MalformedTreeException;
+import org.eclipse.text.edits.TextEdit;
+import org.osgi.service.prefs.BackingStoreException;
+
+
+@SuppressWarnings("rawtypes")
+public class ImportRewrite25Test extends AbstractJavaModelTests {
+
+
+	private static final Class THIS= ImportRewrite25Test.class;
+	private static final String PROJECT = "ImportRewrite25TestProject";
+
+	protected IPackageFragmentRoot sourceFolder;
+	protected IJavaProject project;
+
+	public ImportRewrite25Test(String name) {
+		super(name);
+	}
+
+	public static Test allTests() {
+		return new Suite(THIS);
+	}
+
+	public static Test suite() {
+		return allTests();
+	}
+
+	@Override
+	protected void setUp() throws Exception {
+		super.setUp();
+
+		IJavaProject proj= createJavaProject(PROJECT, new String[] {"src"}, new String[] {"JCL_25_LIB"}, "bin", "25");
+		proj.setOption(DefaultCodeFormatterConstants.FORMATTER_TAB_CHAR, JavaCore.SPACE);
+		proj.setOption(DefaultCodeFormatterConstants.FORMATTER_TAB_SIZE, "4");
+		proj.setOption(JavaCore.COMPILER_COMPLIANCE, JavaCore.VERSION_25);
+		proj.setOption(JavaCore.COMPILER_PB_ASSERT_IDENTIFIER, JavaCore.ERROR);
+		proj.setOption(JavaCore.COMPILER_SOURCE, JavaCore.VERSION_25);
+		proj.setOption(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, JavaCore.VERSION_25);
+		proj.setOption(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, JavaCore.ENABLED);
+		proj.setOption(JavaCore.COMPILER_PB_REPORT_PREVIEW_FEATURES, JavaCore.IGNORE);
+		proj.setOption(DefaultCodeFormatterConstants.FORMATTER_NUMBER_OF_EMPTY_LINES_TO_PRESERVE, String.valueOf(99));
+
+		proj.setOption(DefaultCodeFormatterConstants.FORMATTER_BLANK_LINES_BETWEEN_IMPORT_GROUPS, String.valueOf(1));
+
+		setupExternalJCL("jclMin25");
+		JavaCore.setClasspathVariables(
+				new String[] {"CONVERTER_JCL_25_LIB", "CONVERTER_JCL_25_SRC", "CONVERTER_JCL_25_SRCROOT"},
+				new IPath[] {getConverterJCLPath("25"), getConverterJCLSourcePath("25"), getConverterJCLRootSourcePath()},
+				null);
+
+		this.project= proj;
+		this.sourceFolder = getPackageFragmentRoot(PROJECT, "src");
+
+		waitUntilIndexesReady();
+	}
+	protected static int getJLS25() {
+		return AST.JLS25;
+	}
+	@Override
+	protected void tearDown() throws Exception {
+		deleteProject(PROJECT);
+		super.tearDown();
+	}
+
+	// From Java 24 onwards, we will keep the jclMin*jar and convertJclMin*jar one and same
+	// The /JCL/build.xml has been updated to produce only jclMin*.jar
+	private String jclMinName(String compliance) {
+		long jdkLevel = CompilerOptions.versionToJdkLevel(compliance);
+		return (jdkLevel >= ClassFileConstants.JDK24) ? "jclMin" : "converterJclMin";
+	}
+	protected IPath getConverterJCLPath() {
+		return getConverterJCLPath(CompilerOptions.getFirstSupportedJavaVersion()); //$NON-NLS-1$
+	}
+
+	protected IPath getConverterJCLPath(String compliance) {
+		String jarName = jclMinName(compliance);
+		return new Path(getExternalPath() + jarName + compliance + ".jar"); //$NON-NLS-1$
+	}
+
+	protected IPath getConverterJCLSourcePath() {
+		return getConverterJCLSourcePath(CompilerOptions.getFirstSupportedJavaVersion()); //$NON-NLS-1$
+	}
+
+	protected IPath getConverterJCLSourcePath(String compliance) {
+		String jarName = jclMinName(compliance);
+		return new Path(getExternalPath() + jarName + compliance + "src.zip"); //$NON-NLS-1$
+	}
+
+	protected IPath getConverterJCLRootSourcePath() {
+		return new Path(""); //$NON-NLS-1$
+	}
+
+	public void testImportClassInJavaBase_since_25() throws Exception {
+		String contents = """
+			package pack1;
+			import module java.base;
+			public class X{
+				List<String> a;
+			}
+			""";
+		createFolder("/" + PROJECT + "/src/pack1");
+		createFile("/" + PROJECT + "/src/pack1/X.java", contents);
+
+		ASTParser parser = ASTParser.newParser(getJLS25());
+
+		ICompilationUnit cu = getCompilationUnit("/" + PROJECT + "/src/pack1/X.java");
+		parser.setSource(contents.toCharArray());
+		parser.setProject(this.project);
+		parser.setKind(ASTParser.K_COMPILATION_UNIT);
+		parser.setUnitName("X.java");
+		parser.setResolveBindings(true);
+		parser.setStatementsRecovery(true);
+		CompilationUnit astRoot = (CompilationUnit) parser.createAST(null);
+		Method setTypeRoot= CompilationUnit.class.getDeclaredMethod("setTypeRoot", ITypeRoot.class);
+		setTypeRoot.setAccessible(true);
+		setTypeRoot.invoke(astRoot, cu);
+		TypeDeclaration type= (TypeDeclaration) astRoot.types().get(0);
+		FieldDeclaration [] fields =  type.getFields();
+		FieldDeclaration field = fields[0];
+		List<VariableDeclarationFragment> fragments= field.fragments();
+		VariableDeclarationFragment fragment= fragments.get(0);
+		IVariableBinding varBinding= fragment.resolveBinding();
+		ITypeBinding typeBinding= varBinding.getType();
+		ImportRewrite rewrite = newImportsRewrite((ICompilationUnit) astRoot.getJavaElement(), new String[0], 99, 99, true);
+		Type actualType = rewrite.addImport(typeBinding, astRoot.getAST());
+		assertEquals("List<String>", actualType.toString());
+		assertTrue(actualType.isParameterizedType());
+		apply(rewrite);
+		assertEqualStringIgnoreDelim(cu.getSource(), contents);
+	}
+
+	private void assertEqualStringIgnoreDelim(String actual, String expected) throws IOException {
+		StringAsserts.assertEqualStringIgnoreDelim(actual, expected);
+	}
+
+	private ImportRewrite newImportsRewrite(ICompilationUnit cu, String[] order, int normalThreshold, int staticThreshold, boolean restoreExistingImports) throws CoreException, BackingStoreException {
+		ImportRewrite rewrite= ImportRewrite.create(cu, restoreExistingImports);
+		rewrite.setImportOrder(order);
+		rewrite.setOnDemandImportThreshold(normalThreshold);
+		rewrite.setStaticOnDemandImportThreshold(staticThreshold);
+		return rewrite;
+	}
+
+	protected ImportRewrite newImportsRewrite(CompilationUnit cu, String[] order, int normalThreshold, int staticThreshold, boolean restoreExistingImports) {
+		ImportRewrite rewrite= ImportRewrite.create(cu, restoreExistingImports);
+		rewrite.setImportOrder(order);
+		rewrite.setOnDemandImportThreshold(normalThreshold);
+		rewrite.setStaticOnDemandImportThreshold(staticThreshold);
+		return rewrite;
+	}
+
+	private void apply(ImportRewrite rewrite) throws CoreException, MalformedTreeException, BadLocationException {
+		TextEdit edit= rewrite.rewriteImports(null);
+
+		// not the efficient way!
+		ICompilationUnit compilationUnit= rewrite.getCompilationUnit();
+		Document document= new Document(compilationUnit.getSource());
+		edit.apply(document);
+		compilationUnit.getBuffer().setContents(document.get());
+	}
+
+}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/rewrite/ImportRewrite.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/rewrite/ImportRewrite.java
@@ -363,7 +363,7 @@ public final class ImportRewrite {
 						List<ImportDeclaration> astImports= compilationUnit.imports();
 						ImportDeclaration foundModuleImport= null;
 						for (ImportDeclaration astImport : astImports) {
-							if (Flags.isModule(astImport.getFlags()) && astImport.getName().getFullyQualifiedName().equals(currName)) {
+							if (Modifier.isModule(astImport.getModifiers()) && astImport.getName().getFullyQualifiedName().equals(currName)) {
 								foundModuleImport= astImport;
 								break;
 							}
@@ -375,7 +375,11 @@ public final class ImportRewrite {
 							}
 						}
 					}
-					moduleEntries.put(curr.getElementName(), packageNames);
+					String name= curr.getElementName();
+					if (name.endsWith(".*")) { //$NON-NLS-1$
+						name= name.substring(0, name.length() - 2);
+					}
+					moduleEntries.put(name, packageNames);
 				}
 			}
 		}
@@ -467,13 +471,13 @@ public final class ImportRewrite {
 			for (int i= 0; i < imports.size(); i++) {
 				ImportDeclaration curr= (ImportDeclaration) imports.get(i);
 				StringBuilder buf= new StringBuilder();
-				buf.append(curr.isStatic() ? STATIC_PREFIX : Flags.isModule(curr.getFlags()) ? MODULE_PREFIX : NORMAL_PREFIX).append(curr.getName().getFullyQualifiedName());
+				buf.append(curr.isStatic() ? STATIC_PREFIX : Modifier.isModule(curr.getModifiers()) ? MODULE_PREFIX : NORMAL_PREFIX).append(curr.getName().getFullyQualifiedName());
 				if (curr.isOnDemand()) {
 					if (buf.length() > 1)
 						buf.append('.');
 					buf.append('*');
 				}
-				if (Flags.isModule(curr.getFlags())) {
+				if (Modifier.isModule(curr.getModifiers())) {
 					List<String> packageList= new ArrayList<>();
 					IBinding binding= curr.resolveBinding();
 					if (binding instanceof IModuleBinding moduleBinding) {

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/rewrite/ImportRewrite.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/rewrite/ImportRewrite.java
@@ -409,7 +409,7 @@ public final class ImportRewrite {
 
 	private static void populateTransitiveModules(IModuleBinding binding, Set<IModuleBinding> transitiveModules) {
 		if (transitiveModules.add(binding)) {
-			IModuleBinding[] requiredTransitiveModules= ((IModuleBindingExtended)binding).getRequiredTransitiveModules();
+			IModuleBinding[] requiredTransitiveModules= binding.getRequiredTransitiveModules();
 			for (IModuleBinding requiredModule : requiredTransitiveModules) {
 				populateTransitiveModules(requiredModule, transitiveModules);
 			}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/rewrite/ImportRewrite.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/rewrite/ImportRewrite.java
@@ -397,13 +397,7 @@ public final class ImportRewrite {
 	 */
 	public static List<String> getPackageNamesForModule(IModuleBinding binding) {
 		Set<IModuleBinding> modules= new HashSet<>();
-		modules.add(binding);
-		modules.addAll(Arrays.asList(binding.getRequiredModules()));
-		Set<IModuleBinding> transitiveModules= new HashSet<>();
-		for (IModuleBinding moduleBinding : modules) {
-			populateTransitiveModules(moduleBinding, transitiveModules);
-		}
-		modules.addAll(transitiveModules);
+		populateTransitiveModules(binding, modules);
 		String firstModuleName= binding.getName();
 		Set<String> packageList= new HashSet<>();
 		for (IModuleBinding moduleBinding : modules) {

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/rewrite/ImportRewrite.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/rewrite/ImportRewrite.java
@@ -393,7 +393,9 @@ public final class ImportRewrite {
 		String currentModuleName= null;
 		try {
 			IModuleDescription modDesc= project.getModuleDescription();
-			currentModuleName= modDesc.getElementName();
+			if (modDesc != null) {
+				currentModuleName= modDesc.getElementName();
+			}
 		} catch (JavaModelException e) {
 			// ignore - treat as unnamed module
 		}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/rewrite/ImportRewrite.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/rewrite/ImportRewrite.java
@@ -414,7 +414,7 @@ public final class ImportRewrite {
 
 	private static void populateTransitiveModules(IModuleBinding binding, Set<IModuleBinding> transitiveModules) {
 		if (transitiveModules.add(binding)) {
-			IModuleBinding[] requiredTransitiveModules= binding.getRequiredModules(); // TODO: change to transitive API
+			IModuleBinding[] requiredTransitiveModules= ((IModuleBindingExtended)binding).getRequiredTransitiveModules();
 			for (IModuleBinding requiredModule : requiredTransitiveModules) {
 				populateTransitiveModules(requiredModule, transitiveModules);
 			}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/imports/ImportDeclarationWriter.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/imports/ImportDeclarationWriter.java
@@ -32,6 +32,10 @@ final class ImportDeclarationWriter {
 			sb.append("static "); //$NON-NLS-1$
 		}
 
+		if (importName.isModule) {
+			sb.append("module "); //$NON-NLS-1$
+		}
+
 		sb.append(importName.qualifiedName);
 
 		if (this.insertSpaceBeforeSemicolon) {

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/imports/OnDemandComputer.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/imports/OnDemandComputer.java
@@ -86,15 +86,17 @@ class OnDemandComputer {
 	private Map<ImportName, Collection<ImportName>> mapByContainer(Collection<ImportName> imports) {
 		Map<ImportName, Collection<ImportName>> importsByContainer = new HashMap<>();
 		for (ImportName importName : imports) {
-			ImportName containerOnDemand = importName.getContainerOnDemand();
+			if (!importName.isModule) {
+				ImportName containerOnDemand = importName.getContainerOnDemand();
 
-			Collection<ImportName> containerImports = importsByContainer.get(containerOnDemand);
-			if (containerImports == null) {
-				containerImports = new ArrayList<>();
-				importsByContainer.put(containerOnDemand, containerImports);
+				Collection<ImportName> containerImports = importsByContainer.get(containerOnDemand);
+				if (containerImports == null) {
+					containerImports = new ArrayList<>();
+					importsByContainer.put(containerOnDemand, containerImports);
+				}
+
+				containerImports.add(importName);
 			}
-
-			containerImports.add(importName);
 		}
 
 		return importsByContainer;


### PR DESCRIPTION
- keep a map of modules and exported packages
- when deciding whether an import is needed, check the module package lists
- modify ImportName to support module
- add support for writing out an import module statement to ImportDeclarationWriter
- fixes #4298

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Adds import module support to ImportRewrite and friends so that Organize Imports can support module imports.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
To test will require the JDT UI patch as well which will be pushed soon.  A self-contained test will be added once it is working.  The JDT UI patch has a test that is working.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
