### PR TITLE
AnnotationTest opts in to run.javac mode

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AnnotationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AnnotationTest.java
@@ -107,11 +107,13 @@ public class AnnotationTest extends AbstractComparableTest {
 		return super.getNameEnvironment(testFiles, classPaths, options);
 	}
 
+	// ========= OPT-IN to run.javac mode: ===========
 	/* (non-Javadoc)
 	 * @see junit.framework.TestCase#setUp()
 	 */
 	@Override
 	protected void setUp() throws Exception {
+		this.runJavacOptIn = true;
 		super.setUp();
 		this.reportMissingJavadocComments = null;
 		this.repeatableIntroText =
@@ -120,6 +122,12 @@ public class AnnotationTest extends AbstractComparableTest {
 		". Only annotation types marked @Repeatable can be used multiple times at one target.\n";
 		this.javaClassLib = null; // use only in selected tests
 	}
+	@Override
+	protected void tearDown() throws Exception {
+		super.tearDown();
+		this.runJavacOptIn = false; // do it last, so super can still clean up
+	}
+	// =================================================
 
 	public void test001() {
 		this.runConformTest(


### PR DESCRIPTION
Inspired by #4828 I noticed that AnnotationTest is actually ready for run.javac mode.