### PR TITLE
Fix the comment on Unicode version being built

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/ScannerHelper.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/ScannerHelper.java
@@ -409,31 +409,31 @@ public static boolean isJavaIdentifierPart(long complianceLevel, int codePoint) 
 		if (Tables15 == null) {
 			initializeTableJava15();
 		}
-		return isJavaIdentifierPart0(codePoint, Tables15);
+		return isJavaIdentifierPart0(codePoint, Tables15, true);
 	} else if (complianceLevel <= ClassFileConstants.JDK19) {
 		// java 19 support Unicode 14
 		if (Tables19 == null) {
 			initializeTableJava19();
 		}
-		return isJavaIdentifierPart0(codePoint, Tables19);
+		return isJavaIdentifierPart0(codePoint, Tables19, true);
 	} else if (complianceLevel <= ClassFileConstants.JDK21) {
 		// java 20 and 21 support Unicode 15
 		if (Tables20 == null) {
 			initializeTableJava20();
 		}
-		return isJavaIdentifierPart0(codePoint, Tables20);
+		return isJavaIdentifierPart0(codePoint, Tables20, true);
 	} else if (complianceLevel <= ClassFileConstants.JDK23) {
-		// java 22 and 23 support Unicode 15
+		// java 22 and 23 support Unicode 15.1
 		if (Tables22 == null) {
 			initializeTableJava22();
 		}
-		return isJavaIdentifierPart0(codePoint, Tables22);
+		return isJavaIdentifierPart0(codePoint, Tables22, true);
 	} else if (complianceLevel <= ClassFileConstants.JDK25) {
-		// java 24 and 25 support Unicode 15
+		// java 24 and 25 support Unicode 16
 		if (Tables24 == null) {
 			initializeTableJava24();
 		}
-		return isJavaIdentifierPart0(codePoint, Tables24);
+		return isJavaIdentifierPart0(codePoint, Tables24, true);
 	} else {
 		// java 26 supports Unicode 17
 		if (Tables26 == null) {
@@ -514,31 +514,31 @@ public static boolean isJavaIdentifierStart(long complianceLevel, int codePoint)
 		if (Tables15 == null) {
 			initializeTableJava15();
 		}
-		return isJavaIdentifierStart0(codePoint, Tables15);
+		return isJavaIdentifierStart0(codePoint, Tables15, true);
 	} else if (complianceLevel <= ClassFileConstants.JDK19) {
 		// java 19 support Unicode 14
 		if (Tables19 == null) {
 			initializeTableJava19();
 		}
-		return isJavaIdentifierStart0(codePoint, Tables19);
+		return isJavaIdentifierStart0(codePoint, Tables19, true);
 	} else if (complianceLevel <= ClassFileConstants.JDK21) {
 		// java 20 and 21 support Unicode 15
 		if (Tables20 == null) {
 			initializeTableJava20();
 		}
-		return isJavaIdentifierStart0(codePoint, Tables20);
+		return isJavaIdentifierStart0(codePoint, Tables20, true);
 	} else if (complianceLevel <= ClassFileConstants.JDK23) {
 		// java 22 and 23 support Unicode 15.1
 		if (Tables22 == null) {
 			initializeTableJava22();
 		}
-		return isJavaIdentifierStart0(codePoint, Tables22);
+		return isJavaIdentifierStart0(codePoint, Tables22, true);
 	} else if (complianceLevel <= ClassFileConstants.JDK25) {
 		// java 24 and 25 support Unicode 16
 		if (Tables24 == null) {
 			initializeTableJava24();
 		}
-		return isJavaIdentifierStart0(codePoint, Tables24);
+		return isJavaIdentifierStart0(codePoint, Tables24, true);
 	} else {
 		// java 26 supports Unicode 17
 		if (Tables26 == null) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
Fixes the comment on Unicode version being built

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
