### PR TITLE
Type annotations on type variables in the header of a class declaration are not preserved in the corresponding type bindings

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SingleTypeReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SingleTypeReference.java
@@ -18,7 +18,15 @@ package org.eclipse.jdt.internal.compiler.ast;
 
 import org.eclipse.jdt.internal.compiler.ASTVisitor;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
-import org.eclipse.jdt.internal.compiler.lookup.*;
+import org.eclipse.jdt.internal.compiler.lookup.BlockScope;
+import org.eclipse.jdt.internal.compiler.lookup.ClassScope;
+import org.eclipse.jdt.internal.compiler.lookup.LocalTypeBinding;
+import org.eclipse.jdt.internal.compiler.lookup.MethodScope;
+import org.eclipse.jdt.internal.compiler.lookup.ReferenceBinding;
+import org.eclipse.jdt.internal.compiler.lookup.Scope;
+import org.eclipse.jdt.internal.compiler.lookup.SourceTypeBinding;
+import org.eclipse.jdt.internal.compiler.lookup.TypeBinding;
+import org.eclipse.jdt.internal.compiler.lookup.TypeVariableBinding;
 import org.eclipse.jdt.internal.compiler.problem.ProblemSeverities;
 
 public class SingleTypeReference extends TypeReference {
@@ -157,23 +165,5 @@ public class SingleTypeReference extends TypeReference {
 			}
 		}
 		visitor.endVisit(this, scope);
-	}
-
-	@Override
-	public void updateWithAnnotations(Scope scope, int location) {
-		super.updateWithAnnotations(scope, location);
-		if (this.resolvedType instanceof TypeVariableBinding && !this.resolvedType.hasNullTypeAnnotations()) {
-			// refresh this binding in case a decorated binding was created during ClassScope.connectTypeVariables()
-			TypeVariableBinding tvb = (TypeVariableBinding) this.resolvedType;
-			Binding declaringElement = tvb.declaringElement;
-			if (declaringElement instanceof ReferenceBinding) {
-				TypeVariableBinding[] typeVariables = ((ReferenceBinding) declaringElement).typeVariables();
-				if (typeVariables != null && tvb.rank < typeVariables.length) {
-					TypeVariableBinding refreshed = typeVariables[tvb.rank];
-					if (refreshed != null && refreshed.id == this.resolvedType.id)
-						this.resolvedType = refreshed;
-				}
-			}
-		}
 	}
 }


### PR DESCRIPTION

* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4219

