### PR TITLE
issue #4446 - fix for including superclasses in intersection type in case of type variable

### DIFF
--- a/org.eclipse.jdt.apt.pluggable.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.apt.pluggable.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.apt.pluggable.tests;singleton:=true
-Bundle-Version: 3.6.700.qualifier
+Bundle-Version: 3.6.800.qualifier
 Bundle-Activator: org.eclipse.jdt.apt.pluggable.tests.Apt6TestsPlugin
 Bundle-Localization: plugin
 Require-Bundle: org.junit,

--- a/org.eclipse.jdt.apt.pluggable.tests/plugin.xml
+++ b/org.eclipse.jdt.apt.pluggable.tests/plugin.xml
@@ -9,7 +9,7 @@
     https://www.eclipse.org/legal/epl-2.0/
 
     SPDX-License-Identifier: EPL-2.0
-   
+
     Contributors:
         IBM Corporation - initial API and implementation
         Fabian Steeg <steeg@hbz-nrw.de> - Pass automatically provided options to Java 6 processors - https://bugs.eclipse.org/341298
@@ -62,6 +62,9 @@
          <java6processor
                  class="org.eclipse.jdt.apt.pluggable.tests.processors.buildertester.Issue565Processor">
          </java6processor>
+          <java6processor
+                  class="org.eclipse.jdt.apt.pluggable.tests.processors.buildertester.Issue4446Processor">
+          </java6processor>
       </java6processors>
    </extension>
 </plugin>

--- a/org.eclipse.jdt.apt.pluggable.tests/pom.xml
+++ b/org.eclipse.jdt.apt.pluggable.tests/pom.xml
@@ -19,7 +19,7 @@
     <relativePath>../tests-pom/</relativePath>
   </parent>
   <artifactId>org.eclipse.jdt.apt.pluggable.tests</artifactId>
-  <version>3.6.700-SNAPSHOT</version>
+  <version>3.6.800-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
   <properties>
   	<testSuite>${project.artifactId}</testSuite>

--- a/org.eclipse.jdt.apt.pluggable.tests/resources/targets/issue4446/A.java
+++ b/org.eclipse.jdt.apt.pluggable.tests/resources/targets/issue4446/A.java
@@ -1,0 +1,7 @@
+package targets.issue4446;
+import java.io.Serializable;
+
+@Annotation4446
+public class A<T extends Number & Runnable & Serializable> {
+    public <U extends Number & Runnable> void doSomething(U input) { }
+}

--- a/org.eclipse.jdt.apt.pluggable.tests/resources/targets/issue4446/Annotation4446.java
+++ b/org.eclipse.jdt.apt.pluggable.tests/resources/targets/issue4446/Annotation4446.java
@@ -1,0 +1,6 @@
+package targets.issue4446;
+import java.lang.annotation.Inherited;
+
+@Inherited
+public @interface Annotation4446 {
+}

--- a/org.eclipse.jdt.apt.pluggable.tests/src/org/eclipse/jdt/apt/pluggable/tests/BuilderTests.java
+++ b/org.eclipse.jdt.apt.pluggable.tests/src/org/eclipse/jdt/apt/pluggable/tests/BuilderTests.java
@@ -29,6 +29,7 @@ import org.eclipse.jdt.apt.pluggable.tests.processors.buildertester.Bug510118Pro
 import org.eclipse.jdt.apt.pluggable.tests.processors.buildertester.BugsProc;
 import org.eclipse.jdt.apt.pluggable.tests.processors.buildertester.InheritedAnnoProc;
 import org.eclipse.jdt.apt.pluggable.tests.processors.buildertester.Issue565Processor;
+import org.eclipse.jdt.apt.pluggable.tests.processors.buildertester.Issue4446Processor;
 import org.eclipse.jdt.apt.pluggable.tests.processors.buildertester.TestFinalRoundProc;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.tests.builder.Problem;
@@ -381,6 +382,19 @@ public class BuilderTests extends TestBase
 		expectingNoProblems();
 		assertTrue("Incorrect status received from annotation processor", Issue565Processor.status());
 	}
+
+    public void testIssue4446() throws Throwable {
+        ProcessorTestStatus.reset();
+        IJavaProject jproj = createJavaProject(_projectName);
+        disableJava5Factories(jproj);
+        IProject proj = jproj.getProject();
+        IdeTestUtils.copyResources(proj, "targets/issue4446", "src/targets/issue4446");
+
+        AptConfig.setEnabled(jproj, true);
+        fullBuild();
+        expectingNoProblems();
+        assertTrue("Incorrect status received from annotation processor", Issue4446Processor.status());
+    }
 
 	public void testBug341298() throws Throwable {
 		ProcessorTestStatus.reset();

--- a/org.eclipse.jdt.apt.pluggable.tests/src/org/eclipse/jdt/apt/pluggable/tests/processors/buildertester/Issue4446Processor.java
+++ b/org.eclipse.jdt.apt.pluggable.tests/src/org/eclipse/jdt/apt/pluggable/tests/processors/buildertester/Issue4446Processor.java
@@ -1,0 +1,99 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Kamil Krzywanski
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Kamil Krzywanski - fix for including superclasses in intersection type in case of type variable
+ *******************************************************************************/
+package org.eclipse.jdt.apt.pluggable.tests.processors.buildertester;
+
+import java.util.*;
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.*;
+import javax.lang.model.type.*;
+
+@SupportedAnnotationTypes("targets.issue4446.Annotation4446")
+@SupportedSourceVersion(SourceVersion.RELEASE_6)
+public class Issue4446Processor extends AbstractProcessor {
+    private static boolean status = false;
+
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+
+        if (roundEnv.processingOver()) {
+            // We're not interested in the postprocessing round.
+            return false;
+        }
+        TypeElement anno = processingEnv.getElementUtils().getTypeElement("targets.issue4446.Annotation4446");
+        if (anno == null) {
+            return false;
+        }
+        for (Element element : roundEnv.getElementsAnnotatedWith(anno)) {
+            scanElement(element);
+        }
+        status = true;
+        return false;
+    }
+    public static boolean status() {
+        return status;
+    }
+
+
+    private void scanElement(Element element) {
+        switch (element.getKind()) {
+            case CLASS:
+            case INTERFACE:
+            case ENUM:
+                TypeElement typeElement = (TypeElement) element;
+                for (TypeParameterElement tpe : typeElement.getTypeParameters()) {
+                    handleTypeParameterBounds(tpe);
+                    scanType(tpe.asType());
+                }
+                break;
+            case METHOD:
+                ExecutableElement method = (ExecutableElement) element;
+                for (TypeParameterElement tpe : method.getTypeParameters()) {
+                    handleTypeParameterBounds(tpe);
+                }
+                scanType(method.getReturnType());
+                for (VariableElement param : method.getParameters()) {
+                    scanType(param.asType());
+                }
+                break;
+            default:
+                break;
+        }
+        for (Element enclosed : element.getEnclosedElements()) {
+            scanElement(enclosed);
+        }
+    }
+
+    private void handleTypeParameterBounds(TypeParameterElement tpe) {
+        List<? extends TypeMirror> bounds = tpe.getBounds();
+        if (bounds != null) {
+            for (TypeMirror b : bounds) {
+                scanType(b);
+            }
+        }
+        scanType(tpe.asType());
+    }
+
+    private void scanType(TypeMirror typeMirror) {
+        if (typeMirror == null) return;
+        if (Objects.requireNonNull(typeMirror.getKind()) == TypeKind.TYPEVAR) {
+            TypeVariable tv = (TypeVariable) typeMirror;
+            scanType(tv.getUpperBound());
+            scanType(tv.getLowerBound());
+        }
+    }
+}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/apt/model/IntersectionTypeImpl.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/apt/model/IntersectionTypeImpl.java
@@ -14,6 +14,7 @@
 
 package org.eclipse.jdt.internal.compiler.apt.model;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import javax.lang.model.type.IntersectionType;
@@ -21,6 +22,7 @@ import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.type.TypeVisitor;
 import org.eclipse.jdt.internal.compiler.apt.dispatch.BaseProcessingEnvImpl;
+import org.eclipse.jdt.internal.compiler.lookup.ReferenceBinding;
 import org.eclipse.jdt.internal.compiler.lookup.TypeVariableBinding;
 
 /**
@@ -29,9 +31,15 @@ import org.eclipse.jdt.internal.compiler.lookup.TypeVariableBinding;
 public class IntersectionTypeImpl extends TypeMirrorImpl implements IntersectionType {
 	private final List<? extends TypeMirror> bounds;
 
-	IntersectionTypeImpl(BaseProcessingEnvImpl env, TypeVariableBinding binding) {
+	IntersectionTypeImpl(BaseProcessingEnvImpl env, TypeVariableBinding binding, ReferenceBinding superClass) {
 		super(env, binding);
-		this.bounds = Arrays.stream(binding.superInterfaces).map(referenceBinding -> this._env.getFactory().newTypeMirror(referenceBinding)).toList();
+        List<ReferenceBinding> superTypes = new ArrayList<>(Arrays.asList(binding.superInterfaces));
+        if (superClass != null) {
+            superTypes.add(0, superClass);
+        }
+		this.bounds = superTypes.stream()
+                .map(referenceBinding -> this._env.getFactory().newTypeMirror(referenceBinding))
+                .toList();
 	}
 
 	/* (non-Javadoc)

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/apt/model/TypeVariableImpl.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/apt/model/TypeVariableImpl.java
@@ -22,6 +22,7 @@ import javax.lang.model.type.TypeVisitor;
 import org.eclipse.jdt.internal.compiler.apt.dispatch.BaseProcessingEnvImpl;
 import org.eclipse.jdt.internal.compiler.lookup.ReferenceBinding;
 import org.eclipse.jdt.internal.compiler.lookup.TypeBinding;
+import org.eclipse.jdt.internal.compiler.lookup.TypeIds;
 import org.eclipse.jdt.internal.compiler.lookup.TypeVariableBinding;
 
 /**
@@ -57,6 +58,7 @@ public class TypeVariableImpl extends TypeMirrorImpl implements TypeVariable {
 		TypeVariableBinding typeVariableBinding = (TypeVariableBinding) this._binding;
 		TypeBinding firstBound = typeVariableBinding.firstBound;
 		ReferenceBinding[] superInterfaces = typeVariableBinding.superInterfaces;
+        ReferenceBinding superclass = typeVariableBinding.superclass;
 		if (firstBound == null || superInterfaces.length == 0) {
 			// no explicit bound
 			return this._env.getFactory().newTypeMirror(typeVariableBinding.upperBound());
@@ -65,8 +67,11 @@ public class TypeVariableImpl extends TypeMirrorImpl implements TypeVariable {
 			// only one bound that is an interface
 			return this._env.getFactory().newTypeMirror(typeVariableBinding.upperBound());
 		}
-        if (superInterfaces.length > 1) {
-            return new IntersectionTypeImpl(this._env, typeVariableBinding);
+
+        boolean superClassIsObject = TypeIds.T_JavaLangObject == typeVariableBinding.superclass().id;
+        int superTypeCount = superInterfaces.length + (superClassIsObject ? 0 : 1);
+        if (superTypeCount > 1) {
+            return new IntersectionTypeImpl(this._env, typeVariableBinding, superClassIsObject ? null : superclass);
         }
 
 		return this._env.getFactory().newTypeMirror(this._binding);


### PR DESCRIPTION
issue https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4446 - fix for including superclasses in intersection type in case of type variable