### PR TITLE
Fix double field initializations in constructors with prologue

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ConstructorDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ConstructorDeclaration.java
@@ -561,7 +561,7 @@ private void internalGenerateCode(ClassScope classScope, ClassFile classFile) {
 				if (!this.compilationResult.hasErrors() && (codeStream.stackDepth != 0 || codeStream.operandStack.size() != 0)) {
 					this.scope.problemReporter().operandStackSizeInappropriate(this);
 				}
-				if (lateConstructorCall == statement) {
+				if (lateConstructorCall == statement && lateConstructorCall.accessMode != ExplicitConstructorCall.This) {
 					// with JEP 492 (Flexible Constructor Bodies) involved field inits are generated only *after* the explicit constructor
 					generateFieldInitializations(declaringType, codeStream, initializerScope);
 				}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SuperAfterStatementsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SuperAfterStatementsTest.java
@@ -3512,5 +3512,82 @@ public class SuperAfterStatementsTest extends AbstractRegressionTest9 {
 			"""
 		});
 	}
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4696
+	public void testIssue4696a() {
+	    runConformTest(new String[] {
+	        "EcjBugRepro.java",
+	        """
+	        import java.util.HashMap;
+            import java.util.Map;
+
+            public class EcjBugRepro {
+
+                // 1. Field with implicit initializer
+                private final Map<String, String> data = new HashMap<>();
+
+                // Constructor 1: Uses Java 25 Pre-construction context + Chaining
+                public EcjBugRepro(int check) {
+                    if (check < 0) throw new IllegalArgumentException(); // Pre-construction statement
+                    this("delegated"); // Chaining
+                    // ERROR: ECJ seems to re-run 'data = new HashMap()' here, wiping the map
+                }
+
+                // Constructor 2: Standard
+                public EcjBugRepro(String val) {
+                    super();
+                    // Field init runs here (Correct)
+                    data.put("key", val);
+                    System.out.println("Constructor 2: Added item. Size: " + data.size());
+                }
+
+                public static void main(String[] args) {
+                    // Trigger via Constructor 1
+                    EcjBugRepro instance = new EcjBugRepro(1);
+
+                    if (instance.data.isEmpty()) {
+                        System.err.println("FAILURE: Map is empty! Field was re-initialized.");
+                    } else {
+                        System.out.println("Success: Map size is " + instance.data.size());
+                    }
+                }
+            }
+	        """
+	    },
+        "Constructor 2: Added item. Size: 1\n" +
+        "Success: Map size is 1");
+	}
+	public void testIssue4696b() {
+	    runConformTest(new String[] {
+	        "Problem.java",
+	        """
+  	        public class Problem {
+                private int counter = 0;
+
+                Problem(int counter) {
+                    this.counter = counter;
+                    System.out.println("counter=" + this.counter);
+                }
+
+                Problem(boolean b) {
+                    if (b) {
+                        System.out.println("constructor called");
+                    }
+                    this(1);
+                }
+
+                private Problem() {
+                    this(true);
+                }
+
+                public static void main(String[] args) {
+                	System.out.println(new Problem().counter);
+                }
+            }
+	        """
+	        },
+	        "constructor called\n" +
+	        "counter=1\n" +
+	        "1");
+	}
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
Fixes #4696 

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
