### PR TITLE
Generic record pattern not working in EJC

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
@@ -2014,13 +2014,9 @@ public class InferenceContext18 {
 		return true;
 	}
 	private TypeBinding deriveTPrime(RecordPattern recordPattern, TypeBinding candidateT, InferenceVariable[] alphas, TypeBinding typeBinding) {
-		ParameterizedTypeBinding parameterizedType = null;
-		TypeBinding tPrime = null;
-		if (candidateT.isParameterizedType()) {
-			parameterizedType = InferenceContext18.parameterizedWithWildcard(candidateT);
-		}
-		if (parameterizedType != null && parameterizedType.arguments != null) {
-			TypeBinding[] arguments = parameterizedType.capture(this.scope, recordPattern.sourceStart, recordPattern.sourceEnd).arguments;
+		TypeBinding tPrime = candidateT.capture(this.scope, recordPattern.sourceStart, recordPattern.sourceEnd);
+		if (tPrime instanceof ParameterizedTypeBinding parameterizedType && parameterizedType.arguments != null) {
+			TypeBinding[] arguments = parameterizedType.arguments;
 			/* addTypeVariableSubstitutions() gives a beta for every argument which is
 			 * a super set of betas required by 18_5_5_item_3_bullet_1 betas.
 			 * this happens since we are just reusing 18.5.2.1 utility
@@ -2028,13 +2024,13 @@ public class InferenceContext18 {
 			 * TODO: a Just18_5_5_item_3_bullet_1Betas utility?
 			 */
 			InferenceVariable[] notJust18_5_5_item_3_bullet_1Betas = addTypeVariableSubstitutions(arguments, true);
-			TypeVariableBinding[] typeVariables = getTPrimeArgumentsAndCreateBounds(parameterizedType,
+			TypeBinding[] typeArguments = getTPrimeArgumentsAndCreateBounds(parameterizedType,
 					notJust18_5_5_item_3_bullet_1Betas);
 			tPrime = this.environment.createParameterizedType(
-					parameterizedType.genericType(), typeVariables,
+					parameterizedType.genericType(), typeArguments,
 					parameterizedType.enclosingType(), parameterizedType.getTypeAnnotations());
-			createAdditionalBoundswithU((ParameterizedTypeBinding) tPrime, notJust18_5_5_item_3_bullet_1Betas, typeVariables);
-		} else if (candidateT.isTypeVariable() || candidateT.isIntersectionType18()) {
+			createAdditionalBoundswithU((ParameterizedTypeBinding) tPrime, notJust18_5_5_item_3_bullet_1Betas, typeArguments);
+		} else if (tPrime.isTypeVariable() || tPrime.isIntersectionType18()) {
 			// 18.5.5_item_3_bullet_3
 			/* If T is a type variable or an intersection type, then for each upper bound of the type
 			 * variable or element of the intersection type, this step and step 4 are repeated
@@ -2051,7 +2047,7 @@ public class InferenceContext18 {
 						return null;
 				}
 			}
-			return tPrime = candidateT; //18.5.5_item_3_bullet_2
+			return tPrime = candidateT; //18.5.5_item_3_bullet_4
 		} else if (candidateT.isClass() || candidateT.isInterface()) {
 			tPrime = candidateT; //18.5.5_item_3_bullet_2
 		}
@@ -2059,12 +2055,12 @@ public class InferenceContext18 {
 	}
 
 	private void createAdditionalBoundswithU(ParameterizedTypeBinding tPrime, InferenceVariable[] notJust18_5_5_item_3_bullet_1Betas,
-			TypeVariableBinding[] typeVariables) {
+			TypeBinding[] typeArguments) {
 		TypeVariableBinding[] typeParams = tPrime.original().typeVariables();
 		TypeBinding[] aArr = tPrime.typeArguments();
 		for (int i = 0, l = notJust18_5_5_item_3_bullet_1Betas.length; i < l; ++i) {
 			InferenceVariable beta = notJust18_5_5_item_3_bullet_1Betas[i];
-			if (beta == null || !beta.equals(typeVariables[i])) continue; //not an expected inference variable.
+			if (beta == null || !beta.equals(typeArguments[i])) continue; //not an expected inference variable.
 
 			TypeBinding[] uArr = typeParams[i]!= null ? typeParams[i].allUpperBounds() : null;
 			if (uArr == null || uArr.length == 0) {
@@ -2095,17 +2091,17 @@ public class InferenceContext18 {
 		}
 	}
 
-	private TypeVariableBinding[] getTPrimeArgumentsAndCreateBounds(
+	private TypeBinding[] getTPrimeArgumentsAndCreateBounds(
 			ParameterizedTypeBinding parameterizedType,
 			InferenceVariable[] beta) {
 		TypeBinding[] arguments = parameterizedType.typeArguments();
-		TypeVariableBinding[] typeVariables = new TypeVariableBinding[arguments.length];
+		TypeBinding[] typearguments = Arrays.copyOf(arguments, arguments.length);
 		InferenceSubstitution theta = new InferenceSubstitution(this.environment, beta, this.currentInvocation);
 		TypeBound bound;
 		for (int i = 0, l = arguments.length; i < l; ++i) {
 			bound = null;
-			if (arguments[i].kind() == Binding.WILDCARD_TYPE && beta[i] != null) {
-				WildcardBinding wildcard = (WildcardBinding) arguments[i];
+			if (arguments[i].getClass() == CaptureBinding.class && beta[i] != null) { // exclude subclass CaptureBinding18
+				WildcardBinding wildcard = ((CaptureBinding) arguments[i]).wildcard;
 				switch(wildcard.boundKind) {
 					case Wildcard.EXTENDS :
 						TypeBinding uTheta = Scope.substitute(theta, wildcard.allBounds());
@@ -2121,20 +2117,14 @@ public class InferenceContext18 {
 					default:
 						continue;
 				}
-			} else {
-				/* As per 18_5_5_item_3_bullet_1 should not have a beta here
-				 * instead the same typevariable  */
-				typeVariables[i] = parameterizedType.type.typeVariables()[i];
 			}
 			if (bound != null) {
 				this.currentBounds.addBound(bound, this.environment);
-				typeVariables[i] = beta[i];
-			} else {
-				typeVariables[i] = parameterizedType.type.typeVariables()[i];
+				typearguments[i] = beta[i];
 
 			}
 		}
-		return typeVariables;
+		return typearguments;
 	}
 
 	public boolean isInexactVarargsInference() {


### PR DESCRIPTION
+ remove unmotivated check parameterizedWithWildcard()
+ consistently use the captured type Tc
+ extract wildcard from the expected capture

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4002
