### PR TITLE
Check for default output location if not specified explicitly (#4745)

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/JavaBuilder.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/JavaBuilder.java
@@ -899,12 +899,17 @@ protected int checkOutputFolders(IJavaProject project, int buildKind) {
 		return buildKind;
 	}
 	try {
+		boolean checkDefault = true;
 		IWorkspaceRoot root = project.getProject().getWorkspace().getRoot();
 		for (IClasspathEntry entry : project.getRawClasspath()) {
 			if (entry.getEntryKind() != IClasspathEntry.CPE_SOURCE) {
 				continue;
 			}
 			IPath outputLocation = entry.getOutputLocation();
+			if (outputLocation == null && checkDefault) {
+				outputLocation = project.getOutputLocation();
+				checkDefault = false;
+			}
 			if (outputLocation != null) {
 				IContainer outputContainer;
 				if(outputLocation.segmentCount() == 1) {


### PR DESCRIPTION
Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4745
