### PR TITLE
Fix CompletionParser.attachOrphanCompletionNode()

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests16.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests16.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2024 IBM and others.
+ * Copyright (c) 2020, 2025 IBM and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -1377,4 +1377,23 @@ public class CompletionTests16 extends AbstractJavaModelCompletionTests {
 				requestor.getResults());
 
 	}
+
+	public void test_CompletionOnRecordConstructor_issue4419() throws JavaModelException {
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy(
+				"/Completion/src/Person.java",
+				"public record Person(pack2.P) {\n"
+						+ "    public Per\n"
+						+ "}\n");
+		CompletionTestsRequestor2 requestor = new CompletionTestsRequestor2(true, true, true, false);
+		String str = this.workingCopies[0].getSource();
+		String completeBehind = "public Per";
+		int cursorLocation = str.lastIndexOf(completeBehind) + completeBehind.length();
+		this.workingCopies[0].codeComplete(cursorLocation, requestor, this.wcOwner);
+		assertResults(
+				"Person[TYPE_REF]{Person, , LPerson;, null, null, null, null, [43, 46], "
+						+ (R_DEFAULT + R_RESOLVED + R_INTERESTING + R_CASE + R_UNQUALIFIED + R_NON_RESTRICTED) + "}",
+				requestor.getResults());
+	}
+
 }

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionParser.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionParser.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -329,8 +329,8 @@ protected void attachOrphanCompletionNode(){
 							length);
 					}
 
-					// retrieve available modifiers if any and if its not a record
-					if (!isAtRecordType && this.intPtr >= 2 && this.intStack[this.intPtr - 1] == this.lastModifiersStart
+					// retrieve available modifiers if any
+					if (this.intPtr >= 2 && this.intStack[this.intPtr - 1] == this.lastModifiersStart
 							&& this.intStack[this.intPtr - 2] == this.lastModifiers) {
 						fieldDeclaration.modifiersSourceStart = this.intStack[this.intPtr-1];
 						fieldDeclaration.modifiers = this.intStack[this.intPtr-2];
@@ -346,7 +346,7 @@ protected void attachOrphanCompletionNode(){
 			RecoveredMethod recoveredMethod = (RecoveredMethod)this.currentElement;
 			/* only consider if inside method header */
 			if (!recoveredMethod.foundOpeningBrace) {
-				//if (rParenPos < lParenPos){ // inside arguments
+				//if (rParenPos < lParenPos){ // inside argument
 				if (orphan instanceof TypeReference){
 					this.currentElement = this.currentElement.parent.add(
 						new CompletionOnFieldType((TypeReference)orphan, true), 0);


### PR DESCRIPTION
- remove check for record type add add available modifiers if any
- add new test to CompletionTests16 to complete the type name of a record constructor and verify it doesn't propose a method
- fixes #4419

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
