### PR TITLE
Fix package name and folder mismatch for some test cases

### DIFF
--- a/org.eclipse.jdt.core.tests.model/workspace/Converter15/src/test0041/Action.java
+++ b/org.eclipse.jdt.core.tests.model/workspace/Converter15/src/test0041/Action.java
@@ -1,3 +1,4 @@
+package test0041;
 @interface Action {
 	Forward[] forwards();
 }

--- a/org.eclipse.jdt.core.tests.model/workspace/Converter15/src/test0041/Controller.java
+++ b/org.eclipse.jdt.core.tests.model/workspace/Converter15/src/test0041/Controller.java
@@ -1,1 +1,2 @@
+package test0041;
 @interface Controller {}

--- a/org.eclipse.jdt.core.tests.model/workspace/Converter15/src/test0041/Forward.java
+++ b/org.eclipse.jdt.core.tests.model/workspace/Converter15/src/test0041/Forward.java
@@ -1,3 +1,4 @@
+package test0041;
 @interface Forward {
 	String name();
 	String path();

--- a/org.eclipse.jdt.core.tests.model/workspace/Converter15/src/test0041/ViewProperties.java
+++ b/org.eclipse.jdt.core.tests.model/workspace/Converter15/src/test0041/ViewProperties.java
@@ -1,3 +1,4 @@
+package test0041;
 @interface ViewProperties {
 	String[] val();
 }


### PR DESCRIPTION
## What it does
See #4250

Some test classes have different folder and package names. `javac` uses the package name stated in the class if there's a mismatch, and ECJ uses the folder name. However, the tests using these classes aren't testing for that behaviour; the package mismatch seems to have been an oversight of the person coding the tests.

As a result, I think it's best to make the package and folder line up properly.

## How to test
This involves changes to the existing test case; those tests should still pass

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
