### PR TITLE
Fixes #4971 - NumberFormatException in indexing when using dom based ops

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/DOMToModelPopulator.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/DOMToModelPopulator.java
@@ -849,23 +849,23 @@ public class DOMToModelPopulator extends ASTVisitor {
 	private record ValueRadix(String val, Integer radix) {}
 	private ValueRadix numberToStringRadix(String s) {
 		// 1. Remove underscores
-		s = s.replace("_", "");
+		s = s.replace("_", ""); //$NON-NLS-1$ //$NON-NLS-2$
 
 		// 2. Remove long suffix
-		if (s.endsWith("l") || s.endsWith("L")) {
+		if (s.endsWith("l") || s.endsWith("L")) {//$NON-NLS-1$ //$NON-NLS-2$
 		    s = s.substring(0, s.length() - 1);
 		}
 
 		int radix = 10;
 
 		// 3. Detect radix
-		if (s.startsWith("0x") || s.startsWith("0X")) {
+		if (s.startsWith("0x") || s.startsWith("0X")) {//$NON-NLS-1$ //$NON-NLS-2$
 		    radix = 16;
 		    s = s.substring(2);
-		} else if (s.startsWith("0b") || s.startsWith("0B")) {
+		} else if (s.startsWith("0b") || s.startsWith("0B")) {//$NON-NLS-1$ //$NON-NLS-2$
 		    radix = 2;
 		    s = s.substring(2);
-		} else if (s.startsWith("0") && s.length() > 1) {
+		} else if (s.startsWith("0") && s.length() > 1) {//$NON-NLS-1$
 		    radix = 8;
 		    s = s.substring(1);
 		}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4971 for context.   Dom-based parsing of annotations with numeric attributes / parameters blows up the stack when hex, binary, or octal are used.  This patch creates a method to translate the string into a cleaner string plus a radix to be parsed more accurately. 

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
I believe running with `-DCompilationUnit.DOM_BASED_OPERATIONS=true ` is sufficient to trigger this bug, when having an example class as follows:

```
public class PojpMain {
	@interface A {
	    long value();
	}

	@A(0x0001)
	public interface IPojp {
	}
}
```


## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
