### PR TITLE
[26] fix for typeswitch omission in boolean primitive codegen

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -540,7 +540,7 @@ public class SwitchStatement extends Expression {
 		switch (eType.id) {
 			case TypeIds.T_JavaLangLong, TypeIds.T_JavaLangFloat, TypeIds.T_JavaLangDouble:
 				return true;
-			case TypeIds.T_long, TypeIds.T_double, TypeIds.T_float :
+			case TypeIds.T_boolean, TypeIds.T_long, TypeIds.T_double, TypeIds.T_float :
 				if (this.isPrimitiveSwitch)
 					return true;
 			// note: if no patterns are present we optimize Boolean to use unboxing rather than indy typeSwitch

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PrimitiveInPatternsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PrimitiveInPatternsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024, 2025 IBM Corporation and others.
+ * Copyright (c) 2024, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -12,9 +12,12 @@
  *******************************************************************************/
 package org.eclipse.jdt.core.tests.compiler.regression;
 
+import java.io.IOException;
 import java.util.Map;
 import junit.framework.Test;
 import org.eclipse.jdt.core.tests.util.PreviewTest;
+import org.eclipse.jdt.core.util.ClassFileBytesDisassembler;
+import org.eclipse.jdt.core.util.ClassFormatException;
 import org.eclipse.jdt.internal.compiler.batch.FileSystem;
 import org.eclipse.jdt.internal.compiler.env.INameEnvironment;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
@@ -27,7 +30,7 @@ public class PrimitiveInPatternsTest extends AbstractRegressionTest9 {
 	static {
 //		TESTS_NUMBERS = new int [] { 1 };
 //		TESTS_RANGE = new int[] { 1, -1 };
-//		TESTS_NAMES = new String[] { "testIssue3536" };
+//		TESTS_NAMES = new String[] { "testSwitchPrimitiveboolean_01" };
 	}
 	private String extraLibPath;
 	public static Class<?> testClass() {
@@ -7510,4 +7513,30 @@ public class PrimitiveInPatternsTest extends AbstractRegressionTest9 {
 			},
 			"1");
 	}
+
+	public void testSwitchPrimitiveboolean_01() throws IOException, ClassFormatException {
+		runConformTest(new String[] { "X.java",
+				"""
+				public class X {
+
+				    public static int primitiveSwitch(boolean b) {
+				    	return switch(b) {
+				    	case true -> 100;
+				    	case false -> 200;
+				    	};
+				    }
+
+				    public static void main(String[] args) {
+				        System.out.println(primitiveSwitch(true));
+				        System.out.println(primitiveSwitch(false));
+					}
+				}
+				"""
+			},
+			"100\n"+
+			"200");
+		String expectedOutput = "invokedynamic 1 typeSwitch(boolean, int)";
+		verifyClassFile(expectedOutput, "X.class", ClassFileBytesDisassembler.SYSTEM);
+	}
+
 }


### PR DESCRIPTION
## What it does
Given the preview feature JEP 530 (532 in 27), In code generation for switch expression an indy for typeSwitch was expected. This was omitted by mistake. The PR corrects the same.
## How to test
A unit test case is part of the PR. Comment the change, essentially do /* TypeIds.T_boolean,*/ in indySwitch() in SwitchStatement

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
