### PR TITLE
Fix missing matches in the call hierarchy

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchBugsTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchBugsTests.java
@@ -15159,6 +15159,87 @@ public void testBug521240_001() throws CoreException {
 			"src/pack1/X.java void pack1.X.foo(Y) [foo] EXACT_MATCH"
 	);
 }
+
+/*
+ * See https://github.com/eclipse-jdt/eclipse.jdt.core/pull/4341
+ */
+public void testBugGH4341() throws CoreException, IOException {
+	String testProjectName = "BugGH4341";
+	try {
+		IJavaProject project = createJava9Project(testProjectName, new String[] {"src"});
+
+		setUpProjectCompliance(project, "9", true);
+
+		 // Create a hierarchy of interfaces (D -> A -> B -> C) and an imports relation (C -> D).
+
+		String packageX = "/" + testProjectName + "/src/x";
+		createFolder(packageX);
+		createFile(packageX + "/A.java",
+				"""
+				package x;
+				public interface A extends B {}
+				""");
+
+		createFile(packageX + "/B.java",
+				"""
+				package x;
+				public interface B extends C {}
+				""");
+
+		createFile(packageX + "/C.java",
+				"""
+				package x;
+				import javax.annotation.processing.SupportedSourceVersion;
+				import javax.lang.model.SourceVersion;
+				import y.D;
+				/**
+				 * {@link D}
+				 */
+				@SupportedSourceVersion(SourceVersion.RELEASE_0)
+				public interface C {}
+				""");
+
+
+		String packageY = "/" + testProjectName + "/src/y";
+		createFolder(packageY);
+		createFile(packageY + "/D.java",
+				"""
+				package y;
+				import x.A;
+				public interface D extends A {}
+				""");
+
+
+		String packageZ = "/" + testProjectName + "/src/z";
+		createFolder(packageZ);
+		createFile(packageZ + "/Main.java",
+				"""
+				package z;
+				import x.A;
+				import y.D;
+
+				public class Main {
+					public void method1() {
+						D d = new D() {};
+						method2(d);
+					}
+
+					public void method2(A a) {}
+				}
+				""");
+
+
+		buildAndExpectNoProblems(project);
+
+		IType type = project.findType("z.Main");
+		IMethod method = type.getMethod("method2", new String[] { "QA;" });
+		search(method, REFERENCES, EXACT_RULE, SearchEngine.createWorkspaceScope(), this.resultCollector);
+		assertSearchResults("src/z/Main.java void z.Main.method1() [method2(d)] EXACT_MATCH");
+	} finally {
+		deleteProject(testProjectName);
+	}
+}
+
 public void testBug547051_nonModular() throws Exception {
 	try {
 		IJavaProject project = createJavaProject("P");


### PR DESCRIPTION
## What it does
Integrate the annotations in the hierarchy using their own set of navigated types. The cycle-detection algorithm assumed that the mere presence of a type in the set of visited types was enough to detect a cycle in the hierarchy of classes/interfaces, but integrating the annotations can navigate down the hierarchy (i.e. to subclasses) leading to false positives in the algorithm.

Fixes https://github.com/vi-eclipse/Eclipse-JDT/issues/9 (internal issue)
Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2575 (does it, @ricetrac ?)

## How to test
I wasn't able to create a self-contained reproducer, sorry for that. 

There are some details about (part of) our complex set of classes involved in [this comment](https://github.com/vi-eclipse/Eclipse-JDT/issues/9#issuecomment-3204675292), but I must be missing some piece of the puzzle because I tried exactly that and I can't reproduce the error. 

I can still reproduce it in my real WS though. I can provide details and also share the analysis that I made in this PR if necessary.

## Author checklist

- [x] I have thoroughly tested my changes **in my own Workspace**
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
