### PR TITLE
Different behaviour between ECJ and javac for generic type inference

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
@@ -1232,7 +1232,25 @@ public class InferenceContext18 {
 											}
 										}
 									}
-									tmpBoundSet.addBound(new TypeBound(variable, glb, ReductionResult.SAME), this.environment);
+									boolean addBound = true;
+									if (toResolveSet.contains(variable) && !variable.typeParameter.isRawType()) {
+										boolean add = false;
+										if (this.currentInvocation instanceof MessageSend messageSend) {
+											add = shouldAddBound(messageSend);
+										}
+										if (add && glb.equals(this.object)
+												&& !variable.typeParameter.isWildcard()) {
+											for (TypeBound bound : tmpBoundSet.flatten()) {
+												if (bound.left.equals(variable) && !bound.right.isTypeVariable()) {
+													addBound = false;
+													break;
+												}
+											}
+										}
+									}
+									if (addBound) {
+										tmpBoundSet.addBound(new TypeBound(variable, glb, ReductionResult.SAME), this.environment);
+									}
 								}
 							}
 							toResolveSet.remove(variable);
@@ -1359,6 +1377,44 @@ public class InferenceContext18 {
 			}
 		}
 		return tmpBoundSet;
+	}
+
+	private boolean shouldAddBound(MessageSend messageSend) {
+		boolean hasRawArguments = false;
+		boolean hasArguments = false;
+		TypeBinding[] argumentTypes = messageSend.argumentTypes;
+		if (argumentTypes != null && argumentTypes.length > 0) {
+			hasArguments = argumentTypes.length > 0;
+			for (TypeBinding argumentType : argumentTypes) {
+				if (argumentType == null || argumentType.isRawType() || (argumentType instanceof NullTypeBinding)) {
+					hasRawArguments = true;
+					break;
+				}
+			}
+			if (hasArguments && !hasRawArguments) {
+				for (Expression argument : messageSend.arguments) {
+					if (argument instanceof LambdaExpression || argument instanceof AllocationExpression) {
+						hasRawArguments = true;
+						break;
+					}
+					if (argument instanceof MessageSend ms) {
+						hasRawArguments = !shouldAddBound(ms);
+						if (hasRawArguments) {
+							break;
+						}
+					}
+				}
+			}
+		} else {
+			if (this.seenInnerContexts != null) {
+				for (InferenceContext18 ic : this.seenInnerContexts) {
+					if (Objects.equals(messageSend, ic.currentInvocation)) {
+						return true;
+					}
+				}
+			}
+		}
+		return hasArguments && !hasRawArguments;
 	}
 	/**
 	 * <b>JLS 18.4</b> Resolution

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_1_8.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_1_8.java
@@ -10964,4 +10964,66 @@ public void testBug508834_comment0() {
 			"The method bar(One<Inner<?>>) in the type Bug is not applicable for the arguments (One<Inner<X>>)\n" +
 			"----------\n");
 	}
+	public void testGH3351() {
+		runNegativeTest(
+			new String[] {
+				"PassThroughGenerics.java",
+				"""
+				import java.util.List;
+				public class PassThroughGenerics {
+				    private class MyComp implements Comparable<MyComp> {
+				        @Override public int compareTo(MyComp other) { return 0; }
+				    }
+
+				    static <E extends Comparable<E>> List<E> sort(List<E> list) {
+				        return list;
+				    }
+
+				    static <T> List<T> genericList() {
+				        return null;
+				    }
+
+				    public static void main(String[] args) {
+				        List<MyComp> sorted = sort(genericList());
+				        System.out.println(sorted);
+				    }
+				}
+				"""
+			},
+			"""
+			----------
+			1. ERROR in PassThroughGenerics.java (at line 16)
+				List<MyComp> sorted = sort(genericList());
+				                      ^^^^
+			The method sort(java.util.List<E extends java.lang.Comparable<E>>) in the type PassThroughGenerics is not applicable for the arguments (java.util.List<E extends java.lang.Comparable<E>>)
+			----------
+			""");
+	}
+	public void testGH3351a() {
+		runNegativeTest(
+			new String[] {
+				"Test.java",
+				"""
+				import java.util.List;
+				import java.util.Collections;
+				public class Test {
+				    static <E extends Comparable<E>> List<E> sort(List<E> list) {
+				        return list;
+				    }
+				    public static void main(String[] args) {
+				        sort(Collections.emptyList());
+				        // System.out.println("hello");
+				    }
+				}
+				"""
+			},
+			"""
+			----------
+			1. ERROR in Test.java (at line 8)
+				sort(Collections.emptyList());
+				^^^^
+			The method sort(java.util.List<E extends java.lang.Comparable<E>>) in the type Test is not applicable for the arguments (java.util.List<E extends java.lang.Comparable<E>>)
+			----------
+			""");
+	}
 }


### PR DESCRIPTION
Fixes #3351 
Related to https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4838#issuecomment-3917324020

I have created a simpler class to reproduce the issue.
```
import java.util.List;
import java.util.Collections;
public class Test {
    static <E extends Comparable<E>> List<E> sort(List<E> list) {
        return list;
    }
    public static void main(String[] args) {
        sort(Collections.emptyList());
        System.out.println("hello");
    }
}
```

The IDEA editor also doesn’t report any error in these cases.
If the class is tried to be run, IDEA will report an error when the `javac` compiler is used.

The InferenceContext18.resolve() method will add the `V = java.lang.Object` bound if it cannot resolve some inference variable.
The PR tries to postpone or skip this decision unless there is a bound that:

- isn’t a variable bound 
- doesn’t include raw types
- doesn’t include a lambda expression 

