### PR TITLE
4152 Add newline after annotations on  record paramters

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/formatter/FormatterNewLineRecordParameterTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/formatter/FormatterNewLineRecordParameterTest.java
@@ -1,0 +1,196 @@
+package org.eclipse.jdt.core.tests.formatter;
+
+import java.util.Map;
+import junit.framework.Test;
+import org.eclipse.core.resources.IWorkspaceDescription;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.formatter.CodeFormatter;
+import org.eclipse.jdt.core.tests.model.AbstractJavaModelTests;
+import org.eclipse.jdt.core.tests.util.Util;
+import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
+import org.eclipse.jdt.internal.formatter.DefaultCodeFormatter;
+import org.eclipse.jdt.internal.formatter.DefaultCodeFormatterOptions;
+import org.eclipse.text.edits.TextEdit;
+
+public class FormatterNewLineRecordParameterTest extends AbstractJavaModelTests {
+
+    DefaultCodeFormatterOptions formatterPrefs;
+    Map<String, String> formatterOptions;
+    private long startNanos;
+
+    protected static IJavaProject JAVA_PROJECT;
+    public static final String IN = "_in";
+    public static final String OUT = "_out";
+    public static final boolean DEBUG = false;
+
+    private static final String PROJECT_NAME = "RecordParameterNewLine";
+
+    public FormatterNewLineRecordParameterTest(String name) {
+	super(name);
+    }
+
+    public static Test suite() {
+	return buildModelTestSuite(FormatterNewLineRecordParameterTest.class);
+    }
+
+    /**
+     * Init formatter preferences with Eclipse default settings.
+     */
+    @Override
+    protected void setUp() throws Exception {
+	super.setUp();
+	this.formatterPrefs = DefaultCodeFormatterOptions.getEclipseDefaultSettings();
+	if (JAVA_PROJECT != null) {
+	    this.formatterOptions = JAVA_PROJECT.getOptions(true);
+	}
+	this.formatterOptions.put(CompilerOptions.OPTION_Compliance, CompilerOptions.VERSION_19);
+	this.formatterOptions.put(CompilerOptions.OPTION_TargetPlatform, CompilerOptions.VERSION_19);
+	this.formatterOptions.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_19);
+    }
+
+    /**
+     * Create project and set the jar placeholder.
+     */
+    @Override
+    public void setUpSuite() throws Exception {
+	// ensure autobuilding is turned off
+	IWorkspaceDescription description = getWorkspace().getDescription();
+	if (description.isAutoBuilding()) {
+	    description.setAutoBuilding(false);
+	    getWorkspace().setDescription(description);
+	}
+
+	if (JAVA_PROJECT == null) {
+	    JAVA_PROJECT = setUpJavaProject(PROJECT_NAME, "19"); //$NON-NLS-1$
+	}
+
+	if (DEBUG) {
+	    this.startNanos = System.nanoTime();
+	}
+    }
+
+    /**
+     * Reset the jar placeholder and delete project.
+     */
+    @Override
+    public void tearDownSuite() throws Exception {
+	deleteProject(JAVA_PROJECT); // $NON-NLS-1$
+	JAVA_PROJECT = null;
+	if (DEBUG) {
+	    System.out.println("Time spent = " + (System.nanoTime() - this.startNanos) / 1_000_000L);//$NON-NLS-1$
+	}
+	super.tearDownSuite();
+    }
+
+    private String getIn(String compilationUnitName) {
+	assertNotNull(compilationUnitName);
+	int dotIndex = compilationUnitName.indexOf('.');
+	assertTrue(dotIndex != -1);
+	return compilationUnitName.substring(0, dotIndex) + IN + compilationUnitName.substring(dotIndex);
+    }
+
+    private String getOut(String compilationUnitName) {
+	assertNotNull(compilationUnitName);
+	int dotIndex = compilationUnitName.indexOf('.');
+	assertTrue(dotIndex != -1);
+	return compilationUnitName.substring(0, dotIndex) + OUT + compilationUnitName.substring(dotIndex);
+    }
+
+    void assertLineEquals(String actualContents, String originalSource, String expectedContents, boolean checkNull) {
+	if (actualContents == null) {
+	    assertTrue("actualContents is null", checkNull);
+	    assertEquals(expectedContents, originalSource);
+	    return;
+	}
+	assertSourceEquals("Different number of length", Util.convertToIndependantLineDelimiter(expectedContents),
+		actualContents);
+    }
+
+    String runFormatter(CodeFormatter codeFormatter, String source, int kind, int indentationLevel, int offset,
+	    int length, String lineSeparator, boolean repeat) {
+//	long time = System.currentTimeMillis();
+	TextEdit edit = codeFormatter.format(kind, source, offset, length, indentationLevel, lineSeparator);// $NON-NLS-1$
+//	System.out.println((System.currentTimeMillis() - time) + " ms");
+	if (edit == null)
+	    return null;
+//	System.out.println(edit.getChildrenSize() + " edits");
+	String result = org.eclipse.jdt.internal.core.util.Util.editedString(source, edit);
+
+	if (repeat && length == source.length()) {
+//		time = System.currentTimeMillis();
+	    edit = codeFormatter.format(kind, result, 0, result.length(), indentationLevel, lineSeparator);// $NON-NLS-1$
+//		System.out.println((System.currentTimeMillis() - time) + " ms");
+	    if (edit == null)
+		return null;
+//		assertEquals("Should not have edits", 0, edit.getChildren().length);
+	    final String result2 = org.eclipse.jdt.internal.core.util.Util.editedString(result, edit);
+	    if (!result.equals(result2)) {
+		assertSourceEquals("Second formatting is different from first one!",
+			Util.convertToIndependantLineDelimiter(result),
+			Util.convertToIndependantLineDelimiter(result2));
+	    }
+	}
+	return result;
+    }
+
+    private void runTest(String packageName, String compilationUnitName) {
+	DefaultCodeFormatter codeFormatter = new DefaultCodeFormatter(this.formatterPrefs, this.formatterOptions);
+	runTest(codeFormatter, packageName, compilationUnitName, CodeFormatter.K_COMPILATION_UNIT, 0);
+    }
+
+    private void runTest(CodeFormatter codeFormatter, String packageName, String compilationUnitName, int kind,
+	    int indentationLevel) {
+	runTest(codeFormatter, packageName, compilationUnitName, kind, indentationLevel, false, 0, -1);
+    }
+
+    private void runTest(CodeFormatter codeFormatter, String packageName, String compilationUnitName, int kind,
+	    int indentationLevel, boolean checkNull, int offset, int length) {
+	runTest(codeFormatter, packageName, compilationUnitName, kind, indentationLevel, checkNull, offset, length,
+		null);
+    }
+
+    private void runTest(CodeFormatter codeFormatter, String packageName, String compilationUnitName, int kind,
+	    int indentationLevel, boolean checkNull, int offset, int length, String lineSeparator) {
+	try {
+	    ICompilationUnit sourceUnit = getCompilationUnit(PROJECT_NAME, "", packageName, getIn(compilationUnitName)); //$NON-NLS-1$ //$NON-NLS-2$
+	    String source = sourceUnit.getSource();
+	    assertNotNull(source);
+	    ICompilationUnit outputUnit = getCompilationUnit(PROJECT_NAME, "", packageName, //$NON-NLS-1$
+		    getOut(compilationUnitName)); // $NON-NLS-2$
+	    assertNotNull(outputUnit);
+	    String result;
+	    if (length == -1) {
+		result = runFormatter(codeFormatter, source, kind, indentationLevel, offset, source.length(),
+			lineSeparator, true);
+	    } else {
+		result = runFormatter(codeFormatter, source, kind, indentationLevel, offset, length, lineSeparator,
+			true);
+	    }
+	    assertLineEquals(result, source, outputUnit.getSource(), checkNull);
+	} catch (JavaModelException e) {
+	    e.printStackTrace();
+	    assertTrue(false);
+	}
+    }
+
+    public void test01() {
+	// This is testing a scenario where newline after annotation on record parameter is enabled, but the formatting is
+	// applied to a method declaration.
+	// Expected result, the annotations should still stay on the same line.
+	this.formatterPrefs.insert_new_line_after_annotation_on_record_parameter = true;
+	runTest("test01", "X.java");//$NON-NLS-1$ //$NON-NLS-2$
+	this.formatterPrefs.insert_new_line_after_annotation_on_record_parameter = false;
+    }
+
+    public void test02() {
+	// This is testing a scenario where newline after annotation on record parameter is enabled, but the formatting is
+	// applied to a method declaration.
+	// Expected result, the annotations should still stay on the same line.
+	this.formatterPrefs.insert_new_line_after_annotation_on_record_parameter = true;
+	runTest("test02", "X.java");//$NON-NLS-1$ //$NON-NLS-2$
+	this.formatterPrefs.insert_new_line_after_annotation_on_record_parameter = false;
+    }
+
+}

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/formatter/FormatterNewLineRecordParameterTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/formatter/FormatterNewLineRecordParameterTest.java
@@ -1,3 +1,16 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial test set
+ ********************************************************************************/
 package org.eclipse.jdt.core.tests.formatter;
 
 import java.util.Map;

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/rewrite/describing/ASTRewritingMethodDeclTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/rewrite/describing/ASTRewritingMethodDeclTest.java
@@ -3130,7 +3130,7 @@ public class ASTRewritingMethodDeclTest extends ASTRewritingTest {
 		buf= new StringBuilder();
 		buf.append("package test1;\n");
 		buf.append("class E {\n");
-		buf.append("    public void foo(@X\n    @A int a, @B2 int b, @X\n    int c, @X int d, @X\n    int e) {\n");
+		buf.append("    public void foo(@X\n            @A int a, @B2 int b, @X\n            int c, @X int d, @X\n            int e) {\n");
 		buf.append("    }\n");
 		buf.append("}\n");
 		assertEqualString(preview, buf.toString());

--- a/org.eclipse.jdt.core.tests.model/workspace/Formatter/test545078/F_out.java
+++ b/org.eclipse.jdt.core.tests.model/workspace/Formatter/test545078/F_out.java
@@ -30,7 +30,9 @@ public class Test545078 {
 	}
 
 	public void g(
-			@ParameterAnnotation(key1 = "value1", key2 = "value2") @OtherParameterAnnotation() @ExtraParamAnno
+			@ParameterAnnotation(key1 = "value1", key2 = "value2")
+			@OtherParameterAnnotation()
+			@ExtraParamAnno
 			String arg1) {
 		//
 	}

--- a/org.eclipse.jdt.core.tests.model/workspace/Formatter/test575/A_out.java
+++ b/org.eclipse.jdt.core.tests.model/workspace/Formatter/test575/A_out.java
@@ -1,6 +1,7 @@
 public class A {
-	public Object foo(@Ann("parameter")
-	Object parameter) {
+	public Object foo(
+			@Ann("parameter")
+			Object parameter) {
 		return parameter;
 	}
 }

--- a/org.eclipse.jdt.core.tests.model/workspace/Formatter/test701/X_out.java
+++ b/org.eclipse.jdt.core.tests.model/workspace/Formatter/test701/X_out.java
@@ -2,10 +2,14 @@ public class X {
 
 	@Deprecated
 	@SuppressWarnings("unused")
-	public void setFoo(@Required
-	String name, @NotNull
-	int value, @Required
-	int start, @Required
-	int length) {
+	public void setFoo(
+			@Required
+			String name,
+			@NotNull
+			int value,
+			@Required
+			int start,
+			@Required
+			int length) {
 	}
 }

--- a/org.eclipse.jdt.core.tests.model/workspace/Formatter/test703/X_out.java
+++ b/org.eclipse.jdt.core.tests.model/workspace/Formatter/test703/X_out.java
@@ -1,6 +1,7 @@
 public class X {
 	@Deprecated
-	public void bar(@SuppressWarnings("unused")
-	final int i) {
+	public void bar(
+			@SuppressWarnings("unused")
+			final int i) {
 	}
 }

--- a/org.eclipse.jdt.core.tests.model/workspace/Formatter/test704/X_out.java
+++ b/org.eclipse.jdt.core.tests.model/workspace/Formatter/test704/X_out.java
@@ -1,5 +1,6 @@
 public class X {
-	@Deprecated public void bar(@SuppressWarnings("unused")
-	final int i) {
+	@Deprecated public void bar(
+			@SuppressWarnings("unused")
+			final int i) {
 	}
 }

--- a/org.eclipse.jdt.core.tests.model/workspace/Formatter/test706/X_out.java
+++ b/org.eclipse.jdt.core.tests.model/workspace/Formatter/test706/X_out.java
@@ -33,9 +33,11 @@
 
 	}
 
-	@OnMember public void bar(@OnParameter("unused value")
-	final int i, @OnParameter("unused value")
-	String s) {
+	@OnMember public void bar(
+			@OnParameter("unused value")
+			final int i,
+			@OnParameter("unused value")
+			String s) {
 		@OnLocalVariable @Retention String localString = "string";
 	}
 }

--- a/org.eclipse.jdt.core.tests.model/workspace/Formatter/test707/X_out.java
+++ b/org.eclipse.jdt.core.tests.model/workspace/Formatter/test707/X_out.java
@@ -43,9 +43,11 @@ public class X {
 	}
 
 	@OnMember
-	public void bar(@OnParameter("unused value")
-	final int i, @OnParameter("unused value")
-	String s) {
+	public void bar(
+			@OnParameter("unused value")
+			final int i,
+			@OnParameter("unused value")
+			String s) {
 		@OnLocalVariable @Retention String localString = "string";
 	}
 }

--- a/org.eclipse.jdt.core.tests.model/workspace/Formatter/test710/X_out.java
+++ b/org.eclipse.jdt.core.tests.model/workspace/Formatter/test710/X_out.java
@@ -33,9 +33,11 @@
 
 	}
 
-	@OnMember public void bar(@OnParameter("unused value")
-	final int i, @OnParameter("unused value")
-	String s) {
+	@OnMember public void bar(
+			@OnParameter("unused value")
+			final int i,
+			@OnParameter("unused value")
+			String s) {
 		@OnLocalVariable
 		@Retention
 		String localString = "string";

--- a/org.eclipse.jdt.core.tests.model/workspace/FormatterJSR308/test011/X_out.java
+++ b/org.eclipse.jdt.core.tests.model/workspace/FormatterJSR308/test011/X_out.java
@@ -1,11 +1,8 @@
 public class X {
 	int x() {
-		try (
-				@Marker
-				Integer p = null;
-				final @Marker Integer q = null;
-				@Marker
-				final Integer r = null) {
+		try (@Marker
+		Integer p = null; final @Marker Integer q = null; @Marker
+		final Integer r = null) {
 		}
 		return 10;
 	}

--- a/org.eclipse.jdt.core.tests.model/workspace/FormatterJSR308/test011/X_out.java
+++ b/org.eclipse.jdt.core.tests.model/workspace/FormatterJSR308/test011/X_out.java
@@ -1,8 +1,11 @@
 public class X {
 	int x() {
-		try (@Marker
-		Integer p = null; final @Marker Integer q = null; @Marker
-		final Integer r = null) {
+		try (
+				@Marker
+				Integer p = null;
+				final @Marker Integer q = null;
+				@Marker
+				final Integer r = null) {
 		}
 		return 10;
 	}

--- a/org.eclipse.jdt.core.tests.model/workspace/FormatterJSR308/test012/X_out.java
+++ b/org.eclipse.jdt.core.tests.model/workspace/FormatterJSR308/test012/X_out.java
@@ -1,13 +1,11 @@
 public class X {
 	int x() {
-		for (
-		Z@Marker
+		for (@Marker
 		int i : new int[3]) {
 		}
 		for (final @Marker int i : new int[3]) {
 		}
-		for (
-		@Marker
+		for (@Marker
 		final int i : new int[3]) {
 		}
 		return 10;

--- a/org.eclipse.jdt.core.tests.model/workspace/FormatterJSR308/test012/X_out.java
+++ b/org.eclipse.jdt.core.tests.model/workspace/FormatterJSR308/test012/X_out.java
@@ -1,11 +1,13 @@
 public class X {
 	int x() {
-		for (@Marker
+		for (
+		Z@Marker
 		int i : new int[3]) {
 		}
 		for (final @Marker int i : new int[3]) {
 		}
-		for (@Marker
+		for (
+		@Marker
 		final int i : new int[3]) {
 		}
 		return 10;

--- a/org.eclipse.jdt.core.tests.model/workspace/RecordParameterNewLine/.classpath
+++ b/org.eclipse.jdt.core.tests.model/workspace/RecordParameterNewLine/.classpath
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+    <classpathentry kind="src" path=""/>
+    <classpathentry kind="var" path="JCL18_LIB" sourcepath="JCL18_SRC" rootpath="JCL_SRC18ROOT"/>
+    <classpathentry kind="output" path="bin"/>
+</classpath>

--- a/org.eclipse.jdt.core.tests.model/workspace/RecordParameterNewLine/.project
+++ b/org.eclipse.jdt.core.tests.model/workspace/RecordParameterNewLine/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>RecordParameterNewLine</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/org.eclipse.jdt.core.tests.model/workspace/RecordParameterNewLine/test01/X_in.java
+++ b/org.eclipse.jdt.core.tests.model/workspace/RecordParameterNewLine/test01/X_in.java
@@ -1,0 +1,11 @@
+package test;
+
+import java.io.Serial;
+
+public class TestAnnClass {
+	
+	private void testMethod(@Deprecated @SuppressWarnings( value= {""}) String serial, @Deprecated @SuppressWarnings(value = {""}) String name) {
+
+	}
+
+}

--- a/org.eclipse.jdt.core.tests.model/workspace/RecordParameterNewLine/test01/X_out.java
+++ b/org.eclipse.jdt.core.tests.model/workspace/RecordParameterNewLine/test01/X_out.java
@@ -1,0 +1,12 @@
+package test;
+
+import java.io.Serial;
+
+public class TestAnnClass {
+
+	private void testMethod(@Deprecated @SuppressWarnings(value = { "" }) String serial,
+			@Deprecated @SuppressWarnings(value = { "" }) String name) {
+
+	}
+
+}

--- a/org.eclipse.jdt.core.tests.model/workspace/RecordParameterNewLine/test02/X_in.java
+++ b/org.eclipse.jdt.core.tests.model/workspace/RecordParameterNewLine/test02/X_in.java
@@ -1,0 +1,7 @@
+package test;
+
+import java.lang.annotation.Native;
+
+public record TestRecord(
+        @Deprecated @Native @SuppressWarnings(value = { "" }) String name, @SuppressWarnings(value = { "" }) String age
+	) {}

--- a/org.eclipse.jdt.core.tests.model/workspace/RecordParameterNewLine/test02/X_out.java
+++ b/org.eclipse.jdt.core.tests.model/workspace/RecordParameterNewLine/test02/X_out.java
@@ -1,0 +1,13 @@
+package test;
+
+import java.lang.annotation.Native;
+
+public record TestRecord(
+		@Deprecated
+		@Native
+		@SuppressWarnings(value = {
+				"" })
+		String name,
+		@SuppressWarnings(value = { "" })
+		String age) {
+}

--- a/org.eclipse.jdt.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.core; singleton:=true
-Bundle-Version: 3.46.100.qualifier
+Bundle-Version: 3.47.0.qualifier
 Bundle-Activator: org.eclipse.jdt.core.JavaCore
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/core/formatter/DefaultCodeFormatterConstants.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/core/formatter/DefaultCodeFormatterConstants.java
@@ -2353,6 +2353,19 @@ public class DefaultCodeFormatterConstants {
 
 	/**
 	 * <pre>
+	 * FORMATTER / Option to insert a new line after an annotation on a parameter
+	 *     - option id:         "org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_record_parameter"
+	 *     - possible values:   { INSERT, DO_NOT_INSERT }
+	 *     - default:           DO_NOT_INSERT
+	 * </pre>
+	 * @see JavaCore#INSERT
+	 * @see JavaCore#DO_NOT_INSERT
+	 * @since 3.4
+	 */
+	public static final String FORMATTER_INSERT_NEW_LINE_AFTER_ANNOTATION_ON_RECORD_PARAMETER = JavaCore.PLUGIN_ID + ".formatter.insert_new_line_after_annotation_on_parameter";//$NON-NLS-1$
+
+	/**
+	 * <pre>
 	 * FORMATTER / Option to insert a new line after an annotation on a local variable
 	 *     - option id:         "org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_local_variable"
 	 *     - possible values:   { INSERT, DO_NOT_INSERT }

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/core/formatter/DefaultCodeFormatterConstants.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/core/formatter/DefaultCodeFormatterConstants.java
@@ -2360,7 +2360,7 @@ public class DefaultCodeFormatterConstants {
 	 * </pre>
 	 * @see JavaCore#INSERT
 	 * @see JavaCore#DO_NOT_INSERT
-	 * @since 3.4
+	 * @since 3.46.100
 	 */
 	public static final String FORMATTER_INSERT_NEW_LINE_AFTER_ANNOTATION_ON_RECORD_PARAMETER = JavaCore.PLUGIN_ID + ".formatter.insert_new_line_after_annotation_on_parameter";//$NON-NLS-1$
 

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/core/formatter/DefaultCodeFormatterConstants.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/core/formatter/DefaultCodeFormatterConstants.java
@@ -2360,7 +2360,7 @@ public class DefaultCodeFormatterConstants {
 	 * </pre>
 	 * @see JavaCore#INSERT
 	 * @see JavaCore#DO_NOT_INSERT
-	 * @since 3.46.100
+	 * @since 3.46
 	 */
 	public static final String FORMATTER_INSERT_NEW_LINE_AFTER_ANNOTATION_ON_RECORD_PARAMETER = JavaCore.PLUGIN_ID + ".formatter.insert_new_line_after_annotation_on_record_parameter";//$NON-NLS-1$
 

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/core/formatter/DefaultCodeFormatterConstants.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/core/formatter/DefaultCodeFormatterConstants.java
@@ -2360,7 +2360,7 @@ public class DefaultCodeFormatterConstants {
 	 * </pre>
 	 * @see JavaCore#INSERT
 	 * @see JavaCore#DO_NOT_INSERT
-	 * @since 3.46
+	 * @since 3.47
 	 */
 	public static final String FORMATTER_INSERT_NEW_LINE_AFTER_ANNOTATION_ON_RECORD_PARAMETER = JavaCore.PLUGIN_ID + ".formatter.insert_new_line_after_annotation_on_record_parameter";//$NON-NLS-1$
 

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/core/formatter/DefaultCodeFormatterConstants.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/core/formatter/DefaultCodeFormatterConstants.java
@@ -2362,7 +2362,7 @@ public class DefaultCodeFormatterConstants {
 	 * @see JavaCore#DO_NOT_INSERT
 	 * @since 3.46.100
 	 */
-	public static final String FORMATTER_INSERT_NEW_LINE_AFTER_ANNOTATION_ON_RECORD_PARAMETER = JavaCore.PLUGIN_ID + ".formatter.insert_new_line_after_annotation_on_parameter";//$NON-NLS-1$
+	public static final String FORMATTER_INSERT_NEW_LINE_AFTER_ANNOTATION_ON_RECORD_PARAMETER = JavaCore.PLUGIN_ID + ".formatter.insert_new_line_after_annotation_on_record_parameter";//$NON-NLS-1$
 
 	/**
 	 * <pre>

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/DefaultCodeFormatterOptions.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/DefaultCodeFormatterOptions.java
@@ -283,6 +283,7 @@ public class DefaultCodeFormatterOptions {
 	public boolean insert_new_line_after_annotation_on_method;
 	public boolean insert_new_line_after_annotation_on_package;
 	public boolean insert_new_line_after_annotation_on_parameter;
+	public boolean insert_new_line_after_annotation_on_record_parameter;
 	public boolean insert_new_line_after_annotation_on_local_variable;
 	public boolean insert_new_line_after_label;
 	public boolean insert_new_line_after_opening_brace_in_array_initializer;
@@ -725,6 +726,7 @@ public class DefaultCodeFormatterOptions {
 		options.put(DefaultCodeFormatterConstants.FORMATTER_INSERT_NEW_LINE_AFTER_ANNOTATION_ON_METHOD, this.insert_new_line_after_annotation_on_method ? JavaCore.INSERT : JavaCore.DO_NOT_INSERT);
 		options.put(DefaultCodeFormatterConstants.FORMATTER_INSERT_NEW_LINE_AFTER_ANNOTATION_ON_PACKAGE, this.insert_new_line_after_annotation_on_package ? JavaCore.INSERT : JavaCore.DO_NOT_INSERT);
 		options.put(DefaultCodeFormatterConstants.FORMATTER_INSERT_NEW_LINE_AFTER_ANNOTATION_ON_PARAMETER, this.insert_new_line_after_annotation_on_parameter ? JavaCore.INSERT : JavaCore.DO_NOT_INSERT);
+		options.put(DefaultCodeFormatterConstants.FORMATTER_INSERT_NEW_LINE_AFTER_ANNOTATION_ON_RECORD_PARAMETER, this.insert_new_line_after_annotation_on_record_parameter ? JavaCore.INSERT : JavaCore.DO_NOT_INSERT);
 		options.put(DefaultCodeFormatterConstants.FORMATTER_INSERT_NEW_LINE_AFTER_ANNOTATION_ON_LOCAL_VARIABLE, this.insert_new_line_after_annotation_on_local_variable ? JavaCore.INSERT : JavaCore.DO_NOT_INSERT);
 		options.put(DefaultCodeFormatterConstants.FORMATTER_INSERT_NEW_LINE_AFTER_OPENING_BRACE_IN_ARRAY_INITIALIZER, this.insert_new_line_after_opening_brace_in_array_initializer? JavaCore.INSERT : JavaCore.DO_NOT_INSERT);
 		options.put(DefaultCodeFormatterConstants.FORMATTER_INSERT_NEW_LINE_AT_END_OF_FILE_IF_MISSING, this.insert_new_line_at_end_of_file_if_missing ? JavaCore.INSERT : JavaCore.DO_NOT_INSERT);
@@ -2749,6 +2751,7 @@ public class DefaultCodeFormatterOptions {
 		final Object insertNewLineAfterAnnotationOnPackageOption = settings.get(DefaultCodeFormatterConstants.FORMATTER_INSERT_NEW_LINE_AFTER_ANNOTATION_ON_PACKAGE);
 
 		final Object insertNewLineAfterAnnotationOnParameterOption = settings.get(DefaultCodeFormatterConstants.FORMATTER_INSERT_NEW_LINE_AFTER_ANNOTATION_ON_PARAMETER);
+		final Object insertNewLineAfterAnnotationOnRecordParameterOption = settings.get(DefaultCodeFormatterConstants.FORMATTER_INSERT_NEW_LINE_AFTER_ANNOTATION_ON_RECORD_PARAMETER);
 		final Object insertNewLineAfterAnnotationOnLocalVariableOption = settings.get(DefaultCodeFormatterConstants.FORMATTER_INSERT_NEW_LINE_AFTER_ANNOTATION_ON_LOCAL_VARIABLE);
 
 		if (insertNewLineAfterAnnotationOnTypeOption == null
@@ -2769,6 +2772,9 @@ public class DefaultCodeFormatterOptions {
 				if (insertNewLineAfterAnnotationOnParameterOption != null) {
 					this.insert_new_line_after_annotation_on_parameter = JavaCore.INSERT.equals(insertNewLineAfterAnnotationOnParameterOption);
 				}
+				if (insertNewLineAfterAnnotationOnRecordParameterOption != null) {
+					this.insert_new_line_after_annotation_on_record_parameter = JavaCore.INSERT.equals(insertNewLineAfterAnnotationOnRecordParameterOption);
+				}
 				if (insertNewLineAfterAnnotationOnLocalVariableOption != null) {
 					this.insert_new_line_after_annotation_on_local_variable = JavaCore.INSERT.equals(insertNewLineAfterAnnotationOnLocalVariableOption);
 				}
@@ -2783,6 +2789,7 @@ public class DefaultCodeFormatterOptions {
 					this.insert_new_line_after_annotation_on_method = insert;
 					this.insert_new_line_after_annotation_on_package = insert;
 					this.insert_new_line_after_annotation_on_parameter = insert;
+					this.insert_new_line_after_annotation_on_record_parameter = insert;
 					this.insert_new_line_after_annotation_on_local_variable = insert;
 					int alignment = insert ? Alignment.M_FORCE | Alignment.M_ONE_PER_LINE_SPLIT
 							: Alignment.M_NO_ALIGNMENT;
@@ -2814,6 +2821,9 @@ public class DefaultCodeFormatterOptions {
 			// and the other 3.4 options if available
 			if (insertNewLineAfterAnnotationOnParameterOption != null) {
 				this.insert_new_line_after_annotation_on_parameter = JavaCore.INSERT.equals(insertNewLineAfterAnnotationOnParameterOption);
+			}
+			if (insertNewLineAfterAnnotationOnRecordParameterOption != null) {
+				this.insert_new_line_after_annotation_on_record_parameter = JavaCore.INSERT.equals(insertNewLineAfterAnnotationOnRecordParameterOption);
 			}
 			if (insertNewLineAfterAnnotationOnLocalVariableOption != null) {
 				this.insert_new_line_after_annotation_on_local_variable = JavaCore.INSERT.equals(insertNewLineAfterAnnotationOnLocalVariableOption);
@@ -3135,6 +3145,7 @@ public class DefaultCodeFormatterOptions {
 		this.insert_new_line_after_annotation_on_method = true;
 		this.insert_new_line_after_annotation_on_package = true;
 		this.insert_new_line_after_annotation_on_parameter = false;
+		this.insert_new_line_after_annotation_on_record_parameter = false;
 		this.insert_new_line_after_annotation_on_local_variable = true;
 		this.insert_new_line_after_opening_brace_in_array_initializer = false;
 		this.insert_new_line_at_end_of_file_if_missing = false;
@@ -3542,6 +3553,7 @@ public class DefaultCodeFormatterOptions {
 		this.insert_new_line_after_annotation_on_method = true;
 		this.insert_new_line_after_annotation_on_package = true;
 		this.insert_new_line_after_annotation_on_parameter = false;
+		this.insert_new_line_after_annotation_on_record_parameter = false;
 		this.insert_new_line_after_annotation_on_local_variable = true;
 		this.insert_new_line_after_opening_brace_in_array_initializer = false;
 		this.insert_new_line_at_end_of_file_if_missing = false;

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/LineBreaksPreparator.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/LineBreaksPreparator.java
@@ -433,10 +433,16 @@ public class LineBreaksPreparator extends ASTVisitor {
 
 	@Override
 	public boolean visit(SingleVariableDeclaration node) {
-		handleAnnotations(node.modifiers(),
-				node.getParent() instanceof EnhancedForStatement
-						? this.options.insert_new_line_after_annotation_on_local_variable
-						: this.options.insert_new_line_after_annotation_on_parameter);
+		boolean parameterConfigValue = false;
+		if (node.getParent() instanceof RecordDeclaration) {
+			parameterConfigValue = this.options.insert_new_line_after_annotation_on_record_parameter;
+		} else if (node.getParent() instanceof EnhancedForStatement) {
+			parameterConfigValue = this.options.insert_new_line_after_annotation_on_local_variable;
+		} else {
+			parameterConfigValue = this.options.insert_new_line_after_annotation_on_parameter;
+		}
+		handleAnnotations(node.modifiers(), parameterConfigValue);
+
 		return true;
 	}
 
@@ -471,10 +477,16 @@ public class LineBreaksPreparator extends ASTVisitor {
 			if (modifiers.get(i).isModifier())
 				break;
 			last = (Annotation) modifiers.get(i);
+			if ( last != null && breakAfter) {
+				breakLineBefore(last);
+				if (i == modifiers.size()-1) this.tm.lastTokenIn(last, ANY).breakAfter();
+			}
 		}
+
 		if (last != null && breakAfter) {
 			this.tm.lastTokenIn(last, ANY).breakAfter();
 		}
+
 
 		if (i < modifiers.size()) {
 			// any annotations following other modifiers will be associated with declaration type

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/LineBreaksPreparator.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/LineBreaksPreparator.java
@@ -434,6 +434,7 @@ public class LineBreaksPreparator extends ASTVisitor {
 	@Override
 	public boolean visit(SingleVariableDeclaration node) {
 		boolean parameterConfigValue = false;
+		boolean shouldAddNewLine = isRecordOrMethodDecl(node);
 		if (node.getParent() instanceof RecordDeclaration) {
 			parameterConfigValue = this.options.insert_new_line_after_annotation_on_record_parameter;
 		} else if (node.getParent() instanceof EnhancedForStatement) {
@@ -441,7 +442,7 @@ public class LineBreaksPreparator extends ASTVisitor {
 		} else {
 			parameterConfigValue = this.options.insert_new_line_after_annotation_on_parameter;
 		}
-		handleAnnotations(node.modifiers(), parameterConfigValue);
+		handleAnnotations(node.modifiers(), parameterConfigValue, shouldAddNewLine);
 
 		return true;
 	}
@@ -470,14 +471,25 @@ public class LineBreaksPreparator extends ASTVisitor {
 		return true;
 	}
 
+	private boolean isRecordOrMethodDecl(SingleVariableDeclaration node) {
+		if ( node.getParent() instanceof MethodDeclaration || node.getParent() instanceof RecordDeclaration) {
+			return true;
+		}
+		return false;
+	}
+
 	private void handleAnnotations(List<? extends IExtendedModifier> modifiers, boolean breakAfter) {
+		handleAnnotations(modifiers, breakAfter, false);
+	}
+
+	private void handleAnnotations(List<? extends IExtendedModifier> modifiers, boolean breakAfter, boolean shouldAddNewLines) {
 		Annotation last = null;
 		int i;
 		for (i = 0; i < modifiers.size(); i++) {
 			if (modifiers.get(i).isModifier())
 				break;
 			last = (Annotation) modifiers.get(i);
-			if ( last != null && breakAfter) {
+			if ( last != null && breakAfter && shouldAddNewLines) {
 				breakLineBefore(last);
 				if (i == modifiers.size()-1) this.tm.lastTokenIn(last, ANY).breakAfter();
 			}

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/linewrap/WrapPreparator.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/linewrap/WrapPreparator.java
@@ -1191,10 +1191,14 @@ public class WrapPreparator extends ASTVisitor {
 	private void handleAnnotations(List<? extends IExtendedModifier> modifiers, int wrappingOption) {
 		Annotation last = null;
 		int i;
+		boolean shouldWrapAnnotation = true;
 		for (i = 0; i < modifiers.size(); i++) {
 			if (modifiers.get(i).isModifier())
 				break;
 			Annotation annotation = (Annotation) modifiers.get(i);
+			/*if (annotation.getParent() instanceof RecordDeclaration) {
+				shouldWrapAnnotation = this.options.insert_new_line_after_annotation_on_record_parameter;
+			} */
 			if (i == 0) {
 				this.wrapParentIndex = this.tm.firstIndexIn(annotation, ANY);
 			} else {

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/linewrap/WrapPreparator.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/linewrap/WrapPreparator.java
@@ -977,10 +977,18 @@ public class WrapPreparator extends ASTVisitor {
 
 	@Override
 	public boolean visit(SingleVariableDeclaration node) {
-		handleAnnotations(node.modifiers(),
+		if (node.getParent() instanceof RecordDeclaration) {
+			handleAnnotations(node.modifiers(),
+				node.getParent() instanceof EnhancedForStatement
+						? this.options.alignment_for_annotations_on_local_variable
+						: this.options.alignment_for_annotations_on_parameter,
+				this.options.insert_new_line_after_annotation_on_record_parameter);
+		} else {
+			handleAnnotations(node.modifiers(),
 				node.getParent() instanceof EnhancedForStatement
 						? this.options.alignment_for_annotations_on_local_variable
 						: this.options.alignment_for_annotations_on_parameter);
+		}
 		return true;
 	}
 
@@ -1189,21 +1197,23 @@ public class WrapPreparator extends ASTVisitor {
 	}
 
 	private void handleAnnotations(List<? extends IExtendedModifier> modifiers, int wrappingOption) {
+		handleAnnotations(modifiers, wrappingOption, true);
+	}
+
+	private void handleAnnotations(List<? extends IExtendedModifier> modifiers, int wrappingOption, boolean shouldWrap) {
 		Annotation last = null;
 		int i;
-		boolean shouldWrapAnnotation = true;
 		for (i = 0; i < modifiers.size(); i++) {
 			if (modifiers.get(i).isModifier())
 				break;
 			Annotation annotation = (Annotation) modifiers.get(i);
-			/*if (annotation.getParent() instanceof RecordDeclaration) {
-				shouldWrapAnnotation = this.options.insert_new_line_after_annotation_on_record_parameter;
-			} */
-			if (i == 0) {
-				this.wrapParentIndex = this.tm.firstIndexIn(annotation, ANY);
-			} else {
-				this.wrapIndexes.add(this.tm.firstIndexIn(annotation, ANY));
-				this.wrapGroupEnd = this.tm.lastIndexIn(annotation, ANY);
+			if (shouldWrap) {
+				if (i == 0) {
+					this.wrapParentIndex = this.tm.firstIndexIn(annotation, ANY);
+				} else {
+					this.wrapIndexes.add(this.tm.firstIndexIn(annotation, ANY));
+					this.wrapGroupEnd = this.tm.lastIndexIn(annotation, ANY);
+				}
 			}
 			last = annotation;
 		}

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/linewrap/WrapPreparator.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/linewrap/WrapPreparator.java
@@ -1201,6 +1201,10 @@ public class WrapPreparator extends ASTVisitor {
 	}
 
 	private void handleAnnotations(List<? extends IExtendedModifier> modifiers, int wrappingOption, boolean shouldWrap) {
+		//This method has it's specific rule to handle newline on annotations, that clash with the
+		//insert_new_line_after_annotation_on_record_parameter options, so if Applied, since it uses a different logic
+		//it rewrite the whole line, and remove the formatting just applied. To avoid that the shouldWrap boolean
+		//has been added, making it optional in case of need.
 		Annotation last = null;
 		int i;
 		for (i = 0; i < modifiers.size(); i++) {

--- a/org.eclipse.jdt.core/pom.xml
+++ b/org.eclipse.jdt.core/pom.xml
@@ -17,7 +17,7 @@
     <version>4.41.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.eclipse.jdt.core</artifactId>
-  <version>3.46.100-SNAPSHOT</version>
+  <version>3.47-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>

--- a/org.eclipse.jdt.core/pom.xml
+++ b/org.eclipse.jdt.core/pom.xml
@@ -17,7 +17,7 @@
     <version>4.41.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.eclipse.jdt.core</artifactId>
-  <version>3.47-SNAPSHOT</version>
+  <version>3.47.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>


### PR DESCRIPTION
## What it does
It implement changed discussed in #4152 

## How to test
If the new setting Newline -> After Annotations -> On record parameter is enabled it should format the following code snippete: 

```java
public record TestRecord(
        @Deprecated @Native @SuppressWarnings(value = { "" }) String name, @SuppressWarnings(value = { "" }) String age
	) {}
```

to: 
```java
public record TestRecord(
		@Deprecated
		@Native
		@SuppressWarnings(value = {
				"" })
		String name,
		@SuppressWarnings(value = { "" })
		String age) {
}
```

## Author checklist

- [X] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
