### PR TITLE
ECJ fails to compile array creation with wildcard using Stream while

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/MessageSend.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/MessageSend.java
@@ -1233,10 +1233,6 @@ public boolean isPolyExpression(MethodBinding resolutionCandidate) {
 
 	if (resolutionCandidate != null) {
 		if (resolutionCandidate.returnType != null && resolutionCandidate.returnType.id != TypeIds.T_void) {
-			if (resolutionCandidate instanceof ParameterizedGenericMethodBinding pgmb) {
-				if (pgmb.wasInferred)
-					return true; // if already determined
-			}
 			// resolution may have prematurely instantiated the generic method, we need the original, though:
 			MethodBinding candidateOriginal = resolutionCandidate.original();
 			return candidateOriginal.returnType.mentionsAny(candidateOriginal.typeVariables(), -1);

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
@@ -1927,6 +1927,26 @@ public void testGH4635() {
 
 	});
 }
+public void testGH4604() {
+	runConformTest(new String[] {
+			"X.java",
+			"""
+			import java.util.concurrent.*;
+			import java.util.stream.*;
+			public class X {
+				public static void main(String[] args) {
+					CompletableFuture.allOf(Stream.of(1)
+						.map(value -> future(value))
+						.toArray(CompletableFuture[]::new));
+				}
+
+				public static <T> CompletableFuture<?> future(T t) {
+					return CompletableFuture.completedFuture(t);
+				}
+			}
+			"""
+		});
+}
 
 public static Class<GenericsRegressionTest_9> testClass() {
 	return GenericsRegressionTest_9.class;


### PR DESCRIPTION
javac and ECJ 2025-09 succeed

+ do not rely on PGMB.wasInferred for MessageSend.isPolyExpression()

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4604
