### PR TITLE
ECJ accepts ambiguous method call between concrete parameter and bounded type variable while javac rejects as ambiguous

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/BatchCompilerTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/BatchCompilerTest.java
@@ -8140,6 +8140,15 @@ public void test230_sourcepath_vs_classpath() throws IOException, InterruptedExc
 		"[reading    java/lang/System.class]\n" +
 		"[reading    java/io/PrintStream.class]\n" +
 		"[reading    X.class]\n" +
+		"[reading    java/io/FilterOutputStream.class]\n" +
+		"[reading    java/io/OutputStream.class]\n" +
+		"[reading    java/io/Flushable.class]\n" +
+		"[reading    java/io/Closeable.class]\n" +
+		"[reading    java/lang/AutoCloseable.class]\n" +
+		"[reading    java/lang/Integer.class]\n" +
+		"[reading    java/lang/Number.class]\n" +
+		"[reading    java/io/Serializable.class]\n" +
+		"[reading    java/lang/Appendable.class]\n" +
 		"[writing    Y.class - #1]\n" +
 		"[completed  ---OUTPUT_DIR_PLACEHOLDER---/Y.java - #1/1]\n" +
 		"[1 unit compiled]\n" +
@@ -8169,6 +8178,15 @@ public void test230_sourcepath_vs_classpath() throws IOException, InterruptedExc
 			"[reading    java/lang/System.class]\n" +
 			"[reading    java/io/PrintStream.class]\n" +
 			"[parsing    ---OUTPUT_DIR_PLACEHOLDER---/src2/X.java - #2/2]\n" +
+			"[reading    java/io/FilterOutputStream.class]\n" +
+			"[reading    java/io/OutputStream.class]\n" +
+			"[reading    java/io/Flushable.class]\n" +
+			"[reading    java/io/Closeable.class]\n" +
+			"[reading    java/lang/AutoCloseable.class]\n" +
+			"[reading    java/lang/Integer.class]\n" +
+			"[reading    java/lang/Number.class]\n" +
+			"[reading    java/io/Serializable.class]\n" +
+			"[reading    java/lang/Appendable.class]\n" +
 			"[writing    Y.class - #1]\n" +
 			"[completed  ---OUTPUT_DIR_PLACEHOLDER---/Y.java - #1/2]\n" +
 			"[analyzing  ---OUTPUT_DIR_PLACEHOLDER---/src2/X.java - #2/2]\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
@@ -1781,6 +1781,37 @@ public void testGH1501() {
 		----------
 		""");
 }
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4357
+// ECJ accepts ambiguous method call between concrete parameter and bounded type variable while javac rejects as ambiguous
+public void testIssue4357() {
+	this.runNegativeTest(
+		new String[] {
+			"Test.java",
+			"""
+			public class Test {
+			    public static void main(String[] args) {
+			        TemplateClass<String> instance = new TemplateClass<>();
+			        instance.specializedMethod("test");
+			    }
+			}
+
+			class TemplateClass<T> {
+
+			    public void specializedMethod(String value) {
+			    }
+
+			    public <U extends T> void specializedMethod(U value) {
+			    }
+			}
+			""",
+		},
+		"----------\n" +
+		"1. ERROR in Test.java (at line 4)\n" +
+		"	instance.specializedMethod(\"test\");\n" +
+		"	         ^^^^^^^^^^^^^^^^^\n" +
+		"The method specializedMethod(String) is ambiguous for the type TemplateClass<String>\n" +
+		"----------\n");
+}
 public static Class<GenericsRegressionTest_9> testClass() {
 	return GenericsRegressionTest_9.class;
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ProblemTypeAndMethodTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ProblemTypeAndMethodTest.java
@@ -8870,6 +8870,11 @@ public void testMissingClassNeededForOverloadResolution_varargs1b() {
 				  ^
 			The method m(A1...) from the type B refers to the missing type A1
 			----------
+			8. ERROR in p2\\C.java (at line 12)
+				b.m(new String[0]);	// exact match
+				  ^
+			The method m(A1...) from the type B refers to the missing type A1
+			----------
 			""";
 	runner.runNegativeTest();
 }

--- a/org.eclipse.jdt.core/eval/org/eclipse/jdt/internal/eval/CodeSnippetMessageSend.java
+++ b/org.eclipse.jdt.core/eval/org/eclipse/jdt/internal/eval/CodeSnippetMessageSend.java
@@ -286,8 +286,15 @@ public TypeBinding resolveType(BlockScope scope) {
 						return null;
 					}
 				}
-				scope.problemReporter().invalidMethod(this, this.binding, scope);
-				return null;
+				if (privateBinding instanceof ProblemMethodBinding problemMethod && problemMethod.problemId() == ProblemReasons.NotVisible) {
+					MethodBinding resolvedMethod = problemMethod.closestMatch;
+					if (this.delegateThis.type.isInterface() || localScope.canBeSeenByForCodeSnippet(resolvedMethod, this.delegateThis.type,  this, localScope))
+						this.binding = resolvedMethod;
+				}
+				if (!this.binding.isValidBinding()) {
+					scope.problemReporter().invalidMethod(this, this.binding, scope);
+					return null;
+				}
 			} else {
 				this.binding = privateBinding;
 			}

--- a/org.eclipse.jdt.core/eval/org/eclipse/jdt/internal/eval/CodeSnippetScope.java
+++ b/org.eclipse.jdt.core/eval/org/eclipse/jdt/internal/eval/CodeSnippetScope.java
@@ -243,16 +243,6 @@ public final boolean canBeSeenByForCodeSnippet(ReferenceBinding referenceBinding
 	return receiverType.fPackage == referenceBinding.fPackage;
 }
 // Internal use only
-@Override
-public MethodBinding findExactMethod(ReferenceBinding receiverType, char[] selector, TypeBinding[] argumentTypes, InvocationSite invocationSite) {
-	MethodBinding exactMethod = receiverType.getExactMethod(selector, argumentTypes, null);
-	if (exactMethod != null){
-		if (receiverType.isInterface() || canBeSeenByForCodeSnippet(exactMethod, receiverType, invocationSite, this))
-			return exactMethod;
-	}
-	return null;
-}
-// Internal use only
 
 /*	Answer the field binding that corresponds to fieldName.
 	Start the lookup at the receiverType.
@@ -590,10 +580,8 @@ public FieldBinding getFieldForCodeSnippet(TypeBinding receiverType, char[] fiel
 */
 
 public MethodBinding getImplicitMethod(ReferenceBinding receiverType, char[] selector, TypeBinding[] argumentTypes, InvocationSite invocationSite) {
-	// retrieve an exact visible match (if possible)
-	MethodBinding methodBinding = findExactMethod(receiverType, selector, argumentTypes, invocationSite);
-	if (methodBinding == null)
-		methodBinding = findMethod(receiverType, selector, argumentTypes, invocationSite, false);
+
+	MethodBinding methodBinding = findMethod(receiverType, selector, argumentTypes, invocationSite, false);
 	if (methodBinding != null) { // skip it if we did not find anything
 		if (methodBinding.isValidBinding())
 		    if (!canBeSeenByForCodeSnippet(methodBinding, receiverType, invocationSite, this))


### PR DESCRIPTION
* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4357