### PR TITLE
Require same version of jdt.core.compiler.batch

### DIFF
--- a/org.eclipse.jdt.core/.settings/.api_filters
+++ b/org.eclipse.jdt.core/.settings/.api_filters
@@ -1,5 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <component id="org.eclipse.jdt.core" version="2">
+    <resource path="META-INF/MANIFEST.MF">
+        <filter comment="https://github.com/eclipse-jdt/eclipse.jdt.core/pull/4385" id="929038356">
+            <message_arguments>
+                <message_argument value="3.43.100"/>
+                <message_argument value="org.eclipse.jdt.core.compiler.batch"/>
+            </message_arguments>
+        </filter>
+    </resource>
     <resource path="dom/org/eclipse/jdt/core/dom/AbstractTagElement.java" type="org.eclipse.jdt.core.dom.AbstractTagElement">
         <filter id="576725006">
             <message_arguments>

--- a/org.eclipse.jdt.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core/META-INF/MANIFEST.MF
@@ -47,7 +47,7 @@ Require-Bundle: org.eclipse.core.resources;bundle-version="[3.22.0,4.0.0)",
  org.eclipse.core.filesystem;bundle-version="[1.11.0,2.0.0)",
  org.eclipse.text;bundle-version="[3.6.0,4.0.0)",
  org.eclipse.team.core;bundle-version="[3.1.0,4.0.0)";resolution:=optional,
- org.eclipse.jdt.core.compiler.batch;bundle-version="3.41.50";visibility:=reexport
+ org.eclipse.jdt.core.compiler.batch;bundle-version="3.43.100";visibility:=reexport
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Eclipse-ExtensibleAPI: true
 Bundle-ActivationPolicy: lazy


### PR DESCRIPTION
Keeping in close sync jdt.core and reexported jdt.core.compiler.batch.

