### PR TITLE
Fix testGH902_whenTypeReferenceIsUnknownButQualified_expectToBeFound

### DIFF
--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/DOMToIndexVisitor.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/DOMToIndexVisitor.java
@@ -335,7 +335,9 @@ class DOMToIndexVisitor extends ASTVisitor {
 	}
 	@Override
 	public boolean visit(SimpleName name) {
-		this.sourceIndexer.addNameReference(name.getIdentifier().toCharArray());
+		char[] id = name.getIdentifier().toCharArray();
+		this.sourceIndexer.addNameReference(id);
+		this.sourceIndexer.addIndexMetaQualification(id, false);
 		return true;
 	}
 	// TODO (cf SourceIndexer and SourceIndexerRequestor)


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
A test "testGH902_whenTypeReferenceIsUnknownButQualified_expectToBeFound" is failing in the incubator repository. 

This patch ensures that, when an unknown name reference is found, both 'addNameReference' and 'addIndexMetaQualification' are called on the source indexer. 

This would mirror the behavior found in SourceIndexerRequestor, which looks as follows:

```
public void acceptUnknownReference(char[] name, int sourcePosition) {
	this.indexer.addNameReference(name);
	this.indexer.addIndexMetaQualification(name, false);
}
```

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
