### PR TITLE
Tweak new signature logic that checks context of dollar

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/SignatureTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/SignatureTests.java
@@ -1600,9 +1600,17 @@ public void testCreateIntersectionTypeSignature2() {
 }
 
 public void testDollarPackage() {
-	String signature = Signature.getTypeErasure("Ljava.util.$foo$.Optional");
+	String signature = new String(Signature.toCharArray(new String("Ljava.util.$foo$.Optional;").toCharArray()));
 	assertEquals(
-			"Ljava.util.$foo$.Optional",
+			"java.util.$foo$.Optional",
+			new String(signature.toCharArray())
+			);
+}
+
+public void testDollarPackageDollarClass() {
+	String signature = new String(Signature.toCharArray(new String("Ljava.util.$foo$.$Optional;").toCharArray()));
+	assertEquals(
+			"java.util.$foo$..Optional",
 			new String(signature.toCharArray())
 			);
 }

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/core/Signature.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/core/Signature.java
@@ -667,24 +667,39 @@ private static int appendClassTypeSignature(char[] string, int start, boolean fu
 				}
 				break;
 			 case C_DOLLAR :
-			 	innerTypeStart = buffer.length();
-			 	inAnonymousType = false;
-			 	if (resolved) {
-			 		if (prevC == C_DOT || nextC == C_DOT) {
-			 			buffer.append('$');
-			 		} else {
-			 			// once we hit "$" there are no more package prefixes
-			 			removePackageQualifiers = false;
-			 			/**
-			 			 * Convert '$' in resolved type signatures into '.'.
-			 			 * NOTE: This assumes that the type signature is an inner type
-			 			 * signature. This is true in most cases, but someone can define a
-			 			 * non-inner type name containing a '$'.
-			 			 */
-			 			buffer.append('.');
-			 		}
-			 	}
-			 	break;
+				 if (nextC == C_DOT) {
+					 buffer.append('$');
+				 } else {
+					 boolean foundDotAfterDollar = false;
+					 if (prevC == C_DOT) {
+						 int i = p + 1;
+						 // check to see if we have dollar as part of package or class
+						 while (i < string.length) {
+							 if (string[i++] == C_DOT) {
+								 foundDotAfterDollar = true;
+								 break;
+							 }
+						 }
+					 }
+					 if (foundDotAfterDollar) {
+						 buffer.append('$');
+						 break;
+					 }
+					 innerTypeStart = buffer.length();
+					 inAnonymousType = false;
+					 if (resolved) {
+						 // once we hit "$" there are no more package prefixes
+						 removePackageQualifiers = false;
+						 /**
+						  * Convert '$' in resolved type signatures into '.'.
+						  * NOTE: This assumes that the type signature is an inner type
+						  * signature. This is true in most cases, but someone can define a
+						  * non-inner type name containing a '$'.
+						  */
+						 buffer.append('.');
+					 }
+				 }
+				 break;
 			 default :
 				if (innerTypeStart != -1 && !inAnonymousType && Character.isDigit(c)) {
 					inAnonymousType = true;


### PR DESCRIPTION
- modify Signature.appendClassTypeSignature() logic for the
  last segment to use the old logic as it appears there is other
  code that is not prepared for the dollar being part of the class
  name and expects the dollar being converted to dot

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See commit message.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See #5064 comments.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
