### PR TITLE
Pass FORCE_PROBLEM_DETECTION from reconcile to CompilationUnitResolver

### DIFF
--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ASTParser.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/ASTParser.java
@@ -487,6 +487,21 @@ public class ASTParser {
 	}
 
 	/**
+	 * Requests for the compiler to force problem detection (such as extra analysis
+	 * or linting configured in project).
+	 * @param enabled <code>true</code> if problems are wanted, and <code>false</code>
+	 *                if problems are not of interest.
+	 * @since 3.44
+	 */
+	public void setForceProblemDetection(boolean enabled) {
+		if (enabled) {
+			this.bits |= CompilationUnitResolver.FORCE_PROBLEM_DETECTION;
+		} else {
+			this.bits &= ~CompilationUnitResolver.FORCE_PROBLEM_DETECTION;
+		}
+	}
+
+	/**
 	 * Requests an abridged abstract syntax tree.
 	 * By default, complete ASTs are returned.
 	 * <p>

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/CompilationUnitResolver.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/CompilationUnitResolver.java
@@ -126,6 +126,7 @@ class CompilationUnitResolver extends Compiler {
 	public static final int IGNORE_METHOD_BODIES = 0x8;
 	public static final int BINDING_RECOVERY = 0x10;
 	public static final int INCLUDE_RUNNING_VM_BOOTCLASSPATH = 0x20;
+	public static final int FORCE_PROBLEM_DETECTION = 0x40;
 
 	/* A list of int */
 	static class IntArrayList {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ReconcileWorkingCopyOperation.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ReconcileWorkingCopyOperation.java
@@ -202,8 +202,9 @@ public class ReconcileWorkingCopyOperation extends JavaModelOperation {
 				if (CompilationUnit.DOM_BASED_OPERATIONS) {
 					try {
 						ASTParser parser = ASTParser.newParser(this.astLevel > 0 ? this.astLevel : AST.getJLSLatest());
-						parser.setResolveBindings(this.resolveBindings || (this.reconcileFlags & ICompilationUnit.FORCE_PROBLEM_DETECTION) != 0);
+						parser.setResolveBindings(this.resolveBindings);
 						parser.setCompilerOptions(options);
+						parser.setForceProblemDetection((this.reconcileFlags & ICompilationUnit.FORCE_PROBLEM_DETECTION) != 0);
 						parser.setSource(source);
 						org.eclipse.jdt.core.dom.CompilationUnit newAST = (org.eclipse.jdt.core.dom.CompilationUnit) parser.createAST(this.progressMonitor);
 						if ((this.reconcileFlags & ICompilationUnit.FORCE_PROBLEM_DETECTION) != 0 && newAST != null) {


### PR DESCRIPTION
Through ASTParser.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does

The ASTParser implementation may trigger extra analysis on demand. The FORCE_PROBLEM_DETECTION flag must be somehow passed to underlying ICompilationUnitResolver implementation to allow that.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4631

## How to test

See it in combination with https://github.com/eclipse-jdtls/eclipse-jdt-core-incubator/pull/1879 which clarifies that this flag is necessary to make some tests pass with a DOM-based approach.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
