### PR TITLE
Detect duplicate case labels across promoted constant kinds

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
@@ -309,7 +309,7 @@ public class SwitchStatement extends Expression {
 			return false; // apples and oranges
 		if (current.expression instanceof NullLiteral ^ prior.expression instanceof NullLiteral) // I actually got to use XOR! :)
 			return false;
-		if (current.constant.equals(prior.constant))
+		if (current.constant.compareAfterPromoting(prior.constant))
 			return true;
 		if (current.type.id == TypeIds.T_boolean)
 			this.switchBits |= Exhaustive; // 2 different boolean constants => exhaustive :)

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/impl/Constant.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/impl/Constant.java
@@ -1629,4 +1629,30 @@ public abstract class Constant implements TypeIds, OperatorIds {
 	private static boolean isNegativeZero(double n) {
 		return Double.doubleToRawLongBits(n) == Long.MIN_VALUE;
 	}
+	public boolean compareAfterPromoting(Constant otherConstant) {
+		if (this == otherConstant)
+			return true;
+		if (otherConstant == null)
+			return false;
+		// Preserve the per-kind semantics (incl. float/double zero & NaN handling) for same-typed constants.
+		if (equals(otherConstant))
+			return true;
+		// Case label constants of the integral types byte, short, char and int are compared after
+		// binary numeric promotion to int (JLS 5.6, 14.11.1). Two such constants denoting the same int
+		// value are therefore duplicate case labels even if their compile-time constant kinds differ,
+		// e.g. (byte)0 (ByteConstant) and 0 (IntConstant), or 'A' (CharConstant) and 65 (IntConstant).
+		return comparesAsInt(this) && comparesAsInt(otherConstant) && intValue() == otherConstant.intValue();
+	}
+
+	private static boolean comparesAsInt(Constant constant) {
+		switch (constant.typeID()) {
+			case T_byte:
+			case T_short:
+			case T_char:
+			case T_int:
+				return true;
+			default:
+				return false;
+		}
+	}
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+﻿/*******************************************************************************
  * Copyright (c) 2005, 2023 IBM Corporation and others.
  *
  * This program and the accompanying materials
@@ -3289,6 +3289,75 @@ public void testIssue3379_3() throws Exception {
 	}
 }
 
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4292
+// Duplicate case labels not detected when the two constants have different
+// compile-time kinds but the same value after binary numeric promotion to int,
+// e.g. (byte)0 + (byte)0 (an int constant) vs. a final byte constant 0.
+public void testDuplicateCasePromotedConstant() {
+	this.runNegativeTest(new String[] {
+		"X.java",
+		"public class X {\n" +
+		"	public static void main(String[] argv) {\n" +
+		"		byte var = (byte) 0;\n" +
+		"		final byte cst = (byte) 0;\n" +
+		"		switch (var) {\n" +
+		"			case (byte) 0 + (byte) 0: break;\n" +
+		"			case cst: break;\n" +
+		"		}\n" +
+		"	}\n" +
+		"}\n",
+	},
+	"----------\n" +
+	"1. ERROR in X.java (at line 7)\n" +
+	"	case cst: break;\n" +
+	"	     ^^^\n" +
+	"Duplicate case\n" +
+	"----------\n");
+}
+// Same as testDuplicateCasePromotedConstant but with the case labels in the
+// opposite order, to ensure detection is independent of label ordering.
+public void testDuplicateCasePromotedConstantReversed() {
+	this.runNegativeTest(new String[] {
+		"X.java",
+		"public class X {\n" +
+		"	public static void main(String[] argv) {\n" +
+		"		byte var = (byte) 0;\n" +
+		"		final byte cst = (byte) 0;\n" +
+		"		switch (var) {\n" +
+		"			case cst: break;\n" +
+		"			case (byte) 0 + (byte) 0: break;\n" +
+		"		}\n" +
+		"	}\n" +
+		"}\n",
+	},
+	"----------\n" +
+	"1. ERROR in X.java (at line 7)\n" +
+	"	case (byte) 0 + (byte) 0: break;\n" +
+	"	     ^^^^^^^^^^^^^^^^^^^\n" +
+	"Duplicate case\n" +
+	"----------\n");
+}
+// 'A' (a char constant, value 65) and 65 (an int constant) collide after
+// promotion to int and must be reported as duplicate case labels.
+public void testDuplicateCaseCharVsInt() {
+	this.runNegativeTest(new String[] {
+		"X.java",
+		"public class X {\n" +
+		"	public static void main(String[] argv) {\n" +
+		"		switch (argv.length) {\n" +
+		"			case 'A': break;\n" +
+		"			case 65: break;\n" +
+		"		}\n" +
+		"	}\n" +
+		"}\n",
+	},
+	"----------\n" +
+	"1. ERROR in X.java (at line 5)\n" +
+	"	case 65: break;\n" +
+	"	     ^^\n" +
+	"Duplicate case\n" +
+	"----------\n");
+}
 public static Class testClass() {
 	return SwitchTest.class;
 }


### PR DESCRIPTION
Duplicate case labels were not reported when two case constants had different compile-time constant kinds but the same value after binary numeric promotion to int.

The duplicate check in SwitchStatement#duplicateConstant relied on Constant#equals(), whose first guard is getClass() != obj.getClass(). Constants of byte/short/char/int that share a value but differ in kind (e.g. ByteConstant vs IntConstant) therefore compared unequal.

Per JLS 5.6 / 14.11.1, case constants of byte, short, char and int are compared after binary numeric promotion to int. Introduce Constant#compareAfterPromoting() implementing this rule once, in the base class, so detection is symmetric regardless of label order, and use it at the call site instead of equals(). long/float/double/boolean switches still require an exactly-typed case constant, so they are left unaffected.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
