### PR TITLE
Bump JDT core version to follow batch compiler change

### DIFF
--- a/org.eclipse.jdt.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.core; singleton:=true
-Bundle-Version: 3.44.100.qualifier
+Bundle-Version: 3.45.0.qualifier
 Bundle-Activator: org.eclipse.jdt.core.JavaCore
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
@@ -47,7 +47,7 @@ Require-Bundle: org.eclipse.core.resources;bundle-version="[3.22.0,4.0.0)",
  org.eclipse.core.filesystem;bundle-version="[1.11.0,2.0.0)",
  org.eclipse.text;bundle-version="[3.6.0,4.0.0)",
  org.eclipse.team.core;bundle-version="[3.1.0,4.0.0)";resolution:=optional,
- org.eclipse.jdt.core.compiler.batch;bundle-version="3.44.0";visibility:=reexport
+ org.eclipse.jdt.core.compiler.batch;bundle-version="3.45.0";visibility:=reexport
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Eclipse-ExtensibleAPI: true
 Bundle-ActivationPolicy: lazy

--- a/org.eclipse.jdt.core/pom.xml
+++ b/org.eclipse.jdt.core/pom.xml
@@ -17,7 +17,7 @@
     <version>4.39.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.eclipse.jdt.core</artifactId>
-  <version>3.44.100-SNAPSHOT</version>
+  <version>3.45.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>


### PR DESCRIPTION
Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4805
