### PR TITLE
Take release level into account when check for java9

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ReconcilerMultiReleaseTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ReconcilerMultiReleaseTests.java
@@ -45,9 +45,8 @@ public class ReconcilerMultiReleaseTests extends ModifyingResourceTests {
 	@Override
 	public void setUpSuite() throws Exception {
 		super.setUpSuite();
-
 		IJavaProject mrproject = createJavaProject("ReconcilerMR", new String[] { "src", "src9", "src21" },
-				new String[] { "JCL18_LIB" }, "bin");
+				new String[] { "JCL_21_LIB" }, "bin", "21", true);
 		createFolder("/ReconcilerMR/src/p");
 		createFolder("/ReconcilerMR/src9/p");
 		createFolder("/ReconcilerMR/src21/p");
@@ -112,6 +111,9 @@ public class ReconcilerMultiReleaseTests extends ModifyingResourceTests {
 		mrproject.setOption(JavaCore.COMPILER_RELEASE, JavaCore.ENABLED);
 		mrproject.setOption(JavaCore.COMPILER_PB_UNUSED_LOCAL, JavaCore.IGNORE);
 		mrproject.setOption(JavaCore.COMPILER_PB_INVALID_JAVADOC, JavaCore.WARNING);
+		mrproject.setOption(JavaCore.COMPILER_COMPLIANCE, "1.8");
+		mrproject.setOption(JavaCore.COMPILER_SOURCE, "1.8");
+		mrproject.setOption(JavaCore.COMPILER_CODEGEN_TARGET_PLATFORM, "1.8");
 	}
 
 	@Override
@@ -136,6 +138,8 @@ public class ReconcilerMultiReleaseTests extends ModifyingResourceTests {
 					void m(B b) {
 						// Calling method m only available from Java 21+
 						b.m();
+						// Calling a JDK class should work
+						System.out.println("Running");
 					}
 				}
 			""";

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SearchableEnvironment.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/SearchableEnvironment.java
@@ -115,7 +115,7 @@ public class SearchableEnvironment
 			|| !JavaCore.IGNORE.equals(project.getOption(JavaCore.COMPILER_PB_DISCOURAGED_REFERENCE, true));
 		this.workingCopies = workingCopies;
 		this.nameLookup = project.newNameLookup(workingCopies, excludeTestCode);
-		boolean java9plus = JavaCore.callReadOnly(() -> CompilerOptions
+		boolean java9plus = release >=JavaProject.FIRST_MULTI_RELEASE || JavaCore.callReadOnly(() -> CompilerOptions
 				.versionToJdkLevel(project.getOption(JavaCore.COMPILER_COMPLIANCE, true)) >= ClassFileConstants.JDK9);
 		if (java9plus) {
 			this.knownModuleLocations = new HashMap<>();


### PR DESCRIPTION
Currently in SearchableEnvironment we only check if the project level is larger java9plus but when constructing a release specific SearchableEnvironment this needs to take the release option into account instead.

Fix https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4399

@stephan-herrmann can you review / merge this?