### PR TITLE
Preview features are marked as warnings when set to info

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
@@ -9592,7 +9592,6 @@ public void previewAPIUsed(Scope scope, int sourceStart, int sourceEnd, IBinaryA
 	if (!this.options.enablePreviewFeatures) {
 		if (this.options.complianceLevel < ClassFileConstants.getLatestJDKLevel()) {
 			problemId = IProblem.PreviewAPIUsed;
-			severity = ProblemSeverities.Warning;
 		} else {
 			problemId = IProblem.PreviewAPIDisabled;
 			severity = isReflective ? ProblemSeverities.Warning : ProblemSeverities.Error;
@@ -9600,11 +9599,12 @@ public void previewAPIUsed(Scope scope, int sourceStart, int sourceEnd, IBinaryA
 	} else {
 		this.referenceContext.compilationResult().usesPreview = true;
 		if (this.options.isAnyEnabled(IrritantSet.PREVIEW)) {
-			severity = ProblemSeverities.Warning;
 			problemId = IProblem.PreviewAPIUsed;
 		}
 	}
-	if (problemId == -1 || severity == -1) return;
+	if (problemId == -1) return;
+	if (severity == -1)
+		severity = computeSeverity(IProblem.PreviewAPIUsed);
 	String[] arguments = { featureName };
 	this.handle(problemId, arguments, arguments, severity, sourceStart, sourceEnd);
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PreviewFeatureTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PreviewFeatureTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2021, 2025 IBM Corporation and others.
+ * Copyright (c) 2021, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -390,6 +390,72 @@ public class PreviewFeatureTest extends AbstractRegressionTest9 {
 					options);
 		} finally {
 			options.put(CompilerOptions.OPTION_EnablePreviews, old);
+		}
+	}
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5156
+	// Preview API usage must honor OPTION_ReportPreviewFeatures instead of always
+	// being reported as a warning.
+	public void testGHIssue5156() {
+		if (this.complianceLevel < ClassFileConstants.getLatestJDKLevel()) {
+			return;
+		}
+		String[] classLibs = getClasspathWithPreviewAPI();
+		Map<String, String> options = getCompilerOptions();
+		String oldEnablePreview = options.get(CompilerOptions.OPTION_EnablePreviews);
+		String oldReportPreview = options.get(CompilerOptions.OPTION_ReportPreviewFeatures);
+		boolean savedPreview = this.enablePreview;
+		options.put(CompilerOptions.OPTION_EnablePreviews, CompilerOptions.ENABLED);
+		String[] testFiles = new String[] {
+				"X.java",
+				"import p.*;\n" +
+				"public class X {\n" +
+				"    ABC abc = null;\n" +
+				"    Zork z = null;\n" +
+				"    public static void main(String[] args) {\n" +
+				"        System.out.println(\"Hello World\");\n" +
+				"    }\n" +
+				"}\n",
+		};
+		try {
+			options.put(CompilerOptions.OPTION_ReportPreviewFeatures, CompilerOptions.ERROR);
+			runNegativeTest(
+					testFiles,
+					"----------\n" +
+					"1. ERROR in X.java (at line 3)\n" +
+					"	ABC abc = null;\n" +
+					"	^^^\n" +
+					"You are using an API that is part of the preview feature \'Test Feature\' and may be removed in future\n" +
+					"----------\n" +
+					"2. ERROR in X.java (at line 4)\n" +
+					"	Zork z = null;\n" +
+					"	^^^^\n" +
+					"Zork cannot be resolved to a type\n" +
+					"----------\n",
+					classLibs,
+					true,
+					options);
+
+			options.put(CompilerOptions.OPTION_ReportPreviewFeatures, CompilerOptions.WARNING);
+			runNegativeTest(
+					testFiles,
+					"----------\n" +
+					"1. WARNING in X.java (at line 3)\n" +
+					"	ABC abc = null;\n" +
+					"	^^^\n" +
+					"You are using an API that is part of the preview feature \'Test Feature\' and may be removed in future\n" +
+					"----------\n" +
+					"2. ERROR in X.java (at line 4)\n" +
+					"	Zork z = null;\n" +
+					"	^^^^\n" +
+					"Zork cannot be resolved to a type\n" +
+					"----------\n",
+					classLibs,
+					true,
+					options);
+		} finally {
+			this.enablePreview = savedPreview;
+			options.put(CompilerOptions.OPTION_EnablePreviews, oldEnablePreview);
+			options.put(CompilerOptions.OPTION_ReportPreviewFeatures, oldReportPreview);
 		}
 	}
 }


### PR DESCRIPTION
Preview API usage must honor OPTION_ReportPreviewFeatures instead of always being reported as a warning.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
Fixes #5156

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
