### PR TITLE
Use of InferenceContext18.SIMULATE_BUG_JDK_8026527 in org.eclipse.jdt.internal.compiler.lookup.ReferenceBinding.isConsistentIntersection(TypeBinding[], boolean)

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/CaptureBinding18.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/CaptureBinding18.java
@@ -44,7 +44,7 @@ public class CaptureBinding18 extends CaptureBinding {
 		if (upperBounds.length > 0)
 			this.firstBound = upperBounds[0];
 		int numReferenceInterfaces = 0;
-		if (!isConsistentIntersection(upperBounds))
+		if (!isConsistentIntersection(upperBounds, InferenceContext18.SIMULATE_BUG_JDK_8026527))
 			return false;
 		for (TypeBinding aBound : upperBounds) {
 			if (aBound instanceof ReferenceBinding) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
@@ -1307,7 +1307,7 @@ public class InferenceContext18 {
 			}
 		}
 		IntersectionTypeBinding18 intersection = (IntersectionTypeBinding18) this.environment.createIntersectionType18(refGlbs);
-		if (ReferenceBinding.isConsistentIntersection(intersection.intersectingTypes))
+		if (ReferenceBinding.isConsistentIntersection(intersection.intersectingTypes, InferenceContext18.SIMULATE_BUG_JDK_8026527))
 			return intersection;
 		return null;
 	}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
@@ -2531,7 +2531,7 @@ public MethodBinding getSingleAbstractMethod(Scope scope, boolean replaceWildcar
 }
 
 // See JLS 4.9 bullet 1
-public static boolean isConsistentIntersection(TypeBinding[] intersectingTypes) {
+public static boolean isConsistentIntersection(TypeBinding[] intersectingTypes, boolean simulatingBugJDK8026527) {
 	TypeBinding[] ci = new TypeBinding[intersectingTypes.length];
 	for (int i = 0; i < ci.length; i++) {
 		TypeBinding current = intersectingTypes[i];
@@ -2544,9 +2544,9 @@ public static boolean isConsistentIntersection(TypeBinding[] intersectingTypes) 
 		// when invoked during type inference we only want to check inconsistency among real types:
 		if (current.isTypeVariable() || current.isWildcard() || !current.isProperType(true))
 			continue;
-		if (mostSpecific.isSubtypeOf(current, false))
+		if (mostSpecific.isSubtypeOf(current, simulatingBugJDK8026527))
 			continue;
-		else if (current.isSubtypeOf(mostSpecific, false))
+		else if (current.isSubtypeOf(mostSpecific, simulatingBugJDK8026527))
 			mostSpecific = current;
 		else
 			return false;

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
@@ -1583,6 +1583,21 @@ public void testGH4346() {
 			"""
 	});
 }
+public void testGH4498() {
+	runConformTest(new String[] {
+			"AFactory.java",
+			"""
+			public abstract class AFactory<T> {
+
+			  public <U extends AFactory> U getProcess(Object object) {
+			    return getProcess(object.getClass()); // Type mismatch: cannot convert from AFactory<capture#2-of ?> to U
+			  }
+
+			  public abstract <U extends AFactory<?>> U getProcess(Class<?> classeObject);
+
+			}
+			"""});
+}
 public static Class<GenericsRegressionTest_9> testClass() {
 	return GenericsRegressionTest_9.class;
 }


### PR DESCRIPTION
Use of InferenceContext18.SIMULATE_BUG_JDK_8026527 in org.eclipse.jdt.internal.compiler.lookup.ReferenceBinding.isConsistentIntersection(TypeBinding[], boolean)

Fix : https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4498

- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have thoroughly tested my changes
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
