### PR TITLE
[Build] Generalize skip of baseline check for tests.builder.mockcompiler

### DIFF
--- a/org.eclipse.jdt.core.tests.builder.mockcompiler/pom.xml
+++ b/org.eclipse.jdt.core.tests.builder.mockcompiler/pom.xml
@@ -21,10 +21,9 @@
   </parent>
   <artifactId>org.eclipse.jdt.core.tests.builder.mockcompiler</artifactId>
   <version>1.0.200-SNAPSHOT</version>
-  <!-- Workaround for API baselines tycho problem: don't add this bundle to baselines check -->
-  <packaging>eclipse-test-plugin</packaging>
+  <packaging>eclipse-plugin</packaging>
   <properties>
-    <!-- This plugin is used by tests but has no tests itself, see packaging comment above -->
-    <failIfNoTests>false</failIfNoTests>
+    <!-- This bundle is not published and therefore not in the baseline. -->
+    <version.baseline.check.skip>true</version.baseline.check.skip>
   </properties>
 </project>


### PR DESCRIPTION
## What it does

Improved the solution to skip the baseline check for `org.eclipse.jdt.core.tests.builder.mockcompiler` from
- https://github.com/eclipse-jdt/eclipse.jdt.core/pull/5012

by leveraging the indirection for baseline-check-skip property introduced in
- https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/pull/2381


@iloveeclipse in your comment from https://github.com/eclipse-jdt/eclipse.jdt.core/pull/5012#issuecomment-4280280559, you were right:
> Can't it be solved differently (there was a property in maven/tycho to exclude from baseline checks)?

At that time, I simply forgot that property and somehow didn't found it again.

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
