### PR TITLE
ecj spams the console with irrelevant zip exceptions

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/ClasspathLocation.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/ClasspathLocation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -39,6 +39,7 @@ public abstract class ClasspathLocation implements FileSystem.Classpath,
 	char[] normalizedPath;
 	public final AccessRuleSet accessRuleSet;
 	IModule module;
+	private PathKind kind = PathKind.CP;
 
 	public final String destinationPath;
 		// destination path for compilation units that are reached through this
@@ -55,6 +56,16 @@ public abstract class ClasspathLocation implements FileSystem.Classpath,
 			String destinationPath) {
 		this.accessRuleSet = accessRuleSet;
 		this.destinationPath = destinationPath;
+	}
+
+	@Override
+	public PathKind getPathKind() {
+		return this.kind;
+	}
+
+	@Override
+	public void setPathKind(PathKind kind) {
+		this.kind = kind;
 	}
 
 	/**

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/FileSystem.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/FileSystem.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -19,8 +19,10 @@ package org.eclipse.jdt.internal.compiler.batch;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.PrintWriter;
 import java.nio.file.InvalidPathException;
 import java.nio.file.NoSuchFileException;
+import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -69,6 +71,19 @@ public class FileSystem implements IModuleAwareNameEnvironment, SuffixConstants 
 	 * Sub types of classpath are responsible for appropriate behavior based on this.
 	 */
 	public interface Classpath extends IModulePathEntry {
+		enum PathKind {
+			BOOT("-bootclasspath"), CP("-classpath"), //$NON-NLS-1$ //$NON-NLS-2$
+			ENDORSED("-endorseddirs"), EXT("-extdirs"), //$NON-NLS-1$ //$NON-NLS-2$
+			MODULE("--module-path"), MODULE_SOURCE("--module-source-path"), RELEASE("--release"); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+			String arg;
+			PathKind(String arg) { this.arg = arg; }
+			@Override
+			public String toString() {
+				return this.arg;
+			}
+		}
+		void setPathKind(PathKind kind);
+		PathKind getPathKind();
 		char[][][] findTypeNames(String qualifiedPackageName, String moduleName);
 		NameEnvironmentAnswer findClass(char[] typeName, String qualifiedPackageName, String moduleName, String qualifiedBinaryFileName);
 		NameEnvironmentAnswer findClass(char[] typeName, String qualifiedPackageName, String moduleName, String qualifiedBinaryFileName, boolean asBinaryOnly);
@@ -222,7 +237,7 @@ protected FileSystem(String[] classpathNames, String[] initialFileNames, String 
 	}
 	initializeKnownFileNames(initialFileNames);
 }
-protected FileSystem(Classpath[] paths, String[] initialFileNames, boolean annotationsFromClasspath, Set<String> limitedModules) {
+protected FileSystem(Classpath[] paths, String[] initialFileNames, boolean annotationsFromClasspath, Set<String> limitedModules, PrintWriter err) {
 	final int length = paths.length;
 	int counter = 0;
 	this.classpaths = new FileSystem.Classpath[length];
@@ -241,12 +256,16 @@ protected FileSystem(Classpath[] paths, String[] initialFileNames, boolean annot
 			// we don't warn about inexisting jars (javac does the same as us)
 			// see org.eclipse.jdt.core.tests.compiler.regression.BatchCompilerTest.test017b()
 		} catch (IOException e) {
-			String error = "Failed to init " + classpath; //$NON-NLS-1$
+			String error = MessageFormat.format(
+					"File provided via {0} is not a valid jar: {1}",//$NON-NLS-1$
+					classpath.getPathKind().toString(), classpath.getPath());
 			if (JRTUtil.PROPAGATE_IO_ERRORS) {
 				throw new IllegalStateException(error, e);
 			} else {
-				System.err.println(error);
-				e.printStackTrace();
+				if (err != null)
+					err.println(error);
+				else
+					System.err.println(error);
 			}
 		}
 	}
@@ -282,8 +301,8 @@ private void initializeModuleLocations(Set<String> limitedModules) {
 		}
 	}
 }
-protected FileSystem(Classpath[] paths, String[] initialFileNames, boolean annotationsFromClasspath) {
-	this(paths, initialFileNames, annotationsFromClasspath, null);
+protected FileSystem(Classpath[] paths, String[] initialFileNames, boolean annotationsFromClasspath, PrintWriter err) {
+	this(paths, initialFileNames, annotationsFromClasspath, null, err);
 }
 public static Classpath getClasspath(String classpathName, String encoding, AccessRuleSet accessRuleSet) {
 	return getClasspath(classpathName, encoding, false, accessRuleSet, null, null, null);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/Main.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/Main.java
@@ -61,6 +61,7 @@ import org.eclipse.jdt.internal.compiler.IErrorHandlingPolicy;
 import org.eclipse.jdt.internal.compiler.IProblemFactory;
 import org.eclipse.jdt.internal.compiler.ast.CompilationUnitDeclaration;
 import org.eclipse.jdt.internal.compiler.batch.FileSystem.Classpath;
+import org.eclipse.jdt.internal.compiler.batch.FileSystem.Classpath.PathKind;
 import org.eclipse.jdt.internal.compiler.batch.ModuleFinder.AddExport;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader;
@@ -3388,7 +3389,7 @@ public File getJavaHome() {
 public FileSystem getLibraryAccess() {
 	FileSystem nameEnvironment = new FileSystem(this.checkedClasspaths, this.filenames,
 					this.annotationsFromClasspath && CompilerOptions.ENABLED.equals(this.options.get(CompilerOptions.OPTION_AnnotationBasedNullAnalysis)),
-					this.limitedModules);
+					this.limitedModules, this.err);
 	nameEnvironment.module = this.module;
 	processAddonModuleOptions(nameEnvironment);
 	return nameEnvironment;
@@ -3420,6 +3421,7 @@ protected ArrayList<Classpath> handleBootclasspath(ArrayList<String> bootclasspa
 			throw new IllegalArgumentException(this.bind("configure.invalidSystem", this.javaHomeCache.toString())); //$NON-NLS-1$
 		}
 	}
+	result.forEach(p -> p.setPathKind(PathKind.BOOT));
 	return result;
 }
 private void processAddonModuleOptions(FileSystem env) {
@@ -3507,6 +3509,7 @@ protected ArrayList<FileSystem.Classpath> handleModulepath(String arg) {
 			}
 		}
 	}
+	result.forEach(p -> p.setPathKind(PathKind.MODULE));
 	// TODO: What about chained jars from MANIFEST.MF? Check with spec
 	return result;
 }
@@ -3526,6 +3529,7 @@ protected ArrayList<FileSystem.Classpath> handleModuleSourcepath(String arg) {
 
 				List<Classpath> modules = ModuleFinder.findModules(dir, this.destinationPath, getNewParser(), this.options, false, this.releaseVersion);
 				for (Classpath classpath : modules) {
+					classpath.setPathKind(PathKind.MODULE_SOURCE);
 					result.add(classpath);
 					Path modLocation = Paths.get(classpath.getPath()).toAbsolutePath();
 					String destPath = classpath.getDestinationPath();
@@ -3649,6 +3653,7 @@ protected ArrayList<FileSystem.Classpath> handleClasspath(ArrayList<String> clas
 		String currentPath = current.getPath();
 		if (knownNames.get(currentPath) == null) {
 			knownNames.put(currentPath, current);
+			current.setPathKind(PathKind.CP);
 			result.add(current);
 			List<Classpath> linkedJars = current.fetchLinkedJars(problemReporter);
 			if (linkedJars != null) {
@@ -3704,6 +3709,7 @@ protected ArrayList<FileSystem.Classpath> handleEndorseddirs(ArrayList<String> e
 									file.getAbsolutePath(),
 									null, null, this.options, this.releaseVersion);
 						if (classpath != null) {
+							classpath.setPathKind(PathKind.ENDORSED);
 							result.add(classpath);
 						}
 					}
@@ -3765,6 +3771,7 @@ protected ArrayList<FileSystem.Classpath> handleExtdirs(ArrayList<String> extdir
 									file.getAbsolutePath(),
 									null, null, this.options, this.releaseVersion);
 						if (classpath != null) {
+							classpath.setPathKind(PathKind.EXT);
 							result.add(classpath);
 						}
 					}
@@ -5197,8 +5204,9 @@ protected void setPaths(ArrayList<String> bootclasspaths,
 	if (this.releaseVersion != null && this.complianceLevel < jdkLevel) {
 		// TODO: Revisit for access rules
 		allPaths = new ArrayList<>();
-		allPaths.add(
-				FileSystem.getOlderSystemRelease(this.javaHomeCache.getAbsolutePath(), this.releaseVersion, null));
+		Classpath olderSystemRelease = FileSystem.getOlderSystemRelease(this.javaHomeCache.getAbsolutePath(), this.releaseVersion, null);
+		olderSystemRelease.setPathKind(PathKind.RELEASE);
+		allPaths.add(olderSystemRelease);
 	} else {
 		allPaths = handleBootclasspath(bootclasspaths, customEncoding);
 	}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/BatchCompilerTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/BatchCompilerTest.java
@@ -1428,6 +1428,51 @@ public void test017c(){
         EMPTY_STRING_MATCHER,
         true);
 }
+// specific errors for unsuitable files on -bootclasspath, -endorseddirs etc.
+public void test017d(){
+	this.runTest(
+		true,
+		new String[] {
+			"X.java",
+			"/** */\n" +
+			"public class X {\n" +
+			"	// empty\n" +
+			"}",
+			"not.zip",
+			"not a zip archive\n",
+		},
+		"\"" + OUTPUT_DIR +  File.separator + "X.java\""
+		+ " -1.8 -g -preserveAllLocals"
+		+ " -bootclasspath \"" + OUTPUT_DIR + File.separator + "not.zip\""
+		+ File.pathSeparator + getLibraryClassesAsQuotedString()
+		+ " -endorseddirs \"" + OUTPUT_DIR + "\""
+		+ " -verbose -proceedOnError -referenceInfo"
+		+ " -d \"" + OUTPUT_DIR + "\"",
+		ONE_FILE_GENERATED_MATCHER,
+		new Matcher() {
+			@Override
+			boolean match(String effective) {
+				lines: for (String line : effective.split("\n")) {
+					if (line.startsWith("File provided via -endorseddirs is not a valid jar:")) {
+						for (String suffix : new String[] {"test017dout.txt", "test017derr.txt", "not.zip"} ) {
+							if (line.endsWith(suffix))
+								continue lines;
+						}
+					} else if (line.startsWith("File provided via -bootclasspath is not a valid jar:")) {
+						if (line.endsWith("not.zip"))
+							continue lines;
+					}
+					return false;
+				}
+				return true;
+			}
+			@Override
+			String expected() {
+				return "";
+			}
+		},
+		true);
+}
 // command line - unusual classpath (empty)
 // ok provided we explicit the sourcepath
 public void test018a(){

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/DefaultJavaRuntimeEnvironment.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/DefaultJavaRuntimeEnvironment.java
@@ -26,7 +26,7 @@ public class DefaultJavaRuntimeEnvironment extends FileSystem {
 		super(jreClasspaths, new String[] {} /* ignore initial file names */, null, release);
 	}
 	private DefaultJavaRuntimeEnvironment(Classpath[] jreClasspaths) {
-		super(jreClasspaths, new String[] {} /* ignore initial file names */, false);
+		super(jreClasspaths, new String[] {} /* ignore initial file names */, false, null);
 	}
 
 	private static INameEnvironment[] defaultJreClassLibs;

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/NameEnvironmentWithProgress.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/NameEnvironmentWithProgress.java
@@ -35,7 +35,7 @@ class NameEnvironmentWithProgress extends FileSystem implements INameEnvironment
 	IProgressMonitor monitor;
 
 	public NameEnvironmentWithProgress(Classpath[] paths, String[] initialFileNames, IProgressMonitor monitor) {
-		super(paths, initialFileNames, false);
+		super(paths, initialFileNames, false, null);
 		setMonitor(monitor);
 	}
 	private void checkCanceled() {


### PR DESCRIPTION
+ improve error message
+ remove printing of stack traces
+ make err printout testable

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1578
