### PR TITLE
[WIP] Allow IDE enable/disable escaping classpath entries in jars

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/core/JavaCore.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/core/JavaCore.java
@@ -2716,6 +2716,34 @@ public final class JavaCore extends Plugin {
 	public static final String CORE_MAIN_ONLY_PROJECT_HAS_TEST_ONLY_DEPENDENCY = PLUGIN_ID + ".classpath.mainOnlyProjectHasTestOnlyDependency";  //$NON-NLS-1$
 
 	/**
+	 * Core option ID: Enable escaping classpath entries in jar manifests (like ../bad.jar).
+	 * <p>
+	 * When enabled, the classpath entries in jar manifests can escape current jar directory tree (like
+	 * ../lib/some.jar). When disabled, all classpath entries in manifest must be inside current jar directory tree.
+	 * </p>
+	 * <p>
+	 * This option should be disabled to be consistent with command line compiler, but it is enabled by default for
+	 * backward compatibility reasons (in the IDE escaping classpath entries was possible since Eclipse 3.5, see
+	 * https://bugs.eclipse.org/bugs/show_bug.cgi?id=198572).
+	 * </p>
+	 * <p>
+	 * For performance reasons, any presence of the &quot;..&quot; segment in a classpath entry in a jar manifest will
+	 * cause the compiler to assume that the entry is escaping the current jar directory tree.
+	 * </p>
+	 * <dl>
+	 * <dt>Option id:</dt>
+	 * <dd><code>"org.eclipse.jdt.core.classpath.enableEscapingCpEntriesInJarManifest"</code></dd>
+	 * <dt>Possible values:</dt>
+	 * <dd><code>{ "enabled", "disabled" }</code></dd>
+	 * <dt>Default:</dt>
+	 * <dd><code>"disabled"</code></dd>
+	 * </dl>
+	 *
+	 * @since 3.45
+	 */
+	public static final String CORE_ENABLE_ESACAPING_CP_ENTRIES_IN_JAR_MANIFEST = PLUGIN_ID + ".classpath.enableEscapingCpEntriesInJarManifest";  //$NON-NLS-1$
+
+	/**
 	 * Compiler option ID: Enabling support for preview language features.
 	 * <p>When enabled, the compiler will activate the preview language features of this Java version.</p>
 	 *

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ClasspathEntry.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ClasspathEntry.java
@@ -978,6 +978,16 @@ public class ClasspathEntry implements IClasspathEntry {
 						trace("Invalid Class-Path entry " + calledFileName + " in manifest of jar file: " + jarPath.toOSString()); //$NON-NLS-1$ //$NON-NLS-2$
 					}
 				} else {
+					String escapePref = JavaCore.getOptions()
+							.get(JavaCore.CORE_ENABLE_ESACAPING_CP_ENTRIES_IN_JAR_MANIFEST);
+					if (JavaCore.DISABLED.equals(escapePref) && calledFileName.indexOf(DOT_DOT) != -1
+							&& hasDotDot(Path.fromPortableString(calledFileName))) {
+						if (JavaModelManager.CP_RESOLVE_VERBOSE_FAILURE) {
+							trace("Invalid (escaping jar directory) Class-Path entry " + calledFileName //$NON-NLS-1$
+									+ " in manifest of jar file: " + jarPath.toOSString()); //$NON-NLS-1$
+						}
+						continue;
+					}
 					IPath calledJar = directoryPath.append(new Path(calledFileName));
 					// Ignore if segment count is Zero (https://bugs.eclipse.org/bugs/show_bug.cgi?id=308150)
 					if (calledJar.segmentCount() == 0) {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaCorePreferenceInitializer.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaCorePreferenceInitializer.java
@@ -78,6 +78,7 @@ public class JavaCorePreferenceInitializer extends AbstractPreferenceInitializer
 		defaultOptionsMap.put(JavaCore.CORE_ENABLE_CLASSPATH_MULTIPLE_OUTPUT_LOCATIONS, JavaCore.ENABLED);
 		defaultOptionsMap.put(JavaCore.CORE_OUTPUT_LOCATION_OVERLAPPING_ANOTHER_SOURCE, JavaCore.ERROR);
 		defaultOptionsMap.put(JavaCore.CORE_MAIN_ONLY_PROJECT_HAS_TEST_ONLY_DEPENDENCY, JavaCore.ERROR);
+		defaultOptionsMap.put(JavaCore.CORE_ENABLE_ESACAPING_CP_ENTRIES_IN_JAR_MANIFEST, JavaCore.DISABLED);
 
 		// encoding setting comes from resource plug-in
 		optionNames.add(JavaCore.CORE_ENCODING);


### PR DESCRIPTION
Since b74a7b82d9221b86893a88ea5453e92534ffe51b JDT Core (but not ecj!) supported Class-Path attribute for external jars and added all entries from such jar to the current project classpath.

This change introduces new JavaCore preference that allows JDT ignore "escaping" classpath entries read from external jars (entries, containing ".." path segment).

By default, JDT disables now old behavior and disallows such paths.

See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/258 See https://bugs.eclipse.org/bugs/show_bug.cgi?id=198572
