### PR TITLE
@Deprecated(forRemoval=true) still propagates to members when consumed from binary

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BinaryTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BinaryTypeBinding.java
@@ -656,7 +656,6 @@ private void cachePartsFrom2(IBinaryType binaryType, boolean needFieldsAndMethod
 						if (CharOperation.equals(elementValuePair.name, TypeConstants.FOR_REMOVAL)) {
 							if (elementValuePair.value instanceof BooleanConstant && ((BooleanConstant) elementValuePair.value).booleanValue()) {
 								this.tagBits |= TagBits.AnnotationTerminallyDeprecated;
-								markImplicitTerminalDeprecation(this);
 							}
 						}
 					}
@@ -677,22 +676,6 @@ private void cachePartsFrom2(IBinaryType binaryType, boolean needFieldsAndMethod
 
 		this.environment.requestingType = previousRequester;
 	}
-}
-
-void markImplicitTerminalDeprecation(ReferenceBinding type) {
-	for (ReferenceBinding member : type.memberTypes()) {
-		member.tagBits |= TagBits.AnnotationTerminallyDeprecated;
-		markImplicitTerminalDeprecation(member);
-	}
-	MethodBinding[] methodsOfType = type.unResolvedMethods();
-	if (methodsOfType != null)
-		for (MethodBinding methodBinding : methodsOfType)
-			methodBinding.tagBits |= TagBits.AnnotationTerminallyDeprecated;
-
-	FieldBinding[] fieldsOfType = type.unResolvedFields();
-	if (fieldsOfType != null)
-		for (FieldBinding fieldBinding : fieldsOfType)
-			fieldBinding.tagBits |= TagBits.AnnotationTerminallyDeprecated;
 }
 
 /* When creating a method we need to pass in any default 'nullness' from a @NNBD immediately on this method. */

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/Deprecated9Test.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/Deprecated9Test.java
@@ -1088,6 +1088,39 @@ public class Deprecated9Test extends AbstractRegressionTest9 {
 				""";
 		runner.runWarningTest();
 	}
+	public void testGH4580() {
+		Runner runner = new Runner();
+		runner.testFiles = new String[] {
+				"p/Dep.java",
+				"""
+				package p;
+				@Deprecated(forRemoval=true)
+				public class Dep {
+					@Deprecated public static final String S= "";
+				}
+				"""
+			};
+		runner.runConformTest();
+		runner.shouldFlushOutputDirectory = false;
+		runner.customOptions = getCompilerOptions();
+		runner.customOptions.put(JavaCore.COMPILER_PB_DEPRECATION, JavaCore.ERROR);
+		runner.customOptions.put(JavaCore.COMPILER_PB_TERMINAL_DEPRECATION, JavaCore.ERROR);
+		runner.customOptions.put(JavaCore.COMPILER_PB_UNUSED_WARNING_TOKEN, JavaCore.ERROR);
+		runner.customOptions.put(JavaCore.COMPILER_PB_SUPPRESS_OPTIONAL_ERRORS, JavaCore.ENABLED);
+		runner.testFiles = new String[] {
+				"p/DepSub.java",
+				"""
+				package p;
+
+				@SuppressWarnings({"removal", "deprecation"})
+				public class DepSub extends Dep {
+					@SuppressWarnings("hiding")
+					public static final String S = Dep.S;
+				}
+				"""
+			};
+		runner.runConformTest();
+	}
 	public static Class<?> testClass() {
 		return Deprecated9Test.class;
 	}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordsRestrictedClassTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordsRestrictedClassTest.java
@@ -10980,4 +10980,134 @@ public void testIssue4412() throws Exception {
 				"OK!");
 
 }
+public void testDeprecation_type() {
+	Runner runner = new Runner();
+	runner.testFiles = new String[] {
+		"X.java",
+		"""
+		@Deprecated record R(int i, boolean f) {}
+		public class X {
+			R test() {
+				return new R(1,false);
+			}
+		}
+		"""
+		};
+	runner.expectedCompilerLog =
+		"""
+		----------
+		1. WARNING in X.java (at line 3)
+			R test() {
+			^
+		The type R is deprecated
+		----------
+		2. WARNING in X.java (at line 4)
+			return new R(1,false);
+			           ^
+		The type R is deprecated
+		----------
+		""";
+	runner.runWarningTest();
+}
+public void testDeprecation_altCtor() {
+	Runner runner = new Runner();
+	runner.testFiles = new String[] {
+		"X.java",
+		"""
+		record R(int i, boolean f) {
+			@Deprecated R(int i) {
+				this(i, i>0);
+			}
+			R {
+				i = Math.abs(i);
+			}
+		}
+		public class X {
+			R test(int in) {
+				return switch(in) {
+					case 0 -> new R(0);
+					case 1 -> new R(1, false);
+					default -> null;
+				};
+			}
+		}
+		"""
+		};
+	runner.expectedCompilerLog =
+		"""
+		----------
+		1. WARNING in X.java (at line 12)
+			case 0 -> new R(0);
+			              ^
+		The constructor R(int) is deprecated
+		----------
+		""";
+	runner.runWarningTest();
+}
+public void testDeprecation_compactCtor() {
+	Runner runner = new Runner();
+	runner.testFiles = new String[] {
+		"X.java",
+		"""
+		record R(int i, boolean f) {
+			R(int i) {
+				this(i, i>0);
+			}
+			@Deprecated R {
+				i = Math.abs(i);
+			}
+		}
+		public class X {
+			R test(int in) {
+				return switch(in) {
+					case 0 -> new R(0);
+					case 1 -> new R(1, false);
+					default -> null;
+				};
+			}
+		}
+		"""
+		};
+	runner.expectedCompilerLog =
+		"""
+		----------
+		1. WARNING in X.java (at line 13)
+			case 1 -> new R(1, false);
+			              ^
+		The constructor R(int, boolean) is deprecated
+		----------
+		""";
+	runner.runWarningTest();
+}
+public void testDeprecation_accessor() {
+	Runner runner = new Runner();
+	runner.testFiles = new String[] {
+		"X.java",
+		"""
+		record R(int i, boolean f) {
+			@Deprecated public int i() {
+				return this.i;
+			}
+		}
+		public class X {
+			int test1() {
+				return new R(1,false).i();
+			}
+			boolean test2() {
+				return new R(1,false).f();
+			}
+		}
+		"""
+		};
+	runner.expectedCompilerLog =
+		"""
+		----------
+		1. WARNING in X.java (at line 8)
+			return new R(1,false).i();
+			                      ^
+		The method i() from the type R is deprecated
+		----------
+		""";
+	runner.runWarningTest();
+}
 }


### PR DESCRIPTION
Remove bogus propagation to members also in BinaryTypeBinding

Bonus: add passing tests for deprecation on records

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4580
