### PR TITLE
Fixes issue #4979 - Unboxed Primitive dominance checked

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Pattern.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Pattern.java
@@ -116,12 +116,12 @@ public abstract class Pattern extends Expression {
 	public boolean coversValue(Constant cst, BlockScope scope) {
 		if (!isUnguarded())
 			return false;
-		if (!(this.resolvedType instanceof BaseTypeBinding baseType))
+		if (!(this.resolvedType.unboxedType() instanceof BaseTypeBinding baseType))
 			return false;
 		if (!cst.isExactTestingConversion(baseType))
 			return false;
 		int constantTypeID = cst.typeID();
-		PrimitiveConversionRoute route = findPrimitiveConversionRoute(this.resolvedType, TypeBinding.wellKnownBaseType(constantTypeID), scope);
+		PrimitiveConversionRoute route = findPrimitiveConversionRoute(baseType, TypeBinding.wellKnownBaseType(constantTypeID), scope);
 		switch (route) {
 			// JLS §5.7.2:
 			case NARROWING_PRIMITVE_CONVERSION:

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PrimitiveInPatternsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PrimitiveInPatternsTest.java
@@ -30,7 +30,7 @@ public class PrimitiveInPatternsTest extends AbstractRegressionTest9 {
 	static {
 //		TESTS_NUMBERS = new int [] { 1 };
 //		TESTS_RANGE = new int[] { 1, -1 };
-//		TESTS_NAMES = new String[] { "testSwitchPrimitiveboolean_04" };
+//		TESTS_NAMES = new String[] { "testDominanceIssue4979_001" };
 	}
 	private String extraLibPath;
 	public static Class<?> testClass() {
@@ -7612,6 +7612,40 @@ public class PrimitiveInPatternsTest extends AbstractRegressionTest9 {
 		"	Method arguments:\n" +
 		"		#31 10.0\n";
 		verifyClassFile(expectedOutput, "X.class", ClassFileBytesDisassembler.SYSTEM);
+	}
+	public void testDominanceIssue4979_001() {
+		runNegativeTest(new String[] {
+			"X.java",
+				"""
+				public class X {
+					public int foo(Character c) {
+						int result = 0;
+						switch (c) {
+							case Character c1 -> {
+								result = c1;
+								break;
+							}
+							case 0 -> {  // Same goes for case (int) 0
+								result = 0;
+								break;
+							}
+						}
+						return result;
+					}
+				}
+				"""
+			},
+			"----------\n" +
+			"1. WARNING in X.java (at line 5)\n" +
+			"	case Character c1 -> {\n" +
+			"	     ^^^^^^^^^^^^\n" +
+			"You are using a preview language feature that may or may not be supported in a future release\n" +
+			"----------\n" +
+			"2. ERROR in X.java (at line 9)\n" +
+			"	case 0 -> {  // Same goes for case (int) 0\n" +
+			"	     ^\n" +
+			"This case label is dominated by one of the preceding case labels\n" +
+			"----------\n");
 	}
 
 }


### PR DESCRIPTION
## What it does
Fixes issue #4979 - Unboxed primitive type was not checked for conversion possibility and consequently, the dominance of switch case was not captured. This is fixed by checking the type of the unboxed resolved type instead of just the resolved type of the case arm variable.

## How to test
Uncomment the changes in Pattern.coversValue(), essentially, removed the call to unboxedType() and then run the test PrimitivesInPatternsTest.testDominanceIssue4979_001(). The test should fail. Once the changes are uncommented, the test will pass.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
