### PR TITLE
Parameterized Type Usage with Preview Flag not flagged preview warning 

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ASTNode.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ASTNode.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -599,7 +599,7 @@ public abstract class ASTNode implements Location, TypeConstants, TypeIds {
 			// ignore cases where type is used from inside itself
 			((ReferenceBinding)refType.erasure()).modifiers |= ExtraCompilerModifiers.AccLocallyUsed;
 		}
-		if (type instanceof BinaryTypeBinding btb) {
+		if (type.actualType() instanceof BinaryTypeBinding btb) {
 			reportPreviewAPI(scope, btb.binaryPreviewAnnotation);
 		}
 		if (refType.hasRestrictedAccess()) {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PreviewFeatureTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PreviewFeatureTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2024 IBM Corporation and others.
+ * Copyright (c) 2021, 2025 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -27,7 +27,7 @@ public class PreviewFeatureTest extends AbstractRegressionTest9 {
 	static {
 //		TESTS_NUMBERS = new int [] { 40 };
 //		TESTS_RANGE = new int[] { 1, -1 };
-//		TESTS_NAMES = new String[] { "test001"};
+//		TESTS_NAMES = new String[] { "test006"};
 	}
 
 	public static Class<?> testClass() {
@@ -81,6 +81,12 @@ public class PreviewFeatureTest extends AbstractRegressionTest9 {
 						+ "public class ABC {\n"
 						+ "  @PreviewFeature(feature=PreviewFeature.Feature.TEST)\n"
 						+ "  public void doSomething() {}\n"
+						+ "}",
+						"p/IPQR.java",
+						"package p;\n"
+						+ "import jdk.internal.javac.PreviewFeature;\n"
+						+ "@PreviewFeature(feature=PreviewFeature.Feature.TEST)\n"
+						+ "public interface IPQR<T> {\n"
 						+ "}"
 				},
 				jarPath,
@@ -332,6 +338,61 @@ public class PreviewFeatureTest extends AbstractRegressionTest9 {
 				assertFalse(JavaFeature.PRIMITIVES_IN_PATTERNS.isSupported(new CompilerOptions(options)));
 			else
 				assertTrue(JavaFeature.PRIMITIVES_IN_PATTERNS.isSupported(new CompilerOptions(options)));
+		} finally {
+			options.put(CompilerOptions.OPTION_EnablePreviews, old);
+		}
+	}
+	/*
+	 * Preview API, --enable-preview=false, SuppressWarning=No, Parameterized Type
+	 */
+	public void test006() {
+		if (this.complianceLevel >= ClassFileConstants.JDK17) {
+			return;
+		}
+		String[] classLibs = getClasspathWithPreviewAPI();
+		Map<String, String> options = getCompilerOptions();
+		String old = options.get(CompilerOptions.OPTION_EnablePreviews);
+		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
+		String output = this.complianceLevel == ClassFileConstants.JDK17 ?
+				"----------\n" +
+				"1. ERROR in X.java (at line 3)\n" +
+				"	Zork z = null;\n" +
+				"	^^^^\n" +
+				"Zork cannot be resolved to a type\n" +
+				"----------\n" +
+				"2. WARNING in X.java (at line 4)\n" +
+				"	IPQR<Integer> pqr = null;\n" +
+				"	^^^^\n" +
+				"You are using an API that is part of the preview feature \'Test Feature\' and may be removed in future\n" +
+				"----------\n" :
+					"----------\n" +
+					"1. ERROR in X.java (at line 3)\n" +
+					"	Zork z = null;\n" +
+					"	^^^^\n" +
+					"Zork cannot be resolved to a type\n" +
+					"----------\n" +
+					"2. WARNING in X.java (at line 4)\n" +
+					"	IPQR<Integer> pqr = null;\n" +
+					"	^^^^\n" +
+					"You are using an API that is part of the preview feature \'Test Feature\' and may be removed in future\n" +
+					"----------\n";
+
+		try {
+			runNegativeTest(
+					new String[] {
+							"X.java",
+							"import p.*;\n"+
+							"public class X {\n"+
+							"    Zork z = null;\n" +
+							"    IPQR<Integer> pqr = null;\n" +
+							"   public void foo () {\n"+
+							"   }\n"+
+							"}\n",
+					},
+					output,
+					classLibs,
+					true,
+					options);
 		} finally {
 			options.put(CompilerOptions.OPTION_EnablePreviews, old);
 		}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PreviewFeatureTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PreviewFeatureTest.java
@@ -353,29 +353,23 @@ public class PreviewFeatureTest extends AbstractRegressionTest9 {
 		Map<String, String> options = getCompilerOptions();
 		String old = options.get(CompilerOptions.OPTION_EnablePreviews);
 		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.DISABLED);
-		String output = this.complianceLevel == ClassFileConstants.JDK17 ?
-				"----------\n" +
-				"1. ERROR in X.java (at line 3)\n" +
-				"	Zork z = null;\n" +
-				"	^^^^\n" +
-				"Zork cannot be resolved to a type\n" +
-				"----------\n" +
-				"2. WARNING in X.java (at line 4)\n" +
-				"	IPQR<Integer> pqr = null;\n" +
-				"	^^^^\n" +
-				"You are using an API that is part of the preview feature \'Test Feature\' and may be removed in future\n" +
-				"----------\n" :
-					"----------\n" +
-					"1. ERROR in X.java (at line 3)\n" +
-					"	Zork z = null;\n" +
-					"	^^^^\n" +
-					"Zork cannot be resolved to a type\n" +
-					"----------\n" +
-					"2. WARNING in X.java (at line 4)\n" +
-					"	IPQR<Integer> pqr = null;\n" +
-					"	^^^^\n" +
-					"You are using an API that is part of the preview feature \'Test Feature\' and may be removed in future\n" +
-					"----------\n";
+		String error_output =
+		"----------\n" +
+		"1. ERROR in X.java (at line 3)\n" +
+		"	Zork z = null;\n" +
+		"	^^^^\n" +
+		"Zork cannot be resolved to a type\n" +
+		"----------\n" +
+		"2. WARNING in X.java (at line 4)\n" +
+		"	IPQR<Integer> pqr = null;\n" +
+		"	^^^^\n" +
+		"You are using an API that is part of the preview feature \'Test Feature\' and may be removed in future\n" +
+		"----------\n" +
+		"3. WARNING in X.java (at line 6)\n" +
+		"	IPQR<Integer> local_pqr = null;\n" +
+		"	^^^^\n" +
+		"You are using an API that is part of the preview feature \'Test Feature\' and may be removed in future\n" +
+		"----------\n";
 
 		try {
 			runNegativeTest(
@@ -386,10 +380,11 @@ public class PreviewFeatureTest extends AbstractRegressionTest9 {
 							"    Zork z = null;\n" +
 							"    IPQR<Integer> pqr = null;\n" +
 							"   public void foo () {\n"+
+							"    IPQR<Integer> local_pqr = null;\n" +
 							"   }\n"+
 							"}\n",
 					},
-					output,
+					error_output,
 					classLibs,
 					true,
 					options);


### PR DESCRIPTION
## What it does

while investigating issue #5103 , this was discovered. Consider the generic type mentioned below:
@PreviewFeature(feature = PreviewFeature.Feature.LAZY_CONSTANTS)
public sealed interface LazyConstant<T> {}

and a usage,
public class X {
    final LazyConstant<String> lc = null;// preview  usage error/warning expected

    private static void foo() {
        final LazyConstant<String> lc = null;// preview usage error/warning expected
   }

	public static void main(String[] args) {
		X.foo();
	}
}                

Preview usage error/warning expected where a field / variable of type LazyConstant is declared. This was not happening.

## How to test
a junit test is provided (test006 of PreviewTest) in the pr.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
