### PR TITLE
Fix native varargs methods incorrectly treated as signature-polymorphic #4955

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MethodBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MethodBinding.java
@@ -1437,21 +1437,10 @@ public boolean hasPolymorphicSignature(Scope scope) {
 	if ((this.tagBits & TagBits.AnnotationPolymorphicSignature) != 0) {
 		return true;
 	}
-	if (this.isNative()	&& this.isVarargs() && this.parameters.length == 1) {
-		/*
-		 *  here type will be arrayType we will come here only if the method is of type
-		 *  varargs(represented by arraytype) and with only one parameter.
-		 */
-		if (this.parameters[0].leafComponentType().id == TypeIds.T_JavaLangObject) {
-			ReferenceBinding declaringClassLocal = this.declaringClass;
-			if ((declaringClassLocal != null) && (declaringClassLocal.id == scope.getJavaLangInvokeMethodHandle().id
-					|| declaringClassLocal.id == scope.getJavaLangInvokeVarHandle().id)) {
-				return true;
-			}
-		}
-	}
-
-	return false;
+	return this.isNative() && this.isVarargs() && this.parameters.length == 1 &&
+			this.parameters[0].leafComponentType().id == TypeIds.T_JavaLangObject &&
+				(TypeBinding.equalsEquals(this.declaringClass, scope.getJavaLangInvokeMethodHandle())
+						|| TypeBinding.equalsEquals(this.declaringClass, scope.getJavaLangInvokeVarHandle()));
 }
 public boolean isClosingMethod() {
 	boolean isCloseMethod = CharOperation.equals(this.selector, TypeConstants.CLOSE) && this.parameters == NO_PARAMETERS;  // close()

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/BatchCompilerTest2.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/BatchCompilerTest2.java
@@ -465,6 +465,28 @@ public void testIssue147() throws Exception {
 	String expectedOutput = "java.lang.invoke.MethodHandle.invoke(java.lang.Object)";
 	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
 }
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4955
+// native varargs Object... on user-defined class must NOT be treated as polymorphic
+public void testGH4955() throws Exception {
+	runConformTest(
+		new String[] {
+			"X.java",
+			"public class X {\n" +
+			"    public static native void debug(Object... args);\n" +
+			"    public static void main(String[] args) {\n" +
+			"        debug(\"hello\");\n" +
+			"        debug(\"hello\", 42);\n" +
+			"    }\n" +
+			"}\n"
+		},
+		"\"" + OUTPUT_DIR + File.separator + "X.java\"",
+		"",
+		"",
+		true);
+	// Verify that calls to native varargs use Object[] descriptor, not direct argument types
+	String expectedOutput = "invokestatic X.debug(java.lang.Object[])";
+	checkDisassembledClassFile(OUTPUT_DIR + File.separator + "X.class", "X", expectedOutput);
+}
 public void testGH4744() throws Exception {
 	if (this.complianceLevel < ClassFileConstants.JDK21) {
 		return;


### PR DESCRIPTION
Regression from #147: `hasPolymorphicSignature()` used `id`-based comparison to check if a method's declaring class is `MethodHandle` or `VarHandle`. Since neither type has a pre-assigned `TypeId`, both default to `id = 0` — same as any user-defined class. The comparison `0 == 0` caused false positives.

**Effect:** Any `static native void foo(Object... args)` method on any class was treated as signature-polymorphic. ECJ generated `invokestatic` with direct argument types (e.g. `debug(String)`) instead of the varargs descriptor (`debug(Object[])`), causing `NoSuchMethodError` at runtime.

**Fix:** Replace `declaringClassLocal.id == scope.getJavaLangInvokeMethodHandle().id` with `TypeBinding.equalsEquals(declaringClassLocal, scope.getJavaLangInvokeMethodHandle())`.

**Regression test:** `BatchCompilerTest2.testGH4955()` — compiles a class with `static native void debug(Object... args)`, verifies the disassembled bytecode uses `Object[]` descriptor.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4955