### PR TITLE
Link to newer bug JDK-8387487

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractRegressionTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractRegressionTest.java
@@ -1198,7 +1198,7 @@ protected static class JavacTestOptions {
 					new JavacHasABug(MismatchType.EclipseErrorsJavacNone),
 			JavacBugIvarInterning = // https://mail.openjdk.org/pipermail/compiler-dev/2025-October/031866.html
 					new JavacHasABug(MismatchType.JavacErrorsEclipseNone),
-			JavacBug8297428 = // https://bugs.openjdk.org/browse/JDK-8297428
+			JavacBug8387487 = // https://bugs.openjdk.org/browse/JDK-8297428 and https://bugs.openjdk.org/browse/JDK-8387487
 					new JavacHasABug(MismatchType.JavacErrorsEclipseNone),
 			JavacBug8365676 = // https://bugs.openjdk.org/browse/JDK-8365676
 					new JavacHasABug(MismatchType.EclipseErrorsJavacNone, ClassFileConstants.JDK26, 0000),

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
@@ -1188,7 +1188,7 @@ public void testGH3948() {
 			}
 			"""
 		};
-	runner.javacTestOptions = JavacHasABug.JavacBug8297428;
+	runner.javacTestOptions = JavacHasABug.JavacBug8387487;
 	runner.runConformTest();
 }
 public void testGH4022a() {


### PR DESCRIPTION
Testcase from #3948 can now link to newer, specific https://bugs.openjdk.org/browse/JDK-8387487 as its excuse.