### PR TITLE
Add support to IModuleBinding for required transitive modules

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter9Test.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter9Test.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 IBM Corporation and others.
+ * Copyright (c) 2016, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -1627,6 +1627,109 @@ public class ASTConverter9Test extends ConverterTestSetup {
 			}
 		} finally {
 			deleteProject("ASTParserModelTests");
+		}
+	}
+
+	public void testTransitiveRequires_1() throws Exception { //https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4350
+		try {
+
+			IJavaProject project1 = createJavaProject("ConverterTests9", new String[] {"src"}, new String[] {jcl9lib}, "bin", "9");
+			project1.open(null);
+			addClasspathEntry(project1, JavaCore.newContainerEntry(new Path("org.eclipse.jdt.MODULE_PATH")));
+			String fileContent =
+				"module first {\n" +
+				"    requires transitive second;\n" +
+				"	 uses pack22.I22;\n" +
+				"    provides pack22.I22 with pack1.X11;\n" +
+				"}";
+			createFile("/ConverterTests9/src/module-info.java",	fileContent);
+			createFolder("/ConverterTests9/src/pack1");
+			createFile("/ConverterTests9/src/pack1/X11.java",
+					"package pack1;\n" +
+					"public class X11 implements pack22.I22{}\n");
+
+			IJavaProject project2 = createJavaProject("second", new String[] {"src"}, new String[] {jcl9lib}, "bin", "9");
+			project2.open(null);
+			addClasspathEntry(project2, JavaCore.newContainerEntry(new Path("org.eclipse.jdt.MODULE_PATH")));
+			String secondFile =
+					"module second {\n" +
+					"    exports pack22 to first;\n" +
+					"}";
+			createFile("/second/src/module-info.java",	secondFile);
+			createFolder("/second/src/pack22");
+			createFile("/second/src/pack22/I22.java",
+					"package pack22;\n" +
+					"public interface I22 {}\n");
+
+			addClasspathEntry(project1, JavaCore.newProjectEntry(project2.getPath()));
+
+			project1.close(); // sync
+			project2.close();
+			project2.open(null);
+			project1.open(null);
+
+			ICompilationUnit sourceUnit1 = getCompilationUnit("ConverterTests9" , "src", "", "module-info.java"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
+			ASTNode unit1 = runConversion(this.ast.apiLevel(), sourceUnit1, true);
+			assertEquals("Not a compilation unit", ASTNode.COMPILATION_UNIT, unit1.getNodeType());
+			ModuleDeclaration moduleDecl1 = ((CompilationUnit) unit1).getModule();
+			checkSourceRange(moduleDecl1, fileContent, fileContent);
+
+			IModuleBinding moduleBinding = moduleDecl1.resolveBinding();
+			Name modName1 = moduleDecl1.getName();
+			IBinding binding = modName1.resolveBinding();
+			assertTrue("binding not a module binding", binding instanceof IModuleBinding);
+			moduleBinding = (IModuleBinding) binding;
+
+			assertModuleFirstDetailsTransitive(moduleBinding);
+
+		} finally {
+			deleteProject("ConverterTests9");
+			deleteProject("second");
+		}
+	}
+
+	private void assertModuleFirstDetailsTransitive(IModuleBinding moduleBinding) {
+		assertTrue("Module Binding null", moduleBinding != null);
+		String name = moduleBinding.getName();
+		assertTrue("Module Name null", name != null);
+		assertTrue("Wrong Module Name", name.equals("first"));
+
+		assertTrue("Module Binding null", moduleBinding != null);
+		name = moduleBinding.getName();
+		assertTrue("Module Name null", name != null);
+		assertTrue("Wrong Module Name", name.equals("first"));
+
+		IModuleBinding[] reqs = moduleBinding.getRequiredModules();
+		assertTrue("Null requires", reqs != null);
+		assertTrue("incorrect number of requires modules", reqs.length == 2);
+		assertTrue("incorrect name for requires modules", reqs[0].getName().equals("java.base"));
+		assertTrue("incorrect name for requires modules", reqs[1].getName().equals("second"));
+
+		IModuleBinding[] reqsTransitive= ((IModuleBindingExtended)moduleBinding).getRequiredTransitiveModules();
+		assertTrue("Null requires", reqsTransitive != null);
+		assertTrue("incorrect number of requires transitive modules", reqsTransitive.length == 1);
+		assertTrue("incorrect name for requires transitive modules", reqsTransitive[0].getName().equals("second"));
+
+		IPackageBinding[] secPacks = reqs[1].getExportedPackages();
+		assertTrue("Packages Exported in second module null", secPacks != null);
+		assertTrue("Incorrect number of exported packages in second module", secPacks.length == 1);
+		IPackageBinding pack22 = secPacks[0];
+		assertTrue("Incorrect Package", pack22.getName().equals("pack22"));
+
+		ITypeBinding[] uses = moduleBinding.getUses();
+		assertTrue("uses null", uses != null);
+		assertTrue("Incorrect number of uses", uses.length == 1);
+		assertTrue("Incorrect uses", uses[0].getQualifiedName().equals("pack22.I22"));
+
+		ITypeBinding[] services = moduleBinding.getServices();
+		assertTrue("services null", services != null);
+		assertTrue("Incorrect number of services", services.length == 1);
+		for (ITypeBinding s : services) {
+			assertTrue("Incorrect service", s.getQualifiedName().equals("pack22.I22"));
+			ITypeBinding[] implementations = moduleBinding.getImplementations(s);
+			assertTrue("implementations null", implementations != null);
+			assertTrue("Incorrect number of implementations", implementations.length == 1);
+			assertTrue("Incorrect implementation", implementations[0].getQualifiedName().equals("pack1.X11"));
 		}
 	}
 

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/IModuleBindingExtended.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/IModuleBindingExtended.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2025 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *
+ *******************************************************************************/
+package org.eclipse.jdt.core.dom;
+
+/**
+ * @since 3.43
+ */
+public interface IModuleBindingExtended {
+
+	/**
+	 * Returns all required transivite modules.
+	 * <p>The resulting bindings are in no particular order.</p>
+	 *
+	 * @return all required transitive modules
+	 */
+	public abstract IModuleBinding[] getRequiredTransitiveModules();
+
+}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ModuleBinding.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ModuleBinding.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 IBM Corporation and others.
+ * Copyright (c) 2017, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -27,7 +27,7 @@ import org.eclipse.jdt.internal.core.SearchableEnvironment;
  * Internal implementation of module bindings.
  * @since 3.14
  */
-class ModuleBinding implements IModuleBinding {
+class ModuleBinding implements IModuleBinding, IModuleBindingExtended {
 
 	protected static final ITypeBinding[] NO_TYPE_BINDINGS = new ITypeBinding[0];
 	private final String name = null;
@@ -39,6 +39,7 @@ class ModuleBinding implements IModuleBinding {
 
 	private IAnnotationBinding[] annotations;
 	private IModuleBinding[] requiredModules;
+	private IModuleBinding[] requiredTransitiveModules;
 	private IPackageBinding[] exports; // cached
 	private IPackageBinding[] opens; // cached
 	private ITypeBinding[] uses; // cached
@@ -170,6 +171,20 @@ class ModuleBinding implements IModuleBinding {
 	}
 
 	@Override
+	public IModuleBinding[] getRequiredTransitiveModules() {
+		if (this.requiredTransitiveModules != null)
+			return this.requiredTransitiveModules;
+
+		org.eclipse.jdt.internal.compiler.lookup.ModuleBinding[] reqs = this.binding.getRequiresTransitive();
+		IModuleBinding[] result = new IModuleBinding[reqs != null ? reqs.length : 0];
+		for (int i = 0, l = result.length; i < l; ++i) {
+			org.eclipse.jdt.internal.compiler.lookup.ModuleBinding req = reqs[i];
+			result[i] = req != null ? this.resolver.getModuleBinding(req) : null;
+		}
+		return this.requiredTransitiveModules = result;
+	}
+
+	@Override
 	public IPackageBinding[] getExportedPackages() {
 		if (this.exports == null) {
 			org.eclipse.jdt.internal.compiler.lookup.PackageBinding[] compilerExports = this.binding.getExports();
@@ -238,4 +253,5 @@ class ModuleBinding implements IModuleBinding {
 	public String toString() {
 		return this.binding.toString();
 	}
+
 }


### PR DESCRIPTION
- add new IModuleBindingExtended interface
- modify ModuleBinding to implement new interface
- add test to ASTConverter9Test
- for #4350 and #4313

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Adds a way of obtaining requires transitive module list from a module binding.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
