### PR TITLE
Refactor AbortCompilation to allow non compiler code see the root cause

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/Compiler.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/Compiler.java
@@ -626,11 +626,16 @@ public class Compiler implements ITypeRequestor, ProblemSeverities {
 		CompilationUnitDeclaration unit) {
 
 		/* special treatment for SilentAbort: silently cancelling the compilation process */
+		Throwable cause = abortException.getCause();
 		if (abortException.isSilent) {
-			if (abortException.silentException == null) {
+			if (cause == null) {
 				return;
 			}
-			throw abortException.silentException;
+			if(cause instanceof RuntimeException) {
+				throw (RuntimeException) cause;
+			} else {
+				throw new RuntimeException(cause);
+			}
 		}
 
 		/* uncomment following line to see where the abort came from */
@@ -670,8 +675,8 @@ public class Compiler implements ITypeRequestor, ProblemSeverities {
 				}
 			} else {
 				/* distant internal exception which could not be reported back there */
-				if (abortException.exception != null) {
-					this.handleInternalException(abortException.exception, null, result);
+				if (cause != null) {
+					this.handleInternalException(cause, null, result);
 					return;
 				}
 			}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Parser.java
@@ -46,6 +46,7 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.CancellationException;
 import java.util.stream.Stream;
 import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.core.compiler.InvalidInputException;
@@ -11603,7 +11604,9 @@ try {
 	ProcessTerminals : for (;;) {
 		if (Thread.currentThread().isInterrupted()) {
             Thread.currentThread().interrupt();
-            throw new AbortCompilation(true, null); // fail silently
+            // CancellationException is needed for non-compiler code to
+            // recognize interruption as the root cause for this RuntimeException
+            throw new AbortCompilation(true, new CancellationException()); // fail silently
         }
 
 		int stackLength = this.stack.length;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/AbortCompilation.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/AbortCompilation.java
@@ -28,12 +28,10 @@ import org.eclipse.jdt.internal.compiler.util.Util;
 public class AbortCompilation extends RuntimeException {
 
 	public CompilationResult compilationResult;
-	public Throwable exception;
 	public CategorizedProblem problem;
 
 	/* special fields used to abort silently (e.g. when canceling build process) */
 	public boolean isSilent;
-	public RuntimeException silentException;
 
 	private static final long serialVersionUID = -2047226595083244852L; // backward compatible
 
@@ -48,15 +46,13 @@ public class AbortCompilation extends RuntimeException {
 	}
 
 	public AbortCompilation(CompilationResult compilationResult, Throwable exception) {
-		this();
+		super(exception);
 		this.compilationResult = compilationResult;
-		this.exception = exception;
 	}
 
 	public AbortCompilation(boolean isSilent, RuntimeException silentException) {
-		this();
+		super(silentException);
 		this.isSilent = isSilent;
-		this.silentException = silentException;
 	}
 	@Override
 	public String getMessage() {
@@ -64,11 +60,8 @@ public class AbortCompilation extends RuntimeException {
 		StringBuilder buffer = new StringBuilder(message == null ? Util.EMPTY_STRING : message);
 		if (this.problem != null) {
 			buffer.append(this.problem);
-		} else if (this.exception != null) {
-			message = this.exception.getMessage();
-			buffer.append(message == null ? Util.EMPTY_STRING : message);
-		} else if (this.silentException != null) {
-			message = this.silentException.getMessage();
+		} else if (this.getCause() != null) {
+			message = this.getCause().getMessage();
 			buffer.append(message == null ? Util.EMPTY_STRING : message);
 		}
 		return String.valueOf(buffer);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
@@ -1399,7 +1399,7 @@ public void cannotInvokeSuperConstructorInEnum(ExplicitConstructorCall construct
 }
 public void cannotReadSource(CompilationUnitDeclaration unit, AbortCompilationUnit abortException, boolean verbose) {
 	String fileName = new String(unit.compilationResult.fileName);
-	if (abortException.exception instanceof CharConversionException) {
+	if (abortException.getCause() instanceof CharConversionException) {
 		// specific encoding issue
 		String encoding = abortException.encoding;
 		if (encoding == null) {
@@ -1415,9 +1415,9 @@ public void cannotReadSource(CompilationUnitDeclaration unit, AbortCompilationUn
 		return;
 	}
 	if (verbose) {
-		System.err.println(Util.getStackTrace(abortException.exception));
+		System.err.println(Util.getStackTrace(abortException.getCause()));
 	}
-	String exceptionTrace = abortException.exception.getClass().getName() + ':' + abortException.exception.getMessage();
+	String exceptionTrace = abortException.getCause().getClass().getName() + ':' + abortException.getCause().getMessage();
 	String[] arguments = new String[]{ fileName, exceptionTrace };
 	this.handle(
 			IProblem.CannotReadSource,

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/CompilationUnit.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/CompilationUnit.java
@@ -179,7 +179,7 @@ protected boolean buildStructure(OpenableElementInfo info, final IProgressMonito
 			}
 		} catch (AbortCompilationUnit e) {
 			var problem = e.problem;
-			if (problem == null && e.exception instanceof IOException ioEx) {
+			if (problem == null && e.getCause() instanceof IOException ioEx) {
 				String path = source.getPath().toString();
 				String exceptionTrace = ioEx.getClass().getName() + ':' + ioEx.getMessage();
 				problem = new DefaultProblemFactory().createProblem(

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ReconcileWorkingCopyOperation.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ReconcileWorkingCopyOperation.java
@@ -224,7 +224,7 @@ public class ReconcileWorkingCopyOperation extends JavaModelOperation {
 						}
 					} catch (AbortCompilationUnit ex) {
 						var problem = ex.problem;
-						if (problem == null && ex.exception instanceof IOException ioEx) {
+						if (problem == null && ex.getCause() instanceof IOException ioEx) {
 							String path = source.getPath().toString();
 							String exceptionTrace = ioEx.getClass().getName() + ':' + ioEx.getMessage();
 							problem = new DefaultProblemFactory().createProblem(


### PR DESCRIPTION
After 0dbe2967235238fb5375924d17a13bcd9f9f6483 &
15c8bfb5a86e8978a858bbd8233068e2ad8e0e7f JDT UI may report errors where none should be reported because it is supposed to be "silent cancellation".

This change uses standard Java "cause" in the `AbortCompilation` and removes two different public fields used to keep exceptions before.

An extra change will be needed in at least one place in the UI, where `org.eclipse.jdt.core.manipulation.CoreASTProvider.createAST(ITypeRoot, IProgressMonitor)` should be able to inspect the provided "cause" of the `RuntimeException` and handle it in same way as
`OperationCanceledException`.

Note: `AbortCompilation` itself is not visible outside compiler code, so this type can't be used in UI for any checks.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2769
