### PR TITLE
Fix Javadoc build error: join split {@linkplain} tag onto single line

### DIFF
--- a/org.eclipse.jdt.apt.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.apt.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.apt.core; singleton:=true
-Bundle-Version: 3.8.700.qualifier
+Bundle-Version: 3.8.800.qualifier
 Bundle-Localization: plugin
 Export-Package: com.sun.mirror.apt,
  com.sun.mirror.declaration,

--- a/org.eclipse.jdt.apt.core/src/com/sun/mirror/util/package.html
+++ b/org.eclipse.jdt.apt.core/src/com/sun/mirror/util/package.html
@@ -35,9 +35,7 @@
 </head>
 <body bgcolor="white">
 
-Utilities to assist in the processing of {@linkplain
-com.sun.mirror.declaration declarations} and {@linkplain
-com.sun.mirror.type types}.
+Utilities to assist in the processing of {@linkplain com.sun.mirror.declaration declarations} and {@linkplain com.sun.mirror.type types}.
 
 <p>Note that the <code>apt</code> tool and its associated APIs may be
 changed or superseded in future j2se releases.


### PR DESCRIPTION
## Problem

Building with Java 25's javadoc tool fails because the strict HTML5 parser requires inline tags like \{@linkplain}\ to be on a single line. Splitting the tag name from its argument across a newline causes:

\\\
error: unknown tag. Mistyped @linkplain or an unregistered custom tag?
\\\

## Fix

Join the two split \{@linkplain ...\} tags in \com/sun/mirror/util/package.html\ onto single lines.