### PR TITLE
Unexpected "Resource leak: '...' is never closed" warning

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ForStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ForStatement.java
@@ -242,7 +242,8 @@ public class ForStatement extends Statement {
 			}
 		}
 		this.mergedInitStateIndex = currentScope.methodScope().recordInitializationStates(mergedInfo);
-		this.scope.checkUnclosedCloseables(mergedInfo, loopingContext, null, null);
+		if ((this.bits & ASTNode.NeededScope) != 0)
+			this.scope.checkUnclosedCloseables(mergedInfo, loopingContext, null, null);
 		if (this.condition != null)
 			this.condition.updateFlowOnBooleanResult(mergedInfo, false);
 		return mergedInfo;

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ResourceLeakTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ResourceLeakTests.java
@@ -7424,4 +7424,38 @@ public void testGH4486() {
 	"",
 	compilerOptions);
 }
+public void testGH4511() {
+	Map<String, String> compilerOptions = getCompilerOptions();
+	compilerOptions.put(CompilerOptions.OPTION_ReportUnclosedCloseable, CompilerOptions.ERROR);
+	runLeakTest(new String[] {
+			"Main.java",
+			"""
+			import java.io.BufferedReader;
+			import java.io.BufferedWriter;
+			import java.io.FileReader;
+			import java.io.FileWriter;
+			import java.io.IOException;
+			import java.io.PrintWriter;
+
+			public class Main {
+
+				void foo() throws IOException{
+					BufferedReader in = new BufferedReader(new FileReader("garbage.in"));
+					PrintWriter out = new PrintWriter(new BufferedWriter(new FileWriter("garbage.out")));
+					int N = Integer.parseInt(in.readLine());
+					System.out.println("N = "+N);
+					int i = 0;
+					for (i = 0; i < N; i++) {
+						System.out.println(i);
+					}
+					System.out.println("i = "+i);
+					in.close();
+					out.close();
+				}
+			}
+			"""
+	},
+	"",
+	compilerOptions);
+}
 }


### PR DESCRIPTION
Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4511
