### PR TITLE
Fix unchecked conversion not failed compilation

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedGenericMethodBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedGenericMethodBinding.java
@@ -26,6 +26,7 @@
  *								Bug 434483 - [1.8][compiler][inference] Type inference not picked up with method reference
  *								Bug 446442 - [1.8] merge null annotations from super methods
  *								Bug 457079 - Regression: type inference
+ *     Christoph Rueger         GH4957     - ECJ compiles fine but Java does not: unchecked conversion
  *******************************************************************************/
 package org.eclipse.jdt.internal.compiler.lookup;
 
@@ -75,8 +76,17 @@ public class ParameterizedGenericMethodBinding extends ParameterizedMethodBindin
 			        // incompatible due to wrong arity
 			        return new ProblemMethodBinding(originalMethod, originalMethod.selector, substitutes, ProblemReasons.TypeParameterArityMismatch);
 				}
-				methodSubstitute = environment.createParameterizedGenericMethod(originalMethod, substitutes);
-				break computeSubstitutes;
+				// JLS 15.12.2.6: Check if any explicit type argument is raw.
+				boolean usesUncheckedConversion = false;
+				for (int i = 0; i < typeVariables.length; i++) {
+					if (substitutes[i].isRawType()) {
+						usesUncheckedConversion = true;
+						break;
+					}
+				}
+				methodSubstitute = environment.createParameterizedGenericMethod(originalMethod, substitutes,
+						usesUncheckedConversion, false, null);
+			    break computeSubstitutes;
 			}
 			// perform type argument inference (15.12.2.7)
 			// initializes the map of substitutes (var --> type[][]{ equal, extends, super}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
@@ -2295,6 +2295,68 @@ public void testGH4731() {
 	runner.javacTestOptions = JavacHasABug.JavacBug8016207;
 	runner.runNegativeTest();
 }
+/**
+ * https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4957Eclipse
+ * 2026-03 compiles fine but Java does not: unchecked conversion with Comparator.comparing + raw Comparable
+ */
+public void testGH4957() {
+	this.runNegativeTest(
+			new String[] {
+				"Snippet.java",
+				"import java.util.Comparator;\n"
+				+ "import java.util.Map;\n"
+				+ "\n"
+				+ "public class Snippet {\n"
+				+ "\n"
+				+ "    public static void main(String[] args) {\n"
+				+ "\n"
+				+ "        Comparator<Map<String, Object>> eventComparator = Comparator\n"
+				+ "            .<Map<String, Object>, Comparable>comparing(e -> (Comparable) e.get(\"event_date\"),\n"
+				+ "                Comparator.nullsLast(Comparator.naturalOrder()))\n"
+				+ "            .thenComparing(e -> (String) e.get(\"event_type\"));\n"
+				+ "    }\n"
+				+ "\n"
+				+ "}",
+			},
+			// related to https://docs.oracle.com/javase/specs/jls/se21/html/jls-15.html#jls-15.12.2.6
+			// Eclipse was incorrectly accepting this without warnings/errors;
+		    // javac reports unchecked conversion because raw Comparable is used
+		    // and the resulting Comparator is a raw Comparator (not Comparator<Map<String,Object>>),
+		    // causing thenComparing to operate on raw type Object.
+			"----------\n" +
+			"1. WARNING in Snippet.java (at line 8)\n" +
+			"	Comparator<Map<String, Object>> eventComparator = Comparator\n" +
+			"            .<Map<String, Object>, Comparable>comparing(e -> (Comparable) e.get(\"event_date\"),\n" +
+			"                Comparator.nullsLast(Comparator.naturalOrder()))\n" +
+			"            .thenComparing(e -> (String) e.get(\"event_type\"));\n" +
+			"	                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
+			"Type safety: The method thenComparing(Function) belongs to the raw type Comparator. References to generic type Comparator<T> should be parameterized\n" +
+			"----------\n" +
+			"2. WARNING in Snippet.java (at line 8)\n" +
+			"	Comparator<Map<String, Object>> eventComparator = Comparator\n" +
+			"            .<Map<String, Object>, Comparable>comparing(e -> (Comparable) e.get(\"event_date\"),\n" +
+			"                Comparator.nullsLast(Comparator.naturalOrder()))\n" +
+			"            .thenComparing(e -> (String) e.get(\"event_type\"));\n" +
+			"	                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
+			"Type safety: The expression of type Comparator needs unchecked conversion to conform to Comparator<Map<String,Object>>\n" +
+			"----------\n" +
+			"3. WARNING in Snippet.java (at line 9)\n" +
+			"	.<Map<String, Object>, Comparable>comparing(e -> (Comparable) e.get(\"event_date\"),\n" +
+			"	                       ^^^^^^^^^^\n" +
+			"Comparable is a raw type. References to generic type Comparable<T> should be parameterized\n" +
+			"----------\n" +
+			"4. WARNING in Snippet.java (at line 9)\n" +
+			"	.<Map<String, Object>, Comparable>comparing(e -> (Comparable) e.get(\"event_date\"),\n" +
+			"	                                                  ^^^^^^^^^^\n" +
+			"Comparable is a raw type. References to generic type Comparable<T> should be parameterized\n" +
+			"----------\n" +
+			"5. ERROR in Snippet.java (at line 11)\n" +
+			"	.thenComparing(e -> (String) e.get(\"event_type\"));\n" +
+			"	                               ^^^\n" +
+			"The method get(String) is undefined for the type Object\n" +
+			"----------\n");
+}
+
 public static Class<GenericsRegressionTest_9> testClass() {
 	return GenericsRegressionTest_9.class;
 }


### PR DESCRIPTION
Closes #4957

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

- Detect when any explicit type argument is a raw type and then fail compilation (to achieve same compilation error as javac)
- This seems to be related to https://docs.oracle.com/javase/specs/jls/se21/html/jls-15.html#jls-15.12.2.6

> If unchecked conversion was necessary for the method to be applicable, then the invocation type's parameter types are obtained by applying the substitution [P1:=T1, ..., Pp:=Tp] to the parameter types of the method's type, and the invocation type's return type and thrown types are given by the erasure of the return type and thrown types of the method's type.

- Adds regression test testGH4957 reproducing the Comparator.comparing + raw Comparable scenario  With this fix testGH4957 passes.


## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- run `org.eclipse.jdt.core.tests.compiler.regression.GenericsRegressionTest_9.testGH4957()`  without the fix in `org.eclipse.jdt.internal.compiler.lookup.ParameterizedGenericMethodBinding.computeCompatibleMethod(MethodBinding, TypeBinding[], Scope, InvocationSite)`

or just use e.g. Eclipse 2025-03 (or even 2026-06 (4.40) Build id: I20260319-1800 master) and paste the the following class:

```
import java.util.Comparator;
import java.util.Map;

public class Snippet {

    public static void main(String[] args) {

        Comparator<Map<String, Object>> eventComparator = Comparator
            .<Map<String, Object>, Comparable>comparing(e -> (Comparable) e.get("event_date"),
                Comparator.nullsLast(Comparator.naturalOrder()))
            .thenComparing(e -> (String) e.get("event_type"));
    }

}

```

Expected Result: Compilation should fail in Eclipse
Actual result:  Compiliation succeeds. 

But in javacc compilation fails. 

With this PR compilation fails also in Eclipse. 

But note: Eclipse seems to error with a different message than javac. Not sure this is a deeper problem. But at least it fails at the same place. 

ECJ fails with:
```
"5. ERROR in Snippet.java (at line 11)\n" +
			"	.thenComparing(e -> (String) e.get(\"event_type\"));\n" +
			"	                               ^^^\n" +
			"The method get(String) is undefined for the type Object\n" +
```

while javac failed with:

```
Snippet.java:13: error: cannot find symbol
            .thenComparing(e -> (String) e.get("event_type"));
                                          ^
  symbol:   method get(String)
  location: variable e of type Object
Snippet.java:13: warning: [unchecked] unchecked conversion
            .thenComparing(e -> (String) e.get("event_type"));
                          ^
  required: Comparator<Map<String,Object>>
  found:    Comparator
1 error
5 warnings
error: compilation failed
```


## Disclaimer: 
I used AI to help me understand the issue and spec and find the places in the code. I have manually tested and debugged via latest JDT Dev environment via Oomph and ran my test in Eclipse.
This is my first step in the compiler space. Feel free to reject it or just use it as a base for a better fix if needed. 



## Author checklist

- [x] I have ~~thoroughly~~ tested my changes as good as I can
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
