### PR TITLE
Guard against NPE in ReferenceBinding.canBeSeenBy

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
@@ -333,7 +333,9 @@ public boolean canBeSeenBy(ReferenceBinding receiverType, ReferenceBinding invoc
 		// JLS 6.6-5: A private class member or constructor is accessible only within the body of the top level
 		// class (§7.6) that encloses the declaration of the member or constructor => we should forbid access from top level class `header`.
 		ReferenceBinding topLevelType = invocationType.outermostEnclosingType();
-		if (topLevelType instanceof SourceTypeBinding sourceType && sourceType.scope.referenceContext.staticInitializerScope.insideTypeDeclarationAnnotations)
+		if (topLevelType instanceof SourceTypeBinding sourceType
+				&& sourceType.scope != null
+				&& sourceType.scope.referenceContext.staticInitializerScope.insideTypeDeclarationAnnotations)
 			return false;
 	}
 


### PR DESCRIPTION
* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4832

