### PR TITLE
Ensure URB's are resolved before performing visibility checks

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/FunctionalExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/FunctionalExpression.java
@@ -239,8 +239,6 @@ public abstract class FunctionalExpression extends Expression {
 		}
 
 		private void checkVisibility(ReferenceBinding referenceBinding) {
-			if (referenceBinding.isUnresolvedType())
-				referenceBinding = (ReferenceBinding) BinaryTypeBinding.resolveType(referenceBinding, this.scope.environment(), false);
 			if (!referenceBinding.canBeSeenBy(this.scope)) {
 				this.visible = false;
 				if (this.shouldChatter)

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedTypeBinding.java
@@ -1209,6 +1209,9 @@ public class ParameterizedTypeBinding extends ReferenceBinding implements Substi
 		this.tagBits &= ~TagBits.HasUnresolvedTypeVariables; // can be recursive so only want to call once
 		ReferenceBinding resolvedType = (ReferenceBinding) BinaryTypeBinding.resolveType(this.type, this.environment, false /* no raw conversion */); // still part of parameterized type ref
 		this.tagBits |= resolvedType.tagBits & TagBits.ContainsNestedTypeReferences;
+		if (this.enclosingType != null) {
+			BinaryTypeBinding.resolveType(this.enclosingType, this.environment, false);
+		}
 		if (this.arguments != null) {
 			int argLength = this.arguments.length;
 			if ((this.type.tagBits & TagBits.HasMissingType) == 0) {


### PR DESCRIPTION
+ try to avoid root cause of URB surfacing in unexpected locations

Alternative fix for
https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4632
