### PR TITLE
[Java 25] Duplicate assignment to final field possible with multiple constructors using this() delegation

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypeDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypeDeclaration.java
@@ -761,7 +761,7 @@ private void internalAnalyseCode(FlowContext flowContext, FlowInfo flowInfo) {
 					ctorInfo = constructor.getPrologueInfo();
 					if (ctorInfo == ConstructorDeclaration.EMPTY_FLOW_INFO) {
 						allConstructorsHavePrologue = false;
-					} else {
+					} else if (ctorInfo.hasInits()) {
 						if (prologueInfo == null)
 							prologueInfo = ctorInfo.copy();
 						else

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypeDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypeDeclaration.java
@@ -38,9 +38,11 @@ import org.eclipse.jdt.internal.compiler.CompilationResult;
 import org.eclipse.jdt.internal.compiler.ast.ConstructorDeclaration.AnalysisMode;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 import org.eclipse.jdt.internal.compiler.codegen.CodeStream;
+import org.eclipse.jdt.internal.compiler.flow.DualFlowInfo;
 import org.eclipse.jdt.internal.compiler.flow.FlowContext;
 import org.eclipse.jdt.internal.compiler.flow.FlowInfo;
 import org.eclipse.jdt.internal.compiler.flow.InitializationFlowContext;
+import org.eclipse.jdt.internal.compiler.flow.UnconditionalDualFlowInfo;
 import org.eclipse.jdt.internal.compiler.flow.UnconditionalFlowInfo;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jdt.internal.compiler.impl.JavaFeature;
@@ -749,6 +751,7 @@ private void internalAnalyseCode(FlowContext flowContext, FlowInfo flowInfo) {
 		if (this.methods != null) {
 			// collect field initializations happening in constructor prologues
 			FlowInfo prologueInfo = null;
+			boolean allConstructorsHavePrologue = true;
 			for (int i=0; i<this.methods.length; i++) {
 				AbstractMethodDeclaration method = this.methods[i];
 				if (method.isConstructor()) {
@@ -756,23 +759,32 @@ private void internalAnalyseCode(FlowContext flowContext, FlowInfo flowInfo) {
 					ConstructorDeclaration constructor = (ConstructorDeclaration) method;
 					constructor.analyseCode(this.scope, initializerContext, ctorInfo, ctorInfo.reachMode(), AnalysisMode.PROLOGUE);
 					ctorInfo = constructor.getPrologueInfo();
-					if (prologueInfo == null)
-						prologueInfo = ctorInfo.copy();
-					else
-						prologueInfo = prologueInfo.mergeDefiniteInitsWith(ctorInfo.unconditionalInits()); // will only evaluate field inits below
+					if (ctorInfo == ConstructorDeclaration.EMPTY_FLOW_INFO) {
+						allConstructorsHavePrologue = false;
+					} else {
+						if (prologueInfo == null)
+							prologueInfo = ctorInfo.copy();
+						else
+							prologueInfo = prologueInfo.mergeDefiniteInitsWith(ctorInfo.unconditionalInits()); // will only evaluate field inits below
+					}
 				}
 			}
 			if (prologueInfo != null) {
-				// field initializers should see inits from ctor prologues:
-				for (FieldBinding field : this.binding.fields()) {
-					if (prologueInfo.isDefinitelyAssigned(field)) {
-						nonStaticFieldInfo.markAsDefinitelyAssigned(field);
-					} else if (prologueInfo.isPotentiallyAssigned(field)) {
-						// mimic missing method markAsPotentiallyAssigned(field):
-						UnconditionalFlowInfo assigned = FlowInfo.initial(this.maxFieldCount);
-						assigned.markAsDefinitelyAssigned(field);
-						nonStaticFieldInfo.addPotentialInitializationsFrom(assigned);
+				if (allConstructorsHavePrologue) {
+					// field initializers should see inits from ctor prologues:
+					for (FieldBinding field : this.binding.fields()) {
+						if (prologueInfo.isDefinitelyAssigned(field)) {
+							nonStaticFieldInfo.markAsDefinitelyAssigned(field);
+						} else if (prologueInfo.isPotentiallyAssigned(field)) {
+							// mimic missing method markAsPotentiallyAssigned(field):
+							UnconditionalFlowInfo assigned = FlowInfo.initial(this.maxFieldCount);
+							assigned.markAsDefinitelyAssigned(field);
+							nonStaticFieldInfo.addPotentialInitializationsFrom(assigned);
+						}
 					}
+				} else {
+					// need to keep variants with and without prologue info separate:
+					nonStaticFieldInfo = new DualFlowInfo(nonStaticFieldInfo, prologueInfo);
 				}
 			}
 		}
@@ -845,6 +857,11 @@ private void internalAnalyseCode(FlowContext flowContext, FlowInfo flowInfo) {
 	}
 	if (this.methods != null) {
 		UnconditionalFlowInfo outerInfo = flowInfo.unconditionalFieldLessCopy();
+		if (nonStaticFieldInfo instanceof UnconditionalDualFlowInfo udfi) {
+			nonStaticFieldInfo = udfi.getMainInits(); // drop info from prologues
+		} else if (nonStaticFieldInfo instanceof DualFlowInfo dfi) {
+			nonStaticFieldInfo = dfi.initsWhenTrue;
+		}
 		FlowInfo constructorInfo = nonStaticFieldInfo.unconditionalInits().discardNonFieldInitializations().addInitializationsFrom(outerInfo);
 		SimpleSetOfCharArray jUnitMethodSourceValues = getJUnitMethodSourceValues();
 		for (AbstractMethodDeclaration method : this.methods) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/flow/ConditionalFlowInfo.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/flow/ConditionalFlowInfo.java
@@ -119,6 +119,11 @@ public boolean isDefinitelyUnknown(LocalVariableBinding local) {
 }
 
 @Override
+public boolean hasInits() {
+	return this.initsWhenTrue.hasInits() || this.initsWhenFalse.hasInits();
+}
+
+@Override
 public boolean hasNullInfoFor(LocalVariableBinding local) {
 	return this.initsWhenTrue.hasNullInfoFor(local)
 			|| this.initsWhenFalse.hasNullInfoFor(local);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/flow/DualFlowInfo.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/flow/DualFlowInfo.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2025 GK Software SE and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Stephan Herrmann - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.internal.compiler.flow;
+
+/**
+ * A wrapper for two flow infos being co-maintained side-by-side.
+ *
+ * All inherited methods that dispatch to the individual flow infos {@link #initsWhenTrue} and {@link #initsWhenFalse}
+ * are re-used as-is. Any operations involving some kind of copying need to be overridden.
+ */
+public class DualFlowInfo extends ConditionalFlowInfo {
+
+	public DualFlowInfo(FlowInfo mainInfo, FlowInfo companionInfo) {
+		super(mainInfo, companionInfo);
+	}
+
+	@Override
+	public FlowInfo asNegatedCondition() {
+		this.initsWhenTrue = this.initsWhenTrue.asNegatedCondition();
+		this.initsWhenFalse = this.initsWhenFalse.asNegatedCondition();
+		return this;
+	}
+
+	@Override
+	public FlowInfo copy() {
+		return new DualFlowInfo(this.initsWhenTrue.copy(), this.initsWhenFalse.copy());
+	}
+
+	@Override
+	public UnconditionalFlowInfo mergedWith(UnconditionalFlowInfo otherInits) {
+		return new UnconditionalDualFlowInfo(this.initsWhenTrue.mergedWith(otherInits), this.initsWhenFalse.mergedWith(otherInits));
+	}
+
+	@Override
+	public UnconditionalFlowInfo mergeDefiniteInitsWith(UnconditionalFlowInfo otherInits) {
+		return new UnconditionalDualFlowInfo(this.initsWhenTrue.mergeDefiniteInitsWith(otherInits), this.initsWhenFalse.mergeDefiniteInitsWith(otherInits));
+	}
+
+	@Override
+	public UnconditionalFlowInfo unconditionalCopy() {
+		return new UnconditionalDualFlowInfo(this.initsWhenTrue.unconditionalCopy(), this.initsWhenFalse.unconditionalCopy());
+	}
+
+	@Override
+	public UnconditionalFlowInfo unconditionalFieldLessCopy() {
+		return new UnconditionalDualFlowInfo(this.initsWhenTrue.unconditionalFieldLessCopy(), this.initsWhenFalse.unconditionalFieldLessCopy());
+	}
+
+	@Override
+	public UnconditionalFlowInfo unconditionalInits() {
+		return new UnconditionalDualFlowInfo(this.initsWhenTrue.unconditionalInits(), this.initsWhenFalse.unconditionalInits());
+	}
+
+	@Override
+	public UnconditionalFlowInfo unconditionalInitsWithoutSideEffect() {
+		return new UnconditionalDualFlowInfo(this.initsWhenTrue.unconditionalInitsWithoutSideEffect(), this.initsWhenFalse.unconditionalInitsWithoutSideEffect());
+	}
+
+	@Override
+	public String toString() {
+
+		return "FlowInfo<main: " + this.initsWhenTrue.toString() + ", companion: " + this.initsWhenFalse.toString() + ">"; //$NON-NLS-1$ //$NON-NLS-3$ //$NON-NLS-2$
+	}
+
+}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/flow/FlowInfo.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/flow/FlowInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2019 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -210,6 +210,11 @@ public abstract boolean isDefinitelyUnknown(LocalVariableBinding local);
  * Here even recording of 'UNKNOWN' is considered as null info.
  */
 public abstract boolean hasNullInfoFor(LocalVariableBinding local);
+
+	/**
+	 * Check if this flow info has any relevant inits.
+	 */
+	public abstract boolean hasInits();
 
 	/**
 	 * Check status of potential assignment for a field.

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/flow/UnconditionalDualFlowInfo.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/flow/UnconditionalDualFlowInfo.java
@@ -1,0 +1,218 @@
+/*******************************************************************************
+ * Copyright (c) 2025 GK Software SE and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Stephan Herrmann - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.internal.compiler.flow;
+
+import org.eclipse.jdt.internal.compiler.lookup.FieldBinding;
+import org.eclipse.jdt.internal.compiler.lookup.LocalVariableBinding;
+
+/**
+ * A wrapper for two flow infos being co-maintained side-by-side.
+ *
+ * Dispatch all modifications to both variant infos.
+ * Where copying is involved wrap the result in a new DualFlowInfo or
+ * UnconditionalDualFlowInfo.
+ */
+public class UnconditionalDualFlowInfo extends UnconditionalFlowInfo {
+/* TODO: may need to implement also the following.
+ * Some cannot be simply dispatched because the only exist in UnconditionalFlowInfo.
+ *
+ * Definite assignment:
+ * discardInitializationInfo()
+ * discardNonFieldInitializations()
+ *
+ * Null analysis:
+ * acceptAllIncomingNullness()
+ * acceptIncomingNullnessFrom(UnconditionalFlowInfo)
+ * addPotentialNullInfoFrom(UnconditionalFlowInfo(UnconditionalFlowInfo)
+ * cannotBeDefinitelyNullOrNonNull(LocalVariableBinding)
+ * cannotBeNull(LocalVariableBinding)
+ * canOnlyBeNull(LocalVariableBinding)
+ * isDefinitelyNonNull(LocalVariableBinding)
+ * isDefinitelyNull(LocalVariableBinding)
+ * isDefinitelyUnknown(LocalVariableBinding)
+ * hasNullInfoFor(LocalVariableBinding)
+ * isPotentiallyNonNull(LocalVariableBinding)
+ * isPotentiallyNull(LocalVariableBinding)
+ * isPotentiallyUnknown(LocalVariableBinding)
+ * isProtectedNonNull(LocalVariableBinding)
+ * isProtectedNull(LocalVariableBinding)
+ */
+
+	private FlowInfo companionInits;
+
+	public UnconditionalDualFlowInfo(FlowInfo mainInits, FlowInfo companionInits) {
+		super.addInitializationsFrom(mainInits);
+		super.addNullInfoFrom(mainInits);
+		this.tagBits = mainInits.tagBits & UNREACHABLE;
+		while (!(mainInits instanceof UnconditionalFlowInfo ufi)) {
+			mainInits = mainInits.initsWhenTrue();
+		}
+		this.maxFieldCount = ufi.maxFieldCount;
+		this.companionInits = companionInits;
+	}
+
+	public FlowInfo getMainInits() {
+		return super.copy();
+	}
+
+	@Override
+	public FlowInfo addInitializationsFrom(FlowInfo otherInits) {
+		super.addInitializationsFrom(otherInits);
+		this.companionInits.addInitializationsFrom(otherInits);
+		return this;
+	}
+
+	@Override
+	public FlowInfo addNullInfoFrom(FlowInfo otherInits) {
+		super.addNullInfoFrom(otherInits);
+		this.companionInits.addNullInfoFrom(otherInits);
+		return this;
+	}
+
+	@Override
+	public FlowInfo addPotentialInitializationsFrom(FlowInfo otherInits) {
+		super.addPotentialInitializationsFrom(otherInits);
+		this.companionInits.addPotentialInitializationsFrom(otherInits);
+		return this;
+	}
+
+
+	@Override
+	public FlowInfo asNegatedCondition() {
+		this.companionInits.asNegatedCondition();
+		return super.asNegatedCondition();
+	}
+
+	@Override
+	public FlowInfo copy() {
+		return new UnconditionalDualFlowInfo(super.copy(), this.companionInits.copy());
+	}
+
+	@Override
+	public boolean isDefinitelyAssigned(FieldBinding field) {
+		return super.isDefinitelyAssigned(field) && this.companionInits.isDefinitelyAssigned(field);
+	}
+
+	@Override
+	public boolean isDefinitelyAssigned(LocalVariableBinding local) {
+		return super.isDefinitelyAssigned(local) && this.companionInits.isDefinitelyAssigned(local);
+	}
+
+	@Override
+	public boolean isPotentiallyAssigned(FieldBinding field) {
+		return super.isPotentiallyAssigned(field) || this.companionInits.isPotentiallyAssigned(field);
+	}
+
+	@Override
+	public void markAsComparedEqualToNonNull(LocalVariableBinding local) {
+		super.markAsComparedEqualToNonNull(local);
+		this.companionInits.markAsComparedEqualToNonNull(local);
+	}
+
+	@Override
+	public void markAsComparedEqualToNull(LocalVariableBinding local) {
+		super.markAsComparedEqualToNull(local);
+		this.companionInits.markAsComparedEqualToNull(local);
+	}
+
+	@Override
+	public void markAsDefinitelyAssigned(FieldBinding field) {
+		super.markAsDefinitelyAssigned(field);
+		this.companionInits.markAsDefinitelyAssigned(field);
+	}
+
+	@Override
+	public void markAsDefinitelyAssigned(LocalVariableBinding local) {
+		super.markAsDefinitelyAssigned(local);
+		this.companionInits.markAsDefinitelyAssigned(local);
+	}
+
+	@Override
+	public void markAsDefinitelyNonNull(LocalVariableBinding local) {
+		super.markAsDefinitelyNonNull(local);
+		this.companionInits.markAsDefinitelyNonNull(local);
+	}
+
+	@Override
+	public void markAsDefinitelyNull(LocalVariableBinding local) {
+		super.markAsDefinitelyNull(local);
+		this.companionInits.markAsDefinitelyNull(local);
+	}
+
+	@Override
+	public void markAsDefinitelyUnknown(LocalVariableBinding local) {
+		super.markAsDefinitelyUnknown(local);
+		this.companionInits.markAsDefinitelyUnknown(local);
+	}
+
+	@Override
+	public void markPotentiallyUnknownBit(LocalVariableBinding local) {
+		super.markPotentiallyUnknownBit(local);
+		this.companionInits.markPotentiallyUnknownBit(local);
+	}
+
+	@Override
+	public void markPotentiallyNullBit(LocalVariableBinding local) {
+		super.markPotentiallyNullBit(local);
+		this.companionInits.markPotentiallyNullBit(local);
+	}
+
+	@Override
+	public void markPotentiallyNonNullBit(LocalVariableBinding local) {
+		super.markPotentiallyNonNullBit(local);
+		this.companionInits.markPotentiallyNonNullBit(local);
+	}
+
+	@Override
+	public UnconditionalFlowInfo mergedWith(UnconditionalFlowInfo otherInits) {
+		return new UnconditionalDualFlowInfo(super.mergedWith(otherInits), this.companionInits.mergedWith(otherInits));
+	}
+
+	@Override
+	public UnconditionalFlowInfo mergeDefiniteInitsWith(UnconditionalFlowInfo otherInits) {
+		return new UnconditionalDualFlowInfo(super.mergeDefiniteInitsWith(otherInits), this.companionInits.mergeDefiniteInitsWith(otherInits));
+	}
+
+	@Override
+	public UnconditionalFlowInfo nullInfoLessUnconditionalCopy() {
+		return new UnconditionalDualFlowInfo(super.nullInfoLessUnconditionalCopy(), this.companionInits.nullInfoLessUnconditionalCopy());
+	}
+
+	@Override
+	public void resetNullInfo(LocalVariableBinding local) {
+		super.resetNullInfo(local);
+		this.companionInits.resetNullInfo(local);
+	}
+
+	@Override
+	public void resetAssignmentInfo(LocalVariableBinding local) {
+		super.resetAssignmentInfo(local);
+		this.companionInits.resetAssignmentInfo(local);
+	}
+
+	@Override
+	public FlowInfo setReachMode(int reachMode) {
+		return new DualFlowInfo(super.setReachMode(reachMode), this.companionInits.setReachMode(reachMode));
+	}
+
+	@Override
+	public UnconditionalFlowInfo unconditionalCopy() {
+		return new UnconditionalDualFlowInfo(super.unconditionalCopy(), this.companionInits.unconditionalCopy());
+	}
+
+	@Override
+	public UnconditionalFlowInfo unconditionalFieldLessCopy() {
+		return new UnconditionalDualFlowInfo(super.unconditionalFieldLessCopy(), this.companionInits.unconditionalFieldLessCopy());
+	}
+}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/flow/UnconditionalFlowInfo.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/flow/UnconditionalFlowInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -1013,6 +1013,11 @@ final public boolean isDefinitelyUnknown(LocalVariableBinding local) {
 	return ((this.extra[2][vectorIndex] & this.extra[5][vectorIndex]
 	    & ~this.extra[3][vectorIndex] & ~this.extra[4][vectorIndex])
 		    & (1L << (position % BitCacheSize))) != 0;
+}
+
+@Override
+public boolean hasInits() {
+	return this.definiteInits != 0 || this.potentialInits != 0 || (this.tagBits & NULL_FLAG_MASK) != 0;
 }
 
 @Override

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/flow/UnconditionalFlowInfo.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/flow/UnconditionalFlowInfo.java
@@ -895,7 +895,7 @@ public FlowInfo initsWhenTrue() {
  * It deals with the dual representation of the InitializationInfo2:
  * bits for the first 64 entries, then an array of booleans.
  */
-final private boolean isDefinitelyAssigned(int position) {
+private boolean isDefinitelyAssigned(int position) {
 	if (position < BitCacheSize) {
 		// use bits
 		return (this.definiteInits & (1L << position)) != 0;
@@ -913,7 +913,7 @@ final private boolean isDefinitelyAssigned(int position) {
 }
 
 @Override
-final public boolean isDefinitelyAssigned(FieldBinding field) {
+public boolean isDefinitelyAssigned(FieldBinding field) {
 	// Mirrored in CodeStream.isDefinitelyAssigned(..)
 	// do not want to complain in unreachable code
 	if ((this.tagBits & UNREACHABLE_OR_DEAD) != 0) {
@@ -923,7 +923,7 @@ final public boolean isDefinitelyAssigned(FieldBinding field) {
 }
 
 @Override
-final public boolean isDefinitelyAssigned(LocalVariableBinding local) {
+public boolean isDefinitelyAssigned(LocalVariableBinding local) {
 	// do not want to complain in unreachable code if local declared in reachable code
 	if ((this.tagBits & UNREACHABLE_OR_DEAD) != 0 && (local.declaration.bits & ASTNode.IsLocalDeclarationReachable) != 0) {
 		return true;
@@ -1064,7 +1064,7 @@ final private boolean isPotentiallyAssigned(int position) {
 }
 
 @Override
-final public boolean isPotentiallyAssigned(FieldBinding field) {
+public boolean isPotentiallyAssigned(FieldBinding field) {
 	return isPotentiallyAssigned(field.id);
 }
 
@@ -1411,7 +1411,7 @@ public void markAsComparedEqualToNull(LocalVariableBinding local) {
 /**
  * Record a definite assignment at a given position.
  */
-final private void markAsDefinitelyAssigned(int position) {
+private void markAsDefinitelyAssigned(int position) {
 
 	if (this != DEAD_END) {
 		// position is zero-based

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
@@ -2120,14 +2120,14 @@ public void duplicateInheritedMethods(SourceTypeBinding type, MethodBinding inhe
 		type.sourceStart(),
 		type.sourceEnd());
 }
-public void duplicateInitializationOfBlankFinalField(FieldBinding field, Reference reference) {
+public void duplicateInitializationOfBlankFinalField(FieldBinding field, ASTNode location) {
 	String[] arguments = new String[]{ new String(field.readableName())};
 	this.handle(
 		IProblem.DuplicateBlankFinalFieldInitialization,
 		arguments,
 		arguments,
-		nodeSourceStart(field, reference),
-		nodeSourceEnd(field, reference));
+		nodeSourceStart(field, location),
+		nodeSourceEnd(field, location));
 }
 public void duplicateInitializationOfFinalLocal(LocalVariableBinding local, ASTNode location) {
 	int problemId = local.isPatternVariable() ? IProblem.PatternVariableRedefined : IProblem.DuplicateFinalLocalInitialization;

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SuperAfterStatementsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SuperAfterStatementsTest.java
@@ -3331,4 +3331,161 @@ public class SuperAfterStatementsTest extends AbstractRegressionTest9 {
 		----------
 		""");
 	}
+	public void testGH4449a() {
+		runNegativeTest(new String[] {
+			"X.java",
+			"""
+			public class X {
+
+			  final int i;
+
+			  public X() {
+			    this.i = 1;
+			    this(2);
+			    System.out.print(this.i);
+			  }
+
+			  public X(int i) {
+			    this.i = i;
+			  }
+
+			}
+			"""
+		},
+		"""
+		----------
+		1. ERROR in X.java (at line 7)
+			this(2);
+			^^^^^^^^
+		The final field i may already have been assigned
+		----------
+		""");
+	}
+	public void testGH4449b() {
+		runNegativeTest(new String[] {
+			"X.java",
+			"""
+			public class X {
+
+			  final int i;
+			  public X(Integer o) { this(o.intValue()); }
+			  public X() {
+			    this.i = 1;
+			    this(2);
+			    System.out.print(this.i);
+			  }
+
+			  public X(int i) {
+			    this.i = i;
+			  }
+
+			}
+			"""
+		},
+		"""
+		----------
+		1. ERROR in X.java (at line 7)
+			this(2);
+			^^^^^^^^
+		The final field i may already have been assigned
+		----------
+		""");
+	}
+	public void testGH4449c() {
+		runNegativeTest(new String[] {
+			"X.java",
+			"""
+			public class X {
+
+			  final int i;
+			  public X(Integer o) { this.i = o.intValue(); }
+			  public X() {
+			    this.i = 1;
+			    this(2);
+			    System.out.print(this.i);
+			  }
+
+			  public X(int i) {
+			    this.i = i;
+			  }
+
+			}
+			"""
+		},
+		"""
+		----------
+		1. ERROR in X.java (at line 7)
+			this(2);
+			^^^^^^^^
+		The final field i may already have been assigned
+		----------
+		""");
+	}
+	public void testGH4449d() {
+		runNegativeTest(new String[] {
+			"X.java",
+			"""
+			class X {
+				final Integer f1 = 1;
+				final Integer f2;
+				final Integer f3;
+				final Integer f4;
+				{
+					// f1 DA
+					// f2 DU
+					// f3 PUA
+					// f4 PUA
+					Integer l1;
+					f2 = 2 * f1;
+					if (cond())
+						l1 = f3;
+					else
+						f3 = 3;
+					// f1 DA
+					// f2 DA
+					// f3 PUA
+					// f4 PUA
+				}
+
+				X() {
+					f3 = 31;
+					f4 = 4;
+					// after prologue:
+					// f1 DU
+					// f2 DU
+					// f3 DA
+					// f4 DA
+					super();
+				}
+				X(Double d) {
+					// f1 DA
+					// f2 DA
+					// f3 PUA
+					// f4 DU
+					f3 = 33;
+					f4 = 44;
+				}
+				static boolean cond() { return false; }
+			}
+			"""
+		},
+		"""
+		----------
+		1. ERROR in X.java (at line 14)
+			l1 = f3;
+			     ^^
+		The blank final field f3 may not have been initialized
+		----------
+		2. ERROR in X.java (at line 16)
+			f3 = 3;
+			^^
+		The final field f3 may already have been assigned
+		----------
+		3. ERROR in X.java (at line 38)
+			f3 = 33;
+			^^
+		The final field f3 may already have been assigned
+		----------
+		""");
+	}
 }


### PR DESCRIPTION
+ introduce (Unconditional)DualFlowInfo to co-maintain two flow infos
  1. field initialization info
  2. ctor prologue infos + field initialization info
Constructed and deconstructed in TypeDeclaration.internalAnalyseCode
Transparent for all other code locations.
+ further fine tuning:
  - if all ctors have a prologue then their combined infos are binding for all initializers
  - otherwise that DualFlowInfo is created
+ additionally complain about final fields initialized before this()
  - actually before analysing its arguments
  - assignments in arguments are already reported during their analysis

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4449
