### PR TITLE
Enable DeltaProcessor debug mode in TypeHierarchyNotificationTests

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/TypeHierarchyNotificationTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/TypeHierarchyNotificationTests.java
@@ -28,6 +28,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.jdt.core.*;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
+import org.eclipse.jdt.internal.core.DeltaProcessor;
 
 public class TypeHierarchyNotificationTests extends ModifyingResourceTests implements ITypeHierarchyChangedListener {
 	/**
@@ -111,6 +112,7 @@ protected void setUp() throws Exception {
 	super.setUp();
 	reset();
 	this.setUpJavaProject("TypeHierarchyNotification", CompilerOptions.getFirstSupportedJavaVersion());
+	DeltaProcessor.DEBUG = true;
 }
 static {
 //	TESTS_NAMES= new String[] { "testAddExtendsSourceType3" };
@@ -120,6 +122,7 @@ public static Test suite() {
 }
 @Override
 protected void tearDown() throws Exception {
+	DeltaProcessor.DEBUG = false;
 	this.deleteProject("TypeHierarchyNotification");
 	super.tearDown();
 }


### PR DESCRIPTION
`TypeHierarchyNotificationTests` fails infrequently with missing deltas. This change enables debug mode in `DeltaProcessor`, to hopefully record non-main threads sending notifications, causing a race condition.

See: https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5040
