### PR TITLE
Eclipse 4.39M3 - Compilation fails due to java.lang.NullPointerException: Cannot read field "compatibleCache" because "this" is null

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/CaptureBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/CaptureBinding.java
@@ -307,7 +307,9 @@ public class CaptureBinding extends TypeVariableBinding {
 		if(scope.environment().usesNullTypeAnnotations()) {
 			evaluateNullAnnotations(scope, null);
 		}
-		this.compatibleCache = null; // any checks during initialization may have produced bogus results, get rid of them now
+		if (this.compatibleCache != null) {
+			this.compatibleCache.clear(); // any checks during initialization may have produced bogus results, get rid of them now
+		}
 	}
 
 	@Override


### PR DESCRIPTION
Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4861
