### PR TITLE
No completion right after comma, for method with vararg parameters #4649

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests10.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests10.java
@@ -454,7 +454,7 @@ public void testIssue4649_1() throws JavaModelException {
 				(signature.equals("foo") || signature.equals("bar") || signature.equals("foobar"));
 	};
 	CompletionResult result = complete(
-			"/Completion/src/X.java",
+			"/Completion/src/Test.java",
 			"""
 			class Test {
 				static String foo = "foo";
@@ -484,7 +484,7 @@ public void testIssue4649_2() throws JavaModelException {
 				(signature.equals("foo") || signature.equals("bar") || signature.equals("foobar"));
 	};
 	CompletionResult result = complete(
-			"/Completion/src/X.java",
+			"/Completion/src/Test.java",
 			"""
 			class Test {
 				static String foo = "foo";
@@ -515,7 +515,7 @@ public void testIssue4649_3() throws JavaModelException {
 				(signature.equals("foo") || signature.equals("bar") || signature.equals("foobar"));
 	};
 	CompletionResult result = complete(
-			"/Completion/src/X.java",
+			"/Completion/src/Test.java",
 			"""
 			class Test {
 				static String foo = "foo";
@@ -541,14 +541,15 @@ public void testIssue4649_4() throws JavaModelException {
 		}
 		String signature = new String(sig);
 		return (p.getKind() == CompletionProposal.FIELD_REF) &&
-				(signature.equals("foo") || signature.equals("bar"));
+				(signature.equals("foo") || signature.equals("bar") || signature.equals("foobar"));
 	};
 	CompletionResult result = complete(
-			"/Completion/src/X.java",
+			"/Completion/src/Test.java",
 			"""
 			class Test {
 				static String[] foo = null;
 				static String[] bar = null;
+				static Object foobar = null;
 				void testvarargs(String[]... args) {
 				}
 				void test2() {
@@ -559,6 +560,36 @@ public void testIssue4649_4() throws JavaModelException {
 			"testvarargs(foo,", javaTypeRef);
 	assertResults("bar[FIELD_REF]{bar, LTest;, [Ljava.lang.String;, bar, null, 52}\n"
 			+ "foo[FIELD_REF]{foo, LTest;, [Ljava.lang.String;, foo, null, 52}",
+			result.proposals);
+}
+public void testIssue4649_5() throws JavaModelException {
+	Predicate<CompletionProposal> javaTypeRef = (p) -> {
+		char[] sig = p.getCompletion();
+		if (sig == null) {
+			return false;
+		}
+		String signature = new String(sig);
+		return (p.getKind() == CompletionProposal.FIELD_REF) &&
+				(signature.equals("foo") || signature.equals("bar") || signature.equals("foobar"));
+	};
+	CompletionResult result = complete(
+			"/Completion/src/Test.java",
+			"""
+			class Test {
+				static String foo = null;
+				static String bar = null;
+				static Object foobar = null;
+				void test2() {
+					Name name = new Name(foo,);
+				}
+			}
+			class Name {
+				public Name(String... names) {}
+			}
+			""",
+			"new Name(foo,", javaTypeRef);
+	assertResults("bar[FIELD_REF]{bar, LTest;, Ljava.lang.String;, bar, null, 52}\n"
+			+ "foo[FIELD_REF]{foo, LTest;, Ljava.lang.String;, foo, null, 52}",
 			result.proposals);
 }
 private void assertProposalCount(String proposal, int expectedCount, int expectedOtherCount, CompletionResult result) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
Fixes #4649

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
