### PR TITLE
Re-enable BatchASTCreationTests.test063

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/BatchASTCreationTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/BatchASTCreationTests.java
@@ -1380,7 +1380,7 @@ public class BatchASTCreationTests extends AbstractASTTests {
 	 * Ensures that a raw method binding can be created using its key in batch creation.
 	 * (regression test for bug 87749 different IMethodBindings of generic method have equal getKey())
 	 */
-	public void _2551_test063() throws CoreException {
+	public void test063() throws CoreException {
 		assertRequestedBindingFound(
 			new String[] {
 				"/P/p1/X.java",
@@ -1402,7 +1402,7 @@ public class BatchASTCreationTests extends AbstractASTTests {
 				"class W<T> extends Z<T> {\n" +
 				"}",
 			},
-			"Lp1/X;.foo<T:Lp1/Y<-TT;>;>(Lp1/Z<TT;>;)V%<Lp1/X~Y<Lp1/X~Y;{0}-Lp1/X~Y<Lp1/X~Y;{0}-Lp1/X;:2TT;>;>;>"
+			"Lp1/X;.foo<T:Lp1/Y<-TT;>;>(Lp1/Z<TT;>;)V%<^{166#0};>"
 		);
 	}
 

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/BindingKeyResolver.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/BindingKeyResolver.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2019 IBM Corporation and others.
+ * Copyright (c) 2005, 2025 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -242,6 +242,13 @@ public class BindingKeyResolver extends BindingKeyParser {
 			public boolean visit(MessageSend messageSend, BlockScope blockScope) {
 				if (checkType(messageSend.resolvedType))
 					return false;
+				MethodBinding mBinding = messageSend.binding;
+				if (mBinding.isValidBinding()) {
+					for (TypeBinding parameter : mBinding.parameters) {
+						if (checkType(parameter))
+							return false;
+					}
+				}
 				return super.visit(messageSend, blockScope);
 			}
 			@Override


### PR DESCRIPTION
+ update expected key to reflect use of CaptureBinding18
+ extend BindingKeyResolver to find CB18 in MethodBinding.parameters

See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2758
