### PR TITLE
Bug 551943 - Clean up Javadoc of JavaConvensions that mentions incomplete of Java versions and stale commented out code

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/core/JavaConventions.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/core/JavaConventions.java
@@ -460,8 +460,8 @@ public final class JavaConventions {
 	 * <p>For example, <code>"java.lang.Object"</code>, or <code>"Object"</code>.</p>
 	 *
 	 * <p>The source level and compliance level values should be taken from the constant defined inside
-	 * {@link JavaCore} class. The constants are named <code>JavaCore#VERSION_1_x</code>, x being set
-	 * between '1' and '8'.
+	 * {@link JavaCore} class. The constants are named <code>JavaCore#VERSION_x</code>, x being different versions
+	 * of Java language.
 	 * </p>
 	 *
 	 * @param name the name of a type
@@ -474,15 +474,6 @@ public final class JavaConventions {
 	 *      otherwise a status object indicating what is wrong with
 	 *      the name
 	 * @since 3.3
-	 * @see JavaCore#VERSION_1_1
-	 * @see JavaCore#VERSION_1_2
-	 * @see JavaCore#VERSION_1_3
-	 * @see JavaCore#VERSION_1_4
-	 * @see JavaCore#VERSION_1_5
-	 * @see JavaCore#VERSION_1_6
-	 * @see JavaCore#VERSION_1_7
-	 * @see JavaCore#VERSION_1_8
-	 * @see JavaCore#VERSION_9
 	 * @deprecated Use {@link #validateJavaTypeName(String id, String sourceLevel, String complianceLevel, String previewEnabled)} instead
 	 */
 	public static IStatus validateJavaTypeName(String name, String sourceLevel, String complianceLevel) {
@@ -496,8 +487,8 @@ public final class JavaConventions {
 	 * <p>For example, <code>"java.lang.Object"</code>, or <code>"Object"</code>.</p>
 	 *
 	 * <p>The source level and compliance level values should be taken from the constant defined inside
-	 * {@link JavaCore} class. The constants are named <code>JavaCore#VERSION_1_x</code>, x being set
-	 * between '1' and '8'.
+	 * {@link JavaCore} class. The constants are named <code>JavaCore#VERSION_x</code>, x being different versions
+	 * of Java language.
 	 * </p>
 	 * <p>The preview flag should be one of {@link JavaCore#ENABLED}, {@link JavaCore#DISABLED} or null.
 	 *  When null is passed, the preview is considered to be disabled.
@@ -514,20 +505,6 @@ public final class JavaConventions {
 	 *      otherwise a status object indicating what is wrong with
 	 *      the name
 	 * @since 3.22
-	 * @see JavaCore#VERSION_1_1
-	 * @see JavaCore#VERSION_1_2
-	 * @see JavaCore#VERSION_1_3
-	 * @see JavaCore#VERSION_1_4
-	 * @see JavaCore#VERSION_1_5
-	 * @see JavaCore#VERSION_1_6
-	 * @see JavaCore#VERSION_1_7
-	 * @see JavaCore#VERSION_1_8
-	 * @see JavaCore#VERSION_9
-	 * @see JavaCore#VERSION_10
-	 * @see JavaCore#VERSION_11
-	 * @see JavaCore#VERSION_12
-	 * @see JavaCore#VERSION_13
-	 * @see JavaCore#VERSION_14
 	 */
 	public static IStatus validateJavaTypeName(String name, String sourceLevel, String complianceLevel, String previewEnabled) {
 		return internalValidateJavaTypeName(name, sourceLevel, complianceLevel, previewEnabled);
@@ -851,158 +828,4 @@ public final class JavaConventions {
 		return validateIdentifier(name, sourceLevel, complianceLevel);
 	}
 
-	/**
-	 * Validate that all compiler options of the given project match keys and values
-	 * described in {@link JavaCore#getDefaultOptions()} method.
-	 *
-	 * @param javaProject the given java project
-	 * @param inheritJavaCoreOptions inherit project options from JavaCore or not.
-	 * @return a status object with code <code>IStatus.OK</code> if all project
-	 *		compiler options are valid, otherwise a status object indicating what is wrong
-	 *		with the keys and their value.
-	 * @since 3.1
-	 * TODO (frederic) finalize for all possible options (JavaCore, DefaultCodeFormatterOptions, AssistOptions) and open to API
-	 */
-	/*
-	public static IStatus validateCompilerOptions(IJavaProject javaProject, boolean inheritJavaCoreOptions)	  {
-		return validateCompilerOptions(javaProject.getOptions(inheritJavaCoreOptions));
-	}
-	*/
-
-	/**
-	 * Validate that all compiler options of the given project match keys and values
-	 * described in {@link JavaCore#getDefaultOptions()} method.
-	 *
-	 * @param compilerOptions Map of options
-	 * @return a status object with code <code>IStatus.OK</code> if all
-	 *		compiler options are valid, otherwise a status object indicating what is wrong
-	 *		with the keys and their value.
-	 * @since 3.1
-	 */
-	/*
-	public static IStatus validateCompilerOptions(Map compilerOptions)	  {
-
-		// Get current options
-		String compliance = (String) compilerOptions.get(JavaCore.COMPILER_COMPLIANCE);
-		String source = (String) compilerOptions.get(JavaCore.COMPILER_SOURCE);
-		String target = (String) compilerOptions.get(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM);
-		if (compliance == null && source == null && target == null) {
-			return JavaModelStatus.VERIFIED_OK; // default is OK
-		}
-
-		// Initialize multi-status
-		List errors = new ArrayList();
-
-		// Set default for compliance if necessary (not set on project and not inherited...)
-		if (compliance == null) {
-			compliance = JavaCore.getOption(JavaCore.COMPILER_COMPLIANCE);
-		}
-
-		// Verify compliance level value and set source and target default if necessary
-		long complianceLevel = 0;
-		long sourceLevel = 0;
-		long targetLevel = 0;
-		if (JavaCore.VERSION_1_3.equals(compliance)) {
-			complianceLevel = ClassFileConstants.JDK1_3;
-			if (source == null) {
-				source = JavaCore.VERSION_1_3;
-				sourceLevel = ClassFileConstants.JDK1_3;
-			}
-			if (target == null) {
-				target = JavaCore.VERSION_1_1;
-				targetLevel = ClassFileConstants.JDK1_1;
-			}
-		} else if (JavaCore.VERSION_1_4.equals(compliance)) {
-			complianceLevel = ClassFileConstants.JDK1_4;
-			if (source == null) {
-				source = JavaCore.VERSION_1_3;
-				sourceLevel = ClassFileConstants.JDK1_3;
-			}
-			if (target == null) {
-				target = JavaCore.VERSION_1_2;
-				targetLevel = ClassFileConstants.JDK1_2;
-			}
-		} else if (JavaCore.VERSION_1_5.equals(compliance)) {
-			complianceLevel = ClassFileConstants.JDK1_5;
-			if (source == null) {
-				source = JavaCore.VERSION_1_5;
-				sourceLevel = ClassFileConstants.JDK1_5;
-			}
-			if (target == null) {
-				target = JavaCore.VERSION_1_5;
-				targetLevel = ClassFileConstants.JDK1_5;
-			}
-		} else {
-			// compliance is not valid
-			errors.add(new JavaModelStatus(IStatus.ERROR, Util.bind("convention.compiler.invalidCompilerOption", compliance==null?"":compliance, JavaCore.COMPILER_COMPLIANCE))); //$NON-NLS-1$ //$NON-NLS-2$
-		}
-
-		// Verify source value and set default for target if necessary
-		 if (JavaCore.VERSION_1_4.equals(source)) {
-			sourceLevel = ClassFileConstants.JDK1_4;
-			if (target == null) {
-				target = JavaCore.VERSION_1_4;
-				targetLevel = ClassFileConstants.JDK1_4;
-			}
-		} else if (JavaCore.VERSION_1_5.equals(source)) {
-			sourceLevel = ClassFileConstants.JDK1_5;
-			if (target == null) {
-				target = JavaCore.VERSION_1_5;
-				targetLevel = ClassFileConstants.JDK1_5;
-			}
-		} else if (JavaCore.VERSION_1_3.equals(source)) {
-			sourceLevel = ClassFileConstants.JDK1_3;
-		} else {
-			// source is not valid
-			errors.add(new JavaModelStatus(IStatus.ERROR, Util.bind("convention.compiler.invalidCompilerOption", source==null?"":source, JavaCore.COMPILER_SOURCE))); //$NON-NLS-1$ //$NON-NLS-2$
-		}
-
-		// Verify target value
-		 if (targetLevel == 0) {
-			 targetLevel = CompilerOptions.versionToJdkLevel(target);
-			 if (targetLevel == 0) {
-				// target is not valid
-				errors.add(new JavaModelStatus(IStatus.ERROR, Util.bind("convention.compiler.invalidCompilerOption", target==null?"":target, JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM))); //$NON-NLS-1$ //$NON-NLS-2$
-			 }
-		}
-
-		// Check and set compliance/source/target compatibilities (only if they have valid values)
-		if (complianceLevel != 0 && sourceLevel != 0 && targetLevel != 0) {
-			// target must be 1.5 if source is 1.5
-			if (sourceLevel >= ClassFileConstants.JDK1_5 && targetLevel < ClassFileConstants.JDK1_5) {
-				errors.add(new JavaModelStatus(IStatus.ERROR, Util.bind("convention.compiler.incompatibleTargetForSource", target, JavaCore.VERSION_1_5))); //$NON-NLS-1$
-			}
-	   		else
-		   		// target must be 1.4 if source is 1.4
-	   			if (sourceLevel >= ClassFileConstants.JDK1_4 && targetLevel < ClassFileConstants.JDK1_4) {
-					errors.add(new JavaModelStatus(IStatus.ERROR, Util.bind("convention.compiler.incompatibleTargetForSource", target, JavaCore.VERSION_1_4))); //$NON-NLS-1$
-	   		}
-			// target cannot be greater than compliance level
-			if (complianceLevel < targetLevel){
-				errors.add(new JavaModelStatus(IStatus.ERROR, Util.bind("convention.compiler.incompatibleComplianceForTarget", compliance, JavaCore.VERSION_1_4))); //$NON-NLS-1$
-			}
-			// compliance must be 1.5 if source is 1.5
-			if (source.equals(JavaCore.VERSION_1_5) && complianceLevel < ClassFileConstants.JDK1_5) {
-				errors.add(new JavaModelStatus(IStatus.ERROR, Util.bind("convention.compiler.incompatibleComplianceForSource", compliance, JavaCore.VERSION_1_5))); //$NON-NLS-1$
-			} else
-				// compliance must be 1.4 if source is 1.4
-				if (source.equals(JavaCore.VERSION_1_4) && complianceLevel < ClassFileConstants.JDK1_4) {
-					errors.add(new JavaModelStatus(IStatus.ERROR, Util.bind("convention.compiler.incompatibleComplianceForSource", compliance, JavaCore.VERSION_1_4))); //$NON-NLS-1$
-			}
-		}
-
-		// Return status
-		int size = errors.size();
-		switch (size) {
-			case 0:
-				return JavaModelStatus.VERIFIED_OK;
-			case 1:
-				return (IStatus) errors.get(0);
-			default:
-				IJavaModelStatus[] allStatus = new IJavaModelStatus[size];
-				errors.toArray(allStatus);
-				return JavaModelStatus.newMultiStatus(allStatus);
-		}
-	}
-	*/
 }


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
Fixes https://bugs.eclipse.org/bugs/show_bug.cgi?id=551943

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
