### PR TITLE
Do not throw RuntimeException in Parser::parse #4302

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
@@ -11607,7 +11607,7 @@ try {
 	ProcessTerminals : for (;;) {
 		if (Thread.currentThread().isInterrupted()) {
             Thread.currentThread().interrupt();
-            throw new RuntimeException("[" + Thread.currentThread().getName() + "] Task interrupted", new InterruptedException()); //$NON-NLS-1$ //$NON-NLS-2$
+            throw new AbortCompilation(true, null); // fail silently
         }
 
 		int stackLength = this.stack.length;


### PR DESCRIPTION
See https://github.com/eclipse-jdt/eclipse.jdt.core/pull/4302#issuecomment-3348205396

If this PR gets merged then this one can also be merged:
- https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/2524