### PR TITLE
Almost complete revert of Bug 452788

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AllocationExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AllocationExpression.java
@@ -91,7 +91,6 @@ public class AllocationExpression extends Expression implements IPolyExpression,
 	 // hold on to this context from invocation applicability inference until invocation type inference (per method candidate):
 	private Map<ParameterizedGenericMethodBinding, InferenceContext18> inferenceContexts;
 	public HashMap<TypeBinding, MethodBinding> solutionsPerTargetType;
-	private InferenceContext18 outerInferenceContext; // resolving within the context of an outer (lambda) inference?
 	public boolean argsContainCast;
 	public TypeBinding[] argumentTypes = Binding.NO_PARAMETERS;
 	public boolean argumentsHaveErrors = false;
@@ -855,7 +854,6 @@ public void cleanUpInferenceContexts() {
 		value.cleanUp();
 	}
 	this.inferenceContexts = null;
-	this.outerInferenceContext = null;
 	this.solutionsPerTargetType = null;
 }
 
@@ -866,7 +864,7 @@ public ExpressionContext getExpressionContext() {
 }
 @Override
 public InferenceContext18 freshInferenceContext(Scope scope) {
-	return new InferenceContext18(scope, this.arguments, this, this.outerInferenceContext);
+	return new InferenceContext18(scope, this.arguments, this);
 }
 @Override
 public int nameSourceStart() {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ExplicitConstructorCall.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ExplicitConstructorCall.java
@@ -607,7 +607,7 @@ public class ExplicitConstructorCall extends Statement implements Invocation {
 	// -- interface InvocationSite: --
 	@Override
 	public InferenceContext18 freshInferenceContext(Scope scope) {
-		return new InferenceContext18(scope, this.arguments, this, null);
+		return new InferenceContext18(scope, this.arguments, this);
 	}
 	@Override
 	public int nameSourceEnd() {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Expression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Expression.java
@@ -1115,7 +1115,7 @@ public TypeBinding resolveTypeExpecting(BlockScope scope, TypeBinding expectedTy
 	return expressionType;
 }
 
-public Expression resolveExpressionExpecting(TypeBinding targetType, Scope scope, InferenceContext18 context) {
+public Expression resolveExpressionExpecting(TypeBinding targetType, Scope scope) {
 	return this; // subclasses should implement for a better resolved expression if required.
 }
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/IPolyExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/IPolyExpression.java
@@ -16,7 +16,6 @@
 package org.eclipse.jdt.internal.compiler.ast;
 
 import org.eclipse.jdt.internal.compiler.lookup.BlockScope;
-import org.eclipse.jdt.internal.compiler.lookup.InferenceContext18;
 import org.eclipse.jdt.internal.compiler.lookup.InvocationSite;
 import org.eclipse.jdt.internal.compiler.lookup.MethodBinding;
 import org.eclipse.jdt.internal.compiler.lookup.PolyTypeBinding;
@@ -64,6 +63,6 @@ public interface IPolyExpression {
 	*/
 	public TypeBinding resolveType(BlockScope blockScope);
 	// Resolve expression tentatively - should have no lingering side-effects that may impact final resolution !
-	public Expression resolveExpressionExpecting(TypeBinding targetType, Scope scope, InferenceContext18 inferenceContext);
+	public Expression resolveExpressionExpecting(TypeBinding targetType, Scope scope);
 
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LambdaExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LambdaExpression.java
@@ -102,7 +102,6 @@ public class LambdaExpression extends FunctionalExpression implements IPolyExpre
 	private static final Block NO_BODY = new Block(0);
 	private HashMap<TypeBinding, LambdaExpression> copiesPerTargetType;
 	protected Expression [] resultExpressions = NO_EXPRESSIONS;
-	public InferenceContext18 inferenceContext; // when performing tentative resolve keep a back reference to the driving context
 	private Map<Integer/*sourceStart*/, LocalTypeBinding> localTypes; // support look-up of a local type from this lambda copy
 	public boolean hasVarTypedArguments = false;
 	int firstLocalLocal; // analysis index of first local variable (if any) post parameter(s) in the lambda; ("local local" as opposed to "outer local")
@@ -882,7 +881,7 @@ public class LambdaExpression extends FunctionalExpression implements IPolyExpre
 
 		LambdaExpression copy = null;
 		try {
-			copy = cachedResolvedCopy(targetType, argumentsTypeElided(), false, null, skope); // if argument types are elided, we don't care for result expressions against *this* target, any valid target is OK.
+			copy = cachedResolvedCopy(targetType, argumentsTypeElided(), false, skope); // if argument types are elided, we don't care for result expressions against *this* target, any valid target is OK.
 		} catch (CopyFailureException cfe) {
 			if (this.assistNode)
 				return CompatibilityResult.COMPATIBLE; // can't type check result expressions, just say yes.
@@ -936,7 +935,7 @@ public class LambdaExpression extends FunctionalExpression implements IPolyExpre
 		private static final long serialVersionUID = 1L;
 	}
 
-	private LambdaExpression cachedResolvedCopy(TypeBinding targetType, boolean anyTargetOk, boolean requireExceptionAnalysis, InferenceContext18 context, Scope outerScope) {
+	private LambdaExpression cachedResolvedCopy(TypeBinding targetType, boolean anyTargetOk, boolean requireExceptionAnalysis, Scope outerScope) {
 		if (this.committed && outerScope instanceof BlockScope) {
 			this.enclosingScope = (BlockScope) outerScope;
 			// trust the result of any previous shape analysis:
@@ -981,7 +980,6 @@ public class LambdaExpression extends FunctionalExpression implements IPolyExpre
 
 				copy.setExpressionContext(this.expressionContext);
 				copy.setExpectedType(targetType);
-				copy.inferenceContext = context;
 				TypeBinding type = copy.resolveType(this.enclosingScope, true);
 				if (type == null || !type.isValidBinding())
 					return null;
@@ -1009,10 +1007,10 @@ public class LambdaExpression extends FunctionalExpression implements IPolyExpre
 	 * @return a resolved copy of 'this' or null if significant errors where encountered
 	 */
 	@Override
-	public LambdaExpression resolveExpressionExpecting(TypeBinding targetType, Scope skope, InferenceContext18 context) {
+	public LambdaExpression resolveExpressionExpecting(TypeBinding targetType, Scope skope) {
 		LambdaExpression copy = null;
 		try {
-			copy = cachedResolvedCopy(targetType, false, true, context, null /* to be safe we signal: not yet committed */);
+			copy = cachedResolvedCopy(targetType, false, true, null /* to be safe we signal: not yet committed */);
 		} catch (CopyFailureException cfe) {
 			return null;
 		}
@@ -1065,7 +1063,7 @@ public class LambdaExpression extends FunctionalExpression implements IPolyExpre
 
 		LambdaExpression copy;
 		try {
-			copy = cachedResolvedCopy(s, true /* any resolved copy is good */, false, null, null /*not yet committed*/); // we expect a cached copy - otherwise control won't reach here.
+			copy = cachedResolvedCopy(s, true /* any resolved copy is good */, false, null /*not yet committed*/); // we expect a cached copy - otherwise control won't reach here.
 		} catch (CopyFailureException cfe) {
 			if (this.assistNode)
 				return false;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/MessageSend.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/MessageSend.java
@@ -108,7 +108,6 @@ public class MessageSend extends Expression implements IPolyExpression, Invocati
 	 // hold on to this context from invocation applicability inference until invocation type inference (per method candidate):
 	private Map<ParameterizedGenericMethodBinding, InferenceContext18> inferenceContexts;
 	private HashMap<TypeBinding, MethodBinding> solutionsPerTargetType;
-	private InferenceContext18 outerInferenceContext; // resolving within the context of an outer (lambda) inference?
 
 	private boolean receiverIsType;
 	protected boolean argsContainCast;
@@ -1117,11 +1116,6 @@ protected TypeBinding handleNullnessCodePatterns(BlockScope scope, TypeBinding r
 }
 
 protected TypeBinding findMethodBinding(BlockScope scope) {
-	ReferenceContext referenceContext = scope.methodScope().referenceContext;
-	if (referenceContext instanceof LambdaExpression) {
-		this.outerInferenceContext = ((LambdaExpression) referenceContext).inferenceContext;
-	}
-
 	if (this.expectedType != null && this.binding instanceof PolyParameterizedGenericMethodBinding) {
 		this.binding = this.solutionsPerTargetType.get(this.expectedType);
 	}
@@ -1338,7 +1332,6 @@ public void cleanUpInferenceContexts() {
 			value.cleanUp();
 	}
 	this.inferenceContexts = null;
-	this.outerInferenceContext = null;
 	this.solutionsPerTargetType = null;
 }
 @Override
@@ -1352,7 +1345,7 @@ public ExpressionContext getExpressionContext() {
 // -- Interface InvocationSite: --
 @Override
 public InferenceContext18 freshInferenceContext(Scope scope) {
-	return new InferenceContext18(scope, this.arguments, this, this.outerInferenceContext);
+	return new InferenceContext18(scope, this.arguments, this);
 }
 @Override
 public boolean isQualifiedSuper() {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ReferenceExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ReferenceExpression.java
@@ -1028,7 +1028,7 @@ public class ReferenceExpression extends FunctionalExpression implements IPolyEx
 	}
 
 	@Override
-	public ReferenceExpression resolveExpressionExpecting(TypeBinding targetType, Scope scope, InferenceContext18 inferenceContext) {
+	public ReferenceExpression resolveExpressionExpecting(TypeBinding targetType, Scope scope) {
 		if (this.exactMethodBinding != null) { // We may see inference variables in target type.
 			MethodBinding functionType = targetType.getSingleAbstractMethod(scope, true);
 			if (functionType == null || functionType.problemId() == ProblemReasons.NoSuchSingleAbstractMethod)
@@ -1080,7 +1080,7 @@ public class ReferenceExpression extends FunctionalExpression implements IPolyEx
 	public InferenceContext18 freshInferenceContext(Scope scope) {
 		if (this.expressionContext != ExpressionContext.VANILLA_CONTEXT) {
 			Expression[] arguments = createPseudoExpressions(this.freeParameters);
-			return new InferenceContext18(scope, arguments, this, null);
+			return new InferenceContext18(scope, arguments, this);
 		}
 		return null; // shouldn't happen, actually
 	}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BoundSet.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BoundSet.java
@@ -1302,25 +1302,6 @@ class BoundSet {
 		}
 	}
 
-	public TypeBinding getEquivalentOuterVariable(InferenceVariable variable, InferenceVariable[] outerVariables) {
-		ThreeSets three = this.boundsPerVariable.get(variable);
-		if (three != null) {
-			for (TypeBound bound : three.sameBounds) {
-				for (InferenceVariable iv : outerVariables)
-					if (TypeBinding.equalsEquals(bound.right, iv))
-						return iv;
-			}
-		}
-		for (InferenceVariable iv : outerVariables) {
-			three = this.boundsPerVariable.get(iv);
-			if (three != null && three.sameBounds != null) {
-				for (TypeBound bound : three.sameBounds)
-					if (TypeBinding.equalsEquals(bound.right, variable))
-						return iv;
-			}
-		}
-		return null;
-	}
 	public TypeBinding condition18_5_5_item_4(
 			ReferenceBinding rAlpha,
 			InferenceVariable[] alpha,

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ConstraintExceptionFormula.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ConstraintExceptionFormula.java
@@ -88,12 +88,12 @@ public class ConstraintExceptionFormula extends ConstraintFormula {
 
 		TypeBinding[] ePrime = null;
 		if (this.left instanceof LambdaExpression) {
-			LambdaExpression lambda = ((LambdaExpression) this.left).resolveExpressionExpecting(this.right, inferenceContext.scope, inferenceContext);
+			LambdaExpression lambda = ((LambdaExpression) this.left).resolveExpressionExpecting(this.right, inferenceContext.scope);
 			if (lambda == null)
 				return TRUE; // cannot make use of this buggy constraint
 			ePrime = lambda.getThrownExceptions().toArray(TypeBinding[]::new);
 		} else {
-			ReferenceExpression referenceExpression = ((ReferenceExpression) this.left).resolveExpressionExpecting(this.right, scope, inferenceContext);
+			ReferenceExpression referenceExpression = ((ReferenceExpression) this.left).resolveExpressionExpecting(this.right, scope);
 			MethodBinding method = referenceExpression != null ? referenceExpression.binding : null;
 			if (method != null)
 				ePrime = method.thrownExceptions;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ConstraintExpressionFormula.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ConstraintExpressionFormula.java
@@ -185,7 +185,7 @@ class ConstraintExpressionFormula extends ConstraintFormula {
 					for (TypeBinding parameter : parameters)
 						if (!parameter.isProperType(true))
 							return FALSE;
-				lambda = lambda.resolveExpressionExpecting(t, inferenceContext.scope, inferenceContext);
+				lambda = lambda.resolveExpressionExpecting(t, inferenceContext.scope);
 				if (lambda == null)
 					return FALSE; // not strictly unreduceable, but proceeding with TRUE would likely produce secondary errors
 				if (functionType.returnType == TypeBinding.VOID) {
@@ -268,7 +268,7 @@ class ConstraintExpressionFormula extends ConstraintFormula {
 		if (functionType == null)
 			return FALSE;
 		// potentially-applicable method for the method reference when targeting T (15.13.1),
-		reference = reference.resolveExpressionExpecting(t, inferenceContext.scope, inferenceContext);
+		reference = reference.resolveExpressionExpecting(t, inferenceContext.scope);
 		MethodBinding potentiallyApplicable = reference != null ? reference.binding : null;
 		if (potentiallyApplicable == null)
 			return FALSE;
@@ -518,7 +518,7 @@ class ConstraintExpressionFormula extends ConstraintFormula {
 				if (sam.returnType != TypeBinding.VOID) {
 					// ii)
 					final TypeBinding r = sam.returnType;
-					LambdaExpression resolved = lambda.resolveExpressionExpecting(this.right, context.scope, context);
+					LambdaExpression resolved = lambda.resolveExpressionExpecting(this.right, context.scope);
 					Expression[] resultExpressions = resolved != null ? resolved.resultExpressions() : null;
 					for (int i = 0, length = resultExpressions == null ? 0 : resultExpressions.length; i < length; i++) {
 						variables.addAll(new ConstraintExpressionFormula(resultExpressions[i], r, COMPATIBLE).inputVariables(context));

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
@@ -194,13 +194,12 @@ public class InferenceContext18 {
 	}
 
 	/** Construct an inference context for an invocation (method/constructor). */
-	public InferenceContext18(Scope scope, Expression[] arguments, InvocationSite site, InferenceContext18 outerContext) {
+	public InferenceContext18(Scope scope, Expression[] arguments, InvocationSite site) {
 		this.scope = scope;
 		this.environment = scope.environment();
 		this.object = scope.getJavaLangObject();
 		this.invocationArguments = arguments;
 		this.currentInvocation = site;
-		this.outerContext = outerContext;
 		if (site instanceof Invocation)
 			scope.compilationUnitScope().registerInferredInvocation((Invocation) site);
 	}
@@ -671,7 +670,7 @@ public class InferenceContext18 {
 						t = ConstraintExpressionFormula.findGroundTargetType(this, skope, lambda, withWildCards);
 					}
 					MethodBinding functionType;
-					if (t != null && (functionType = t.getSingleAbstractMethod(skope, true)) != null && (lambda = lambda.resolveExpressionExpecting(t, this.scope, this)) != null) {
+					if (t != null && (functionType = t.getSingleAbstractMethod(skope, true)) != null && (lambda = lambda.resolveExpressionExpecting(t, this.scope)) != null) {
 						TypeBinding r = functionType.returnType;
 						Expression[] resultExpressions = lambda.resultExpressions();
 						for (int i = 0, length = resultExpressions == null ? 0 : resultExpressions.length; i < length; i++) {
@@ -1111,17 +1110,10 @@ public class InferenceContext18 {
 	public TypeBinding /*@Nullable*/[] getSolutions(TypeVariableBinding[] typeParameters, InvocationSite site, BoundSet boundSet) {
 		int len = typeParameters.length;
 		TypeBinding[] substitutions = new TypeBinding[len];
-		InferenceVariable[] outerVariables = null;
-		if (this.outerContext != null && this.outerContext.stepCompleted < TYPE_INFERRED)
-			outerVariables = this.outerContext.inferenceVariables;
 		for (int i = 0; i < typeParameters.length; i++) {
 			for (InferenceVariable variable : this.inferenceVariables) {
 				if (isSameSite(variable.site, site) && TypeBinding.equalsEquals(variable.typeParameter, typeParameters[i])) {
-					TypeBinding outerVar = null;
-					if (outerVariables != null && (outerVar = boundSet.getEquivalentOuterVariable(variable, outerVariables)) != null)
-						substitutions[i] = outerVar;
-					else
-						substitutions[i] = boundSet.getInstantiation(variable, this.environment);
+					substitutions[i] = boundSet.getInstantiation(variable, this.environment);
 					break;
 				}
 			}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
@@ -64,13 +64,11 @@ import java.util.function.Predicate;
 import java.util.stream.Stream;
 import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.internal.compiler.ast.ASTNode;
-import org.eclipse.jdt.internal.compiler.ast.LambdaExpression;
 import org.eclipse.jdt.internal.compiler.ast.MethodDeclaration;
 import org.eclipse.jdt.internal.compiler.ast.NullAnnotationMatching;
 import org.eclipse.jdt.internal.compiler.ast.RecordComponent;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
-import org.eclipse.jdt.internal.compiler.impl.ReferenceContext;
 
 /*
 Not all fields defined by this type (& its subclasses) are initialized when it is created.
@@ -1519,18 +1517,6 @@ private boolean isCompatibleWith0(TypeBinding otherType, /*@Nullable*/ Scope cap
 				if ((otherLowerBound = otherCapture.lowerBound) != null) {
 					if (otherLowerBound.isArrayType()) return false;
 					return isCompatibleWith(otherLowerBound);
-				}
-			}
-			if (otherType instanceof InferenceVariable) {
-				// may interpret InferenceVariable as a joker, but only when within an outer lambda inference:
-				if (captureScope != null) {
-					MethodScope methodScope = captureScope.methodScope();
-					if (methodScope != null) {
-						ReferenceContext referenceContext = methodScope.referenceContext;
-						if (referenceContext instanceof LambdaExpression
-								&& ((LambdaExpression)referenceContext).inferenceContext != null)
-							return true;
-					}
 				}
 			}
 			//$FALL-THROUGH$

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Scope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Scope.java
@@ -4620,7 +4620,7 @@ public abstract class Scope {
 					} else {
 						expressions = ((ReferenceExpression)invocationSite).createPseudoExpressions(argumentTypes);
 					}
-					InferenceContext18 ic18 = new InferenceContext18(this, expressions, invocationSite, null);
+					InferenceContext18 ic18 = new InferenceContext18(this, expressions, invocationSite);
 					if (!ic18.isMoreSpecificThan(mbj, mbk, levelj == VARARGS_COMPATIBLE, levelk == VARARGS_COMPATIBLE)) {
 						continue nextJ;
 					}


### PR DESCRIPTION
see https://github.com/eclipse-jdt/eclipse.jdt.core/commit/bac0b688c9760eba84723fa01c9ef8fce3bf0175

Discovery from discussion in #4565: this change was not strictly backed by JLS ("reading between the lines"), and as of today it doesn't seem to be needed any more.