### PR TITLE
Fix ASTRewriteAnalyzer.ListRewriter to properly indent new methods

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/rewrite/describing/ASTRewritingExpressionsTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/rewrite/describing/ASTRewritingExpressionsTest.java
@@ -18,6 +18,7 @@ import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IPackageFragment;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.dom.*;
+import org.eclipse.jdt.core.dom.Modifier.ModifierKeyword;
 import org.eclipse.jdt.core.dom.rewrite.ASTRewrite;
 import org.eclipse.jdt.core.dom.rewrite.ListRewrite;
 import org.eclipse.jdt.core.formatter.DefaultCodeFormatterConstants;
@@ -2399,6 +2400,62 @@ public class ASTRewritingExpressionsTest extends ASTRewritingTest {
 				"  public void bar();\n" +
 				"}\n";
 		assertEqualString(preview, content);
+	}
+
+	public void testIssue4099() throws Exception { //https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4099
+		IPackageFragment pack1= this.sourceFolder.createPackageFragment("test1", false, null);
+		String source= """
+				package test1;
+				public class E
+						implements Object {
+					public E() {
+					}
+				}
+				""";
+		ICompilationUnit cu= pack1.createCompilationUnit("E.java", source, false, null);
+
+		CompilationUnit astRoot= createAST(cu);
+		ASTRewrite rewrite= ASTRewrite.create(astRoot.getAST());
+
+		AST ast= astRoot.getAST();
+
+		assertTrue("Parse errors", (astRoot.getFlags() & ASTNode.MALFORMED) == 0);
+		TypeDeclaration type= findTypeDeclaration(astRoot, "E");
+		ListRewrite listRewrite= rewrite.getListRewrite(type, TypeDeclaration.BODY_DECLARATIONS_PROPERTY);
+
+		MethodDeclaration newHashCode= ast.newMethodDeclaration();
+		newHashCode.setName(ast.newSimpleName("hashCode"));
+		newHashCode.setReturnType2(ast.newPrimitiveType(PrimitiveType.INT));
+		Block block= ast.newBlock();
+		newHashCode.setBody(block);
+		List<Statement> statements= block.statements();
+		ReturnStatement returnStatement= ast.newReturnStatement();
+		returnStatement.setExpression(ast.newNumberLiteral("3"));
+		statements.add(returnStatement);
+		Annotation annotation= ast.newMarkerAnnotation();
+		annotation.setTypeName(ast.newSimpleName("Override"));
+		List<IExtendedModifier> modifiers= newHashCode.modifiers();
+		modifiers.add(annotation);
+		modifiers.add(ast.newModifier(ModifierKeyword.PUBLIC_KEYWORD));
+
+		listRewrite.insertLast(newHashCode, null);
+
+		String preview= evaluateRewrite(cu, rewrite);
+
+		String expected= """
+				package test1;
+				public class E
+						implements Object {
+					public E() {
+					}
+
+				    @Override
+				    public int hashCode() {
+				        return 3;
+				    }
+				}
+				""";
+		assertEqualString(preview, expected);
 	}
 
 }

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/ASTRewriteAnalyzer.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/ASTRewriteAnalyzer.java
@@ -628,7 +628,7 @@ public final class ASTRewriteAnalyzer extends ASTVisitor {
 				String endKeyword,
 				int offset) {
 			this.startPos= offset;
-			this.nodeIndentPos= offset;
+			this.nodeIndentPos= parent.getStartPosition();
 			this.list= getEvent(parent, property).getChildren();
 
 			if (parent.getLocationInParent() == TryStatement.BODY_PROPERTY) {


### PR DESCRIPTION
- fix ASTRewriteAnalyzer.ListRewriter.rewriteList() to set the nodeIndentPos based on the parent node instead of using the passed in offset which is the location after the left brace for a method body
- add new test to ASTRewritingExpressionsTest
- fixes #4099

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
