### PR TITLE
Valid java code with multiple upper bounded type parameter with wildcards gives "cannot be implemented more than once with different arguments"

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Scope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Scope.java
@@ -3731,13 +3731,48 @@ public abstract class Scope {
 				Object value = invocations.get(mec);
 				if (value instanceof TypeBinding[]) {
 					TypeBinding[] invalidInvocations = (TypeBinding[]) value;
-					problemReporter().superinterfacesCollide(invalidInvocations[0].erasure(), typeRef, invalidInvocations[0], invalidInvocations[1]);
-					type.tagBits |= TagBits.HierarchyHasProblems;
-					return true;
+					if (areSignificantlyDifferent(invalidInvocations[0], invalidInvocations[1])) {
+						problemReporter().superinterfacesCollide(invalidInvocations[0].erasure(), typeRef, invalidInvocations[0], invalidInvocations[1]);
+						type.tagBits |= TagBits.HierarchyHasProblems;
+						return true;
+					}
 				}
 			}
 		}
 		return false;
+	}
+
+	private boolean areSignificantlyDifferent(TypeBinding one, TypeBinding two) {
+		if (!one.enterRecursiveFunction())
+			return true;
+		try {
+			if (one instanceof ParameterizedTypeBinding ptb1 && two instanceof ParameterizedTypeBinding ptb2) {
+				if (TypeBinding.notEquals(ptb1.erasure(), ptb2.erasure()))
+					return true;
+				return areSignificantlyDifferent(ptb1.arguments, ptb2.arguments);
+			} else if (one instanceof WildcardBinding wb1 && two instanceof WildcardBinding wb2) {
+				if (wb1.boundKind() != wb2.boundKind())
+					return true;
+				if (TypeBinding.notEquals(wb1.bound, wb2.bound))
+					return true;
+				return areSignificantlyDifferent(wb1.otherBounds, wb2.otherBounds);
+			}
+			return TypeBinding.notEquals(one, two);
+		} finally {
+			one.exitRecursiveFunction();
+		}
+	}
+
+	private boolean areSignificantlyDifferent(TypeBinding[] ones, TypeBinding[] twos) {
+		if (ones == null || twos == null)
+			return ones != twos;
+		if (ones.length != twos.length)
+			return true;
+		for (int i = 0; i < ones.length; i++) {
+			if (areSignificantlyDifferent(ones[i], twos[i]))
+				return true;
+		}
+		return false; // no significant difference found
 	}
 
 	/**

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
@@ -1781,6 +1781,43 @@ public void testGH1501() {
 		----------
 		""");
 }
+public void testGH4463() {
+	runConformTest(new String[] {
+		"A.java",
+		"""
+		interface A<T> {}
+		interface B<T> extends A<T> {}
+		interface C<T> extends A<T> {}
+
+		class BC1 implements B<String>, C<String> {}
+		class BC2 implements B<Integer>, C<Integer> {}
+
+		// Eclipse Compile error "The interface A cannot be implemented more than once with different arguments: A<?> and A<?>"
+		interface IHelperBC<T extends B<?> & C<?>> {}
+
+		class HelperBC1 implements IHelperBC<BC1> {}
+		class HelperBC2 implements IHelperBC<BC2> {}
+		"""
+	});
+}
+public void testGH4463b() {
+	runConformTest(new String[] {
+		"A.java",
+		"""
+		interface A<T> {}
+		interface B<T> extends A<T> {}
+		interface C<T> extends A<T> {}
+
+		class BC1 implements B<String>, C<String> {}
+		class BC2 implements B<Integer>, C<Integer> {}
+
+		// eclipse compile error "The interface A cannot be implemented more than once with different arguments: A<? super T> and A<? super T>"
+		interface IHelperBCSuper<T, BC extends B<? super T> & C<? super T>> {}
+		// eclipse compile error "The interface A cannot be implemented more than once with different arguments: A<? extends T> and A<? extends T>"
+		interface IHelperBCExtends<T, BC extends B<? extends T> & C<? extends T>> {}
+		"""
+	});
+}
 public static Class<GenericsRegressionTest_9> testClass() {
 	return GenericsRegressionTest_9.class;
 }


### PR DESCRIPTION
+ weaken this particular check, to admit pairs of equivalent wildcards at the same rank (at any nesting level)

https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4463
