### PR TITLE
Fixed for Bug4986

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
@@ -3359,6 +3359,16 @@ public void importProblem(ImportReference importRef, Binding expectedImport) {
 				id = (expectedImport.problemId() == ProblemReasons.NotVisible) ? IProblem.NotVisibleField : IProblem.NotAccessibleField;
 				readableArguments = new String[] {CharOperation.toString(importRef.tokens), new String(field.declaringClass.readableName())};
 				shortArguments = new String[] {CharOperation.toString(importRef.tokens), new String(field.declaringClass.shortReadableName())};
+			    if (importRef.isStatic() && isSelfImport(field) && field.declaringClass != null&& field.declaringClass.enclosingType() == null) {
+			        // messages.properties uses:
+			        // 71 = The field {1}.{0} is not visible
+			        // so pass {0}=field name, {1}=declaring type (short name keeps nested types, avoids package noise)
+			        readableArguments = new String[] {
+			                new String(field.name), // {0}
+			                new String(field.declaringClass.shortReadableName()) // {1}
+			        };
+			        shortArguments = readableArguments;
+			    }
 				break;
 			case ProblemReasons.Ambiguous :
 				id = IProblem.AmbiguousField;
@@ -5038,6 +5048,32 @@ private boolean isRecoveredName(char[][] qualifiedName) {
 	}
 	return false;
 }
+
+private boolean isSelfImport(FieldBinding field) {
+    if (!(this.referenceContext instanceof CompilationUnitDeclaration))
+        return false;
+
+    CompilationUnitDeclaration cud = (CompilationUnitDeclaration) this.referenceContext;
+
+    // In your branch, CompilationUnitDeclaration exposes compilationResult (not compilationUnit)
+    if (cud.compilationResult == null)
+        return false;
+
+    char[] currentFile = cud.compilationResult.getFileName();
+    if (currentFile == null)
+        return false;
+
+    if (field.declaringClass == null)
+        return false;
+
+    // Don't access declaringClass.fileName directly (not visible); use getter
+    char[] declaringFile = field.declaringClass.getFileName();
+    if (declaringFile == null)
+        return false;
+
+    return CharOperation.equals(currentFile, declaringFile);
+}
+
 
 public void javadocAmbiguousMethodReference(int sourceStart, int sourceEnd, Binding fieldBinding, int modifiers) {
 	int severity = computeSeverity(IProblem.JavadocAmbiguousMethodReference);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
@@ -3357,8 +3357,27 @@ public void importProblem(ImportReference importRef, Binding expectedImport) {
 			case ProblemReasons.NotVisible :
 			case ProblemReasons.NotAccessible :
 				id = (expectedImport.problemId() == ProblemReasons.NotVisible) ? IProblem.NotVisibleField : IProblem.NotAccessibleField;
-				readableArguments = new String[] {CharOperation.toString(importRef.tokens), new String(field.declaringClass.readableName())};
-				shortArguments = new String[] {CharOperation.toString(importRef.tokens), new String(field.declaringClass.shortReadableName())};
+				if (importRef.isStatic() && field.declaringClass != null) {
+					// messages.properties uses:
+					// 71 = The field {1}.{0} is not visible
+					readableArguments = new String[] {
+							new String(field.name), // {0}
+							new String(field.declaringClass.readableName()) // {1}
+					};
+					shortArguments = new String[] {
+							new String(field.name), // {0}
+							new String(field.declaringClass.shortReadableName()) // {1}
+					};
+				} else {
+					readableArguments = new String[] {
+							CharOperation.toString(importRef.tokens),
+							new String(field.declaringClass.readableName())
+					};
+					shortArguments = new String[] {
+							CharOperation.toString(importRef.tokens),
+							new String(field.declaringClass.shortReadableName())
+					};
+				}
 				break;
 			case ProblemReasons.Ambiguous :
 				id = IProblem.AmbiguousField;
@@ -5038,6 +5057,7 @@ private boolean isRecoveredName(char[][] qualifiedName) {
 	}
 	return false;
 }
+
 
 public void javadocAmbiguousMethodReference(int sourceStart, int sourceEnd, Binding fieldBinding, int modifiers) {
 	int severity = computeSeverity(IProblem.JavadocAmbiguousMethodReference);

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NonFatalErrorTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NonFatalErrorTest.java
@@ -518,7 +518,7 @@ public class NonFatalErrorTest extends AbstractRegressionTest {
 			"2. ERROR in X.java (at line 2)\n" +
 			"	import static p1.Y.f;\n" +
 			"	              ^^^^^^\n" +
-			"The field Y.p1.Y.f is not visible\n" +
+			"The field Y.f is not visible\n" +
 			"----------\n",
 			"OK",
 			"",

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/StaticImportTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/StaticImportTest.java
@@ -3559,4 +3559,31 @@ public class StaticImportTest extends AbstractComparableTest {
 		runner.expectedOutputString = "1";
 		runner.runConformTest();
 	}
+
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4986
+	// Test that error message for inaccessible static import field is correctly formatted
+	public void testBug4986() {
+	    this.runNegativeTest(
+	        new String[] {
+	            "p/C.java",
+	            "package p;\n" +
+	            "import static p.C.f;\n" +
+	            "public class C {\n" +
+	            "    private static int f;\n" +
+	            "}\n"
+	        },
+	        "----------\n" +
+	        "1. ERROR in p\\C.java (at line 2)\n" +
+	        "\timport static p.C.f;\n" +
+	        "\t              ^^^^^\n" +
+	        "The field C.f is not visible\n" +
+	        "----------\n" +
+	        "2. WARNING in p\\C.java (at line 4)\n" +
+	        "\tprivate static int f;\n" +
+	        "\t                   ^\n" +
+	        "The value of the field C.f is not used\n" +
+	        "----------\n"
+	    );
+	}
+
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/StaticImportTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/StaticImportTest.java
@@ -254,7 +254,7 @@ public class StaticImportTest extends AbstractComparableTest {
 		"1. ERROR in p\\X.java (at line 3)\n" +
 		"	import static p2.Z.Zint;\n" +
 		"	              ^^^^^^^^^\n" +
-		"The field Z.p2.Z.Zint is not visible\n" +
+		"The field Z.Zint is not visible\n" +
 		"----------\n" +
 		"2. ERROR in p\\X.java (at line 4)\n" +
 		"	import static p2.Z.ZMember;\n" +
@@ -1368,7 +1368,7 @@ public class StaticImportTest extends AbstractComparableTest {
 			"1. ERROR in X.java (at line 2)\n" +
 			"	import static p.A.CONSTANT_B;\n" +
 			"	              ^^^^^^^^^^^^^^\n" +
-			"The field B.p.A.CONSTANT_B is not visible\n" +
+			"The field B.CONSTANT_B is not visible\n" +
 			"----------\n" +
 			"2. ERROR in X.java (at line 5)\n" +
 			"	static int j = p.A.CONSTANT_B;\n" +
@@ -2517,7 +2517,7 @@ public class StaticImportTest extends AbstractComparableTest {
 			"1. ERROR in test\\Outer.java (at line 2)\n" +
 			"	import static test.Outer.Inner.VALUE;\n" +
 			"	              ^^^^^^^^^^^^^^^^^^^^^^\n" +
-			"The field Outer.Inner.test.Outer.Inner.VALUE is not visible\n" +
+			"The field Outer.Inner.VALUE is not visible\n" +
 			"----------\n" +
 			"2. ERROR in test\\Outer.java (at line 4)\n" +
 			"	int i = VALUE;\n" +
@@ -3559,4 +3559,37 @@ public class StaticImportTest extends AbstractComparableTest {
 		runner.expectedOutputString = "1";
 		runner.runConformTest();
 	}
+
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4986
+	// Test that error message for inaccessible static import field is correctly formatted
+	public void testBug4986() {
+		this.runNegativeTest(
+			new String[] {
+				"p/C.java",
+				"""
+				package p;
+				
+				import static p.C.f;
+				
+				public class C {
+					private static int f;
+				}
+				"""
+			},
+			"""
+			----------
+			1. ERROR in p\\C.java (at line 3)
+				import static p.C.f;
+				              ^^^^^
+			The field C.f is not visible
+			----------
+			2. WARNING in p\\C.java (at line 6)
+				private static int f;
+				                   ^
+			The value of the field C.f is not used
+			----------
+			"""
+		);
+	}
+
 }


### PR DESCRIPTION
Fix https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4986
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
Fixes a malformed error message shown for inaccessible fields used via static imports and adds a regression test.


## How to test
Reproduce with a private static field referenced via import static; verify the error text matches the expected output.

##Before fix 
<img width="588" height="258" alt="Screenshot 2026-04-12 at 11 53 03 AM" src="https://github.com/user-attachments/assets/b0549275-3155-473e-bb7c-c695aa7025e5" />


## after fix 
<img width="955" height="425" alt="Screenshot 2026-04-12 at 11 24 03 AM" src="https://github.com/user-attachments/assets/02e18f30-efd0-4f8f-aef0-5512adb2e1bc" />

<img width="968" height="425" alt="Screenshot 2026-04-12 at 11 23 52 AM" src="https://github.com/user-attachments/assets/489be713-9a0d-4c56-b055-eed6d713afa7" />
