### PR TITLE
Avoid duplicated read of file attributes in ExternalFoldersManager

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ExternalFoldersManager.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ExternalFoldersManager.java
@@ -17,10 +17,10 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.core;
 
-import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -151,12 +151,16 @@ public class ExternalFoldersManager {
 			return false;
 		}
 		// Test if this an absolute path in local file system (not the workspace path)
-		File externalFolder = externalPath.toFile();
-		if (Files.isRegularFile(externalFolder.toPath())) {
+		BasicFileAttributes externalAttributes = null;
+		try {
+			externalAttributes = Files.readAttributes(externalPath.toPath(), BasicFileAttributes.class);
+		} catch (IOException e) { // assume not existing
+		}
+		if (externalAttributes != null && externalAttributes.isRegularFile()) {
 			manager.addExternalFile(externalPath, true);
 			return false;
 		}
-		if (Files.isDirectory(externalFolder.toPath())) {
+		if (externalAttributes != null && externalAttributes.isDirectory()) {
 			return true;
 		}
 		// this can be now only full workspace path or an external path to a not existing file or folder


### PR DESCRIPTION
## What it does
Avoid duplicated read of file attributes in `ExternalFoldersManager` in case the tested path is a directory.
`Files.isRegularFile()` and `Files.isDirectory()` both read the attributes of the specified file/path and check if the corresponding flags for file or directory are set.
Actually it is sufficient to read the attributes once and only check the read attributes for both cases.

I haven't run any benchmarks, but since this method is called frequently (at least that's my impression) such simple optimization could already help a little bit.
In the worst case, it's not notably faster.

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
