### PR TITLE
content of code tag is parsed outside

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/AbstractCommentParser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/AbstractCommentParser.java
@@ -365,6 +365,7 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 								considerTagAsPlainText = false; // re-enable tag validation
 							}
 						}
+						boolean isLiteralOrCode = this.tagValue == TAG_LITERAL_VALUE || this.tagValue == TAG_CODE_VALUE;
 						if (this.inlineTagStarted) {
 							textEndPosition = this.index - 1;
 							boolean treatAsText= considerTagAsPlainText || (this.inlineReturn && this.inlineReturnOpenBraces > 0);
@@ -377,8 +378,12 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 							}
 							if (!isFormatterParser && !treatAsText && (!this.inlineReturn || this.inlineReturnOpenBraces <= 0))
 								this.textStart = this.index;
-							if ((!isTagElementClose && this.markdown) || !this.markdown) {  //The comment parser should create a TagElement only if the previous one is closed - markdown.
+							if (!isTagElementClose && this.markdown) {  //The comment parser should create a TagElement only if the previous one is closed - markdown.
 								setInlineTagStarted(false);
+							} else if (!this.markdown) {
+								if (!(isLiteralOrCode && openingBraces != 0)) {
+							        setInlineTagStarted(false);
+							    }
 							}
 							if (this.inlineReturn) {
 								if (this.inlineReturnOpenBraces > 0) {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterJavadocTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterJavadocTest.java
@@ -3404,19 +3404,16 @@ public class ASTConverterJavadocTest extends ConverterTestSetup {
 			assumeEquals(this.prefix+"Wrong number of tags", 1, docComment.tags().size());
 			TagElement tagElement = (TagElement) docComment.tags().get(0);
 			assumeNull(this.prefix+"Wrong type of tag ["+tagElement+"]", tagElement.getTagName());
-			assumeEquals(this.prefix+"Wrong number of fragments in tag ["+tagElement+"]", 3, tagElement.fragments().size());
+			assumeEquals(this.prefix+"Wrong number of fragments in tag ["+tagElement+"]", 2, tagElement.fragments().size());
 			ASTNode fragment = (ASTNode) tagElement.fragments().get(0);
 			assumeEquals(this.prefix+"Invalid type for fragment ["+fragment+"]", ASTNode.TEXT_ELEMENT, fragment.getNodeType());
 			fragment = (ASTNode) tagElement.fragments().get(1);
 			assumeEquals(this.prefix+"Invalid type for fragment ["+fragment+"]", ASTNode.TAG_ELEMENT, fragment.getNodeType());
 			TagElement inlineTag = (TagElement) fragment;
-			assumeEquals(this.prefix+"Wrong number of fragments in tag ["+inlineTag+"]", 1, inlineTag.fragments().size());
-			fragment = (ASTNode) inlineTag.fragments().get(0);
-			assumeEquals(this.prefix+"Invalid type for fragment ["+fragment+"]", ASTNode.TEXT_ELEMENT, fragment.getNodeType());
-			fragment = (ASTNode) tagElement.fragments().get(2);
-			assumeEquals(this.prefix+"Invalid type for fragment ["+fragment+"]", ASTNode.TEXT_ELEMENT, fragment.getNodeType());
-			TextElement textElement = (TextElement) fragment;
-			assumeEquals(this.prefix+"Invalid content for text element ", "{@link BadLink} is just text}", textElement.getText());
+			assumeEquals(this.prefix+"Wrong number of fragments in tag ["+inlineTag+"]", 2, inlineTag.fragments().size());
+			ASTNode fragment1 = (ASTNode) inlineTag.fragments().get(0);
+			assumeEquals(this.prefix+"Invalid type for fragment ["+fragment1+"]", ASTNode.TEXT_ELEMENT, fragment1.getNodeType());
+			assumeEquals(this.prefix+"Invalid content for text element ", "{@literal raw text:{@link BadLink} is just text}", fragment.toString());
 		}
 	}
 	/**
@@ -3451,19 +3448,139 @@ public class ASTConverterJavadocTest extends ConverterTestSetup {
 			assumeEquals(this.prefix+"Wrong number of tags", 1, docComment.tags().size());
 			TagElement tagElement = (TagElement) docComment.tags().get(0);
 			assumeNull(this.prefix+"Wrong type of tag ["+tagElement+"]", tagElement.getTagName());
-			assumeEquals(this.prefix+"Wrong number of fragments in tag ["+tagElement+"]", 3, tagElement.fragments().size());
+			assumeEquals(this.prefix+"Wrong number of fragments in tag ["+tagElement+"]", 2, tagElement.fragments().size());
 			ASTNode fragment = (ASTNode) tagElement.fragments().get(0);
 			assumeEquals(this.prefix+"Invalid type for fragment ["+fragment+"]", ASTNode.TEXT_ELEMENT, fragment.getNodeType());
 			fragment = (ASTNode) tagElement.fragments().get(1);
 			assumeEquals(this.prefix+"Invalid type for fragment ["+fragment+"]", ASTNode.TAG_ELEMENT, fragment.getNodeType());
 			TagElement inlineTag = (TagElement) fragment;
-			assumeEquals(this.prefix+"Wrong number of fragments in tag ["+inlineTag+"]", 1, inlineTag.fragments().size());
+			assumeEquals(this.prefix+"Wrong number of fragments in tag ["+inlineTag+"]", 2, inlineTag.fragments().size());
 			fragment = (ASTNode) inlineTag.fragments().get(0);
 			assumeEquals(this.prefix+"Invalid type for fragment ["+fragment+"]", ASTNode.TEXT_ELEMENT, fragment.getNodeType());
-			fragment = (ASTNode) tagElement.fragments().get(2);
-			assumeEquals(this.prefix+"Invalid type for fragment ["+fragment+"]", ASTNode.TEXT_ELEMENT, fragment.getNodeType());
-			TextElement textElement = (TextElement) fragment;
-			assumeEquals(this.prefix+"Invalid content for text element ", "{@link BadLink} is just text}", textElement.getText());
+			assumeEquals(this.prefix+"Invalid content for text element ", "{@link BadLink} is just text", inlineTag.fragments().get(1).toString());
 		}
+	}
+
+	public void testContentOfCodeParsedOutside4615_01() throws JavaModelException {
+		this.workingCopies = new ICompilationUnit[1];
+		this.astLevel = AST.JLS25;
+		this.workingCopies[0] = getWorkingCopy("/Converter25/src/javadoc/X.java",
+				"""
+					/**
+					* {@code public class Example { final int a = 1; } }
+					*/
+					public class X {}
+				"""
+		);
+		CompilationUnit compilUnit = (CompilationUnit) runConversion(this.workingCopies[0], true);
+		List unitComments = compilUnit.getCommentList();
+		assertEquals("Wrong number of comments", 1, unitComments.size());
+		Comment comment = (Comment) unitComments.get(0);
+		assertEquals("Comment should be javadoc", comment.getNodeType(), ASTNode.JAVADOC);
+		Javadoc docComment = (Javadoc) compilUnit.getCommentList().get(0);
+		assumeEquals("Wrong number of tags", 1, docComment.tags().size());
+		TagElement tagElement = (TagElement) docComment.tags().get(0);
+		List<TagElement> listFrag = tagElement.fragments();
+		assumeEquals("wrong number of tags", 1, listFrag.size());
+	}
+
+	public void testContentOfCodeParsedOutside4615_02() throws JavaModelException {
+		this.workingCopies = new ICompilationUnit[1];
+		this.astLevel = AST.JLS25;
+		this.workingCopies[0] = getWorkingCopy("/Converter25/src/javadoc/X.java",
+				"""
+				   /**
+				   * {@code com/{filename:\\w+}.jsp}
+					*/
+					public class X {}
+				"""
+				);
+		CompilationUnit compilUnit = (CompilationUnit) runConversion(this.workingCopies[0], true);
+		List unitComments = compilUnit.getCommentList();
+		assertEquals("Wrong number of comments", 1, unitComments.size());
+		Comment comment = (Comment) unitComments.get(0);
+		assertEquals("Comment should be javadoc", comment.getNodeType(), ASTNode.JAVADOC);
+		Javadoc docComment = (Javadoc) compilUnit.getCommentList().get(0);
+		assumeEquals("wrong number of tags", 1, docComment.tags().size());
+		TagElement parentTag = (TagElement) docComment.tags().get(0);
+		List<?> frags = parentTag.fragments();
+		assumeEquals("wrong number of frags", 1, frags.size());
+		TagElement problematicTag = (TagElement) frags.get(0);
+		assumeEquals("invalid content", "{@code com/{filename:\\w+}.jsp}", problematicTag.toString());
+	}
+
+	public void testContentOfCodeParsedOutside4615_03() throws JavaModelException {
+		this.workingCopies = new ICompilationUnit[1];
+		this.astLevel = AST.JLS25;
+		this.workingCopies[0] = getWorkingCopy("/Converter25/src/javadoc/X.java",
+				"""
+					/**
+					* {@code public class X { void foo() { int x; } } }
+					*/
+					public class X {}
+				"""
+		);
+		CompilationUnit compilUnit = (CompilationUnit) runConversion(this.workingCopies[0], true);
+		List unitComments = compilUnit.getCommentList();
+		assertEquals("Wrong number of comments", 1, unitComments.size());
+		Comment comment = (Comment) unitComments.get(0);
+		assertEquals("Comment should be javadoc", comment.getNodeType(), ASTNode.JAVADOC);
+		Javadoc docComment = (Javadoc) compilUnit.getCommentList().get(0);
+		assumeEquals("Wrong number of tags", 1, docComment.tags().size());
+		TagElement tagElement = (TagElement) docComment.tags().get(0);
+		List<TagElement> listFrag = tagElement.fragments();
+		assumeEquals("wrong number of tags", 1, listFrag.size());
+		assumeEquals("Invalid content", "{@code public class X { void foo() { int x; } } }", listFrag.get(0).toString());
+	}
+
+	public void testContentOfCodeParsedOutside4615_04() throws JavaModelException {
+		this.workingCopies = new ICompilationUnit[1];
+		this.astLevel = AST.JLS25;
+		this.workingCopies[0] = getWorkingCopy("/Converter25/src/javadoc/X.java",
+				"""
+					/**
+					* {@code public class Example { final int sasi; } class B{}}
+					*/
+					public class X {}
+				"""
+		);
+		CompilationUnit compilUnit = (CompilationUnit) runConversion(this.workingCopies[0], true);
+		List unitComments = compilUnit.getCommentList();
+		assertEquals("Wrong number of comments", 1, unitComments.size());
+		Comment comment = (Comment) unitComments.get(0);
+		assertEquals("Comment should be javadoc", comment.getNodeType(), ASTNode.JAVADOC);
+		Javadoc docComment = (Javadoc) compilUnit.getCommentList().get(0);
+		assumeEquals("Wrong number of tags", 1, docComment.tags().size());
+		TagElement tagElement = (TagElement) docComment.tags().get(0);
+		List<TagElement> listFrag = tagElement.fragments();
+		assumeEquals("wrong number of tags", 1, listFrag.size());
+		assumeEquals("Invalid content", "{@code public class Example { final int sasi; } class B{}}", listFrag.get(0).toString());
+	}
+
+	//code tag in multiple lines
+	public void testContentOfCodeParsedOutside4615_05() throws JavaModelException {
+		this.workingCopies = new ICompilationUnit[1];
+		this.astLevel = AST.JLS25;
+		this.workingCopies[0] = getWorkingCopy("/Converter25/src/javadoc/X.java",
+				"""
+				   /**
+				   * {@code com/{filename:\\w+}
+				   * .jsp}
+					*/
+					public class X {}
+				"""
+				);
+		CompilationUnit compilUnit = (CompilationUnit) runConversion(this.workingCopies[0], true);
+		List unitComments = compilUnit.getCommentList();
+		assertEquals("Wrong number of comments", 1, unitComments.size());
+		Comment comment = (Comment) unitComments.get(0);
+		assertEquals("Comment should be javadoc", comment.getNodeType(), ASTNode.JAVADOC);
+		Javadoc docComment = (Javadoc) compilUnit.getCommentList().get(0);
+		assumeEquals("wrong number of tags", 1, docComment.tags().size());
+		TagElement parentTag = (TagElement) docComment.tags().get(0);
+		List<?> frags = parentTag.fragments();
+		assumeEquals("wrong number of frags", 1, frags.size());
+		TagElement problematicTag = (TagElement) frags.get(0);
+		assumeEquals("invalid content", "{@code com/{filename:\\w+}.jsp}", problematicTag.toString());
 	}
 }


### PR DESCRIPTION
The content of the `@code` tag is being parsed outside the code tag

Fix: https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4598

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
#### Scenario 1
```
/**
* <p>The mapping matches URLs using the following rules:<br>
* <ul>
* <li>{@code {spring:[a-z]+}} matches the regexp {@code [a-z]+} as a path variable named "spring"</li>
* <li>{@code com/{filename:\\w+}.jsp} will match {@code com/test.jsp} and assign the value {@code test}
* to the {@code filename} variable</li>
* </ul>
*/
```

#### Scenario 2
```
/**
  * {@code com/{filename:\\w+}
  * .jsp}
*/
```

#### Scenario 3
```
/**
* {@code public class X { void foo() { int x; } } }
*/
```

#### Scenario 4
```
/**
* {@code public class Example { final int sasi; } class B{}}
*/
```

#### Scenario 5
```
/**
* {@code public class Example { final int a = 1; } }
*/
```
Please place the above Javadoc in any class or method, then hover over the respective class or method. You’ll notice that whatever appears inside the @code tag is rendered as a snippet


## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
