### PR TITLE
Adjust the disabled CopyMoveResourcesTests and enable to reflect the current behavior

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CopyMoveResourcesTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CopyMoveResourcesTests.java
@@ -1080,7 +1080,7 @@ public void testMoveCU12() throws CoreException {
  * Ensures that the Javadoc comment is not lost if moving a cu to the default package
  * (regression test for https://bugs.eclipse.org/bugs/show_bug.cgi?id=247757 )
  */
-public void _2551_testMoveCU13() throws CoreException {
+public void testMoveCU13() throws CoreException {
 	createFolder("/P/src/p1");
 	createFile(
 		"/P/src/p1/X.java",
@@ -1098,7 +1098,30 @@ public void _2551_testMoveCU13() throws CoreException {
 	assertSourceEquals(
 		"Unexpected source",
 		"/** some Javadoc */\n" +
+		"\n" +
+		"public class X {\n" +
+		"}",
+		cuDest.getSource());
+}
+public void testMoveCU14() throws CoreException {
+	createFolder("/P/src/p1");
+	createFile(
+		"/P/src/p1/X.java",
 		"// some line comment\n" +
+		"/** some Javadoc */\n" +
+		"package p1;\n" +
+		"public class X {\n" +
+		"}"
+	);
+	ICompilationUnit cuSource = getCompilationUnit("/P/src/p1/X.java");
+	IPackageFragment pkgDest = getPackage("/P/src");
+	cuSource.move(pkgDest, null/*no sibling*/, null/*no rename*/, false/*don't replace*/, null/*no progress*/);
+
+	ICompilationUnit cuDest = getCompilationUnit("/P/src/X.java");
+	assertSourceEquals(
+		"Unexpected source",
+		"// some line comment\n" +
+		"/** some Javadoc */\n" +
 		"\n" +
 		"public class X {\n" +
 		"}",


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
Fixes one of the failing tests mentioned in [2758](https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2758)

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
