### PR TITLE
New compiler warning in `org.eclipse.jdt.internal.core.builder.ClasspathJar`

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/ClasspathJar.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/ClasspathJar.java
@@ -109,7 +109,7 @@ protected Set<String> readPackageNames() {
 IModule initializeModule() {
 	IModule mod = null;
 	try (ZipFile file = new ZipFile(this.zipFilename)) {
-		String releasePath = Util.METAINF_VERSIONS + this.compliance + '/' + IModule.MODULE_INFO_CLASS; //$NON-NLS-1$
+		String releasePath = Util.METAINF_VERSIONS + this.compliance + '/' + IModule.MODULE_INFO_CLASS;
 		ClassFileReader classfile = null;
 		try {
 			classfile = ClassFileReader.read(file, releasePath);


### PR DESCRIPTION


* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4857

