### PR TITLE
Stop using Color constructors with Display

### DIFF
--- a/org.eclipse.jdt.core.tests.model/workspace/Converter/src/test0501/JavaEditor.java
+++ b/org.eclipse.jdt.core.tests.model/workspace/Converter/src/test0501/JavaEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2003 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials 
  * are made available under the terms of the Common Public License v1.0
  * which accompanies this distribution, and is available at
@@ -429,15 +429,14 @@ public abstract class JavaEditor extends ExtendedTextEditor implements IViewPart
 			if (text == null || text.isDisposed())
 				return;
 
-			Display display= text.getDisplay();
-			fColor= createColor(getPreferenceStore(), JavaEditor.LINK_COLOR, display);
+			fColor= createColor(getPreferenceStore(), JavaEditor.LINK_COLOR);
 		}
 
 		/**
 		 * Creates a color from the information stored in the given preference store.
 		 * Returns <code>null</code> if there is no such information available.
 		 */
-		private Color createColor(IPreferenceStore store, String key, Display display) {
+		private Color createColor(IPreferenceStore store, String key) {
 		
 			RGB rgb= null;		
 			
@@ -449,7 +448,7 @@ public abstract class JavaEditor extends ExtendedTextEditor implements IViewPart
 					rgb= PreferenceConverter.getColor(store, key);
 			
 				if (rgb != null)
-					return new Color(display, rgb);
+					return new Color(rgb);
 			}
 			
 			return null;

--- a/org.eclipse.jdt.core.tests.model/workspace/FormatterJavadoc/test/wksp/eclipse/X26.java
+++ b/org.eclipse.jdt.core.tests.model/workspace/FormatterJavadoc/test/wksp/eclipse/X26.java
@@ -13,7 +13,7 @@ package test.wksp.eclipse;
 * <code><pre>
 * Canvas canvas = new Canvas(shell, SWT.BORDER);
 * canvas.setBounds(10, 10, 300, 300);	
-* Color color = new Color(null, 255, 0, 0);
+* Color color = new Color(255, 0, 0);
 * canvas.setBackground(color);
 * ControlEditor editor = new ControlEditor (canvas);
 * // The editor will be a button in the bottom right corner of the canvas.
@@ -28,7 +28,7 @@ package test.wksp.eclipse;
 * 		RGB rgb = dialog.getRGB();
 * 		if (rgb != null) {
 * 			if (color != null) color.dispose();
-* 			color = new Color(null, rgb);
+* 			color = new Color(rgb);
 * 			canvas.setBackground(color);
 * 		}
 * 		

--- a/org.eclipse.jdt.core.tests.model/workspace/FormatterJavadoc/test/wksp/eclipse/out/default/X26.java
+++ b/org.eclipse.jdt.core.tests.model/workspace/FormatterJavadoc/test/wksp/eclipse/out/default/X26.java
@@ -14,7 +14,7 @@ package test.wksp.eclipse;
  * <code><pre>
 * Canvas canvas = new Canvas(shell, SWT.BORDER);
 * canvas.setBounds(10, 10, 300, 300);	
-* Color color = new Color(null, 255, 0, 0);
+* Color color = new Color(255, 0, 0);
 * canvas.setBackground(color);
 * ControlEditor editor = new ControlEditor (canvas);
 * // The editor will be a button in the bottom right corner of the canvas.
@@ -29,7 +29,7 @@ package test.wksp.eclipse;
 * 		RGB rgb = dialog.getRGB();
 * 		if (rgb != null) {
 * 			if (color != null) color.dispose();
-* 			color = new Color(null, rgb);
+* 			color = new Color(rgb);
 * 			canvas.setBackground(color);
 * 		}
 * 		


### PR DESCRIPTION
Simplifies the code and reduces chances for problems. Contributes to eclipse-platform/eclipse.platform.swt#3233 .

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
