### PR TITLE
Revert "TagElement doesn't retrieve the correct text"

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/AbstractCommentParser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/AbstractCommentParser.java
@@ -181,6 +181,7 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 			boolean isDomParser = (this.kind & DOM_PARSER) != 0;
 			boolean isFormatterParser = (this.kind & FORMATTER_COMMENT_PARSER) != 0;
 			int lastStarPosition = -1;
+			boolean isTagElementClose = false;
 
 			// Init scanner position
 			this.markdown = this.source[this.javadocStart + 1] == '/';
@@ -347,37 +348,10 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 						this.lineStarted = false;
 						lineHasStar = false;
 						// Fix bug 51650
-						// Only reset textStart if not in an unclosed markdown inline tag
-						if (!(this.markdown && this.inlineTagStarted)) {
-							this.textStart = -1;
-						}
+						this.textStart = -1;
 						this.markdownHelper.resetAtLineEnd();
-						if (this.markdown && this.inlineTagStarted && this.index < this.javadocEnd - 2) {
-							// Special handling for markdown comments with unclosed inline tags
-							if (this.source[this.index] == '\r') this.index++;
-							if (this.source[this.index] == '\n') this.index++;
-
-							// Skip any whitespace before the /// sequence
-							while (this.index < this.javadocEnd && ScannerHelper.isWhitespace(this.source[this.index])) {
-						        this.index++;
-						    }
-
-							// Skip exact '///' sequence if present
-							if (this.index + 2 < this.javadocEnd &&
-									this.source[this.index] == '/' &&
-									this.source[this.index + 1] == '/' &&
-									this.source[this.index + 2] == '/') {
-								this.index += 3;
-							}
-
-							// Skip additional whitespace after ///
-							while (this.index < this.javadocEnd && ScannerHelper.isWhitespace(this.source[this.index])) {
-								this.index++;
-							}
-							// Preserve textStart position for continued tag content
-							if (this.textStart == -1) {
-								this.textStart = this.index;
-							}
+						if (this.inlineTagStarted && this.markdown) {
+							isTagElementClose = true;
 						}
 						break;
 					case '}' :
@@ -401,16 +375,11 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 								}
 								refreshInlineTagPosition(previousPosition);
 							}
-							if (!isFormatterParser && !treatAsText && (!this.inlineReturn || this.inlineReturnOpenBraces <= 0)) {
-								// Reset textStart only if there's content after the tag
-								if (this.index < this.javadocEnd) {
-									char next = this.source[this.index];
-									if (!(this.markdown && (next == '\r' || next == '\n'))) {
-										this.textStart = this.index;
-									}
-								}
+							if (!isFormatterParser && !treatAsText && (!this.inlineReturn || this.inlineReturnOpenBraces <= 0))
+								this.textStart = this.index;
+							if ((!isTagElementClose && this.markdown) || !this.markdown) {  //The comment parser should create a TagElement only if the previous one is closed - markdown.
+								setInlineTagStarted(false);
 							}
-							setInlineTagStarted(false);
 							if (this.inlineReturn) {
 								if (this.inlineReturnOpenBraces > 0) {
 									--this.inlineReturnOpenBraces;
@@ -435,39 +404,30 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 						// https://bugs.eclipse.org/bugs/show_bug.cgi?id=206345: count opening braces when ignoring tags
 						if (considerTagAsPlainText) {
 							openingBraces++;
-						} else {
-							if (this.markdown) {
-								if (this.inlineTagStarted && this.tagValue == TAG_RETURN_VALUE) {
-									this.inlineReturn= true;
-									this.inlineReturnOpenBraces++;
-								}
-							} else {
-								if (this.inlineTagStarted) {
-									if (this.tagValue == TAG_RETURN_VALUE) {
-										this.inlineReturn= true;
-									}
-									if (this.inlineReturn && peekChar() != '@') {
-										++this.inlineReturnOpenBraces;
-										doNotResetInlineTagStart= true;
-									} else {
-										if (this.lineStarted && this.textStart != -1 && this.textStart < textEndPosition) {
-											pushText(this.textStart, textEndPosition);
-										}
-										setInlineTagStarted(false);
-										// bug https://bugs.eclipse.org/bugs/show_bug.cgi?id=53279
-										// Cannot have opening brace in inline comment
-										if (this.reportProblems && !this.inlineReturn) {
-											int end = previousPosition<invalidInlineTagLineEnd ? previousPosition : invalidInlineTagLineEnd;
-											this.sourceParser.problemReporter().javadocUnterminatedInlineTag(this.inlineTagStart, end);
-										}
-										refreshInlineTagPosition(textEndPosition);
-										textEndPosition = this.index;
-									}
-								} else if (peekChar() != '@') {
-									if (this.textStart == -1) this.textStart = previousPosition;
-									textEndPosition = this.index;
-								}
+						} else if (this.inlineTagStarted) {
+							if (this.tagValue == TAG_RETURN_VALUE) {
+								this.inlineReturn= true;
 							}
+							if (this.inlineReturn && peekChar() != '@') {
+								++this.inlineReturnOpenBraces;
+								doNotResetInlineTagStart= true;
+							} else {
+								if (this.lineStarted && this.textStart != -1 && this.textStart < textEndPosition) {
+									pushText(this.textStart, textEndPosition);
+								}
+								setInlineTagStarted(false);
+								// bug https://bugs.eclipse.org/bugs/show_bug.cgi?id=53279
+								// Cannot have opening brace in inline comment
+								if (this.reportProblems && !this.inlineReturn) {
+									int end = previousPosition<invalidInlineTagLineEnd ? previousPosition : invalidInlineTagLineEnd;
+									this.sourceParser.problemReporter().javadocUnterminatedInlineTag(this.inlineTagStart, end);
+								}
+								refreshInlineTagPosition(textEndPosition);
+								textEndPosition = this.index;
+							}
+						} else if (peekChar() != '@') {
+							if (this.textStart == -1) this.textStart = previousPosition;
+							textEndPosition = this.index;
 						}
 						if (!this.lineStarted && !this.inlineReturn) {
 							this.textStart = previousPosition;

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterMarkdownTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterMarkdownTest.java
@@ -1882,134 +1882,14 @@ public class ASTConverterMarkdownTest extends ConverterTestSetup {
 			List<TagElement> te = javadoc.tags();
 			assertEquals("TagElement length is grater than one", 1, te.size());
 			List<TagElement> tes = (te.get(0)).fragments();
-			assertEquals("fragments count does not match", 2, tes.size());
+//			assertEquals("fragments count does not match", 1, tes.size());
 			assertEquals("TagName", "@link", tes.get(0).getTagName());
 			List<?> fragments = tes.get(0).fragments();
-
-			assertTrue(fragments.get(0) instanceof MethodRef);
-			assertTrue(fragments.get(1) instanceof TextElement);
-			assertEquals("Incorrect text", "value{", fragments.get(1).toString());
-			assertEquals("Incorrect name", "#getValue()", fragments.get(0).toString());
-		}
-	}
-
-	public void testTagElementRetrieveIncorrectly_3912_01() throws JavaModelException {
-		String source= """
-				/// {@link #getValue()
-				/// value} dsfsdf
-				public class IncorrectTagElement {}
-				""";
-		this.workingCopies = new ICompilationUnit[1];
-		this.workingCopies[0] = getWorkingCopy("/Converter_23/src/markdown/gh3761/IncorrectTagElement.java", source, null);
-		if (this.docCommentSupport.equals(JavaCore.ENABLED)) {
-			CompilationUnit compilUnit = (CompilationUnit) runConversion(this.workingCopies[0], true);
-			TypeDeclaration typedeclaration =  (TypeDeclaration) compilUnit.types().get(0);
-			Javadoc javadoc = typedeclaration.getJavadoc();
-			List<TagElement> te = javadoc.tags();
-			assertEquals("TagElement length is grater than one", 1, te.size());
-			List<?> tes = te.get(0).fragments();
-			assertEquals("fragments count does not match", 2, tes.size());
-			assertEquals("TagName", "@link", ((TagElement) tes.get(0)).getTagName());
-			List<?> fragments = ((TagElement) tes.get(0)).fragments();
 			assertTrue(fragments.get(0) instanceof MethodRef);
 			assertTrue(fragments.get(1) instanceof TextElement);
 			assertEquals("Incorrect text", "value", fragments.get(1).toString());
 			assertEquals("Incorrect name", "#getValue()", fragments.get(0).toString());
-			assertEquals("TextElement in correct", " dsfsdf", tes.get(1).toString());
-		}
-	}
-
-	public void testTagElementRetrieveIncorrectly_3912_02() throws JavaModelException {
-		String source= """
-				/// {@link #getValue()
-				/// value}} }dsfsdf {@link #getValue()
-				/// value1 } test
-				public class IncorrectTagElement {}
-				""";
-		this.workingCopies = new ICompilationUnit[1];
-		this.workingCopies[0] = getWorkingCopy("/Converter_23/src/markdown/gh3761/IncorrectTagElement.java", source, null);
-		if (this.docCommentSupport.equals(JavaCore.ENABLED)) {
-			CompilationUnit compilUnit = (CompilationUnit) runConversion(this.workingCopies[0], true);
-			TypeDeclaration typedeclaration =  (TypeDeclaration) compilUnit.types().get(0);
-			Javadoc javadoc = typedeclaration.getJavadoc();
-			List<TagElement> te = javadoc.tags();
-			assertEquals("TagElement length is grater than one", 1, te.size());
-			List<?> tes = te.get(0).fragments();
-			assertEquals("fragments count does not match", 4, tes.size());
-			assertEquals("TagName", "@link", ((TagElement) tes.get(0)).getTagName());
-			List<?> fragments = ((TagElement) tes.get(0)).fragments();
-			assertTrue(fragments.get(0) instanceof MethodRef);
-			assertTrue(fragments.get(1) instanceof TextElement);
-			assertEquals("Incorrect text", "value", fragments.get(1).toString());
-			assertEquals("Incorrect name", "#getValue()", fragments.get(0).toString());
-			assertEquals("TextElement in correct", "} }dsfsdf ", tes.get(1).toString());
-
-			List<?> secondTagElement =  ((TagElement) tes.get(2)).fragments();
-			assertTrue(secondTagElement.get(0) instanceof MethodRef);
-			assertTrue(secondTagElement.get(1) instanceof TextElement);
-			assertEquals("Incorrect text", "value1 ", secondTagElement.get(1).toString());
-			assertEquals("Incorrect name", "#getValue()", secondTagElement.get(0).toString());
-
-			assertEquals("TextElement in correct", " test", tes.get(3).toString());
-
-
-		}
-	}
-
-	public void testTagElementRetrieveIncorrectly_3912_03() throws JavaModelException {
-		String source= """
-				/// {@link https://www.eclipse.org}
-				public class IncorrectTagElement {}
-				""";
-		this.workingCopies = new ICompilationUnit[1];
-		this.workingCopies[0] = getWorkingCopy("/Converter_23/src/markdown/gh3761/IncorrectTagElement.java", source, null);
-		if (this.docCommentSupport.equals(JavaCore.ENABLED)) {
-			CompilationUnit compilUnit = (CompilationUnit) runConversion(this.workingCopies[0], true);
-			TypeDeclaration typedeclaration =  (TypeDeclaration) compilUnit.types().get(0);
-			Javadoc javadoc = typedeclaration.getJavadoc();
-			List<TagElement> te = javadoc.tags();
-			assertEquals("TagElement length is grater than one", 1, te.size());
-			List<?> tes = te.get(0).fragments();
-			assertTrue(tes.get(0) instanceof TagElement);
-			List<?> fragments = ((TagElement) tes.get(0)).fragments();
-			assertTrue(fragments.get(0) instanceof TextElement);
-			assertEquals("TextElement in correct", " https://www.eclipse.org", fragments.get(0).toString());
-		}
-	}
-
-	//This test is similar to testTagElementRetrieveIncorrectly_3912_02. Add white spaces before ///
-	public void testTagElementRetrieveIncorrectly_3912_04() throws JavaModelException {
-		String source= """
-				///{@link #getValue()
-				 /// value}} }dsfsdf {@link #getValue()
-				 /// value1 } test
-				public class IncorrectTagElement {}
-				""";
-		this.workingCopies = new ICompilationUnit[1];
-		this.workingCopies[0] = getWorkingCopy("/Converter_23/src/markdown/gh3761/IncorrectTagElement.java", source, null);
-		if (this.docCommentSupport.equals(JavaCore.ENABLED)) {
-			CompilationUnit compilUnit = (CompilationUnit) runConversion(this.workingCopies[0], true);
-			TypeDeclaration typedeclaration =  (TypeDeclaration) compilUnit.types().get(0);
-			Javadoc javadoc = typedeclaration.getJavadoc();
-			List<TagElement> te = javadoc.tags();
-			assertEquals("TagElement length is grater than one", 1, te.size());
-			List<?> tes = te.get(0).fragments();
-			assertEquals("fragments count does not match", 4, tes.size());
-			assertEquals("TagName", "@link", ((TagElement) tes.get(0)).getTagName());
-			List<?> fragments = ((TagElement) tes.get(0)).fragments();
-			assertTrue(fragments.get(0) instanceof MethodRef);
-			assertTrue(fragments.get(1) instanceof TextElement);
-			assertEquals("Incorrect text", "value", fragments.get(1).toString());
-			assertEquals("Incorrect name", "#getValue()", fragments.get(0).toString());
-			assertEquals("TextElement in correct", "} }dsfsdf ", tes.get(1).toString());
-
-			List<?> secondTagElement =  ((TagElement) tes.get(2)).fragments();
-			assertTrue(secondTagElement.get(0) instanceof MethodRef);
-			assertTrue(secondTagElement.get(1) instanceof TextElement);
-			assertEquals("Incorrect text", "value1 ", secondTagElement.get(1).toString());
-			assertEquals("Incorrect name", "#getValue()", secondTagElement.get(0).toString());
-
-			assertEquals("TextElement in correct", " test", tes.get(3).toString());
+			assertTrue(te.get(0).getLength() < tes.get(0).getLength());
 		}
 	}
 


### PR DESCRIPTION
This reverts commit e22815faa9e996e698758df29abb865e1b697a48.

In light of the discussion https://github.com/eclipse-jdt/eclipse.jdt.core/pull/4519#issuecomment-3430723318, reverting https://github.com/eclipse-jdt/eclipse.jdt.core/pull/4203

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
