### PR TITLE
Show debug/traceToStdOut tracing option in the run configurations

### DIFF
--- a/org.eclipse.jdt.core/.options
+++ b/org.eclipse.jdt.core/.options
@@ -74,6 +74,9 @@ org.eclipse.jdt.core/debug/search=false
 # Reports source mapper activity
 org.eclipse.jdt.core/debug/sourcemapper=false
 
+# Send traces from the JavaModelManager to the standard output instead of the trace file
+org.eclipse.jdt.core/debug/traceToStdOut=false
+
 # Reports code formatter activity
 org.eclipse.jdt.core/debug/formatter=false
 


### PR DESCRIPTION
## What it does
Shows `debug/traceToStdOut` under `org.eclipse.jdt.core`, which end up setting this constant:
- `org.eclipse.jdt.internal.core.JavaModelManager.TRACE_TO_STDOUT`.

## How to test
The setting should be visible in the tracing options:

<img width="1178" height="932" alt="image" src="https://github.com/user-attachments/assets/b0a97e2f-4f9b-43f5-ab4e-7ed422c8631a" />

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
