### PR TITLE
[Build] Set extended timeout for long running jdt.core tests

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/pom.xml
+++ b/org.eclipse.jdt.core.tests.compiler/pom.xml
@@ -24,6 +24,7 @@
 
   <properties>
     <defaultSigning-excludeInnerJars>true</defaultSigning-excludeInnerJars>
+    <surefire.timeout>5400</surefire.timeout><!-- timeout in seconds -->
   </properties>
 
   <build>

--- a/org.eclipse.jdt.core.tests.model/pom.xml
+++ b/org.eclipse.jdt.core.tests.model/pom.xml
@@ -25,7 +25,7 @@
   <properties>
     <defaultSigning-excludeInnerJars>true</defaultSigning-excludeInnerJars>
     <jitExclusion>-XX:CompileCommand=exclude,org.eclipse.jdt.internal.core.dom.rewrite.ASTRewriteAnalyzer::getExtendedRange</jitExclusion>
-
+    <surefire.timeout>1800</surefire.timeout><!-- timeout in seconds -->
   </properties>
 
   <build>


### PR DESCRIPTION
Set the following extended timeouts
- for org.eclipse.jdt.core.tests.compiler to 90min (usually runs ~45min)
- for org.eclipse.jdt.core.tests.model to 30min (usually runs ~15min)

This extends the general timeout, which could be too strict in this case and is introduced via
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/3427

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
