### PR TITLE
Incorrect warning for @SuppressWarnings for forRemoval deprecations in light of JEP 277

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ASTNode.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ASTNode.java
@@ -492,13 +492,16 @@ public abstract class ASTNode implements Location, TypeConstants, TypeIds {
 			}
 		}
 
-		if (!field.isViewedAsDeprecated()) return false;
+		if (!field.isDeprecated()) return false;
 
 		// inside same outermost enclosing type - no report
 		if (scope.isDefinedInSameEnclosingType(field.declaringClass.outermostEnclosingType())) return false;
 
-		// if context is deprecated, may avoid reporting
-		if (!scope.compilerOptions().reportDeprecationInsideDeprecatedCode && scope.isInsideDeprecatedCode()) return false;
+		// if context is deprecated, may avoid reporting ordinary deprecation
+		if ((field.tagBits & TagBits.AnnotationTerminallyDeprecated) == 0
+				&& !scope.compilerOptions().reportDeprecationInsideDeprecatedCode
+				&& scope.isInsideDeprecatedCode())
+			return false;
 		return true;
 	}
 
@@ -542,19 +545,16 @@ public abstract class ASTNode implements Location, TypeConstants, TypeIds {
 			}
 		}
 
-		if (!method.isViewedAsDeprecated()) return false;
+		if (!method.isDeprecated()) return false;
 
 		// inside same outermost enclosing type - no report
 		if (scope.isDefinedInSameEnclosingType(method.declaringClass.outermostEnclosingType())) return false;
 
-		// non explicit use and non explicitly deprecated - no report
-		if (!isExplicitUse &&
-				(method.modifiers & ClassFileConstants.AccDeprecated) == 0) {
+		// if context is deprecated, may avoid reporting ordinary deprecation
+		if ((method.tagBits & TagBits.AnnotationTerminallyDeprecated) == 0
+				&& !scope.compilerOptions().reportDeprecationInsideDeprecatedCode
+				&& scope.isInsideDeprecatedCode())
 			return false;
-		}
-
-		// if context is deprecated, may avoid reporting
-		if (!scope.compilerOptions().reportDeprecationInsideDeprecatedCode && scope.isInsideDeprecatedCode()) return false;
 		return true;
 	}
 
@@ -615,13 +615,16 @@ public abstract class ASTNode implements Location, TypeConstants, TypeIds {
 		// force annotations resolution before deciding whether the type may be deprecated
 		refType.initializeDeprecatedAnnotationTagBits();
 
-		if (!refType.isViewedAsDeprecated()) return false;
+		if (!refType.isDeprecated()) return false;
 
 		// inside same outermost enclosing type - no report
 		if (scope.isDefinedInSameEnclosingType(refType.outermostEnclosingType())) return false;
 
-		// if context is deprecated, may avoid reporting
-		if (!scope.compilerOptions().reportDeprecationInsideDeprecatedCode && scope.isInsideDeprecatedCode()) return false;
+		// if context is deprecated, may avoid reporting ordinary deprecation
+		if ((type.tagBits & TagBits.AnnotationTerminallyDeprecated) == 0
+				&& !scope.compilerOptions().reportDeprecationInsideDeprecatedCode
+				&& scope.isInsideDeprecatedCode())
+			return false;
 		return true;
 	}
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/FieldBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/FieldBinding.java
@@ -370,12 +370,6 @@ public final boolean isUsedOnlyInCompound() {
 /* Answer true if the receiver has protected visibility
 */
 
-public final boolean isViewedAsDeprecated() {
-	return (this.modifiers & ClassFileConstants.AccDeprecated) != 0;
-}
-/* Answer true if the receiver is a volatile field
-*/
-
 @Override
 public final boolean isVolatile() {
 	return (this.modifiers & ClassFileConstants.AccVolatile) != 0;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MethodBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MethodBinding.java
@@ -981,12 +981,6 @@ public boolean isParameterizedGeneric() {
 public boolean isPolymorphic() {
 	return false;
 }
-/* Answer true if the receiver's declaring type is deprecated (or any of its enclosing types)
-*/
-public final boolean isViewedAsDeprecated() {
-	return (this.modifiers & ClassFileConstants.AccDeprecated) != 0;
-}
-
 @Override
 public final int kind() {
 	return Binding.METHOD;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MethodVerifier.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MethodVerifier.java
@@ -183,8 +183,8 @@ void checkAgainstInheritedMethods(MethodBinding currentMethod, MethodBinding[] m
 			if(inheritedMethod.isSynchronized() && !currentMethod.isSynchronized()) {
 				problemReporter(currentMethod).missingSynchronizedOnInheritedMethod(currentMethod, inheritedMethod);
 			}
-			if (options.reportDeprecationWhenOverridingDeprecatedMethod && inheritedMethod.isViewedAsDeprecated()) {
-				if (!currentMethod.isViewedAsDeprecated() || options.reportDeprecationInsideDeprecatedCode) {
+			if (options.reportDeprecationWhenOverridingDeprecatedMethod && inheritedMethod.isDeprecated()) {
+				if (!currentMethod.isDeprecated() || options.reportDeprecationInsideDeprecatedCode) {
 					// check against the other inherited methods to see if they hide this inheritedMethod
 					ReferenceBinding declaringClass = inheritedMethod.declaringClass;
 					if (declaringClass.isInterface())

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
@@ -1833,14 +1833,6 @@ public final boolean isUsed() {
 	return (this.modifiers & ExtraCompilerModifiers.AccLocallyUsed) != 0;
 }
 
-/**
- * Answer true if the receiver is deprecated (or any of its enclosing types)
- */
-public final boolean isViewedAsDeprecated() {
-	if ((this.modifiers & ClassFileConstants.AccDeprecated) != 0)
-		return true;
-	return false;
-}
 public boolean isImplicitType() {
 	return false;
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Scope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Scope.java
@@ -3897,20 +3897,20 @@ public abstract class Scope {
 					ReferenceContext referenceContext = methodScope.referenceContext();
 					if (referenceContext instanceof AbstractMethodDeclaration) {
 						MethodBinding context = ((AbstractMethodDeclaration) referenceContext).binding;
-						if (context != null && context.isViewedAsDeprecated())
+						if (context != null && context.isDeprecated())
 							return true;
 					} else if (referenceContext instanceof ModuleDeclaration) {
 						ModuleBinding context = ((ModuleDeclaration) referenceContext).binding;
 						return context != null && context.isDeprecated();
 					}
-				} else if (methodScope.initializedField != null && methodScope.initializedField.isViewedAsDeprecated()) {
+				} else if (methodScope.initializedField != null && methodScope.initializedField.isDeprecated()) {
 					// inside field declaration ? check field modifier to see if deprecated
 					return true;
 				}
 				SourceTypeBinding declaringType = ((BlockScope)this).referenceType().binding;
 				if (declaringType != null) {
 					declaringType.initializeDeprecatedAnnotationTagBits(); // may not have been resolved until then
-					if (declaringType.isViewedAsDeprecated())
+					if (declaringType.isDeprecated())
 						return true;
 				}
 				break;
@@ -3918,7 +3918,7 @@ public abstract class Scope {
 				ReferenceBinding context = ((ClassScope)this).referenceType().binding;
 				if (context != null) {
 					context.initializeDeprecatedAnnotationTagBits(); // may not have been resolved until then
-					if (context.isViewedAsDeprecated())
+					if (context.isDeprecated())
 						return true;
 				}
 				break;
@@ -3929,7 +3929,7 @@ public abstract class Scope {
 					SourceTypeBinding type = unit.types[0].binding;
 					if (type != null) {
 						type.initializeDeprecatedAnnotationTagBits(); // may not have been resolved until then
-						if (type.isViewedAsDeprecated())
+						if (type.isDeprecated())
 							return true;
 					}
 				}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractRegressionTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractRegressionTest.java
@@ -4252,6 +4252,7 @@ protected void runNegativeTest(
 				Util.flushDirectoryContent(JAVAC_OUTPUT_DIR);
 			}
 			printJavacResultsSummary();
+			javacUsePathOption(" -classpath ");
 		}
 	}
 	/**

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/CompletionEngine.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/CompletionEngine.java
@@ -5997,7 +5997,7 @@ public final class CompletionEngine
 					if (constructor.isSynthetic()) continue next;
 
 					if (this.options.checkDeprecation &&
-							constructor.isViewedAsDeprecated() &&
+							constructor.isDeprecated() &&
 							!scope.isDefinedInSameUnit(constructor.declaringClass))
 						continue next;
 
@@ -6733,7 +6733,7 @@ public final class CompletionEngine
 			return;
 
 		if (this.options.checkDeprecation &&
-				exceptionType.isViewedAsDeprecated() &&
+				exceptionType.isDeprecated() &&
 				!scope.isDefinedInSameUnit(exceptionType))
 			return;
 
@@ -6923,7 +6923,7 @@ public final class CompletionEngine
 					if (constructor.isSynthetic()) continue next;
 
 					if (this.options.checkDeprecation &&
-							constructor.isViewedAsDeprecated() &&
+							constructor.isDeprecated() &&
 							!scope.isDefinedInSameUnit(constructor.declaringClass))
 						continue next;
 
@@ -7074,7 +7074,7 @@ public final class CompletionEngine
 			if (isFailedMatch(fieldName, field.name))	continue next;
 
 			if (this.options.checkDeprecation &&
-					field.isViewedAsDeprecated() &&
+					field.isDeprecated() &&
 					!scope.isDefinedInSameUnit(field.declaringClass))
 				continue next;
 
@@ -8352,7 +8352,7 @@ public final class CompletionEngine
 			if (isFailedMatch(fieldName, field.name))	continue next;
 
 			if (this.options.checkDeprecation &&
-					field.isViewedAsDeprecated() &&
+					field.isDeprecated() &&
 					!scope.isDefinedInSameUnit(field.declaringClass))
 				continue next;
 
@@ -8596,7 +8596,7 @@ public final class CompletionEngine
 			if (isFailedMatch(typeName, memberType.sourceName))
 				continue next;
 
-			if (this.options.checkDeprecation && memberType.isViewedAsDeprecated()) continue next;
+			if (this.options.checkDeprecation && memberType.isDeprecated()) continue next;
 
 			if (this.options.checkVisibility
 				&& !memberType.canBeSeenBy(this.unitScope.fPackage))
@@ -8652,7 +8652,7 @@ public final class CompletionEngine
 			if (isFailedMatch(fieldName, field.name))
 				continue next;
 
-			if (this.options.checkDeprecation && field.isViewedAsDeprecated()) continue next;
+			if (this.options.checkDeprecation && field.isDeprecated()) continue next;
 
 			if (this.options.checkVisibility
 				&& !field.canBeSeenBy(this.unitScope.fPackage))
@@ -8705,7 +8705,7 @@ public final class CompletionEngine
 
 			if (!method.isStatic()) continue next;
 
-			if (this.options.checkDeprecation && method.isViewedAsDeprecated()) continue next;
+			if (this.options.checkDeprecation && method.isDeprecated()) continue next;
 
 			if (this.options.checkVisibility
 				&& !method.canBeSeenBy(this.unitScope.fPackage)) continue next;
@@ -9225,7 +9225,7 @@ public final class CompletionEngine
             }
 
 			if (this.options.checkDeprecation &&
-					method.isViewedAsDeprecated() &&
+					method.isDeprecated() &&
 					!scope.isDefinedInSameUnit(method.declaringClass))
 				continue next;
 
@@ -9385,7 +9385,7 @@ public final class CompletionEngine
 			if (method.isConstructor()) continue next;
 
 			if (this.options.checkDeprecation &&
-					method.isViewedAsDeprecated() &&
+					method.isDeprecated() &&
 					!scope.isDefinedInSameUnit(method.declaringClass))
 				continue next;
 
@@ -9845,7 +9845,7 @@ public final class CompletionEngine
 				if (method.isConstructor()) continue next;
 
 				if (this.options.checkDeprecation &&
-						method.isViewedAsDeprecated() &&
+						method.isDeprecated() &&
 						!scope.isDefinedInSameUnit(method.declaringClass))
 					continue next;
 
@@ -10136,7 +10136,7 @@ public final class CompletionEngine
 			if (!method.isStatic()) continue next;
 
 			if (this.options.checkDeprecation &&
-					method.isViewedAsDeprecated() &&
+					method.isDeprecated() &&
 					!scope.isDefinedInSameUnit(method.declaringClass))
 				continue next;
 
@@ -10642,7 +10642,7 @@ public final class CompletionEngine
 				continue next;
 
 			if (this.options.checkDeprecation &&
-					memberType.isViewedAsDeprecated() &&
+					memberType.isDeprecated() &&
 					!scope.isDefinedInSameUnit(memberType))
 				continue next;
 
@@ -11417,7 +11417,7 @@ public final class CompletionEngine
 		ReferenceBinding refBinding = (ReferenceBinding) ref.resolvedType;
 		if(refBinding != null) {
 			if (this.options.checkDeprecation &&
-					refBinding.isViewedAsDeprecated() &&
+					refBinding.isDeprecated() &&
 					!scope.isDefinedInSameUnit(refBinding))
 				return;
 
@@ -12072,7 +12072,7 @@ public final class CompletionEngine
 						&& !(this.options.camelCaseMatch && CharOperation.camelCaseMatch(token, sourceType.sourceName)))	continue;
 
 				if (this.options.checkDeprecation &&
-						sourceType.isViewedAsDeprecated() &&
+						sourceType.isDeprecated() &&
 						!scope.isDefinedInSameUnit(sourceType))
 					continue;
 
@@ -12230,7 +12230,7 @@ public final class CompletionEngine
 						continue next;
 					}
 					if (this.options.checkDeprecation &&
-							refBinding.isViewedAsDeprecated() &&
+							refBinding.isDeprecated() &&
 							!scope.isDefinedInSameUnit(refBinding))
 						continue next;
 


### PR DESCRIPTION
Inside deprecated code suppress only ordinary deprecation warnings

Some more clean-up after PR #4564:
+ remove distinction isDeprecated() vs. isViewedAsDeprecated()
+ remove obsolete dead branch regarding implicit deprecation

Let Deprecated9Test opt-in to run.javac mode

Improve test isolation

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4579
