### PR TITLE
Improve debug tracing

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BoundSet.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BoundSet.java
@@ -383,10 +383,6 @@ class BoundSet {
 	}
 
 	public void addBound(TypeBound bound, LookupEnvironment environment) {
-		if (InferenceContext18.DEBUG) {
-			System.out.println("Adding "+bound); //$NON-NLS-1$
-		}
-
 		if (bound.relation == ReductionResult.SUBTYPE && bound.right.id == TypeIds.T_JavaLangObject)
 			return;
 		if (bound.left == bound.right) //$IDENTITY-COMPARISON$
@@ -418,6 +414,9 @@ class BoundSet {
 		if (three == null)
 			this.boundsPerVariable.put(variable, (three = new ThreeSets()));
 		if (three.addBound(bound)) {
+			if (InferenceContext18.DEBUG) {
+				System.out.println("Added "+bound); //$NON-NLS-1$
+			}
 			int unincorporatedBoundsLength = this.unincorporatedBounds.length;
 			if (this.unincorporatedBoundsCount >= unincorporatedBoundsLength)
 				System.arraycopy(this.unincorporatedBounds, 0, this.unincorporatedBounds = new TypeBound[unincorporatedBoundsLength * 2], 0, unincorporatedBoundsLength);
@@ -600,8 +599,11 @@ class BoundSet {
 						mostRecentFormulas[1] = mostRecentFormulas[0];
 						mostRecentFormulas[0] = newConstraint;
 
-						if (!reduceOneConstraint(context, newConstraint))
+						if (!reduceOneConstraint(context, newConstraint)) {
+							if (InferenceContext18.DEBUG)
+								System.out.println("Incorporation failed to reduce new constraint "+newConstraint); //$NON-NLS-1$
 							return false;
+						}
 
 						if (analyzeNull) {
 							// not per JLS: if the new constraint relates types where at least one has a null annotations,
@@ -619,8 +621,11 @@ class BoundSet {
 					}
 					if (deriveTypeArgumentConstraints) {
 						for (ConstraintTypeFormula typeArgumentConstraint : deriveTypeArgumentConstraints(bound1, bound2, context)) {
-							if (!reduceOneConstraint(context, typeArgumentConstraint))
+							if (!reduceOneConstraint(context, typeArgumentConstraint)) {
+								if (InferenceContext18.DEBUG)
+									System.out.println("Incorporation failed to reduce new constraint "+newConstraint); //$NON-NLS-1$
 								return false;
+							}
 						}
 					}
 					if (iteration == 2) {
@@ -722,7 +727,8 @@ class BoundSet {
 		if (InferenceContext18.DEBUG) {
 			if (!capturesToRemove.isEmpty()) {
 				for (ParameterizedTypeBinding toRemove : capturesToRemove) {
-					System.out.println("Removing capture bound " + //$NON-NLS-1$
+					if (this.captures.containsKey(toRemove))
+						System.out.println("Removing capture bound " + //$NON-NLS-1$
 							String.valueOf(toRemove.shortReadableName()) +
 							"=capture("+String.valueOf(this.captures.get(toRemove).shortReadableName())+")"); //$NON-NLS-1$ //$NON-NLS-2$
 				}
@@ -1014,7 +1020,13 @@ class BoundSet {
 	public boolean reduceOneConstraint(InferenceContext18 context, ConstraintFormula currentConstraint) throws InferenceFailureException {
 		Object result = currentConstraint.reduce(context);
 		if (InferenceContext18.DEBUG_FINE) {
-			System.out.println("Reduced\t"+currentConstraint+"\n  to   \t"+result); //$NON-NLS-1$ //$NON-NLS-2$
+			if (result instanceof ReductionResult[] array) {
+				System.out.println("Reduced\t"+currentConstraint); //$NON-NLS-1$
+				for (ReductionResult res1 : array)
+					System.out.println("  to   \t"+res1); //$NON-NLS-1$
+			} else {
+				System.out.println("Reduced\t"+currentConstraint+"\n  to   \t"+result); //$NON-NLS-1$ //$NON-NLS-2$
+			}
 		}
 		if (result == ReductionResult.FALSE) {
 			if (InferenceContext18.DEBUG) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ConstraintFormula.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ConstraintFormula.java
@@ -26,6 +26,7 @@ import java.util.Set;
  */
 abstract class ConstraintFormula extends ReductionResult {
 
+	public static final boolean DEBUG_USE_LONG_NAMES = Boolean.getBoolean("ecj.typeinference.debug.longNames"); //$NON-NLS-1$
 	static final List<InferenceVariable> EMPTY_VARIABLE_LIST = Collections.emptyList();
 	static final ConstraintFormula[] NO_CONSTRAINTS = new ConstraintTypeFormula[0];
 
@@ -58,10 +59,10 @@ abstract class ConstraintFormula extends ReductionResult {
 	}
 
 	// for debug toString():
-	protected void appendTypeName(StringBuilder buf, TypeBinding type) {
+	public static void appendTypeName(StringBuilder buf, TypeBinding type) {
 		if (type instanceof CaptureBinding18)
 			buf.append(type.toString()); // contains more info than readable name
 		else
-			buf.append(type.readableName());
+			buf.append(DEBUG_USE_LONG_NAMES ? type.readableName() : type.shortReadableName());
 	}
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
@@ -92,8 +92,8 @@ import org.eclipse.jdt.internal.compiler.util.Sorting;
  */
 public class InferenceContext18 {
 
-	public final static boolean DEBUG = false;
-	public final static boolean DEBUG_FINE = false;
+	public final static boolean DEBUG = Boolean.getBoolean("ecj.typeinference.debug"); //$NON-NLS-1$
+	public final static boolean DEBUG_FINE = Boolean.getBoolean("ecj.typeinference.debug.fine"); //$NON-NLS-1$;
 
 	/** NON-JLS: to conform with javac regarding https://bugs.openjdk.java.net/browse/JDK-8026527 */
 	static final boolean SIMULATE_BUG_JDK_8026527 = true;
@@ -1901,6 +1901,7 @@ public class InferenceContext18 {
 		}
 		if (this.currentBounds != null && isResolved(this.currentBounds))
 			buf.append(" (resolved)"); //$NON-NLS-1$
+		buf.append(' ').append(this.currentInvocation);
 		buf.append('\n');
 		if (this.inferenceVariables != null) {
 			buf.append("Inference Variables:\n"); //$NON-NLS-1$

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedGenericMethodBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedGenericMethodBinding.java
@@ -213,10 +213,12 @@ public class ParameterizedGenericMethodBinding extends ParameterizedMethodBindin
 			if (expectedType != null || !invocationSite.getExpressionContext().definesTargetType() || !isPolyExpression) {
 				// ---- 18.5.2 (Invocation type): ----
 				provisionalResult = result;
-				result = infCtx18.inferInvocationType(expectedType, invocationSite, originalMethod);
 				if (InferenceContext18.DEBUG) {
 					System.out.println("Infer invocation type for "+invocationSite+ " with target " //$NON-NLS-1$ //$NON-NLS-2$
 							+(expectedType == null ? "<no type>" : expectedType.debugName())); //$NON-NLS-1$
+				}
+				result = infCtx18.inferInvocationType(expectedType, invocationSite, originalMethod);
+				if (InferenceContext18.DEBUG) {
 					System.out.println("Result=\n"+result); //$NON-NLS-1$
 				}
 				invocationTypeInferred = infCtx18.stepCompleted == InferenceContext18.TYPE_INFERRED_FINAL;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeBound.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeBound.java
@@ -88,10 +88,7 @@ public class TypeBound extends ReductionResult {
 		buf.append(isBound ? "TypeBound  " : "Dependency "); //$NON-NLS-1$ //$NON-NLS-2$
 		buf.append(this.left.sourceName);
 		buf.append(relationToString(this.relation));
-		if (this.right instanceof CaptureBinding18)
-			buf.append(this.right.toString());
-		else
-			buf.append(this.right.readableName());
+		ConstraintFormula.appendTypeName(buf, this.right);
 		return buf.toString();
 	}
 }


### PR DESCRIPTION
+ make tracing configurable via system properties
   * -Decj.typeinference.debug=true/false
   * -Decj.typeinference.debug.fine=true/false 
  * -Decj.typeinference.debug.longNames=true/false 
       * new: by default show short type names, back to long via this option
+ fix NPE in tracing in BoundSet.incorporate()
+ log failed reduction during incorporation
+ don't log "Added bound" when about to skip
+ better formatting when reduction produces several new constraints
+ print invocation as part of InferenceContext18.toString()
+ show "Infer invocation type ..." before starting that inference
