### PR TITLE
Add missing ASTConverter Javadoc tests for @snippet tag (Java 18)

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterJavadocTest_18.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterJavadocTest_18.java
@@ -1057,4 +1057,315 @@ public class ASTConverterJavadocTest_18 extends ConverterTestSetup {
 		assertEquals("Tag element fragment should be TextElement", true, tagElem.fragments().get(0) instanceof TextElement);
 		assertEquals("Fourth fragment should be TextElement", true, fragments.get(3) instanceof TextElement);
 	}
+
+	public void testSnippetMultilineOnlyJavadoc5() throws JavaModelException {
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy("/Converter_15_1/src/javadoc/X.java",
+				"""
+					package javadoc;
+					public class X {
+						/**
+						 * {@snippet :
+						 * 	int a = 1;
+						 * 	int b = 2;
+						 * }
+						 */
+						 public static void foo(Object object) {}
+					}
+				"""
+			);
+		CompilationUnit compilUnit = verifyComments(this.workingCopies[0]);
+		List unitComments = compilUnit.getCommentList();
+		assertEquals("Wrong number of comments", 1, unitComments.size());
+		Javadoc javadoc = (Javadoc) unitComments.get(0);
+		TagElement snippetTag = getSnippetTag(javadoc);
+		List<TextElement> snippetFrags = snippetTag.fragments();
+		assertEquals("Invalid snippet elements", 3, snippetFrags.size());
+		assertEquals("Incorrect content for firstElemnt", " 	int a = 1;\n", snippetFrags.get(0).getText());
+		assertEquals("Incorrect content for secondElemnt", " 	int b = 2;\n", snippetFrags.get(1).getText());
+
+	}
+
+	public void testSnippetNestedBlocksJavadoc() throws JavaModelException {
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy(
+			"/Converter_15_1/src/javadoc/X.java",
+			"""
+			package javadoc;
+			public class X {
+				/**
+				 * {@snippet:
+				 *   if (a) {
+				 *      while (b) {
+				 *         foo();
+				 *      }
+				 *   }
+				 * }
+				 */
+				public static void foo(Object o) {}
+			}
+			"""
+		);
+
+		CompilationUnit cu = verifyComments(this.workingCopies[0]);
+		List unitComments = cu.getCommentList();
+		assertEquals("Wrong number of comments", 1, unitComments.size());
+
+		Javadoc javadoc = (Javadoc) unitComments.get(0);
+		TagElement snippetTag = getSnippetTag(javadoc);
+		assertNotNull("Snippet tag should be present", snippetTag);
+
+		List fragments = snippetTag.fragments();
+		assertFalse("Snippet should have fragments", fragments.isEmpty());
+		assertTrue( "Snippet should contain multiple text elements",fragments.size() >= 3);
+		assertTrue("Snippet should contain if block", ((TextElement) fragments.get(0)).getText().contains("if (a)"));
+		assertTrue("Snippet should contain while loop", ((TextElement) fragments.get(1)).getText().contains("while (b)"));
+		assertTrue("Snippet should contain method call", ((TextElement) fragments.get(2)).getText().contains("foo();"));
+	}
+
+	public void testSnippetEmptyBodyJavadoc() throws JavaModelException {
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy(
+			"/Converter_15_1/src/javadoc/X.java",
+			"""
+			package javadoc;
+			public class X {
+				/**
+				 * {@snippet :
+				 * }
+				 */
+				public static void foo(Object o) {}
+			}
+			"""
+		);
+
+		CompilationUnit compilUnit = verifyComments(this.workingCopies[0]);
+		List unitComments = compilUnit.getCommentList();
+		assertEquals("Wrong number of comments", 1, unitComments.size());
+
+		Javadoc javadoc = (Javadoc) unitComments.get(0);
+		TagElement snippetTag = getSnippetTag(javadoc);
+		assertNotNull("Snippet tag should be present", snippetTag);
+
+		List<?> fragments = snippetTag.fragments();
+		assertFalse("Snippet should have fragments", fragments.isEmpty());
+
+		String empty_text = ((TextElement) fragments.get(0)).getText();
+		assertTrue("Empty snippet should not contain non-empty text",empty_text.trim().isEmpty());
+	}
+
+	public void testSnippetSingleElementJavadoc() throws JavaModelException {
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy(
+			"/Converter_15_1/src/javadoc/X.java",
+			"""
+			package javadoc;
+			public class X {
+				/**
+				 * {@snippet :
+				 * int a = 10;
+				 * }
+				 */
+				public static void foo(Object o) {}
+			}
+			"""
+		);
+
+		CompilationUnit compilUnit = verifyComments(this.workingCopies[0]);
+		List unitComments = compilUnit.getCommentList();
+		assertEquals("Wrong number of comments", 1, unitComments.size());
+
+		Javadoc javadoc = (Javadoc) unitComments.get(0);
+		TagElement snippetTag = getSnippetTag(javadoc);
+		assertNotNull("Snippet tag should be present", snippetTag);
+
+		List<?> fragments = snippetTag.fragments();
+		assertFalse("Snippet should have fragments", fragments.isEmpty());
+		assertTrue("Snippet should contain the statement", ((TextElement) fragments.get(0)).getText().contains("int a = 10;"));
+	}
+
+	public void testSnippetBlankLineInsideBodyJavadoc() throws JavaModelException {
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy(
+			"/Converter_15_1/src/javadoc/X.java",
+			"""
+			package javadoc;
+			public class X {
+				/**
+				 * {@snippet :
+				 *
+				 * int a = 1;
+				 *
+				 * int b = 2;
+				 * }
+				 */
+				public static void foo(Object o) {}
+			}
+			"""
+		);
+
+		CompilationUnit compilUnit = verifyComments(this.workingCopies[0]);
+		List unitComments = compilUnit.getCommentList();
+		assertEquals("Wrong number of comments", 1, unitComments.size());
+
+		Javadoc javadoc = (Javadoc) unitComments.get(0);
+		TagElement snippetTag = getSnippetTag(javadoc);
+		assertNotNull("Snippet tag should be present", snippetTag);
+
+		List<?> fragments = snippetTag.fragments();
+		assertFalse("Snippet should have fragments", fragments.isEmpty());
+
+		assertTrue("Snippet should contain first statement", ((TextElement) fragments.get(1)).getText().contains("int a = 1;"));
+		assertTrue("Snippet should contain second statement", ((TextElement) fragments.get(3)).getText().contains("int b = 2;"));
+	}
+
+	public void testSnippetMultipleAttributesJavadoc() throws JavaModelException {
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy(
+			"/Converter_15_1/src/javadoc/X.java",
+			"""
+			package javadoc;
+			public class X {
+				/**
+				 * {@snippet id="x1" lang=java region="main" :
+				 *   int a;
+				 * }
+				 */
+				public static void foo(Object o) {}
+			}
+			"""
+		);
+
+		CompilationUnit compilUnit = verifyComments(this.workingCopies[0]);
+		List unitComments = compilUnit.getCommentList();
+		assertEquals("Wrong number of comments", 1, unitComments.size());
+
+		Javadoc javadoc = (Javadoc) unitComments.get(0);
+		TagElement snippetTag = getSnippetTag(javadoc);
+		assertNotNull("Snippet tag should be present", snippetTag);
+
+		List<?> fragments = snippetTag.fragments();
+		assertFalse("Snippet should have fragments", fragments.isEmpty());
+		assertTrue("Snippet should contain the statement", ((TextElement) fragments.get(0)).getText().contains("int a;"));
+	}
+
+	public void testSnippetSingleQuoteAttributesJavadoc() throws JavaModelException {
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy(
+			"/Converter_15_1/src/javadoc/X.java",
+			"""
+			package javadoc;
+			public class X {
+				/**
+				 * {@snippet id='demo' lang='java' :
+				 *   int a;
+				 * }
+				 */
+				public static void foo(Object o) {}
+			}
+			"""
+		);
+
+		CompilationUnit compilUnit = verifyComments(this.workingCopies[0]);
+		List unitComments = compilUnit.getCommentList();
+		assertEquals("Wrong number of comments", 1, unitComments.size());
+
+		Javadoc javadoc = (Javadoc) unitComments.get(0);
+		TagElement snippetTag = getSnippetTag(javadoc);
+		assertNotNull("Snippet tag should be present", snippetTag);
+
+		List<?> fragments = snippetTag.fragments();
+		assertFalse("Snippet should have fragments", fragments.isEmpty());
+		assertTrue("Snippet should contain the statement", ((TextElement) fragments.get(0)).getText().contains("int a;"));
+	}
+
+
+	public void testSnippetReplaceTagJavadoc() throws JavaModelException {
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy(
+			"/Converter_15_1/src/javadoc/X.java",
+			"""
+			package javadoc;
+			public class X {
+				/**
+				 * {@snippet :
+				 * System.out.println("abc"); // @replace substring="abc" replacement="xyz"
+				 * }
+				 */
+				public static void foo(Object o) {}
+			}
+			"""
+		);
+
+		CompilationUnit compilUnit = verifyComments(this.workingCopies[0]);
+		List unitComments = compilUnit.getCommentList();
+		assertEquals("Wrong number of comments", 1, unitComments.size());
+
+		Javadoc javadoc = (Javadoc) unitComments.get(0);
+		TagElement snippetTag = getSnippetTag(javadoc);
+		assertNotNull("Snippet tag should be present", snippetTag);
+
+		List<?> fragments = snippetTag.fragments();
+		assertFalse("Snippet should have fragments", fragments.isEmpty());
+		TagElement firstTag = (TagElement) fragments.get(0);
+		assertEquals(
+				"Unexpected tag inside snippet",
+				"@replace",
+				firstTag.getTagName()
+			);
+		List<?> tagFragments = firstTag.fragments();
+		assertFalse("Tag should have inner fragments", tagFragments.isEmpty());
+		TextElement textElement = (TextElement) tagFragments.get(0);
+		assertTrue(
+			    "Snippet should contain System.out.println(\"abc\")",
+			    textElement.getText().contains("System.out.println(\"abc\")")
+			);
+		assertFalse(
+			    "Snippet should contain System.out.println(\"xyz\")",
+			    textElement.getText().contains("System.out.println(\"xyz\")")
+			);
+	}
+
+	public void testSnippetLinkTagJavadoc() throws JavaModelException {
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy(
+			"/Converter_15_1/src/javadoc/X.java",
+			"""
+			package javadoc;
+			public class X {
+				/**
+				 * {@snippet :
+				 * System.out.println("abc"); // @link substring="System" target="System"
+				 * }
+				 */
+				public static void foo(Object o) {}
+			}
+			"""
+		);
+
+		CompilationUnit compilUnit = verifyComments(this.workingCopies[0]);
+		List unitComments = compilUnit.getCommentList();
+		assertEquals("Wrong number of comments", 1, unitComments.size());
+
+		Javadoc javadoc = (Javadoc) unitComments.get(0);
+		TagElement snippetTag = getSnippetTag(javadoc);
+		assertNotNull("Snippet tag should be present", snippetTag);
+
+		List<?> fragments = snippetTag.fragments();
+		assertFalse("Snippet should have fragments", fragments.isEmpty());
+
+		TagElement firstTag = (TagElement) fragments.get(0);
+		assertEquals(
+				"Unexpected tag inside snippet",
+				"@link",
+				firstTag.getTagName()
+			);
+		List<?> tagFragments = firstTag.fragments();
+		assertFalse("Tag should have inner fragments", tagFragments.isEmpty());
+		TextElement textElement = (TextElement) tagFragments.get(0);
+		assertTrue(
+			    "Original text should be preserved in AST",
+			    textElement.getText().contains("System.out.println(\"abc\")")
+			);
+	}
 }


### PR DESCRIPTION
# why
https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5035
ASTConveter javadoc pending tests for the snippet tag 

# What 
This change adds a set of new ASTConverter tests covering previously missing scenarios for the @snippet Javadoc tag introduced in Java 18 (JEP 413).
The tests focus on validating AST‑level parsing behavior (DOM construction) and intentionally avoid doclet/rendering semantics.


The following scenarios are now covered in ASTConverterJavadocTest_18:
• Empty snippet body
• Single‑element snippet
• Multi‑line plain snippet
• Blank lines inside snippet body
• Multiple attributes (id, lang, region)
• Single‑quoted attributes
• Nested code blocks
• @replace markup inside snippet
• @link markup inside snippet


###  Note on {@code} Inside @snippet
A dedicated test for the case:
{@snippet :
 {@code int a = 0;}
}
was intentionally not added.
While JEP 413 specifies that {@code} inside a snippet is treated as plain text, the current ASTConverterJavadocTest_18 infrastructure counts raw @tag tokens during source scanning and expects a matching number of AST TagElements.

tested:
<img width="878" height="445" alt="Screenshot 2026-04-30 at 2 53 16 PM" src="https://github.com/user-attachments/assets/a0dba4a9-bcb4-44ef-b475-2f1311d8fddc" />
