### PR TITLE
ASTConverterJavadocTest_18 test failure fix

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterJavadocTest_18.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterJavadocTest_18.java
@@ -1399,6 +1399,6 @@ public class ASTConverterJavadocTest_18 extends ConverterTestSetup {
 		List<TextElement> frags = snippetTag.fragments();
 		assertEquals("Invalid snippet fragments", 6, frags.size());
 		assertEquals("Invalid content for first Element", " @MyAnnotation\n", frags.get(0).getText());
-		assertEquals("Invalid content for third Element", "     @AnotherAnnotation\n", frags.get(2).getText());
+		assertEquals("Invalid content for third Element", "     @AnotherAnnotation" + System.lineSeparator(), frags.get(2).getText());
 	}
 }


### PR DESCRIPTION
ASTConverterJavadocTest_18.testJavadocIncorrectlyParsingAnnotationInlineTag5055 test failure fix

Fix: https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5110

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
