### PR TITLE
Wait for auto-build in JavaModelTests.testGetNonJavaResources

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaModelTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaModelTests.java
@@ -486,23 +486,26 @@ public void testGetJavaProjects2() throws CoreException {
 /*
  * Test retrieving non-Java projects.
  */
-public void testGetNonJavaResources() throws CoreException {
+public void testGetNonJavaResources() throws Exception {
 	try {
 		IJavaModel model = getJavaModel();
 
 		this.createJavaProject("JP", new String[]{}, "");
+		waitForAutoBuild();
 		assertResourceNamesEqual(
 			"Unexpected non-Java resources",
 			"",
 			model.getNonJavaResources());
 
 		createProject("SP1");
+		waitForAutoBuild();
 		assertResourceNamesEqual(
 			"Unexpected non-Java resources after creation of SP1",
 			"SP1",
 			model.getNonJavaResources());
 
 		createProject("SP2");
+		waitForAutoBuild();
 		assertResourceNamesEqual(
 			"Unexpected non-Java resources after creation of SP2",
 			"SP1\n" +
@@ -510,6 +513,7 @@ public void testGetNonJavaResources() throws CoreException {
 			model.getNonJavaResources());
 
 		this.deleteProject("SP1");
+		waitForAutoBuild();
 		assertResourceNamesEqual(
 			"Unexpected non-Java resources after deletion of SP1",
 			"SP2",


### PR DESCRIPTION
Logging of received deltas shows `AutoBuildJob.AutoBuildOffJob` usually sending the deltas necessary for the test to pass. In the case of `testGetNonJavaResources` failing, `AutoBuildOffJob` ran slightly earlier and did not notify about changes for test project `SP2`.

This change adds waiting on auto-build, which will also join the `AutoBuildOffJob`. This hopefully ensures delta notifications are received before doing assertions in the test.

See: https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2716
