### PR TITLE
Invert conditions in PackageFragment.validateExistence(IResource)

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/PackageFragment.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/PackageFragment.java
@@ -186,7 +186,7 @@ public boolean exists() {
 	// so also ensure that:
 	//  - the package is not excluded (see https://bugs.eclipse.org/bugs/show_bug.cgi?id=138577)
 	//  - its name is valide (see https://bugs.eclipse.org/bugs/show_bug.cgi?id=108456)
-	return super.exists() && !Util.isExcluded(this) && isValidPackageName();
+	return isValidPackageName() && !Util.isExcluded(this) && super.exists();
 }
 /**
  * @see IPackageFragment#getOrdinaryClassFile(String)
@@ -591,14 +591,12 @@ protected IStatus validateExistence(IResource underlyingResource) {
 		return newDoesNotExistStatus();
 
 	// check that it is not excluded (https://bugs.eclipse.org/bugs/show_bug.cgi?id=138577)
-	int kind;
 	try {
-		kind = getKind();
+		if (Util.isExcluded(this) && getKind() == IPackageFragmentRoot.K_SOURCE)
+			return newDoesNotExistStatus();
 	} catch (JavaModelException e) {
 		return e.getStatus();
 	}
-	if (kind == IPackageFragmentRoot.K_SOURCE && Util.isExcluded(this))
-		return newDoesNotExistStatus();
 
 	return JavaModelStatus.VERIFIED_OK;
 }


### PR DESCRIPTION
Check if the package is excluded before asking for its kind (the latter might be expensive).

Contributes to https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1860

See https://github.com/eclipse-jdt/eclipse.jdt.core/pull/4342#issue-3341833317

> Maybe even !Util.isExcluded(this) could go before super.exists(), but since that one uses this and I'm not sure if it depends on its current state, I didn't risk it.