### PR TITLE
Wait for RefreshJob before waiting on indexer in ModifyingResourceTests.createFile()

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ModifyingResourceTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ModifyingResourceTests.java
@@ -168,6 +168,11 @@ protected void createExternalFile(String relativePath, String contents) {
 protected IFile createFile(String path, byte[] content) throws CoreException {
 	IFile file = super.createFile(path, content);
 	if(!isIndexDisabledForTest()) {
+		/*
+		 * Its possible that the RefreshJob picks up the file delta and requests indexing,
+		 * instead of the main thread (in which tests run). Make sure we don't miss that index request in the wait below.
+		 */
+		waitForAutoRefresh();
 		JavaModelManager.getIndexManager().waitForIndex(false, null);
 	}
 	return file;


### PR DESCRIPTION
Latest test logs from failures in `JavaSearchBugsTests2` show that `RefreshJob` can request indexing of test files in parallel to the main thread. Likely the `RefreshJob` picks up the delta first and the main thread finishes waiting before the indexing request is sent by `RefreshJob`.

This change adds waiting on `RefreshJob` before waiting on indexing, to hopefully prevent the test from not waiting on the index request.

See: https://github.com/eclipse-jdt/eclipse.jdt.core/issues/421