### PR TITLE
[26] Fixing the omissions in test infra delta for running with 26

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractRegressionTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractRegressionTest.java
@@ -8,6 +8,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Stephan Herrmann - Contribution for
@@ -342,6 +346,8 @@ static class JavacCompiler {
 			return JavaCore.VERSION_24;
 		} else if(rawVersion.startsWith("25")) {
 			return JavaCore.VERSION_25;
+		} else if(rawVersion.startsWith("26")) {
+			return JavaCore.VERSION_26;
 		} else {
 			throw new RuntimeException("unknown javac version: " + rawVersion);
 		}
@@ -589,6 +595,16 @@ static class JavacCompiler {
 		if (version == JavaCore.VERSION_25) {
 			switch(rawVersion) {
 				case "25-ea", "25-beta", "25":
+					return 0000;
+				case "25.0.1":
+					return 0100;
+				case "25.0.2":
+					return 0200;
+			}
+		}
+		if (version == JavaCore.VERSION_26) {
+			switch(rawVersion) {
+				case "26-ea", "26-beta", "26":
 					return 0000;
 			}
 		}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TestAll.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TestAll.java
@@ -263,11 +263,11 @@ public static Test suite() {
 	 since_25.add(ModuleImportTests.class);
 	 since_25.add(SuperAfterStatementsTest.class);
 	 since_25.add(ImplicitlyDeclaredClassesTest.class);
-	 since_25.add(PrimitiveInPatternsTest.class);
-	 since_25.add(PrimitiveInPatternsTestSH.class);
 
 	 ArrayList since_26 = new ArrayList();
 	 since_26.add(PreviewFlagTest.class);
+	 since_26.add(PrimitiveInPatternsTest.class);
+	 since_26.add(PrimitiveInPatternsTestSH.class);
 
 	record TestsAddition(ArrayList newTests, long testLevel, long jdkVersion) {}
 


### PR DESCRIPTION
## What it does
Fixes an omission of version_26 recognition that is required to run with Java 26

## How to test
Run a test, say `PrimitivesInPatternsTest` with `-Drun.javac=enabled -Djdk.root=<path-to-JDK-26>`. Without the fix there will be a runtime error with the following ST:

java.lang.RuntimeException: unknown javac version: 26-ea
	at org.eclipse.jdt.core.tests.compiler.regression.AbstractRegressionTest$JavacCompiler.versionFromRawVersion(AbstractRegressionTest.java:352)
	at org.eclipse.jdt.core.tests.compiler.regression.AbstractRegressionTest$JavacCompiler.<init>(AbstractRegressionTest.java:231)
	at org.eclipse.jdt.core.tests.compiler.regression.AbstractRegressionTest$JavacCompiler.<init>(AbstractRegressionTest.java:221)
	at org.eclipse.jdt.core.tests.compiler.regression.AbstractRegressionTest.setupJavac(AbstractRegressionTest.java:4225)
	at org.eclipse.jdt.core.tests.compiler.regression.AbstractRegressionTest.setUp(AbstractRegressionTest.java:4173)
	at org.eclipse.jdt.core.tests.compiler.regression.PrimitiveInPatternsTest.setUp(PrimitiveInPatternsTest.java:51)
	at junit.framework.TestCase.runBare(TestCase.java:140)


## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
