### PR TITLE
Method call with wildcard generic parameter fails to compile

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BoundSet.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BoundSet.java
@@ -380,6 +380,7 @@ class BoundSet {
 		if (this.unincorporatedBoundsCount > 0)
 			System.arraycopy(this.unincorporatedBounds, 0, copy.unincorporatedBounds = new TypeBound[this.unincorporatedBounds.length], 0, this.unincorporatedBounds.length);
 		copy.unincorporatedBoundsCount = this.unincorporatedBoundsCount;
+		copy.isRecordPatternInference = this.isRecordPatternInference;
 		return copy;
 	}
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/CaptureBinding18.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/CaptureBinding18.java
@@ -87,7 +87,7 @@ public class CaptureBinding18 extends CaptureBinding {
 
 	@Override
 	public MethodBinding[] getMethods(char[] selector) {
-		if (this.upperBounds.length == 1 && this.upperBounds[0] instanceof ReferenceBinding)
+		if (this.upperBounds != null && this.upperBounds.length == 1 && this.upperBounds[0] instanceof ReferenceBinding)
 			return ((ReferenceBinding)this.upperBounds[0]).getMethods(selector);
 		return super.getMethods(selector);
 	}
@@ -175,6 +175,26 @@ public class CaptureBinding18 extends CaptureBinding {
 
 				for (int i = 0; i < length; i++) {
 					if (this.upperBounds[i].isCompatibleWith(otherType, captureScope))
+						return true;
+				}
+			}
+			return false;
+		} finally {
+			this.inRecursiveFunction = false;
+		}
+	}
+
+	@Override
+	public boolean isSubtypeOf(TypeBinding other, boolean simulatingBugJDK8026527) {
+		if (this.inRecursiveFunction)
+			return true;
+		this.inRecursiveFunction = true;
+		try {
+			if (super.isSubtypeOf(other, simulatingBugJDK8026527))
+				return true;
+			if (this.upperBounds != null) {
+				for (TypeBinding upper : this.upperBounds) {
+					if (upper.isSubtypeOf(other, simulatingBugJDK8026527))
 						return true;
 				}
 			}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
@@ -104,6 +104,8 @@ public class InferenceContext18 {
 
 	static final boolean SHOULD_WORKAROUND_BUG_JDK_8153748 = true; // NON-JLS emulating javac behaviour after private email communication
 
+	static final boolean SHOULD_WORKAROUND_BUG_JDK_6573446 = true; // NON-JLS, see also https://mail.openjdk.org/archives/list/compiler-dev@openjdk.org/thread/TLIVNI7SPUVX646O7RTGG7IOYJVWSV47/
+
 	/**
 	 * NON-JLS: Detail flag to control the extent of {@link #SIMULATE_BUG_JDK_8026527}.
 	 * A setting of 'false' implements the advice from http://mail.openjdk.java.net/pipermail/lambda-spec-experts/2013-December/000447.html
@@ -1144,19 +1146,31 @@ public class InferenceContext18 {
 		return this.currentBounds.reduceOneConstraint(this, constraint); // TODO(SH): should we immediately call a diat incorporate, or can we simply wait for the next round?
 	}
 
-	 /** <b>JLS 18.4 </b> Resolution
-	  * @param isRecordPatternTypeInference for 18.5.5_item_3_bullet_5
+	/** <b>JLS 18.4 </b> Resolution
+	 * @param isRecordPatternTypeInference for 18.5.5_item_3_bullet_5
 	 * @return answer null if some constraint resolved to FALSE, otherwise the boundset representing the solution
 	 */
 	private /*@Nullable*/ BoundSet resolve(
 			InferenceVariable[] toResolve,
 			boolean isRecordPatternTypeInference) throws InferenceFailureException {
 		this.captureId = 0;
+		BoundSet result = resolve(toResolve, isRecordPatternTypeInference, true);
+		if (result == FAIL_AFTER_USING_LOWER_BOUNDS && SHOULD_WORKAROUND_BUG_JDK_6573446) {
+			result = resolve(toResolve, isRecordPatternTypeInference, false);
+		}
+		return result;
+	}
+	/** Marker Object for a failed resolution where lower bounds have been used. */
+	private static BoundSet FAIL_AFTER_USING_LOWER_BOUNDS = new BoundSet();
+	private /*@Nullable*/ BoundSet resolve(InferenceVariable[] toResolve, boolean isRecordPatternTypeInference, boolean useLowerBounds)
+			throws InferenceFailureException
+	{
 		// NOTE: 18.5.2 ...
 		// "(While it was necessary to demonstrate that the inference variables in B1 could be resolved
 		//   in order to establish applicability, the resulting instantiations are not considered part of B1.)
 		// For this reason, resolve works on a temporary copy of the bound set.
 		BoundSet tmpBoundSet = this.currentBounds.copy();
+		boolean lowerBoundUsed = false;
 		if (this.inferenceVariables != null) {
 			Set<InferenceVariable> toResolveSet = new LinkedHashSet<>(Arrays.asList(toResolve));
 			// find a minimal set of dependent variables:
@@ -1175,7 +1189,9 @@ public class InferenceContext18 {
 					if (!isRecordPatternTypeInference && !tmpBoundSet.hasCaptureBound(variableSet)) {
 						// try to instantiate this set of variables in tmpBoundSet, but keep a copy for roll-back
 						BoundSet prevBoundSet = tmpBoundSet.copy();
-						if (resolveFirstAttempt(tmpBoundSet, toResolveSet, variableSet, variables)) {
+						ResolveOutcome firstAttempt = resolveFirstAttempt(tmpBoundSet, toResolveSet, variableSet, variables, useLowerBounds);
+						lowerBoundUsed |= firstAttempt.lowerBoundUsed;
+						if (firstAttempt.success) {
 							continue;
 						}
 						// roll back for second attempt:
@@ -1186,7 +1202,7 @@ public class InferenceContext18 {
 							continue;
 						}
 					}
-					return null;
+					return lowerBoundUsed ? FAIL_AFTER_USING_LOWER_BOUNDS : null;
 				}
 				if (tmpBoundSet.numUninstantiatedVariables(this.inferenceVariables) == oldNumUninstantiated)
 					return null; // abort because we made no progress
@@ -1195,8 +1211,11 @@ public class InferenceContext18 {
 		return tmpBoundSet;
 	}
 
-	 private boolean resolveFirstAttempt(BoundSet tmpBoundSet, Set<InferenceVariable> toResolveSet,
-			Set<InferenceVariable> variableSet, final InferenceVariable[] variables) throws InferenceFailureException {
+	record ResolveOutcome(boolean success, boolean lowerBoundUsed) {}
+	private ResolveOutcome resolveFirstAttempt(BoundSet tmpBoundSet, Set<InferenceVariable> toResolveSet,
+			Set<InferenceVariable> variableSet, final InferenceVariable[] variables, boolean useLowerBounds)
+					throws InferenceFailureException {
+		boolean lowerBoundsUsed = false;
 		for (int j = 0; j < variables.length; j++) {
 			InferenceVariable variable = variables[j];
 			if (tmpBoundSet.isInstantiated(variable)) { // NON-JLS: may happen when exception bound has been incorporated
@@ -1206,11 +1225,12 @@ public class InferenceContext18 {
 			}
 			// try lower bounds:
 			TypeBinding[] lowerBounds = tmpBoundSet.lowerBounds(variable, true/*onlyProper*/);
-			if (lowerBounds != Binding.NO_TYPES) {
+			if (lowerBounds != Binding.NO_TYPES && useLowerBounds) {
 				TypeBinding lub = this.scope.lowerUpperBound(lowerBounds);
 				if (lub == TypeBinding.VOID || lub == null)
-					return false; // TODO: directly fail entire resolution?
+					return new ResolveOutcome(false, lowerBoundsUsed);
 				tmpBoundSet.addBound(new TypeBound(variable, lub, ReductionResult.SAME), this.environment);
+				lowerBoundsUsed = true;
 			} else {
 				TypeBinding[] upperBounds = tmpBoundSet.upperBounds(variable, true/*onlyProper*/);
 				// check exception bounds:
@@ -1219,7 +1239,7 @@ public class InferenceContext18 {
 					tmpBoundSet.addBound(new TypeBound(variable, runtimeException, ReductionResult.SAME), this.environment);
 					// NON-JLS: propagate RuntimeException to equivalent ivars:
 					if (!tmpBoundSet.incorporate(this)) {
-						return false; // go for second attempt
+						return new ResolveOutcome(false, lowerBoundsUsed); // go for second attempt
 					}
 				} else {
 					// try upper bounds:
@@ -1231,14 +1251,14 @@ public class InferenceContext18 {
 							TypeBinding[] glbs = Scope.greaterLowerBound(upperBounds, this.scope, this.environment);
 							if (glbs == null) {
 								// inconsistent intersection
-								return false; // go for second attempt
+								return new ResolveOutcome(false, lowerBoundsUsed); // go for second attempt
 							} else if (glbs.length == 1) {
 								glb = glbs[0];
 							} else {
 								glb = intersectionFromGlb(glbs);
 								if (glb == null) {
 									// inconsistent intersection
-									return false; // go for second attempt
+									return new ResolveOutcome(false, lowerBoundsUsed); // go for second attempt
 								}
 							}
 						}
@@ -1250,8 +1270,8 @@ public class InferenceContext18 {
 			variableSet.remove(variable);
 		}
 		if (tmpBoundSet.incorporate(this))
-			return true; // success!
-		return false; // go for second attempt
+			return new ResolveOutcome(true, lowerBoundsUsed); // success!
+		return new ResolveOutcome(false, lowerBoundsUsed); // go for second attempt
 	}
 
 	private boolean resolveSecondAttempt(BoundSet tmpBoundSet, Set<InferenceVariable> toResolveSet,

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
@@ -1155,8 +1155,8 @@ public class InferenceContext18 {
 		// NOTE: 18.5.2 ...
 		// "(While it was necessary to demonstrate that the inference variables in B1 could be resolved
 		//   in order to establish applicability, the resulting instantiations are not considered part of B1.)
-		// For this reason, resolve works on a temporary bound set, copied before any modification.
-		BoundSet tmpBoundSet = this.currentBounds;
+		// For this reason, resolve works on a temporary copy of the bound set.
+		BoundSet tmpBoundSet = this.currentBounds.copy();
 		if (this.inferenceVariables != null) {
 			Set<InferenceVariable> toResolveSet = new LinkedHashSet<>(Arrays.asList(toResolve));
 			// find a minimal set of dependent variables:
@@ -1172,178 +1172,19 @@ public class InferenceContext18 {
 						System.out.println("Resolving ivars: "+ofRank); //$NON-NLS-1$
 					}
 					final InferenceVariable[] variables = ofRank.toArray(new InferenceVariable[numVars]);
-					variables: if (!isRecordPatternTypeInference && !tmpBoundSet.hasCaptureBound(variableSet)) {
-						// try to instantiate this set of variables in a fresh copy of the bound set:
-						BoundSet prevBoundSet = tmpBoundSet;
-						tmpBoundSet = tmpBoundSet.copy();
-						for (int j = 0; j < variables.length; j++) {
-							InferenceVariable variable = variables[j];
-							if (tmpBoundSet.isInstantiated(variable)) { // NON-JLS: may happen when exception bound has been incorporated
-								toResolveSet.remove(variable);
-								variableSet.remove(variable);
-								continue;
-							}
-							// try lower bounds:
-							TypeBinding[] lowerBounds = tmpBoundSet.lowerBounds(variable, true/*onlyProper*/);
-							if (lowerBounds != Binding.NO_TYPES) {
-								TypeBinding lub = this.scope.lowerUpperBound(lowerBounds);
-								if (lub == TypeBinding.VOID || lub == null)
-									return null;
-								tmpBoundSet.addBound(new TypeBound(variable, lub, ReductionResult.SAME), this.environment);
-							} else {
-								TypeBinding[] upperBounds = tmpBoundSet.upperBounds(variable, true/*onlyProper*/);
-								// check exception bounds:
-								if (tmpBoundSet.inThrows.contains(variable.prototype()) && tmpBoundSet.hasOnlyTrivialExceptionBounds(variable, upperBounds)) {
-									TypeBinding runtimeException = this.scope.getType(TypeConstants.JAVA_LANG_RUNTIMEEXCEPTION, 3);
-									tmpBoundSet.addBound(new TypeBound(variable, runtimeException, ReductionResult.SAME), this.environment);
-									// NON-JLS: propagate RuntimeException to equivalent ivars:
-									if (!tmpBoundSet.incorporate(this)) {
-										tmpBoundSet = prevBoundSet;// clean-up for second attempt
-										break variables;
-									}
-								} else {
-									// try upper bounds:
-									TypeBinding glb = this.object;
-									if (upperBounds != Binding.NO_TYPES) {
-										if (upperBounds.length == 1) {
-											glb = upperBounds[0];
-										} else {
-											TypeBinding[] glbs = Scope.greaterLowerBound(upperBounds, this.scope, this.environment);
-											if (glbs == null) {
-												// inconsistent intersection
-												tmpBoundSet = prevBoundSet; // clean up
-												break variables; // and start over
-											} else if (glbs.length == 1) {
-												glb = glbs[0];
-											} else {
-												glb = intersectionFromGlb(glbs);
-												if (glb == null) {
-													// inconsistent intersection
-													tmpBoundSet = prevBoundSet; // clean up
-													break variables; // and start over
-												}
-											}
-										}
-									}
-									tmpBoundSet.addBound(new TypeBound(variable, glb, ReductionResult.SAME), this.environment);
-								}
-							}
-							toResolveSet.remove(variable);
-							variableSet.remove(variable);
-						}
-						if (tmpBoundSet.incorporate(this))
+					if (!isRecordPatternTypeInference && !tmpBoundSet.hasCaptureBound(variableSet)) {
+						// try to instantiate this set of variables in tmpBoundSet, but keep a copy for roll-back
+						BoundSet prevBoundSet = tmpBoundSet.copy();
+						if (resolveFirstAttempt(tmpBoundSet, toResolveSet, variableSet, variables)) {
 							continue;
-						tmpBoundSet = prevBoundSet;// clean-up for second attempt
+						}
+						// roll back for second attempt:
+						tmpBoundSet = prevBoundSet;
 					}
-					// Otherwise, a second attempt is made...
-					Sorting.sortInferenceVariables(variables); // ensure stability of capture IDs
-					final CaptureBinding18[] ys = new CaptureBinding18[numVars];
-					for (int j = 0; j < numVars; j++)
-						ys[j] = freshCapture(variables[j]);
-					final BoundSet kurrentBoundSet = tmpBoundSet;
-					Substitution theta = new Substitution() {
-						@Override
-						public LookupEnvironment environment() {
-							return InferenceContext18.this.environment;
+					if (resolveSecondAttempt(tmpBoundSet, toResolveSet, variableSet, numVars, variables)) {
+						if (tmpBoundSet.incorporate(this)) {
+							continue;
 						}
-						@Override
-						public boolean isRawSubstitution() {
-							return false;
-						}
-						@Override
-						public TypeBinding substitute(TypeVariableBinding typeVariable) {
-							for (int j = 0; j < numVars; j++)
-								if (TypeBinding.equalsEquals(variables[j], typeVariable) && ys[j] != null)
-									return ys[j];
-							/* If we have an instantiation, lower it to the instantiation. We don't want downstream abstractions to be confused about multiple versions of bounds without
-							   and with instantiations propagated by incorporation. See https://bugs.eclipse.org/bugs/show_bug.cgi?id=430686. There is no value whatsoever in continuing
-							   to speak in two tongues. Also fixes https://bugs.eclipse.org/bugs/show_bug.cgi?id=425031.
-							*/
-							if (typeVariable instanceof InferenceVariable) {
-								InferenceVariable inferenceVariable = (InferenceVariable) typeVariable;
-								TypeBinding instantiation = kurrentBoundSet.getInstantiation(inferenceVariable, null);
-								if (instantiation != null)
-									return instantiation;
-							}
-							return typeVariable;
-						}
-					};
-					for (int j = 0; j < numVars; j++) {
-						InferenceVariable variable = variables[j];
-						variableSet.remove(variable);
-						CaptureBinding18 yj = ys[j];
-						// NON-JLS: leverage existing same bounds if they become proper by substitution:
-						boolean typeboundCreated = false;
-						TypeBinding[] sameBounds = tmpBoundSet.sameBounds(variable);
-						if (sameBounds != Binding.NO_TYPES) {
-							int l = 0;
-							for (int k = 0; k < sameBounds.length; k++) {
-								TypeBinding subst = Scope.substitute(theta, sameBounds[k]);
-								if (subst.isProperType(true))
-									sameBounds[l++] = subst;
-							}
-							if (l > 0) {
-								if (l < sameBounds.length)
-									sameBounds = Arrays.copyOf(sameBounds, l);
-								sameBounds = Scope.greaterLowerBound(sameBounds, this.scope, this.environment);
-								if (sameBounds != null && sameBounds.length == 1) {
-									tmpBoundSet.addBound(new TypeBound(variable, sameBounds[0], ReductionResult.SAME), this.environment);
-									typeboundCreated = true;
-									ys[j] = null;
-								}
-							}
-						}
-						//
-						if (!typeboundCreated) {
-							// if no same bounds found, proceed as specified in JLS:
-							// add lower bounds:
-							TypeBinding[] lowerBounds = tmpBoundSet.lowerBounds(variable, true/*onlyProper*/);
-							if (lowerBounds != Binding.NO_TYPES) {
-								TypeBinding lub = this.scope.lowerUpperBound(lowerBounds);
-								if (lub != TypeBinding.VOID && lub != null)
-									yj.lowerBound = lub;
-							}
-							// add upper bounds:
-							TypeBinding[] upperBounds = tmpBoundSet.upperBounds(variable, false/*onlyProper*/);
-							if (upperBounds != Binding.NO_TYPES) {
-								for (int k = 0; k < upperBounds.length; k++)
-									upperBounds[k] = Scope.substitute(theta, upperBounds[k]);
-								if (!setUpperBounds(yj, upperBounds))
-									continue; // at violation of well-formedness skip this candidate and proceed
-							} else {
-								yj.setSuperClass(this.object);
-							}
-						}
-						if (tmpBoundSet == this.currentBounds)
-							tmpBoundSet = tmpBoundSet.copy();
-						Iterator<ParameterizedTypeBinding> captureKeys = tmpBoundSet.captures.keySet().iterator();
-						while (captureKeys.hasNext()) {
-							ParameterizedTypeBinding key = captureKeys.next();
-							int len = key.arguments.length;
-							for (int i = 0; i < len; i++) {
-								if (TypeBinding.equalsEquals(key.arguments[i], variable)) {
-									captureKeys.remove();
-									break;
-								}
-							}
-						}
-						captureKeys = tmpBoundSet.allCaptures.keySet().iterator();
-						while (captureKeys.hasNext()) {
-							ParameterizedTypeBinding key = captureKeys.next();
-							int len = key.arguments.length;
-							for (int i = 0; i < len; i++) {
-								if (TypeBinding.equalsEquals(key.arguments[i], variable)) {
-									captureKeys.remove();
-									break;
-								}
-							}
-						}
-						if (!typeboundCreated)
-							tmpBoundSet.addBound(new TypeBound(variable, yj, ReductionResult.SAME), this.environment);
-						toResolveSet.remove(variable);
-					}
-					if (tmpBoundSet.incorporate(this)) {
-						continue;
 					}
 					return null;
 				}
@@ -1353,6 +1194,176 @@ public class InferenceContext18 {
 		}
 		return tmpBoundSet;
 	}
+
+	 private boolean resolveFirstAttempt(BoundSet tmpBoundSet, Set<InferenceVariable> toResolveSet,
+			Set<InferenceVariable> variableSet, final InferenceVariable[] variables) throws InferenceFailureException {
+		for (int j = 0; j < variables.length; j++) {
+			InferenceVariable variable = variables[j];
+			if (tmpBoundSet.isInstantiated(variable)) { // NON-JLS: may happen when exception bound has been incorporated
+				toResolveSet.remove(variable);
+				variableSet.remove(variable);
+				continue;
+			}
+			// try lower bounds:
+			TypeBinding[] lowerBounds = tmpBoundSet.lowerBounds(variable, true/*onlyProper*/);
+			if (lowerBounds != Binding.NO_TYPES) {
+				TypeBinding lub = this.scope.lowerUpperBound(lowerBounds);
+				if (lub == TypeBinding.VOID || lub == null)
+					return false; // TODO: directly fail entire resolution?
+				tmpBoundSet.addBound(new TypeBound(variable, lub, ReductionResult.SAME), this.environment);
+			} else {
+				TypeBinding[] upperBounds = tmpBoundSet.upperBounds(variable, true/*onlyProper*/);
+				// check exception bounds:
+				if (tmpBoundSet.inThrows.contains(variable.prototype()) && tmpBoundSet.hasOnlyTrivialExceptionBounds(variable, upperBounds)) {
+					TypeBinding runtimeException = this.scope.getType(TypeConstants.JAVA_LANG_RUNTIMEEXCEPTION, 3);
+					tmpBoundSet.addBound(new TypeBound(variable, runtimeException, ReductionResult.SAME), this.environment);
+					// NON-JLS: propagate RuntimeException to equivalent ivars:
+					if (!tmpBoundSet.incorporate(this)) {
+						return false; // go for second attempt
+					}
+				} else {
+					// try upper bounds:
+					TypeBinding glb = this.object;
+					if (upperBounds != Binding.NO_TYPES) {
+						if (upperBounds.length == 1) {
+							glb = upperBounds[0];
+						} else {
+							TypeBinding[] glbs = Scope.greaterLowerBound(upperBounds, this.scope, this.environment);
+							if (glbs == null) {
+								// inconsistent intersection
+								return false; // go for second attempt
+							} else if (glbs.length == 1) {
+								glb = glbs[0];
+							} else {
+								glb = intersectionFromGlb(glbs);
+								if (glb == null) {
+									// inconsistent intersection
+									return false; // go for second attempt
+								}
+							}
+						}
+					}
+					tmpBoundSet.addBound(new TypeBound(variable, glb, ReductionResult.SAME), this.environment);
+				}
+			}
+			toResolveSet.remove(variable);
+			variableSet.remove(variable);
+		}
+		if (tmpBoundSet.incorporate(this))
+			return true; // success!
+		return false; // go for second attempt
+	}
+
+	private boolean resolveSecondAttempt(BoundSet tmpBoundSet, Set<InferenceVariable> toResolveSet,
+			Set<InferenceVariable> variableSet, final int numVars, final InferenceVariable[] variables) {
+		// Otherwise, a second attempt is made...
+		Sorting.sortInferenceVariables(variables); // ensure stability of capture IDs
+		final CaptureBinding18[] ys = new CaptureBinding18[numVars];
+		for (int j = 0; j < numVars; j++)
+			ys[j] = freshCapture(variables[j]);
+		final BoundSet kurrentBoundSet = tmpBoundSet;
+		Substitution theta = new Substitution() {
+			@Override
+			public LookupEnvironment environment() {
+				return InferenceContext18.this.environment;
+			}
+			@Override
+			public boolean isRawSubstitution() {
+				return false;
+			}
+			@Override
+			public TypeBinding substitute(TypeVariableBinding typeVariable) {
+				for (int j = 0; j < numVars; j++)
+					if (TypeBinding.equalsEquals(variables[j], typeVariable) && ys[j] != null)
+						return ys[j];
+				/* If we have an instantiation, lower it to the instantiation. We don't want downstream abstractions to be confused about multiple versions of bounds without
+				   and with instantiations propagated by incorporation. See https://bugs.eclipse.org/bugs/show_bug.cgi?id=430686. There is no value whatsoever in continuing
+				   to speak in two tongues. Also fixes https://bugs.eclipse.org/bugs/show_bug.cgi?id=425031.
+				*/
+				if (typeVariable instanceof InferenceVariable) {
+					InferenceVariable inferenceVariable = (InferenceVariable) typeVariable;
+					TypeBinding instantiation = kurrentBoundSet.getInstantiation(inferenceVariable, null);
+					if (instantiation != null)
+						return instantiation;
+				}
+				return typeVariable;
+			}
+		};
+		for (int j = 0; j < numVars; j++) {
+			InferenceVariable variable = variables[j];
+			variableSet.remove(variable);
+			CaptureBinding18 yj = ys[j];
+			// NON-JLS: leverage existing same bounds if they become proper by substitution:
+			boolean typeboundCreated = false;
+			TypeBinding[] sameBounds = tmpBoundSet.sameBounds(variable);
+			if (sameBounds != Binding.NO_TYPES) {
+				int l = 0;
+				for (int k = 0; k < sameBounds.length; k++) {
+					TypeBinding subst = Scope.substitute(theta, sameBounds[k]);
+					if (subst.isProperType(true))
+						sameBounds[l++] = subst;
+				}
+				if (l > 0) {
+					if (l < sameBounds.length)
+						sameBounds = Arrays.copyOf(sameBounds, l);
+					sameBounds = Scope.greaterLowerBound(sameBounds, this.scope, this.environment);
+					if (sameBounds != null && sameBounds.length == 1) {
+						tmpBoundSet.addBound(new TypeBound(variable, sameBounds[0], ReductionResult.SAME), this.environment);
+						typeboundCreated = true;
+						ys[j] = null;
+					}
+				}
+			}
+			//
+			if (!typeboundCreated) {
+				// if no same bounds found, proceed as specified in JLS:
+				// add lower bounds:
+				TypeBinding[] lowerBounds = tmpBoundSet.lowerBounds(variable, true/*onlyProper*/);
+				if (lowerBounds != Binding.NO_TYPES) {
+					TypeBinding lub = this.scope.lowerUpperBound(lowerBounds);
+					if (lub != TypeBinding.VOID && lub != null)
+						yj.lowerBound = lub;
+				}
+				// add upper bounds:
+				TypeBinding[] upperBounds = tmpBoundSet.upperBounds(variable, false/*onlyProper*/);
+				if (upperBounds != Binding.NO_TYPES) {
+					for (int k = 0; k < upperBounds.length; k++)
+						upperBounds[k] = Scope.substitute(theta, upperBounds[k]);
+					if (!setUpperBounds(yj, upperBounds))
+						return false; // violation of well-formedness
+				} else {
+					yj.setSuperClass(this.object);
+				}
+			}
+			Iterator<ParameterizedTypeBinding> captureKeys = tmpBoundSet.captures.keySet().iterator();
+			while (captureKeys.hasNext()) {
+				ParameterizedTypeBinding key = captureKeys.next();
+				int len = key.arguments.length;
+				for (int i = 0; i < len; i++) {
+					if (TypeBinding.equalsEquals(key.arguments[i], variable)) {
+						captureKeys.remove();
+						break;
+					}
+				}
+			}
+			captureKeys = tmpBoundSet.allCaptures.keySet().iterator();
+			while (captureKeys.hasNext()) {
+				ParameterizedTypeBinding key = captureKeys.next();
+				int len = key.arguments.length;
+				for (int i = 0; i < len; i++) {
+					if (TypeBinding.equalsEquals(key.arguments[i], variable)) {
+						captureKeys.remove();
+						break;
+					}
+				}
+			}
+			if (!typeboundCreated)
+				tmpBoundSet.addBound(new TypeBound(variable, yj, ReductionResult.SAME), this.environment);
+			toResolveSet.remove(variable);
+		}
+		return true;
+	}
+
 	/**
 	 * <b>JLS 18.4</b> Resolution
 	 * @return answer null if some constraint resolved to FALSE, otherwise the boundset representing the solution

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericTypeTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericTypeTest.java
@@ -38316,7 +38316,7 @@ public void test1141() {
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=190945
 public void test1142() {
-	runNegativeTest(
+	runConformTest(
 		// test directory preparation
 		new String[] { /* test files */
 			"X.java",
@@ -38334,16 +38334,7 @@ public void test1142() {
 			"    return null;\n" +
 			"  }\n" +
 			"}\n", // =================
-		},
-		// compiler results
-		"----------\n" + /* expected compiler log */
-		"1. ERROR in X.java (at line 5)\n" +
-		"	return compound(asList(a, b));\n" +
-		"	       ^^^^^^^^\n" +
-		"The method compound(Iterable<? extends Comparator<? super T>>) in the type X is not applicable for the arguments (List<Comparator<?>>)\n" +
-		"----------\n",
-		// javac options
-		JavacTestOptions.JavacHasABug.JavacBug6573446 /* javac test options */);
+		});
 }
 //https://bugs.eclipse.org/bugs/show_bug.cgi?id=190945 - variation
 public void test1143() {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
@@ -2230,20 +2230,7 @@ public void testGH4774() throws Exception {
 			}
 			"""
 		};
-	runner.expectedCompilerLog =
-		"""
-		----------
-		1. ERROR in Test.java (at line 4)
-			Z<B> z = new Z<>(List.of(
-						new Y<>(new A()),
-						new Y<>(new B()),
-						new Y<>(new C())));
-			         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-		Cannot infer type arguments for Z<>
-		----------
-		""";
-	runner.javacTestOptions = JavacHasABug.JavacBug6573446;
-	runner.runNegativeTest();
+	runner.runConformTest();
 }
 public void testGH4774b() throws Exception {
 	Runner runner = new Runner();
@@ -2268,17 +2255,7 @@ public void testGH4774b() throws Exception {
 			}
 			"""
 		};
-	runner.expectedCompilerLog =
-			"""
-			----------
-			1. ERROR in Test.java (at line 4)
-				List<Z> l = consume(List.of(
-				            ^^^^^^^
-			The method consume(List<? extends Test.A<? super U>>) in the type Test is not applicable for the arguments (List<Test.A<? extends Test.Y>>)
-			----------
-			""";
-	runner.javacTestOptions = JavacHasABug.JavacBug6573446;
-	runner.runNegativeTest();
+	runner.runConformTest();
 }
 public void testGH4731() {
 	Runner runner = new Runner();
@@ -2369,6 +2346,26 @@ public void testGH3351() {
 		The method sort(java.util.List<E extends java.lang.Comparable<E>>) in the type PassThroughGenerics is not applicable for the arguments (java.util.List<E extends java.lang.Comparable<E>>)
 		----------
 		""");
+}
+public void testGH3367() {
+	Runner runner = new Runner();
+	runner.testFiles = new String[] {
+			"Test.java",
+			"""
+			class A<S> {}
+			class B<T> {}
+			public interface Test {
+			   <U> B<U> b(U t);
+			   <V> B<A<? super V>> bOfA(B<? super V> t);
+			   <W> void errors(W t, B<? super W> m);
+
+			   default void test(A<String> a) {
+			      errors(a, bOfA(b(a)));
+			   }
+			}
+			"""
+		};
+	runner.runConformTest();
 }
 
 public static Class<GenericsRegressionTest_9> testClass() {


### PR DESCRIPTION
Flag SHOULD_WORKAROUND_BUG_JDK_6573446 to control a new workaround:
+ during resolution detect when a lower bound was used
+ if so, and if resolution eventually fails then:
  - try again but now ignoring all lower bounds

Relates to https://bugs.openjdk.org/browse/JDK-6573446
+ still in some cases ignoring lower bounds gives *better* results.

Aligns the following tests with javac (excuse no longer needed):
+ GenericTypeTest.test1142
+ GenericsRegressionTest_9.testGH4774
+ GenericsRegressionTest_9.testGH4774b

Collateral fixes in CaptureBinding18

First commit refactors IC18.resolve() extracting new `resolveFirstAttempt()` and `resolveSecondAttempt()`.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3367
