### PR TITLE
Incorrect handling of inlines tags in Markdown

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/AbstractCommentParser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/AbstractCommentParser.java
@@ -551,7 +551,8 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 				refreshInlineTagPosition(textEndPosition);
 				setInlineTagStarted(false);
 			} else if (this.lineStarted && this.textStart != -1 && this.textStart <= textEndPosition && (this.textStart < this.starPosition || this.starPosition == lastStarPosition || this.markdown)) {
-				pushText(this.textStart, textEndPosition);
+				if (!(invalidInlineTagLineEnd > 0 && nextCharacter == '}' && this.markdown && this.index == this.javadocEnd))
+					pushText(this.textStart, textEndPosition);
 			}
 			updateDocComment();
 		} catch (Exception ex) {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterMarkdownTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterMarkdownTest.java
@@ -2234,4 +2234,84 @@ public class ASTConverterMarkdownTest extends ConverterTestSetup {
 			assertEquals("incorrect Fifth tagElement", ASTNode.TAG_ELEMENT, tags.get(4).getNodeType());
 		}
 	}
+
+	public void testIncorrectLinkTagParsing4743_01() throws JavaModelException {
+		String source ="""
+				/// {@link java.lang.String}
+				public class Markdown{}
+				""";
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy("/Converter_25/src/markdown/Markdown.java", source, null);
+		if (this.docCommentSupport.equals(JavaCore.ENABLED)) {
+			CompilationUnit compilUnit = (CompilationUnit) runConversion(this.workingCopies[0], true);
+			TypeDeclaration typedeclaration =  (TypeDeclaration) compilUnit.types().get(0);
+			Javadoc javadoc = typedeclaration.getJavadoc();
+			List<TagElement> tags = javadoc.tags();
+			TagElement firstTag = tags.get(0);
+			List<?> frags = firstTag.fragments();
+			assertEquals("Incorrect Frags", 1, frags.size());
+			TagElement innerTag = (TagElement) frags.get(0);
+			assertEquals("invalid tag name","@link" ,innerTag.getTagName());
+		}
+	}
+
+	public void testIncorrectLinkTagParsing4743_02() throws JavaModelException {
+		String source ="""
+				/// {@linkplain java.lang.String}
+				public class Markdown{}
+				""";
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy("/Converter_25/src/markdown/Markdown.java", source, null);
+		if (this.docCommentSupport.equals(JavaCore.ENABLED)) {
+			CompilationUnit compilUnit = (CompilationUnit) runConversion(this.workingCopies[0], true);
+			TypeDeclaration typedeclaration =  (TypeDeclaration) compilUnit.types().get(0);
+			Javadoc javadoc = typedeclaration.getJavadoc();
+			List<TagElement> tags = javadoc.tags();
+			TagElement firstTag = tags.get(0);
+			List<?> frags = firstTag.fragments();
+			assertEquals("Incorrect Frags", 1, frags.size());
+			TagElement innerTag = (TagElement) frags.get(0);
+			assertEquals("invalid tag name","@linkplain" ,innerTag.getTagName());
+		}
+	}
+
+	public void testIncorrectLinkTagParsing4743_03() throws JavaModelException {
+		String source ="""
+				/// {@code List<String>}
+				public class Markdown{}
+				""";
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy("/Converter_25/src/markdown/Markdown.java", source, null);
+		if (this.docCommentSupport.equals(JavaCore.ENABLED)) {
+			CompilationUnit compilUnit = (CompilationUnit) runConversion(this.workingCopies[0], true);
+			TypeDeclaration typedeclaration =  (TypeDeclaration) compilUnit.types().get(0);
+			Javadoc javadoc = typedeclaration.getJavadoc();
+			List<TagElement> tags = javadoc.tags();
+			TagElement firstTag = tags.get(0);
+			List<?> frags = firstTag.fragments();
+			assertEquals("Incorrect Frags", 1, frags.size());
+			TagElement innerTag = (TagElement) frags.get(0);
+			assertEquals("invalid tag name","@code" ,innerTag.getTagName());
+		}
+	}
+
+	public void testIncorrectLinkTagParsing4743_04() throws JavaModelException {
+		String source ="""
+				/// {@literal List<String>}
+				public class Markdown{}
+				""";
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy("/Converter_25/src/markdown/Markdown.java", source, null);
+		if (this.docCommentSupport.equals(JavaCore.ENABLED)) {
+			CompilationUnit compilUnit = (CompilationUnit) runConversion(this.workingCopies[0], true);
+			TypeDeclaration typedeclaration =  (TypeDeclaration) compilUnit.types().get(0);
+			Javadoc javadoc = typedeclaration.getJavadoc();
+			List<TagElement> tags = javadoc.tags();
+			TagElement firstTag = tags.get(0);
+			List<?> frags = firstTag.fragments();
+			assertEquals("Incorrect Frags", 1, frags.size());
+			TagElement innerTag = (TagElement) frags.get(0);
+			assertEquals("invalid tag name","@literal" ,innerTag.getTagName());
+		}
+	}
 }


### PR DESCRIPTION
This PR fixes a generic issue in Markdown where an extra TextElement is created when an inline tag ends at the end of the Markdown content, resulting in incorrect parsing behavior.

Fix: https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4743

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
