### PR TITLE
[Formatter] Remove empty spaceBefore handling for lambdas

### DIFF
--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/SpacePreparator.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/SpacePreparator.java
@@ -596,12 +596,8 @@ public class SpacePreparator extends ASTVisitor {
 				this.options.insert_space_after_lambda_arrow);
 		List<VariableDeclaration> parameters = node.parameters();
 		if (node.hasParentheses()) {
-			if (handleEmptyParens(node, this.options.insert_space_between_empty_parens_in_method_declaration)) {
-				handleToken(node, TokenNameLPAREN,
-						this.options.insert_space_before_opening_paren_in_method_declaration, false);
-			} else {
-				handleToken(node, TokenNameLPAREN,
-						this.options.insert_space_before_opening_paren_in_method_declaration,
+			if (!handleEmptyParens(node, this.options.insert_space_between_empty_parens_in_method_declaration)) {
+				handleToken(node, TokenNameLPAREN, false,
 						this.options.insert_space_after_opening_paren_in_method_declaration);
 
 				handleTokenBefore(node.getBody(), TokenNameRPAREN,


### PR DESCRIPTION
This change introduces a dedicated formatter option to control spacing before lambda empty parameter parentheses. Lambda formatting is now handled independently, ensuring method declaration settings no longer affect lambda expressions.

<img width="1080" height="608" alt="Lambda" src="https://github.com/user-attachments/assets/4c21bed1-af6a-4791-80d4-e5fb0bbd0db7" />

<img width="664" height="170" alt="Screenshot 2026-04-20 at 4 02 16 PM" src="https://github.com/user-attachments/assets/8b4cfb40-eb36-4659-84b4-c1b82b066fc8" />


Fixes : https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4998

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
