### PR TITLE
Fix newline bug reported and add new test

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/formatter/FormatterTextBlockTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/formatter/FormatterTextBlockTests.java
@@ -238,4 +238,14 @@ public class FormatterTextBlockTests extends AbstractJavaModelTests {
 		this.formatterPrefs.put_text_block_quotes_on_new_line = false;
 	}
 
+	public void test09() {
+		// To test the fix added for the bug:https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/3003
+        this.formatterPrefs.put_text_block_quotes_on_new_line = true;
+		this.formatterPrefs.text_block_indentation = Alignment.M_INDENT_ON_COLUMN;
+		runTest("test09", "X.java");//$NON-NLS-1$ //$NON-NLS-2$
+		this.formatterPrefs.text_block_indentation = Alignment.M_INDENT_DEFAULT;
+		this.formatterPrefs.put_text_block_quotes_on_new_line = false;
+	}
+
+
 }

--- a/org.eclipse.jdt.core.tests.model/workspace/FormatterTextBlock/test09/X_in.java
+++ b/org.eclipse.jdt.core.tests.model/workspace/FormatterTextBlock/test09/X_in.java
@@ -1,0 +1,7 @@
+public class X {
+	String str3 = """
+			subd3
+			ospl
+
+			test""";
+}

--- a/org.eclipse.jdt.core.tests.model/workspace/FormatterTextBlock/test09/X_out.java
+++ b/org.eclipse.jdt.core.tests.model/workspace/FormatterTextBlock/test09/X_out.java
@@ -1,0 +1,9 @@
+public class X {
+	String str3 =
+	"""
+	subd3
+	ospl
+
+	test\
+	""";
+}

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/TextEditsBuilder.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/TextEditsBuilder.java
@@ -418,11 +418,20 @@ public class TextEditsBuilder extends TokenTraverser {
 			int splitPlace = stringToCheck.indexOf(closingQuotes);
 			if (splitPlace > 0) {
 				// There is no new line because it is already present in the buffer field.
+				String newBuffer = getClosingQuotesBuffer(this.buffer.toString());
 				this.edits.add(getReplaceEdit(position + splitPlace, position + splitPlace,
-						'\\' + this.buffer.toString(), region));
+						'\\' + newBuffer, region));
 			}
 		}
 		return;
+	}
+
+	private String getClosingQuotesBuffer(String curBuffer) {
+		// FOr the closing quote buffer, we want to ensure that there is only a single newline.
+		// But this can't be the case if the line before the last contains an extra newline (one or more).
+		// So we need to strip any extra newline.
+		StringBuilder newBuffer = new StringBuilder (this.options.line_separator + curBuffer.replace(this.options.line_separator, "")); //$NON-NLS-1$
+		return newBuffer.toString();
 	}
 
 	private ReplaceEdit getReplaceEdit(int editStart, int editEnd, String text, IRegion region) {


### PR DESCRIPTION
## What it does
It fix the bug reported here: [eclipse.jdt.ui:3003](org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/formatter/FormatterTextBlockTests.java)

## How to test

1.  Make sure that the formatter option: New Lines/"After and before  opening and closing a text block " is enabled.
2.  Create a String like: 

```java
String str3 = """
			subd3
			ospl

			test""";
```

Make sure to keep the newline in that position.
3. Run the formatter 

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
