### PR TITLE
Add preference for disabling indexing of specific files

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/IndexManagerTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/IndexManagerTests.java
@@ -29,9 +29,17 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.compiler.CharOperation;
+import org.eclipse.jdt.core.search.IJavaSearchConstants;
+import org.eclipse.jdt.core.search.IJavaSearchScope;
+import org.eclipse.jdt.core.search.SearchEngine;
 import org.eclipse.jdt.core.search.SearchPattern;
+import org.eclipse.jdt.core.tests.model.AbstractJavaSearchTests.JavaSearchResultCollector;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jdt.internal.core.JavaModelManager;
 import org.eclipse.jdt.internal.core.index.EntryResult;
@@ -174,6 +182,45 @@ public class IndexManagerTests extends ModifyingResourceTests {
 		Optional<Set<String>> indexNames = searchInMetaIndex("app.Q1");
 		assertTrue("No meta index", indexNames.isPresent());
 		assertEquals("No results found", 1, indexNames.get().size());
+	}
+
+	public void testDisableIndexingForRestrictedFile() throws Exception {
+		if (SKIP_TESTS) return;
+		this.indexDisabledForTest = true;
+		IEclipsePreferences node = InstanceScope.INSTANCE.getNode(JavaCore.PLUGIN_ID);
+		String pref = JavaModelManager.DISABLE_RESTRICTED_FILE_INDEXING_PREFERENCE;
+		node.putBoolean(pref, true);
+		node.flush();
+		boolean wasIndexerEnabled = JavaModelManager.getIndexManager().isEnabled();
+		try {
+			disableIndexer();
+
+			createFolder("/IndexProject/src/p");
+			IFile file1 = createFile("/IndexProject/src/p/TestClass1.java", "package p;\n public class TestClass1 {\n" + "}");
+			createFile("/IndexProject/src/p/TestClass2.java", "package p;\n public class TestClass2 {\n" + "}");
+			file1.setContentRestricted(true);
+			JavaModelManager.getIndexManager().indexAll(this.project.getProject());
+			waitUntilIndexesReady();
+
+			JavaSearchResultCollector collector = new JavaSearchResultCollector();
+			IJavaSearchScope scope = SearchEngine.createJavaSearchScope(new IJavaElement[] {this.project});
+			search("TestClass1", IJavaSearchConstants.TYPE, IJavaSearchConstants.ALL_OCCURRENCES, scope, collector);
+			assertSearchResults(
+				"",
+				collector);
+
+			collector = new JavaSearchResultCollector();
+			search("TestClass2", IJavaSearchConstants.TYPE, IJavaSearchConstants.ALL_OCCURRENCES, scope, collector);
+			assertSearchResults(
+				"src/p/TestClass2.java p.TestClass2 [TestClass2]",
+				collector);
+		} finally {
+			if (wasIndexerEnabled) {
+				enableIndexer();
+			}
+			node.remove(pref);
+			node.flush();
+		}
 	}
 
 	private void changeFile(String path, String content) {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelManager.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelManager.java
@@ -329,6 +329,8 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 	public static final String CONTAINER_INITIALIZER_PERF = JavaCore.PLUGIN_ID + "/perf/containerinitializer" ; //$NON-NLS-1$
 	public static final String RECONCILE_PERF = JavaCore.PLUGIN_ID + "/perf/reconcile" ; //$NON-NLS-1$
 
+	public static final String DISABLE_RESTRICTED_FILE_INDEXING_PREFERENCE = "disableRestrictedFileIndexing" ; //$NON-NLS-1$
+
 	public static boolean PERF_VARIABLE_INITIALIZER = false;
 	public static boolean PERF_CONTAINER_INITIALIZER = false;
 	// Non-static, which will give it a chance to retain the default when and if JavaModelManager is restarted.
@@ -348,6 +350,8 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 	public final IEclipsePreferences[] preferencesLookup = new IEclipsePreferences[2];
 	static final int PREF_INSTANCE = 0;
 	static final int PREF_DEFAULT = 1;
+
+	private static volatile boolean disableRestrictedFileIndexing;
 
 	static final Object[][] NO_PARTICIPANTS = new Object[0][];
 
@@ -1762,7 +1766,9 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 					UserLibraryManager manager = JavaModelManager.getUserLibraryManager();
 	        		manager.updateUserLibrary(libName, (String)event.getNewValue());
 	        	}
-	        }
+	        } else if (propertyName.equals(DISABLE_RESTRICTED_FILE_INDEXING_PREFERENCE)) {
+				setDisableRestrictedFileIndexing();
+			}
         	// Reset all project caches (see https://bugs.eclipse.org/bugs/show_bug.cgi?id=233568 )
         	try {
         		IJavaProject[] projects = JavaModelManager.getJavaModelManager().getJavaModel().getJavaProjects();
@@ -3396,6 +3402,8 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 			}
 		};
 		((IEclipsePreferences) this.preferencesLookup[PREF_DEFAULT].parent()).addNodeChangeListener(this.defaultNodeListener);
+
+		setDisableRestrictedFileIndexing();
 	}
 
 	void touchProjectsAsync(final IProject[] projectsToTouch) throws JavaModelException {
@@ -5731,5 +5739,14 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 		} finally {
 			getJavaModelManager().flushZipFiles(instance);
 		}
+	}
+
+	private static void setDisableRestrictedFileIndexing() {
+		disableRestrictedFileIndexing =  Platform.getPreferencesService().getBoolean(
+				JavaCore.PLUGIN_ID, DISABLE_RESTRICTED_FILE_INDEXING_PREFERENCE, false, null);
+	}
+
+	public static boolean disableRestrictedFileIndexing() {
+		return disableRestrictedFileIndexing;
 	}
 }

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/SourceIndexer.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/SourceIndexer.java
@@ -17,7 +17,9 @@ import static org.eclipse.jdt.internal.core.JavaModelManager.trace;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
@@ -100,6 +102,9 @@ public class SourceIndexer extends AbstractIndexer implements ITypeRequestor, Su
 
 	@Override
 	public void indexDocument() {
+		if (disabledForFile()) {
+			return;
+		}
 		if (usedDomBasedIndexing()) {
 			indexDocumentFromDOM();
 			return;
@@ -385,8 +390,8 @@ public class SourceIndexer extends AbstractIndexer implements ITypeRequestor, Su
 	}
 
 	private org.eclipse.jdt.core.ICompilationUnit getUnit() {
-		if (this.document instanceof JavaSearchDocument javaSearchDoc) {
-			IFile file = javaSearchDoc.getFile();
+		IFile file = getJavaSearchFile();
+		if (file != null) {
 			try {
 				if (JavaProject.hasJavaNature(file.getProject())) {
 					IJavaProject javaProject = JavaCore.create(file.getProject());
@@ -401,6 +406,13 @@ public class SourceIndexer extends AbstractIndexer implements ITypeRequestor, Su
 			} catch (Exception ex) {
 				ILog.get().error("Failed to index document from DOM for " + this.document.getPath(), ex); //$NON-NLS-1$
 			}
+		}
+		return null;
+	}
+
+	private IFile getJavaSearchFile() {
+		if (this.document instanceof JavaSearchDocument javaSearchDoc) {
+			return javaSearchDoc.getFile();
 		}
 		return null;
 	}
@@ -454,4 +466,25 @@ public class SourceIndexer extends AbstractIndexer implements ITypeRequestor, Su
 		return false;
 	}
 
+	private boolean disabledForFile() {
+		if (JavaModelManager.disableRestrictedFileIndexing()) {
+			IFile file = getJavaSearchFile();
+			if (file == null) {
+				IPath path = new Path(this.document.getPath());
+				IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
+				file = root.getFile(path);
+			}
+			try {
+				return file.isContentRestricted();
+			} catch (CoreException e) {
+				JavaCore.getPlugin().getLog().log(e.getStatus());
+				/*
+				 * Assume indexing is disabled for the file, since the preference for disabling is set
+				 * but we cannot determine if the file is restricted.
+				 */
+				return true;
+			}
+		}
+		return false;
+	}
 }


### PR DESCRIPTION
This change adds a new preference to `org.eclipse.jdt.core`:
```
disableRestrictedFileIndexing
```
If the preference is set to `true` and a file is restricted, index requests for the file will be ignored.

Example preference for product customization:
```
org.eclipse.jdt.core/disableRestrictedFileIndexing=true
```
Fixes: https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4970