### PR TITLE
Log exceptions when indexing #1303

### DIFF
--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/AddJarFileToIndex.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/AddJarFileToIndex.java
@@ -137,13 +137,12 @@ class AddJarFileToIndex extends BinaryContainer {
 					try {
 						file = org.eclipse.jdt.internal.core.util.Util.toLocalFile(location, progressMonitor);
 					} catch (CoreException e) {
-						if (JobManager.VERBOSE) {
-							trace("-> failed to index " + location.getPath() + " because of the following exception:", e); //$NON-NLS-1$ //$NON-NLS-2$
-						}
+						org.eclipse.jdt.internal.core.util.Util.log(e,
+								"Failed to index " + location.getPath() + ": " + e.getMessage()); //$NON-NLS-1$ //$NON-NLS-2$
 					}
 					if (file == null) {
-						if (JobManager.VERBOSE)
-							trace("-> failed to index " + location.getPath() + " because the file could not be fetched"); //$NON-NLS-1$ //$NON-NLS-2$
+						org.eclipse.jdt.internal.core.util.Util.log(Status.warning(
+								"Failed to index " + location.getPath() + " because the file could not be fetched")); //$NON-NLS-1$ //$NON-NLS-2$
 						return false;
 					}
 					if (JavaModelManager.ZIP_ACCESS_VERBOSE)

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/AddJrtToIndex.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/AddJrtToIndex.java
@@ -25,6 +25,7 @@ import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.jdt.core.search.IJavaSearchScope;
 import org.eclipse.jdt.core.search.SearchEngine;
 import org.eclipse.jdt.core.search.SearchParticipant;
@@ -201,14 +202,11 @@ public class AddJrtToIndex extends BinaryContainer {
 					try {
 						file = Util.toLocalFile(location, progressMonitor);
 					} catch (CoreException e) {
-						if (JobManager.VERBOSE) {
-							trace("-> failed to index " + location.getPath() + " because of the following exception:", e); //$NON-NLS-1$ //$NON-NLS-2$
-						}
+						Util.log(e, "Failed to index " + location.getPath() + ": " + e.getMessage()); //$NON-NLS-1$ //$NON-NLS-2$
 					}
 					if (file == null) {
-						if (JobManager.VERBOSE) {
-							trace("-> failed to index " + location.getPath() + " because the file could not be fetched"); //$NON-NLS-1$ //$NON-NLS-2$
-						}
+						Util.log(Status.warning(
+								"Failed to index " + location.getPath() + " because the file could not be fetched")); //$NON-NLS-1$ //$NON-NLS-2$
 						return false;
 					}
 					fileName = file.getAbsolutePath();

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/IndexManager.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/IndexManager.java
@@ -896,9 +896,7 @@ public synchronized Index recreateIndex(IPath containerPath) {
 		return index;
 	} catch (IOException e) {
 		// The file could not be created. Possible reason: the project has been deleted.
-		if (VERBOSE) {
-			trace("-> failed to recreate index for path: "+containerPathString, e); //$NON-NLS-1$
-		}
+		Util.log(Status.warning("Failed to recreate index for path: " + containerPathString)); //$NON-NLS-1$
 		return null;
 	}
 }
@@ -1100,9 +1098,7 @@ public synchronized boolean resetIndex(IPath containerPath) {
 		return true;
 	} catch (IOException e) {
 		// The file could not be created. Possible reason: the project has been deleted.
-		if (VERBOSE) {
-			trace("-> failed to reset index for path: "+containerPathString, e); //$NON-NLS-1$
-		}
+		Util.log(Status.warning("Failed to reset index for path: " + containerPathString)); //$NON-NLS-1$
 		return false;
 	}
 }
@@ -1673,9 +1669,7 @@ void updateMetaIndex(String indexFileName, List<IndexQualifier> qualifications) 
 			trace("-> meta-index updated for " + indexFileName); //$NON-NLS-1$
 		}
 	} catch (IOException e) {
-		if (JobManager.VERBOSE) {
-			trace("-> failed to update meta index for index " + indexFileName + " because of the following exception:", e); //$NON-NLS-1$ //$NON-NLS-2$
-		}
+		Util.log(e, "Failed to update meta index for index " + indexFileName + ": " + e.getMessage()); //$NON-NLS-1$ //$NON-NLS-2$
 	} finally {
 		if(monitor != null) {
 			monitor.exitWrite();
@@ -1757,10 +1751,7 @@ class MetaIndexUpdateRequest implements IJob {
 				if (cause != null) {
 					Util.log(e, "Failed to update meta index"); //$NON-NLS-1$
 				} else {
-					if (JobManager.VERBOSE) {
-						trace("-> failed to update meta index for index " + indexFile.getName() //$NON-NLS-1$
-								+ " because of the following exception:", e); //$NON-NLS-1$
-					}
+					Util.log(e, "Failed to update meta index for index " + indexFile.getName() + ": " + e.getMessage()); //$NON-NLS-1$ //$NON-NLS-2$
 				}
 			}
 		}


### PR DESCRIPTION
Similar to #4388 (but this time for the indexing of JARs/JRTs), do not rely on the `VERBOSE` flag, let the exceptions come to the error log and to the UI instead for better debugging.

Notice that I logged some exceptions as _warnings_ since the operation will be retried _i.e._ it's recoverable.

Contributes to https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1303