### PR TITLE
Make readable names of CaptureBinding18 more explicit

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/CaptureBinding18.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/CaptureBinding18.java
@@ -311,56 +311,45 @@ public class CaptureBinding18 extends CaptureBinding {
 
 	@Override
 	public char[] readableName() {
-		if (this.lowerBound == null && this.firstBound != null) {
-			if (this.prototype().recursionLevel < 2) {
-				try {
-					this.prototype().recursionLevel++;
-					if (this.upperBounds != null && this.upperBounds.length > 1) {
-						StringBuilder sb = new StringBuilder();
-						sb.append(this.upperBounds[0].readableName());
-						for (int i = 1; i < this.upperBounds.length; i++)
-							sb.append('&').append(this.upperBounds[i].readableName());
-						int len = sb.length();
-						char[] name = new char[len];
-						sb.getChars(0, len, name, 0);
-						return name;
-					}
-					return this.firstBound.readableName();
-				} finally {
-					this.prototype().recursionLevel--;
-				}
-			} else {
-				return this.originalName;
-			}
-		}
-		return super.readableName();
+		return genericReadableName(false);
 	}
 
 	@Override
 	public char[] shortReadableName() {
-		if (this.lowerBound == null && this.firstBound != null) {
-			if (this.prototype().recursionLevel < 2) {
-				try {
-					this.prototype().recursionLevel++;
-					if (this.upperBounds != null && this.upperBounds.length > 1) {
-						StringBuilder sb = new StringBuilder();
-						sb.append(this.upperBounds[0].shortReadableName());
-						for (int i = 1; i < this.upperBounds.length; i++)
-							sb.append('&').append(this.upperBounds[i].shortReadableName());
-						int len = sb.length();
-						char[] name = new char[len];
-						sb.getChars(0, len, name, 0);
-						return name;
+		return genericReadableName(true);
+
+	}
+
+	private char[] genericReadableName(boolean makeShort) {
+		int dash = CharOperation.indexOf('-', this.sourceName);
+		StringBuilder sb = new StringBuilder();
+		sb.append("capture-").append(CharOperation.subarray(this.sourceName, 0, dash)); //$NON-NLS-1$
+		sb.append("-of ").append(this.originalName); //$NON-NLS-1$
+		if (this.prototype().recursionLevel == 0) {
+			try {
+				this.prototype().recursionLevel++;
+				if (this.upperBounds != null && this.upperBounds.length > 1) {
+					sb.append(" extends "); //$NON-NLS-1$
+					for (int i = 0; i < this.upperBounds.length; i++) {
+						if (i > 0) sb.append('&');
+						TypeBinding bound = this.upperBounds[i];
+						sb.append(makeShort ? bound.shortReadableName() : bound.readableName());
 					}
-					return this.firstBound.shortReadableName();
-				} finally {
-					this.prototype().recursionLevel--;
+				} else if (this.firstBound != null) {
+					sb.append(" extends "); //$NON-NLS-1$
+					sb.append(makeShort ? this.firstBound.shortReadableName() : this.firstBound.readableName());
 				}
-			} else {
-				return this.originalName;
+				if (this.lowerBound != null) {
+					sb.append(" super ").append(makeShort ? this.lowerBound.shortReadableName() : this.lowerBound.readableName()); //$NON-NLS-1$
+				}
+			} finally {
+				this.prototype().recursionLevel--;
 			}
 		}
-		return super.shortReadableName();
+		int len = sb.length();
+		char[] name = new char[len];
+		sb.getChars(0, len, name, 0);
+		return name;
 	}
 
 	@Override

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
@@ -1245,9 +1245,9 @@ public class InferenceContext18 {
 						return resolve(toResolve, isRecordPatternTypeInference, false);
 					// Otherwise, a second attempt is made...
 					Sorting.sortInferenceVariables(variables); // ensure stability of capture IDs
-					final CaptureBinding18[] zs = new CaptureBinding18[numVars];
+					final CaptureBinding18[] ys = new CaptureBinding18[numVars];
 					for (int j = 0; j < numVars; j++)
-						zs[j] = freshCapture(variables[j]);
+						ys[j] = freshCapture(variables[j]);
 					final BoundSet kurrentBoundSet = tmpBoundSet;
 					Substitution theta = new Substitution() {
 						@Override
@@ -1261,8 +1261,8 @@ public class InferenceContext18 {
 						@Override
 						public TypeBinding substitute(TypeVariableBinding typeVariable) {
 							for (int j = 0; j < numVars; j++)
-								if (TypeBinding.equalsEquals(variables[j], typeVariable) && zs[j] != null)
-									return zs[j];
+								if (TypeBinding.equalsEquals(variables[j], typeVariable) && ys[j] != null)
+									return ys[j];
 							/* If we have an instantiation, lower it to the instantiation. We don't want downstream abstractions to be confused about multiple versions of bounds without
 							   and with instantiations propagated by incorporation. See https://bugs.eclipse.org/bugs/show_bug.cgi?id=430686. There is no value whatsoever in continuing
 							   to speak in two tongues. Also fixes https://bugs.eclipse.org/bugs/show_bug.cgi?id=425031.
@@ -1278,7 +1278,7 @@ public class InferenceContext18 {
 					};
 					for (int j = 0; j < numVars; j++) {
 						InferenceVariable variable = variables[j];
-						CaptureBinding18 zsj = zs[j];
+						CaptureBinding18 yj = ys[j];
 						// NON-JLS: leverage existing same bounds if they become proper by substitution:
 						boolean typeboundCreated = false;
 						TypeBinding[] sameBounds = tmpBoundSet.sameBounds(variable);
@@ -1296,7 +1296,7 @@ public class InferenceContext18 {
 								if (sameBounds != null && sameBounds.length == 1) {
 									tmpBoundSet.addBound(new TypeBound(variable, sameBounds[0], ReductionResult.SAME), this.environment);
 									typeboundCreated = true;
-									zs[j] = null;
+									ys[j] = null;
 								}
 							}
 						}
@@ -1308,17 +1308,17 @@ public class InferenceContext18 {
 							if (lowerBounds != Binding.NO_TYPES) {
 								TypeBinding lub = this.scope.lowerUpperBound(lowerBounds);
 								if (lub != TypeBinding.VOID && lub != null)
-									zsj.lowerBound = lub;
+									yj.lowerBound = lub;
 							}
 							// add upper bounds:
 							TypeBinding[] upperBounds = tmpBoundSet.upperBounds(variable, false/*onlyProper*/);
 							if (upperBounds != Binding.NO_TYPES) {
 								for (int k = 0; k < upperBounds.length; k++)
 									upperBounds[k] = Scope.substitute(theta, upperBounds[k]);
-								if (!setUpperBounds(zsj, upperBounds))
+								if (!setUpperBounds(yj, upperBounds))
 									continue; // at violation of well-formedness skip this candidate and proceed
 							} else {
-								zsj.setSuperClass(this.object);
+								yj.setSuperClass(this.object);
 							}
 						}
 						if (tmpBoundSet == this.currentBounds)
@@ -1346,7 +1346,7 @@ public class InferenceContext18 {
 							}
 						}
 						if (!typeboundCreated)
-							tmpBoundSet.addBound(new TypeBound(variable, zsj, ReductionResult.SAME), this.environment);
+							tmpBoundSet.addBound(new TypeBound(variable, yj, ReductionResult.SAME), this.environment);
 						toResolveSet.remove(variable);
 					}
 					if (tmpBoundSet.incorporate(this)) {
@@ -1385,10 +1385,10 @@ public class InferenceContext18 {
 
 	int captureId = 0;
 
-	/** For 18.4: "Let Z1, ..., Zn be fresh type variables" use capture bindings. */
+	/** For 18.4: "Let Y1, ..., Yn be fresh type variables" use capture bindings. */
 	private CaptureBinding18 freshCapture(InferenceVariable variable) {
 		int id = this.captureId++;
-		char[] sourceName = CharOperation.concat("Z".toCharArray(), '#', String.valueOf(id).toCharArray(), '-', variable.sourceName); //$NON-NLS-1$
+		char[] sourceName = CharOperation.concat("Y".toCharArray(), '#', String.valueOf(id).toCharArray(), '-', variable.sourceName); //$NON-NLS-1$
 		int start = this.currentInvocation != null ? this.currentInvocation.sourceStart() : 0;
 		int end = this.currentInvocation != null ? this.currentInvocation.sourceEnd() : 0;
 		return new CaptureBinding18(this.scope.enclosingSourceType(), sourceName, variable.typeParameter.shortReadableName(),

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericTypeTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericTypeTest.java
@@ -16481,7 +16481,7 @@ public void test0500(){
 			"6. WARNING in X.java (at line 10)\n" +
 			"	EnumSet<Enum> eSet = EnumSet.allOf(c);\n" +
 			"	                                   ^\n" +
-			"Type safety: The expression of type Class needs unchecked conversion to conform to Class<Enum<Enum<E>>>\n" +
+			"Type safety: The expression of type Class needs unchecked conversion to conform to Class<capture-Y#0-of E extends Enum<capture-Y#0-of E>>\n" +
 			"----------\n");
 	}
 	//https://bugs.eclipse.org/bugs/show_bug.cgi?id=86838 - variation
@@ -16564,7 +16564,7 @@ public void test0500(){
 			"4. WARNING in X.java (at line 10)\n" +
 			"	EnumSet<?> eSet = (EnumSet<?>) EnumSet.allOf(c);\n" +
 			"	                                             ^\n" +
-			"Type safety: The expression of type Class needs unchecked conversion to conform to Class<Enum<Enum<E>>>\n" +
+			"Type safety: The expression of type Class needs unchecked conversion to conform to Class<capture-Y#0-of E extends Enum<capture-Y#0-of E>>\n" +
 			"----------\n" +
 			"5. ERROR in X.java (at line 12)\n" +
 			"	Zork z;\n" +
@@ -16606,7 +16606,7 @@ public void test0500(){
 			"3. WARNING in X.java (at line 10)\n" +
 			"	EnumSet<?> eSet = EnumSet.allOf(c);\n" +
 			"	                                ^\n" +
-			"Type safety: The expression of type Class needs unchecked conversion to conform to Class<Enum<Enum<E>>>\n" +
+			"Type safety: The expression of type Class needs unchecked conversion to conform to Class<capture-Y#0-of E extends Enum<capture-Y#0-of E>>\n" +
 			"----------\n" +
 			"4. ERROR in X.java (at line 12)\n" +
 			"	Zork z;\n" +
@@ -16656,7 +16656,7 @@ public void test0500(){
 			"5. WARNING in X.java (at line 10)\n" +
 			"	EnumSet<Enum<?>> eSet = EnumSet.allOf(c);\n" +
 			"	                                      ^\n" +
-			"Type safety: The expression of type Class needs unchecked conversion to conform to Class<Enum<Enum<E>>>\n" +
+			"Type safety: The expression of type Class needs unchecked conversion to conform to Class<capture-Y#0-of E extends Enum<capture-Y#0-of E>>\n" +
 			"----------\n");
 	}
 	//https://bugs.eclipse.org/bugs/show_bug.cgi?id=86838 - variation
@@ -28092,7 +28092,7 @@ public void test0881() {
 		"1. ERROR in X.java (at line 9)\n" +
 		"	String s = (String) Foo.foo();\n" +
 		"	           ^^^^^^^^^^^^^^^^^^\n" +
-		"Cannot cast from List<List<U>> to String\n" +
+		"Cannot cast from capture-Y#0-of U extends List<capture-Y#0-of U> to String\n" +
 		"----------\n");
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=121369 - variation
@@ -31001,7 +31001,7 @@ public void test0961() {
 		"5. WARNING in X.java (at line 7)\n" +
 		"	Comparable c = newInstance2(x);\n" +
 		"	                            ^\n" +
-		"Type safety: The expression of type X needs unchecked conversion to conform to X<Comparable<Comparable<B>>>\n" +
+		"Type safety: The expression of type X needs unchecked conversion to conform to X<capture-Y#0-of B extends Comparable<capture-Y#0-of B>>\n" +
 		"----------\n" +
 		"6. ERROR in X.java (at line 9)\n" +
 		"	Zork z;\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest.java
@@ -2467,7 +2467,7 @@ public void test366131b() {
 		"4. WARNING in X.java (at line 13)\n" +
 		"	return castTo((Class) null).containsNC((Comparable) null);\n" +
 		"	              ^^^^^^^^^^^^\n" +
-		"Type safety: The expression of type Class needs unchecked conversion to conform to Class<Comparable<? super Comparable<? super N>&Number>&Number>\n" +
+		"Type safety: The expression of type Class needs unchecked conversion to conform to Class<capture-Y#0-of N extends Comparable<? super capture-Y#0-of N>&Number>\n" +
 		"----------\n" +
 		"5. WARNING in X.java (at line 13)\n" +
 		"	return castTo((Class) null).containsNC((Comparable) null);\n" +
@@ -5337,7 +5337,7 @@ public void testBug454644() {
 		"5. WARNING in example\\CollectionFactory.java (at line 87)\n" +
 		"	return EnumSet.noneOf((Class) elementType);\n" +
 		"	                      ^^^^^^^^^^^^^^^^^^^\n" +
-		"Type safety: The expression of type Class needs unchecked conversion to conform to Class<Enum<Enum<E>>>\n" +
+		"Type safety: The expression of type Class needs unchecked conversion to conform to Class<capture-Y#0-of E extends Enum<capture-Y#0-of E>>\n" +
 		"----------\n" +
 		"6. WARNING in example\\CollectionFactory.java (at line 87)\n" +
 		"	return EnumSet.noneOf((Class) elementType);\n" +
@@ -5393,7 +5393,7 @@ public void testBug456459a() {
 		"5. WARNING in EnumTest.java (at line 9)\n" +
 		"	EnumSet<? extends T> set = EnumSet.allOf(enumType);\n" +
 		"	                                         ^^^^^^^^\n" +
-		"Type safety: The expression of type Class needs unchecked conversion to conform to Class<Enum<Enum<E>>>\n" +
+		"Type safety: The expression of type Class needs unchecked conversion to conform to Class<capture-Y#0-of E extends Enum<capture-Y#0-of E>>\n" +
 		"----------\n" +
 		"6. ERROR in EnumTest.java (at line 10)\n" +
 		"	return set.iterator().next();\n" +

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_1_8.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_1_8.java
@@ -7021,7 +7021,7 @@ public void testBug502350() {
 		"1. ERROR in makeCompilerFreeze\\EclipseJava8Bug.java (at line 20)\n" +
 		"	Stuff.func(Comparator.naturalOrder());\n" +
 		"	      ^^^^\n" +
-		"The method func(Comparator<T>) in the type Stuff is not applicable for the arguments (Comparator<Comparable<Comparable<B>>>)\n" +
+		"The method func(Comparator<T>) in the type Stuff is not applicable for the arguments (Comparator<capture-Y#0-of B extends Comparable<capture-Y#0-of B>>)\n" +
 		"----------\n"
 	);
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullTypeAnnotationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullTypeAnnotationTest.java
@@ -7248,7 +7248,7 @@ public void testBug445227() {
 		"1. WARNING in Bar.java (at line 6)\n" +
 		"	this((Iterable<E>) emptyList());\n" +
 		"	     ^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
-		"Type safety: Unchecked cast from Iterable<Bar.Foo<Bar.Foo<X>>> to Iterable<E>\n" +
+		"Type safety: Unchecked cast from Iterable<capture-Y#0-of X extends Bar.Foo<capture-Y#0-of X>> to Iterable<E>\n" +
 		"----------\n");
 }
 // https://bugs.eclipse.org/bugs/show_bug.cgi?id=446715, [compiler] org.eclipse.jdt.internal.compiler.lookup.TypeSystem.cacheDerivedType


### PR DESCRIPTION
+ print as special form of capture
  + naming update from JLS where they are now called "Y"
+ show all upper and lower bounds

