### PR TITLE
Fix incorrect parsing of multiline inline Javadoc tags containing @

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/AbstractCommentParser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/AbstractCommentParser.java
@@ -181,6 +181,7 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 			boolean isDomParser = (this.kind & DOM_PARSER) != 0;
 			boolean isFormatterParser = (this.kind & FORMATTER_COMMENT_PARSER) != 0;
 			int lastStarPosition = -1;
+			boolean annotationAtSymbolHandling = false;
 
 			// Init scanner position
 			this.markdown = this.source[this.javadocStart + 1] == '/';
@@ -260,7 +261,7 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 						// https://bugs.eclipse.org/bugs/show_bug.cgi?id=206345: ignore all tags when inside @literal or @code tags
 						if (considerTagAsPlainText || this.markdownHelper.isInCode()) {
 							// new tag found
-							if (!this.lineStarted) {
+							if (!this.lineStarted && !checkInlineTagForAnnotaion()) {
 								// we may want to report invalid syntax when no closing brace found,
 								// or when incoherent number of closing braces found
 								if (openingBraces > 0 && this.reportProblems) {
@@ -341,9 +342,10 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 								textEndPosition = previousPosition;
 							}
 							if (this.textStart != -1 && this.textStart < textEndPosition) {
-								pushText(this.textStart, textEndPosition);
+								pushText(annotationAtSymbolHandling ? this.textStart - 1 : this.textStart, textEndPosition);
 							}
 						}
+						annotationAtSymbolHandling = false;
 						this.lineStarted = false;
 						lineHasStar = false;
 						// Fix bug 51650
@@ -529,6 +531,9 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 						if (!this.lineStarted || this.textStart == -1) {
 							this.textStart = previousPosition;
 						}
+						if (previousChar == '@' && checkInlineTagForAnnotaion()) {
+							annotationAtSymbolHandling = true;
+						}
 						this.lineStarted = true;
 						textEndPosition = this.index;
 						break;
@@ -588,6 +593,10 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 	        pos--;
 	    }
 	    return false;
+	}
+
+	protected boolean checkInlineTagForAnnotaion() {
+		return (this.tagValue == TAG_SNIPPET_VALUE || this.tagValue == TAG_CODE_VALUE || this.tagValue == TAG_LITERAL_VALUE);
 	}
 
 	protected void addFragmentToInlineReturn() {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterJavadocTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterJavadocTest.java
@@ -3690,4 +3690,86 @@ public class ASTConverterJavadocTest extends ConverterTestSetup {
 		assumeEquals("Invalid eighth TextElement content","}" , textFrags.get(7).getText());
 		assumeEquals("Invalid nineth TextElement content","return -1;" , textFrags.get(8).getText());
 	}
+
+	public void testJavadocIncorrectlyParsingAnnotationInlineTag5055_01() throws JavaModelException {
+		this.workingCopies = new ICompilationUnit[1];
+		this.astLevel = AST.JLS25;
+		this.workingCopies[0] = getWorkingCopy("/Converter25/src/javadoc/Javadoc.java",
+			"""
+			  /**
+			   * Example showing formatter bug with {@code @} in pre blocks.
+			   *
+			   * <pre>
+			   * {@code
+			   * @MyAnnotation
+			   * public class Example {
+			   *	 @AnotherAnnotation
+			   *     private String field;
+			   * }
+			   * }
+			   * </pre>
+			   */
+			   public class Javadoc{}
+			"""
+		);
+		CompilationUnit compilUnit = (CompilationUnit) runConversion(this.workingCopies[0], true);
+		List unitComments = compilUnit.getCommentList();
+		assertEquals("Wrong number of comments", 1, unitComments.size());
+		Comment comment = (Comment) unitComments.get(0);
+		assertEquals("Comment should be javadoc", comment.getNodeType(), ASTNode.JAVADOC);
+		Javadoc docComment = (Javadoc) compilUnit.getCommentList().get(0);
+		assumeEquals("wrong number of tags", 1, docComment.tags().size());
+		TagElement parentTag = (TagElement) docComment.tags().get(0);
+		List<?> frags = parentTag.fragments();
+		assumeEquals("wrong number of Parent elements", 1, docComment.tags().size());
+		TagElement firstInnerTag = (TagElement) frags.get(1);
+		TagElement secondInnerTag = (TagElement) frags.get(4);
+		assertTrue(firstInnerTag.getNodeType() == ASTNode.TAG_ELEMENT && firstInnerTag.toString().contains("{@code @}"));
+		assertTrue(secondInnerTag.getNodeType() == ASTNode.TAG_ELEMENT);
+		List<TextElement> innerFrags = secondInnerTag.fragments();
+		assumeEquals("wrong number of Child elements", 5, innerFrags.size());
+		assumeEquals("Incorrect child content", "@MyAnnotation", innerFrags.get(0).getText());
+		assumeEquals("Incorrect child content", "@AnotherAnnotation", innerFrags.get(2).getText());
+	}
+
+	public void testJavadocIncorrectlyParsingAnnotationInlineTag5055_02() throws JavaModelException {
+		this.workingCopies = new ICompilationUnit[1];
+		this.astLevel = AST.JLS25;
+		this.workingCopies[0] = getWorkingCopy("/Converter25/src/javadoc/Javadoc.java",
+			"""
+			  /**
+			   * Example showing formatter bug with {@code @} in pre blocks.
+			   *
+			   * <pre>
+			   * {@literal
+			   * @MyAnnotation
+			   * public class Example {
+			   *	 @AnotherAnnotation
+			   *     private String field;
+			   * }
+			   * }
+			   * </pre>
+			   */
+			   public class Javadoc{}
+			"""
+		);
+		CompilationUnit compilUnit = (CompilationUnit) runConversion(this.workingCopies[0], true);
+		List unitComments = compilUnit.getCommentList();
+		assertEquals("Wrong number of comments", 1, unitComments.size());
+		Comment comment = (Comment) unitComments.get(0);
+		assertEquals("Comment should be javadoc", comment.getNodeType(), ASTNode.JAVADOC);
+		Javadoc docComment = (Javadoc) compilUnit.getCommentList().get(0);
+		assumeEquals("wrong number of tags", 1, docComment.tags().size());
+		TagElement parentTag = (TagElement) docComment.tags().get(0);
+		List<?> frags = parentTag.fragments();
+		assumeEquals("wrong number of Parent elements", 1, docComment.tags().size());
+		TagElement firstInnerTag = (TagElement) frags.get(1);
+		TagElement secondInnerTag = (TagElement) frags.get(4);
+		assertTrue(firstInnerTag.getNodeType() == ASTNode.TAG_ELEMENT && firstInnerTag.toString().contains("{@code @}"));
+		assertTrue(secondInnerTag.getNodeType() == ASTNode.TAG_ELEMENT);
+		List<TextElement> innerFrags = secondInnerTag.fragments();
+		assumeEquals("wrong number of Child elements", 5, innerFrags.size());
+		assumeEquals("Incorrect child content", "@MyAnnotation", innerFrags.get(0).getText());
+		assumeEquals("Incorrect child content", "@AnotherAnnotation", innerFrags.get(2).getText());
+	}
 }

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterJavadocTest_18.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterJavadocTest_18.java
@@ -724,7 +724,8 @@ public class ASTConverterJavadocTest_18 extends ConverterTestSetup {
 			// Verify javdoc tags positions and bindings
 			if (comment.isDocComment()) {
 				Javadoc docComment = (Javadoc)comment;
-				assumeEquals(this.prefix+"Invalid tags number in javadoc:\n"+docComment+"\n", tags.size(), allTags(docComment));
+				int counter = (int) tags.stream().filter(s -> s != null && !((String) s).trim().isEmpty()).count();
+				assumeEquals(this.prefix+"Invalid tags number in javadoc:\n"+docComment+"\n", counter, allTags(docComment));
 			}
 		}
 
@@ -1367,5 +1368,37 @@ public class ASTConverterJavadocTest_18 extends ConverterTestSetup {
 			    "Original text should be preserved in AST",
 			    textElement.getText().contains("System.out.println(\"abc\")")
 			);
+	}
+
+	public void testJavadocIncorrectlyParsingAnnotationInlineTag5055() throws JavaModelException {
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy(
+			"/Converter_15_1/src/javadoc/X.java",
+			"""
+			package javadoc;
+			public class X {
+				/**
+				 * {@snippet :
+				 * @MyAnnotation
+				 * public class Example {
+				 *     @AnotherAnnotation
+				 *     private String field;
+				 * }
+				 * }
+				 */
+				public static void foo(Object o) {}
+			}
+			"""
+		);
+		CompilationUnit compilUnit = verifyComments(this.workingCopies[0]);
+		List unitComments = compilUnit.getCommentList();
+		assertEquals("Wrong number of comments", 1, unitComments.size());
+
+		Javadoc javadoc = (Javadoc) unitComments.get(0);
+		TagElement snippetTag = getSnippetTag(javadoc);
+		List<TextElement> frags = snippetTag.fragments();
+		assertEquals("Invalid snippet fragments", 6, frags.size());
+		assertEquals("Invalid content for first Element", " @MyAnnotation\n", frags.get(0).getText());
+		assertEquals("Invalid content for third Element", "     @AnotherAnnotation\n", frags.get(2).getText());
 	}
 }

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterMarkdownSnippetTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterMarkdownSnippetTest.java
@@ -594,6 +594,7 @@ public class ASTConverterMarkdownSnippetTest extends ConverterTestSetup {
 					/// {@snippet :
 					///   {@code int a = 0;}
 					/// }
+					public class Markdown {}
 				""";
 		this.workingCopies = new ICompilationUnit[1];
 		this.workingCopies[0] = getWorkingCopy("/Converter_26/src/markdown/Markdown.java", source, null);
@@ -607,6 +608,33 @@ public class ASTConverterMarkdownSnippetTest extends ConverterTestSetup {
 			List<TextElement> frags = snippetTag.fragments();
 			assertEquals("Fragments should be 1", 1, frags.size());
 			assertEquals("Incorrect text content", "   {@code int a = 0;}", frags.get(0).getText());
+		}
+	}
+
+	// this is an invalid test, should be corrected later(https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5075)
+	public void testJavadocIncorrectlyParsingAnnotationInlineTag5055() throws JavaModelException {
+		String source = """
+				/// Example showing formatter bug with {@code @} in snippet blocks.
+				/// {@snippet :
+				/// 	@MyAnnotation
+				///		public class Example {
+				///			@AnotherAnnotation
+				///			private String field;
+				///		}
+				/// }
+				public class Markdown {}
+			""";
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy("/Converter_26/src/markdown/Markdown.java", source, null);
+		if (this.docCommentSupport.equals(JavaCore.ENABLED)) {
+			CompilationUnit compilUnit = verifyComments(this.workingCopies[0]);
+			List unitComments = compilUnit.getCommentList();
+			int size = unitComments.size();
+			assertEquals("Wrong number of comments", 1, size);
+			Javadoc javadoc = (Javadoc) unitComments.get(0);
+			TagElement snippetTag = getSnippetTag(javadoc);
+			assertFalse("Wrong number of elements", snippetTag.fragments().size() == 5);
+			System.out.println("sasi");
 		}
 	}
 }

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterMarkdownTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterMarkdownTest.java
@@ -2433,4 +2433,64 @@ public class ASTConverterMarkdownTest extends ConverterTestSetup {
 			assertEquals("Invalid content", "**Bold**", ((TextElement)frags.get(0)).getText());
 		}
 	}
+
+	public void testJavadocIncorrectlyParsingAnnotationInlineTag5055_01() throws JavaModelException {
+		String source = """
+				/// Example showing formatter bug with {@code @} in pre blocks.
+				///
+				/// <pre>
+				/// {@code
+				/// @MyAnnotation
+				/// public class Example {
+				/// 	@AnotherAnnotation
+				/// 	private String field;
+				/// }
+				/// }
+				/// </pre>
+				public class Markdown {}
+				""";
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy("/Converter_25/src/markdown/Markdown.java", source, null);
+		if (this.docCommentSupport.equals(JavaCore.ENABLED)) {
+			CompilationUnit compilUnit = (CompilationUnit) runConversion(this.workingCopies[0], true);
+			TypeDeclaration typedeclaration =  (TypeDeclaration) compilUnit.types().get(0);
+			Javadoc javadoc = typedeclaration.getJavadoc();
+			TagElement parentTag = (TagElement)javadoc.tags().get(0);
+			List<?> frags = parentTag.fragments();
+			assumeEquals("wrong number of Child elements", 6, frags.size());
+			List<TextElement> innerFrags = ((TagElement) frags.get(4)).fragments();
+			assumeEquals("Incorrect child content", "@MyAnnotation", innerFrags.get(0).getText());
+			assumeEquals("Incorrect child content", "	@AnotherAnnotation", innerFrags.get(2).getText());
+		}
+	}
+
+	public void testJavadocIncorrectlyParsingAnnotationInlineTag5055_02() throws JavaModelException {
+		String source = """
+				/// Example showing formatter bug with {@code @} in pre blocks.
+				///
+				/// <pre>
+				/// {@literal
+				/// @MyAnnotation
+				/// public class Example {
+				/// 	@AnotherAnnotation
+				/// 	private String field;
+				/// }
+				/// }
+				/// </pre>
+				public class Markdown {}
+				""";
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy("/Converter_25/src/markdown/Markdown.java", source, null);
+		if (this.docCommentSupport.equals(JavaCore.ENABLED)) {
+			CompilationUnit compilUnit = (CompilationUnit) runConversion(this.workingCopies[0], true);
+			TypeDeclaration typedeclaration =  (TypeDeclaration) compilUnit.types().get(0);
+			Javadoc javadoc = typedeclaration.getJavadoc();
+			TagElement parentTag = (TagElement)javadoc.tags().get(0);
+			List<?> frags = parentTag.fragments();
+			assumeEquals("wrong number of Child elements", 6, frags.size());
+			List<TextElement> innerFrags = ((TagElement) frags.get(4)).fragments();
+			assumeEquals("Incorrect child content", "@MyAnnotation", innerFrags.get(0).getText());
+			assumeEquals("Incorrect child content", "	@AnotherAnnotation", innerFrags.get(2).getText());
+		}
+	}
 }


### PR DESCRIPTION
Prevent @ content inside multiline inline Javadoc tags such as {@code}, {@literal}, and {@snippet} from being incorrectly parsed as Javadoc tags. This fixes invalid AST tag generation for annotation-like content within inline tag bodies.

This PR indented to fold the problems in {@code}, {@literal} and {@snippet} tags in both javadoc and markdown. However showing unexpected behaviour for {@snippet} tag in markdown and which is addressed in a different ticket #5075 

Fix: https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5055

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
