### PR TITLE
[Formatter] Preserve annotations in @code blocks within <pre> sections

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/formatter/FormatterCommentsBugsTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/formatter/FormatterCommentsBugsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2022 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -7841,5 +7841,137 @@ public void testIssue3372() {
 		}
 		""";
 	formatSource(source);
+}
+
+/**
+ * https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4874
+ */
+public void testBug4874a() {
+	this.formatterPrefs.comment_format_source = false;
+	String source ="""
+		  /**
+		   * <pre>
+		   * {@code
+		   * @MyAnnotation
+		   * public class Example {
+		   *
+		   *    @AnotherAnnotation
+		   *  private String field;
+		   * }
+		   * }
+		   * </pre>
+		   */
+		  public interface ExampleService {
+
+		      /**
+		       * Another method with annotation in javadoc.
+		       *
+		       * <pre>
+		       * {@code
+		       * @Override
+		       * public void doSomething() {
+		       *     // implementation
+		       * }
+		       * }
+		       * </pre>
+		       */
+		      void doSomething();
+		  }
+			""";
+	String expected = """
+			/**
+			 * <pre>
+			 * {@code
+			 * @MyAnnotation
+			 * public class Example {
+			 *
+			 *    @AnotherAnnotation
+			 *  private String field;
+			 * }
+			 * }
+			 * </pre>
+			 */
+			public interface ExampleService {
+
+				/**
+				 * Another method with annotation in javadoc.
+				 *
+				 * <pre>
+				 * {@code
+				 * @Override
+				 * public void doSomething() {
+				 *     // implementation
+				 * }
+				 * }
+				 * </pre>
+				 */
+				void doSomething();
+			}
+			""";
+	formatSource(source,expected);
+}
+/**
+ * https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4874
+ */
+public void testBug4874b() {
+	this.formatterPrefs.comment_format_source = true;
+	String source ="""
+		  /**
+		   * <pre>
+		   * {@code
+		   * @MyAnnotation
+		   * public class Example {
+		   *
+		   *    @AnotherAnnotation
+		   *  private String field;
+		   * }
+		   * }
+		   * </pre>
+		   */
+		  public interface ExampleService {
+
+		      /**
+		       * Another method with annotation in javadoc.
+		       *
+		       * <pre>
+		       * {@snippet
+		       * @Override
+		       * public void doSomething() {
+		       *     // implementation
+		       * }
+		       * }
+		       * </pre>
+		       */
+		      void doSomething();
+		  }
+			""";
+	String expected = """
+			/**
+			 * <pre>
+			 * {@code @MyAnnotation
+			 * public class Example { @AnotherAnnotation
+			 * 	private String field;
+			 * }
+			 * }
+			 * </pre>
+			 */
+			public interface ExampleService {
+
+				/**
+				 * Another method with annotation in javadoc.
+				 *
+				 * <pre>
+				 * {@snippet
+				 * @Override
+				 * public void doSomething() {
+				 *     // implementation
+				 * }
+				 * }
+				 * </pre>
+				 */
+				void doSomething();
+			}
+			""";
+	formatSource(source,expected);
 }
 }

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/CommentsPreparator.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/CommentsPreparator.java
@@ -34,8 +34,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -98,6 +100,7 @@ public class CommentsPreparator extends ASTVisitor {
 	private final static Pattern MARKDOWN_FENCE_PATTERN = Pattern.compile("(`{3,}|~{3,})(.*)"); //$NON-NLS-1$
 	private final static Pattern MARKDOWN_TABLE_START = Pattern.compile("(?m)(?<=^[ \\t]*)\\|"); //$NON-NLS-1$
 	private final static Pattern MARKDOWN_TABLE_END = Pattern.compile("(?m)\\|(?!.*\\|)"); //$NON-NLS-1$
+	private final static Pattern CODE_ANNOTATION_PATTERN = Pattern.compile("^\\s*\\*\\s*@\\p{javaJavaIdentifierStart}[\\p{javaJavaIdentifierPart}.$]*"); //$NON-NLS-1$
 
 	// Param tags list copied from IJavaDocTagConstants in legacy formatter for compatibility.
 	// There were the following comments:
@@ -1352,8 +1355,16 @@ public class CommentsPreparator extends ASTVisitor {
 
 		Token noFormatToken = new Token(startToken.originalStart, endToken.originalEnd, TokenNameCOMMENT_JAVADOC);
 		List<Token> lines = commentToLines(noFormatToken, findCommentLineIndent(startIndex));
-		for (Token line : lines)
-			line.setToEscape(isHtml);
+		if (isHtml) {
+			Set<Token> codeAnnotationLines = extractCodeAnnotationLines(lines);
+			for (Token line : lines) {
+				if (!codeAnnotationLines.contains(line))
+					line.setToEscape(isHtml);
+			}
+		} else {
+			for (Token line : lines)
+				line.setToEscape(isHtml);
+		}
 		Token first = lines.get(0);
 		if (startToken.isSpaceBefore())
 			first.spaceBefore();
@@ -1369,6 +1380,50 @@ public class CommentsPreparator extends ASTVisitor {
 		List<Token> tokensToReplace = this.commentStructure.subList(startIndex, endIndex + 1);
 		tokensToReplace.clear();
 		tokensToReplace.addAll(lines);
+	}
+
+	private Set<Token> extractCodeAnnotationLines(List<Token> lines) {
+		Set<Token> result = new HashSet<>();
+
+		Token firstLine = lines.get(0);
+		Token lastLine = lines.get(lines.size() - 1);
+
+		int blockStart = firstLine.originalStart;
+		String source = this.ctm.getSource().substring(blockStart, lastLine.originalEnd + 1);
+
+		for (int i = 0; i < lines.size(); i++) {
+			Token startLine = lines.get(i);
+			String text = this.tm.toString(startLine);
+
+			if (!text.contains("{@code") && !text.contains("{@snippet")) { //$NON-NLS-1$ //$NON-NLS-2$
+				continue;
+			}
+
+			int openingPos = startLine.originalStart - blockStart;
+			int closingBracePos = openingPos + 1;
+
+			for (int braces = 1; braces > 0 && closingBracePos < source.length(); closingBracePos++) {
+				if (source.charAt(closingBracePos) == '{')
+					braces++;
+				if (source.charAt(closingBracePos) == '}')
+					braces--;
+			}
+			closingBracePos--;
+
+			int absoluteClosingPos = blockStart + closingBracePos;
+
+			for (int j = i + 1; j < lines.size(); j++) {
+				Token line = lines.get(j);
+
+				if (line.originalStart >= absoluteClosingPos)
+					break;
+
+				if (CODE_ANNOTATION_PATTERN.matcher(this.tm.toString(line)).find())
+					result.add(line);
+			}
+		}
+
+		return result;
 	}
 
 	private void disableFormattingExclusively(int openingTagIndex, int closingTagIndex, boolean isSnippet) {


### PR DESCRIPTION
Prevent escaping annotation lines inside {@code} & {@snippet} blocks contained in HTML '\<pre>\' sections.

Fixes : https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4874

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
