### PR TITLE
Do not let BinaryIndexer modify shared array of ClassFileReader

### DIFF
--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/BinaryIndexer.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/BinaryIndexer.java
@@ -16,6 +16,7 @@ package org.eclipse.jdt.internal.core.search.indexing;
 import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Arrays;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.jdt.core.Flags;
@@ -728,7 +729,7 @@ public class BinaryIndexer extends AbstractIndexer implements SuffixConstants {
 			char[][] typeParameterSignatures = null;
 			char[] genericSignature = reader.getGenericSignature();
 			if (genericSignature != null) {
-				CharOperation.replace(genericSignature, '/', '.');
+				genericSignature = replace('/', '.', genericSignature);
 				typeParameterSignatures = Signature.getTypeParameters(genericSignature);
 			}
 
@@ -948,21 +949,23 @@ public class BinaryIndexer extends AbstractIndexer implements SuffixConstants {
 			return descriptor;
 		}
 	}
-	/*
-	 * Modify the array by replacing all occurences of toBeReplaced with newChar
+	/**
+	 * @return a copy of the array, replacing all occurences of toBeReplaced with newChar
 	 */
 	private char[][] replace(char toBeReplaced, char newChar, char[][] array) {
 		if (array == null) return null;
-		for (char[] element : array) {
-			replace(toBeReplaced, newChar, element);
+		array = Arrays.copyOf(array, array.length);
+		for (int i = 0; i < array.length; i++) {
+			array[i] = replace(toBeReplaced, newChar, array[i]);
 		}
 		return array;
 	}
-	/*
-	 * Modify the array by replacing all occurences of toBeReplaced with newChar
+	/**
+	 * @return a copy of the array, replacing all occurences of toBeReplaced with newChar
 	 */
 	private char[] replace(char toBeReplaced, char newChar, char[] array) {
 		if (array == null) return null;
+		array = Arrays.copyOf(array, array.length);
 		for (int i = 0, max = array.length; i < max; i++) {
 			if (array[i] == toBeReplaced) {
 				array[i] = newChar;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/pull/4389

## How to test

With Javac/DOM-first backend, run ASTConverter15Test.test0167 , without the patch, the test fails; with this patch it works.
Note that the behavior with Javac/DOM is different because the order of model population vs indexing seems reversed (ECJ seems to first index, then populate model; Javac does it the other way round); but the bug is still there anyway and may impact other parts of the code, even with ECJ.

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
