### PR TITLE
Java 27 test harness alignment - missed out changes

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractRegressionTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractRegressionTest.java
@@ -8,6 +8,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *
+ * This is an implementation of an early-draft specification developed under the Java
+ * Community Process (JCP) and is made available for testing and evaluation purposes
+ * only. The code is not compatible with any specification of the JCP.
+ *
  * Contributors:
  *     IBM Corporation - initial API and implementation
  *     Stephan Herrmann - Contribution for
@@ -344,6 +348,8 @@ static class JavacCompiler {
 			return JavaCore.VERSION_25;
 		} else if(rawVersion.startsWith("26")) {
 			return JavaCore.VERSION_26;
+		} else if(rawVersion.startsWith("27")) {
+			return JavaCore.VERSION_27;
 		} else {
 			throw new RuntimeException("unknown javac version: " + rawVersion);
 		}
@@ -601,6 +607,12 @@ static class JavacCompiler {
 		if (version == JavaCore.VERSION_26) {
 			switch(rawVersion) {
 				case "26-ea", "26-beta", "26":
+					return 0000;
+			}
+		}
+		if (version == JavaCore.VERSION_27) {
+			switch(rawVersion) {
+				case "27-ea", "27-beta", "27":
 					return 0000;
 			}
 		}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/util/AbstractCompilerTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/util/AbstractCompilerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -422,7 +422,8 @@ public class AbstractCompilerTest extends TestCase {
 						System.out.println(CompilerOptions.VERSION_23 + ", ");
 						System.out.println(CompilerOptions.VERSION_24 + ", ");
 						System.out.println(CompilerOptions.VERSION_25 + ", ");
-						System.out.println(CompilerOptions.VERSION_26);
+						System.out.println(CompilerOptions.VERSION_26 + ", ");
+						System.out.println(CompilerOptions.VERSION_27);
 					}
 				}
 				if (possibleComplianceLevels == 0) {


### PR DESCRIPTION
## What it does
This PR fixes a few missed out changes in the Java 27 test harness. These (and some more changes) were suggested by co-pilot in https://github.com/eclipse-jdt/eclipse.jdt.core/pull/5114/changes. However could not rebase it and hence creating a separate PR here.

## How to test
test infra changes only 

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
