### PR TITLE
Record type inference fails when 'var' and <> mixed

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordPatternTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordPatternTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2023 IBM Corporation and others.
+ * Copyright (c) 2022, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -28,7 +28,7 @@ public class RecordPatternTest extends AbstractRegressionTest9 {
 	static {
 //		TESTS_NUMBERS = new int [] { 40 };
 //		TESTS_RANGE = new int[] { 1, -1 };
-//		TESTS_NAMES = new String[] { "testRecordTypeInfer_4643" };
+//		TESTS_NAMES = new String[] { "testRecordPatternTypeInference_001" };
 	}
 	private String extraLibPath;
 	public static Class<?> testClass() {
@@ -5088,6 +5088,26 @@ public class RecordPatternTest extends AbstractRegressionTest9 {
 			"	                          ^^^^^^^^^^^^^^\n" +
 			"Record component with type Integer is not compatible with type String\n" +
 			"----------\n");
+	}
+	public void testRecordTypeInfer_1361_001() {
+		runConformTest(new String[] { "X.java",
+		"""
+		record Record<T>(T a) {}
+		public class X {
+			static void test(Object o) {
+				if (o instanceof Record(var x)) {
+					var v = new Record<>(x);
+					Record<Object> r = v;
+					System.out.println(true);
+				}
+			}
+			public static void main(String[] args) {
+				Record<Integer> r = new Record<>(10);
+				test(r);
+			}
+		}
+		""" },
+		"true");
 	}
 
 }


### PR DESCRIPTION
Fixes #1361

## What it does
- The type inference in record pattern was more restrictive in implementation compared to what was mentioned in spec.

In [JLS Section 18.5.5](https://docs.oracle.com/javase/specs/jls/se25/html/jls-18.html#jls-18.5.5), item 5 says "Unlike normal resolution, in this case resolution skips the step that attempts to produce an instantiation for an inference variable from its proper lower bounds or proper upper bounds; instead, any new instantiations are created by skipping directly to the step that introduces fresh type variables." 

However, the entire processing was missed via the [!recordTypeInference](https://github.com/eclipse-jdt/eclipse.jdt.core/blob/df7f21e771a9130efeb7c64eb6af5088a122674a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java#L1152C21-L1152C51) condition which implied that the " α1 = T1, ..., αn = Tn" were consequently missed being incorporated with the current bound set as per [this line in JLS Section 18.4 ](https://docs.oracle.com/javase/specs/jls/se25/html/jls-18.html#jls-18.4:~:text=The%20bounds%20%CE%B11%20%3D%20T1%2C%20...%2C%20%CE%B1n%20%3D%20Tn%20are%20incorporated%20with%20the%20current%20bound%20set.)

The fix addresses this part.

Fixes issue #1361

## How to test
The reviewer can use the code mentioned in issue #1361 to test the fix.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
