### PR TITLE
Make qualified parameterized type resolve work like single type

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter15JLS4Test.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter15JLS4Test.java
@@ -2187,7 +2187,7 @@ public class ASTConverter15JLS4Test extends ConverterTestSetup {
 		SimpleName simpleName2 = (SimpleName) name;
 		typeBinding = simpleName2.resolveTypeBinding();
 		assertNotNull("No binding", typeBinding);
-        assertEquals("Wrong name 3", "test0070.Outer", typeBinding.getQualifiedName());
+        assertEquals("Wrong name 3", "test0070.Outer<java.lang.String>", typeBinding.getQualifiedName());
 	}
 
 	/**
@@ -4001,7 +4001,7 @@ public class ASTConverter15JLS4Test extends ConverterTestSetup {
 		simpleName = qualifiedType.getName();
 		typeBinding = simpleName.resolveTypeBinding();
 		assertNotNull("No binding", typeBinding);
-		assertEquals("Wrong qualified name 5", "Outer.Inner", typeBinding.getQualifiedName());
+		assertEquals("Wrong qualified name 5", "Outer<java.lang.String>.Inner", typeBinding.getQualifiedName());
 		type = qualifiedType.getQualifier();
 		assertTrue("Not a parameterized type", type.isParameterizedType());
 		parameterizedType = (ParameterizedType) type;
@@ -4019,7 +4019,7 @@ public class ASTConverter15JLS4Test extends ConverterTestSetup {
 		simpleName = (SimpleName) name;
 		typeBinding = simpleName.resolveTypeBinding();
 		assertNotNull("No binding", typeBinding);
-		assertEquals("Wrong qualified name 8", "Outer", typeBinding.getQualifiedName());
+		assertEquals("Wrong qualified name 8", "Outer<java.lang.String>", typeBinding.getQualifiedName());
    }
 
     // https://bugs.eclipse.org/bugs/show_bug.cgi?id=84140

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter15JLS8Test.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter15JLS8Test.java
@@ -2183,7 +2183,7 @@ public class ASTConverter15JLS8Test extends ConverterTestSetup {
 		SimpleName simpleName2 = (SimpleName) name;
 		typeBinding = simpleName2.resolveTypeBinding();
 		assertNotNull("No binding", typeBinding);
-        assertEquals("Wrong name 3", "test0070.Outer", typeBinding.getQualifiedName());
+        assertEquals("Wrong name 3", "test0070.Outer<java.lang.String>", typeBinding.getQualifiedName());
 	}
 
 	/**
@@ -3997,7 +3997,7 @@ public class ASTConverter15JLS8Test extends ConverterTestSetup {
 		simpleName = qualifiedType.getName();
 		typeBinding = simpleName.resolveTypeBinding();
 		assertNotNull("No binding", typeBinding);
-		assertEquals("Wrong qualified name 5", "Outer.Inner", typeBinding.getQualifiedName());
+		assertEquals("Wrong qualified name 5", "Outer<java.lang.String>.Inner", typeBinding.getQualifiedName());
 		type = qualifiedType.getQualifier();
 		assertTrue("Not a parameterized type", type.isParameterizedType());
 		parameterizedType = (ParameterizedType) type;
@@ -4015,7 +4015,7 @@ public class ASTConverter15JLS8Test extends ConverterTestSetup {
 		simpleName = (SimpleName) name;
 		typeBinding = simpleName.resolveTypeBinding();
 		assertNotNull("No binding", typeBinding);
-		assertEquals("Wrong qualified name 8", "Outer", typeBinding.getQualifiedName());
+		assertEquals("Wrong qualified name 8", "Outer<java.lang.String>", typeBinding.getQualifiedName());
    }
 
     // https://bugs.eclipse.org/bugs/show_bug.cgi?id=84140

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/DefaultBindingResolver.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/DefaultBindingResolver.java
@@ -1080,25 +1080,42 @@ class DefaultBindingResolver extends BindingResolver {
 				return this.getTypeBinding(qualifiedTypeReference.resolvedType.leafComponentType());
 			} else {
 				if (index >= 0) {
-					BlockScope internalScope = (BlockScope) this.astNodesToBlockScope.get(name);
-					Binding binding = null;
-					try {
-						if (internalScope == null) {
-							if (this.scope == null) return null;
-							binding = this.scope.getTypeOrPackage(CharOperation.subarray(qualifiedTypeReference.tokens, 0, index));
-						} else {
-							binding = internalScope.getTypeOrPackage(CharOperation.subarray(qualifiedTypeReference.tokens, 0, index));
+					Binding binding = qualifiedTypeReference.resolvedType;
+					for (int i = 0; i < (qualifiedTypeReference.tokens.length - index); i++) {
+						if (!(binding instanceof org.eclipse.jdt.internal.compiler.lookup.TypeBinding typeBinding)) {
+							binding = null;
+							break;
 						}
-					} catch (AbortCompilation e) {
-						// see https://bugs.eclipse.org/bugs/show_bug.cgi?id=53357
+						binding = typeBinding.enclosingType();
+						if (binding == null) {
+							break;
+						}
 					}
-					if (binding instanceof org.eclipse.jdt.internal.compiler.lookup.PackageBinding) {
-						return null;
-					} else if (binding instanceof org.eclipse.jdt.internal.compiler.lookup.TypeBinding) {
-						// it is a type
-						return this.getTypeBinding((org.eclipse.jdt.internal.compiler.lookup.TypeBinding)binding);
+					if (binding != null) {
+						return this.getTypeBinding((org.eclipse.jdt.internal.compiler.lookup.TypeBinding) binding);
 					} else {
-						return null;
+						BlockScope internalScope = (BlockScope) this.astNodesToBlockScope.get(name);
+						try {
+							if (internalScope == null) {
+								if (this.scope == null)
+									return null;
+								binding = this.scope.getTypeOrPackage(
+										CharOperation.subarray(qualifiedTypeReference.tokens, 0, index));
+							} else {
+								binding = internalScope.getTypeOrPackage(
+										CharOperation.subarray(qualifiedTypeReference.tokens, 0, index));
+							}
+						} catch (AbortCompilation e) {
+							// see https://bugs.eclipse.org/bugs/show_bug.cgi?id=53357
+						}
+						if (binding instanceof org.eclipse.jdt.internal.compiler.lookup.PackageBinding) {
+							return null;
+						} else if (binding instanceof org.eclipse.jdt.internal.compiler.lookup.TypeBinding) {
+							// it is a type
+							return this.getTypeBinding((org.eclipse.jdt.internal.compiler.lookup.TypeBinding) binding);
+						} else {
+							return null;
+						}
 					}
 				}
 			}
@@ -1313,25 +1330,42 @@ class DefaultBindingResolver extends BindingResolver {
 				return this.getTypeBinding(qualifiedTypeReference.resolvedType.leafComponentType());
 			} else {
 				if (index >= 0) {
-					BlockScope internalScope = (BlockScope) this.astNodesToBlockScope.get(name);
-					Binding binding = null;
-					try {
-						if (internalScope == null) {
-							if (this.scope == null) return null;
-							binding = this.scope.getTypeOrPackage(CharOperation.subarray(qualifiedTypeReference.tokens, 0, index));
-						} else {
-							binding = internalScope.getTypeOrPackage(CharOperation.subarray(qualifiedTypeReference.tokens, 0, index));
+					Binding binding = qualifiedTypeReference.resolvedType;
+					for (int i = 0; i < (qualifiedTypeReference.tokens.length - index); i++) {
+						if (!(binding instanceof org.eclipse.jdt.internal.compiler.lookup.TypeBinding typeBinding)) {
+							binding = null;
+							break;
 						}
-					} catch (AbortCompilation e) {
-						// see https://bugs.eclipse.org/bugs/show_bug.cgi?id=53357
+						binding = typeBinding.enclosingType();
+						if (binding == null) {
+							break;
+						}
 					}
-					if (binding instanceof org.eclipse.jdt.internal.compiler.lookup.PackageBinding) {
-						return getPackageBinding((org.eclipse.jdt.internal.compiler.lookup.PackageBinding)binding);
-					} else if (binding instanceof org.eclipse.jdt.internal.compiler.lookup.TypeBinding) {
-						// it is a type
+					if (binding != null) {
 						return this.getTypeBinding((org.eclipse.jdt.internal.compiler.lookup.TypeBinding)binding);
 					} else {
-						return null;
+						BlockScope internalScope = (BlockScope) this.astNodesToBlockScope.get(name);
+						try {
+							if (internalScope == null) {
+								if (this.scope == null)
+									return null;
+								binding = this.scope.getTypeOrPackage(
+										CharOperation.subarray(qualifiedTypeReference.tokens, 0, index));
+							} else {
+								binding = internalScope.getTypeOrPackage(
+										CharOperation.subarray(qualifiedTypeReference.tokens, 0, index));
+							}
+						} catch (AbortCompilation e) {
+							// see https://bugs.eclipse.org/bugs/show_bug.cgi?id=53357
+						}
+						if (binding instanceof org.eclipse.jdt.internal.compiler.lookup.PackageBinding) {
+							return getPackageBinding((org.eclipse.jdt.internal.compiler.lookup.PackageBinding) binding);
+						} else if (binding instanceof org.eclipse.jdt.internal.compiler.lookup.TypeBinding) {
+							// it is a type
+							return this.getTypeBinding((org.eclipse.jdt.internal.compiler.lookup.TypeBinding) binding);
+						} else {
+							return null;
+						}
 					}
 				}
 			}


### PR DESCRIPTION
## What it does
The type arguments should be preserved when resolving the type binding through the SimpleName.

For instance:

```java
class Sandwich {}

class Outer<X> {
  public class Inner {
    public class InnerInner<Y> {
    }
  }
}

public class Main {
  public Outer<Sandwich> method1() {
    //   ^^^^^ call resolve binding on this simple name
    return null;
  }
  public Outer<Sandwich>.Inner.InnerInner<Sandwich> method2() {
    //   ^^^^^ call resolve binding on this simple name
    return null;
  }
}
```

I expect the results to be the same; I expect the result to be `Outer<Sandwich>`.

## How to test
I'll adjust the failing unit and integration tests.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
