### PR TITLE
[Formatter] Do not escape annotations inside snippet tags

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/formatter/FormatterCommentsTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/formatter/FormatterCommentsTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -1399,6 +1399,63 @@ public void testSnippet06() {
 		"public class T {\n" +
 		"}"
 	);
+}
+
+public void testAtInSnippet01() {
+	setComplianceLevel(CompilerOptions.VERSION_18);
+	String source = """
+			/**
+			 * {@snippet :
+			 * @SomeAnnotation
+			 * public class Example {
+			 * 			final int a =1;
+			 * 	final boolean b = 		true;
+			 * }
+			 * }
+			 */
+			class SomeClass3 {
+			}
+			""";
+	String expected = """
+			/**
+			 * {@snippet :
+			 * @SomeAnnotation
+			 * public class Example {
+			 * 	final int a = 1;
+			 * 	final boolean b = true;
+			 * }
+			 * }
+			 */
+			class SomeClass3 {
+			}
+			""";
+	formatSource(source, expected);
+}
+public void testAtInSnippet02() {
+	setComplianceLevel(CompilerOptions.VERSION_18);
+	String source = """
+			/**
+			 * {@snippet :
+			 * @SomeAnnotation
+			 * void someMethod(@ThisAnnotationWillBeFine blah) {
+			 * }
+			 * }
+			 */
+			class SomeClass {
+			}
+			""";
+	String expected = """
+			/**
+			 * {@snippet :
+			 * @SomeAnnotation
+			 * void someMethod(@ThisAnnotationWillBeFine blah) {
+			 * }
+			 * }
+			 */
+			class SomeClass {
+			}
+			""";
+	formatSource(source, expected);
 }
 public void testJoinLineComment01() {
 	this.formatterPrefs.join_line_comments = true;


### PR DESCRIPTION
The formatter currently converts lines starting with '@' into
<img width="161" height="76" alt="image" src="https://github.com/user-attachments/assets/71d705ff-c07e-4dfc-bc31-713d26869e37" /> inside snippet bodies. This commit prevents snippets to be marked as escape strings

Fixes : https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2071

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
