### PR TITLE
JDT generates invalid "Unnecessary cast" warning on ambiguous reference

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/CastExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/CastExpression.java
@@ -182,16 +182,18 @@ public static void checkNeedForArgumentCasts(BlockScope scope, Expression receiv
 	TypeBinding[] rawArgumentTypes = argumentTypes;
 	for (int i = 0; i < length; i++) {
 		Expression argument = arguments[i];
-		if (argument instanceof CastExpression) {
+		if (argument instanceof CastExpression castExpression) {
 			// narrowing conversion on base type may change value, thus necessary
 			if ((argument.bits & ASTNode.UnnecessaryCast) == 0 && argument.resolvedType.isBaseType()) {
 				continue;
 			}
-			TypeBinding castedExpressionType = ((CastExpression)argument).expression.resolvedType;
+			if (castExpression.expression instanceof MessageSend messageSend && messageSend.binding instanceof ParameterizedGenericMethodBinding)
+				return; // removing the cast makes the message send feature in invocation context thereby making it a poly-expression. Don't touch it.
+			TypeBinding castedExpressionType = castExpression.expression.resolvedType;
 			if (castedExpressionType == null) return; // cannot do better
 			// obvious identity cast
 			if (TypeBinding.equalsEquals(castedExpressionType, argumentTypes[i])) {
-				scope.problemReporter().unnecessaryCast((CastExpression)argument);
+				scope.problemReporter().unnecessaryCast(castExpression);
 			} else if (castedExpressionType == TypeBinding.NULL){
 				continue; // tolerate null argument cast
 			} else if ((argument.implicitConversion & TypeIds.BOXING) != 0) {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/CastTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/CastTest.java
@@ -3440,7 +3440,38 @@ public void testGH2470_overload() {
 	runner.expectedOutputString = "CharSequence.String.";
 	runner.runConformTest();
 }
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4375
+// JDT generates invalid "Unnecessary cast" warning on ambiguous reference
+public void testIssue4375() {
+	Runner runner = new Runner();
+	runner.testFiles = new String[] {
+			"Test.java",
+			"""
+			import java.util.Collection;
+			import java.util.Collections;
+			import java.util.Set;
 
+			public interface Test {
+				default void findObject() {
+					findObjectExcluding((Collections.emptySet()));
+					findObjectExcluding(((Set<?>) Collections.emptySet()));
+				}
+
+				void findObjectExcluding(Collection<String> col);
+
+				void findObjectExcluding(Set<?> col);
+			}
+			"""
+		};
+	runner.expectedCompilerLog =
+			"----------\n" +
+			"1. ERROR in Test.java (at line 7)\n" +
+			"	findObjectExcluding((Collections.emptySet()));\n" +
+			"	^^^^^^^^^^^^^^^^^^^\n" +
+			"The method findObjectExcluding(Collection<String>) is ambiguous for the type Test\n" +
+			"----------\n";
+	runner.runNegativeTest();
+}
 public static Class testClass() {
 	return CastTest.class;
 }


### PR DESCRIPTION
* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4375

