### PR TITLE
Investigate tests disabled during transition to minimal 1.8 target

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ExtendedTagBits.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ExtendedTagBits.java
@@ -39,4 +39,6 @@ public interface ExtendedTagBits {
 	static boolean areAllAnnotationsResolved(long extendedTagBits) {
 		return (extendedTagBits & AllAnnotationsResolved) == AllAnnotationsResolved;
 	}
+
+	int IsNullAnnotationPackage = ASTNode.Bit1; // package
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/LookupEnvironment.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/LookupEnvironment.java
@@ -126,10 +126,6 @@ public class LookupEnvironment implements ProblemReasons, TypeConstants {
 	public boolean isProcessingAnnotations = false; // ROOT_ONLY
 	public boolean mayTolerateMissingType = false;
 
-	PackageBinding nullableAnnotationPackage;			// the package supposed to contain the Nullable annotation type
-	PackageBinding nonnullAnnotationPackage;			// the package supposed to contain the NonNull annotation type
-	PackageBinding nonnullByDefaultAnnotationPackage;	// the package supposed to contain the NonNullByDefault annotation type
-
 	AnnotationBinding nonNullAnnotation;
 	AnnotationBinding nullableAnnotation;
 
@@ -1627,6 +1623,11 @@ public char[][] getNonNullByDefaultAnnotationName() {
 	return this.globalOptions.nonNullByDefaultAnnotationName;
 }
 
+public char[][][] allNullAnnotationNames() {
+	// should we include names of secondary annotations?
+	return new char[][][] { getNullableAnnotationName(), getNonNullAnnotationName(), getNonNullByDefaultAnnotationName() };
+}
+
 public char[][] getOwningAnnotationName() {
 	return this.globalOptions.owningAnnotationName;
 }
@@ -1706,10 +1707,6 @@ public long checkForMissingAnalysisAnnotation(TypeBinding resolvedType) {
 }
 private boolean matchesSimpleName(char[] simpleName, char[][] qualifiedName) {
 	return CharOperation.equals(simpleName, qualifiedName[qualifiedName.length-1]);
-}
-
-public boolean isNullnessAnnotationPackage(PackageBinding pkg) {
-	return this.nonnullAnnotationPackage == pkg || this.nullableAnnotationPackage == pkg || this.nonnullByDefaultAnnotationPackage == pkg;
 }
 
 public boolean usesNullTypeAnnotations() {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SourceTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SourceTypeBinding.java
@@ -2317,7 +2317,7 @@ public void evaluateNullAnnotations() {
 	PackageBinding pkg = getPackage();
 	boolean isInDefaultPkg = (pkg.compoundName == CharOperation.NO_CHAR_CHAR);
 	if (!isPackageInfo) {
-		boolean isInNullnessAnnotationPackage = this.scope.environment().isNullnessAnnotationPackage(pkg);
+		boolean isInNullnessAnnotationPackage = (pkg.extendedTagBits & ExtendedTagBits.IsNullAnnotationPackage) != 0;
 		if (pkg.getDefaultNullness() == NO_NULL_DEFAULT && !isInDefaultPkg && !isInNullnessAnnotationPackage && !(this instanceof NestedTypeBinding)) {
 			ReferenceBinding packageInfo = pkg.getType(TypeConstants.PACKAGE_INFO_NAME, this.module);
 			if (packageInfo == null) {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullAnnotationBatchCompilerTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullAnnotationBatchCompilerTest.java
@@ -188,7 +188,7 @@ public class NullAnnotationBatchCompilerTest extends AbstractBatchCompilerTest {
 
 	// -warn option - regression tests to check option nullAnnot and missingNullDefault
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=372012
-	public void _2551_test315_warn_options() {
+	public void test315_warn_options() {
 		this.runConformTest(
 			new String[] {
 					"p/package-info.java",


### PR DESCRIPTION
+ improve protocol for initialization null annotations & their package
+ re-enable NullAnnotationBatchCompilerTest.test315_warn_options()

See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2758

