### PR TITLE
Log exceptions when indexing #1303

### DIFF
--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/IndexAllProject.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/IndexAllProject.java
@@ -13,8 +13,6 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.core.search.indexing;
 
-import static org.eclipse.jdt.internal.core.JavaModelManager.trace;
-
 import java.io.IOException;
 import java.net.URI;
 import java.util.HashSet;
@@ -36,7 +34,6 @@ import org.eclipse.jdt.internal.compiler.util.SimpleLookupTable;
 import org.eclipse.jdt.internal.core.ClasspathEntry;
 import org.eclipse.jdt.internal.core.JavaProject;
 import org.eclipse.jdt.internal.core.index.Index;
-import org.eclipse.jdt.internal.core.search.processing.JobManager;
 import org.eclipse.jdt.internal.core.util.Util;
 
 public class IndexAllProject extends IndexRequest {
@@ -230,9 +227,7 @@ public class IndexAllProject extends IndexRequest {
 			// request to save index when all cus have been indexed... also sets state to SAVED_STATE
 			this.manager.request(new SaveIndex(this.containerPath, this.manager));
 		} catch (CoreException | IOException e) {
-			if (JobManager.VERBOSE) {
-				trace("-> failed to index " + this.project + " because of the following exception:", e); //$NON-NLS-1$ //$NON-NLS-2$
-			}
+			Util.log(e, "Failed to index " + this.project + ": " + e.getMessage()); //$NON-NLS-1$ //$NON-NLS-2$
 			this.manager.removeIndex(this.containerPath);
 			return false;
 		} finally {

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/IndexBinaryFolder.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/IndexBinaryFolder.java
@@ -13,8 +13,6 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.core.search.indexing;
 
-import static org.eclipse.jdt.internal.core.JavaModelManager.trace;
-
 import java.io.IOException;
 import java.net.URI;
 import org.eclipse.core.filesystem.EFS;
@@ -27,7 +25,6 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.internal.compiler.util.SimpleLookupTable;
 import org.eclipse.jdt.internal.core.index.Index;
-import org.eclipse.jdt.internal.core.search.processing.JobManager;
 import org.eclipse.jdt.internal.core.util.Util;
 
 public class IndexBinaryFolder extends IndexRequest {
@@ -137,9 +134,7 @@ public class IndexBinaryFolder extends IndexRequest {
 			// request to save index when all class files have been indexed... also sets state to SAVED_STATE
 			this.manager.request(new SaveIndex(this.containerPath, this.manager));
 		} catch (CoreException | IOException e) {
-			if (JobManager.VERBOSE) {
-				trace("-> failed to index " + this.folder + " because of the following exception:", e); //$NON-NLS-1$ //$NON-NLS-2$
-			}
+			Util.log(e, "Failed to index " + this.folder + ": " + e.getMessage()); //$NON-NLS-1$ //$NON-NLS-2$
 			this.manager.removeIndex(this.containerPath);
 			return false;
 		} finally {

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/RemoveFolderFromIndex.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/RemoveFolderFromIndex.java
@@ -13,15 +13,12 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.core.search.indexing;
 
-import static org.eclipse.jdt.internal.core.JavaModelManager.trace;
-
 import java.io.IOException;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.jdt.internal.core.index.Index;
-import org.eclipse.jdt.internal.core.search.processing.JobManager;
 import org.eclipse.jdt.internal.core.util.Util;
 
 class RemoveFolderFromIndex extends IndexRequest {
@@ -65,9 +62,7 @@ class RemoveFolderFromIndex extends IndexRequest {
 				}
 			}
 		} catch (IOException e) {
-			if (JobManager.VERBOSE) {
-				trace("-> failed to remove " + this.folderPath + " from index because of the following exception:", e); //$NON-NLS-1$ //$NON-NLS-2$
-			}
+			Util.log(e, "Failed to remove " + this.folderPath + " from index: " + e.getMessage()); //$NON-NLS-1$ //$NON-NLS-2$
 			return false;
 		} finally {
 			monitor.exitRead(); // free read lock

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/SaveIndex.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/SaveIndex.java
@@ -13,13 +13,12 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.core.search.indexing;
 
-import static org.eclipse.jdt.internal.core.JavaModelManager.trace;
-
 import java.io.IOException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.jdt.internal.core.index.Index;
-import org.eclipse.jdt.internal.core.search.processing.JobManager;
+import org.eclipse.jdt.internal.core.util.Util;
 
 /*
  * Save the index of a project.
@@ -43,9 +42,7 @@ public class SaveIndex extends IndexRequest {
 			monitor.enterWrite(); // ask permission to write
 			this.manager.saveIndex(index);
 		} catch (IOException e) {
-			if (JobManager.VERBOSE) {
-				trace("-> failed to save index " + this.containerPath + " because of the following exception:", e); //$NON-NLS-1$ //$NON-NLS-2$
-			}
+			Util.log(Status.warning("Failed to save index " + this.containerPath + ". The index will not be persisted into disk but it is still available in memory and it is usable: " + e.getMessage(), e)); //$NON-NLS-1$ //$NON-NLS-2$
 			return false;
 		} finally {
 			monitor.exitWrite(); // free write lock


### PR DESCRIPTION
## What it does

Don't rely on the `VERBOSE` configuration to be enabled, bring the errors to the user so they are visible in the _Error Log_ view and the error log files too.

Contributes to
https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1303