### PR TITLE
Fixing the Short_byte_dominance issue of issue #4979

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
@@ -331,6 +331,8 @@ public class SwitchStatement extends Expression {
 			if (labelExpression.expression instanceof NullLiteral) {
 				if (this.defaultCase != null)
 					this.scope.problemReporter().patternDominatedByAnother(labelExpression.expression);
+			} else if (this.unconditionalPatternCase != null) {
+				this.scope.problemReporter().patternDominatedByAnother(labelExpression.expression);
 			} else {
 				TypeBinding boxedType = labelExpression.type.isBaseType() ? this.scope.environment().computeBoxingType(labelExpression.type) : labelExpression.type;
 				for (int i = 0; i < this.labelExpressionIndex; i++) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
@@ -331,20 +331,31 @@ public class SwitchStatement extends Expression {
 			if (labelExpression.expression instanceof NullLiteral) {
 				if (this.defaultCase != null)
 					this.scope.problemReporter().patternDominatedByAnother(labelExpression.expression);
-			} else if (this.unconditionalPatternCase != null) {
-				this.scope.problemReporter().patternDominatedByAnother(labelExpression.expression);
 			} else {
-				TypeBinding boxedType = labelExpression.type.isBaseType() ? this.scope.environment().computeBoxingType(labelExpression.type) : labelExpression.type;
-				for (int i = 0; i < this.labelExpressionIndex; i++) {
-					if (this.labelExpressions[i].expression instanceof Pattern priorPattern) {
-						if (priorPattern.coversType(boxedType, this.scope)) {
-							this.scope.problemReporter().patternDominatedByAnother(labelExpression.expression);
-							break;
-						}
-						Constant cst = labelExpression.expression.constant;
-						if (cst != null && cst != Constant.NotAConstant && priorPattern.coversValue(cst, this.scope)) {
-							this.scope.problemReporter().patternDominatedByAnother(labelExpression.expression);
-							break;
+				boolean dominatedByUnconditional = false;
+				if (JavaFeature.PRIMITIVES_IN_PATTERNS.isSupported(this.scope.compilerOptions())
+						&& this.unconditionalPatternCase != null) {
+					Constant cst = labelExpression.expression.constant;
+					TypeBinding resolvedType1 = labelExpression.expression.resolvedType;
+					if (cst != null && cst != Constant.NotAConstant && resolvedType1 != null
+							&& resolvedType1.isPrimitiveType()) {
+						this.scope.problemReporter().patternDominatedByAnother(labelExpression.expression);
+						dominatedByUnconditional = true;
+					}
+				}
+				if (!dominatedByUnconditional) {
+					TypeBinding boxedType = labelExpression.type.isBaseType() ? this.scope.environment().computeBoxingType(labelExpression.type) : labelExpression.type;
+					for (int i = 0; i < this.labelExpressionIndex; i++) {
+						if (this.labelExpressions[i].expression instanceof Pattern priorPattern) {
+							if (priorPattern.coversType(boxedType, this.scope)) {
+								this.scope.problemReporter().patternDominatedByAnother(labelExpression.expression);
+								break;
+							}
+							Constant cst = labelExpression.expression.constant;
+							if (cst != null && cst != Constant.NotAConstant && priorPattern.coversValue(cst, this.scope)) {
+								this.scope.problemReporter().patternDominatedByAnother(labelExpression.expression);
+								break;
+							}
 						}
 					}
 				}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PrimitiveInPatternsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PrimitiveInPatternsTest.java
@@ -30,7 +30,7 @@ public class PrimitiveInPatternsTest extends AbstractRegressionTest9 {
 	static {
 //		TESTS_NUMBERS = new int [] { 1 };
 //		TESTS_RANGE = new int[] { 1, -1 };
-//		TESTS_NAMES = new String[] { "testDominanceIssue4979_001" };
+//		TESTS_NAMES = new String[] { "testDominanceIssue4979_002" };
 	}
 	private String extraLibPath;
 	public static Class<?> testClass() {
@@ -7636,16 +7636,72 @@ public class PrimitiveInPatternsTest extends AbstractRegressionTest9 {
 				"""
 			},
 			"----------\n" +
-			"1. WARNING in X.java (at line 5)\n" +
-			"	case Character c1 -> {\n" +
-			"	     ^^^^^^^^^^^^\n" +
-			"You are using a preview language feature that may or may not be supported in a future release\n" +
-			"----------\n" +
-			"2. ERROR in X.java (at line 9)\n" +
+			"1. ERROR in X.java (at line 9)\n" +
 			"	case 0 -> {  // Same goes for case (int) 0\n" +
 			"	     ^\n" +
 			"This case label is dominated by one of the preceding case labels\n" +
 			"----------\n");
+	}
+
+	public void testDominanceIssue4979_002() {
+		runNegativeTest(new String[] {
+			"X.java",
+				"""
+				public class X {
+					public int foo1(Short c) {
+						int result = 0;
+						switch (c) {
+						  case Short c1 -> {
+							result = c1;
+							break;
+						  }
+						  case (byte) 0 -> {
+							result = 0;
+							break;
+						  }
+						}
+						return result;
+					}
+				}
+				"""
+			},
+			"----------\n" +
+			"1. ERROR in X.java (at line 9)\n" +
+			"	case (byte) 0 -> {\n" +
+			"	     ^^^^^^^^\n" +
+			"This case label is dominated by one of the preceding case labels\n" +
+			"----------\n");
+	}
+	public void testDominanceIssue4979_003() {
+		runNegativeTest(new String[] {
+				"X.java",
+				"""
+				@SuppressWarnings("preview")
+				public class X {
+					void foo() {
+						int j = 1;
+						switch(j) {
+							case byte b ->
+								System.out.println("A byte");
+							case 260 ->						// not dominated
+								System.out.println("An int that can be represented as a byte exactly");
+							default ->
+								System.out.println("Integer that cannot be represented as a float exactly");
+						}
+					}
+					public static void main(String[] args) {
+						Zork();
+					}
+				}
+				"""
+			},
+				"----------\n" +
+				"1. ERROR in X.java (at line 15)\n" +
+				"	Zork();\n" +
+				"	^^^^\n" +
+				"The method Zork() is undefined for the type X\n" +
+				"----------\n"
+			);
 	}
 
 }


### PR DESCRIPTION


## What it does
Fixes the dominance issue as mentioned in https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4979#issuecomment-4715810255
## How to test
PrimitivesInPatternsTest.testDominanceIssue4979_002() is the junit test case to test

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
