### PR TITLE
Provide NameLookup.Answer check if type has forbidden access

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/NameLookupTests2.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/NameLookupTests2.java
@@ -425,5 +425,41 @@ public void testTransitionFromInvalidToValidJar() throws CoreException, IOExcept
 		deleteProject("P");
 	}
 }
+/**
+ * Test for: {@link org.eclipse.jdt.internal.core.NameLookup.Answer#isNonAccessible()}
+ */
+public void testNonAccessibleAccessAnswer() throws Exception {
+	try {
+		JavaProject project = (JavaProject)createJavaProject("P");
+		addLibrary(
+				project, "lib.jar", "libsrc.zip",
+				new String[] {
+					"p/A.java",
+					"""
+					package p;
+					public class A {}
+					""",
+				},
+				null,
+				null,
+				new String[] {"**/*"}, // all types in the jar should be inaccessible for this test
+				CompilerOptions.getFirstSupportedJavaVersion(),
+				null);
+		waitForAutoBuild();
+
+		NameLookup.Answer answer = getNameLookup(project).findType(
+				"p.A",
+				false /* no partial matches */,
+				NameLookup.ACCEPT_ALL,
+				false /* no secondary types */,
+				true /* wait for indexer */,
+				true /* check restrictions */,
+				null);
+		assertNotNull("Expected to find type", answer);
+		assertTrue("Expected type to be non-accessible", answer.isNonAccessible());
+	} finally {
+		deleteProject("P");
+	}
+}
 }
 

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/NameLookup.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/NameLookup.java
@@ -33,6 +33,7 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.jdt.core.*;
 import org.eclipse.jdt.core.compiler.CharOperation;
+import org.eclipse.jdt.core.compiler.IProblem;
 import org.eclipse.jdt.internal.compiler.ast.ASTNode;
 import org.eclipse.jdt.internal.compiler.ast.TypeDeclaration;
 import org.eclipse.jdt.internal.compiler.env.AccessRestriction;
@@ -99,6 +100,14 @@ public class NameLookup implements SuffixConstants {
 			if (this.restriction == null) return true;
 			return otherAnswer.restriction != null
 				&& this.restriction.getProblemId() < otherAnswer.restriction.getProblemId();
+		}
+		/**
+		 * Returns whether the type in this answer is forbidden/non-accessible
+		 * according to access rules.
+		 * See: {@link IProblem#ForbiddenReference}, {@link org.eclipse.jdt.core.IAccessRule#K_NON_ACCESSIBLE}
+		 */
+		public boolean isNonAccessible() {
+			return this.restriction != null && this.restriction.getProblemId() == IProblem.ForbiddenReference;
 		}
 		@Override
 		public String toString() {


### PR DESCRIPTION
Calling `NameLookup.findType()` with flag `checkRestrictions=true` results in `NameLookup.Answer` containing the respective `AccessRestriction` in the resulting `NameLookup.Answer`.

This change adds a method `Answer.isForbidden()`,
which can be used to determine if the type in the `Answer` is forbidden according to the access rules of the types classpath entry.

Callers can then use this method to only use the found type, if its not forbidden by classpath access rules.

Such checks are useful in the context of:

https://github.com/eclipse-pde/eclipse.pde/issues/2244

The PDE classpath container contains transitive dependencies, with forbidden pattern `**/*`.

Fixes: #4964

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
