### PR TITLE
Trace resetting project preferences

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/rewrite/describing/ASTRewritingStatementsTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/rewrite/describing/ASTRewritingStatementsTest.java
@@ -25,6 +25,7 @@ import org.eclipse.jdt.core.dom.rewrite.ListRewrite;
 import org.eclipse.jdt.core.formatter.CodeFormatter;
 import org.eclipse.jdt.core.formatter.DefaultCodeFormatterConstants;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
+import org.eclipse.jdt.internal.core.JavaModelManager;
 import org.eclipse.jdt.internal.core.dom.rewrite.ASTRewriteFormatter;
 import org.eclipse.jface.text.Document;
 import org.eclipse.text.edits.TextEdit;
@@ -44,6 +45,18 @@ public class ASTRewritingStatementsTest extends ASTRewritingTest {
 
 	public static Test suite() {
 		return createSuite(ASTRewritingStatementsTest.class);
+	}
+
+	@Override
+	public void setUpSuite() throws Exception {
+		super.setUpSuite();
+		JavaModelManager.VERBOSE = true;
+	}
+
+	@Override
+	public void tearDownSuite() throws Exception {
+		JavaModelManager.VERBOSE = false;
+		super.tearDownSuite();
 	}
 
 	@SuppressWarnings("deprecation")

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelManager.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelManager.java
@@ -4328,6 +4328,16 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 			IProject project = javaProject.getProject();
 			PerProjectInfo info= this.perProjectInfos.get(project);
 			if (info != null) {
+				if (VERBOSE) {
+					StringBuilder buffer = new StringBuilder();
+					buffer.append('(');
+					buffer.append(Thread.currentThread());
+					buffer.append(')');
+					buffer.append(" JavaModelManager.resetProjectPreferences("); //$NON-NLS-1$
+					buffer.append(project.getName());
+					buffer.append(')');
+					trace(buffer.toString());
+				}
 				info.preferences = null;
 			}
 		}


### PR DESCRIPTION
Add tracing for `JavaModelManagerresetProjectPreferences()` during `ASTRewritingStatementsTest`, so that logs contain which thread resets `PerProjectInfo.preferences`.
This should help with analyzing sporadic failures for missing project preferences.

See: https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5071
