### PR TITLE
Markdown Javadoc links to URLs not properly interpreted 4531

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/JavadocParser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/JavadocParser.java
@@ -581,6 +581,8 @@ public class JavadocParser extends AbstractCommentParser {
 						// move it past '['
 						currentChar = readChar();
 						start = this.index;
+					} else if (peekChar() == '(') {
+						valid = parseURLReference(this.index, true);
 					} else {
 						break loop;
 					}
@@ -602,7 +604,8 @@ public class JavadocParser extends AbstractCommentParser {
 		int eofBkup = this.scanner.eofPosition;
 		this.scanner.resetTo(start, Math.max(this.javadocEnd, this.index));
 		this.tagValue = TAG_LINK_VALUE;
-		valid = parseReference(true);
+		if (!valid)
+			valid = parseReference(true);
 		this.tagValue = NO_TAG_VALUE;
 		this.scanner.eofPosition = eofBkup;
 		this.markdownHelper.resetLineStart();

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterMarkdownTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterMarkdownTest.java
@@ -1931,4 +1931,250 @@ public class ASTConverterMarkdownTest extends ConverterTestSetup {
 			assertEquals("Incorrect TextElement value", "Where is my **bold text**???", textElement.getText());
 		}
 	}
+	public void testMarkdownURLs4531_01() throws JavaModelException {
+		String source = """
+				/// @see [Ex Si](ex.com)
+				public class Markdown() {}
+				""";
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy("/Converter_25/src/markdown/gh3761/Markdown.java", source, null);
+		if (this.docCommentSupport.equals(JavaCore.ENABLED)) {
+			CompilationUnit compilUnit = (CompilationUnit) runConversion(this.workingCopies[0], true);
+			TypeDeclaration typedeclaration =  (TypeDeclaration) compilUnit.types().get(0);
+			Javadoc javadoc = typedeclaration.getJavadoc();
+			TagElement tags = (TagElement) javadoc.tags().get(0);
+			assertEquals("fragments count does not match", 2, tags.fragments().size());
+			TagElement tagElement = (TagElement) tags.fragments().get(1);
+			List<?> tagFragments = tagElement.fragments();
+			assertTrue(tagFragments.get(0) instanceof TextElement);
+			assertTrue(tagFragments.get(1) instanceof SimpleName);
+		}
+	}
+
+	public void testMarkdownURLs4531_02() throws JavaModelException {
+		String source = """
+				/// @see [Ex Si](http://ex.com)
+				public class Markdown() {}
+				""";
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy("/Converter_25/src/markdown/gh3761/Markdown.java", source, null);
+		if (this.docCommentSupport.equals(JavaCore.ENABLED)) {
+			CompilationUnit compilUnit = (CompilationUnit) runConversion(this.workingCopies[0], true);
+			TypeDeclaration typedeclaration =  (TypeDeclaration) compilUnit.types().get(0);
+			Javadoc javadoc = typedeclaration.getJavadoc();
+			TagElement tags = (TagElement) javadoc.tags().get(0);
+			assertEquals("fragments count does not match", 2, tags.fragments().size());
+			TagElement tagElement = (TagElement) tags.fragments().get(1);
+			List<?> tagFragments = tagElement.fragments();
+			assertTrue(tagFragments.get(0) instanceof TextElement);
+			assertTrue(tagFragments.get(1) instanceof SimpleName);
+		}
+	}
+
+	public void testMarkdownURLs4531_03() throws JavaModelException {
+		String source = """
+				/// @see [Ex Si](https://ex.com/a)
+				public class Markdown() {}
+				""";
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy("/Converter_25/src/markdown/gh3761/Markdown.java", source, null);
+		if (this.docCommentSupport.equals(JavaCore.ENABLED)) {
+			CompilationUnit compilUnit = (CompilationUnit) runConversion(this.workingCopies[0], true);
+			TypeDeclaration typedeclaration =  (TypeDeclaration) compilUnit.types().get(0);
+			Javadoc javadoc = typedeclaration.getJavadoc();
+			TagElement tags = (TagElement) javadoc.tags().get(0);
+			assertEquals("fragments count does not match", 2, tags.fragments().size());
+			TagElement tagElement = (TagElement) tags.fragments().get(1);
+			List<?> tagFragments = tagElement.fragments();
+			assertTrue(tagFragments.get(0) instanceof TextElement);
+			assertTrue(tagFragments.get(1) instanceof SimpleName);
+		}
+	}
+
+	public void testMarkdownURLs4531_04() throws JavaModelException {
+		String source = """
+				/// @see [Ex Si](https://www.ex.net/a)
+				public class Markdown() {}
+				""";
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy("/Converter_25/src/markdown/gh3761/Markdown.java", source, null);
+		if (this.docCommentSupport.equals(JavaCore.ENABLED)) {
+			CompilationUnit compilUnit = (CompilationUnit) runConversion(this.workingCopies[0], true);
+			TypeDeclaration typedeclaration =  (TypeDeclaration) compilUnit.types().get(0);
+			Javadoc javadoc = typedeclaration.getJavadoc();
+			TagElement tags = (TagElement) javadoc.tags().get(0);
+			assertEquals("fragments count does not match", 2, tags.fragments().size());
+			TagElement tagElement = (TagElement) tags.fragments().get(1);
+			List<?> tagFragments = tagElement.fragments();
+			assertTrue(tagFragments.get(0) instanceof TextElement);
+			assertTrue(tagFragments.get(1) instanceof SimpleName);
+		}
+	}
+
+	// invalid syntax
+	public void testMarkdownURLs4531_05() throws JavaModelException {
+		String source = """
+				/// @see [Ex Si][http://ex.com]
+				public class Markdown() {}
+				""";
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy("/Converter_25/src/markdown/gh3761/Markdown.java", source, null);
+		if (this.docCommentSupport.equals(JavaCore.ENABLED)) {
+			CompilationUnit compilUnit = (CompilationUnit) runConversion(this.workingCopies[0], true);
+			TypeDeclaration typedeclaration =  (TypeDeclaration) compilUnit.types().get(0);
+			Javadoc javadoc = typedeclaration.getJavadoc();
+			TagElement tags = (TagElement) javadoc.tags().get(0);
+			assertEquals("fragments count does not match", 3, tags.fragments().size());
+			assertTrue(tags.fragments().get(0) instanceof TextElement);
+			assertTrue(tags.fragments().get(1) instanceof TextElement);
+			assertTrue(tags.fragments().get(2) instanceof TextElement);
+		}
+	}
+
+	// [)[) - invalid condition
+	public void testMarkdownURLs4531_06() throws JavaModelException {
+		String source = """
+				/// @see [Ex Si)[http://ex.com)
+				public class Markdown() {}
+				""";
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy("/Converter_25/src/markdown/gh3761/Markdown.java", source, null);
+		if (this.docCommentSupport.equals(JavaCore.ENABLED)) {
+			CompilationUnit compilUnit = (CompilationUnit) runConversion(this.workingCopies[0], true);
+			TypeDeclaration typedeclaration =  (TypeDeclaration) compilUnit.types().get(0);
+			Javadoc javadoc = typedeclaration.getJavadoc();
+			assertEquals("Tags count does not match", 1, javadoc.tags().size());
+			TagElement tags = (TagElement) javadoc.tags().get(0);
+			assertTrue(tags.fragments().get(0) instanceof TextElement);
+			assertTrue(tags.fragments().get(1) instanceof TextElement);
+		}
+	}
+
+	// (](] - invalid condition
+	public void testMarkdownURLs4531_07() throws JavaModelException {
+		String source = """
+				/// @see (Ex Si](http://ex.com]
+				public class Markdown() {}
+				""";
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy("/Converter_25/src/markdown/gh3761/Markdown.java", source, null);
+		if (this.docCommentSupport.equals(JavaCore.ENABLED)) {
+			CompilationUnit compilUnit = (CompilationUnit) runConversion(this.workingCopies[0], true);
+			TypeDeclaration typedeclaration =  (TypeDeclaration) compilUnit.types().get(0);
+			Javadoc javadoc = typedeclaration.getJavadoc();
+			TagElement tags = (TagElement) javadoc.tags().get(0);
+			assertEquals("fragments count does not match", 1, tags.fragments().size());
+			assertTrue(tags.fragments().get(0) instanceof TextElement);
+		}
+	}
+
+	// ()[] - invalid condition
+	public void testMarkdownURLs4531_08() throws JavaModelException {
+		String source = """
+				/// @see (Ex Si)[http://ex.com]
+				public class Markdown() {}
+				""";
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy("/Converter_25/src/markdown/gh3761/Markdown.java", source, null);
+		if (this.docCommentSupport.equals(JavaCore.ENABLED)) {
+			CompilationUnit compilUnit = (CompilationUnit) runConversion(this.workingCopies[0], true);
+			TypeDeclaration typedeclaration =  (TypeDeclaration) compilUnit.types().get(0);
+			Javadoc javadoc = typedeclaration.getJavadoc();
+			TagElement tags = (TagElement) javadoc.tags().get(0);
+			assertEquals("fragments count does not match", 2, tags.fragments().size());
+			assertTrue(tags.fragments().get(0) instanceof TextElement);
+			assertTrue(tags.fragments().get(1) instanceof TextElement);
+		}
+	}
+
+	public void testMarkdownURLs4531_09() throws JavaModelException {
+		String source = """
+				/// @see [Ex Si](                         http://ex.com)
+				public class Markdown() {}
+				""";
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy("/Converter_25/src/markdown/gh3761/Markdown.java", source, null);
+		if (this.docCommentSupport.equals(JavaCore.ENABLED)) {
+			CompilationUnit compilUnit = (CompilationUnit) runConversion(this.workingCopies[0], true);
+			TypeDeclaration typedeclaration =  (TypeDeclaration) compilUnit.types().get(0);
+			Javadoc javadoc = typedeclaration.getJavadoc();
+			TagElement tags = (TagElement) javadoc.tags().get(0);
+			assertEquals("fragments count does not match", 2, tags.fragments().size());
+			assertTrue(tags.fragments().get(0) instanceof TextElement);
+			assertTrue(tags.fragments().get(1) instanceof TagElement);
+			TagElement fragTag = (TagElement) tags.fragments().get(1);
+			assertTrue(fragTag.fragments().get(0) instanceof TextElement);
+			assertTrue(fragTag.fragments().get(1) instanceof SimpleName);
+		}
+	}
+
+	public void testMarkdownURLs4531_10() throws JavaModelException {
+		String source = """
+				/// @see [Ex Si][java.lang.String]
+				public class Markdown() {}
+				""";
+
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy("/Converter_25/src/markdown/gh3761/Markdown.java", source, null);
+		if (this.docCommentSupport.equals(JavaCore.ENABLED)) {
+			CompilationUnit compilUnit = (CompilationUnit) runConversion(this.workingCopies[0], true);
+			TypeDeclaration typedeclaration =  (TypeDeclaration) compilUnit.types().get(0);
+			Javadoc javadoc = typedeclaration.getJavadoc();
+			TagElement tags = (TagElement) javadoc.tags().get(0);
+			assertEquals("fragments count does not match", 2, tags.fragments().size());
+			assertTrue(tags.fragments().get(0) instanceof TextElement);
+			assertTrue(tags.fragments().get(1) instanceof TagElement);
+			TagElement fragTag = (TagElement) tags.fragments().get(1);
+			assertTrue(fragTag.fragments().get(0) instanceof TextElement);
+			assertTrue(fragTag.fragments().get(1) instanceof QualifiedName);
+		}
+	}
+
+	public void testMarkdownURLs4531_11() throws JavaModelException {
+		String source = """
+				/// @see [Ex Si][               java.lang.String]
+				public class Markdown() {}
+				""";
+
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy("/Converter_25/src/markdown/gh3761/Markdown.java", source, null);
+		if (this.docCommentSupport.equals(JavaCore.ENABLED)) {
+			CompilationUnit compilUnit = (CompilationUnit) runConversion(this.workingCopies[0], true);
+			TypeDeclaration typedeclaration =  (TypeDeclaration) compilUnit.types().get(0);
+			Javadoc javadoc = typedeclaration.getJavadoc();
+			TagElement tags = (TagElement) javadoc.tags().get(0);
+			assertEquals("fragments count does not match", 2, tags.fragments().size());
+			assertTrue(tags.fragments().get(0) instanceof TextElement);
+			assertTrue(tags.fragments().get(1) instanceof TagElement);
+			TagElement fragTag = (TagElement) tags.fragments().get(1);
+			assertTrue(fragTag.fragments().get(0) instanceof TextElement);
+			assertTrue(fragTag.fragments().get(1) instanceof QualifiedName);
+		}
+	}
+
+	public void testMarkdownURLs4531_12() throws JavaModelException {
+		String source = """
+				/// @see [Ex Si](http://ex.com    ) [Ex Si](    https://www.ex.com)
+				public class Markdown() {}
+				""";
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy("/Converter_25/src/markdown/gh3761/Markdown.java", source, null);
+		if (this.docCommentSupport.equals(JavaCore.ENABLED)) {
+			CompilationUnit compilUnit = (CompilationUnit) runConversion(this.workingCopies[0], true);
+			TypeDeclaration typedeclaration =  (TypeDeclaration) compilUnit.types().get(0);
+			Javadoc javadoc = typedeclaration.getJavadoc();
+			TagElement tags = (TagElement) javadoc.tags().get(0);
+			assertEquals("fragments count does not match", 4, tags.fragments().size());
+			assertTrue(tags.fragments().get(0) instanceof TextElement);
+			assertTrue(tags.fragments().get(1) instanceof TagElement);
+			TagElement tagFrag1 = (TagElement) tags.fragments().get(1);
+			SimpleName simplName1 = (SimpleName) tagFrag1.fragments().get(1);
+			assertEquals("SimpleName1 value not match", "http://ex.com", simplName1.getIdentifier());
+			assertTrue(tags.fragments().get(0) instanceof TextElement);
+			assertTrue(tags.fragments().get(1) instanceof TagElement);
+			TagElement tagFrag2 = (TagElement) tags.fragments().get(3);
+			SimpleName simplName2 = (SimpleName) tagFrag2.fragments().get(1);
+			assertEquals("SimpleName2 value not match", "https://www.ex.com", simplName2.getIdentifier());
+		}
+	}
 }


### PR DESCRIPTION
Markdown links `[description](url)` syntax now interpreting properly

Fix: https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4531

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
Scenario 1
---------
`/// @see [Ex Si](ex.com)`

Scenario 2
----------
`/// @see [Ex Si](http://ex.com)`. --> `http/https/ http://www` similar cases

Scenario 3
----------
`/// @see [Ex Si][http://ex.com]`
## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
