### PR TITLE
Wait for auto-refresh in TypeHierarchyNotificationTests.testAddPackageFragmentRoot

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/TypeHierarchyNotificationTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/TypeHierarchyNotificationTests.java
@@ -536,6 +536,7 @@ public void testAddPackageFragmentRoot() throws CoreException {
 		// now create the actual resource for the root and populate it
 		reset();
 		project.getProject().getFolder("extra").create(false, true, null);
+		waitForAutoRefresh();
 		IPackageFragmentRoot newRoot= getPackageFragmentRoot("TypeHierarchyNotification", "extra");
 		assertTrue("New root should now be visible", newRoot != null);
 		assertOneChange(h);


### PR DESCRIPTION
Tracing in latest `testAddPackageFragmentRoot` fail shows a workspace refresh job, running in parallel to the test and sending delta notifications. This change joins auto-refresh jobs, to hopefully ensure such delta notifications are noticed by the test.

See: https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5040
