### PR TITLE
ECJ erroneously allows a local record class to access its outer local variable and crashes while generating code

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/QualifiedNameReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/QualifiedNameReference.java
@@ -991,6 +991,8 @@ public TypeBinding reportError(BlockScope scope) {
 		scope.problemReporter().invalidField(this, (FieldBinding) this.binding);
 	} else if (this.binding instanceof ProblemReferenceBinding || this.binding instanceof MissingTypeBinding) {
 		scope.problemReporter().invalidType(this, (TypeBinding) this.binding);
+	} else if (this.binding instanceof ProblemLocalVariableBinding plvb && plvb.problemId() == ProblemReasons.NonStaticReferenceInStaticContext) {
+		scope.problemReporter().recordStaticReferenceToOuterLocalVariable(plvb.closestMatch, this);
 	} else {
 		scope.problemReporter().unresolvableReference(this, this.binding);
 	}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SingleNameReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SingleNameReference.java
@@ -983,6 +983,8 @@ public TypeBinding reportError(BlockScope scope) {
 		scope.problemReporter().invalidField(this, (FieldBinding) this.binding);
 	} else if (this.binding instanceof ProblemReferenceBinding || this.binding instanceof MissingTypeBinding) {
 		scope.problemReporter().invalidType(this, (TypeBinding) this.binding);
+	} else if (this.binding instanceof ProblemLocalVariableBinding plvb && plvb.problemId() == ProblemReasons.NonStaticReferenceInStaticContext) {
+		scope.problemReporter().recordStaticReferenceToOuterLocalVariable(plvb.closestMatch, this);
 	} else {
 		scope.problemReporter().unresolvableReference(this, this.binding);
 	}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/CodeStream.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/CodeStream.java
@@ -4364,7 +4364,7 @@ public void invoke(byte opcode, MethodBinding methodBinding, TypeBinding declari
 		case Opcodes.OPC_invokespecial :
 			receiverAndArgsSize = 1; // receiver
 			if (methodBinding.isConstructor()) {
-				if (declaringClass.isNestedType()) {
+				if (declaringClass.hasEnclosingInstanceContext()) {
 					ReferenceBinding nestedType = (ReferenceBinding) declaringClass;
 					// enclosing instances
 					receiverAndArgsSize += nestedType.getEnclosingInstancesSlotSize();

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/LocalVariableBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/LocalVariableBinding.java
@@ -51,7 +51,7 @@ public class LocalVariableBinding extends VariableBinding {
 
 	public Set<MethodScope> uninitializedInMethod;
 
-	// for synthetic local variables
+	// for synthetic and problem local variables
 	// if declaration slot is not positioned, the variable will not be listed in attribute
 	// note that the name of a variable should be chosen so as not to conflict with user ones (usually starting with a space char is all needed)
 	public LocalVariableBinding(char[] name, TypeBinding type, int modifiers, boolean isArgument) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ProblemLocalVariableBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ProblemLocalVariableBinding.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+* Copyright (c) 2026 Advantest Europe GmbH and others.
+*
+* This program and the accompanying materials
+* are made available under the terms of the Eclipse Public License 2.0
+* which accompanies this distribution, and is available at
+* https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Srikanth Sankaran - initial implementation
+*******************************************************************************/
+
+package org.eclipse.jdt.internal.compiler.lookup;
+
+public class ProblemLocalVariableBinding extends LocalVariableBinding {
+	private final int problemId;
+	public LocalVariableBinding closestMatch;
+
+public ProblemLocalVariableBinding(LocalVariableBinding closestMatch, int problemId) {
+	super(closestMatch.name, closestMatch.type, closestMatch.modifiers, closestMatch.isParameter());
+	this.problemId = problemId;
+	this.closestMatch = closestMatch;
+}
+
+@Override
+public final int problemId() {
+	return this.problemId;
+}
+}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
@@ -2533,6 +2533,7 @@ public ModuleBinding module() {
 	return null;
 }
 
+@Override
 public boolean hasEnclosingInstanceContext() {
 	// This method intentionally disregards early construction contexts (JEP 513).
 	// Details of how each outer level is handled are coordinated in

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Scope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Scope.java
@@ -2023,6 +2023,7 @@ public abstract class Scope {
 			FieldBinding problemField = null;
 			if ((mask & Binding.VARIABLE) != 0) {
 				boolean insideStaticContext = false;
+				boolean insideLocalRecordContext = false;
 				boolean insideConstructorCall = false;
 				boolean insideTypeAnnotation = false;
 
@@ -2052,6 +2053,11 @@ public abstract class Scope {
 							LocalVariableBinding variableBinding = scope.findVariable(name);
 							// looks in this scope only
 							if (variableBinding != null) {
+								if (insideLocalRecordContext) {
+									return new ProblemLocalVariableBinding(
+											variableBinding,
+											ProblemReasons.NonStaticReferenceInStaticContext);
+								}
 								if (foundField != null && foundField.isValidBinding())
 									return new ProblemFieldBinding(
 										foundField, // closest match
@@ -2156,6 +2162,7 @@ public abstract class Scope {
 							depth++;
 							shouldTrackOuterLocals = true;
 							insideStaticContext |= receiverType.isStatic();
+							insideLocalRecordContext |= receiverType.isRecord() && receiverType.isLocalType();
 							// 1EX5I8Z - accessing outer fields within a constructor call is permitted
 							// in order to do so, we change the flag as we exit from the type, not the method
 							// itself, because the class scope is used to retrieve the fields.

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeBinding.java
@@ -1609,6 +1609,10 @@ public boolean hasValueBasedTypeAnnotation() {
 	return (this.extendedTagBits & ExtendedTagBits.AnnotationValueBased) != 0;
 }
 
+public boolean hasEnclosingInstanceContext() {
+	return false;
+}
+
 /**
  * Answer the qualified name of the receiver's package separated by periods
  * or an empty string if its the default package.


### PR DESCRIPTION


* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4749

