### PR TITLE
@code and @literal tags behave differently in Markdown

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/AbstractCommentParser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/AbstractCommentParser.java
@@ -181,7 +181,6 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 			boolean isDomParser = (this.kind & DOM_PARSER) != 0;
 			boolean isFormatterParser = (this.kind & FORMATTER_COMMENT_PARSER) != 0;
 			int lastStarPosition = -1;
-			boolean isTagElementClose = false;
 
 			// Init scanner position
 			this.markdown = this.source[this.javadocStart + 1] == '/';
@@ -350,9 +349,6 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 						// Fix bug 51650
 						this.textStart = -1;
 						this.markdownHelper.resetAtLineEnd();
-						if (this.inlineTagStarted && this.markdown) {
-							isTagElementClose = true;
-						}
 						break;
 					case '}' :
 						if (verifText && this.tagValue == TAG_RETURN_VALUE && this.returnStatement != null) {
@@ -366,6 +362,10 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 							}
 						}
 						boolean isLiteralOrCode = this.tagValue == TAG_LITERAL_VALUE || this.tagValue == TAG_CODE_VALUE;
+						boolean shouldCloseInlineTag =
+						        this.inlineTagStarted
+						        && !considerTagAsPlainText
+						        && !(isLiteralOrCode && openingBraces != 0);
 						if (this.inlineTagStarted) {
 							textEndPosition = this.index - 1;
 							boolean treatAsText= considerTagAsPlainText || (this.inlineReturn && this.inlineReturnOpenBraces > 0);
@@ -380,12 +380,8 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 							}
 							if (!isFormatterParser && !treatAsText && (!this.inlineReturn || this.inlineReturnOpenBraces <= 0))
 								this.textStart = this.index;
-							if (!isTagElementClose && this.markdown) {  //The comment parser should create a TagElement only if the previous one is closed - markdown.
+							if (shouldCloseInlineTag) {
 								setInlineTagStarted(false);
-							} else if (!this.markdown) {
-								if (!(isLiteralOrCode && openingBraces != 0)) {
-							        setInlineTagStarted(false);
-							    }
 							}
 							if (this.inlineReturn) {
 								if (this.inlineReturnOpenBraces > 0) {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterMarkdownTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterMarkdownTest.java
@@ -2314,4 +2314,105 @@ public class ASTConverterMarkdownTest extends ConverterTestSetup {
 			assertEquals("invalid tag name","@literal" ,innerTag.getTagName());
 		}
 	}
+
+	public void testInconsistencyInCodeAndLiteralTagsMarkdown4609_01() throws JavaModelException {
+		String source = """
+				/// Performs:
+				///
+				/// {@code
+				/// 	for (String s : strings) {
+				/// 		if (s.equals(value)) {
+				/// 			return 0;
+				/// 		}
+				/// 		if (s.startsWith(value)) {
+				/// 		return 1;
+				/// 		}
+				/// 		return -1;
+				/// 	}
+				/// }
+				/// The general contract of `hashCode` is:
+				///
+				///   - Whenever it is invoked on the same object more than once during
+				///     an execution of a Java application, the `hashCode` method
+				///     must consistently return the same integer, provided no information
+				///     used in `equals` comparisons on the object is modified.
+				///     This integer need not remain consistent from one execution of an
+				///     application to another execution of the same application.
+				///   - If two objects are equal according to the
+				///     [equals][#equals(Object)] method, then calling the
+				///     `hashCode` method on each of the two objects must produce the
+				///     same integer result.
+				///   - It is _not_ required that if two objects are unequal
+				///     according to the [equals][#equals(Object)] method, then
+				///     calling the `hashCode` method on each of the two objects
+				///     must produce distinct integer results.  However, the programmer
+				///     should be aware that producing distinct integer results for
+				///     unequal objects may improve the performance of hash tables.
+				public class Markdown{}
+				""";
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy("/Converter_25/src/markdown/Markdown.java", source, null);
+		if (this.docCommentSupport.equals(JavaCore.ENABLED)) {
+			CompilationUnit compilUnit = (CompilationUnit) runConversion(this.workingCopies[0], true);
+			TypeDeclaration typedeclaration =  (TypeDeclaration) compilUnit.types().get(0);
+			Javadoc javadoc = typedeclaration.getJavadoc();
+			List<TagElement> tags = javadoc.tags();
+			List<ASTNode> frags = tags.get(0).fragments();
+
+			assertEquals("Incorrect Frags", 22, frags.size());
+			assertEquals("Invalid element", ASTNode.TAG_ELEMENT, frags.get(1).getNodeType());
+			assertEquals("Invalid Text element content", "The general contract of `hashCode` is:", frags.get(2).toString());
+		}
+
+	}
+
+	public void testInconsistencyInCodeAndLiteralTagsMarkdown4609_02() throws JavaModelException {
+		String source = """
+				/// Performs:
+				///
+				/// {@literal
+				/// 	for (String s : strings) {
+				/// 		if (s.equals(value)) {
+				/// 			return 0;
+				/// 		}
+				/// 		if (s.startsWith(value)) {
+				/// 		return 1;
+				/// 		}
+				/// 		return -1;
+				/// 	}
+				/// }
+				/// The general contract of `hashCode` is:
+				///
+				///   - Whenever it is invoked on the same object more than once during
+				///     an execution of a Java application, the `hashCode` method
+				///     must consistently return the same integer, provided no information
+				///     used in `equals` comparisons on the object is modified.
+				///     This integer need not remain consistent from one execution of an
+				///     application to another execution of the same application.
+				///   - If two objects are equal according to the
+				///     [equals][#equals(Object)] method, then calling the
+				///     `hashCode` method on each of the two objects must produce the
+				///     same integer result.
+				///   - It is _not_ required that if two objects are unequal
+				///     according to the [equals][#equals(Object)] method, then
+				///     calling the `hashCode` method on each of the two objects
+				///     must produce distinct integer results.  However, the programmer
+				///     should be aware that producing distinct integer results for
+				///     unequal objects may improve the performance of hash tables.
+				public class Markdown{}
+				""";
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy("/Converter_25/src/markdown/Markdown.java", source, null);
+		if (this.docCommentSupport.equals(JavaCore.ENABLED)) {
+			CompilationUnit compilUnit = (CompilationUnit) runConversion(this.workingCopies[0], true);
+			TypeDeclaration typedeclaration =  (TypeDeclaration) compilUnit.types().get(0);
+			Javadoc javadoc = typedeclaration.getJavadoc();
+			List<TagElement> tags = javadoc.tags();
+			List<ASTNode> frags = tags.get(0).fragments();
+
+			assertEquals("Incorrect Frags", 22, frags.size());
+			assertEquals("Invalid element", ASTNode.TAG_ELEMENT, frags.get(1).getNodeType());
+			assertEquals("Invalid Text element content", "The general contract of `hashCode` is:", frags.get(2).toString());
+		}
+	}
 }


### PR DESCRIPTION
The inline code tag and inline literal tag behave differently in Markdown

Fix:https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4695

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
