### PR TITLE
VerifyError: Instruction type does not match stack map - Regression in String-switch dispatch for methods exceeding 32 KB

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
@@ -925,7 +925,7 @@ public class SwitchStatement extends Expression {
 				this.swich.breakLabel.initialize(codeStream);
 				this.caseLabels = new BranchLabel[this.swich.nConstants];
 				gatherLabels(codeStream, BranchLabel::new);
-				this.swich.defaultLabel = new CaseLabel(codeStream, true /* allow narrow branch to */);
+				this.swich.defaultLabel = new CaseLabel(codeStream, true /* reachable also via goto[_w] */);
 				if (this.swich.defaultCase != null)
 					this.swich.defaultCase.targetLabel = this.swich.defaultLabel; // Replace the vanilla branch label with a case label that doubles as a branch label.
 			}
@@ -980,7 +980,7 @@ public class SwitchStatement extends Expression {
 					if (i == 0 || hashCode != lastHashCode) {
 						lastHashCode = hashCode;
 						if (i != 0)
-							codeStream.goto_(this.swich.defaultLabel);
+							codeStream.goto_(this.swich.defaultLabel.branchLabel);
 						this.caseLabels[j++].place();
 					}
 					codeStream.load(this.swich.selector);
@@ -988,7 +988,7 @@ public class SwitchStatement extends Expression {
 					codeStream.invokeStringEquals();
 					codeStream.ifne(this.stringCaseConstants[i].label);
 				}
-				codeStream.goto_(this.swich.defaultLabel);
+				codeStream.goto_(this.swich.defaultLabel.branchLabel);
 			}
 		}
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/CaseLabel.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/CaseLabel.java
@@ -16,15 +16,15 @@ package org.eclipse.jdt.internal.compiler.codegen;
 public class CaseLabel extends BranchLabel {
 
 	public int instructionPosition = POS_NOT_SET;
-	private BranchLabel branchLabel; // doppelganger
+	public BranchLabel branchLabel; // doppelganger label useful in situations where the location can be reached via a goto or goto_w. The CaseLabel itself is reachable only by switch
 
 public CaseLabel(CodeStream codeStream) {
 	super(codeStream);
 }
 
-public CaseLabel(CodeStream codeStream, boolean allowNarrowBranch) {
+public CaseLabel(CodeStream codeStream, boolean reachableViaGoto) {
 	super(codeStream);
-	if (allowNarrowBranch)
+	if (reachableViaGoto)
 		this.branchLabel = new BranchLabel(codeStream);
 }
 

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/XLargeTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/XLargeTest.java
@@ -2041,6 +2041,49 @@ public void testIssue1359() {
 			"The operand stack is exceeding the 65535 bytes limit\n" +
 			"----------\n");
 }
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5020
+// VerifyError: Instruction type does not match stack map - Regression in String-switch dispatch for methods exceeding 32 KB
+public void testIssue5020() {
+	StringBuilder sourceCode = new StringBuilder(
+			"""
+			public class X {
+			    public int run(String label) {
+			        int x = 0; int y = 0;
+			        loop: while (true) {
+			            switch (label) {
+			                default:
+			                case "A":
+
+			""");
+
+	for (int i = 0; i < 49; i++) {
+		for (int j = 0; j < 100; j++)
+			sourceCode.append("\t\t		x += " + j + "; y = x ^ y;\n");
+	}
+	sourceCode.append(
+			"""
+			    				label = "B";
+			                    continue loop;
+			                case "B":
+			                    return x + y;
+			            }
+			        }
+			    }
+			    public static void main(String[] args) {
+			        System.out.println(new X().run("A"));
+			    }
+			}
+			""");
+
+
+	this.runConformTest(
+			new String[] {
+					"X.java",
+					sourceCode.toString()
+			},
+			"413914");
+
+}
 public static Class testClass() {
 	return XLargeTest.class;
 }


### PR DESCRIPTION


* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5020

