### PR TITLE
Fix 3 layer nested method calls with the return type includes a wildcard

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
@@ -425,8 +425,8 @@ public class InferenceContext18 {
 			if (!addConstraintsToC(this.invocationArguments, c, method, this.inferenceKind, invocationSite))
 				return null;
 			// 5. bullet: determine B4 from C
-			List<Set<InferenceVariable>> components = this.currentBounds.computeConnectedComponents(this.inferenceVariables);
 			while (!c.isEmpty()) {
+				List<Set<InferenceVariable>> components = this.currentBounds.computeConnectedComponents(this.inferenceVariables);
 				// *
 				Set<ConstraintFormula> bottomSet = findBottomSet(c, allOutputVariables(c), components);
 				if (bottomSet.isEmpty()) {
@@ -459,6 +459,12 @@ public class InferenceContext18 {
 				// * reduce and incorporate
 					if (!this.currentBounds.reduceOneConstraint(this, constraint))
 						return null;
+				}
+				for (ConstraintFormula constraint : bottomSet) {
+					// https://bugs.openjdk.org/browse/JDK-8052325
+					if (constraint instanceof ConstraintExpressionFormula expressionFormula && expressionFormula.left instanceof LambdaExpression lambda && lambda.argumentsTypeElided()) {
+						addLambdaConstraintsToC(lambda, c, method, expressionFormula.right);
+					}
 				}
 			}
 			// 6. bullet: solve
@@ -645,6 +651,31 @@ public class InferenceContext18 {
 		return true;
 	}
 
+	private boolean addLambdaConstraintsToC(LambdaExpression lambda, Set<ConstraintFormula> c, MethodBinding method, TypeBinding substF)
+			throws InferenceFailureException
+	{
+		// https://bugs.openjdk.java.net/browse/JDK-8038747
+		BlockScope skope = lambda.enclosingScope;
+		if (substF.isFunctionalInterface(skope)) { // could be an inference variable.
+			ReferenceBinding t = (ReferenceBinding) substF;
+			ParameterizedTypeBinding withWildCards = InferenceContext18.parameterizedWithWildcard(t);
+			if (withWildCards != null) {
+				t = ConstraintExpressionFormula.findGroundTargetType(this, skope, lambda, withWildCards);
+			}
+			MethodBinding functionType;
+			if (t != null && (functionType = t.getSingleAbstractMethod(skope, true)) != null && (lambda = lambda.resolveExpressionExpecting(t, this.scope)) != null) {
+				TypeBinding r = functionType.returnType;
+				Expression[] resultExpressions = lambda.resultExpressions();
+				for (int i = 0, length = resultExpressions == null ? 0 : resultExpressions.length; i < length; i++) {
+					Expression resultExpression = resultExpressions[i];
+					if (!addConstraintsToC_OneExpr(resultExpression, c, r.original(), r, method))
+						return false;
+				}
+			}
+		}
+		return true;
+	}
+
 	private boolean addConstraintsToC_OneExpr(Expression expri, Set<ConstraintFormula> c, TypeBinding fsi, TypeBinding substF, MethodBinding method)
 			throws InferenceFailureException
 	{
@@ -659,27 +690,9 @@ public class InferenceContext18 {
 		}
 		if (expri instanceof FunctionalExpression) {
 			c.add(new ConstraintExceptionFormula((FunctionalExpression) expri, substF));
-			if (expri instanceof LambdaExpression) {
-				// https://bugs.openjdk.java.net/browse/JDK-8038747
-				LambdaExpression lambda = (LambdaExpression) expri;
-				BlockScope skope = lambda.enclosingScope;
-				if (substF.isFunctionalInterface(skope)) { // could be an inference variable.
-					ReferenceBinding t = (ReferenceBinding) substF;
-					ParameterizedTypeBinding withWildCards = InferenceContext18.parameterizedWithWildcard(t);
-					if (withWildCards != null) {
-						t = ConstraintExpressionFormula.findGroundTargetType(this, skope, lambda, withWildCards);
-					}
-					MethodBinding functionType;
-					if (t != null && (functionType = t.getSingleAbstractMethod(skope, true)) != null && (lambda = lambda.resolveExpressionExpecting(t, this.scope)) != null) {
-						TypeBinding r = functionType.returnType;
-						Expression[] resultExpressions = lambda.resultExpressions();
-						for (int i = 0, length = resultExpressions == null ? 0 : resultExpressions.length; i < length; i++) {
-							Expression resultExpression = resultExpressions[i];
-							if (!addConstraintsToC_OneExpr(resultExpression, c, r.original(), r, method))
-								return false;
-						}
-					}
-				}
+			// https://bugs.openjdk.org/browse/JDK-8052325
+			if (expri instanceof LambdaExpression lambda && !lambda.argumentsTypeElided()) {
+				addLambdaConstraintsToC(lambda, c, method, substF);
 			}
 		} else if (expri instanceof Invocation && expri.isPolyExpression()) {
 
@@ -709,7 +722,6 @@ public class InferenceContext18 {
 				if (!innerContext.computeB3(invocation, substF, shallowMethod))
 					return false;
 				if (innerContext.addConstraintsToC(arguments, c, innerMethod.genericMethod(), innerContext.inferenceKind, invocation)) {
-					this.currentBounds.addBounds(innerContext.currentBounds, this.environment);
 					return true;
 				}
 				return false;

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest.java
@@ -7058,5 +7058,23 @@ public void testGH4314c() {
 		},
 		"");
 }
+
+public void testGH4557() {
+    runConformTest(new String[] {
+            "Test.java",
+            """
+            import java.util.List;
+            public class Test {
+                public static void main(List<?> l) {
+                    get(get(get(l)));
+                }
+                public static <T> List<?> get(List<T> l) {
+                    return l;
+                }
+            }
+            """
+        },
+        "");
+}
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
Fixes #4557 

I did try changing https://github.com/eclipse-jdt/eclipse.jdt.core/blob/545483d5e69ae02a4ecbb98b1b813054abb0d0d8/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java#L713
to use `b3` from the inner context but that caused a test to fail. I also tried collecting all of the `b3`s into a single bound set but that caused another test to fail and whenever I fixed a test another test would start failing. Eventually I found [this](https://bugs.openjdk.org/browse/JDK-8052325) bug report for JLS and implementing the suggestion in the latest comment to only add constraints from implicit lambdas when they are reduced and incorporated instead of adding the current bounds from every generic method allows the new test to succeed without causing any additional test failures.

## How to test
Attempt to compile
```java
public class Test {
    public static void main(List<?> l) {
        get(get(get(l)));
    }
    public static <T> List<?> get(List<T> l) {
        return l;
    }
}
```

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)

@stephan-herrmann 