### PR TITLE
Type inference failure in recursive generic class with wildcard

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest.java
@@ -6974,5 +6974,51 @@ public void testGH4254() {
 		}
 	);
 }
+
+public void testCannotInferTypeArguments_01() {
+	runConformTest(new String[] {
+	    "InferenceTest.java",
+        """
+	        public class InferenceTest {
+                public static class A<I extends C<I, ?>> {}
+                public static class B<I extends C<I, ?>, J> {
+                    public B(A<I> a) {}
+                }
+                public static class C<I extends C<I, J>, J> {}
+                public static void test(A<?> a) {
+                    new B<>(a);
+                }
+            }
+	    """
+	}
+	);
+}
+
+public void testCannotInferTypeArguments_02() {
+	runConformTest(new String[] {
+	    "InferenceTest.java",
+        """
+	        public class InferenceTest {
+                public static class A<I extends C<I, ?>> {}
+                public static class B<I extends C<I, ?>, J> {
+                    public B(A<I> a) {}
+                }
+                public static class C<I extends C<I, J>, J> {}
+                public static class D<K extends D<K, V>, V> {}
+                public static class E<V extends D<V, ?>> {}
+                public static class F<K extends D<K, W>, W, X> {
+                    public F(E<K> e) {}
+                }
+                public static void test(A<?> a) {
+                    new B<>(a);
+                }
+                public static void testD(E<?> e) {
+                    new F<>(e);
+                }
+            }
+	    """
+	}
+	);
+}
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
The compiler failed to infer type arguments for diamond operator when a constructor with recursive generic parameter was passed a wildcard argument

Fix: https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4281

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
