### PR TITLE
Adjusted resource delta logging in CopyMoveElementsTests

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CopyMoveElementsTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CopyMoveElementsTests.java
@@ -71,12 +71,12 @@ public static Test suite() {
  */
 @Override
 public void tearDown() throws Exception {
-	getWorkspace().removeResourceChangeListener(LOG_RESOURCE_DELTA);
 	this.deleteProject("P");
 	super.tearDown();
 }
 @Override
 public void tearDownSuite() throws Exception {
+	getWorkspace().removeResourceChangeListener(LOG_RESOURCE_DELTA);
 	this.deleteProject("BinaryProject");
 	super.tearDownSuite();
 }


### PR DESCRIPTION
Currently delta listener is unregistered in `tearDown()`, but should be unregistered in `tearDownSuite()`.

See: https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2552