### PR TITLE
Fix NPE in RecoveredMethod.updateFromParserState when argument.type is null

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/RecoveredMethod.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/RecoveredMethod.java
@@ -514,13 +514,14 @@ public void updateFromParserState(){
 				int count;
 				for (count = 0; count < argLength; count++){
 					ASTNode aNode = parser.astStack[argStart+count];
-					if(aNode instanceof Argument) {
-						Argument argument = (Argument)aNode;
-						/* cannot be an argument if non final */
-						char[][] argTypeName = argument.type.getTypeName();
-						if ((argument.modifiers & ~ClassFileConstants.AccFinal) != 0
-							|| (argTypeName.length == 1
-								&& CharOperation.equals(argTypeName[0], TypeBinding.VOID.sourceName()))){
+                    if(aNode instanceof Argument) {                                                                                                                                                  
+                        Argument argument = (Argument)aNode;                                                                                                                                     
+                        // cannot be an argument if non final                                                                                                                            
+                        // argument.type can be null for lambda parameters with inferred types, e.g. (x) -> x                                                                                    
+                        if (argument.type == null                                                                                                                                                
+							|| (argument.modifiers & ~ClassFileConstants.AccFinal) != 0                                                                                                      
+                            || (argument.type.getTypeName().length == 1                                                                                                                      
+                                && CharOperation.equals(argument.type.getTypeName()[0], TypeBinding.VOID.sourceName()))){
 							parser.astLengthStack[parser.astLengthPtr] = count;
 							parser.astPtr = argStart+count-1;
 							parser.listLength = count;

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/parser/DietRecoveryTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/parser/DietRecoveryTest.java
@@ -8121,4 +8121,55 @@ public void test456861() {
 		expectedFullUnitToString,
 		expectedCompletionDietUnitToString, testName);
 }
+
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4924
+	public void testGH4924() {
+		String s =                                                                                                                                                                                                 
+			"public class X {\n" +                                                                                                                                                                                 
+			"    void foo() {\n" +                                                                                                                                                                                 
+			"        bar((x) ->\n" +                                                                                                                                                                               
+			"    }\n" +                                                                                                                                                                                            
+			"    void bar(java.util.function.Consumer<String> c) {}\n" +                                                                                                                                           
+			"}\n";                                                                                                                                                                                                 
+                                                                                                                                                                                                                 
+      	// Before the fix, RecoveredMethod.updateFromParserState() threw NPE at                                                                                                                                    
+      	// argument.type.getTypeName() because lambda parameters with inferred types                                                                                                                               
+      	// (e.g. the 'x' in (x) ->) produce Argument nodes with type == null,                                                                                                                                      
+      	// which can land on the parser's AST stack during diet-parse error recovery.                                                                                                                              
+      	String expectedDietUnitToString =                                                                                                                                                                          
+			"public class X {\n" +                                                                                                                                                                                 
+			"  X() {\n" +                                                                                                                                                                                          
+			"  }\n" +                                                                                                                                                                                              
+			"  void foo() {\n" +                                                                                                                                                                                   
+			"  }\n" +                                                                                                                                                                                              
+			"  void bar(java.util.function.Consumer<String> c) {\n" +                                                                                                                                              
+			"  }\n" +                                                                                                                                                                                              
+			"}\n";
+
+		String expectedDietPlusBodyUnitToString =                                                                                                                                                                  
+			"public class X {\n" +                                                                                                                                                                                 
+			"  X() {\n" +                                                                                                                                                                                          
+			"    super();\n" +                                                                                                                                                                                     
+			"  }\n" +                                                                                                                                                                                              
+			"  void foo() {\n" +                                                                                                                                                                                   
+			"  }\n" +                                                                                                                                                                                              
+			"  void bar(java.util.function.Consumer<String> c) {\n" +                                                                                                                                              
+			"  }\n" +                                                                                                                                                                                              
+			"}\n";
+
+      	String expectedDietPlusBodyPlusStatementsRecoveryUnitToString = expectedDietPlusBodyUnitToString;                                                                                                                                                                      
+                                                                                                                                                                                                                 
+      	String expectedFullUnitToString = expectedDietUnitToString;                                                                                                                                                                              
+                                                                                                                                                                                                                 
+      	String expectedCompletionDietUnitToString = expectedDietUnitToString;                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            
+                                                                                                                                                                                                               
+        checkParse(                                                                                                                                                                                                
+        	s.toCharArray(),                                                                                                                                                                                       
+          	expectedDietUnitToString,                                                                                                                                                                              
+          	expectedDietPlusBodyUnitToString,                                                                                                                                                                      
+          	expectedDietPlusBodyPlusStatementsRecoveryUnitToString,                                                                                                                                                
+          	expectedFullUnitToString,                                                                                                                                                                              
+          	expectedCompletionDietUnitToString,                                                                                                                                                                    
+          	"testGH4924");             
+	}
 }


### PR DESCRIPTION
## What it does                                                                                                                                                                                                 
                                                                                                                                                                                                                 
  `RecoveredMethod.updateFromParserState()` unconditionally calls                                                                                                                                                
  `argument.type.getTypeName()` (line 520) without checking for null.                                                                                                                                            
  An `Argument` with `type == null` is a valid AST node representing a lambda                                                                                                                                    
  parameter with an inferred type (e.g. `(x) -> x`, `(req, resp) -> { ... }`).                                                                                                                                   
                                                                                                                                                                                                                 
  When `dietParse` enters `resumeOnSyntaxError` on a source file that combines                                                                                                                                   
  a recovery-triggering construct with nearby lambdas, these inferred-type                                                                                                                                       
  `Argument` nodes end up on the parser's AST stack. The recovery code then                                                                                                                                      
  crashes at line 520.                                                                                                                                                                                           
                                                                                                                                                                                                                 
  This NPE surfaces as an `Internal error` response to `textDocument/references`                                                                                                                                 
  and `callHierarchyIncomingCalls` LSP requests, and is reproducible on any Java                                                                                                                                 
  8+ project that has lambdas with inferred parameter types.                                                                                                                                                     
                                                                                                                                                                                                                 
  Reproduced on ECJ 3.45.0 (jdtls 1.57.0) and ECJ 3.46.0 (jdtls 1.58.0).                                                                                                                                         
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       
  Add a null check for `argument.type` before dereferencing it. When the type is                                                                                                                                 
  null, stop processing further parameters at that index — the same behaviour as                                                                                                                                 
  for non-`Argument` nodes and `void`-typed arguments. This is safe for error                                                                                                                                    
  recovery since a recovered method with an unresolvable parameter type cannot                                                                                                                                   
  have a meaningful parameter list beyond that point.                                                                                                                                                            
                                                                                                                                                                                                                 
  Fixes #4924                                                                                                                                                                                                    
  Related: eclipse-jdtls/eclipse.jdt.ls#3657      

## How to test
  An `Argument` with `type == null` is a valid AST node representing a lambda                                                                                                                                    
  parameter with an inferred type (e.g. `(x) -> x`, `(req, resp) -> { ... }`).

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
