### PR TITLE
Do the cheap checks first.

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/PackageFragment.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/PackageFragment.java
@@ -186,7 +186,7 @@ public boolean exists() {
 	// so also ensure that:
 	//  - the package is not excluded (see https://bugs.eclipse.org/bugs/show_bug.cgi?id=138577)
 	//  - its name is valide (see https://bugs.eclipse.org/bugs/show_bug.cgi?id=108456)
-	return super.exists() && !Util.isExcluded(this) && isValidPackageName();
+	return isValidPackageName() && super.exists() && !Util.isExcluded(this);
 }
 /**
  * @see IPackageFragment#getOrdinaryClassFile(String)


### PR DESCRIPTION
Since `super.exists()` might be expensive (See https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1860) and `isValidPackageName()` is `final` and relies on a final field too.

Maybe even `!Util.isExcluded(this)` could go before `super.exists()`, but since that one uses `this` and I'm not sure if it depends on its current state, I didn't risk it.