### PR TITLE
Remove dependency on com.ibm.icu from JDT Core

### DIFF
--- a/org.eclipse.jdt.core.tests.model/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.tests.model/META-INF/MANIFEST.MF
@@ -25,7 +25,6 @@ Require-Bundle: org.eclipse.core.resources;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.jdt.launching;bundle-version="[3.23.100,4.0.0)",
  org.eclipse.team.core;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.text;bundle-version="[3.2.0,4.0.0)",
- com.ibm.icu;bundle-version="3.4.4",
  org.eclipse.core.filesystem;bundle-version="[1.2.0,2.0.0)",
  org.eclipse.jdt.annotation;bundle-version="[2.0.0,3.0.0)";resolution:=optional
 Bundle-RequiredExecutionEnvironment: JavaSE-21

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/formatter/DecodeCodeFormatterPreferences.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/formatter/DecodeCodeFormatterPreferences.java
@@ -13,7 +13,6 @@
  *******************************************************************************/
 package org.eclipse.jdt.core.tests.formatter;
 
-import com.ibm.icu.util.StringTokenizer;
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileReader;
@@ -21,6 +20,7 @@ import java.io.IOException;
 import java.io.LineNumberReader;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.StringTokenizer;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import javax.xml.parsers.FactoryConfigurationError;

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/DefaultJavaElementComparator.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/DefaultJavaElementComparator.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.eclipse.jdt.core.tests.model;
 
-import com.ibm.icu.text.Collator;
+import java.text.Collator;
 import java.util.Comparator;
 import java.util.List;
 import org.eclipse.jdt.core.Flags;


### PR DESCRIPTION
Replace the two remaining ICU4J usages in the test bundle with equivalent JDK classes (java.text.Collator, java.util.StringTokenizer) and drop the com.ibm.icu require-bundle entry.


## What it does
Replaces the non to be removed icu library with standard Java.

## How to test

Run the Maven build and verify that no new tests are failing
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ x] I have thoroughly tested my changes
- [ x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
