### PR TITLE
Fix Signature to check context before converting $ to dot

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/SignatureTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/SignatureTests.java
@@ -1598,6 +1598,15 @@ public void testCreateIntersectionTypeSignature2() {
 			Signature.getIntersectionTypeBounds(signature)
 		);
 }
+
+public void testDollarPackage() {
+	String signature = Signature.getTypeErasure("Ljava.util.$foo$.Optional");
+	assertEquals(
+			"Ljava.util.$foo$.Optional",
+			new String(signature.toCharArray())
+			);
+}
+
 // Bug 380048 - error popup when navigating to source files
 public void testSourceMapperSigConversion01() {
 	SourceMapper mapper = new SourceMapper();

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/core/Signature.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/core/Signature.java
@@ -638,6 +638,8 @@ private static int appendClassTypeSignature(char[] string, int start, boolean fu
 			throw newIllegalArgumentException(string, start);
 		}
 		c = string[p];
+		char prevC = string[p - 1];
+		char nextC = p < string.length - 1 ? string[p + 1] : 0;
 		switch(c) {
 			case C_SEMICOLON :
 				// all done
@@ -668,15 +670,19 @@ private static int appendClassTypeSignature(char[] string, int start, boolean fu
 			 	innerTypeStart = buffer.length();
 			 	inAnonymousType = false;
 			 	if (resolved) {
-					// once we hit "$" there are no more package prefixes
-					removePackageQualifiers = false;
-					/**
-					 * Convert '$' in resolved type signatures into '.'.
-					 * NOTE: This assumes that the type signature is an inner type
-					 * signature. This is true in most cases, but someone can define a
-					 * non-inner type name containing a '$'.
-					 */
-					buffer.append('.');
+			 		if (prevC == C_DOT || nextC == C_DOT) {
+			 			buffer.append('$');
+			 		} else {
+			 			// once we hit "$" there are no more package prefixes
+			 			removePackageQualifiers = false;
+			 			/**
+			 			 * Convert '$' in resolved type signatures into '.'.
+			 			 * NOTE: This assumes that the type signature is an inner type
+			 			 * signature. This is true in most cases, but someone can define a
+			 			 * non-inner type name containing a '$'.
+			 			 */
+			 			buffer.append('.');
+			 		}
 			 	}
 			 	break;
 			 default :


### PR DESCRIPTION
- add a check in Signature.appendClassTypeSignature to see if a $ is preceded or followed by a dot before assuming it is an inner class and not part of a package name
- add new test to SignatureTests
- for https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5056

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See referenced issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See referenced issue.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
