### PR TITLE
Print warning if adding parent folder of library to the classpath #4797

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ClasspathEntry.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ClasspathEntry.java
@@ -986,6 +986,14 @@ public class ClasspathEntry implements IClasspathEntry {
 						}
 						continue;
 					}
+					if (JavaModelManager.CP_RESOLVE_VERBOSE_FAILURE && calledJar.isPrefixOf(jarPath)) {
+						// Adding parent folders is a hack that some JARs use to spare some effort,
+						// but it may cause issues like having invalid duplicated classes in the classpath.
+						// See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4797
+						trace("WARN: Classpath entry " + calledFileName + " in manifest of jar file: " //$NON-NLS-1$ //$NON-NLS-2$
+								+ jarPath.toOSString()
+								+ " references a parent folder. This may cause issues like duplicated classes in the classpath, wrong hierarchies, etc. For more details, see https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4797."); //$NON-NLS-1$
+					}
 					resolvedChainedLibraries(calledJar, visited, result);
 					result.add(calledJar);
 				}


### PR DESCRIPTION
## What it does

Print a warning in the trace log if the Class-Path entry in the manifest file of a third-party library includes a parent folder. This might not be forbidden but it's a dangerous practice.

Contributes to: https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4797

## How to test
- Launch the _Runtime Workspace_, making sure that _tracing_ is enabled like this:
 
<img width="853" height="293" alt="image" src="https://github.com/user-attachments/assets/4e99a360-541f-4688-b03c-012df0d7a565" />


- Import the 2 projects in this ZIP: [projects.zip](https://github.com/user-attachments/files/25047329/runtime-workspace.zip)
- Restart the application

### Expected
This should appear in the Console output:

```
| main | 2026-02-03 14:26:33.814 | org.eclipse.jdt.core | /debug | org.eclipse.jdt.internal.core.ClasspathEntry | resolvedChainedLibraries | 993 | WARN: Classpath entry ../ in manifest of jar file: \a\lib\badlib.jar references a parent folder. This may cause issues like: https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4797 |
```

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
