### PR TITLE
Total IDE freeze during type inference of recursive generic type

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BoundSet.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BoundSet.java
@@ -867,12 +867,19 @@ class BoundSet {
 
 	private ConstraintTypeFormula combineEqualSupers(TypeBound boundS, TypeBound boundT) {
 		//  more permutations of: S <: α and α <: T imply ⟨S <: T⟩
+		boolean outerSame = false;
+		boolean innerSame = false;
 		if (TypeBinding.equalsEquals(boundS.left, boundT.right))
-			// came in as: α REL S and T REL α imply ⟨T REL S⟩
-			return ConstraintTypeFormula.create(boundT.left, boundS.right, boundS.relation, boundT.isSoft||boundS.isSoft);
+			outerSame = true; // came in as: α REL S and T REL α imply ⟨T REL S⟩
 		if (TypeBinding.equalsEquals(boundS.right, boundT.left))
-			// came in as: S REL α and α REL T imply ⟨S REL T⟩
+			innerSame = true; // came in as: S REL α and α REL T imply ⟨S REL T⟩
+		if (outerSame) {
+			if (innerSame) // NON-JLS bidirectional subtyping implies equality:
+				return ConstraintTypeFormula.create(boundS.left, boundS.right, ReductionResult.SAME, false);
+			return ConstraintTypeFormula.create(boundT.left, boundS.right, boundS.relation, boundT.isSoft||boundS.isSoft);
+		} else if (innerSame) {
 			return ConstraintTypeFormula.create(boundS.left, boundT.right, boundS.relation, boundT.isSoft||boundS.isSoft);
+		}
 		return null;
 	}
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeBound.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeBound.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2018 GK Software AG and others.
+ * Copyright (c) 2013, 2026 GK Software SE and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -88,7 +88,10 @@ public class TypeBound extends ReductionResult {
 		buf.append(isBound ? "TypeBound  " : "Dependency "); //$NON-NLS-1$ //$NON-NLS-2$
 		buf.append(this.left.sourceName);
 		buf.append(relationToString(this.relation));
-		buf.append(this.right.readableName());
+		if (this.right instanceof CaptureBinding18)
+			buf.append(this.right.toString());
+		else
+			buf.append(this.right.readableName());
 		return buf.toString();
 	}
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
@@ -2074,6 +2074,36 @@ public void testIssue4864() {
 	});
 }
 
+public void testGH5052() {
+	runConformTest(new String[] {
+			"Freeze.java",
+			"""
+			import java.util.function.Function;
+
+			public class Freeze {
+				interface Ifc<S> {}
+				class Val implements Ifc<Val> {}
+
+				public static void main(String... args) {
+					Val v = null; // specific value doesn't matter here
+					consume(v, t -> someMapper(t));
+				}
+
+				static <T> void consume(T t, Function<T,T> mapper) {
+					mapper.apply(null);
+					System.out.print("consume");
+					// impl doesn't matter here
+				}
+
+				static <U extends Ifc<U>> U someMapper(U u) {
+					System.out.print("map.");
+					return null; // impl doesn't matter here
+				}
+			}
+			"""
+		},
+		"map.consume");
+}
 public static Class<GenericsRegressionTest_9> testClass() {
 	return GenericsRegressionTest_9.class;
 }


### PR DESCRIPTION
+ invent new incorporation rule: `S#0 <: T#1` && `S#0 :> T#1` => `S#0 = T#1`
+ change in TypeBound is only for improved debugging support

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5052
