### PR TITLE
Compilation disagreement between ECJ and javac with multiple generic bounds

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractRegressionTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractRegressionTest.java
@@ -848,6 +848,8 @@ protected static class JavacTestOptions {
 		JavacErrorsEclipseNone =
 				new DubiousOutcome(MismatchType.JavacErrorsEclipseNone),
 		JDK8319461 = // https://bugs.openjdk.org/browse/JDK-8319461
+				new DubiousOutcome(MismatchType.JavacErrorsEclipseNone),
+		JDK8364144 = // https://bugs.openjdk.org/browse/JDK-8364144
 				new DubiousOutcome(MismatchType.JavacErrorsEclipseNone);
 	}
 	public static class EclipseHasABug extends Excuse {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/DubiousOutcomeTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/DubiousOutcomeTest.java
@@ -44,6 +44,19 @@ public class DubiousOutcomeTest extends AbstractRegressionTest {
 		return buildMinimalComplianceTestSuite(testClass(), F_1_8);
 	}
 
+	// ========= OPT-IN to run.javac mode: ===========
+	@Override
+	protected void setUp() throws Exception {
+		this.runJavacOptIn = true;
+		super.setUp();
+	}
+	@Override
+	protected void tearDown() throws Exception {
+		super.tearDown();
+		this.runJavacOptIn = false; // do it last, so super can still clean up
+	}
+	// =================================================
+
 	public void testGH1591() {
 		// javac accepts
 		Runner runner = new Runner();
@@ -251,6 +264,33 @@ public class DubiousOutcomeTest extends AbstractRegressionTest {
 				"""
 			};
 		runner.javacTestOptions = DubiousOutcome.JDK8319461;
+		runner.runConformTest();
+	}
+
+	public void testGH4226() {
+		Runner runner = new Runner();
+		runner.testFiles = new String[] {
+			"NumberGenerator.java",
+			"""
+			interface Culprit {}
+
+			class EntityInfo<E extends NumberGenerator<?> & Culprit> {}
+
+			class NumberGenerator<N extends Number> implements NumberSupplier<N> {
+
+				@Override
+				public N getNumber() {
+					return null;
+				}
+			}
+
+			interface NumberSupplier<N extends Number>  {
+
+				N getNumber();
+			}
+			"""
+		};
+		runner.javacTestOptions = DubiousOutcome.JDK8364144;
 		runner.runConformTest();
 	}
 }


### PR DESCRIPTION
+ add test to DubiousOutcomeTest
+ let that suite opt-in to run.javac mode

Relates to https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4226
