### PR TITLE
fixes #5024 - Disassembler omitting to show primitive data types in

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PrimitiveInPatternsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PrimitiveInPatternsTest.java
@@ -30,7 +30,7 @@ public class PrimitiveInPatternsTest extends AbstractRegressionTest9 {
 	static {
 //		TESTS_NUMBERS = new int [] { 1 };
 //		TESTS_RANGE = new int[] { 1, -1 };
-//		TESTS_NAMES = new String[] { "testSwitchPrimitiveboolean_01" };
+//		TESTS_NAMES = new String[] { "testSwitchPrimitiveboolean_04" };
 	}
 	private String extraLibPath;
 	public static Class<?> testClass() {
@@ -7536,6 +7536,81 @@ public class PrimitiveInPatternsTest extends AbstractRegressionTest9 {
 			"100\n"+
 			"200");
 		String expectedOutput = "invokedynamic 1 typeSwitch(boolean, int)";
+		verifyClassFile(expectedOutput, "X.class", ClassFileBytesDisassembler.SYSTEM);
+	}
+
+	public void testSwitchPrimitiveboolean_02() throws IOException, ClassFormatException {
+		runConformTest(new String[] { "X.java",
+				"""
+				public class X {
+					public static int primitiveSwitch(float f) {
+						return switch (f) {
+						case 1.0f -> 100;
+						//		case 0.999999999f -> 200;
+						default -> 300;
+						};
+					}
+
+					public static void main(String[] args) {
+						System.out.println(primitiveSwitch(1.0f));
+
+					}
+				}
+				"""
+			},
+			"100");
+		String expectedOutput =
+		"	Method arguments:\n" +
+		"		#50 1.0\n";
+		verifyClassFile(expectedOutput, "X.class", ClassFileBytesDisassembler.SYSTEM);
+	}
+	public void testSwitchPrimitiveboolean_03() throws IOException, ClassFormatException {
+		runConformTest(new String[] { "X.java",
+				"""
+				public class X {
+					public static int primitiveSwitch(long l) {
+						return switch (l) {
+						case 10L -> 100;
+						default -> 300;
+						};
+					}
+
+					public static void main(String[] args) {
+						System.out.println(primitiveSwitch(10L));
+
+					}
+				}
+				"""
+			},
+			"100");
+		String expectedOutput =
+		"	Method arguments:\n" +
+		"		#31 10\n";
+		verifyClassFile(expectedOutput, "X.class", ClassFileBytesDisassembler.SYSTEM);
+	}
+
+	public void testSwitchPrimitiveboolean_04() throws IOException, ClassFormatException {
+		runConformTest(new String[] { "X.java",
+				"""
+				public class X {
+					public static int primitiveSwitch(double d) {
+						return switch (d) {
+						case 10.0 -> 100;
+						default -> 300;
+						};
+					}
+
+					public static void main(String[] args) {
+						System.out.println(primitiveSwitch(10.0));
+
+					}
+				}
+				"""
+			},
+			"100");
+		String expectedOutput =
+		"	Method arguments:\n" +
+		"		#31 10.0\n";
 		verifyClassFile(expectedOutput, "X.class", ClassFileBytesDisassembler.SYSTEM);
 	}
 

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/Disassembler.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/util/Disassembler.java
@@ -1924,6 +1924,15 @@ public class Disassembler extends ClassFileBytesDisassembler {
 				case IConstantPoolConstant.CONSTANT_Integer:
 					arguments[i] = Integer.toString(constantPoolEntry.getIntegerValue());
 					break;
+				case IConstantPoolConstant.CONSTANT_Float:
+					arguments[i] = Float.toString(constantPoolEntry.getFloatValue());
+					break;
+				case IConstantPoolConstant.CONSTANT_Long:
+					arguments[i] = Long.toString(constantPoolEntry.getLongValue());
+					break;
+				case IConstantPoolConstant.CONSTANT_Double:
+					arguments[i] = Double.toString(constantPoolEntry.getDoubleValue());
+					break;
 				case IConstantPoolConstant.CONSTANT_MethodHandle:
 					// http://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.4.8
 					// If the value of the reference_kind item is 5 (REF_invokeVirtual), 6 (REF_invokeStatic),


### PR DESCRIPTION

## What it does
fixes #5024 
Disassembler shows null as arguments in BootStrap methods 


## How to test
unit tests are provided. Comment the changes in Disassembler.bootstrapArgumentsDescription() and then run the tests. You will see the failures. Now uncomment and run to see the tests pass.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
