### PR TITLE
CompleteTypeBindingsSteps.INTEGRATE_ANNOTATIONS_IN_HIERARCHY violates TypeBinding's protocol by direct updation of fields in various places

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypeDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypeDeclaration.java
@@ -1881,7 +1881,7 @@ public void updateSupertypesWithAnnotations(Map<ReferenceBinding,ReferenceBindin
 		}
 	}
 	if (this.superclass != null) {
-		this.binding.superclass = updateWithAnnotations(this.superclass, this.binding.superclass, outerUpdates, updates);
+		this.binding.setSuperClass(updateWithAnnotations(this.superclass, this.binding.superclass, outerUpdates, updates)); // don't assign directly to superclass!
 	}
 	if (this.superInterfaces != null) {
 		ReferenceBinding[] superIfcBindings = this.binding.superInterfaces;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypeParameter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypeParameter.java
@@ -236,9 +236,9 @@ public class TypeParameter extends AbstractVariableDeclaration {
 			this.type.updateWithAnnotations(scope, Binding.DefaultLocationTypeBound);
 			if (this.type.resolvedType instanceof ReferenceBinding && prevType != this.type.resolvedType) { //$IDENTITY-COMPARISON$
 				ReferenceBinding newType = (ReferenceBinding) this.type.resolvedType;
-				this.binding.firstBound = newType;
+				this.binding.setFirstBound(newType); // do not assign to firstBound directly!
 				if (newType.isClass())
-					this.binding.superclass = newType;
+					this.binding.setSuperClass(newType); // do not assign to superclass directly!
 			}
 		}
 		if (this.bounds != null) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ClassScope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ClassScope.java
@@ -486,7 +486,7 @@ public class ClassScope extends Scope {
 		}
 
 		TypeParameter[] typeParameters = this.referenceContext.typeParameters;
-		sourceType.typeVariables = typeParameters == null || typeParameters.length == 0 ? Binding.NO_TYPE_VARIABLES : null;
+		sourceType.setTypeVariables(typeParameters == null || typeParameters.length == 0 ? Binding.NO_TYPE_VARIABLES : null); // don't assign directly!
 		sourceType.fPackage.addType(sourceType);
 		checkAndSetModifiers();
 		buildTypeVariables();
@@ -1376,7 +1376,7 @@ public class ClassScope extends Scope {
 			}
 			if (count != rcbs.length) // remove duplicate or broken components
 				System.arraycopy(rcbs, 0, rcbs = count == 0 ? Binding.NO_COMPONENTS : new RecordComponentBinding[count], 0, count);
-			sourceType.components = rcbs;
+			sourceType.setComponents(rcbs); // don't assign directly to components!
 		}
 		ReferenceBinding[] memberTypes = sourceType.memberTypes;
 		if (memberTypes != null) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SourceTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SourceTypeBinding.java
@@ -2547,6 +2547,10 @@ private void setImplicitPermittedType(SourceTypeBinding permittedType) {
 		if (sz == 0) {
 			typesPermitted = new ReferenceBinding[] { permittedType };
 		} else {
+			for (int i = 0; i < sz; i++) {
+				if (TypeBinding.equalsEquals(typesPermitted[i], permittedType))
+					return; // don't include twice once without and once with annotations.
+			}
 			System.arraycopy(typesPermitted, 0, typesPermitted = new ReferenceBinding[sz + 1], 0, sz);
 			typesPermitted[sz] = permittedType;
 		}


### PR DESCRIPTION
* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4823

