### PR TITLE
Change expected message in test #4922

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ClasspathTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ClasspathTests.java
@@ -50,6 +50,7 @@ import org.eclipse.jdt.internal.core.JavaModelManager;
 import org.eclipse.jdt.internal.core.JavaProject;
 import org.eclipse.jdt.internal.core.UserLibraryClasspathContainer;
 import org.eclipse.jdt.internal.core.builder.State;
+import org.eclipse.jdt.internal.core.util.Messages;
 import org.eclipse.team.core.RepositoryProvider;
 
 @SuppressWarnings({"rawtypes", "unchecked"})
@@ -7434,9 +7435,10 @@ public void testBug539998() throws CoreException {
 
 		IJavaModelStatus status = JavaConventions.validateClasspath(proj, newCP, proj.getOutputLocation());
 
-		assertStatus("should complain",
-				"Project has only main sources but depends on project 'P1' which has only test sources.",
-				status);
+		final String expected = Messages.bind(Messages.classpath_main_only_project_depends_on_test_only_project,
+				new String[] { proj.getElementName(), proj1TestOnly.getElementName() });
+
+		assertStatus("should complain", expected, status);
 	} finally {
 		this.deleteProjects(new String[] { "P1", "P2" });
 	}


### PR DESCRIPTION
See https://github.com/eclipse-jdt/eclipse.jdt.core/pull/4992#issuecomment-4265669732

@trancexpress I only found 1 failing test because of #4922 in the nightly builds and I am currently running `org.eclipse.jdt.core.tests.model.AllJavaModelTests` locally to see if something else broke. I'll undraft this PR as soon as the tests run green locally.