### PR TITLE
Compiler fails to generate tagElements for Markdown fences

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/IMarkdownCommentHelper.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/IMarkdownCommentHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 GK Software SE and others.
+ * Copyright (c) 2024, 2026 GK Software SE and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -137,8 +137,14 @@ class MarkdownCommentHelper implements IMarkdownCommentHelper {
 			this.fenceCharCount = 1;
 			return;
 		}
-		if (next != this.fenceChar || previous != next)
+		if (next != this.fenceChar)
 			return;
+		if (previous != next) {
+			if (this.insideFencedCodeBlock) {
+				this.fenceCharCount = 1;
+			}
+			return;
+		}
 		int required = this.insideFencedCodeBlock ? this.fenceLength : 3;
 		if (++this.fenceCharCount == required) {
 			this.insideFencedCodeBlock^=true;
@@ -192,6 +198,7 @@ class MarkdownCommentHelper implements IMarkdownCommentHelper {
 		this.leadingSpaces = 0;
 		this.markdownLineStart = -1;
 		this.fenceCharCount = 0;
+		this.inInlineCode = false;
 		// do not reset `insideFence`
 	}
 }

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterMarkdownTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterMarkdownTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -2175,6 +2175,63 @@ public class ASTConverterMarkdownTest extends ConverterTestSetup {
 			TagElement tagFrag2 = (TagElement) tags.fragments().get(3);
 			SimpleName simplName2 = (SimpleName) tagFrag2.fragments().get(1);
 			assertEquals("SimpleName2 value not match", "https://www.ex.com", simplName2.getIdentifier());
+		}
+	}
+
+	public void testIncorrectParsingBacktick4609_01() throws JavaModelException {
+		String source = """
+				/// The following is some sample code which illustrates source formatting within markdown comments:
+				/// ``` public class Example { final int a = 1; final boolean b = true;} ```
+				/// Descriptions of parameters and return values are best appended at end of the markdown comment.
+				/// @param first  The first parameter. For an optimum result, this should be an odd number between 0 and 100.
+				/// @param second The second parameter.
+				/// @throws Exception when the foo operation cannot be performed for one reason or another.
+				/// @return The result of the foo operation, usually an even number within 0 and 1000.
+				public class Markdown{}
+				""";
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy("/Converter_25/src/markdown/Markdown.java", source, null);
+		if (this.docCommentSupport.equals(JavaCore.ENABLED)) {
+			CompilationUnit compilUnit = (CompilationUnit) runConversion(this.workingCopies[0], true);
+			TypeDeclaration typedeclaration =  (TypeDeclaration) compilUnit.types().get(0);
+			Javadoc javadoc = typedeclaration.getJavadoc();
+			List<TagElement> tags = javadoc.tags();
+			assertEquals("Incorrect Tags", 5, tags.size());
+			assertEquals("incorrect first tagElement", ASTNode.TAG_ELEMENT, tags.get(0).getNodeType());
+			assertEquals("incorrect second tagElement", ASTNode.TAG_ELEMENT, tags.get(1).getNodeType());
+			assertEquals("incorrect Third tagElement", ASTNode.TAG_ELEMENT, tags.get(2).getNodeType());
+			assertEquals("incorrect Fourth tagElement", ASTNode.TAG_ELEMENT, tags.get(3).getNodeType());
+			assertEquals("incorrect Fifth tagElement", ASTNode.TAG_ELEMENT, tags.get(4).getNodeType());
+		}
+	}
+
+	// malfound test - single backtick should not be in single line
+	public void testIncorrectParsingBacktick4609_02() throws JavaModelException {
+		String source = """
+				/// The following is some sample code which illustrates source formatting within markdown comments:
+				/// ` public class Example {
+				/// 		 final int a = 1; final boolean b = true;
+				/// 	} `
+				/// Descriptions of parameters and return values are best appended at end of the markdown comment.
+				/// @param first  The first parameter. For an optimum result, this should be an odd number between 0 and 100.
+				/// @param second The second parameter.
+				/// @throws Exception when the foo operation cannot be performed for one reason or another.
+				/// @return The result of the foo operation, usually an even number within 0 and 1000.
+				public class Markdown{}
+				""";
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy("/Converter_25/src/markdown/Markdown.java", source, null);
+		if (this.docCommentSupport.equals(JavaCore.ENABLED)) {
+			CompilationUnit compilUnit = (CompilationUnit) runConversion(this.workingCopies[0], true);
+			TypeDeclaration typedeclaration =  (TypeDeclaration) compilUnit.types().get(0);
+			Javadoc javadoc = typedeclaration.getJavadoc();
+			List<TagElement> tags = javadoc.tags();
+			assertEquals("Incorrect Tags", 5, tags.size());
+			assertEquals("incorrect first tagElement", ASTNode.TAG_ELEMENT, tags.get(0).getNodeType());
+			assertEquals("incorrect second tagElement", ASTNode.TAG_ELEMENT, tags.get(1).getNodeType());
+			assertEquals("incorrect Third tagElement", ASTNode.TAG_ELEMENT, tags.get(2).getNodeType());
+			assertEquals("incorrect Fourth tagElement", ASTNode.TAG_ELEMENT, tags.get(3).getNodeType());
+			assertEquals("incorrect Fifth tagElement", ASTNode.TAG_ELEMENT, tags.get(4).getNodeType());
 		}
 	}
 }


### PR DESCRIPTION
Markdown parser fails to generate TagElements after single-line triple backtick fence

Fix: https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4609

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
```
/// The following is some sample code which illustrates source formatting within markdown comments:
/// ``` public class Example { final int a = 1; final boolean b = true;} ```
/// Descriptions of parameters and return values are best appended at end of the markdown comment.
/// @param first  The first parameter. For an optimum result, this should be an odd number between 0 and 100.
/// @param second The second parameter.
/// @throws Exception when the foo operation cannot be performed for one reason or another.
/// @return The result of the foo operation, usually an even number within 0 and 1000.
public class Markdown{}
```

Hover over the Markdown portion of the example and examine the AST view to verify that TagElements are properly generated once the triple backtick fence has been parsed.
## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
