### PR TITLE
[Eclipse 2025-12 regression]: Type inference issue in Collectors.toMap method within Collectors.partitioningBy method

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BoundSet.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BoundSet.java
@@ -451,12 +451,14 @@ class BoundSet {
 		return hasProperBound;
 	}
 
-	public void addBounds(BoundSet that, LookupEnvironment environment) {
+	public void addBounds(BoundSet that, LookupEnvironment environment, boolean includeCaptureBounds) {
 		if (that == null || environment == null)
 			return;
 		addBounds(that.flatten(), environment);
 		this.inThrows.addAll(that.inThrows);
-		this.captures.putAll(that.captures);
+		if (includeCaptureBounds) {
+			this.captures.putAll(that.captures);
+		}
 	}
 
 	public boolean isInstantiated(InferenceVariable inferenceVariable) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
@@ -491,11 +491,11 @@ public class InferenceContext18 {
 			BoundSet toPush = deferred ? this.currentBounds.copy() : this.currentBounds;
 			Runnable job = () -> {
 				if (outer.directlyAcceptingInnerBounds) {
-					outer.currentBounds.addBounds(toPush, this.environment);
+					outer.currentBounds.addBounds(toPush, this.environment, false);
 				} else if (outer.innerInbox == null) {
 					outer.innerInbox = deferred ? toPush : toPush.copy(); // copy now, unless already copied on behalf of 'deferred'
 				} else {
-					outer.innerInbox.addBounds(toPush, this.environment);
+					outer.innerInbox.addBounds(toPush, this.environment, false);
 				}
 			};
 			if (deferred) {
@@ -515,7 +515,7 @@ public class InferenceContext18 {
 	/** Not JLS: merge pending bounds of inner inference into current. */
 	private void mergeInnerBounds() {
 		if (this.innerInbox != null) {
-			this.currentBounds.addBounds(this.innerInbox, this.environment);
+			this.currentBounds.addBounds(this.innerInbox, this.environment, false);
 			this.innerInbox = null;
 		}
 	}
@@ -709,7 +709,7 @@ public class InferenceContext18 {
 				if (!innerContext.computeB3(invocation, substF, shallowMethod))
 					return false;
 				if (innerContext.addConstraintsToC(arguments, c, innerMethod.genericMethod(), innerContext.inferenceKind, invocation)) {
-					this.currentBounds.addBounds(innerContext.currentBounds, this.environment);
+					this.currentBounds.addBounds(innerContext.currentBounds, this.environment, false);
 					return true;
 				}
 				return false;
@@ -1587,7 +1587,7 @@ public class InferenceContext18 {
 	}
 
 	public void integrateInnerInferenceB2(InferenceContext18 innerCtx) {
-		this.currentBounds.addBounds(innerCtx.b2, this.environment);
+		this.currentBounds.addBounds(innerCtx.b2, this.environment, true);
 		this.inferenceVariables = innerCtx.inferenceVariables;
 		this.inferenceKind = innerCtx.inferenceKind;
 		if (!isSameSite(innerCtx.currentInvocation, this.currentInvocation))

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
@@ -1664,6 +1664,39 @@ public void testIssue4503_matches_with_javac() {
 			"Unhandled exception type Throwable\n" +
 			"----------\n");
 }
+public void testGH4715() {
+	runConformTest(new String[] {
+		"TestMain.java",
+		"""
+		import java.util.Map;
+		import java.util.Map.Entry;
+		import java.util.Set;
+		import java.util.stream.Collectors;
+
+		public class TestMain {
+			public static void main(String[] args) {
+				final Map<String, Set<String>> pathToPIDMap = Map.ofEntries(
+						Map.entry("i1", Set.of("PID1")),
+						Map.entry("i1,i2", Set.of("PID2"))
+						);
+
+				final Map<Boolean, Map<String, Set<String>>> partitiionedPathToPIDSet = pathToPIDMap.entrySet().stream() // Error 3
+					.collect(Collectors.partitioningBy(entry -> {
+						final Set<String> pidSet = entry.getValue();
+						final boolean isSinglePIDSet = pidSet.size() == 1;
+						return isSinglePIDSet;
+					}, Collectors.mapping(entry -> {
+						final String path = entry.getKey();
+						final Set<String> pidSet = entry.getValue();
+
+						return Map.entry(path, pidSet);
+					}, Collectors.toMap(Entry::getKey, Entry::getValue)))); //Errors 1 and 2
+			}
+		}
+
+		"""
+	});
+}
 public void testGH4533() {
 	runConformTest(new String[] {
 		"X.java",


### PR DESCRIPTION
Behavior change is due to the fix #4520.

Fixed by heuristically including / excluding capture bounds during copy

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4715
