### PR TITLE
[Build] Replace not permitted method in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,6 +75,6 @@ def installTool(String toolType, String url) {
 		if (dirContent.isEmpty()) { // Prevent repeated downloads
 			sh "curl --fail --location ${url} | tar -xzf -"
 		}
-		return "${pwd()}/" + sh(script: 'ls', returnStdout: true).strip()
+		return "${pwd()}/" + sh(script: 'ls', returnStdout: true).trim()
 	}
 }


### PR DESCRIPTION
## What it does

Fixes the customized build of the `VALCO_PDOT_1` branch.
The method `java.lang.String strip` is not permitted within the JDT Jenkins instance.

Fixes the error from
- https://github.com/eclipse-jdt/eclipse.jdt.core/pull/5088#issuecomment-4788330934

@mpalat, @stephan-herrmann please review this.

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
