### PR TITLE
Repair branch build by fixing repo url to 4.37-Y-builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <profile>
       <id>build-individual-bundles</id>
       <properties>
-      	<eclipse-p2-repo.url>https://download.eclipse.org/eclipse/updates/Y-builds</eclipse-p2-repo.url>
+      	<eclipse-p2-repo.url>https://download.eclipse.org/eclipse/updates/4.37-Y-builds/</eclipse-p2-repo.url>
       	<skipAPIAnalysis>true</skipAPIAnalysis>
       </properties>
       <repositories>


### PR DESCRIPTION
The generic url https://download.eclipse.org/eclipse/updates/Y-builds currently points to 4.38-Y-builds, which, however, is empty. This results in build failures like https://ci.eclipse.org/jdt/job/eclipse.jdt.core-run.javac-25/26/console

Therefor, branch builds may should use the specific 4.37-Y-builds repo for now.