### PR TITLE
Type error due to wrong binding of type variables in generic methods with wildcard argument type "T foo(X<? extends T> param)"

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedTypeBinding.java
@@ -1455,11 +1455,10 @@ public class ParameterizedTypeBinding extends ReferenceBinding implements Substi
     		}
 	    }
 	    if (CapturingContext.isActive()) {
-	    	ReferenceBinding[] captured = new ReferenceBinding[this.superInterfaces.length];
-	    	for (int i = 0; i < captured.length; i++) {
-				captured[i] = CapturingContext.maybeCapture(this.superInterfaces[i]);
-			}
-	    	return captured;
+	    	ReferenceBinding capturedThis = CapturingContext.maybeCapture(this);
+	    	if (capturedThis != this) { //$IDENTITY-COMPARISON$
+	    		return capturedThis.superInterfaces();
+	    	}
 	    }
 		return this.superInterfaces;
 	}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractRegressionTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractRegressionTest.java
@@ -1191,8 +1191,9 @@ protected static class JavacTestOptions {
 			JavacBug8348410 = // https://bugs.openjdk.org/browse/JDK-8348410
 					new JavacHasABug(MismatchType.EclipseErrorsJavacNone, ClassFileConstants.JDK25, 0000),
 			JavacBug8016196 = // https://bugs.openjdk.org/browse/JDK-8016196
-					new JavacHasABug(MismatchType.JavacErrorsEclipseNone);
-
+					new JavacHasABug(MismatchType.JavacErrorsEclipseNone),
+			JavacBug8016207 = // https://bugs.openjdk.org/browse/JDK-8016207 Widening of capture vars occurs at unspecified times
+					new JavacHasABug(MismatchType.EclipseErrorsJavacNone);
 
 		// bugs that have been fixed but that we've not identified
 		public static JavacHasABug

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
@@ -2261,6 +2261,40 @@ public void testGH4774b() throws Exception {
 	runner.javacTestOptions = JavacHasABug.JavacBug6573446;
 	runner.runNegativeTest();
 }
+public void testGH4731() {
+	Runner runner = new Runner();
+	runner.testFiles = new String[] {
+			"TestWildcard.java",
+			"""
+			import java.util.Collection;
+			import java.util.Iterator;
+
+			public class TestWildcard {
+
+				private Collection<? extends Collection<? extends Runnable>> _parts;
+
+				public Iterator<Runnable> iterator() {
+					return TestWildcard.concat(_parts).iterator();
+				}
+
+				public static <T> Iterable<T> concat(Iterable<? extends Iterable<? extends T>> entries) {
+					return null;
+				}
+
+			}
+			"""
+		};
+	runner.expectedCompilerLog = """
+			----------
+			1. ERROR in TestWildcard.java (at line 9)
+				return TestWildcard.concat(_parts).iterator();
+				       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+			Type mismatch: cannot convert from Iterator<capture#2-of ? extends Runnable> to Iterator<Runnable>
+			----------
+			""";
+	runner.javacTestOptions = JavacHasABug.JavacBug8016207;
+	runner.runNegativeTest();
+}
 public static Class<GenericsRegressionTest_9> testClass() {
 	return GenericsRegressionTest_9.class;
 }


### PR DESCRIPTION
+ includes more precise computation of capturing supertype
  - no observable difference for any test including the new one here

Test for https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4731
