### PR TITLE
Issue #4736 - Type Elided Lambda Arguments not participating in rawtype

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LambdaExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LambdaExpression.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2025 IBM Corporation and others.
+ * Copyright (c) 2012, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -331,7 +331,15 @@ public class LambdaExpression extends FunctionalExpression implements IPolyExpre
 				}
 				if ((argumentType.tagBits & TagBits.HasMissingType) != 0) {
 					this.binding.tagBits |= TagBits.HasMissingType;
+				} else if (argumentsTypeElided) { // argument with type was already checked before.
+					argumentType = this.scope.environment().convertToRawType(argumentType, false /*do not force conversion of enclosing types*/);
+					if (argumentType.leafComponentType().isRawType()
+							&& (this.bits & ASTNode.IgnoreRawTypeCheck) == 0
+							&& this.scope.compilerOptions().getSeverity(CompilerOptions.RawTypeReference) != ProblemSeverities.Ignore) {
+						this.scope.problemReporter().rawTypeReference(this, argumentType);
+					}
 				}
+
 			}
 		}
 		if (!argumentsTypeElided && !argumentsHaveErrors) {


### PR DESCRIPTION
## What it does
ref issue #4736. The problem was that the type elided lambda arguments not participating in raw type warning checks. This PR fixes that issue.

## How to test
A Test case is part of the PR.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
