### PR TITLE
Set jdt.core.tests.builder.mockcompiler packaging to eclipse-test-plugin

### DIFF
--- a/org.eclipse.jdt.core.tests.builder.mockcompiler/pom.xml
+++ b/org.eclipse.jdt.core.tests.builder.mockcompiler/pom.xml
@@ -21,5 +21,5 @@
   </parent>
   <artifactId>org.eclipse.jdt.core.tests.builder.mockcompiler</artifactId>
   <version>1.0.200-SNAPSHOT</version>
-  <packaging>eclipse-plugin</packaging>
+  <packaging>eclipse-test-plugin</packaging>
 </project>


### PR DESCRIPTION
## What it does
Set `jdt.core.tests.builder.mockcompiler` packaging to `eclipse-test-plugin`.

Technically it's not test Plug-in, but it contains only resources for tests and is not part of the Eclipse p2-Repository and thus not part of the baseline and therefore should be treated like a test plugin.


Contributes to
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/3784

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
