### PR TITLE
Wait for auto-refresh in JavaModelTests.testGetNonJavaResources()

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaModelTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaModelTests.java
@@ -491,21 +491,21 @@ public void testGetNonJavaResources() throws Exception {
 		IJavaModel model = getJavaModel();
 
 		this.createJavaProject("JP", new String[]{}, "");
-		waitForAutoBuild();
+		waitForRefreshAndAutoBuild();
 		assertResourceNamesEqual(
 			"Unexpected non-Java resources",
 			"",
 			model.getNonJavaResources());
 
 		createProject("SP1");
-		waitForAutoBuild();
+		waitForRefreshAndAutoBuild();
 		assertResourceNamesEqual(
 			"Unexpected non-Java resources after creation of SP1",
 			"SP1",
 			model.getNonJavaResources());
 
 		createProject("SP2");
-		waitForAutoBuild();
+		waitForRefreshAndAutoBuild();
 		assertResourceNamesEqual(
 			"Unexpected non-Java resources after creation of SP2",
 			"SP1\n" +
@@ -513,7 +513,7 @@ public void testGetNonJavaResources() throws Exception {
 			model.getNonJavaResources());
 
 		this.deleteProject("SP1");
-		waitForAutoBuild();
+		waitForRefreshAndAutoBuild();
 		assertResourceNamesEqual(
 			"Unexpected non-Java resources after deletion of SP1",
 			"SP2",
@@ -714,6 +714,10 @@ public void testPreProcessingResourceChangedListener04() throws CoreException {
 		JavaCore.removePreProcessingResourceChangedListener(listener);
 		deleteProject("Test");
 	}
+}
+private void waitForRefreshAndAutoBuild() throws Exception {
+	waitForAutoRefresh();
+	waitForAutoBuild();
 }
 }
 


### PR DESCRIPTION
Logging from latest fail in `JavaModelTests.testGetNonJavaResources()` shows `RefreshJob` running in parallel to the test, sending a delta notification.

This change adds waiting on `RefreshJob`, to make the test behavior more deterministic.

See: https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2716