### PR TITLE
ExceptionInInitializerError creating an ASTParser in an OSGI env #4438

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelManager.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelManager.java
@@ -1819,10 +1819,10 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 		// singleton: prevent others from creating a new instance
 		/*
 		 * It is required to initialize all fields that depends on a headless environment
-		 * only if the platform is running. Otherwise this breaks the ability to use
+		 * only if the JavaCore is running. Otherwise this breaks the ability to use
 		 * ASTParser in a non-headless environment.
 		 */
-		if (Platform.isRunning()) {
+		if (JavaCore.getPlugin() != null) {
 			this.indexManager = new IndexManager();
 			this.nonChainingJars = loadClasspathListCache(NON_CHAINING_JARS_CACHE);
 			Set<IPath> external = loadClasspathListCache(EXTERNAL_FILES_CACHE);


### PR DESCRIPTION
Only initializes the JavaModelManager if the org.eclipse.jdt.core bundle was started. This is checked via JavaCore.getPlugin(). This allows to use ASTParser in an OSGI-environment without to start the org.eclipse.jdt.core bundle.

https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4438

## What it does
See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4438

## How to test
Use ASTParser in test code and depend on classes in org.eclipse.jdt.core.
Start the test code, in an OSGI environment, but do not start the bundle org.eclipse.jdt.core

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)