### PR TITLE
Align inference resolution with javac by applying hints from Maurizio

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BoundSet.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BoundSet.java
@@ -315,7 +315,7 @@ class BoundSet {
 	 * <dl>
 	 * <dt>captures<dd>IC18.resumeSuspendedInference() will reset these to avoid captures from nested
 	 * 	inference spilling blindly into the current inference.<br>
-	 *  {@link InferenceContext18#collectDependencies(BoundSet, boolean, boolean[])} considers only "local" {@link #captures}.
+	 *  {@link InferenceContext18#collectDependencies(BoundSet)} considers only "local" {@link #captures}.
 	 * <dt>allCaptures<dd>Still {@link #hasCaptureBound(Set)} and {@link #incorporate(InferenceContext18)} will
 	 * 	operate on {@link #allCaptures}.
 	 */

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BoundSet.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BoundSet.java
@@ -1070,6 +1070,23 @@ class BoundSet {
 		return true;
 	}
 
+	public int rankIVar(InferenceVariable ivar) {
+		// implements the ranking of ivars according to their bounds as explained in
+		// https://mail.openjdk.org/archives/list/compiler-dev@openjdk.org/message/GN6RTCGMME6I5JVLSFZRIR32XY6QKOI2/
+		ThreeSets three = this.boundsPerVariable.get(ivar.prototype());
+		if (three != null) {
+			if (three.sameBounds != null)
+				for (TypeBound bound :three.sameBounds)
+					if (!(bound.right instanceof InferenceVariable))
+						return 1;
+			if (three.superBounds != null)
+				for (TypeBound bound :three.superBounds)
+					if (!(bound.right instanceof InferenceVariable))
+						return 2;
+		}
+		return 3;
+	}
+
 	/**
 	 * JLS 18.1.3:
 	 * Answer all upper bounds for the given inference variable as defined by any bounds in this set.

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BoundSet.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BoundSet.java
@@ -327,6 +327,7 @@ class BoundSet {
 	private TypeBound[] unincorporatedBounds = new TypeBound[8];
 	private int unincorporatedBoundsCount = 0;
 	private final TypeBound[] mostRecentBounds = new TypeBound[4]; // for quick & dirty duplicate elimination
+	public boolean isRecordPatternInference;
 
 	public BoundSet() {}
 
@@ -428,11 +429,10 @@ class BoundSet {
 				three.setInstantiation(typeBinding, variable, environment);
 			if (bound.right instanceof InferenceVariable) {
 				// for a dependency between two IVs make a note about the inverse bound.
-				// this should be needed to determine IV dependencies independent of direction.
-				// TODO: so far no test could be identified which actually needs it ...
 				int relation = switch (bound.relation) {
 					case ReductionResult.SUBTYPE -> ReductionResult.SUPERTYPE;
 					case ReductionResult.SUPERTYPE -> ReductionResult.SUBTYPE;
+					case ReductionResult.SAME -> this.isRecordPatternInference ? -1 : ReductionResult.SAME;
 					default -> -1;
 				};
 				if (relation != -1) {
@@ -1083,9 +1083,19 @@ class BoundSet {
 		ThreeSets three = this.boundsPerVariable.get(ivar.prototype());
 		if (three != null) {
 			if (three.sameBounds != null)
-				for (TypeBound bound :three.sameBounds)
-					if (!(bound.right instanceof InferenceVariable))
-						return 1;
+				if (!three.sameBounds.isEmpty())
+					return 1;
+			if (this.isRecordPatternInference) {
+				// workaround for not having inverse bounds of type SAME (see addBound(TypeBound, LookupEnvironment)):
+				for (ThreeSets dep3 : this.boundsPerVariable.values()) {
+					if (dep3 != null && dep3.sameBounds != null) {
+						for (TypeBound depBound : dep3.sameBounds) {
+							if (depBound.right.equals(ivar))
+								return 1;
+						}
+					}
+				}
+			}
 			if (three.superBounds != null)
 				if (!three.superBounds.isEmpty())
 						return 2;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BoundSet.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BoundSet.java
@@ -438,7 +438,7 @@ class BoundSet {
 				if (relation != -1) {
 					InferenceVariable rightIV = (InferenceVariable) bound.right.prototype();
 					three = this.boundsPerVariable.computeIfAbsent(rightIV, k -> new ThreeSets());
-					three.addBound(new TypeBound(rightIV, bound.left, relation));
+					three.addBound(new TypeBound(rightIV, bound.left, relation, bound.isSoft));
 				}
 			}
 		}
@@ -606,8 +606,11 @@ class BoundSet {
 						mostRecentFormulas[1] = mostRecentFormulas[0];
 						mostRecentFormulas[0] = newConstraint;
 
-						if (!reduceOneConstraint(context, newConstraint))
+						if (!reduceOneConstraint(context, newConstraint)) {
+							if (InferenceContext18.DEBUG)
+								System.out.println("Incorporation failed to reduce new constraint "+newConstraint); //$NON-NLS-1$
 							return false;
+						}
 
 						if (analyzeNull) {
 							// not per JLS: if the new constraint relates types where at least one has a null annotations,
@@ -625,8 +628,11 @@ class BoundSet {
 					}
 					if (deriveTypeArgumentConstraints) {
 						for (ConstraintTypeFormula typeArgumentConstraint : deriveTypeArgumentConstraints(bound1, bound2, context)) {
-							if (!reduceOneConstraint(context, typeArgumentConstraint))
+							if (!reduceOneConstraint(context, typeArgumentConstraint)) {
+								if (InferenceContext18.DEBUG)
+									System.out.println("Incorporation failed to reduce new constraint "+newConstraint); //$NON-NLS-1$
 								return false;
+							}
 						}
 					}
 					if (iteration == 2) {
@@ -746,11 +752,11 @@ class BoundSet {
 		ConstraintFormula formula = null;
 		if (boundKind == Wildcard.EXTENDS) {
 			if (bi.id == TypeIds.T_JavaLangObject)
-				formula = ConstraintTypeFormula.create(t, r, ReductionResult.SUBTYPE);
+				formula = ConstraintTypeFormula.create(t, r, ReductionResult.SUBTYPE, true);
 			if (t.id == TypeIds.T_JavaLangObject)
-				formula = ConstraintTypeFormula.create(theta.substitute(theta, bi), r, ReductionResult.SUBTYPE);
+				formula = ConstraintTypeFormula.create(theta.substitute(theta, bi), r, ReductionResult.SUBTYPE, true);
 		} else {
-			formula = ConstraintTypeFormula.create(theta.substitute(theta, bi), r, ReductionResult.SUBTYPE);
+			formula = ConstraintTypeFormula.create(theta.substitute(theta, bi), r, ReductionResult.SUBTYPE, true);
 		}
 		if (formula != null) {
 			reduceOneConstraint(context, formula);
@@ -882,7 +888,7 @@ class BoundSet {
 			innerSame = true; // came in as: S REL α and α REL T imply ⟨S REL T⟩
 		if (outerSame) {
 			if (innerSame) // NON-JLS bidirectional subtyping implies equality:
-				return ConstraintTypeFormula.create(boundS.left, boundS.right, ReductionResult.SAME, false);
+				return ConstraintTypeFormula.create(boundS.left, boundS.right, ReductionResult.SAME, boundT.isSoft||boundS.isSoft);
 			return ConstraintTypeFormula.create(boundT.left, boundS.right, boundS.relation, boundT.isSoft||boundS.isSoft);
 		} else if (innerSame) {
 			return ConstraintTypeFormula.create(boundS.left, boundT.right, boundS.relation, boundT.isSoft||boundS.isSoft);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BoundSet.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BoundSet.java
@@ -430,10 +430,16 @@ class BoundSet {
 				// for a dependency between two IVs make a note about the inverse bound.
 				// this should be needed to determine IV dependencies independent of direction.
 				// TODO: so far no test could be identified which actually needs it ...
-				InferenceVariable rightIV = (InferenceVariable) bound.right.prototype();
-				three = this.boundsPerVariable.get(rightIV);
-				if (three == null)
-					this.boundsPerVariable.put(rightIV, (three = new ThreeSets()));
+				int relation = switch (bound.relation) {
+					case ReductionResult.SUBTYPE -> ReductionResult.SUPERTYPE;
+					case ReductionResult.SUPERTYPE -> ReductionResult.SUBTYPE;
+					default -> -1;
+				};
+				if (relation != -1) {
+					InferenceVariable rightIV = (InferenceVariable) bound.right.prototype();
+					three = this.boundsPerVariable.computeIfAbsent(rightIV, k -> new ThreeSets());
+					three.addBound(new TypeBound(rightIV, bound.left, relation));
+				}
 			}
 		}
 	}
@@ -722,7 +728,8 @@ class BoundSet {
 		if (InferenceContext18.DEBUG) {
 			if (!capturesToRemove.isEmpty()) {
 				for (ParameterizedTypeBinding toRemove : capturesToRemove) {
-					System.out.println("Removing capture bound " + //$NON-NLS-1$
+					if (this.captures.containsKey(toRemove))
+						System.out.println("Removing capture bound " + //$NON-NLS-1$
 							String.valueOf(toRemove.shortReadableName()) +
 							"=capture("+String.valueOf(this.captures.get(toRemove).shortReadableName())+")"); //$NON-NLS-1$ //$NON-NLS-2$
 				}
@@ -1080,8 +1087,7 @@ class BoundSet {
 					if (!(bound.right instanceof InferenceVariable))
 						return 1;
 			if (three.superBounds != null)
-				for (TypeBound bound :three.superBounds)
-					if (!(bound.right instanceof InferenceVariable))
+				if (!three.superBounds.isEmpty())
 						return 2;
 		}
 		return 3;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
@@ -16,6 +16,7 @@ package org.eclipse.jdt.internal.compiler.lookup;
 
 import java.util.*;
 import java.util.Map.Entry;
+import java.util.stream.Collectors;
 import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.internal.compiler.ast.*;
 import org.eclipse.jdt.internal.compiler.lookup.TypeConstants.BoundCheckStatus;
@@ -1169,19 +1170,14 @@ public class InferenceContext18 {
 			// find a minimal set of dependent variables:
 			Set<InferenceVariable> variableSet;
 			boolean[] hasSkippedSuperBound = { false };
-			while ((variableSet = getSmallestVariableSet(tmpBoundSet, toResolveSet, maySkipSuperBound, hasSkippedSuperBound)) != null) {
+			while ((variableSet = getSmallestVariableSet(tmpBoundSet, toResolveSet, false, hasSkippedSuperBound)) != null) {
 				int oldNumUninstantiated = tmpBoundSet.numUninstantiatedVariables(this.inferenceVariables);
-				final int numVars = variableSet.size();
-				if (numVars > 0) {
-					final InferenceVariable[] variables = variableSet.toArray(new InferenceVariable[numVars]);
-					// NON-JLS: prioritize ivars in 'inThrows' as those may pull in new information by extra rule below (=RuntimeException)
-					BoundSet tSet = tmpBoundSet;
-					Arrays.sort(variables, (v1, v2) -> {
-						int r1 = tSet.inThrows.contains(v1) ? -1 : 0;
-						int r2 = tSet.inThrows.contains(v2) ? -1 : 0;
-						return r1 - r2;
-					});
-					//
+				List<InferenceVariable> ofRank;
+				while ((ofRank = pickIvarsByRank(variableSet, tmpBoundSet)) != null) {
+					final int numVars = ofRank.size();
+					if (numVars == 0)
+						continue;
+					final InferenceVariable[] variables = ofRank.toArray(new InferenceVariable[numVars]);
 					variables: if (!isRecordPatternTypeInference && !tmpBoundSet.hasCaptureBound(variableSet)) {
 						// try to instantiate this set of variables in a fresh copy of the bound set:
 						BoundSet prevBoundSet = tmpBoundSet;
@@ -1190,6 +1186,7 @@ public class InferenceContext18 {
 							InferenceVariable variable = variables[j];
 							if (tmpBoundSet.isInstantiated(variable)) { // NON-JLS: may happen when exception bound has been incorporated
 								toResolveSet.remove(variable);
+								variableSet.remove(variable);
 								continue;
 							}
 							// try lower bounds:
@@ -1236,11 +1233,13 @@ public class InferenceContext18 {
 								}
 							}
 							toResolveSet.remove(variable);
+							variableSet.remove(variable);
 						}
 						if (tmpBoundSet.incorporate(this))
 							continue;
 						tmpBoundSet = prevBoundSet;// clean-up for second attempt
 					}
+
 					if (maySkipSuperBound && hasSkippedSuperBound[0])
 						return resolve(toResolve, isRecordPatternTypeInference, false);
 					// Otherwise, a second attempt is made...
@@ -1348,6 +1347,7 @@ public class InferenceContext18 {
 						if (!typeboundCreated)
 							tmpBoundSet.addBound(new TypeBound(variable, zsj, ReductionResult.SAME), this.environment);
 						toResolveSet.remove(variable);
+						variableSet.remove(variable);
 					}
 					if (tmpBoundSet.incorporate(this)) {
 						if (tmpBoundSet.numUninstantiatedVariables(this.inferenceVariables) == oldNumUninstantiated)
@@ -1458,7 +1458,9 @@ public class InferenceContext18 {
 			//  "... and ii) there exists no non-empty proper subset of { α1, ..., αn } with this property."
 			// -> find a smallest among candidate sets:
 			if (set == null) {
-				return Collections.singleton(currentVariable);
+				set = new HashSet<>();
+				set.add(currentVariable);
+				return set;
 			}
 			for (Iterator<InferenceVariable> iter = set.iterator(); iter.hasNext();) {
 				InferenceVariable iv = iter.next();
@@ -1474,6 +1476,22 @@ public class InferenceContext18 {
 			}
 		}
 		return result;
+	}
+
+	static List<InferenceVariable> pickIvarsByRank(Set<InferenceVariable> variableSet, BoundSet tmpBoundSet) {
+		// apply the ranking of ivars according to their bounds as explained in
+		// https://mail.openjdk.org/archives/list/compiler-dev@openjdk.org/message/GN6RTCGMME6I5JVLSFZRIR32XY6QKOI2/
+		Map<Integer, List<InferenceVariable>> byRank = variableSet.stream().collect(Collectors.groupingBy(tmpBoundSet::rankIVar));
+		for (int rank = 0; rank < 4; rank++) {
+			List<InferenceVariable> ofRank = byRank.get(rank);
+			if (ofRank == null)
+				continue;
+			final int numVars = ofRank.size();
+			if (numVars == 0)
+				continue;
+			return ofRank;
+		}
+		return null;
 	}
 
 	/**

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
@@ -430,7 +430,7 @@ public class InferenceContext18 {
 				return null;
 			// 5. bullet: determine B4 from C
 			while (!c.isEmpty()) {
-				Map<InferenceVariable,Set<InferenceVariable>> dependencies = collectDependencies(this.currentBounds, false, new boolean[1]);
+				Map<InferenceVariable,Set<InferenceVariable>> dependencies = collectDependencies(this.currentBounds);
 				List<Set<InferenceVariable>> components = new ArrayList<>(dependencies.values());
 				// *
 				Set<ConstraintFormula> bottomSet = findBottomSet(c, allOutputVariables(c), components);
@@ -1152,13 +1152,6 @@ public class InferenceContext18 {
 	private /*@Nullable*/ BoundSet resolve(
 			InferenceVariable[] toResolve,
 			boolean isRecordPatternTypeInference) throws InferenceFailureException {
-		return resolve(toResolve, isRecordPatternTypeInference, true);
-	}
-	private /*@Nullable*/ BoundSet resolve(
-			InferenceVariable[] toResolve,
-			boolean isRecordPatternTypeInference,
-			boolean maySkipSuperBound) throws InferenceFailureException {
-
 		this.captureId = 0;
 		// NOTE: 18.5.2 ...
 		// "(While it was necessary to demonstrate that the inference variables in B1 could be resolved
@@ -1169,8 +1162,7 @@ public class InferenceContext18 {
 			Set<InferenceVariable> toResolveSet = new LinkedHashSet<>(Arrays.asList(toResolve));
 			// find a minimal set of dependent variables:
 			Set<InferenceVariable> variableSet;
-			boolean[] hasSkippedSuperBound = { false };
-			while ((variableSet = getSmallestVariableSet(tmpBoundSet, toResolveSet, false, hasSkippedSuperBound)) != null) {
+			while ((variableSet = getSmallestVariableSet(tmpBoundSet, toResolveSet)) != null) {
 				int oldNumUninstantiated = tmpBoundSet.numUninstantiatedVariables(this.inferenceVariables);
 				List<InferenceVariable> ofRank;
 				while ((ofRank = pickIvarsByRank(variableSet, tmpBoundSet)) != null) {
@@ -1239,9 +1231,6 @@ public class InferenceContext18 {
 							continue;
 						tmpBoundSet = prevBoundSet;// clean-up for second attempt
 					}
-
-					if (maySkipSuperBound && hasSkippedSuperBound[0])
-						return resolve(toResolve, isRecordPatternTypeInference, false);
 					// Otherwise, a second attempt is made...
 					Sorting.sortInferenceVariables(variables); // ensure stability of capture IDs
 					final CaptureBinding18[] zs = new CaptureBinding18[numVars];
@@ -1432,11 +1421,11 @@ public class InferenceContext18 {
 	 * Find the smallest set of uninstantiated inference variables not depending
 	 * on any uninstantiated variable outside the set.
 	 */
-	public Set<InferenceVariable> getSmallestVariableSet(BoundSet bounds, Set<InferenceVariable> subSet, boolean maySkipSuperBound, boolean[] hasSkippedSuperBound) {
+	public Set<InferenceVariable> getSmallestVariableSet(BoundSet bounds, Set<InferenceVariable> subSet) {
 		// "Given a set of inference variables to resolve, let V be the union of this set and
 		//  all variables upon which the resolution of at least one variable in this set depends."
 		Set<InferenceVariable> v = new LinkedHashSet<>(subSet);
-		Map<InferenceVariable,Set<InferenceVariable>> dependencies = collectDependencies(bounds, maySkipSuperBound, hasSkippedSuperBound);
+		Map<InferenceVariable,Set<InferenceVariable>> dependencies = collectDependencies(bounds);
 		for (InferenceVariable iv : subSet) {
 			Set<InferenceVariable> tmp = dependencies.get(iv);
 			if (tmp != null)
@@ -1497,11 +1486,9 @@ public class InferenceContext18 {
 	/**
 	 * Collect dependencies of all our ivars based on TypeBounds of 'bounds'
 	 * @param bounds consider all its TypeBounds
-	 * @param maySkipSuperBound if true, then α :> β bounds will not be treated as a dependency from α to β (only the inverse)
-	 * @param hasSkippedSuperBound output parameter to signal to the caller if maySkipSuperBound has been used
 	 * @return a map from an ivar to the set of all its dependencies including itself.
 	 */
-	Map<InferenceVariable,Set<InferenceVariable>> collectDependencies(BoundSet bounds, boolean maySkipSuperBound, boolean[] hasSkippedSuperBound) {
+	Map<InferenceVariable,Set<InferenceVariable>> collectDependencies(BoundSet bounds) {
 		// Implements the definition of dependencies from JLS §18.4:
 		Map<InferenceVariable,Set<InferenceVariable>> dependsOn = new LinkedHashMap<>();
 		// "An inference variable α depends on the resolution of itself."
@@ -1517,38 +1504,31 @@ public class InferenceContext18 {
 			// T = α  -- encoded as α = T
 			// T <: α -- encoded as α :> T
 			for (int i=0; i<2; i++) { // 2 attempts, reading the bound left-to-right, then right-to-left
-				if (maySkipSuperBound && typeBound.relation == ReductionResult.SUPERTYPE && typeBound.right instanceof InferenceVariable) {
-					// NON-JLS: first try to ignore any dependencies resulting from a supertype bound,
-					// i.e., given α :> β do not consider α to depend on β
-					hasSkippedSuperBound[0] = true; // signal the application of this tweak to upstream,
-													// so they can retry with the tweak disabled (maySkip=false)
-				} else {
-					Set<InferenceVariable> betas = new LinkedHashSet<>();
-					typeBound.right.collectInferenceVariables(betas);
-					if (!betas.isEmpty()) {
-						InferenceVariable alpha = typeBound.left;
-						// Determine the direction of dependencies to add:
-						// "If α appears on the left-hand side of another bound of the form G<..., α, ...> = capture(G<...>),
-						// then β depends on the resolution of α. Otherwise, α depends on the resolution of β."
-						boolean alphaDependsOnBeta = true;
-						captureTest: for (ParameterizedTypeBinding gCap : bounds.captures.keySet()) {
-							for (TypeBinding arg : gCap.arguments) {
-								if (TypeBinding.equalsEquals(arg, alpha)) {
-									alphaDependsOnBeta = false;
-									break captureTest;
-								}
+				Set<InferenceVariable> betas = new LinkedHashSet<>();
+				typeBound.right.collectInferenceVariables(betas);
+				if (!betas.isEmpty()) {
+					InferenceVariable alpha = typeBound.left;
+					// Determine the direction of dependencies to add:
+					// "If α appears on the left-hand side of another bound of the form G<..., α, ...> = capture(G<...>),
+					// then β depends on the resolution of α. Otherwise, α depends on the resolution of β."
+					boolean alphaDependsOnBeta = true;
+					captureTest: for (ParameterizedTypeBinding gCap : bounds.captures.keySet()) {
+						for (TypeBinding arg : gCap.arguments) {
+							if (TypeBinding.equalsEquals(arg, alpha)) {
+								alphaDependsOnBeta = false;
+								break captureTest;
 							}
 						}
-						if (alphaDependsOnBeta) {
-							Set<InferenceVariable> deps = dependsOn.computeIfAbsent(alpha, iv -> new LinkedHashSet<>());
-							deps.addAll(betas);
-							deps.add(alpha); // add self-dependency, alpha might not yet be recorded if its from inner inference
-						} else {
-							for (InferenceVariable beta : betas) {
-								Set<InferenceVariable> deps = dependsOn.computeIfAbsent(beta, iv -> new LinkedHashSet<>());
-								deps.add(alpha);
-								deps.add(beta); // add self-dependency, beta might not yet be recorded if its from inner inference
-							}
+					}
+					if (alphaDependsOnBeta) {
+						Set<InferenceVariable> deps = dependsOn.computeIfAbsent(alpha, iv -> new LinkedHashSet<>());
+						deps.addAll(betas);
+						deps.add(alpha); // add self-dependency, alpha might not yet be recorded if its from inner inference
+					} else {
+						for (InferenceVariable beta : betas) {
+							Set<InferenceVariable> deps = dependsOn.computeIfAbsent(beta, iv -> new LinkedHashSet<>());
+							deps.add(alpha);
+							deps.add(beta); // add self-dependency, beta might not yet be recorded if its from inner inference
 						}
 					}
 				}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
@@ -93,8 +93,8 @@ import org.eclipse.jdt.internal.compiler.util.Sorting;
  */
 public class InferenceContext18 {
 
-	public final static boolean DEBUG = false;
-	public final static boolean DEBUG_FINE = false;
+	public final static boolean DEBUG = Boolean.getBoolean("ecj.typeinference.debug"); //$NON-NLS-1$
+	public final static boolean DEBUG_FINE = Boolean.getBoolean("ecj.typeinference.debug.fine"); //$NON-NLS-1$;
 
 	/** NON-JLS: to conform with javac regarding https://bugs.openjdk.java.net/browse/JDK-8026527 */
 	static final boolean SIMULATE_BUG_JDK_8026527 = true;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
@@ -106,12 +106,11 @@ public class InferenceContext18 {
 
 	/**
 	 * NON-JLS: Detail flag to control the extent of {@link #SIMULATE_BUG_JDK_8026527}.
-	 * A setting of 'false' would implement the advice from http://mail.openjdk.java.net/pipermail/lambda-spec-experts/2013-December/000447.html
+	 * A setting of 'false' implements the advice from http://mail.openjdk.java.net/pipermail/lambda-spec-experts/2013-December/000447.html
 	 * i.e., raw types are not considered as compatible in constraints/bounds derived from invocation arguments,
 	 * but only for constraints derived from type variable bounds.
-	 * NON-JLS: Unfortunately, 'true' is required by GenericsRegressionTest.test434118()
 	 */
-	static final boolean ARGUMENT_CONSTRAINTS_ARE_SOFT = true;
+	static final boolean ARGUMENT_CONSTRAINTS_ARE_SOFT = false;
 
 	// --- Main State of the Inference: ---
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
@@ -1169,6 +1169,9 @@ public class InferenceContext18 {
 					final int numVars = ofRank.size();
 					if (numVars == 0)
 						continue;
+					if (DEBUG) {
+						System.out.println("Resolving ivars: "+ofRank); //$NON-NLS-1$
+					}
 					final InferenceVariable[] variables = ofRank.toArray(new InferenceVariable[numVars]);
 					variables: if (!isRecordPatternTypeInference && !tmpBoundSet.hasCaptureBound(variableSet)) {
 						// try to instantiate this set of variables in a fresh copy of the bound set:
@@ -1266,6 +1269,7 @@ public class InferenceContext18 {
 					};
 					for (int j = 0; j < numVars; j++) {
 						InferenceVariable variable = variables[j];
+						variableSet.remove(variable);
 						CaptureBinding18 zsj = zs[j];
 						// NON-JLS: leverage existing same bounds if they become proper by substitution:
 						boolean typeboundCreated = false;
@@ -1336,15 +1340,14 @@ public class InferenceContext18 {
 						if (!typeboundCreated)
 							tmpBoundSet.addBound(new TypeBound(variable, zsj, ReductionResult.SAME), this.environment);
 						toResolveSet.remove(variable);
-						variableSet.remove(variable);
 					}
 					if (tmpBoundSet.incorporate(this)) {
-						if (tmpBoundSet.numUninstantiatedVariables(this.inferenceVariables) == oldNumUninstantiated)
-							return null; // abort because we made no progress
 						continue;
 					}
 					return null;
 				}
+				if (tmpBoundSet.numUninstantiatedVariables(this.inferenceVariables) == oldNumUninstantiated)
+					return null; // abort because we made no progress
 			}
 		}
 		return tmpBoundSet;
@@ -2093,6 +2096,9 @@ public class InferenceContext18 {
 		TypeVariableBinding[] typeVariables = typeBinding.original().typeVariables();// type para
 		if (typeVariables == null)
 			return null;
+		// before adding any bounds signal that we are working on behalf of a record pattern:
+		this.currentBounds = new BoundSet();
+		this.currentBounds.isRecordPatternInference = true;
 		// An initial bound set, B0, is generated from the declared bounds of P1, ..., Pn,
 		// as described in 18.1.3.
 		InferenceVariable[] alphas = createInitialBoundSet(typeVariables); // creates initial bound set B

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
@@ -2315,6 +2315,43 @@ public void testGH4937() {
 	});
 }
 
+public void testGH3351() {
+	// error message is bogus (see https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5078)
+	// but rejecting is in line with javac
+	runNegativeTest(new String[] {
+			"PassThroughGenerics.java",
+			"""
+			import java.util.List;
+			public class PassThroughGenerics {
+			    private class MyComp implements Comparable<MyComp> {
+			        @Override public int compareTo(MyComp other) { return 0; }
+			    }
+
+			    static <E extends Comparable<E>> List<E> sort(List<E> list) {
+			        return list;
+			    }
+
+			    static <T> List<T> genericList() {
+			        return null;
+			    }
+
+			    public static void main(String[] args) {
+			        List<MyComp> sorted = sort(genericList());
+			        System.out.println(sorted);
+			    }
+			}
+			"""
+		},
+		"""
+		----------
+		1. ERROR in PassThroughGenerics.java (at line 16)
+			List<MyComp> sorted = sort(genericList());
+			                      ^^^^
+		The method sort(java.util.List<E extends java.lang.Comparable<E>>) in the type PassThroughGenerics is not applicable for the arguments (java.util.List<E extends java.lang.Comparable<E>>)
+		----------
+		""");
+}
+
 public static Class<GenericsRegressionTest_9> testClass() {
 	return GenericsRegressionTest_9.class;
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
@@ -15,8 +15,8 @@ package org.eclipse.jdt.core.tests.compiler.regression;
 
 import java.util.Map;
 import junit.framework.Test;
-import org.eclipse.jdt.core.tests.compiler.regression.AbstractRegressionTest.JavacTestOptions.JavacHasABug;
 import org.eclipse.jdt.core.tests.compiler.regression.AbstractRegressionTest.JavacTestOptions.Excuse;
+import org.eclipse.jdt.core.tests.compiler.regression.AbstractRegressionTest.JavacTestOptions.JavacHasABug;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 
@@ -2295,6 +2295,26 @@ public void testGH4731() {
 	runner.javacTestOptions = JavacHasABug.JavacBug8016207;
 	runner.runNegativeTest();
 }
+public void testGH4937() {
+	runConformTest(new String[] {
+		"A.java",
+		"""
+		import java.util.List;
+
+		public class A {
+		    public static void foo() {
+		        System.out.println(List.of(BusinessExtractBuilder.create())); // Error here
+		    }
+		    public static class BusinessExtractBuilder<T> {
+		        public static <U extends BusinessExtractBuilder<U>> U create() {
+		            return null;
+		        }
+		    }
+		}
+		"""
+	});
+}
+
 public static Class<GenericsRegressionTest_9> testClass() {
 	return GenericsRegressionTest_9.class;
 }


### PR DESCRIPTION
Working towards replacing a speculative part of our fix from #4735 with "official" hints from https://mail.openjdk.org/archives/list/compiler-dev@openjdk.org/message/GN6RTCGMME6I5JVLSFZRIR32XY6QKOI2/

Our own tweak from ad3653ec10042399c89d72d171bddfe7a147eb23 has been removed.

No new tests included because we only switch implementation strategies from our own invention to something closer to javac. For known test cases both strategies are indeed equivalent.