### PR TITLE
ECJ fails to detect name clash between Function.andThen and BiFunction.andThen methods with same erasure

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MethodVerifier15.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MethodVerifier15.java
@@ -795,12 +795,7 @@ void checkTypeVariableMethods(TypeParameter typeParameter) {
 boolean detectInheritedNameClash(MethodBinding inherited, MethodBinding otherInherited) {
 	if (!inherited.areParameterErasuresEqual(otherInherited))
 		return false;
-	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=322001
-	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=323693
-	// When reporting a name clash between two inherited methods, we should not look for a
-	// signature clash, but instead should be looking for method descriptor clash.
-	if (TypeBinding.notEquals(inherited.returnType.erasure(), otherInherited.returnType.erasure()))
-		return false;
+
 	// skip it if otherInherited is defined by a subtype of inherited's declaringClass or vice versa.
 	// avoid being order sensitive and check with the roles reversed also.
 	if (TypeBinding.notEquals(inherited.declaringClass.erasure(), otherInherited.declaringClass.erasure())) {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/MethodVerifyTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/MethodVerifyTest.java
@@ -9785,40 +9785,39 @@ public void test176() {
 	options);
 }
 
-//https://bugs.eclipse.org/bugs/show_bug.cgi?id=251091
-// Srikanth, Aug 10th 2010. This test does not elicit any name clash error from javac 5 or javac6
-// javac7 reports "X.java:7: name clash: foo(Collection<?>) in X and foo(Collection) in A have the
-// same erasure, yet neither overrides the other"
-// After the fix for https://bugs.eclipse.org/bugs/show_bug.cgi?id=322001, we match
-// JDK7 (7b100) behavior. (earlier we would issue an extra name clash)
 public void test177() {
 	String expectedCompilerLog =
-				"----------\n" +
-				"1. WARNING in X.java (at line 3)\n" +
-				"	class A extends LinkedHashMap {\n" +
-				"	      ^\n" +
-				"The serializable class A does not declare a static final serialVersionUID field of type long\n" +
-				"----------\n" +
-				"2. WARNING in X.java (at line 3)\n" +
-				"	class A extends LinkedHashMap {\n" +
-				"	                ^^^^^^^^^^^^^\n" +
-				"LinkedHashMap is a raw type. References to generic type LinkedHashMap<K,V> should be parameterized\n" +
-				"----------\n" +
-				"3. WARNING in X.java (at line 4)\n" +
-				"	public A foo(Collection c) { return this; }\n" +
-				"	             ^^^^^^^^^^\n" +
-				"Collection is a raw type. References to generic type Collection<E> should be parameterized\n" +
-				"----------\n" +
-				"4. WARNING in X.java (at line 6)\n" +
-				"	class X extends A implements I {\n" +
-				"	      ^\n" +
-				"The serializable class X does not declare a static final serialVersionUID field of type long\n" +
-				"----------\n" +
-				"5. ERROR in X.java (at line 7)\n" +
-				"	@Override public X foo(Collection<?> c) { return this; }\n" +
-				"	                   ^^^^^^^^^^^^^^^^^^^^\n" +
-				"Name clash: The method foo(Collection<?>) of type X has the same erasure as foo(Collection) of type A but does not override it\n" +
-				"----------\n";
+			"----------\n" +
+			"1. WARNING in X.java (at line 3)\n" +
+			"	class A extends LinkedHashMap {\n" +
+			"	      ^\n" +
+			"The serializable class A does not declare a static final serialVersionUID field of type long\n" +
+			"----------\n" +
+			"2. WARNING in X.java (at line 3)\n" +
+			"	class A extends LinkedHashMap {\n" +
+			"	                ^^^^^^^^^^^^^\n" +
+			"LinkedHashMap is a raw type. References to generic type LinkedHashMap<K,V> should be parameterized\n" +
+			"----------\n" +
+			"3. WARNING in X.java (at line 4)\n" +
+			"	public A foo(Collection c) { return this; }\n" +
+			"	             ^^^^^^^^^^\n" +
+			"Collection is a raw type. References to generic type Collection<E> should be parameterized\n" +
+			"----------\n" +
+			"4. ERROR in X.java (at line 6)\n" +
+			"	class X extends A implements I {\n" +
+			"	      ^\n" +
+			"Name clash: The method foo(Collection<?>) of type I has the same erasure as foo(Collection) of type A but does not override it\n" +
+			"----------\n" +
+			"5. WARNING in X.java (at line 6)\n" +
+			"	class X extends A implements I {\n" +
+			"	      ^\n" +
+			"The serializable class X does not declare a static final serialVersionUID field of type long\n" +
+			"----------\n" +
+			"6. ERROR in X.java (at line 7)\n" +
+			"	@Override public X foo(Collection<?> c) { return this; }\n" +
+			"	                   ^^^^^^^^^^^^^^^^^^^^\n" +
+			"Name clash: The method foo(Collection<?>) of type X has the same erasure as foo(Collection) of type A but does not override it\n" +
+			"----------\n";
 	this.runNegativeTest(
 		new String[] {
 			"X.java",
@@ -10299,22 +10298,27 @@ public void test186() {
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=?
 public void test187() {
 	String expectedCompilerLog =
-				"----------\n" +
-				"1. ERROR in X.java (at line 6)\n" +
-				"	double f(List<Integer> l) {return 0;}\n" +
-				"	       ^^^^^^^^^^^^^^^^^^\n" +
-				"Name clash: The method f(List<Integer>) of type Y has the same erasure as f(List<String>) of type X but does not override it\n" +
-				"----------\n" +
-				"2. ERROR in X.java (at line 13)\n" +
-				"	int f(List<String> l) {return 0;}\n" +
-				"	    ^^^^^^^^^^^^^^^^^\n" +
-				"Erasure of method f(List<String>) is the same as another method in type XX\n" +
-				"----------\n" +
-				"3. ERROR in X.java (at line 14)\n" +
-				"	double f(List<Integer> l) {return 0;}\n" +
-				"	       ^^^^^^^^^^^^^^^^^^\n" +
-				"Erasure of method f(List<Integer>) is the same as another method in type XX\n" +
-				"----------\n";
+			"----------\n" +
+			"1. ERROR in X.java (at line 6)\n" +
+			"	double f(List<Integer> l) {return 0;}\n" +
+			"	       ^^^^^^^^^^^^^^^^^^\n" +
+			"Name clash: The method f(List<Integer>) of type Y has the same erasure as f(List<String>) of type X but does not override it\n" +
+			"----------\n" +
+			"2. ERROR in X.java (at line 11)\n" +
+			"	abstract class Z extends X implements I {}\n" +
+			"	               ^\n" +
+			"Name clash: The method f(List<String>) of type X has the same erasure as f(List<Integer>) of type I but does not override it\n" +
+			"----------\n" +
+			"3. ERROR in X.java (at line 13)\n" +
+			"	int f(List<String> l) {return 0;}\n" +
+			"	    ^^^^^^^^^^^^^^^^^\n" +
+			"Erasure of method f(List<String>) is the same as another method in type XX\n" +
+			"----------\n" +
+			"4. ERROR in X.java (at line 14)\n" +
+			"	double f(List<Integer> l) {return 0;}\n" +
+			"	       ^^^^^^^^^^^^^^^^^^\n" +
+			"Erasure of method f(List<Integer>) is the same as another method in type XX\n" +
+			"----------\n";
 	this.runNegativeTest(
 		new String[] {
 			"X.java",
@@ -11095,6 +11099,16 @@ public void test209() {
 		"	class Bar extends Zork {}\n" +
 		"	                  ^^^^\n" +
 		"Zork cannot be resolved to a type\n" +
+		"----------\n" +
+		"2. ERROR in Concrete.java (at line 11)\n" +
+		"	public class Concrete implements Predicate<Foo>, Function<Bar, Boolean> {\n" +
+		"	             ^^^^^^^^\n" +
+		"Name clash: The method apply(T) of type Predicate<T> has the same erasure as apply(F) of type Function<F,T> but does not override it\n" +
+		"----------\n" +
+		"3. ERROR in Concrete.java (at line 11)\n" +
+		"	public class Concrete implements Predicate<Foo>, Function<Bar, Boolean> {\n" +
+		"	             ^^^^^^^^\n" +
+		"Name clash: The method apply(F) of type Function<F,T> has the same erasure as apply(T) of type Predicate<T> but does not override it\n" +
 		"----------\n");
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=321548
@@ -11117,6 +11131,16 @@ public void test210() {
 		},
 		"----------\n" +
 		"1. ERROR in ErasureTest.java (at line 7)\n" +
+		"	public class ErasureTest extends Zork implements Interface1<String>, Interface2<Double> {\n" +
+		"	             ^^^^^^^^^^^\n" +
+		"Name clash: The method hello(T) of type Interface2<T> has the same erasure as hello(T) of type Interface1<T> but does not override it\n" +
+		"----------\n" +
+		"2. ERROR in ErasureTest.java (at line 7)\n" +
+		"	public class ErasureTest extends Zork implements Interface1<String>, Interface2<Double> {\n" +
+		"	             ^^^^^^^^^^^\n" +
+		"Name clash: The method hello(T) of type Interface1<T> has the same erasure as hello(T) of type Interface2<T> but does not override it\n" +
+		"----------\n" +
+		"3. ERROR in ErasureTest.java (at line 7)\n" +
 		"	public class ErasureTest extends Zork implements Interface1<String>, Interface2<Double> {\n" +
 		"	                                 ^^^^\n" +
 		"Zork cannot be resolved to a type\n" +
@@ -13587,5 +13611,50 @@ public void testBug536978_comment5() {
 			"}\n"
 		},
 		errMsg);
+}
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4354
+// ECJ fails to detect name clash between Function.andThen and BiFunction.andThen methods with same erasure
+public void testIssue4354() {
+	this.runNegativeTest(
+		new String[] {
+			"Test.java",
+			"""
+			public class Test {
+			    public static void main(String[] strArr) {
+			    }
+			}
+
+			class MyLambda implements java.util.function.Function<Integer, String>,
+			        java.util.function.BiFunction<Integer, Integer, Integer>, java.util.function.Supplier<String>,
+			        java.util.function.Consumer<Integer> {
+
+			    @Override
+			    public String apply(Integer t) {
+			        return "";
+			    }
+
+			    @Override
+			    public Integer apply(Integer t, Integer u) {
+			        return 1;
+			    }
+
+			    @Override
+			    public String get() {
+			        return "";
+			    }
+
+			    @Override
+			    public void accept(Integer t) {
+			    }
+			}
+			"""
+		},
+		"----------\n" +
+		"1. ERROR in Test.java (at line 6)\n" +
+		"	class MyLambda implements java.util.function.Function<Integer, String>,\n" +
+		"	      ^^^^^^^^\n" +
+		"Name clash: The method andThen(Function<? super R,? extends V>) of type BiFunction<T,U,R> has the same erasure as andThen(Function<? super R,? extends V>) of type Function<T,R> but does not override it\n" +
+		"----------\n"
+	);
 }
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NegativeLambdaExpressionsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NegativeLambdaExpressionsTest.java
@@ -1601,57 +1601,62 @@ public void test043() {
 			"}\n"
 			},
 			"----------\n" +
-			"1. ERROR in X.java (at line 17)\n" +
+			"1. ERROR in X.java (at line 14)\n" +
+			"	interface M extends I, L {}\n" +
+			"	          ^\n" +
+			"Name clash: The method foo(List<Integer>) of type L has the same erasure as foo(List<String>) of type I but does not override it\n" +
+			"----------\n" +
+			"2. ERROR in X.java (at line 17)\n" +
 			"	interface P extends N, O {}\n" +
 			"	          ^\n" +
 			"Name clash: The method foo(List, Class<?>) of type O has the same erasure as foo(List<String>, Class) of type N but does not override it\n" +
 			"----------\n" +
-			"2. ERROR in X.java (at line 20)\n" +
+			"3. ERROR in X.java (at line 20)\n" +
 			"	interface S extends Q, R {}\n" +
 			"	          ^\n" +
 			"The return types are incompatible for the inherited methods Q.foo(), R.foo()\n" +
 			"----------\n" +
-			"3. ERROR in X.java (at line 23)\n" +
+			"4. ERROR in X.java (at line 23)\n" +
 			"	interface V<P, Q> extends T<P>, U<Q> {}\n" +
 			"	          ^\n" +
 			"Name clash: The method foo(P) of type U<P> has the same erasure as foo(P) of type T<P> but does not override it\n" +
 			"----------\n" +
-			"4. ERROR in X.java (at line 29)\n" +
+			"5. ERROR in X.java (at line 29)\n" +
 			"	B b              =    () -> {};\n" +
 			"	                      ^^^^^\n" +
 			"The target type of this expression must be a functional interface\n" +
 			"----------\n" +
-			"5. ERROR in X.java (at line 32)\n" +
+			"6. ERROR in X.java (at line 32)\n" +
 			"	E e              =    () -> {};\n" +
 			"	                      ^^^^^\n" +
 			"The target type of this expression must be a functional interface\n" +
 			"----------\n" +
-			"6. ERROR in X.java (at line 40)\n" +
+			"7. ERROR in X.java (at line 40)\n" +
 			"	M m              =    (p0) -> {};\n" +
 			"	                      ^^^^^^^\n" +
 			"The target type of this expression must be a functional interface\n" +
 			"----------\n" +
-			"7. ERROR in X.java (at line 43)\n" +
+			"8. ERROR in X.java (at line 43)\n" +
 			"	P p              =    (p0, q0) -> {};\n" +
 			"	                      ^^^^^^^^^^^\n" +
 			"The target type of this expression must be a functional interface\n" +
 			"----------\n" +
-			"8. ERROR in X.java (at line 46)\n" +
+			"9. ERROR in X.java (at line 46)\n" +
 			"	S s              =    () -> {};\n" +
 			"	                      ^^^^^\n" +
 			"The target type of this expression must be a functional interface\n" +
 			"----------\n" +
-			"9. ERROR in X.java (at line 49)\n" +
+			"10. ERROR in X.java (at line 49)\n" +
 			"	V<?,?> v         =    (p0) -> {};\n" +
 			"	                      ^^^^^^^\n" +
 			"The target type of this expression must be a functional interface\n" +
 			"----------\n" +
-			"10. ERROR in X.java (at line 50)\n" +
+			"11. ERROR in X.java (at line 50)\n" +
 			"	W<?,?> w         =    (p0) -> {};\n" +
 			"	                      ^^^^^^^\n" +
 			"The target type of this expression must be a functional interface\n" +
 			"----------\n" +
-			"11. ERROR in X.java (at line 51)\n" +
+			"12. ERROR in X.java (at line 51)\n" +
 			"	X x              =    (p0) -> {};\n" +
 			"	                      ^^^^^^^\n" +
 			"The target type of this expression must be a functional interface\n" +


### PR DESCRIPTION


* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4354

