### PR TITLE
Add opt-in ZIP magic classpath filtering

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/FileSystem.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/FileSystem.java
@@ -433,7 +433,7 @@ public void cleanup() {
 	for (Classpath classpath : this.classpaths)
 		classpath.reset();
 }
-private static String convertPathSeparators(String path) {
+static String convertPathSeparators(String path) {
 	return File.separatorChar == '/'
 		? path.replace('\\', '/')
 		 : path.replace('/', '\\');

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/Main.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/Main.java
@@ -1380,6 +1380,7 @@ public class Main implements ProblemSeverities, SuffixConstants {
 	public long startTime;
 	public ArrayList<String> pendingErrors;
 	public boolean systemExitWhenFinished = true;
+	public boolean detectZipMagic = false;
 
 	public static final int TIMING_DISABLED = 0;
 	public static final int TIMING_ENABLED = 1;
@@ -1582,6 +1583,10 @@ protected void addNewEntry(ArrayList<FileSystem.Classpath> paths, String current
 		destPath = NONE; // keep == comparison valid
 	}
 
+	if (shouldSkipClasspathEntryByZipMagic(currentClasspathName)) {
+		return;
+	}
+
 	if (rejectDestinationPathOnJars && destPath != null &&
 			Util.archiveFormat(currentClasspathName) > -1) {
 		throw new IllegalArgumentException(
@@ -1603,6 +1608,43 @@ protected void addNewEntry(ArrayList<FileSystem.Classpath> paths, String current
 		addPendingErrors(this.bind("configure.incorrectClasspath", currentClasspathName));//$NON-NLS-1$
 	}
 }
+
+/**
+ * Returns true if ZIP magic detection is enabled and the classpath entry is an
+ * existing non-ZIP regular file that should not be opened as a ZIP archive.
+ */
+private boolean shouldSkipClasspathEntryByZipMagic(String classpathName) {
+	if (!this.detectZipMagic || Util.archiveFormat(classpathName) == Util.JMOD_FILE) {
+		return false;
+	}
+	File file = new File(FileSystem.convertPathSeparators(classpathName));
+	if (!file.isFile()) {
+		return false;
+	}
+	try {
+		return !hasZipMagic(file);
+	} catch (IOException e) {
+		return false;
+	}
+}
+
+/**
+ * Returns true if the file starts with one of the recognized ZIP signatures.
+ */
+private static boolean hasZipMagic(File file) throws IOException {
+	byte[] header = new byte[4];
+	try (InputStream input = new FileInputStream(file)) {
+		if (input.read(header) != header.length) {
+			return false;
+		}
+	}
+	return header[0] == 0x50 // 'P'
+			&& header[1] == 0x4B // 'K'
+			&& ((header[2] == 0x03 && header[3] == 0x04) // local file header
+					|| (header[2] == 0x05 && header[3] == 0x06) // empty archive
+					|| (header[2] == 0x07 && header[3] == 0x08)); // spanned archive
+}
+
 void addPendingErrors(String message) {
 	if (this.pendingErrors == null) {
 		this.pendingErrors = new ArrayList<>();
@@ -2141,6 +2183,11 @@ public void configure(String[] argv) {
 				if (currentArg.equals("-failOnWarning")) { //$NON-NLS-1$
 					mode = DEFAULT;
 					this.failOnWarning = true;
+					continue;
+				}
+				if (currentArg.equals("-detectZipMagic")) { //$NON-NLS-1$
+					mode = DEFAULT;
+					this.detectZipMagic = true;
 					continue;
 				}
 				if (currentArg.equals("-time")) { //$NON-NLS-1$
@@ -3621,6 +3668,9 @@ protected ArrayList<FileSystem.Classpath> handleClasspath(ArrayList<String> clas
 			String token;
 			while (tokenizer.hasMoreTokens()) {
 				token = tokenizer.nextToken();
+				if (shouldSkipClasspathEntryByZipMagic(token)) {
+					continue;
+				}
 				FileSystem.Classpath currentClasspath = FileSystem
 						.getClasspath(token, customEncoding, null, this.options, this.releaseVersion);
 				if (currentClasspath != null) {
@@ -3699,6 +3749,9 @@ protected ArrayList<FileSystem.Classpath> handleEndorseddirs(ArrayList<String> e
 				File[] current = endorsedDirsJars[i];
 				if (current != null) {
 					for (File file : current) {
+						if (shouldSkipClasspathEntryByZipMagic(file.getAbsolutePath())) {
+							continue;
+						}
 						FileSystem.Classpath classpath =
 							FileSystem.getClasspath(
 									file.getAbsolutePath(),
@@ -3760,6 +3813,9 @@ protected ArrayList<FileSystem.Classpath> handleExtdirs(ArrayList<String> extdir
 				File[] current = extdirsJars[i];
 				if (current != null) {
 					for (File file : current) {
+						if (shouldSkipClasspathEntryByZipMagic(file.getAbsolutePath())) {
+							continue;
+						}
 						FileSystem.Classpath classpath =
 							FileSystem.getClasspath(
 									file.getAbsolutePath(),

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/messages.properties
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/messages.properties
@@ -337,6 +337,8 @@ misc.usage = {1} {2}\n\
 \                       problem methods\n\
 \                       With ":Fatal", all optional errors are treated as fatal\n\
 \    -failOnWarning     fail compilation if there are warnings\n\
+\    -detectZipMagic    ignore ZIP archive classpath candidates whose first\n\
+\                       bytes are not a ZIP signature\n\
 \    -verbose           enable verbose output\n\
 \    -referenceInfo     compute reference info\n\
 \    -progress          show progress (only in -log mode)\n\

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/BatchCompilerTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/BatchCompilerTest.java
@@ -753,6 +753,8 @@ public void test012(){
         "                       problem methods\n" +
         "                       With \":Fatal\", all optional errors are treated as fatal\n" +
         "    -failOnWarning     fail compilation if there are warnings\n" +
+        "    -detectZipMagic    ignore ZIP archive classpath candidates whose first\n" +
+        "                       bytes are not a ZIP signature\n" +
         "    -verbose           enable verbose output\n" +
         "    -referenceInfo     compute reference info\n" +
         "    -progress          show progress (only in -log mode)\n" +
@@ -1399,6 +1401,32 @@ public void test017b(){
         + " -verbose -proceedOnError -referenceInfo"
         + " -d \"" + OUTPUT_DIR + "\"",
         TWO_FILES_GENERATED_MATCHER,
+        EMPTY_STRING_MATCHER,
+        true);
+}
+// optional ZIP magic detection skips existing non-ZIP classpath entries before ZipFile opens them
+public void test017d(){
+	this.runTest(
+		true,
+		new String[] {
+			"X.java",
+			"/** */\n" +
+			"public class X {\n" +
+			"	// empty\n" +
+			"}",
+			"not.zip",
+			"not a zip archive\n",
+			"classlist",
+			"not a zip archive\n"
+		},
+        "\"" + OUTPUT_DIR +  File.separator + "X.java\""
+        + " -1.8 -g -preserveAllLocals"
+        + " -bootclasspath \"" + OUTPUT_DIR + File.separator + "not.zip\""
+        + File.pathSeparator + "\"" + OUTPUT_DIR + File.separator + "classlist\""
+        + File.pathSeparator + getLibraryClassesAsQuotedString()
+        + " -detectZipMagic -verbose -proceedOnError -referenceInfo"
+        + " -d \"" + OUTPUT_DIR + "\"",
+        ONE_FILE_GENERATED_MATCHER,
         EMPTY_STRING_MATCHER,
         true);
 }


### PR DESCRIPTION
## What it does

Issue #1578 discusses noisy ZipException stack traces when Java 8 runtime directories or build tools pass non-archive files as compiler classpath inputs. Keep the current filename/probing behavior by default, but add -detectZipMagic for callers that prefer to skip existing regular files whose leading bytes are not ZIP signatures before ClasspathJar opens them.

Apply the opt-in check to explicit classpath entries and to files enumerated from extdirs/endorseddirs, while preserving jmod handling. Document the switch in batch compiler help and cover both a dotted non-ZIP file and an extensionless JRE-style file in BatchCompilerTest.

## How to test

See issue #1578.

## Author checklist

- [ ] I have thoroughly tested my changes
- [X] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [X] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
