### PR TITLE
Cache isTest/isWithoutTestCode in ClasspathEntry constructor

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/core/IClasspathEntry.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/core/IClasspathEntry.java
@@ -475,7 +475,7 @@ public interface IClasspathEntry {
 	IClasspathEntry getResolvedEntry();
 
 	/**
-	 * This is a convience method, that returns <code>true</code> if the extra attributes contain an attribute whose name
+	 * This is a convenience method, that returns <code>true</code> if the extra attributes contain an attribute whose name
 	 * is {@link IClasspathAttribute#TEST} and whose value is 'true'.
 	 *
 	 * @see #getExtraAttributes()
@@ -493,7 +493,7 @@ public interface IClasspathEntry {
 	}
 
 	/**
-	 * This is a convience method, that returns <code>true</code> if the extra attributes contain an attribute whose name
+	 * This is a convenience method, that returns <code>true</code> if the extra attributes contain an attribute whose name
 	 * is {@link IClasspathAttribute#WITHOUT_TEST_CODE} and whose value is 'true'.
 	 *
 	 * @see #getExtraAttributes()

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ClasspathEntry.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ClasspathEntry.java
@@ -244,6 +244,9 @@ public class ClasspathEntry implements IClasspathEntry {
 	 */
 	public IClasspathAttribute[] extraAttributes;
 
+	private final boolean isTest;
+	private final boolean isWithoutTestCode;
+
 	public ClasspathEntry(
 			int contentKind,
 			int entryKind,
@@ -325,6 +328,18 @@ public class ClasspathEntry implements IClasspathEntry {
 		this.combineAccessRules = combineAccessRules;
 		this.extraAttributes = extraAttributes.length > 0 ? extraAttributes : NO_EXTRA_ATTRIBUTES;
 
+		String test = null;
+		String withoutTestCode = null;
+		for (IClasspathAttribute attribute : this.extraAttributes) {
+			if (IClasspathAttribute.TEST.equals(attribute.getName())) {
+				test = attribute.getValue();
+			} else if (IClasspathAttribute.WITHOUT_TEST_CODE.equals(attribute.getName()) ) {
+				withoutTestCode = attribute.getValue();
+			}
+		}
+		this.isTest = Boolean.valueOf(test);
+		this.isWithoutTestCode = Boolean.valueOf(withoutTestCode);
+
 	    if (inclusionPatterns != INCLUDE_ALL && inclusionPatterns.length > 0) {
 			this.fullInclusionPatternChars = UNINIT_PATTERNS;
 	    }
@@ -335,6 +350,16 @@ public class ClasspathEntry implements IClasspathEntry {
 		this.sourceAttachmentRootPath = sourceAttachmentRootPath;
 		this.specificOutputLocation = specificOutputLocation;
 		this.isExported = isExported;
+	}
+
+	@Override
+	public boolean isTest() {
+		return this.isTest;
+	}
+
+	@Override
+	public boolean isWithoutTestCode() {
+		return this.isWithoutTestCode;
 	}
 
 	@Override


### PR DESCRIPTION
Override `isTest()` and `isWithoutTestCode()` in `ClasspathEntry` to avoid iterating over the extra attributes array on every call. Instead, compute and cache the boolean values in the constructor, since extra attributes are immutable after construction.

Fixes eclipse-jdt/eclipse.jdt.core#4927