### PR TITLE
Fix unexpected end tag JavaDoc error

### DIFF
--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/IPackageBinding.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/IPackageBinding.java
@@ -71,6 +71,7 @@ public interface IPackageBinding extends IBinding {
 	 * name of the class or interface. For member classes and interfaces, the
 	 * name is prefixed by its outer class(es) with a dot separator.
 	 * For example, for the following class:
+	 *</p>
 	 * <pre><code>
 	 *    public class Outer {
 	 *        public static class Inner {
@@ -80,7 +81,6 @@ public interface IPackageBinding extends IBinding {
 	 * </code></pre> the first inner class is referenced via:
 	 * <code>"Outer.Inner"</code> and it's inner class can be accessed via
 	 * <code>"Outer.Inner.Inner2"</code>.
-	 * </p>
 	 *
 	 * @param name the name of a class or interface
 	 * @return the type binding for the class or interface with the


### PR DESCRIPTION
## What it does

An attempt to fix the failure of the latest I-build:
https://ci.eclipse.org/releng/job/Builds/job/I-build-4.38/81/

I'm not entirly sure if that's the right thing to do, but from my past experience I know that not everything is allowed within a `p` element.

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
