### PR TITLE
Regression in Eclipse 2025-12: Type mismatch even for variables with the exact same type

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/CaptureBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/CaptureBinding.java
@@ -307,6 +307,7 @@ public class CaptureBinding extends TypeVariableBinding {
 		if(scope.environment().usesNullTypeAnnotations()) {
 			evaluateNullAnnotations(scope, null);
 		}
+		this.compatibleCache = null; // any checks during initialization may have produced bogus results, get rid of them now
 	}
 
 	@Override

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/LookupEnvironment.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/LookupEnvironment.java
@@ -1114,6 +1114,14 @@ public TypeBinding createIntersectionType18(ReferenceBinding[] intersectingTypes
 			}
 		});
 	}
+	int j = 0;
+	for (int i = 1; i < intersectingTypes.length; i++) {
+		if (!TypeBinding.equalsEquals(intersectingTypes[j], intersectingTypes[i])) {
+			intersectingTypes[++j] = intersectingTypes[i];
+		}
+	}
+	if (j < intersectingTypes.length)
+		intersectingTypes = Arrays.copyOfRange(intersectingTypes, 0, j+1);
 	return this.typeSystem.getIntersectionType18(intersectingTypes);
 }
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
@@ -91,7 +91,7 @@ abstract public class ReferenceBinding extends TypeBinding {
 	char[] constantPoolName;
 	char[] signature;
 
-	private Map<TypeBinding, Boolean> compatibleCache;
+	protected Map<TypeBinding, Boolean> compatibleCache;
 
 	int typeBits; // additional bits characterizing this type
 	protected MethodBinding [] singleAbstractMethod;

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
@@ -1947,6 +1947,61 @@ public void testGH4604() {
 			"""
 		});
 }
+public void testGH4699_1() {
+	if (this.complianceLevel < ClassFileConstants.JDK10) return; // uses 'var'
+	runConformTest(new String[] {
+			"EclipseBug.java",
+			"""
+			public class EclipseBug {
+				void error1() {
+					var someObject = getObject(); // <<--- Compiler complains here
+				}
+				private SomeObject<? extends SomeType<?, ? extends SpecialLocation>, ? extends SpecialLocation, ?> getObject() {
+					return null;
+				}
+				static interface SomeLocation { }
+				static interface SpecialLocation extends SomeLocation { }
+
+				static interface SomeType<O extends SomeObject<? extends SomeType<?, L>, L, ? extends SomeObject<?, ?, ?>>, L extends SomeLocation> { }
+
+				public interface SomeObject<T extends SomeType<?, L>, L extends SomeLocation, P extends SomeObject<?, ?, ?>> { }
+			}
+			"""
+		});
+}
+public void testGH4699_full() {
+	if (this.complianceLevel < ClassFileConstants.JDK10) return; // uses 'var'
+	runConformTest(new String[] {
+			"EclipseBug.java",
+			"""
+			public class EclipseBug {
+
+				void error1() {
+					var someObject = getObject();
+				}
+
+				void error2(SomeObject<? extends SomeType<?, ? extends SpecialLocation>, ? extends SpecialLocation, ?> theObject) {
+					method(theObject);
+				}
+
+				void error3(SomeObject<? extends SomeType<?, ? extends SpecialLocation>, ? extends SpecialLocation, ?> theObject) {
+					SomeObject<? extends SomeType<?, ? extends SpecialLocation>, ? extends SpecialLocation, ?> theObject2 = theObject;
+				}
+
+				void method(SomeObject<? extends SomeType<?, ? extends SpecialLocation>, ? extends SpecialLocation, ?> theObject) { }
+
+				private SomeObject<? extends SomeType<?, ? extends SpecialLocation>, ? extends SpecialLocation, ?> getObject() {
+					return null;
+				}
+
+				static interface SomeLocation { }
+				static interface SpecialLocation extends SomeLocation { }
+				static interface SomeType<O extends SomeObject<? extends SomeType<?, L>, L, ? extends SomeObject<?, ?, ?>>, L extends SomeLocation> { }
+				public interface SomeObject<T extends SomeType<?, L>, L extends SomeLocation, P extends SomeObject<?, ?, ?>> { }
+			}
+			"""
+		});
+}
 
 public static Class<GenericsRegressionTest_9> testClass() {
 	return GenericsRegressionTest_9.class;


### PR DESCRIPTION
2 technical fixes:
+ don't cache premature compatibility checks from capture initialization
+ avoid duplicate intersecting types in IntersectionTypeBinding18

Adjust the test program to avoid using uninitialized local vars

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4699
