### PR TITLE
Remove the point fix from PR #1079 which is no longer needed after #4740

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeVariableBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeVariableBinding.java
@@ -253,17 +253,6 @@ public class TypeVariableBinding extends ReferenceBinding {
 					break;
 			}
 			return BoundCheckStatus.OK;
-		} else if (checkNullAnnotations && argumentType.kind() == Binding.TYPE_PARAMETER && !argumentType.hasNullTypeAnnotations()) {
-			// refresh argumentType in case a nullness default(TYPE_PARAMETER) was applied late:
-			TypeVariableBinding tvb = (TypeVariableBinding) argumentType;
-			if (tvb.declaringElement instanceof SourceTypeBinding) {
-				TypeVariableBinding[] typeVariables = ((SourceTypeBinding) tvb.declaringElement).typeVariables;
-				if (typeVariables != null && typeVariables.length > tvb.rank) {
-					TypeVariableBinding refreshed = typeVariables[tvb.rank];
-					if (refreshed.id == argumentType.id)
-						argumentType = refreshed;
-				}
-			}
 		}
 		boolean unchecked = false;
 		if (this.superclass.id != TypeIds.T_JavaLangObject) {


### PR DESCRIPTION
This removes the point fix from  https://github.com/eclipse-jdt/eclipse.jdt.core/pull/1079/changes/65f3393d4bd5f13698d35320e0cb67bf4d7b2fd6

After #4740 this kind of "refreshing" is no longer needed, since annotations on type parameters are now inserted in-place.

I locally ran TestAll at 25 after replacing like this:
```diff
-						argumentType = refreshed;
+						assert argumentType == refreshed; //$IDENTITY-COMPARISON$
```
which passed.

The same for model tests relating to null annotations.