### PR TITLE
Improvement to getCustomOptions to prevent premature loading of elementInfo

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompilationUnitTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompilationUnitTests.java
@@ -36,9 +36,11 @@ import org.eclipse.jdt.core.dom.AST;
 import org.eclipse.jdt.core.dom.ASTParser;
 import org.eclipse.jdt.core.dom.rewrite.ImportRewrite;
 import org.eclipse.jdt.core.formatter.DefaultCodeFormatterConstants;
+import org.eclipse.jdt.internal.compiler.env.IElementInfo;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jdt.internal.core.Buffer;
 import org.eclipse.jdt.internal.core.CompilationUnit;
+import org.eclipse.jdt.internal.core.JavaModelManager;
 import org.eclipse.jdt.internal.core.util.Util;
 import org.eclipse.text.edits.ReplaceEdit;
 import org.eclipse.text.edits.TextEdit;
@@ -2881,5 +2883,53 @@ public void testCompilationUnitProblemsWhenNonCompiling() throws CoreException {
 
 	assertTrue(methodStatements.size() == 1);
 	assertTrue("Should have at least 1 problem", problems.length > 0);
+}
+
+/**
+ * Test that calling getOptions(true) on a closed ICompilationUnit does NOT
+ * cause the element info to be loaded (i.e., does not trigger parsing/opening).
+ *
+ * Regression test for https://github.com/eclipse-jdt/eclipse.jdt.core/pull/4779
+ *
+ * Before the fix, getCustomOptions() unconditionally called
+ * getCompilationUnitElementInfo(), which triggered openWhenClosed() ->
+ * buildStructure() -> parse, even when no setOptions() had ever been called
+ * on the CU.  After the fix it uses JavaModelManager.getInfo(this) which
+ * returns null without opening when the element is not yet cached.
+ */
+public void testGetOptionsDoesNotLoadElementInfo() throws CoreException {
+    // Use a CU that is definitely not open (force-close it first).
+    ICompilationUnit cu2 = getCompilationUnit("P", "src", "p", "X.java");
+    cu2.close(); // ensure info is evicted from the model cache
+
+    // Precondition: info must be null before we call getOptions.
+    IElementInfo infoBefore = JavaModelManager.getJavaModelManager().getInfo(cu2);
+    assertNull("Precondition failed: element info should be null before getOptions()", infoBefore);
+
+    // Call the API under test.
+    cu2.getOptions(true);
+
+    // The fix: info must STILL be null — getOptions must not have opened the CU.
+    IElementInfo infoAfter = JavaModelManager.getJavaModelManager().getInfo(cu2);
+    assertNull(
+        "getOptions(true) should not load the IElementInfo when setOptions() " +
+        "has never been called on this CU",
+        infoAfter);
+}
+
+public void testGetOptionsReturnsCustomOptionsWhenSet() throws CoreException {
+    ICompilationUnit cu2 = getCompilationUnit("P", "src", "p", "X.java");
+    ICompilationUnit wc = null;
+    try {
+        wc = cu2.getWorkingCopy(null);
+        Map<String, String> opts = new HashMap<>();
+        opts.put(JavaCore.COMPILER_SOURCE, "11");
+        wc.setOptions(opts);
+
+        Map<String, String> result = wc.getOptions(false);
+        assertEquals("11", result.get(JavaCore.COMPILER_SOURCE));
+    } finally {
+        if (wc != null) wc.discardWorkingCopy();
+    }
 }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

ICompilationUnit.getCustomOptions() has the following javadoc:

/**
 * Returns the table of the current custom options for this ICompilationUnit. If there is no <code>setOptions</code> called
 * for the ICompliationUnit, then return an empty table.
 *
 * @return the table of the current custom options for this ICompilationUnit
 * @since 3.25
 */


If the IElementInfo has not yet been loaded or does not yet exist, then nobody could have possibly called setOptions on it. Options on a per-cu basis are not persisted in any way, so the only way to set options on a unit is if it's element info has been loaded. 

One of the side effects of loading the element info is that source indexer gets called or an attempt to build the structure of the file gets initiated, which may parse the file in order to do that. In many cases, the entire purpose of calling getCustomOptions is to discover what options should be used to parse the file.  If the act of calling getCustomOptions to use when parsing the file has the side effect of parsing the file beforehand, then the work of parsing is done twice to no benefit. 

For example:

```
		ASTParser astParser = etc;
		astParser.setWorkingCopyOwner(cu.getOwner());
		astParser.setSource(this instanceof ClassFileWorkingCopy ? source : cu);
		astParser.setProject(cu.getJavaProject());
		astParser.setCompilerOptions(cu.getOptions(true));
		ASTNode dom = null;
		try {
			dom = astParser.createAST(pm);
```

In this example, the purpose of calling getOptions() is to discover what options to use when creating the AST. But the act of calling getOptions(true) loads the IElementInfo, which then calls openWhenClosed(), and then calls buildStructure().  Almost all calls to buildStructure will, in fact, parse the file in one way or another.  

Upon returning back up the stack, the parser in the snippet above will, also, parse the file. 

The end result is the file gets parsed twice, and the CU gets opened. But the javadoc does not specify that as the result. The javadoc says it should "Returns the table of the current custom options for this ICompilationUnit" and if setOptions() hasn't been called, it should just return empty. 

I think checking if the element info has been loaded should be sufficient. If it hasn't been created, nobody could have called setOptions() on it, and the empty map should be returned. This would avoid the first unnecessary parse as a side effect of loading the options. 

I suspect, but am unable to prove conclusively, that this is a safe patch. 

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
