### PR TITLE
The Markdown parser parses the comment incorrectly

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/AbstractCommentParser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/AbstractCommentParser.java
@@ -405,8 +405,12 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 								// Reset textStart only if there's content after the tag
 								if (this.index < this.javadocEnd) {
 									char next = this.source[this.index];
-									if (!(this.markdown && (next == '\r' || next == '\n'))) {
+									if (!this.markdown || !(next == '\r' || next == '\n') || (previousChar == '@' && nextCharacter == '}')) {
 										this.textStart = this.index;
+									}
+								} else if (this.index == this.javadocEnd) {
+									if (!this.markdown || (previousChar == '@' && nextCharacter == '}')) {
+										this.textStart = -1;
 									}
 								}
 							}

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterMarkdownTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterMarkdownTest.java
@@ -2034,4 +2034,84 @@ public class ASTConverterMarkdownTest extends ConverterTestSetup {
 			assertEquals("Incorrect TagElement", 1, (fragments.get(3).getFlags() & ASTNode.MALFORMED));  //MALFOUND flag
 		}
 	}
+
+	public void testTagElementRetrieveIncorrectly_4497_01() throws JavaModelException {
+		String source= """
+				/// {@inheritDoc}
+				/// In addition, this methods calls [#wait()].
+				/// @param i the index
+				public class IncorrectTagElement {}
+				""";
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy("/Converter_25/src/markdown/gh3761/IncorrectTagElement.java", source, null);
+		if (this.docCommentSupport.equals(JavaCore.ENABLED)) {
+			CompilationUnit compilUnit = (CompilationUnit) runConversion(this.workingCopies[0], true);
+			TypeDeclaration typedeclaration =  (TypeDeclaration) compilUnit.types().get(0);
+			Javadoc javadoc = typedeclaration.getJavadoc();
+			List<TagElement> te = javadoc.tags();
+			TagElement firstTag = te.get(0);
+			TagElement secondTag = te.get(1);
+			assertEquals("Incorrect Second TagElement", 2, secondTag.fragments().size());
+			assertEquals("Incorrect First TagElement", 4, firstTag.fragments().size());
+		}
+	}
+
+	public void testTagElementRetrieveIncorrectly_4497_02() throws JavaModelException {
+		String source= """
+				/// {@inheritDoc}}
+				/// In addition, this methods calls [#wait()].
+				/// @param i the index
+				public class IncorrectTagElement {}
+				""";
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy("/Converter_25/src/markdown/gh3761/IncorrectTagElement.java", source, null);
+		if (this.docCommentSupport.equals(JavaCore.ENABLED)) {
+			CompilationUnit compilUnit = (CompilationUnit) runConversion(this.workingCopies[0], true);
+			TypeDeclaration typedeclaration =  (TypeDeclaration) compilUnit.types().get(0);
+			Javadoc javadoc = typedeclaration.getJavadoc();
+			List<TagElement> te = javadoc.tags();
+			TagElement firstTag = te.get(0);
+			TagElement secondTag = te.get(1);
+			assertEquals("Incorrect Second TagElement", 2, secondTag.fragments().size());
+			assertEquals("Incorrect First TagElement", 5, firstTag.fragments().size());
+		}
+	}
+
+	public void testTagElementRetrieveIncorrectly_4497_03() throws JavaModelException {
+		String source= """
+				/// {@inheritDoc}
+				/// {@link
+				///SomeClass}
+				public class IncorrectTagElement {}
+				""";
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy("/Converter_25/src/markdown/gh3761/IncorrectTagElement.java", source, null);
+		if (this.docCommentSupport.equals(JavaCore.ENABLED)) {
+			CompilationUnit compilUnit = (CompilationUnit) runConversion(this.workingCopies[0], true);
+			TypeDeclaration typedeclaration =  (TypeDeclaration) compilUnit.types().get(0);
+			Javadoc javadoc = typedeclaration.getJavadoc();
+			List<TagElement> te = javadoc.tags();
+			TagElement tags = te.get(0);
+			assertEquals("Incorrect TagElements", 2, tags.fragments().size());
+		}
+	}
+
+	public void testTagElementRetrieveIncorrectly_4497_04() throws JavaModelException {
+		String source= """
+				/// {@inheritDoc} }
+				/// {@inheritDoc}}
+				/// Duplicate inheritDoc
+				public class IncorrectTagElement {}
+				""";
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy("/Converter_25/src/markdown/gh3761/IncorrectTagElement.java", source, null);
+		if (this.docCommentSupport.equals(JavaCore.ENABLED)) {
+			CompilationUnit compilUnit = (CompilationUnit) runConversion(this.workingCopies[0], true);
+			TypeDeclaration typedeclaration =  (TypeDeclaration) compilUnit.types().get(0);
+			Javadoc javadoc = typedeclaration.getJavadoc();
+			List<TagElement> te = javadoc.tags();
+			TagElement tags = te.get(0);
+			assertEquals("Incorrect TagElements", 5, tags.fragments().size());
+		}
+	}
 }


### PR DESCRIPTION
Fixed the issues in AbstractCommentParser related to the inheritDoc inconsistency

Fix: https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4497

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.


Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
**Scenario 1**
```
/// {@inheritDoc}
/// In addition, this methods calls [#wait()].
///
/// @param i the index
```

**Scenario 2**
```
/// {@inheritDoc}}
/// In addition, this methods calls [#wait()].
/// @param i the index
```

**Scenario 3**
```
/// {@inheritDoc}
/// {@link
///SomeClass}
```

**Scenario 4**
```
/// {@inheritDoc} }
/// {@inheritDoc}}
/// Duplicate inheritDoc
```

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
