### PR TITLE
Non-optional problem when using TYPE_USE null annotation in constructor call expression

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/NullAnnotationMatching.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/NullAnnotationMatching.java
@@ -348,17 +348,27 @@ public class NullAnnotationMatching {
 						okStatus = okNonNullStatus(providedExpression, localFlow || requiredBits == TagBits.AnnotationNonNull);
 				}
 				if (severity != Severity.MISMATCH && nullStatus != FlowInfo.NULL) {  // null value has no details
-					TypeBinding providedSuper = providedType.findSuperTypeOriginatingFrom(requiredType);
-					TypeBinding providedSubstituteSuper = providedSubstitute != null ? providedSubstitute.findSuperTypeOriginatingFrom(requiredType) : null;
-					if (severity == Severity.UNCHECKED && requiredType.isTypeVariable() && providedType.isTypeVariable() && (providedSuper == requiredType || providedSubstituteSuper == requiredType)) { //$IDENTITY-COMPARISON$
+					TypeBinding providedToCheck = providedType.findSuperTypeOriginatingFrom(requiredType);
+					TypeBinding providedSubstituteToCheck = providedSubstitute != null ? providedSubstitute.findSuperTypeOriginatingFrom(requiredType) : null;
+					if (severity == Severity.UNCHECKED && requiredType.isTypeVariable() && providedType.isTypeVariable() && (providedToCheck == requiredType || providedSubstituteToCheck == requiredType)) { //$IDENTITY-COMPARISON$
 						severity = Severity.OK;
 					}
-					if (providedSuper != providedType) //$IDENTITY-COMPARISON$
-						superTypeHint = providedSuper;
-					if (requiredType.isParameterizedType()  && providedSuper instanceof ParameterizedTypeBinding) { // TODO(stephan): handle providedType.isRaw()
-						TypeBinding[] requiredArguments = ((ParameterizedTypeBinding) requiredType).arguments;
-						TypeBinding[] providedArguments = ((ParameterizedTypeBinding) providedSuper).arguments;
-						TypeBinding[] providedSubstitutes = (providedSubstituteSuper instanceof ParameterizedTypeBinding) ? ((ParameterizedTypeBinding)providedSubstituteSuper).arguments : null;
+					if (providedToCheck != providedType) //$IDENTITY-COMPARISON$
+						superTypeHint = providedToCheck;
+					TypeBinding requiredToCheck = requiredType;
+					if (providedToCheck == null) { // when analyzing a cast expression, supertype search goes the opposite direction:
+						requiredToCheck = requiredType.findSuperTypeOriginatingFrom(providedType);
+						if (requiredToCheck != null) {
+							providedToCheck = providedType;
+							providedSubstituteToCheck = providedSubstitute;
+						} else {
+							requiredToCheck = requiredType;
+						}
+					}
+					if (requiredToCheck.isParameterizedType()  && providedToCheck instanceof ParameterizedTypeBinding) { // TODO(stephan): handle providedType.isRaw()
+						TypeBinding[] requiredArguments = ((ParameterizedTypeBinding) requiredToCheck).arguments;
+						TypeBinding[] providedArguments = ((ParameterizedTypeBinding) providedToCheck).arguments;
+						TypeBinding[] providedSubstitutes = (providedSubstituteToCheck instanceof ParameterizedTypeBinding) ? ((ParameterizedTypeBinding)providedSubstituteToCheck).arguments : null;
 						if (requiredArguments != null && providedArguments != null && requiredArguments.length == providedArguments.length) {
 							for (int i = 0; i < requiredArguments.length; i++) {
 								TypeBinding providedArgSubstitute = providedSubstitutes != null ? providedSubstitutes[i] : null;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/impl/CompilerOptions.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/impl/CompilerOptions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -406,6 +406,7 @@ public class CompilerOptions {
 	public static final int IncompatibleOwningContract = IrritantSet.GROUP3 | ASTNode.Bit2;
 	public static final int UnusedLambdaParameter = IrritantSet.GROUP3 | ASTNode.Bit3;
 	public static final int MemberOfDeprecatedType = IrritantSet.GROUP3 | ASTNode.Bit4;
+	public static final int NullAnnotationUnsupportedLocation = IrritantSet.GROUP3 | ASTNode.Bit5;
 
 
 	// Severity level for handlers
@@ -1213,6 +1214,7 @@ public class CompilerOptions {
 			case PessimisticNullAnalysisForFreeTypeVariables:
 			case NonNullTypeVariableFromLegacyInvocation:
 			case AnnotatedTypeArgumentToUnannotated:
+			case NullAnnotationUnsupportedLocation:
 				return "null"; //$NON-NLS-1$
 			case FallthroughCase :
 				return "fallthrough"; //$NON-NLS-1$

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/impl/IrritantSet.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/impl/IrritantSet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -165,7 +165,8 @@ public class IrritantSet {
 			.set(CompilerOptions.MissingNonNullByDefaultAnnotation)
 			.set(CompilerOptions.PessimisticNullAnalysisForFreeTypeVariables)
 			.set(CompilerOptions.NonNullTypeVariableFromLegacyInvocation)
-			.set(CompilerOptions.AnnotatedTypeArgumentToUnannotated);
+			.set(CompilerOptions.AnnotatedTypeArgumentToUnannotated)
+			.set(CompilerOptions.NullAnnotationUnsupportedLocation);
 
 		RESTRICTION.set(CompilerOptions.DiscouragedReference);
 		STATIC_ACCESS.set(CompilerOptions.NonStaticAccessToStatic);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/impl/IrritantSet.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/impl/IrritantSet.java
@@ -147,7 +147,8 @@ public class IrritantSet {
 		// default errors IF AnnotationBasedNullAnalysis is enabled:
 		COMPILER_DEFAULT_ERRORS.set(
 				CompilerOptions.NullSpecViolation
-				|CompilerOptions.NullAnnotationInferenceConflict);
+				|CompilerOptions.NullAnnotationInferenceConflict)
+			.set(CompilerOptions.NullAnnotationUnsupportedLocation);
 
 		ALL.setAll();
 		HIDING

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
@@ -402,6 +402,11 @@ public static int getIrritant(int problemID) {
 		case IProblem.RecordComponentIncompatibleNullnessVsInheritedAccessor:
 			return CompilerOptions.NullSpecViolation;
 
+		case IProblem.NullAnnotationUnsupportedLocation:
+		case IProblem.NullAnnotationAtQualifyingType:
+		case IProblem.NullAnnotationUnsupportedLocationAtType:
+			return CompilerOptions.NullAnnotationUnsupportedLocation;
+
 		case IProblem.NullNotCompatibleToFreeTypeVariable:
 		case IProblem.NullityMismatchAgainstFreeTypeVariable:
 		case IProblem.UncheckedAccessOfValueOfFreeTypeVariable:
@@ -6225,7 +6230,7 @@ public void nullAnnotationUnsupportedLocation(TypeReference type) {
 	}
 
 	handle(IProblem.NullAnnotationUnsupportedLocationAtType,
-		NoArgument, NoArgument, type.sourceStart, sourceEnd);
+		NoArgument, NoArgument, ProblemSeverities.Error|ProblemSeverities.Fatal, type.sourceStart, sourceEnd);
 }
 private char[][] missingAnalysisAnnotationName(AnnotationBinding[] annotations, LookupEnvironment environment) {
 	for (AnnotationBinding annotationBinding : annotations) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
@@ -6189,7 +6189,7 @@ public void nullAnnotationUnsupportedLocation(Annotation annotation) {
 	String[] shortArguments = new String[] {
 		String.valueOf(annotation.resolvedType.shortReadableName())
 	};
-	int severity = ProblemSeverities.Error | ProblemSeverities.Fatal;
+	int severity = ProblemSeverities.Error;
 	if (annotation.recipient instanceof ReferenceBinding) {
 		if (((ReferenceBinding) annotation.recipient).isAnnotationType())
 			severity = ProblemSeverities.Warning; // special case for https://bugs.eclipse.org/461878
@@ -6206,7 +6206,7 @@ public void nullAnnotationAtQualifyingType(Annotation annotation) {
 	String[] shortArguments = new String[] {
 		String.valueOf(annotation.resolvedType.shortReadableName())
 	};
-	int severity = ProblemSeverities.Error | ProblemSeverities.Fatal;
+	int severity = ProblemSeverities.Error;
 	handle(IProblem.NullAnnotationAtQualifyingType,
 			arguments, shortArguments,
 			severity,
@@ -6230,7 +6230,7 @@ public void nullAnnotationUnsupportedLocation(TypeReference type) {
 	}
 
 	handle(IProblem.NullAnnotationUnsupportedLocationAtType,
-		NoArgument, NoArgument, ProblemSeverities.Error|ProblemSeverities.Fatal, type.sourceStart, sourceEnd);
+		NoArgument, NoArgument, ProblemSeverities.Error, type.sourceStart, sourceEnd);
 }
 private char[][] missingAnalysisAnnotationName(AnnotationBinding[] annotations, LookupEnvironment environment) {
 	for (AnnotationBinding annotationBinding : annotations) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/messages.properties
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/messages.properties
@@ -848,7 +848,7 @@
 960 = Null type safety at method return type: Method descriptor {0} promises ''{1}'' but referenced method provides ''{2}''
 961 = Redundant null check: comparing ''{0}'' against null
 962 = The nullness annotation ''{0}'' is not applicable at this location
-963 = Nullness annotations are not applicable at this location 
+963 = Nullness annotations are not applicable at this location
 964 = Null constraint mismatch: The type ''{1}'' is not a valid substitute for the type parameter ''{0}''
 965 = This nullness annotation conflicts with a ''@{0}'' annotation which is effective on the same type parameter 
 966 = Contradictory null annotations: method was inferred as ''{2} {3}({4})'', but only one of ''@{0}'' and ''@{1}'' can be effective at any location

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullTypeAnnotationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullTypeAnnotationTest.java
@@ -2325,11 +2325,14 @@ public class NullTypeAnnotationTest extends AbstractNullAnnotationTest {
 			"	return (java.util.List<@NonNull X>)arg;\n" +
 			"	       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
 			"Null type safety: Unchecked cast from List<X> to List<@NonNull X>\n" +
+			(this.complianceLevel >= ClassFileConstants.JDK16
+			?
 			"----------\n" +
 			"4. WARNING in p\\X.java (at line 8)\n" +
 			"	return arg;\n" +
 			"	       ^^^\n" +
-			"Null type safety (type annotations): The expression of type \'List<X>\' needs unchecked conversion to conform to \'List<@NonNull X>\'\n" +
+			"Null type safety (type annotations): The expression of type \'List<X>\' needs unchecked conversion to conform to \'List<@NonNull X>\'\n"
+			: "") +
 			"----------\n" +
 			"5. WARNING in p\\X.java (at line 11)\n" +
 			"	if (!(arg instanceof X @NonNull[]))\n" +
@@ -2347,6 +2350,11 @@ public class NullTypeAnnotationTest extends AbstractNullAnnotationTest {
 			"Null type safety: Unchecked cast from X[] to X @NonNull[]\n" +
 			"----------\n" +
 			"8. WARNING in p\\X.java (at line 18)\n" +
+			"	return (ArrayList<String>) l;\n" +
+			"	       ^^^^^^^^^^^^^^^^^^^^^\n" +
+			"Null type safety: Unchecked cast from List<@NonNull String> to ArrayList<String>\n" +
+			"----------\n" +
+			"9. WARNING in p\\X.java (at line 18)\n" +
 			"	return (ArrayList<String>) l;\n" +
 			"	       ^^^^^^^^^^^^^^^^^^^^^\n" +
 			"Null type safety (type annotations): The expression of type \'ArrayList<String>\' needs unchecked conversion to conform to \'ArrayList<@NonNull String>\'\n" +
@@ -19908,5 +19916,67 @@ public void testGH5042() throws Exception {
 		},
 		options,
 		"");
+}
+
+public void testGH5042b() throws Exception {
+	if (this.complianceLevel < ClassFileConstants.JDK16)
+		return;
+	// documents reporting against instanceof and cast
+	runNegativeTestWithLibs(new String[] {
+			"X.java",
+			"""
+			import java.util.Collection;
+			import org.eclipse.jdt.annotation.*;
+			interface MyList<T> extends Collection<T> {
+				T get(int i);
+			}
+			public class X {
+				static @NonNull X casting1(@Nullable Object o) {
+					if (o instanceof @NonNull X)
+						return (@NonNull X) o;
+					throw new NullPointerException();
+				}
+				static @NonNull X instanceofAndCast(Collection<X> l) {
+					if (l instanceof MyList<@NonNull X>)
+						return ((MyList<@NonNull X>) l).get(0);
+					throw new NullPointerException();
+				}
+				static @NonNull X instanceofPattern(Collection<X> l) {
+					if (l instanceof MyList<@NonNull X> lnn)
+						return lnn.get(0);
+					throw new NullPointerException();
+				}
+			}
+			"""
+		},
+		getCompilerOptions(),
+		"""
+		----------
+		1. ERROR in X.java (at line 8)
+			if (o instanceof @NonNull X)
+			                 ^^^^^^^^^^
+		Nullness annotations are not applicable at this location
+		----------
+		2. WARNING in X.java (at line 9)
+			return (@NonNull X) o;
+			       ^^^^^^^^^^^^^^
+		Null type safety: Unchecked cast from @Nullable Object to @NonNull X
+		----------
+		3. ERROR in X.java (at line 13)
+			if (l instanceof MyList<@NonNull X>)
+			                 ^^^^^^^^^^^^^^^^^^
+		Nullness annotations are not applicable at this location
+		----------
+		4. WARNING in X.java (at line 14)
+			return ((MyList<@NonNull X>) l).get(0);
+			       ^^^^^^^^^^^^^^^^^^^^^^^^
+		Null type safety: Unchecked cast from Collection<X> to MyList<@NonNull X>
+		----------
+		6. ERROR in X.java (at line 18)
+			if (l instanceof MyList<@NonNull X> lnn)
+			                 ^^^^^^^^^^^^^^^^^^
+		Nullness annotations are not applicable at this location
+		----------
+		""");
 }
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullTypeAnnotationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullTypeAnnotationTest.java
@@ -2326,22 +2326,27 @@ public class NullTypeAnnotationTest extends AbstractNullAnnotationTest {
 			"	       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
 			"Null type safety: Unchecked cast from List<X> to List<@NonNull X>\n" +
 			"----------\n" +
-			"4. WARNING in p\\X.java (at line 11)\n" +
+			"4. WARNING in p\\X.java (at line 8)\n" +
+			"	return arg;\n" +
+			"	       ^^^\n" +
+			"Null type safety (type annotations): The expression of type \'List<X>\' needs unchecked conversion to conform to \'List<@NonNull X>\'\n" +
+			"----------\n" +
+			"5. WARNING in p\\X.java (at line 11)\n" +
 			"	if (!(arg instanceof X @NonNull[]))\n" +
 			"	     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
 			"The expression of type X[] is already an instance of type X[]\n" +
 			"----------\n" +
-			"5. ERROR in p\\X.java (at line 11)\n" +
+			"6. ERROR in p\\X.java (at line 11)\n" +
 			"	if (!(arg instanceof X @NonNull[]))\n" +
 			"	                     ^^^^^^^^^^^^\n" +
 			"Nullness annotations are not applicable at this location\n" +
 			"----------\n" +
-			"6. WARNING in p\\X.java (at line 12)\n" +
+			"7. WARNING in p\\X.java (at line 12)\n" +
 			"	return (p.X @NonNull[])arg;\n" +
 			"	       ^^^^^^^^^^^^^^^^^^^\n" +
 			"Null type safety: Unchecked cast from X[] to X @NonNull[]\n" +
 			"----------\n" +
-			"7. WARNING in p\\X.java (at line 18)\n" +
+			"8. WARNING in p\\X.java (at line 18)\n" +
 			"	return (ArrayList<String>) l;\n" +
 			"	       ^^^^^^^^^^^^^^^^^^^^^\n" +
 			"Null type safety (type annotations): The expression of type \'ArrayList<String>\' needs unchecked conversion to conform to \'ArrayList<@NonNull String>\'\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullTypeAnnotationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullTypeAnnotationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2012, 2021 GK Software AG and others.
+ * Copyright (c) 2012, 2026 GK Software SE and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -19879,5 +19879,29 @@ public void testGH4494() throws Exception {
 			}
 			"""
 	});
+}
+
+public void testGH5042() throws Exception {
+	Map options = getCompilerOptions();
+	options.put(JavaCore.COMPILER_PB_SUPPRESS_OPTIONAL_ERRORS, JavaCore.ENABLED);
+	runConformTestWithLibs(new String[] {
+			"X.java",
+			"""
+			import org.eclipse.jdt.annotation.*;
+			public class X {
+				@SuppressWarnings("null")
+				static void create(Object o) {
+					@Nullable X x = new @Nullable X();
+					@NonNull X.Inner inner = null;
+					if (o instanceof @Nullable String)
+						System.out.print("nullable string");
+				}
+				class Inner {
+				}
+			}
+			"""
+		},
+		options,
+		"");
 }
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullTypeAnnotationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullTypeAnnotationTest.java
@@ -878,7 +878,7 @@ public class NullTypeAnnotationTest extends AbstractNullAnnotationTest {
 			"1. ERROR in Test.java (at line 9)\n" +
 			"	public void foo( @A X. @NonNull Y this) {}\n" +
 			"	                 ^^^^^^^^^^^^^^^^\n" +
-			"Nullness annotations are not applicable at this location \n" +
+			"Nullness annotations are not applicable at this location\n" +
 			"----------\n");
 	}
 
@@ -2265,7 +2265,7 @@ public class NullTypeAnnotationTest extends AbstractNullAnnotationTest {
 			"2. ERROR in X.java (at line 4)\n" +
 			"	if (!(arg instanceof @NonNull X))\n" +
 			"	                     ^^^^^^^^^^\n" +
-			"Nullness annotations are not applicable at this location \n" +
+			"Nullness annotations are not applicable at this location\n" +
 			"----------\n" +
 			"3. WARNING in X.java (at line 5)\n" +
 			"	return (@NonNull X)arg;\n" +
@@ -2319,7 +2319,7 @@ public class NullTypeAnnotationTest extends AbstractNullAnnotationTest {
 			"2. ERROR in p\\X.java (at line 6)\n" +
 			"	if (!(arg instanceof List<@NonNull X>))\n" +
 			"	                     ^^^^^^^^^^^^^^^^\n" +
-			"Nullness annotations are not applicable at this location \n" +
+			"Nullness annotations are not applicable at this location\n" +
 			"----------\n" +
 			"3. WARNING in p\\X.java (at line 7)\n" +
 			"	return (java.util.List<@NonNull X>)arg;\n" +
@@ -2334,7 +2334,7 @@ public class NullTypeAnnotationTest extends AbstractNullAnnotationTest {
 			"5. ERROR in p\\X.java (at line 11)\n" +
 			"	if (!(arg instanceof X @NonNull[]))\n" +
 			"	                     ^^^^^^^^^^^^\n" +
-			"Nullness annotations are not applicable at this location \n" +
+			"Nullness annotations are not applicable at this location\n" +
 			"----------\n" +
 			"6. WARNING in p\\X.java (at line 12)\n" +
 			"	return (p.X @NonNull[])arg;\n" +
@@ -2367,7 +2367,7 @@ public class NullTypeAnnotationTest extends AbstractNullAnnotationTest {
 			"1. ERROR in X.java (at line 5)\n" +
 			"	return o instanceof List<@Nullable ?>;\n" +
 			"	                    ^^^^^^^^^^^^^^^^^\n" +
-			"Nullness annotations are not applicable at this location \n" +
+			"Nullness annotations are not applicable at this location\n" +
 			"----------\n");
 	}
 
@@ -2411,7 +2411,7 @@ public class NullTypeAnnotationTest extends AbstractNullAnnotationTest {
 			"1. ERROR in X.java (at line 3)\n" +
 			"	void receiver(@Nullable X this, Object o) {}\n" +
 			"	              ^^^^^^^^^^^\n" +
-			"Nullness annotations are not applicable at this location \n" +
+			"Nullness annotations are not applicable at this location\n" +
 			"----------\n");
 	}
 
@@ -2435,12 +2435,12 @@ public class NullTypeAnnotationTest extends AbstractNullAnnotationTest {
 			"1. ERROR in X.java (at line 7)\n" +
 			"	consume(@NonNull X::supply);\n" +
 			"	        ^^^^^^^^^^\n" +
-			"Nullness annotations are not applicable at this location \n" +
+			"Nullness annotations are not applicable at this location\n" +
 			"----------\n" +
 			"2. ERROR in X.java (at line 8)\n" +
 			"	consume(@NonNull X::new);\n" +
 			"	        ^^^^^^^^^^\n" +
-			"Nullness annotations are not applicable at this location \n" +
+			"Nullness annotations are not applicable at this location\n" +
 			"----------\n");
 	}
 
@@ -2464,12 +2464,12 @@ public class NullTypeAnnotationTest extends AbstractNullAnnotationTest {
 			"1. ERROR in X.java (at line 4)\n" +
 			"	void throwsDecl() throws @Nullable IOException {}\n" +
 			"	                         ^^^^^^^^^^^^^^^^^^^^^\n" +
-			"Nullness annotations are not applicable at this location \n" +
+			"Nullness annotations are not applicable at this location\n" +
 			"----------\n" +
 			"2. ERROR in X.java (at line 8)\n" +
 			"	} catch (@NonNull IOException ioe) {}\n" +
 			"	                  ^^^^^^^^^^^\n" +
-			"Nullness annotations are not applicable at this location \n" +
+			"Nullness annotations are not applicable at this location\n" +
 			"----------\n");
 	}
 
@@ -8528,7 +8528,7 @@ public void testBug466713d() {
 		"2. ERROR in Bug.java (at line 3)\n" +
 		"	return o instanceof java.util.Iterator<java.lang. @MyAnnot @org.eclipse.jdt.annotation.Nullable String>;\n" +
 		"	                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
-		"Nullness annotations are not applicable at this location \n" +
+		"Nullness annotations are not applicable at this location\n" +
 		"----------\n",
 		this.LIBS,
 		true/*flush*/);


### PR DESCRIPTION
+ allow the problem to be suppressed with token "null"
+ remove Fatal flag from errors re unsupported null-annotation location
+ improve analysis for casts to null annotated parameterized type

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5042