### PR TITLE
Don't run ImplicitlyDeclaredClassesTest with JRE 25 before Java 25 merger

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ImplicitlyDeclaredClassesTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ImplicitlyDeclaredClassesTest.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Stream;
+import javax.lang.model.SourceVersion;
 import org.eclipse.jdt.core.util.ClassFileBytesDisassembler;
 import org.eclipse.jdt.core.util.ClassFormatException;
 import org.eclipse.jdt.internal.compiler.CompilationResult;
@@ -48,7 +49,8 @@ public class ImplicitlyDeclaredClassesTest extends AbstractRegressionTest9 {
 	protected void setUp() throws Exception {
 		this.runJavacOptIn = true;
 		super.setUp();
-	}
+		this.isJRE25Plus = isRunningIn25Jre();
+ 	}
 	@Override
 	protected void tearDown() throws Exception {
 		super.tearDown();
@@ -67,6 +69,15 @@ public class ImplicitlyDeclaredClassesTest extends AbstractRegressionTest9 {
 	protected Map<String, String> getCompilerOptions() {
 		return getCompilerOptions(true);
 	}
+	private boolean isJRE25Plus = false;
+	public boolean isRunningIn25Jre() {
+		try {
+			SourceVersion.valueOf("RELEASE_25");
+		} catch(IllegalArgumentException iae) {
+			return false;
+		}
+		return true;
+	}
 	// Enables the tests to run individually
 	protected Map<String, String> getCompilerOptions(boolean previewFlag) {
 		Map<String, String> defaultOptions = super.getCompilerOptions();
@@ -79,13 +90,13 @@ public class ImplicitlyDeclaredClassesTest extends AbstractRegressionTest9 {
 	}
 	@Override
 	protected void runConformTest(String[] testFiles, String expectedOutput) {
-		if(!isJRE23Plus)
+		if(this.isJRE25Plus)
 			return;
 		runConformTest(testFiles, expectedOutput, null, VMARGS, new JavacTestOptions("-source 24 --enable-preview"));
 	}
 	@Override
 	protected void runConformTest(String[] testFiles, String expectedOutput, Map<String, String> customOptions) {
-		if(!isJRE23Plus)
+		if(this.isJRE25Plus)
 			return;
 		runConformTest(testFiles, expectedOutput, customOptions, VMARGS, JAVAC_OPTIONS);
 	}
@@ -263,6 +274,8 @@ public class ImplicitlyDeclaredClassesTest extends AbstractRegressionTest9 {
 	// Test implicit type with a valid candidate main method (public but no static, and String[] argument)
 	@Test
 	public void testImplicitType006() throws IOException, ClassFormatException {
+		if (this.isJRE25Plus)
+			return;
 		try {
 			runConformTest(
 					new String[] {"X.java",
@@ -370,6 +383,8 @@ public class ImplicitlyDeclaredClassesTest extends AbstractRegressionTest9 {
 		"Hello2");
 	}
 	public void testGH3137b() {
+		if (this.isJRE25Plus)
+			return;
 		runConformTest(new String[] {
 				"X.java",
 				"""
@@ -385,6 +400,8 @@ public class ImplicitlyDeclaredClassesTest extends AbstractRegressionTest9 {
 		JavacTestOptions.SKIP);
 	}
 	public void testGH3714() {
+		if (this.isJRE25Plus)
+			return;
 		runConformTest(new String[] {
 				"Main.java",
 				"""


### PR DESCRIPTION
upgrade

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
