### PR TITLE
False javadoc warning for valid @snippet tags #1583

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/JavadocParser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/JavadocParser.java
@@ -1047,7 +1047,7 @@ public class JavadocParser extends AbstractCommentParser {
 	@Override
 	protected void  pushSnippetText(char[] text, int start, int end, boolean addNewLine, Object snippetTag) {
 		// The tag gets its description => clear the flag
-		this.tagWaitingForDescription = TAG_SNIPPET_VALUE;
+		this.tagWaitingForDescription = NO_TAG_VALUE;
 	}
 
 	@Override
@@ -1059,7 +1059,7 @@ public class JavadocParser extends AbstractCommentParser {
 	@Override
 	protected void pushExternalSnippetText(char[] text, int start, int end, boolean addNewLine, Object snippetTag) {
 		// The tag gets its description => clear the flag
-		this.tagWaitingForDescription = TAG_SNIPPET_VALUE;
+		this.tagWaitingForDescription = NO_TAG_VALUE;
 	}
 
 	/*

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocTest_18.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocTest_18.java
@@ -368,5 +368,88 @@ public void test010() {
 			JavacTestOptions.Excuse.EclipseWarningConfiguredAsError
 	);
 }
+
+/**
+ * https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1583
+ * Valid {@code @snippet} tags must not report "Description expected after @snippet"
+ * when missingJavadocTagDescription=all_standard_tags.
+ */
+public void testIssue1583_validSnippetNoMissingDescription() {
+	if (this.complianceLevel < ClassFileConstants.JDK18) {
+		return;
+	}
+	this.reportMissingJavadocDescription = CompilerOptions.ALL_STANDARD_TAGS;
+	this.runConformTest(
+		new String[] {
+			"X.java",
+			"/**\n"
+			+ " * The following code shows how to use {@code Optional.isPresent}:\n"
+			+ " * {@snippet :\n"
+			+ " * if (v.isPresent()) {\n"
+			+ " *     System.out.println(\"v: \" + v.get());\n"
+			+ " * }\n"
+			+ " * }\n"
+			+ " */\n"
+			+ "public class X {\n"
+			+ "}\n",
+		}
+	);
+}
+
+/**
+ * https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1583
+ * Snippet with attributes and body content must not report a false missing-description
+ * warning under all_standard_tags.
+ */
+public void testIssue1583_snippetWithAttributesNoMissingDescription() {
+	if (this.complianceLevel < ClassFileConstants.JDK18) {
+		return;
+	}
+	this.reportMissingJavadocDescription = CompilerOptions.ALL_STANDARD_TAGS;
+	this.runConformTest(
+		new String[] {
+			"X.java",
+			"/**\n"
+			+ " * {@snippet lang=\"java\" id=\"example\" :\n"
+			+ " * System.out.println(\"hello\");\n"
+			+ " * }\n"
+			+ " */\n"
+			+ "public class X {\n"
+			+ "}\n",
+		}
+	);
+}
+
+/**
+ * https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1583
+ * Empty {@code @snippet} with no content should still report missing description
+ * when missingJavadocTagDescription=all_standard_tags.
+ */
+public void testIssue1583_emptySnippetMissingDescription() {
+	if (this.complianceLevel < ClassFileConstants.JDK18) {
+		return;
+	}
+	this.reportMissingJavadocDescription = CompilerOptions.ALL_STANDARD_TAGS;
+	this.runNegativeTest(
+		new String[] {
+			"X.java",
+			"/**\n"
+			+ " * {@snippet}\n"
+			+ " */\n"
+			+ "public class X {\n"
+			+ "}\n",
+		},
+		"----------\n" +
+		"1. ERROR in X.java (at line 2)\n" +
+		"	* {@snippet}\n" +
+		"	    ^^^^^^^\n" +
+		"Javadoc: Description expected after @snippet\n" +
+		"----------\n" +
+		"2. ERROR in X.java\n" +
+		"Javadoc: Snippet is invalid due to missing colon\n" +
+		"----------\n",
+		JavacTestOptions.Excuse.EclipseWarningConfiguredAsError
+	);
+}
 }
 


### PR DESCRIPTION
## Summary

- Fixes false positive `Javadoc: Description expected after @snippet` when `missingJavadocTagDescription=all_standard_tags`.
- Root cause: `pushSnippetText` / `pushExternalSnippetText` set `tagWaitingForDescription` to `TAG_SNIPPET_VALUE` instead of clearing it to `NO_TAG_VALUE` after snippet content was provided (comment already said "clear the flag").
- Adds regression tests in `JavadocTest_18` for valid snippets, snippets with attributes, and empty snippets.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1583

## Test plan

- [x] Reproduced the issue with ECJ using the prefs from the issue (`all_standard_tags`)
- [x] Verified valid snippets no longer warn after the fix
- [x] Verified empty `{@snippet}` still reports missing description
- [x] Ran `JavadocTest_18` (52 tests, 0 failures) with the fix
- [x] Confirmed the new positive tests fail without the fix (8 failures) and pass with it