### PR TITLE
Markdown comment ending with tag parsed incorrectly

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/AbstractCommentParser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/AbstractCommentParser.java
@@ -480,6 +480,10 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 									}
 								}
 							}
+						} else {
+							if (this.index == this.javadocEnd) {
+								pushText(this.textStart, this.javadocEnd);
+							}
 						}
 						break;
 						//$FALL-THROUGH$

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterMarkdownTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterMarkdownTest.java
@@ -2314,4 +2314,22 @@ public class ASTConverterMarkdownTest extends ConverterTestSetup {
 			assertEquals("invalid tag name","@literal" ,innerTag.getTagName());
 		}
 	}
+
+	public void testIncorrectTagWhenMarkdownEndsWithMarkdownTag4786() throws JavaModelException {
+		String source = """
+				/// **Bold**
+				public class Markdown {}
+				""";
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy("/Converter_25/src/markdown/Markdown.java", source, null);
+		if (this.docCommentSupport.equals(JavaCore.ENABLED)) {
+			CompilationUnit compilUnit = (CompilationUnit) runConversion(this.workingCopies[0], true);
+			TypeDeclaration typedeclaration =  (TypeDeclaration) compilUnit.types().get(0);
+			Javadoc javadoc = typedeclaration.getJavadoc();
+			List<TagElement> tags = javadoc.tags();
+			List<ASTNode> frags = tags.get(0).fragments();
+			assertTrue(frags.get(0) instanceof TextElement);
+			assertEquals("Invalid content", "**Bold**", ((TextElement)frags.get(0)).getText());
+		}
+	}
 }


### PR DESCRIPTION
This PR fixes an issue in the markdown parser where a markdown comment ending with a markdown tag is not handled correctly. The parser fails to properly close the trailing tag, resulting in an incorrect TagElement or TextElement

Fix: https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4786

<img width="1168" height="730" alt="image" src="https://github.com/user-attachments/assets/33faa3bd-d163-44f1-b576-561af7ca7b4a" />
Currently, the parser behaves as expected.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
