### PR TITLE
Provide constants for Markdown formatter

### DIFF
--- a/org.eclipse.jdt.core/.settings/.api_filters
+++ b/org.eclipse.jdt.core/.settings/.api_filters
@@ -1,13 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <component id="org.eclipse.jdt.core" version="2">
-    <resource path="META-INF/MANIFEST.MF">
-        <filter comment="https://github.com/eclipse-jdt/eclipse.jdt.core/pull/4385" id="929038356">
-            <message_arguments>
-                <message_argument value="3.43.100"/>
-                <message_argument value="org.eclipse.jdt.core.compiler.batch"/>
-            </message_arguments>
-        </filter>
-    </resource>
     <resource path="dom/org/eclipse/jdt/core/dom/AbstractTagElement.java" type="org.eclipse.jdt.core.dom.AbstractTagElement">
         <filter id="576725006">
             <message_arguments>

--- a/org.eclipse.jdt.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.core; singleton:=true
-Bundle-Version: 3.43.100.qualifier
+Bundle-Version: 3.44.0.qualifier
 Bundle-Activator: org.eclipse.jdt.core.JavaCore
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/core/formatter/DefaultCodeFormatterConstants.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/core/formatter/DefaultCodeFormatterConstants.java
@@ -1512,6 +1512,19 @@ public class DefaultCodeFormatterConstants {
 
 	/**
 	 * <pre>
+	 * FORMATTER / Option to control whether markdown comments are formatted
+	 *     - option id:         "org.eclipse.jdt.core.formatter.comment.format_markdown_comments"
+	 *     - possible values:   { TRUE, FALSE }
+	 *     - default:           TRUE
+	 * </pre>
+	 * @see #TRUE
+	 * @see #FALSE
+	 * @since 3.43
+	 */
+	public final static String FORMATTER_COMMENT_FORMAT_MARKDOWN_COMMENT = "org.eclipse.jdt.core.formatter.comment.format_markdown_comments"; //$NON-NLS-1$
+
+	/**
+	 * <pre>
 	 * FORMATTER / Option to control whether the header comment of a Java source file is formatted
 	 *     - option id:         "org.eclipse.jdt.core.formatter.comment.format_header"
 	 *     - possible values:   { TRUE, FALSE }

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/core/formatter/DefaultCodeFormatterConstants.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/core/formatter/DefaultCodeFormatterConstants.java
@@ -1519,7 +1519,7 @@ public class DefaultCodeFormatterConstants {
 	 * </pre>
 	 * @see #TRUE
 	 * @see #FALSE
-	 * @since 3.43
+	 * @since 3.44
 	 */
 	public final static String FORMATTER_COMMENT_FORMAT_MARKDOWN_COMMENT = "org.eclipse.jdt.core.formatter.comment.format_markdown_comments"; //$NON-NLS-1$
 

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/DefaultCodeFormatterOptions.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/DefaultCodeFormatterOptions.java
@@ -238,6 +238,7 @@ public class DefaultCodeFormatterOptions {
 	public boolean comment_new_lines_at_javadoc_boundaries;
 	public boolean comment_javadoc_do_not_separate_block_tags;
 	public boolean comment_format_javadoc_comment;
+	public boolean comment_format_markdown_comment;
 	public boolean comment_format_line_comment;
 	public boolean comment_format_line_comment_starting_on_first_column;
 	public boolean comment_format_block_comment;
@@ -667,6 +668,7 @@ public class DefaultCodeFormatterOptions {
 		options.put(DefaultCodeFormatterConstants.FORMATTER_COMMENT_FORMAT_HEADER, this.comment_format_header ? DefaultCodeFormatterConstants.TRUE : DefaultCodeFormatterConstants.FALSE);
 		options.put(DefaultCodeFormatterConstants.FORMATTER_COMMENT_FORMAT_HTML, this.comment_format_html ? DefaultCodeFormatterConstants.TRUE : DefaultCodeFormatterConstants.FALSE);
 		options.put(DefaultCodeFormatterConstants.FORMATTER_COMMENT_FORMAT_JAVADOC_COMMENT, this.comment_format_javadoc_comment ? DefaultCodeFormatterConstants.TRUE : DefaultCodeFormatterConstants.FALSE);
+		options.put(DefaultCodeFormatterConstants.FORMATTER_COMMENT_FORMAT_MARKDOWN_COMMENT, this.comment_format_markdown_comment ? DefaultCodeFormatterConstants.TRUE : DefaultCodeFormatterConstants.FALSE);
 		options.put(DefaultCodeFormatterConstants.FORMATTER_COMMENT_FORMAT_LINE_COMMENT, this.comment_format_line_comment ? DefaultCodeFormatterConstants.TRUE : DefaultCodeFormatterConstants.FALSE);
 		options.put(DefaultCodeFormatterConstants.FORMATTER_COMMENT_FORMAT_LINE_COMMENT_STARTING_ON_FIRST_COLUMN, this.comment_format_line_comment_starting_on_first_column ? DefaultCodeFormatterConstants.TRUE : DefaultCodeFormatterConstants.FALSE);
 		options.put(DefaultCodeFormatterConstants.FORMATTER_COMMENT_FORMAT_SOURCE, this.comment_format_source ? DefaultCodeFormatterConstants.TRUE : DefaultCodeFormatterConstants.FALSE);
@@ -1569,6 +1571,10 @@ public class DefaultCodeFormatterOptions {
 		final Object commentFormatJavadocCommentOption = settings.get(DefaultCodeFormatterConstants.FORMATTER_COMMENT_FORMAT_JAVADOC_COMMENT);
 		if (commentFormatJavadocCommentOption != null) {
 			this.comment_format_javadoc_comment = DefaultCodeFormatterConstants.TRUE.equals(commentFormatJavadocCommentOption);
+		}
+		final Object commentFormatMarkdownCommentOption = settings.get(DefaultCodeFormatterConstants.FORMATTER_COMMENT_FORMAT_MARKDOWN_COMMENT);
+		if (commentFormatMarkdownCommentOption != null) {
+			this.comment_format_markdown_comment = DefaultCodeFormatterConstants.TRUE.equals(commentFormatMarkdownCommentOption);
 		}
 		final Object commentFormatBlockCommentOption = settings.get(DefaultCodeFormatterConstants.FORMATTER_COMMENT_FORMAT_BLOCK_COMMENT);
 		if (commentFormatBlockCommentOption != null) {
@@ -3063,6 +3069,7 @@ public class DefaultCodeFormatterOptions {
 		this.comment_clear_blank_lines_in_javadoc_comment = false;
 		this.comment_format_block_comment = true;
 		this.comment_format_javadoc_comment = true;
+		this.comment_format_markdown_comment = true;
 		this.comment_format_line_comment = true;
 		this.comment_format_line_comment_starting_on_first_column = true;
 		this.comment_format_header = false;
@@ -3468,6 +3475,7 @@ public class DefaultCodeFormatterOptions {
 		this.comment_clear_blank_lines_in_javadoc_comment = false;
 		this.comment_format_block_comment = true;
 		this.comment_format_javadoc_comment = true;
+		this.comment_format_markdown_comment = true;
 		this.comment_format_line_comment = true;
 		this.comment_format_line_comment_starting_on_first_column = false;
 		this.comment_format_header = false;

--- a/org.eclipse.jdt.core/pom.xml
+++ b/org.eclipse.jdt.core/pom.xml
@@ -17,7 +17,7 @@
     <version>4.38.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.eclipse.jdt.core</artifactId>
-  <version>3.43.100-SNAPSHOT</version>
+  <version>3.44.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>


### PR DESCRIPTION
This commit provides constant and fields for markdown formatting enablement

partial fix :
https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4335

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
