### PR TITLE
ECJ reports about non-existing modifiers on a local class in a switch expression

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ClassScope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ClassScope.java
@@ -596,8 +596,8 @@ public class ClassScope extends Scope {
 						}
 					}
 			    }
-			} else if (this.parent.referenceContext() instanceof TypeDeclaration) {
-				TypeDeclaration typeDecl = (TypeDeclaration) this.parent.referenceContext();
+			} else if (this.parent instanceof ClassScope classScope && classScope.referenceContext != null) {
+				TypeDeclaration typeDecl = classScope.referenceContext;
 				if (TypeDeclaration.kind(typeDecl.modifiers) == TypeDeclaration.INTERFACE_DECL) {
 					// Sec 8.1.3 applies for local types as well
 					modifiers |= ClassFileConstants.AccStatic;

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LocalStaticsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LocalStaticsTest.java
@@ -1705,4 +1705,30 @@ public class LocalStaticsTest extends AbstractRegressionTest {
 			"Hi from MyTest\n" +
 			"Hi from EnumTester");
 	}
+	// ECJ reports about non-existing modifiers on a local class in a switch expression
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4584
+	public void testIssue4584() throws Exception {
+		runConformTest(
+			new String[] {
+					"X.java",
+					"""
+					public interface X {
+					    int i = switch (0) {
+					        case 2 -> {
+					            class ParentLocal { // This is rejected
+					            }
+					            yield 1;
+					        }
+					        default -> {
+					            yield 0;
+					        }
+					    };
+					    public static void main(String [] args) {
+					        System.out.println("OK!");
+					    }
+					}
+					"""
+				},
+			"OK!");
+	}
 }


### PR DESCRIPTION


* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4584

