### PR TITLE
Add ImportRewrite options to keep existing on-demand imports and to disable on-demand collapsing

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/rewrite/describing/ImportRewriteTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/rewrite/describing/ImportRewriteTest.java
@@ -4997,6 +4997,200 @@ public class ImportRewriteTest extends AbstractJavaModelTests {
 		assertEquals("pack1.X", actualType.toString());
 	}
 
+	public void testKeepExistingOnDemandImport() throws Exception {
+		StringBuilder contents = new StringBuilder();
+		contents.append("package pack1;\n");
+		contents.append("\n");
+		contents.append("import java.util.*;\n");
+		contents.append("\n");
+		contents.append("public class Clazz {}");
+		ICompilationUnit cu = createCompilationUnit("pack1", "Clazz", contents.toString());
+
+		ImportRewrite imports = newImportsRewrite(cu, new String[0], 99, 99, false);
+		imports.setKeepExistingOnDemandImports(true);
+		imports.addImport("java.util.List");
+		imports.addImport("java.util.Map");
+
+		apply(imports);
+
+		// The existing on-demand import is preserved and the referenced types fold into it.
+		StringBuilder expected = new StringBuilder();
+		expected.append("package pack1;\n");
+		expected.append("\n");
+		expected.append("import java.util.*;\n");
+		expected.append("\n");
+		expected.append("public class Clazz {}");
+		assertEqualString(cu.getSource(), expected.toString());
+	}
+
+	public void testExistingOnDemandImportExpandedByDefault() throws Exception {
+		StringBuilder contents = new StringBuilder();
+		contents.append("package pack1;\n");
+		contents.append("\n");
+		contents.append("import java.util.*;\n");
+		contents.append("\n");
+		contents.append("public class Clazz {}");
+		ICompilationUnit cu = createCompilationUnit("pack1", "Clazz", contents.toString());
+
+		// keepExistingOnDemandImports defaults to false, so the on-demand import is expanded.
+		ImportRewrite imports = newImportsRewrite(cu, new String[0], 99, 99, false);
+		imports.addImport("java.util.List");
+		imports.addImport("java.util.Map");
+
+		apply(imports);
+
+		StringBuilder expected = new StringBuilder();
+		expected.append("package pack1;\n");
+		expected.append("\n");
+		expected.append("import java.util.List;\n");
+		expected.append("import java.util.Map;\n");
+		expected.append("\n");
+		expected.append("public class Clazz {}");
+		assertEqualString(cu.getSource(), expected.toString());
+	}
+
+	public void testUnreferencedExistingOnDemandImportIsRemoved() throws Exception {
+		StringBuilder contents = new StringBuilder();
+		contents.append("package pack1;\n");
+		contents.append("\n");
+		contents.append("import java.util.*;\n");
+		contents.append("\n");
+		contents.append("public class Clazz {}");
+		ICompilationUnit cu = createCompilationUnit("pack1", "Clazz", contents.toString());
+
+		// The existing on-demand import is no longer referenced, so it is removed as unused.
+		ImportRewrite imports = newImportsRewrite(cu, new String[0], 99, 99, false);
+		imports.setKeepExistingOnDemandImports(true);
+		imports.addImport("java.io.File");
+
+		apply(imports);
+
+		StringBuilder expected = new StringBuilder();
+		expected.append("package pack1;\n");
+		expected.append("\n");
+		expected.append("import java.io.File;\n");
+		expected.append("\n");
+		expected.append("public class Clazz {}");
+		assertEqualString(cu.getSource(), expected.toString());
+	}
+
+	public void testKeepExistingStaticOnDemandImport() throws Exception {
+		StringBuilder values = new StringBuilder();
+		values.append("package statics;\n");
+		values.append("\n");
+		values.append("public class Values {\n");
+		values.append("    public static final int A = 0;\n");
+		values.append("    public static final int B = 0;\n");
+		values.append("}\n");
+		createCompilationUnit("statics", "Values", values.toString());
+
+		StringBuilder contents = new StringBuilder();
+		contents.append("package pack1;\n");
+		contents.append("\n");
+		contents.append("import static statics.Values.*;\n");
+		contents.append("\n");
+		contents.append("public class Clazz {}");
+		ICompilationUnit cu = createCompilationUnit("pack1", "Clazz", contents.toString());
+
+		ImportRewrite imports = newImportsRewrite(cu, new String[0], 99, 99, false);
+		imports.setKeepExistingOnDemandImports(true);
+		imports.addStaticImport("statics.Values", "A", true);
+		imports.addStaticImport("statics.Values", "B", true);
+
+		apply(imports);
+
+		StringBuilder expected = new StringBuilder();
+		expected.append("package pack1;\n");
+		expected.append("\n");
+		expected.append("import static statics.Values.*;\n");
+		expected.append("\n");
+		expected.append("public class Clazz {}");
+		assertEqualString(cu.getSource(), expected.toString());
+	}
+
+	public void testCollapseSingleImportsToOnDemandByDefault() throws Exception {
+		StringBuilder contents = new StringBuilder();
+		contents.append("package pack1;\n");
+		contents.append("\n");
+		contents.append("public class Clazz {}");
+		ICompilationUnit cu = createCompilationUnit("pack1", "Clazz", contents.toString());
+
+		// collapseSingleImportsToOnDemand defaults to true: the threshold still applies.
+		ImportRewrite imports = newImportsRewrite(cu, new String[0], 2, 2, false);
+		imports.addImport("java.util.List");
+		imports.addImport("java.util.Map");
+		imports.addImport("java.util.Set");
+
+		apply(imports);
+
+		StringBuilder expected = new StringBuilder();
+		expected.append("package pack1;\n");
+		expected.append("\n");
+		expected.append("import java.util.*;\n");
+		expected.append("\n");
+		expected.append("public class Clazz {}");
+		assertEqualString(cu.getSource(), expected.toString());
+	}
+
+	public void testCollapseSingleImportsToOnDemandDisabled() throws Exception {
+		StringBuilder contents = new StringBuilder();
+		contents.append("package pack1;\n");
+		contents.append("\n");
+		contents.append("public class Clazz {}");
+		ICompilationUnit cu = createCompilationUnit("pack1", "Clazz", contents.toString());
+
+		// With collapsing disabled, the threshold is ignored and single imports are kept.
+		ImportRewrite imports = newImportsRewrite(cu, new String[0], 2, 2, false);
+		imports.setCollapseSingleImportsToOnDemand(false);
+		imports.addImport("java.util.List");
+		imports.addImport("java.util.Map");
+		imports.addImport("java.util.Set");
+
+		apply(imports);
+
+		StringBuilder expected = new StringBuilder();
+		expected.append("package pack1;\n");
+		expected.append("\n");
+		expected.append("import java.util.List;\n");
+		expected.append("import java.util.Map;\n");
+		expected.append("import java.util.Set;\n");
+		expected.append("\n");
+		expected.append("public class Clazz {}");
+		assertEqualString(cu.getSource(), expected.toString());
+	}
+
+	public void testKeepExistingOnDemandImportWithoutCollapsingOtherGroups() throws Exception {
+		StringBuilder contents = new StringBuilder();
+		contents.append("package pack1;\n");
+		contents.append("\n");
+		contents.append("import java.util.*;\n");
+		contents.append("\n");
+		contents.append("public class Clazz {}");
+		ICompilationUnit cu = createCompilationUnit("pack1", "Clazz", contents.toString());
+
+		// Existing on-demand import is kept; a different group stays as single imports (no new star).
+		ImportRewrite imports = newImportsRewrite(cu, new String[0], 2, 2, false);
+		imports.setKeepExistingOnDemandImports(true);
+		imports.setCollapseSingleImportsToOnDemand(false);
+		imports.addImport("java.util.List");
+		imports.addImport("java.io.File");
+		imports.addImport("java.io.InputStream");
+		imports.addImport("java.io.OutputStream");
+
+		apply(imports);
+
+		StringBuilder expected = new StringBuilder();
+		expected.append("package pack1;\n");
+		expected.append("\n");
+		expected.append("import java.io.File;\n");
+		expected.append("import java.io.InputStream;\n");
+		expected.append("import java.io.OutputStream;\n");
+		expected.append("import java.util.*;\n");
+		expected.append("\n");
+		expected.append("public class Clazz {}");
+		assertEqualString(cu.getSource(), expected.toString());
+	}
+
 	private ICompilationUnit createCompilationUnit(String packageName, String className) throws JavaModelException {
 		StringBuilder contents = new StringBuilder();
 		contents.append("package " + packageName + ";\n");

--- a/org.eclipse.jdt.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.core; singleton:=true
-Bundle-Version: 3.46.100.qualifier
+Bundle-Version: 3.47.0.qualifier
 Bundle-Activator: org.eclipse.jdt.core.JavaCore
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/rewrite/ImportRewrite.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/rewrite/ImportRewrite.java
@@ -291,6 +291,8 @@ public final class ImportRewrite {
 	private String[] importOrder;
 	private int importOnDemandThreshold;
 	private int staticImportOnDemandThreshold;
+	private boolean keepExistingOnDemandImports;
+	private boolean collapseSingleImportsToOnDemand;
 
 	private List<String> addedImports;
 	private List<String> removedImports;
@@ -559,6 +561,8 @@ public final class ImportRewrite {
 		this.importOrder= CharOperation.NO_STRINGS;
 		this.importOnDemandThreshold= 99;
 		this.staticImportOnDemandThreshold= 99;
+		this.keepExistingOnDemandImports= false;
+		this.collapseSingleImportsToOnDemand= true;
 
 		this.importsKindMap = new HashMap();
 	}
@@ -607,6 +611,39 @@ public final class ImportRewrite {
 		if (threshold <= 0)
 			throw new IllegalArgumentException("Threshold must be positive."); //$NON-NLS-1$
 		this.staticImportOnDemandThreshold= threshold;
+	}
+
+	/**
+	 * Sets whether existing on-demand (star) import declarations should be preserved as
+	 * on-demand imports instead of being expanded into single imports.
+	 * <p>
+	 * This applies to both normal and static on-demand imports. It only has an effect on
+	 * on-demand imports whose container (package or type) is still referenced; an on-demand
+	 * import which is no longer used is removed as usual. The default is <code>false</code>.
+	 *
+	 * @param keepExistingOnDemandImports <code>true</code> to preserve existing on-demand
+	 * imports, <code>false</code> to allow them to be expanded into single imports
+	 * @since 3.47
+	 */
+	public void setKeepExistingOnDemandImports(boolean keepExistingOnDemandImports) {
+		this.keepExistingOnDemandImports= keepExistingOnDemandImports;
+	}
+
+	/**
+	 * Sets whether single imports may be collapsed into a new on-demand (star) import once the
+	 * corresponding on-demand threshold is reached.
+	 * <p>
+	 * When set to <code>false</code>, the on-demand thresholds are ignored and no new on-demand
+	 * import is created from single imports; single imports are still folded into an on-demand
+	 * import which is already present in their container. The default is <code>true</code>.
+	 *
+	 * @param collapseSingleImportsToOnDemand <code>true</code> to collapse single imports into a
+	 * new on-demand import when the threshold is reached, <code>false</code> to keep single
+	 * imports even beyond the threshold
+	 * @since 3.47
+	 */
+	public void setCollapseSingleImportsToOnDemand(boolean collapseSingleImportsToOnDemand) {
+		this.collapseSingleImportsToOnDemand= collapseSingleImportsToOnDemand;
 	}
 
 	/**
@@ -1538,6 +1575,8 @@ public final class ImportRewrite {
 		configBuilder.setImportOrder(Arrays.asList(this.importOrder));
 		configBuilder.setTypeOnDemandThreshold(this.importOnDemandThreshold);
 		configBuilder.setStaticOnDemandThreshold(this.staticImportOnDemandThreshold);
+		configBuilder.setKeepExistingOnDemandImports(this.keepExistingOnDemandImports);
+		configBuilder.setCollapseSingleImportsToOnDemand(this.collapseSingleImportsToOnDemand);
 
 		configBuilder.setTypeContainerSorting(this.useContextToFilterImplicitImports ?
 				ImportContainerSorting.BY_PACKAGE : ImportContainerSorting.BY_PACKAGE_AND_CONTAINING_TYPE);

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/imports/ImportRewriteAnalyzer.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/imports/ImportRewriteAnalyzer.java
@@ -419,6 +419,9 @@ public final class ImportRewriteAnalyzer {
 
 	private final boolean reportAllResultantImportsAsCreated;
 
+	private final boolean keepExistingOnDemandImports;
+	private final Set<ImportName> originalOnDemandImports;
+
 	private final Set<String> typeExplicitSimpleNames;
 	private final Set<String> staticExplicitSimpleNames;
 
@@ -442,13 +445,19 @@ public final class ImportRewriteAnalyzer {
 
 		List<ImportName> importsList = new ArrayList<>(this.originalImportEntries.size());
 		Set<ImportName> importsSet = new HashSet<>();
+		Set<ImportName> onDemandImports = new HashSet<>();
 		for (ImportEntry originalImportEntry : this.originalImportEntries) {
 			ImportName importName = originalImportEntry.importName;
 			importsList.add(importName);
 			importsSet.add(importName);
+			if (importName.isOnDemand() && !importName.isModule) {
+				onDemandImports.add(importName);
+			}
 		}
 		this.originalImportsList = Collections.unmodifiableList(importsList);
 		this.originalImportsSet = Collections.unmodifiableSet(importsSet);
+		this.originalOnDemandImports = Collections.unmodifiableSet(onDemandImports);
+		this.keepExistingOnDemandImports = configuration.keepExistingOnDemandImports;
 
 		this.importsToAdd = new LinkedHashSet<>();
 
@@ -477,7 +486,8 @@ public final class ImportRewriteAnalyzer {
 
 		this.onDemandComputer = new OnDemandComputer(
 				configuration.typeOnDemandThreshold,
-				configuration.staticOnDemandThreshold);
+				configuration.staticOnDemandThreshold,
+				configuration.collapseSingleImportsToOnDemand);
 
 		this.conflictIdentifier = new ConflictIdentifier(
 				this.onDemandComputer,
@@ -568,6 +578,23 @@ public final class ImportRewriteAnalyzer {
 		Set<ImportName> importsWithAdditionsAndRemovals = new HashSet<>(this.originalImportsSet);
 		importsWithAdditionsAndRemovals.addAll(this.importsToAdd);
 		importsWithAdditionsAndRemovals.removeAll(this.importsToRemove);
+
+		if (this.keepExistingOnDemandImports && !this.originalOnDemandImports.isEmpty()) {
+			// Re-introduce each existing on-demand import whose container is still referenced, so that
+			// it is preserved as an on-demand import instead of being expanded into single imports. The
+			// referenced single imports are then folded back into it by the on-demand reduction below.
+			Set<ImportName> referencedContainers = new HashSet<>();
+			for (ImportName importToAdd : this.importsToAdd) {
+				if (!importToAdd.isModule) {
+					referencedContainers.add(importToAdd.getContainerOnDemand());
+				}
+			}
+			for (ImportName onDemandImport : this.originalOnDemandImports) {
+				if (referencedContainers.contains(onDemandImport)) {
+					importsWithAdditionsAndRemovals.add(onDemandImport);
+				}
+			}
+		}
 
 		Set<ImportName> touchedContainers = determineTouchedContainers();
 

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/imports/ImportRewriteConfiguration.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/imports/ImportRewriteConfiguration.java
@@ -218,6 +218,8 @@ public final class ImportRewriteConfiguration {
 		List<String> importOrder;
 		Integer typeOnDemandThreshold;
 		Integer staticOnDemandThreshold;
+		boolean keepExistingOnDemandImports;
+		boolean collapseSingleImportsToOnDemand;
 
 		private Builder(OriginalImportHandling originalImportHandling) {
 			this.originalImportHandling = originalImportHandling;
@@ -227,6 +229,8 @@ public final class ImportRewriteConfiguration {
 			this.importOrder = Collections.emptyList();
 			this.typeOnDemandThreshold = null;
 			this.staticOnDemandThreshold = null;
+			this.keepExistingOnDemandImports = false;
+			this.collapseSingleImportsToOnDemand = true;
 		}
 
 		public Builder setTypeContainerSorting(ImportContainerSorting typeContainerSorting) {
@@ -259,6 +263,29 @@ public final class ImportRewriteConfiguration {
 			return this;
 		}
 
+		/**
+		 * Specifies whether existing on-demand (".*") imports should be preserved as on-demand
+		 * imports, instead of being expanded into single imports. Has an effect only for
+		 * on-demand imports whose container is still referenced; unreferenced on-demand imports
+		 * are removed as unused.
+		 */
+		public Builder setKeepExistingOnDemandImports(boolean keepExistingOnDemandImports) {
+			this.keepExistingOnDemandImports = keepExistingOnDemandImports;
+			return this;
+		}
+
+		/**
+		 * Specifies whether single imports may be collapsed into a new on-demand (".*") import
+		 * once the corresponding on-demand threshold is reached. When {@code false}, the
+		 * thresholds are ignored and no new on-demand import is created from single imports;
+		 * single imports are still folded into an on-demand import which is already present in
+		 * their container.
+		 */
+		public Builder setCollapseSingleImportsToOnDemand(boolean collapseSingleImportsToOnDemand) {
+			this.collapseSingleImportsToOnDemand = collapseSingleImportsToOnDemand;
+			return this;
+		}
+
 		public ImportRewriteConfiguration build() {
 			return new ImportRewriteConfiguration(this);
 		}
@@ -271,6 +298,8 @@ public final class ImportRewriteConfiguration {
 	final List<String> importOrder;
 	final int typeOnDemandThreshold;
 	final int staticOnDemandThreshold;
+	final boolean keepExistingOnDemandImports;
+	final boolean collapseSingleImportsToOnDemand;
 
 	ImportRewriteConfiguration(Builder builder) {
 		this.originalImportHandling = builder.originalImportHandling;
@@ -280,5 +309,7 @@ public final class ImportRewriteConfiguration {
 		this.importOrder = builder.importOrder;
 		this.typeOnDemandThreshold = builder.typeOnDemandThreshold;
 		this.staticOnDemandThreshold = builder.staticOnDemandThreshold;
+		this.keepExistingOnDemandImports = builder.keepExistingOnDemandImports;
+		this.collapseSingleImportsToOnDemand = builder.collapseSingleImportsToOnDemand;
 	}
 }

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/imports/OnDemandComputer.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/internal/core/dom/rewrite/imports/OnDemandComputer.java
@@ -22,10 +22,12 @@ import java.util.Set;
 class OnDemandComputer {
 	private final int typeOnDemandThreshold;
 	private final int staticOnDemandThreshold;
+	private final boolean reduceByThreshold;
 
-	OnDemandComputer(int typeOnDemandThreshold, int staticOnDemandThreshold) {
+	OnDemandComputer(int typeOnDemandThreshold, int staticOnDemandThreshold, boolean reduceByThreshold) {
 		this.typeOnDemandThreshold = typeOnDemandThreshold;
 		this.staticOnDemandThreshold = staticOnDemandThreshold;
+		this.reduceByThreshold = reduceByThreshold;
 	}
 
 	/**
@@ -120,7 +122,7 @@ class OnDemandComputer {
 			}
 		}
 
-		if (containerHasOnDemand || reducibleImports.size() >= onDemandThreshold) {
+		if (containerHasOnDemand || (this.reduceByThreshold && reducibleImports.size() >= onDemandThreshold)) {
 			return new OnDemandReduction(containerOnDemand, reducibleImports);
 		}
 

--- a/org.eclipse.jdt.core/pom.xml
+++ b/org.eclipse.jdt.core/pom.xml
@@ -17,7 +17,7 @@
     <version>4.41.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.eclipse.jdt.core</artifactId>
-  <version>3.46.100-SNAPSHOT</version>
+  <version>3.47.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>


### PR DESCRIPTION
Organize Imports rebuilds the import block from scratch. This expands existing on-demand (".*") imports into single imports, and it collapses single imports into a new on-demand import once the configured on-demand threshold is reached.

This adds two independent options to ImportRewrite that let callers control each of these directions:

- setKeepExistingOnDemandImports(boolean): when enabled, a referenced existing on-demand import (static or normal) is preserved as an on-demand import instead of being expanded into single imports. On-demand imports whose container is no longer referenced are still removed as unused.

- setCollapseSingleImportsToOnDemand(boolean): when disabled, the on-demand thresholds are ignored and no new on-demand import is created from single imports. Single imports are still folded into an on-demand import which is already present in their container.

Both options default to the current behaviour (keep-existing off, collapse on), so existing clients are unaffected.

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
