### PR TITLE
Stop using stCarolas/setup-maven

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,10 +38,6 @@ jobs:
           JavaSE-21
           JavaSE-25
         distribution: 'temurin'
-    - name: Set up Maven
-      uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1 # v5
-      with:
-        maven-version: 3.9.12
     - name: Build with Maven 🏗️
       run: |
         mvn clean install --batch-mode -f org.eclipse.jdt.core.compiler.batch -DlocalEcjVersion=99.99


### PR DESCRIPTION
* Ubuntu image used already includes Maven
* Maven version in it is more actively than this gha
* Using "sha #v5" makes dependabot not handle updates of the setup-maven and thus it's stuck to v 5.0.0 and uses deprecated Node.js 20

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
