### PR TITLE
Problem detected during type inference: expression has no value

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/MessageSend.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/MessageSend.java
@@ -1235,12 +1235,11 @@ public boolean isPolyExpression(MethodBinding resolutionCandidate) {
 		throw new UnsupportedOperationException("Unresolved MessageSend can't be queried if it is a polyexpression"); //$NON-NLS-1$
 
 	if (resolutionCandidate != null) {
-		if (resolutionCandidate instanceof ParameterizedGenericMethodBinding) {
-			ParameterizedGenericMethodBinding pgmb = (ParameterizedGenericMethodBinding) resolutionCandidate;
-			if (pgmb.wasInferred)
-				return true; // if already determined
-		}
-		if (resolutionCandidate.returnType != null) {
+		if (resolutionCandidate.returnType != null && resolutionCandidate.returnType.id != TypeIds.T_void) {
+			if (resolutionCandidate instanceof ParameterizedGenericMethodBinding pgmb) {
+				if (pgmb.wasInferred)
+					return true; // if already determined
+			}
 			// resolution may have prematurely instantiated the generic method, we need the original, though:
 			MethodBinding candidateOriginal = resolutionCandidate.original();
 			return candidateOriginal.returnType.mentionsAny(candidateOriginal.typeVariables(), -1);

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
@@ -1664,6 +1664,39 @@ public void testIssue4503_matches_with_javac() {
 			"Unhandled exception type Throwable\n" +
 			"----------\n");
 }
+public void testGH4533() {
+	runConformTest(new String[] {
+		"X.java",
+		"""
+		import java.util.function.Supplier;
+
+		public class X implements Foo {
+
+			private final Foo delegate;
+			private final Helper helper;
+
+			public X(Helper helper, Foo delegate) {
+				this.helper = helper;
+				this.delegate = delegate;
+			}
+
+			@Override
+			public <T> void setProperty(T value) {
+				helper.run(() -> delegate.setProperty(value));  // Problem detected during type inference: expression has no value
+			}
+		}
+
+		interface Foo {
+			public <T> void setProperty(T value);
+		}
+
+		interface Helper {
+			public void run(Runnable runnable); // comment out this to see a different error
+			public <R> R run(Supplier<R> supplier);
+		}
+		"""
+	});
+}
 public static Class<GenericsRegressionTest_9> testClass() {
 	return GenericsRegressionTest_9.class;
 }


### PR DESCRIPTION
Method with void return is never a poly expression

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4533
