### PR TITLE
[25] ECJ reports a bogus "The final field t may already have been assigned" error

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ConstructorDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ConstructorDeclaration.java
@@ -316,7 +316,7 @@ private void complainAboutInitializedFinalFields(FlowInfo flowInfo, ExplicitCons
 		// if calling 'this(...)', complain about final fields that are already assigned
 		FieldBinding[] fields = this.binding.declaringClass.fields();
 		for (FieldBinding field : fields) {
-			if (!field.isStatic()) {
+			if (field.isBlankFinal() && !field.isStatic()) {
 				if (flowInfo.isPotentiallyAssigned(field))
 					this.scope.problemReporter().duplicateInitializationOfBlankFinalField(field, call);
 			}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SuperAfterStatementsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SuperAfterStatementsTest.java
@@ -3488,4 +3488,29 @@ public class SuperAfterStatementsTest extends AbstractRegressionTest9 {
 		----------
 		""");
 	}
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4585
+	// [25] ECJ reports a bogus "The final field t may already have been assigned" error
+	public void testIssue4585() {
+		runConformTest(new String[] {
+			"X.java",
+			"""
+			public class X {
+				class TestClass<T extends Object> {
+					T t;
+					TestClass() {}
+
+					TestClass(T v) {
+						switch (0) {
+							case 2:
+								t = v;
+								break;
+						}
+						this(); // Error here
+					}
+				}
+			}
+			"""
+		});
+	}
 }
+


### PR DESCRIPTION


* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4585

