### PR TITLE
Remove duplicated setup/teardown from test class

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/DubiousOutcomeTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/DubiousOutcomeTest.java
@@ -56,19 +56,6 @@ public class DubiousOutcomeTest extends AbstractRegressionTest {
 	}
 	// =================================================
 
-	// ========= OPT-IN to run.javac mode: ===========
-	@Override
-	protected void setUp() throws Exception {
-		this.runJavacOptIn = true;
-		super.setUp();
-	}
-	@Override
-	protected void tearDown() throws Exception {
-		super.tearDown();
-		this.runJavacOptIn = false; // do it last, so super can still clean up
-	}
-	// =================================================
-
 	public void testGH1591() {
 		// javac accepts
 		Runner runner = new Runner();


### PR DESCRIPTION
Both fd197fc and c71a026 added setup/teardown methods to DubiousOutcomeTest.

Fixes https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3343
