### PR TITLE
Guard against NPE that may arise due to re-entrancy

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Annotation.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Annotation.java
@@ -1377,6 +1377,8 @@ public abstract class Annotation extends Expression {
 
 		nextAnnotation:
 			for (Annotation annotation : annotations) {
+				if (annotation.resolvedType == null) // barked elsewhere or still cooking and we come here due to re-entrancy
+					continue;
 				long metaTagBits = annotation.resolvedType.getAnnotationTagBits();
 				if ((metaTagBits & TagBits.AnnotationForTypeUse) != 0 && (metaTagBits & TagBits.AnnotationForDeclarationMASK) == 0) {
 					ReferenceBinding currentType = (ReferenceBinding) resolvedType;


### PR DESCRIPTION
* Possible fix for https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4652