### PR TITLE
Solve b2 when reducing ConstraintExpressionFormula

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ConstraintExpressionFormula.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ConstraintExpressionFormula.java
@@ -132,6 +132,9 @@ class ConstraintExpressionFormula extends ConstraintFormula {
 						inferenceContext.inferenceKind = inferenceContext.getInferenceKind(previousMethod, argumentTypes);
 						boolean isDiamond = method.isConstructor() && this.left.isPolyExpression(method);
 						inferInvocationApplicability(inferenceContext, method, argumentTypes, isDiamond, inferenceContext.inferenceKind);
+						if (inferenceContext.solve(true) == null)
+							return FALSE;
+						inferenceContext.restoreB2();
 						// b2 has been lifted, inferring poly invocation type amounts to lifting b3.
 					}
 					if (!inferenceContext.computeB3(invocation, this.right, method))

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
@@ -2213,4 +2213,8 @@ public class InferenceContext18 {
 		}
 		return false;
 	}
+
+	public void restoreB2() {
+		this.currentBounds = this.b2.copy();
+	}
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest.java
@@ -6974,5 +6974,28 @@ public void testGH4254() {
 		}
 	);
 }
+
+public void testGH4314() {
+    runConformTest(new String[] {
+            "Test.java",
+            """
+            import java.util.function.Function;
+
+            public class Test {
+
+                public static void main(String[] args) {
+                    m(
+                            i -> new A<>(i),
+                            b -> b.intValue());
+                }
+
+                private static <T, R> void m(Function<Integer, A<T>> f1, Function<T, R> f2) {}
+                private static class A<T> {
+                    public A(T t) {}
+                }
+            }
+            """
+    });
+}
 }
 

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NegativeLambdaExpressionsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NegativeLambdaExpressionsTest.java
@@ -10529,33 +10529,17 @@ public void testIssue3956() {
 				"""
 			},
 			"----------\n" +
-			"1. ERROR in TestMe.java (at line 15)\n" +
-			"	future = active.thenComposeAsync(recording -> {\n" +
-			"				recording.stop().run();\n" +
-			"// This code (should) have compile errors but instead triggers ClassCastException\n" +
-			"\n" +
-			"				return update().handleAsync(() -> recording.process());\n" +
-			"\n" +
-			"// Deleting the line and using this code would work\n" +
-			"//				return update().handleAsync((a, b) -> {\n" +
-			"//					recording.process();\n" +
-			"//					return null;\n" +
-			"//				});\n" +
-			"			});\n" +
-			"	         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
-			"Type mismatch: cannot convert from CompletableFuture<Object> to CompletableFuture<Void>\n" +
-			"----------\n" +
-			"2. ERROR in TestMe.java (at line 19)\n" +
+			"1. ERROR in TestMe.java (at line 19)\n" +
 			"	return update().handleAsync(() -> recording.process());\n" +
 			"	                ^^^^^^^^^^^\n" +
 			"The method handleAsync(BiFunction<? super capture#1-of ?,Throwable,? extends U>) in the type CompletableFuture<capture#1-of ?> is not applicable for the arguments (() -> {})\n" +
 			"----------\n" +
-			"3. ERROR in TestMe.java (at line 19)\n" +
+			"2. ERROR in TestMe.java (at line 19)\n" +
 			"	return update().handleAsync(() -> recording.process());\n" +
 			"	                            ^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
 			"Lambda expression's signature does not match the signature of the functional interface method apply(? super capture#1-of ?, Throwable)\n" +
 			"----------\n" +
-			"4. ERROR in TestMe.java (at line 19)\n" +
+			"3. ERROR in TestMe.java (at line 19)\n" +
 			"	return update().handleAsync(() -> recording.process());\n" +
 			"	                                  ^^^^^^^^^^^^^^^^^^^\n" +
 			"Cannot return a void result\n" +


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
Fixes #4314 by solving the b2 bound set prior to using it for the b3 bound set when the class of the method isn't `ParameterizedGenericMethodBinding`

The removed error from the existing test seems to be originally caused by the b3 bound set (which succeeded without solving the b2 bound set)

## How to test
Attempt to compile the test case

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
