### PR TITLE
Avoid dodgy cast in InferenceContext18.solve()

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Location.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Location.java
@@ -16,6 +16,4 @@ package org.eclipse.jdt.internal.compiler.ast;
 public interface Location {
 	int sourceEnd();
 	int sourceStart();
-	default int nameSourceStart() { return sourceStart(); }
-	default int nameSourceEnd() { return sourceEnd(); }
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/CompilationUnitScope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/CompilationUnitScope.java
@@ -765,7 +765,7 @@ ImportBinding[] getDefaultImports() {
 		problemReporter().isClassPathCorrect(
 				TypeConstants.JAVA_LANG_OBJECT,
 			this.referenceContext,
-			this.environment, false, null/*resolving j.l.O is not specific to any referencing type*/);
+			this.environment.missingClassFileLocation, false, null/*resolving j.l.O is not specific to any referencing type*/);
 		BinaryTypeBinding missingObject = this.environment.createMissingType(null, TypeConstants.JAVA_LANG_OBJECT);
 		importBinding = missingObject.fPackage;
 		implicitImports[0] = new ImportBinding(TypeConstants.JAVA_LANG, true, importBinding, null);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InvocationSite.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InvocationSite.java
@@ -33,6 +33,8 @@ public interface InvocationSite extends Location {
 	void setActualReceiverType(ReferenceBinding receiverType);
 	void setDepth(int depth);
 	void setFieldIndex(int depth);
+	default int nameSourceStart() { return sourceStart(); }
+	default int nameSourceEnd() { return sourceEnd(); }
 	TypeBinding invocationTargetType();
 	boolean receiverIsImplicitThis();
 	boolean checkingPotentialCompatibility();

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/LookupEnvironment.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/LookupEnvironment.java
@@ -1878,7 +1878,7 @@ public ReferenceBinding getResolvedType(char[][] compoundName, ModuleBinding mod
 	this.problemReporter.isClassPathCorrect(
 		compoundName,
 		scope == null ? this.root.unitBeingCompleted : scope.referenceCompilationUnit(),
-		this, implicitAnnotationUse, this.requestingType);
+		this.missingClassFileLocation, implicitAnnotationUse, this.requestingType);
 	return createMissingType(null, compoundName);
 }
 public ReferenceBinding getResolvedJavaBaseType(char[][] compoundName, Scope scope) {
@@ -1997,7 +1997,7 @@ private ReferenceBinding getTypeFromCompoundName(char[][] compoundName, boolean 
 			 * misconfiguration now that did not also exist in some equivalent form while producing the class files which encode
 			 * these missing types. So no need to bark again. Note that wasMissingType == true signals a type referenced in a .class
 			 * file which could not be found when the binary was produced. See https://bugs.eclipse.org/bugs/show_bug.cgi?id=364450 */
-			this.problemReporter.isClassPathCorrect(compoundName, this.root.unitBeingCompleted, this, false, this.requestingType);
+			this.problemReporter.isClassPathCorrect(compoundName, this.root.unitBeingCompleted, this.missingClassFileLocation, false, this.requestingType);
 		}
 		// create a proxy for the missing BinaryType
 		binding = createMissingType(null, compoundName);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/UnresolvedReferenceBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/UnresolvedReferenceBinding.java
@@ -125,7 +125,7 @@ ReferenceBinding resolve(LookupEnvironment environment, boolean convertGenericTo
 				environment.problemReporter.isClassPathCorrect(
 					this.compoundName,
 					environment.root.unitBeingCompleted,
-					environment,
+					environment.missingClassFileLocation,
 					false,
 					this.requestingType);
 			}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
@@ -4973,7 +4973,7 @@ public void discouragedValueBasedTypeToSynchronize(Expression expression, TypeBi
 		expression.sourceEnd);
 }
 public void isClassPathCorrect(char[][] wellKnownTypeName, CompilationUnitDeclaration compUnitDecl,
-					LookupEnvironment environment, boolean implicitAnnotationUse, ReferenceBinding referencingType)
+					Location location, boolean implicitAnnotationUse, ReferenceBinding referencingType)
 {
 	// ProblemReporter is not designed to be reentrant. Just in case, we discovered a build path problem while we are already
 	// in the midst of reporting some other problem, save and restore reference context thereby mimicking a stack.
@@ -4982,9 +4982,9 @@ public void isClassPathCorrect(char[][] wellKnownTypeName, CompilationUnitDeclar
 	this.referenceContext = compUnitDecl;
 	String[] arguments = new String[] {CharOperation.toString(wellKnownTypeName)};
 	int start = 0, end = 0;
-	if (environment.missingClassFileLocation != null) {
-		start = environment.missingClassFileLocation.sourceStart();
-		end = environment.missingClassFileLocation.sourceEnd();
+	if (location != null) {
+		start = location.sourceStart();
+		end = location.sourceEnd();
 	}
 	try {
 		int pId = IProblem.IsClassPathCorrect;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

InferenceContext18.solve() was assuming that it is always safe to cast from `InvocationSite` to `ASTNode`.  These two classes are not actually related, but the only thing the resulting variable was being used for was to call `sourceStart()` and `sourceEnd()`, two methods that are defined on both classes.

A cleaner solution is to use the existing `InvocationSite.EmptyWithAstNode` wrapper class, which includes a passthrough implementation of the two relevant methods.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

This should be functionally equivalent to the previous code, but the old cast was very inconvenient for my project that uses the ECJ as a base for implementing operator overloading in Java.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
