### PR TITLE
Add null check in ClassRileReader.getMemberTypes() #5186

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/ClassFileReader.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/ClassFileReader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -810,10 +810,11 @@ public IBinaryNestedType[] getMemberTypes() {
 			 * So I added this extra check to filter out this anonymous class from the
 			 * member types.
 			 */
+			char[] innerSourceName = currentInnerInfo.getSourceName();
 			if (outerClassNameIdx != 0
 				&& innerNameIndex != 0
 				&& outerClassNameIdx == this.classNameIndex
-				&& currentInnerInfo.getSourceName().length != 0) {
+				&& innerSourceName != null && innerSourceName.length != 0) {
 				memberTypes[memberTypeIndex++] = currentInnerInfo;
 			}
 		}


### PR DESCRIPTION
## What it does

Calling `InnerClassInfo.getSourceName()` may return null and thus leads to a `NullPointerException` when determining its length.

Closes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5186

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
