### PR TITLE
Don't report AbortCompilation exceptions from parser

### DIFF
--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/CompilationUnitResolver.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/CompilationUnitResolver.java
@@ -1326,6 +1326,14 @@ class CompilationUnitResolver extends Compiler {
 			return unit;
 		} catch (AbortCompilation e) {
 			this.handleInternalException(e, unit);
+			if(e.isSilent) {
+				if (e.silentException == null) {
+					if (this.monitor != null) {
+						this.monitor.setCanceled(true);
+					}
+					throw new OperationCanceledException();
+				}
+			}
 			return unit == null ? this.unitsToProcess[0] : unit;
 		} catch (Error | RuntimeException e) {
 			this.handleInternalException(e, unit, null);


### PR DESCRIPTION
Regression from
https://github.com/eclipse-jdt/eclipse.jdt.core/pull/4451 & https://github.com/eclipse-jdt/eclipse.jdt.core/pull/4302.

If Java Editor interrupts hover computation, nothing should be reported, as it is expected. After changes above two errors are reported into the log (with same stack).

Fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2769
