### PR TITLE
Spurious Warnings With Nullable Fields and Null Analysis checking

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Assignment.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Assignment.java
@@ -128,7 +128,7 @@ public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext, Fl
 				int timeToLive = (this.bits & InsideExpressionStatement) != 0
 									? 2  // assignment is statement: make info survives the end of this statement
 									: 1; // assignment is expression: expire on next event.
-				flowContext.recordNullCheckedFieldReference((Reference) this.lhs, timeToLive);
+				flowContext.recordNullCheckedFieldReference((Reference) this.lhs, timeToLive, FlowInfo.NON_NULL);
 			}
 		}
 	}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/EqualExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/EqualExpression.java
@@ -55,7 +55,8 @@ public class EqualExpression extends BinaryExpression {
 		// - method/field annotated @NonNull
 		// - allocation expression, some literals, this reference (see inside expressionNonNullComparison(..))
 		// these checks do not leverage the flowInfo.
-		boolean checkEquality = ((this.bits & OperatorMASK) >> OperatorSHIFT) == EQUAL_EQUAL;
+		boolean checkEquality = ((this.bits & OperatorMASK) >> OperatorSHIFT) == EQUAL_EQUAL
+								^ ((flowContext.tagBits & FlowContext.INSIDE_NEGATION) != 0);
 		if ((flowContext.tagBits & FlowContext.HIDE_NULL_COMPARISON_WARNING_MASK) == 0) {
 			if (leftStatus == FlowInfo.NON_NULL && rightStatus == FlowInfo.NULL) {
 				leftNonNullChecked = scope.problemReporter().expressionNonNullComparison(this.left, checkEquality);
@@ -64,7 +65,6 @@ public class EqualExpression extends BinaryExpression {
 			}
 		}
 
-		boolean contextualCheckEquality = checkEquality ^ ((flowContext.tagBits & FlowContext.INSIDE_NEGATION) != 0);
 		// perform flowInfo-based checks for variables and record info for syntactic null analysis for fields:
 		if (!leftNonNullChecked) {
 			LocalVariableBinding local = this.left.localVariableBinding();
@@ -73,12 +73,13 @@ public class EqualExpression extends BinaryExpression {
 					checkVariableComparison(scope, flowContext, flowInfo, initsWhenTrue, initsWhenFalse, local, rightStatus, this.left);
 				}
 			} else if (this.left instanceof Reference reference
-							&& ((contextualCheckEquality ? rightStatus == FlowInfo.NON_NULL : rightStatus == FlowInfo.NULL))
+							&& (rightStatus == FlowInfo.NON_NULL || rightStatus == FlowInfo.NULL)
 							&& shouldPerformSyntacticAnalsysisFor(scope, reference))
 			{
 				FieldBinding field = reference.lastFieldBinding();
 				if (field != null && (field.type.tagBits & TagBits.IsBaseType) == 0) {
-					flowContext.recordNullCheckedFieldReference((Reference) this.left, 1);
+					int checkedInfo = checkEquality ? rightStatus : FlowInfo.nullInverse(rightStatus);
+					flowContext.recordNullCheckedFieldReference((Reference) this.left, 1, checkedInfo);
 				}
 			}
 		}
@@ -89,12 +90,13 @@ public class EqualExpression extends BinaryExpression {
 					checkVariableComparison(scope, flowContext, flowInfo, initsWhenTrue, initsWhenFalse, local, leftStatus, this.right);
 				}
 			} else if (this.right instanceof Reference reference
-							&& ((contextualCheckEquality ? leftStatus == FlowInfo.NON_NULL : leftStatus == FlowInfo.NULL))
+							&& (leftStatus == FlowInfo.NON_NULL || leftStatus == FlowInfo.NULL)
 							&& shouldPerformSyntacticAnalsysisFor(scope, reference))
 			{
 				FieldBinding field = reference.lastFieldBinding();
 				if (field != null && (field.type.tagBits & TagBits.IsBaseType) == 0) {
-					flowContext.recordNullCheckedFieldReference((Reference) this.right, 1);
+					int checkedInfo = checkEquality ? leftStatus : FlowInfo.nullInverse(leftStatus);
+					flowContext.recordNullCheckedFieldReference((Reference) this.right, 1, checkedInfo);
 				}
 			}
 		}
@@ -132,7 +134,7 @@ public class EqualExpression extends BinaryExpression {
 		{
 			FieldBinding field = ((Reference)this.left).lastFieldBinding();
 			if (field != null && (field.type.tagBits & TagBits.IsBaseType) == 0) {
-				flowContext.recordNullCheckedFieldReference((Reference) this.left, 1);
+				flowContext.recordNullCheckedFieldReference((Reference) this.left, 1, FlowInfo.NON_NULL);
 			}
 		}
 		int leftStatus = this.left.nullStatus(flowInfo, flowContext);
@@ -142,7 +144,7 @@ public class EqualExpression extends BinaryExpression {
 		{
 			FieldBinding field = ((Reference)this.right).lastFieldBinding();
 			if (field != null && (field.type.tagBits & TagBits.IsBaseType) == 0) {
-				flowContext.recordNullCheckedFieldReference((Reference) this.right, 1);
+				flowContext.recordNullCheckedFieldReference((Reference) this.right, 1, FlowInfo.NON_NULL);
 			}
 		}
 	}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/IfStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/IfStatement.java
@@ -24,6 +24,7 @@ import org.eclipse.jdt.internal.compiler.codegen.BranchLabel;
 import org.eclipse.jdt.internal.compiler.codegen.CodeStream;
 import org.eclipse.jdt.internal.compiler.flow.FlowContext;
 import org.eclipse.jdt.internal.compiler.flow.FlowInfo;
+import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jdt.internal.compiler.impl.Constant;
 import org.eclipse.jdt.internal.compiler.lookup.BlockScope;
 import org.eclipse.jdt.internal.compiler.lookup.FieldBinding;
@@ -72,8 +73,15 @@ public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext, Fl
 	int initialComplaintLevel = (flowInfo.reachMode() & FlowInfo.UNREACHABLE) != 0 ? Statement.COMPLAINED_FAKE_REACHABLE : Statement.NOT_COMPLAINED;
 
 	FieldBinding[] nullCheckedFields = null;
-	if (currentScope.compilerOptions().isAnnotationBasedResourceAnalysisEnabled && this.condition instanceof EqualExpression) { // simple checks only
-		nullCheckedFields = flowContext.nullCheckedFields(); // store before info expires
+	Reference[] nullFields = null;
+	CompilerOptions options = currentScope.compilerOptions();
+	if (this.condition instanceof EqualExpression) {
+		if (options.isAnnotationBasedResourceAnalysisEnabled) { // simple checks only
+			nullCheckedFields = flowContext.nullCheckedFields(); // store before info expires
+		}
+		if (options.isAnnotationBasedNullAnalysisEnabled && options.enableSyntacticNullAnalysisForFields) {
+			nullFields = flowContext.nullFieldReferences(FlowInfo.NULL); // store (f==null) before info expires
+		}
 	}
 
 	Constant cst = this.condition.optimizedBooleanConstant();
@@ -103,7 +111,7 @@ public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext, Fl
 		// No need if the whole if-else construct itself lies in unreachable code
 		this.bits |= ASTNode.IsElseStatementUnreachable;
 	}
-	boolean reportDeadCodeForKnownPattern = !isKnowDeadCodePattern(this.condition) || currentScope.compilerOptions().reportDeadCodeInTrivialIfStatement;
+	boolean reportDeadCodeForKnownPattern = !isKnowDeadCodePattern(this.condition) || options.reportDeadCodeInTrivialIfStatement;
 	if (this.thenStatement != null) {
 		// Save info for code gen
 		this.thenInitStateIndex = currentScope.methodScope().recordInitializationStates(thenFlowInfo);
@@ -123,8 +131,16 @@ public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext, Fl
 	}
 	// any null check from the condition is now expired
 	flowContext.expireNullCheckedFieldInfo();
+	boolean thenExit = (thenFlowInfo.tagBits & FlowInfo.UNREACHABLE_OR_DEAD) != 0;
+	if (nullFields != null && (this.elseStatement != null || thenExit)) {
+		// fields known to be null in "then" are safe (a) in "else" or (b) after "if" if then terminates abruptly
+		for (Reference nullField : nullFields) {
+			int ttl = this.elseStatement != null ? 1 : 2;
+			flowContext.recordNullCheckedFieldReference(nullField, ttl, FlowInfo.NON_NULL);
+		}
+	}
 	// code gen: optimizing the jump around the ELSE part
-	if ((thenFlowInfo.tagBits & FlowInfo.UNREACHABLE_OR_DEAD) != 0) {
+	if (thenExit) {
 		this.bits |= ASTNode.ThenExit;
 	}
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/InstanceOfExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/InstanceOfExpression.java
@@ -92,7 +92,7 @@ public FlowInfo analyseCode(BlockScope currentScope, FlowContext flowContext, Fl
 		if (currentScope.compilerOptions().enableSyntacticNullAnalysisForFields) {
 			FieldBinding field = ((Reference)this.expression).lastFieldBinding();
 			if (field != null && (field.type.tagBits & TagBits.IsBaseType) == 0) {
-				flowContext.recordNullCheckedFieldReference((Reference) this.expression, 1);
+				flowContext.recordNullCheckedFieldReference((Reference) this.expression, 1, FlowInfo.NON_NULL);
 			}
 		}
 	}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/MessageSend.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/MessageSend.java
@@ -498,7 +498,7 @@ private FlowInfo analyseNullAssertion(BlockScope currentScope, Expression argume
 		{
 			FieldBinding field = ((Reference)argument).lastFieldBinding();
 			if (field != null && (field.type.tagBits & TagBits.IsBaseType) == 0) {
-				flowContext.recordNullCheckedFieldReference((Reference) argument, 3); // survive this assert as a MessageSend and as a Statement
+				flowContext.recordNullCheckedFieldReference((Reference) argument, 3, FlowInfo.NON_NULL); // survive this assert as a MessageSend and as a Statement
 			}
 		}
 	}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/OR_OR_Expression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/OR_OR_Expression.java
@@ -64,9 +64,13 @@ public class OR_OR_Expression extends BinaryExpression {
 			return mergedInfo;
 		}
 
+		boolean oldNegation = (flowContext.tagBits & FlowContext.INSIDE_NEGATION) != 0;
+		flowContext.tagBits |= FlowContext.INSIDE_NEGATION; // record field nullness from !left for use in right, seen as an else branch
 		FlowInfo leftInfo = this.left.analyseCode(currentScope, flowContext, flowInfo);
 		if ((flowContext.tagBits & FlowContext.INSIDE_NEGATION) == 0)
 			flowContext.expireNullCheckedFieldInfo();
+		if (!oldNegation)
+			flowContext.tagBits &= ~FlowContext.INSIDE_NEGATION;
 
 		// rightInfo captures the flow (!left then right):
 		FlowInfo rightInfo = leftInfo.initsWhenFalse().unconditionalCopy();

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Reference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Reference.java
@@ -55,7 +55,7 @@ public boolean checkNPE(BlockScope scope, FlowContext flowContext, FlowInfo flow
 protected boolean checkNullableFieldDereference(Scope scope, FieldBinding field, long sourcePosition, FlowContext flowContext, int ttlForFieldCheck) {
 	if (field != null) {
 		if (ttlForFieldCheck > 0 && scope.compilerOptions().enableSyntacticNullAnalysisForFields)
-			flowContext.recordNullCheckedFieldReference(this, ttlForFieldCheck);
+			flowContext.recordNullCheckedFieldReference(this, ttlForFieldCheck, FlowInfo.NON_NULL);
 		// preference to type annotations if we have any
 		if ((field.type.tagBits & TagBits.AnnotationNullable) != 0) {
 			scope.problemReporter().dereferencingNullableExpression(sourcePosition, scope.environment());

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
@@ -696,11 +696,11 @@ public class SwitchStatement extends Expression {
 										caseInits.markAsDefinitelyNonNull(reference.localVariableBinding());
 									} else if (reference.lastFieldBinding() != null) {
 										if (this.scope.compilerOptions().enableSyntacticNullAnalysisForFields)
-											switchContext.recordNullCheckedFieldReference(reference, 2); // survive this case statement and into the next
+											switchContext.recordNullCheckedFieldReference(reference, 2, FlowInfo.NON_NULL); // survive this case statement and into the next
 									}
 								} else if (this.expression instanceof FieldReference) {
 									if (this.scope.compilerOptions().enableSyntacticNullAnalysisForFields)
-										switchContext.recordNullCheckedFieldReference((FieldReference) this.expression, 2); // survive this case statement and into the next
+										switchContext.recordNullCheckedFieldReference((FieldReference) this.expression, 2, FlowInfo.NON_NULL); // survive this case statement and into the next
 								}
 							}
 						}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/flow/FlowInfo.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/flow/FlowInfo.java
@@ -680,6 +680,14 @@ abstract public UnconditionalFlowInfo unconditionalInitsWithoutSideEffect();
  */
 abstract public void resetAssignmentInfo(LocalVariableBinding local);
 
+public static int nullInverse(int status) {
+	return switch(status) {
+		case NULL -> NON_NULL;
+		case NON_NULL -> NULL;
+		default -> 0;
+	};
+}
+
 /**
  * Check whether 'tagBits' contains either {@link TagBits#AnnotationNonNull} or {@link TagBits#AnnotationNullable},
  * and answer the corresponding null status ({@link #NON_NULL} etc.).

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullTypeAnnotationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullTypeAnnotationTest.java
@@ -19691,4 +19691,125 @@ public void testGH4668a() throws Exception {
 			""";
 	runner.runNegativeTest();
 }
+public void testGH4717_OR() {
+	Runner runner = new Runner();
+	runner.customOptions = getCompilerOptions();
+	runner.customOptions.put(CompilerOptions.OPTION_SyntacticNullAnalysisForFields, CompilerOptions.ENABLED);
+	runner.classLibraries = this.LIBS;
+	runner.testFiles = new String[] {
+		"CheckingNullableField.java",
+		"""
+		import org.eclipse.jdt.annotation.NonNull;
+		import org.eclipse.jdt.annotation.Nullable;
+
+		public class CheckingNullableField {
+
+			// Change request ID - null if change not checked
+			protected @Nullable String changeRequestID;
+
+			public CheckingNullableField(@Nullable String aChangeRequestID) {
+				changeRequestID = aChangeRequestID;
+			}
+
+			public boolean verifyRequest1a(@NonNull String aRequestID) {
+				if ( (changeRequestID == null) || (changeRequestID.isEmpty()) ) {
+					changeRequestID.isEmpty(); // check is expired here
+					return true;
+				}
+				return aRequestID.equalsIgnoreCase(changeRequestID);
+			}
+
+			public boolean verifyRequest1b(@NonNull String aRequestID) {
+				if (!((changeRequestID == null) || changeRequestID.isEmpty())) {
+					return false;
+				}
+				return aRequestID.equalsIgnoreCase(changeRequestID);
+			}
+		}
+		"""
+	};
+	runner.expectedCompilerLog =
+			"""
+			----------
+			1. ERROR in CheckingNullableField.java (at line 15)
+				changeRequestID.isEmpty(); // check is expired here
+				^^^^^^^^^^^^^^^
+			Potential null pointer access: this expression has a '@Nullable' type
+			----------
+			""";
+	runner.runNegativeTest();
+}
+public void testGH4717_nullExit() {
+	Runner runner = new Runner();
+	runner.customOptions = getCompilerOptions();
+	runner.customOptions.put(CompilerOptions.OPTION_SyntacticNullAnalysisForFields, CompilerOptions.ENABLED);
+	runner.customOptions.put(CompilerOptions.OPTION_ReportUnnecessaryElse, CompilerOptions.IGNORE);
+	runner.classLibraries = this.LIBS;
+	runner.testFiles = new String[] {
+		"CheckingNullableField.java",
+		"""
+		import org.eclipse.jdt.annotation.NonNull;
+		import org.eclipse.jdt.annotation.Nullable;
+
+		public class CheckingNullableField {
+
+			// Change request ID - null if change not checked
+			protected @Nullable String changeRequestID;
+
+			public CheckingNullableField(@Nullable String aChangeRequestID) {
+				changeRequestID = aChangeRequestID;
+			}
+
+			public boolean verifyRequest2a(@NonNull String aRequestID) {
+				if (changeRequestID == null) {
+					return true;
+				}
+				if (changeRequestID.isEmpty()) {
+					return true;
+				}
+				return aRequestID.equalsIgnoreCase(changeRequestID);
+			}
+			public boolean verifyRequest2b(@NonNull String aRequestID) {
+				if (changeRequestID == null) {
+					return true;
+				}
+				expire();
+				if (changeRequestID.isEmpty()) { // check is expired here
+					return true;
+				}
+				return aRequestID.equalsIgnoreCase(changeRequestID);
+			}
+			public boolean verifyRequest2c(@NonNull String aRequestID) {
+				if (changeRequestID == null) {
+					return true;
+				} else {
+					if (changeRequestID.isEmpty()) {
+						return true;
+					}
+				}
+				if (changeRequestID.isEmpty()) { // check is expired here
+					return true;
+				}
+				return aRequestID.equalsIgnoreCase(changeRequestID);
+			}
+			void expire() {}
+		}
+		"""
+	};
+	runner.expectedCompilerLog =
+			"""
+			----------
+			1. ERROR in CheckingNullableField.java (at line 27)
+				if (changeRequestID.isEmpty()) { // check is expired here
+				    ^^^^^^^^^^^^^^^
+			Potential null pointer access: this expression has a '@Nullable' type
+			----------
+			2. ERROR in CheckingNullableField.java (at line 40)
+				if (changeRequestID.isEmpty()) { // check is expired here
+				    ^^^^^^^^^^^^^^^
+			Potential null pointer access: this expression has a '@Nullable' type
+			----------
+			""";
+	runner.runNegativeTest();
+}
 }


### PR DESCRIPTION
+ syntactic analysis now stores known NULL along with known NON_NULL
+ use FlowContext.INSIDE_NEGATION to switch between NULL & NON_NULL
+ treat OR_OR_EXPRESSION.right like an else branch

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4717
