### PR TITLE
Define compliance levels for tests run on jre 26

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/test.xml
+++ b/org.eclipse.jdt.core.tests.compiler/test.xml
@@ -57,7 +57,7 @@
       <property name="classname" 
                 value="org.eclipse.jdt.core.tests.compiler.regression.TestAll"/>
       <property name="vmargs" 
-      	value="-Dcompliance.jre.17=1.8,11,17 -Dcompliance.jre.21=1.8,11,17,20,21 -Dcompliance.jre.22=1.8,11,17,21,22 -Dcompliance.jre.23=1.8,11,17,21,23 -Dcompliance.jre.24=1.8,11,17,21,24 -Dcompliance.jre.25=1.8,11,17,21,25 "
+      	value="-Dcompliance.jre.17=1.8,11,17 -Dcompliance.jre.21=1.8,11,17,20,21 -Dcompliance.jre.22=1.8,11,17,21,22 -Dcompliance.jre.23=1.8,11,17,21,23 -Dcompliance.jre.24=1.8,11,17,21,24 -Dcompliance.jre.25=1.8,11,17,21,25 -Dcompliance.jre.26=1.8,11,17,21,25,26 "
       />
     </ant>
 


### PR DESCRIPTION
Currently, Y-build tests on jre 26 run compiler tests at all possible compliance levels.

Following the rule to test on all "LTS" versions plus latest I'm setting `-Dcompliance.jre.26=1.8,11,17,21,25,26`