### PR TITLE
Add some excuses for differences ecj <-> javac

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
@@ -16,6 +16,7 @@ package org.eclipse.jdt.core.tests.compiler.regression;
 import java.util.Map;
 import junit.framework.Test;
 import org.eclipse.jdt.core.tests.compiler.regression.AbstractRegressionTest.JavacTestOptions.JavacHasABug;
+import org.eclipse.jdt.core.tests.compiler.regression.AbstractRegressionTest.JavacTestOptions.Excuse;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 
@@ -380,9 +381,10 @@ public void testBug488663_012() {
 }
 // Redundant type argument specification - TODO - confirm that this is correct
 public void testBug488663_013() {
-	Map<String, String> options = getCompilerOptions();
-	options.put(CompilerOptions.OPTION_ReportRedundantSpecificationOfTypeArguments, CompilerOptions.ERROR);
-	this.runNegativeTest(
+	Runner runner = new Runner();
+	runner.customOptions = getCompilerOptions();
+	runner.customOptions.put(CompilerOptions.OPTION_ReportRedundantSpecificationOfTypeArguments, CompilerOptions.ERROR);
+	runner.testFiles =
 		new String[] {
 			"X.java",
 			"public class X {\n" +
@@ -406,14 +408,16 @@ public void testBug488663_013() {
 			"interface I<T> {\n" +
 			"	String toString(T t);\n" +
 			"}"
-		},
+		};
+	runner.expectedCompilerLog =
 		"----------\n" +
 		"1. ERROR in X.java (at line 11)\n" +
 		"	I<X> i = new I<X>() {\n" +
 		"	             ^\n" +
 		"Redundant specification of type arguments <X>\n" +
-		"----------\n",
-		null, true, options);
+		"----------\n";
+	runner.javacTestOptions = Excuse.EclipseWarningConfiguredAsError;
+	runner.runNegativeTest();
 }
 // All non-private methods of an anonymous class instantiated with '<>' must be treated as being annotated with @override
 public void testBug488663_014() {
@@ -602,7 +606,8 @@ public void testBug521815b() {
 	if (this.complianceLevel <= ClassFileConstants.JDK1_8) {
 		return;
 	}
-	runNegativeTest(
+	Runner runner = new Runner();
+	runner.testFiles =
 			new String[] {
 					"a/b/X.java",
 					"package a.b;\n" +
@@ -618,13 +623,16 @@ public void testBug521815b() {
 					"import static a.b.X.Inner;\n" +
 					"public class Y {;\n" +
 					"}\n"
-			},
+			};
+	runner.expectedCompilerLog =
 			"----------\n" +
 			"1. WARNING in a\\Y.java (at line 2)\n" +
 			"	import static a.b.X.Inner;\n" +
 			"	              ^^^^^^^^^^^\n" +
 			"The import a.b.X.Inner is never used\n" +
-			"----------\n");
+			"----------\n";
+	runner.javacTestOptions = Excuse.EclipseHasSomeMoreWarnings;
+	runner.runWarningTest();
 }
 public void testBug533644() {
 	runConformTest(
@@ -702,9 +710,10 @@ public void testBug551913_001() {
 // "Remove redundant type arguments" diagnostic should be reported ONLY if all the non-private methods defined in the anonymous class
 // are also present in the parent class.
 public void testBug551913_002() {
-	Map<String, String> options = getCompilerOptions();
-	options.put(CompilerOptions.OPTION_ReportRedundantSpecificationOfTypeArguments, CompilerOptions.ERROR);
-	this.runNegativeTest(
+	Runner runner = new Runner();
+	runner.customOptions = getCompilerOptions();
+	runner.customOptions.put(CompilerOptions.OPTION_ReportRedundantSpecificationOfTypeArguments, CompilerOptions.ERROR);
+	runner.testFiles =
 		new String[] {
 			"X.java",
 			"public class X {\n" +
@@ -716,22 +725,25 @@ public void testBug551913_002() {
 			"		};\n" +
 			"	}\n" +
 			"}",
-		},
+		};
+	runner.expectedCompilerLog =
 		"----------\n" +
 		"1. ERROR in X.java (at line 4)\n" +
 		"	java.util.HashSet<String> b = new java.util.HashSet<String>(a) {\n" +
 		"	                                            ^^^^^^^\n" +
 		"Redundant specification of type arguments <String>\n" +
-		"----------\n",
-		null, true, options);
+		"----------\n";
+	runner.javacTestOptions = Excuse.EclipseWarningConfiguredAsError;
+	runner.runNegativeTest();
 }
 
 // https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1506
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=551913
 public void testBug551913_003() {
-	Map<String, String> options = getCompilerOptions();
-	options.put(CompilerOptions.OPTION_ReportRedundantSpecificationOfTypeArguments, CompilerOptions.ERROR);
-	this.runNegativeTest(
+	Runner runner = new Runner();
+	runner.customOptions = getCompilerOptions();
+	runner.customOptions.put(CompilerOptions.OPTION_ReportRedundantSpecificationOfTypeArguments, CompilerOptions.ERROR);
+	runner.testFiles =
 		new String[] {
 			"X.java",
 			"public class X {\n" +
@@ -744,14 +756,16 @@ public void testBug551913_003() {
 			"		};\n" +
 			"	}\n" +
 			"}",
-		},
+		};
+	runner.expectedCompilerLog =
 		"----------\n" +
 		"1. ERROR in X.java (at line 4)\n" +
 		"	java.util.HashSet<String> b = new java.util.HashSet<String>(a) {\n" +
 		"	                                            ^^^^^^^\n" +
 		"Redundant specification of type arguments <String>\n" +
-		"----------\n",
-		null, true, options);
+		"----------\n";
+	runner.javacTestOptions = Excuse.EclipseWarningConfiguredAsError;
+	runner.runNegativeTest();
 }
 // https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1506
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=551913
@@ -811,9 +825,10 @@ public void testGH1506() {
 // https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1506
 // Recommendation from compiler to drop type arguments leads to compile error
 public void testGH1506_2() {
-	Map<String, String> options = getCompilerOptions();
-	options.put(CompilerOptions.OPTION_ReportRedundantSpecificationOfTypeArguments, CompilerOptions.ERROR);
-	this.runNegativeTest(
+	Runner runner = new Runner();
+	runner.customOptions = getCompilerOptions();
+	runner.customOptions.put(CompilerOptions.OPTION_ReportRedundantSpecificationOfTypeArguments, CompilerOptions.ERROR);
+	runner.testFiles =
 		new String[] {
 			"X.java",
 			"import java.io.File;\n" +
@@ -837,14 +852,16 @@ public void testGH1506_2() {
 			"		};\n" +
 			"	}\n" +
 			"}\n",
-		},
+		};
+	runner.expectedCompilerLog =
 		"----------\n"
 		+ "1. ERROR in X.java (at line 8)\n"
 		+ "	return new Iterable<File>() {\n"
 		+ "	           ^^^^^^^^\n"
 		+ "Redundant specification of type arguments <File>\n"
-		+ "----------\n",
-		null, true, options);
+		+ "----------\n";
+	runner.javacTestOptions = Excuse.EclipseWarningConfiguredAsError;
+	runner.runNegativeTest();
 }
 // https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1506
 // Recommendation from compiler to drop type arguments leads to compile error


### PR DESCRIPTION
Some steps towards including GenericsRegressionTest_9 in run.javac mode, see https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2959