### PR TITLE
Normalize line separators in assertions

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterJavadocTest_18.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterJavadocTest_18.java
@@ -1081,8 +1081,8 @@ public class ASTConverterJavadocTest_18 extends ConverterTestSetup {
 		TagElement snippetTag = getSnippetTag(javadoc);
 		List<TextElement> snippetFrags = snippetTag.fragments();
 		assertEquals("Invalid snippet elements", 3, snippetFrags.size());
-		assertEquals("Incorrect content for firstElemnt", " 	int a = 1;\n", snippetFrags.get(0).getText());
-		assertEquals("Incorrect content for secondElemnt", " 	int b = 2;\n", snippetFrags.get(1).getText());
+		assertEquals("Incorrect content for firstElemnt", " 	int a = 1;\n", snippetFrags.get(0).getText().replaceAll("\\R", "\n"));
+		assertEquals("Incorrect content for secondElemnt", " 	int b = 2;\n", snippetFrags.get(1).getText().replaceAll("\\R", "\n"));
 
 	}
 


### PR DESCRIPTION
This fixes the failure reported in https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5057, where
ASTConverterJavadocTest_18.testSnippetMultilineOnlyJavadoc5 was failing in Windows

Updated the test assertions to normalize line separators using \\R → \n before comparison ensuring consistent behaviour across all environments.