### PR TITLE
Fix compiling prologue constructors that don't initialize all final fields

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SuperAfterStatementsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SuperAfterStatementsTest.java
@@ -3589,5 +3589,33 @@ public class SuperAfterStatementsTest extends AbstractRegressionTest9 {
 	        "counter=1\n" +
 	        "1");
 	}
+	public void testIssue4720() {
+		runNegativeTest(new String[] {
+			"Test.java",
+			"""
+			public class Test {
+				private final Object o;
+
+				public Test() {
+					System.out.println();
+					super();
+				}
+			}
+			"""
+			},
+			"""
+			----------
+			1. WARNING in Test.java (at line 2)
+				private final Object o;
+				                     ^
+			The value of the field Test.o is not used
+			----------
+			2. ERROR in Test.java (at line 4)
+				public Test() {
+				       ^^^^^^
+			The blank final field o may not have been initialized
+			----------
+			""");
+	}
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
Fixes #4720 

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)

@stephan-herrmann 
