### PR TITLE
Revert "APIDocumentationTests requires org.eclipse.jdt.core.source bundle"

### DIFF
--- a/org.eclipse.jdt.core.tests.model/build.properties
+++ b/org.eclipse.jdt.core.tests.model/build.properties
@@ -24,5 +24,3 @@ src.includes = about.html
 source.. = src/
 output.. = bin/
 javacWarnings..=+fieldHiding,-unavoidableGenericProblems
-# Required for APIDocumentationTests
-additional.bundles = org.eclipse.jdt.core.source


### PR DESCRIPTION
This reverts commit 98a67960a9985d38a21f18af0cf4534a6076ac52 as it doesn't fix the original issue with missing source bundle.
