### PR TITLE
Regression: Eclipse compiler fails to infer the correct type

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedGenericMethodBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedGenericMethodBinding.java
@@ -36,6 +36,7 @@ import org.eclipse.jdt.internal.compiler.ast.NullAnnotationMatching;
 import org.eclipse.jdt.internal.compiler.ast.ReferenceExpression;
 import org.eclipse.jdt.internal.compiler.ast.Wildcard;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
+import org.eclipse.jdt.internal.compiler.lookup.TypeConstants.BoundCheckStatus;
 
 /**
  * Binding denoting a generic method after type parameter substitutions got performed.
@@ -256,13 +257,7 @@ public class ParameterizedGenericMethodBinding extends ParameterizedMethodBindin
 						if (invocationTypeInferred) {
 							if (compilerOptions.isAnnotationBasedNullAnalysisEnabled)
 								NullAnnotationMatching.checkForContradictions(methodSubstitute, invocationSite, scope);
-							MethodBinding problemMethod = methodSubstitute.boundCheck18(scope, arguments, invocationSite);
-							if (problemMethod != null) {
-								if (InferenceContext18.DEBUG) {
-									System.out.println("Bound check after inference failed: "+problemMethod); //$NON-NLS-1$
-								}
-								return problemMethod;
-							}
+							methodSubstitute.boundCheck18(scope, arguments, invocationSite); // detect unchecked type arguments
 						} else {
 							methodSubstitute = new PolyParameterizedGenericMethodBinding(methodSubstitute);
 							if (InferenceContext18.DEBUG) {
@@ -291,34 +286,21 @@ public class ParameterizedGenericMethodBinding extends ParameterizedMethodBindin
 		}
 	}
 
-	MethodBinding boundCheck18(Scope scope, TypeBinding[] arguments, InvocationSite site) {
+	void boundCheck18(Scope scope, TypeBinding[] arguments, InvocationSite site) {
 		Substitution substitution = this;
 		ParameterizedGenericMethodBinding methodSubstitute = this;
 		TypeVariableBinding[] originalTypeVariables = this.originalMethod.typeVariables;
-		// mostly original extract from above, TODO: remove stuff that's no longer needed in 1.8+
 		for (int i = 0, length = originalTypeVariables.length; i < length; i++) {
-		    TypeVariableBinding typeVariable = originalTypeVariables[i];
-		    TypeBinding substitute = methodSubstitute.typeArguments[i]; // retain for diagnostics
+			TypeVariableBinding typeVariable = originalTypeVariables[i];
+			TypeBinding substitute = methodSubstitute.typeArguments[i];
 
 			ASTNode location = site instanceof ASTNode ? (ASTNode) site : null;
-			switch (typeVariable.boundCheck(substitution, substitute, scope, location)) {
-				case MISMATCH :
-			        // incompatible due to bound check
-					int argLength = arguments.length;
-					TypeBinding[] augmentedArguments = new TypeBinding[argLength + 2]; // append offending substitute and typeVariable
-					System.arraycopy(arguments, 0, augmentedArguments, 0, argLength);
-					augmentedArguments[argLength] = substitute;
-					augmentedArguments[argLength+1] = typeVariable;
-			        return new ProblemMethodBinding(methodSubstitute, this.originalMethod.selector, augmentedArguments, ProblemReasons.ParameterBoundMismatch);
-				case UNCHECKED :
-					// tolerate unchecked bounds
-					methodSubstitute.tagBits |= TagBits.HasUncheckedTypeArgumentForBoundCheck;
-					break;
-				default:
-					break;
+			if (typeVariable.boundCheck(substitution, substitute, scope, location) == BoundCheckStatus.UNCHECKED) {
+				// tolerate but record unchecked bounds
+				methodSubstitute.tagBits |= TagBits.HasUncheckedTypeArgumentForBoundCheck;
+				break;
 			}
 		}
-		return null;
 	}
 
 	/**

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
@@ -2404,6 +2404,45 @@ public void testGH4984() throws Exception {
 		""" });
 }
 
+public void testGH4893() throws Exception  {
+	runConformTest(new String[] {
+		"Bug.java",
+		"""
+		public class Bug {
+			public static <K1 extends Key<? extends P1>, P1 extends Provider> P1 getProvider(K1 key) {
+				return null;
+			}
+			interface Key<P2 extends Provider> { }
+			interface Provider { }
+
+			interface AnObject<K2 extends Key<? extends AnObjectProvider<?>>> {
+				default K2 getKey() {
+					return null;
+				}
+
+				public default AnObjectProvider<?> getObjectProvider() {
+					// OK for all javac and all eclipse compilers
+					return getProvider(getKey());
+				}
+			}
+
+			interface AnObjectProvider<P3 extends AnObjectProvider<P3>> extends Provider { }
+			interface SubKey<P4 extends SubProvider> extends Key<P4> { }
+			interface SubProvider extends Provider { }
+
+			interface AnSubObject<K3 extends SubKey<? extends AnSubObjectProvider<?>>> extends AnObject<K3> {
+				public default AnSubObjectProvider<?> getObjectProvider() {
+					// OK for all javac compilers and all eclipse compilers up to 2025-09
+					return getProvider(getKey()); // fails with eclipse 2025-12 and 2026-03 RC2
+				}
+			}
+
+			interface AnSubObjectProvider<P5 extends AnSubObjectProvider<P5>> extends AnObjectProvider<P5> { }
+		}
+		"""
+	});
+}
+
 public static Class<GenericsRegressionTest_9> testClass() {
 	return GenericsRegressionTest_9.class;
 }


### PR DESCRIPTION
Remove left-over checks from Java 1.7

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4893

