### PR TITLE
Search references doesn't work when a referenced project has module-info

### DIFF
--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/ClasspathSourceDirectory.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/ClasspathSourceDirectory.java
@@ -26,6 +26,7 @@ import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.internal.compiler.env.IModule;
 import org.eclipse.jdt.internal.compiler.env.IModulePathEntry;
 import org.eclipse.jdt.internal.compiler.env.NameEnvironmentAnswer;
 import org.eclipse.jdt.internal.core.JavaModelManager;
@@ -40,18 +41,27 @@ public class ClasspathSourceDirectory extends ClasspathLocation implements IModu
 	private static final Map<String, IResource> missingPackageHolder = new HashMap<>();
 	final char[][] fullExclusionPatternChars;
 	final char[][] fulInclusionPatternChars;
+	private boolean isOnModulePath = false;
 
-ClasspathSourceDirectory(IContainer sourceFolder, char[][] fullExclusionPatternChars, char[][] fulInclusionPatternChars) {
+ClasspathSourceDirectory(IContainer sourceFolder,
+		char[][] fullExclusionPatternChars,
+		char[][] fulInclusionPatternChars,
+		boolean isOnModulePath) {
 	this.sourceFolder = sourceFolder;
 	this.fullExclusionPatternChars = fullExclusionPatternChars;
 	this.fulInclusionPatternChars = fulInclusionPatternChars;
+	this.isOnModulePath = isOnModulePath;
 }
 
 @Override
 public void cleanup() {
 	this.directoryCache.clear();
 }
-
+@Override
+public void setModule (IModule mod) {
+	if (this.isOnModulePath)
+		this.module = mod;
+}
 Map<String, IResource> directoryTable(String qualifiedPackageName) {
 	Map<String, IResource> dirTable = this.directoryCache.get(qualifiedPackageName);
 	if (dirTable == missingPackageHolder) return null; // package exists in another classpath directory or jar

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/JavaSearchNameEnvironment.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/JavaSearchNameEnvironment.java
@@ -283,11 +283,11 @@ private ClasspathLocation mapToClassPathLocation(JavaModelManager manager, Packa
 					ClasspathLocation.forLibrary(manager.getZipFile(path), rawClasspathEntry.getAccessRuleSet(), rawClasspathEntry.isModular(), compliance) ;
 		} else {
 			Object target = JavaModel.getTarget(root, true);
+			ClasspathEntry rawClasspathEntry = (ClasspathEntry) root.getRawClasspathEntry();
 			if (target != null) {
 				if (root.getKind() == IPackageFragmentRoot.K_SOURCE) {
-					cp = new ClasspathSourceDirectory((IContainer)target, root.fullExclusionPatternChars(), root.fullInclusionPatternChars());
+					cp = new ClasspathSourceDirectory((IContainer)target, root.fullExclusionPatternChars(), root.fullInclusionPatternChars(), rawClasspathEntry.isModular());
 				} else {
-					ClasspathEntry rawClasspathEntry = (ClasspathEntry) root.getRawClasspathEntry();
 					cp = ClasspathLocation.forBinaryFolder((IContainer) target, false, rawClasspathEntry.getAccessRuleSet(),
 														null, rawClasspathEntry.isModular());
 				}

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/JavaSearchNameEnvironment.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/JavaSearchNameEnvironment.java
@@ -286,7 +286,7 @@ private ClasspathLocation mapToClassPathLocation(JavaModelManager manager, Packa
 			ClasspathEntry rawClasspathEntry = (ClasspathEntry) root.getRawClasspathEntry();
 			if (target != null) {
 				if (root.getKind() == IPackageFragmentRoot.K_SOURCE) {
-					cp = new ClasspathSourceDirectory((IContainer)target, root.fullExclusionPatternChars(), root.fullInclusionPatternChars(), rawClasspathEntry.isModular());
+					cp = new ClasspathSourceDirectory((IContainer)target, root.fullExclusionPatternChars(), root.fullInclusionPatternChars(), defaultModule != null);
 				} else {
 					cp = ClasspathLocation.forBinaryFolder((IContainer) target, false, rawClasspathEntry.getAccessRuleSet(),
 														null, rawClasspathEntry.isModular());


### PR DESCRIPTION
but is on classpath

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
Fixes the use case reported in https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4677#issuecomment-3664213712

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
