### PR TITLE
Version bump for new stream

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.tests.compiler/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.core.tests.compiler;singleton:=true
-Bundle-Version: 3.13.1200.qualifier
+Bundle-Version: 3.13.1300.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jdt.core.tests.compiler,

--- a/org.eclipse.jdt.core.tests.compiler/pom.xml
+++ b/org.eclipse.jdt.core.tests.compiler/pom.xml
@@ -19,7 +19,7 @@
     <relativePath>../tests-pom/</relativePath>
   </parent>
   <artifactId>org.eclipse.jdt.core.tests.compiler</artifactId>
-  <version>3.13.1200-SNAPSHOT</version>
+  <version>3.13.1300-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>


### PR DESCRIPTION
As reported:
IU id	Reference (old) version	Current (new) version org.eclipse.jdt.core.tests.compiler	3.13.1200.v20260528-0407	3.13.1200.v20260602-1458 org.eclipse.jdt.core.tests.compiler.source	3.13.1200.v20260528-0407	3.13.1200.v20260602-1458

in https://download.eclipse.org/eclipse/downloads/drops4/I20260607-1800/buildlogs/reporeports/reports/versionChecks.html

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
