### PR TITLE
Wait for auto-refresh before copying test file in CopyMoveElementsTests

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CopyMoveElementsTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CopyMoveElementsTests.java
@@ -403,6 +403,7 @@ public void testCopyFieldsMultiStatus() throws CoreException {
 	}
 	dests[1] = fieldsSource[0]; //invalid destination
 	dests[2]=  fieldsSource[0];
+	waitForAutoRefresh();
 	DeltaListener listener = new DeltaListener();
 	try {
 		startDeltas(listener);

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CopyMoveTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CopyMoveTests.java
@@ -59,6 +59,8 @@ public void copyNegative(IJavaElement[] elements, IJavaElement[] destinations, I
  * encountered are thrown.
  */
 public IJavaElement copyPositive(IJavaElement element, IJavaElement container, IJavaElement sibling, String rename, boolean force) throws CoreException {
+	// make sure auto-refresh is not interfering with the test, see e.g.: https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2552
+	waitForAutoRefresh();
 	// if forcing, ensure that a name collision exists
 	if (force) {
 		IJavaElement collision = generateHandle(element, rename, container);


### PR DESCRIPTION
To avoid delta notifications sent asynchronously from `RefreshJob`, this change adjusts intermittently failing tests in `CopyMoveElementsTests` to wait on the auto-refresh before copying test files.

See: https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2552
