### PR TITLE
Add more details to error message

### DIFF
--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ClasspathEntry.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/ClasspathEntry.java
@@ -1843,7 +1843,7 @@ public class ClasspathEntry implements IClasspathEntry {
 
 		IProject project = javaProject.getProject();
 		IPath projectPath= project.getFullPath();
-		String projectName = javaProject.getElementName();
+		final String projectName = javaProject.getElementName();
 
 		/* validate output location */
 		if (projectOutputLocation == null) {
@@ -2163,7 +2163,7 @@ public class ClasspathEntry implements IClasspathEntry {
 						if (hasTest && !hasMain) {
 							return new JavaModelStatus(IJavaModelStatusConstants.MAIN_ONLY_PROJECT_DEPENDS_ON_TEST_ONLY_PROJECT,
 									Messages.bind(Messages.classpath_main_only_project_depends_on_test_only_project,
-											new String[] { prereqProject.getElementName() }));
+											new String[] { projectName, prereqProject.getElementName() }));
 						}
 					}
 				}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/messages.properties
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/messages.properties
@@ -190,7 +190,7 @@ classpath_deprecated_variable = Classpath variable ''{0}'' in project ''{1}'' is
 classpath_invalidExternalAnnotationPath = Invalid external annotation path: ''{0}'' in project ''{1}'', for classpath entry ''{2}''
 classpath_testSourceRequiresSeparateOutputFolder=Test source folder ''{0}'' in project ''{1}'' must have a separate output folder
 classpath_testOutputFolderMustBeSeparateFromMainOutputFolders=Test source folder ''{0}'' in project ''{1}'' must have an output folder that is not also used for main sources
-classpath_main_only_project_depends_on_test_only_project=Project has only main sources but depends on project ''{0}'' which has only test sources.
+classpath_main_only_project_depends_on_test_only_project=Project ''{0}'' has only main sources but depends on project ''{1}'' which has only test sources.
 classpath_illegalAddExportsSystemModule=Exporting a package from system module ''{0}'' is not allowed with --release.
 
 


### PR DESCRIPTION
Mention the name of the project that has the error in order to better deal with it. This is useful when running the action in several projects, otherwise one can not easily know which project failed to update its classpath

## To test
- Right click on a plugin project > Plugin Tools > Update Classpath

<img width="740" height="182" alt="image" src="https://github.com/user-attachments/assets/e1f80df1-4288-46ac-a2fe-4b4095b66576" />


## Expected behavior
If the plugin has only main sources but depends on a plugin that has only test sources, you should see the message:

```
Updating failed. See log for details.
  Project 'abc' has only main sources but depends on project 'xyz' which has only test sources.
```

<img width="1199" height="136" alt="image" src="https://github.com/user-attachments/assets/53e99c2a-4849-47c8-9f69-697e3ee6bdf1" />
