### PR TITLE
Improve statement recovery in AST generated by ASTParser when there's a lambda

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/dom/StandAloneASTParserTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/dom/StandAloneASTParserTest.java
@@ -92,6 +92,7 @@ public class StandAloneASTParserTest extends AbstractRegressionTest {
 		ModuleDeclaration module = unit.getModule();
 		assertTrue("Incorrect Module Name", module.getName().getFullyQualifiedName().equals("m"));
 	}
+
 	public void test1() {
 		String contents =
 				"package p;\n" +
@@ -2025,5 +2026,50 @@ public class StandAloneASTParserTest extends AbstractRegressionTest {
                 }
             }
         }
+	}
+
+	public void testGH4530_001() {
+		String contents =
+				"""
+				package p;
+				import java.util.function.Function;
+				public class X {
+					public static void main(String[] args) {
+						Function<Integer, Integer> myFunc = a -> a;
+						System.out.println("yippeeee!");
+						word
+					}
+				}
+				""";
+		ASTNode node = runConversion(AST_JLS_LATEST, contents, true, true, true, "p/X.java");
+		assertTrue("should be compilation unit", node instanceof CompilationUnit);
+		CompilationUnit unit = (CompilationUnit)node;
+		TypeDeclaration typeDecl = (TypeDeclaration)unit.types().get(0);
+		MethodDeclaration methodDecl = (MethodDeclaration)typeDecl.getMethods()[0];
+		Block block = methodDecl.getBody();
+		assertEquals(block.statements().size(), 2);
+	}
+
+	public void testGH4530_002() {
+		String contents =
+				"""
+				package p;
+				import java.util.stream.Stream;
+				public class X {
+					public static void main(String[] args) {
+						int a = 4;
+						Stream.iterate(0,i -> ++i).limit(10);
+						"String".var
+					}
+				}
+				""";
+		ASTNode node = runConversion(AST_JLS_LATEST, contents, true, true, true, "p/X.java");
+		assertTrue("should be compilation unit", node instanceof CompilationUnit);
+		CompilationUnit unit = (CompilationUnit)node;
+		TypeDeclaration typeDecl = (TypeDeclaration)unit.types().get(0);
+		MethodDeclaration methodDecl = (MethodDeclaration)typeDecl.getMethods()[0];
+		Block block = methodDecl.getBody();
+		assertEquals(block.statements().size(), 3);
+		assertTrue(block.statements().get(2) instanceof ExpressionStatement);
 	}
 }

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionParser.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/complete/CompletionParser.java
@@ -6615,6 +6615,12 @@ public class CompletionParser extends AssistParser {
 							element = element.parent;
 						}
 					}
+				} else if (method.statements != null) {
+					// "double" recovery; base parser recovered statements and assist parser recovered the assist node
+					Statement[] newStatements = new Statement[method.statements.length + 1];
+					System.arraycopy(method.statements, 0, newStatements, 0, method.statements.length);
+					newStatements[method.statements.length] = statement;
+					method.statements = newStatements;
 				}
 			}
 			if (this.assistNode != null && !(this.assistNode instanceof CompletionOnKeyword) // no useful context

--- a/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/impl/AssistParser.java
+++ b/org.eclipse.jdt.core/codeassist/org/eclipse/jdt/internal/codeassist/impl/AssistParser.java
@@ -2070,6 +2070,8 @@ public void parseBlockStatements(MethodDeclaration md, CompilationUnitDeclaratio
 	if ((md.modifiers & ExtraCompilerModifiers.AccSemicolonBody) != 0)
 		return;
 
+	boolean oldStateRecoveryActivated = this.statementRecoveryActivated;
+	this.statementRecoveryActivated = true;
 	initialize();
 	// set the lastModifiers to reflect the modifiers of the method whose
 	// block statements are being parsed
@@ -2090,6 +2092,7 @@ public void parseBlockStatements(MethodDeclaration md, CompilationUnitDeclaratio
 		this.lastAct = ERROR_ACTION;
 	} finally {
 		this.nestedMethod[this.nestedType]--;
+		this.statementRecoveryActivated = oldStateRecoveryActivated;
 	}
 
 	if (this.lastAct == ERROR_ACTION) {


### PR DESCRIPTION
## What it does
Fixes #4530.

Recover statements in method bodies with syntax errors when parsing using `ASTParser`.

Also recover expressions as expression statements.

## How to test
I've added unit tests.

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)