### PR TITLE
Revert "Skip completely inaccessible classpath elements in package caching"

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AccessRestrictionsTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AccessRestrictionsTests.java
@@ -1108,13 +1108,28 @@ public void test011() throws CoreException {
 			"----------\n" +
 			"1. ERROR in /P1/src/q/Y.java (at line 4)\n" +
 			"	p.X x = new p.X();\n" +
-			"	^\n" +
-			"p cannot be resolved to a type\n" +
+			"	^^^\n" +
+			"Access restriction: The type \'X\' is not accessible (restriction on required library \'AccessRestrictions/lib.jar\')\n" +
 			"----------\n" +
 			"2. ERROR in /P1/src/q/Y.java (at line 4)\n" +
 			"	p.X x = new p.X();\n" +
-			"	            ^\n" +
-			"p cannot be resolved to a type\n" +
+			"	            ^^^\n" +
+			"Access restriction: The type \'X\' is not accessible (restriction on required library \'AccessRestrictions/lib.jar\')\n" +
+			"----------\n" +
+			"3. ERROR in /P1/src/q/Y.java (at line 4)\n" +
+			"	p.X x = new p.X();\n" +
+			"	            ^^^\n" +
+			"Access restriction: The constructor \'X()\' is not accessible (restriction on required library \'AccessRestrictions/lib.jar\')\n" +
+			"----------\n" +
+			"4. ERROR in /P1/src/q/Y.java (at line 5)\n" +
+			"	x.foo();\n" +
+			"	  ^^^\n" +
+			"Access restriction: The method \'X.foo()\' is not accessible (restriction on required library \'AccessRestrictions/lib.jar\')\n" +
+			"----------\n" +
+			"5. ERROR in /P1/src/q/Y.java (at line 6)\n" +
+			"	if (x.m > 0) {}\n" +
+			"	      ^\n" +
+			"Access restriction: The field \'X.m\' is not accessible (restriction on required library \'AccessRestrictions/lib.jar\')\n" +
 			"----------\n"
 		);
 	} finally {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/NameLookupTests2.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/NameLookupTests2.java
@@ -450,7 +450,8 @@ public void testNonAccessibleAccessAnswer() throws Exception {
 				true /* wait for indexer */,
 				true /* check restrictions */,
 				null);
-		assertNull("Expected to not find type", answer);
+		assertNotNull("Expected to find type", answer);
+		assertTrue("Expected type to be non-accessible", answer.isNonAccessible());
 	} finally {
 		deleteProject("P");
 	}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaProjectElementInfo.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaProjectElementInfo.java
@@ -13,7 +13,6 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.core;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import org.eclipse.core.resources.IContainer;
@@ -27,9 +26,6 @@ import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
-import org.eclipse.jdt.core.compiler.IProblem;
-import org.eclipse.jdt.internal.compiler.env.AccessRule;
-import org.eclipse.jdt.internal.compiler.env.AccessRuleSet;
 import org.eclipse.jdt.internal.core.DeltaProcessor.RootInfo;
 import org.eclipse.jdt.internal.core.util.HashSetOfArray;
 import org.eclipse.jdt.internal.core.util.HashtableOfArrayToObject;
@@ -244,10 +240,7 @@ class JavaProjectElementInfo extends OpenableElementInfo {
 					roots[i] = root = (IPackageFragmentRoot) manager.getExistingElement(root);
 					// compute fragment cache
 					HashSetOfArray fragmentsCache = new HashSetOfArray();
-					if (!(reverseMap.get(root) instanceof ClasspathEntry cpEntry)
-							|| !isCompletelyNonAccessible(cpEntry)) {
-						initializePackageNames(root, fragmentsCache);
-					}
+					initializePackageNames(root, fragmentsCache);
 					pkgFragmentsCaches.put(root, fragmentsCache);
 				}
 			}
@@ -260,22 +253,6 @@ class JavaProjectElementInfo extends OpenableElementInfo {
 			}
 		}
 		return cache;
-	}
-
-	private static final char[] ALL_ELEMENTS = {'*', '*', '/', '*'};
-
-	private boolean isCompletelyNonAccessible(ClasspathEntry cpEntry) {
-		AccessRuleSet accessRules = cpEntry.getAccessRuleSet();
-		if (accessRules != null) {
-			AccessRule[] rules = accessRules.getAccessRules();
-			if (rules.length == 1) {
-				AccessRule rule = rules[0];
-				if (rule.getProblemId() == IProblem.ForbiddenReference && Arrays.equals(ALL_ELEMENTS, rule.pattern)) {
-					return true;
-				}
-			}
-		}
-		return false;
 	}
 
 	/**


### PR DESCRIPTION
This reverts
- https://github.com/eclipse-jdt/eclipse.jdt.core/pull/4910

Fixes
- https://github.com/eclipse-pde/eclipse.pde/issues/2358
- https://github.com/eclipse-pde/eclipse.pde/issues/2359

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
