### PR TITLE
Fix compile error with final field assignment in constructor with prologue in local class in constructor

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypeDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypeDeclaration.java
@@ -264,7 +264,7 @@ public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext, Fl
 		}
 		manageEnclosingInstanceAccessIfNecessary(currentScope, flowInfo);
 		updateMaxFieldCount(); // propagate down the max field count
-		internalAnalyseCode(flowContext, flowInfo.unconditionalFieldLessCopy());
+		internalAnalyseCode(flowContext, flowInfo.unconditionalFieldLessCopy()); // discards info about fields of enclosing classes
 	} catch (AbortType e) {
 		this.ignoreFurtherInvestigation = true;
 	}
@@ -300,7 +300,7 @@ public void analyseCode(ClassScope currentScope, FlowContext flowContext, FlowIn
 		}
 		manageEnclosingInstanceAccessIfNecessary(currentScope, flowInfo);
 		updateMaxFieldCount(); // propagate down the max field count
-		internalAnalyseCode(flowContext, flowInfo.unconditionalFieldLessCopy());
+		internalAnalyseCode(flowContext, flowInfo.unconditionalFieldLessCopy()); // discards info about fields of enclosing classes
 	} catch (AbortType e) {
 		this.ignoreFurtherInvestigation = true;
 	}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SuperAfterStatementsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SuperAfterStatementsTest.java
@@ -3639,5 +3639,39 @@ public class SuperAfterStatementsTest extends AbstractRegressionTest9 {
         	"""
 	    });
 	}
+	public void testIssue4700b() {
+		runNegativeTest(new String[] {
+			"Test.java",
+			"""
+			@SuppressWarnings("unused")
+			public class Test {
+				private final Object a;
+				public Test() {
+					a = new Object();
+					class Test2 {
+						private final Object b;
+						public Test2() {
+							System.out.println();
+							super();
+							try {
+								b = new Object();
+							} finally {
+								a = new Object();
+							}
+						}
+					}
+				}
+			}
+			"""
+			},
+			"""
+			----------
+			1. ERROR in Test.java (at line 14)
+				a = new Object();
+				^
+			The final field Test.a cannot be assigned
+			----------
+			""");
+	}
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
Fixes #4700 

## How to test
Attempt to compile
```java
public class Test {
	private final Object a;
	public Test() {
		a = new Object();
		class Test2 {
			private final Object b;
			public Test2() {
				System.out.println();
				super();
				b = new Object();
			}
		}
	}
}
```

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
