### PR TITLE
APIDocumentationTests requires org.eclipse.jdt.core.source bundle

### DIFF
--- a/org.eclipse.jdt.core.tests.model/build.properties
+++ b/org.eclipse.jdt.core.tests.model/build.properties
@@ -24,3 +24,5 @@ src.includes = about.html
 source.. = src/
 output.. = bin/
 javacWarnings..=+fieldHiding,-unavoidableGenericProblems
+# Required for APIDocumentationTests
+additional.bundles = org.eclipse.jdt.core.source


### PR DESCRIPTION
Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4684
