### PR TITLE
Active a couple of more disabled tests

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter17Test.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverter17Test.java
@@ -772,7 +772,7 @@ public class ASTConverter17Test extends ConverterTestSetup {
 	/*
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=399791
 	 */
-	public void _2551_test0021() throws JavaModelException {
+	public void test0021() throws JavaModelException {
 		String contents =
 				"public interface X {\n" +
 				"	static void foo(){}\n" +
@@ -786,17 +786,15 @@ public class ASTConverter17Test extends ConverterTestSetup {
 			node = (ASTNode) type.bodyDeclarations().get(0);
 			assertEquals("Not a method Declaration", ASTNode.METHOD_DECLARATION, node.getNodeType());
 			MethodDeclaration method = (MethodDeclaration) node;
-			assertEquals("Method should be malformed", ASTNode.MALFORMED, (method.getFlags() & ASTNode.MALFORMED));
+			assertFalse("Method should NOT be malformed", ASTNode.MALFORMED == (method.getFlags() & ASTNode.MALFORMED));
 
 			method = (MethodDeclaration) type.bodyDeclarations().get(1);
-			assertEquals("Method should be malformed", ASTNode.MALFORMED, (method.getFlags() & ASTNode.MALFORMED));
+			assertFalse("Method should NOT be malformed", ASTNode.MALFORMED == (method.getFlags() & ASTNode.MALFORMED));
 	}
 	/**
 	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=405934
-	 *
-	 * @deprecated as it uses deprecated methods
 	 */
-	public void _2551_test0022() throws JavaModelException {
+	public void test0022() throws JavaModelException {
 		String contents =
 				"public class X {\n" +
 				"	void foo() throws  @NonNull EOFException, java.io.@NonNull FileNotFoundException {}\n" +
@@ -809,9 +807,9 @@ public class ASTConverter17Test extends ConverterTestSetup {
 		node = (ASTNode) type.bodyDeclarations().get(0);
 		assertEquals("Not a method Declaration", ASTNode.METHOD_DECLARATION, node.getNodeType());
 		MethodDeclaration method = (MethodDeclaration) node;
-		SimpleName exception1 = (SimpleName) method.thrownExceptions().get(0);
-		assertEquals("QualifiedName should be malformed", ASTNode.MALFORMED, (exception1.getFlags() & ASTNode.MALFORMED));
-		QualifiedName exception2 = (QualifiedName) method.thrownExceptions().get(1);
-		assertEquals("QualifiedName should be malformed", ASTNode.MALFORMED, (exception2.getFlags() & ASTNode.MALFORMED));
+		SimpleName exception1 = (SimpleName) ((SimpleType) method.thrownExceptionTypes().get(0)).getName();
+		assertFalse("QualifiedName should NOT be malformed", ASTNode.MALFORMED == (exception1.getFlags() & ASTNode.MALFORMED));
+		SimpleName exception2 = ((NameQualifiedType) method.thrownExceptionTypes().get(1)).getName();
+		assertFalse("QualifiedName should NOT be malformed", ASTNode.MALFORMED == (exception2.getFlags() & ASTNode.MALFORMED));
 	}
 }


### PR DESCRIPTION
Adjust expectation that at 1.8, interface static methods, default methods and type annotations present in source would result in AST being flagged MALFORMED and reenabled disabled tests

