### PR TITLE
issue #4637 - Make compiler exception stacktrace visible in verbose mode

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/Compiler.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/Compiler.java
@@ -612,7 +612,7 @@ public class Compiler implements ITypeRequestor, ProblemSeverities {
 				needToPrint = false;
 			}
 		}
-		if (needToPrint) {
+		if (needToPrint || this.options.verbose) {
 			/* dump a stack trace to the console */
 			internalException.printStackTrace();
 		}


### PR DESCRIPTION
My proposed solution to #4637