### PR TITLE
Accept partially qualified member types in javadoc links #517

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Javadoc.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/Javadoc.java
@@ -1106,14 +1106,14 @@ public class Javadoc extends ASTNode {
 						}
 					}
 					if (typeReference instanceof JavadocQualifiedTypeReference && !scope.isDefinedInSameUnit(resolvedType)) {
-						// https://bugs.eclipse.org/bugs/show_bug.cgi?id=222188
-						// partially qualified references from a different CU should be warned
+						// Package may be omitted when the reference starts at a top-level type
+						// name (e.g. {@link Map.Entry} with import java.util.Map). Matches the
+						// Documentation Comment Specification / standard doclet. Previously this
+						// was restricted to the same package only (bugs 221539, 222188).
 						char[][] typeRefName = ((JavadocQualifiedTypeReference) typeReference).getTypeName();
 						int skipLength = 0;
-						if (topLevelScope.getCurrentPackage() == resolvedType.getPackage()
-								&& typeRefName.length < computedCompoundName.length) {
-							// https://bugs.eclipse.org/bugs/show_bug.cgi?id=221539: references can be partially qualified
-							// in same package and hence if the package name is not given, ignore package name check
+						if (typeRefName.length < computedCompoundName.length) {
+							// omit package segments; remaining name must match the type path
 							skipLength = resolvedType.fPackage.compoundName.length;
 						}
 						boolean valid = true;

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocBugsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocBugsTest.java
@@ -8411,7 +8411,8 @@ public void testBug316782() {
  * @see "https://bugs.eclipse.org/bugs/show_bug.cgi?id=222188"
  */
 public void testBug222188a() {
-	// case 1: partially qualified reference in another package
+	// case 1: partially qualified reference in another package via import is valid
+	// for the standard doclet (see also https://github.com/eclipse-jdt/eclipse.jdt.core/issues/517)
 	String[] units = new String[] {
 		"pack/Test.java",
 		"package pack;\n" +
@@ -8424,21 +8425,12 @@ public void testBug222188a() {
 		"import pack.Test;\n" +
 		"public class X {\n" +
 		"/**\n" +
-		" * See also {@link Test.Inner} -- error/warning \n" +
+		" * See also {@link Test.Inner}\n" +
 		" */\n" +
 		"     public void m() { }\n" +
 		"}\n"
 	};
-	runNegativeTest(units,
-		// warning - Tag @link: reference not found: Test.Inner
-		"----------\n" +
-		"1. ERROR in pack2\\X.java (at line 5)\n" +
-		"	* See also {@link Test.Inner} -- error/warning \n" +
-		"	                  ^^^^^^^^^^\n" +
-		"Javadoc: Invalid member type qualification\n" +
-		"----------\n",
-		JavacTestOptions.Excuse.EclipseWarningConfiguredAsError
-	);
+	runConformTest(units);
 }
 public void testBug222188b() {
 	// case 2: fully but invalid qualified reference in another package
@@ -8505,13 +8497,14 @@ public void testBug221539a() {
 }
 public void testBug221539b() {
 	// partially qualified reference in different package
+	// Foo.Inner is valid via import (standard doclet); Test.Inner is still wrong outer type
 	String[] units = new String[] {
 		"p1/Test.java",
 		"package p1;\n" +
 		"import p2.Foo;\n" +
 		"/**\n" +
 		" * {@link Test.Inner} not ok for Javadoc\n" +
-		" * {@link Foo.Inner} not ok Javadoc\n" +
+		" * {@link Foo.Inner} ok via import\n" +
 		" * {@link p2.Foo.Inner} ok for Javadoc as fully qualified\n" +
 		" */\n" +
 		"public class Test extends Foo {\n" +
@@ -8525,16 +8518,10 @@ public void testBug221539b() {
 	};
 	runNegativeTest(units,
 		// warning - Tag @link: reference not found: Test.Inner
-		// warning - Tag @link: reference not found: Foo.Inner
 		"----------\n" +
 		"1. ERROR in p1\\Test.java (at line 4)\n" +
 		"	* {@link Test.Inner} not ok for Javadoc\n" +
 		"	         ^^^^^^^^^^\n" +
-		"Javadoc: Invalid member type qualification\n" +
-		"----------\n" +
-		"2. ERROR in p1\\Test.java (at line 5)\n" +
-		"	* {@link Foo.Inner} not ok Javadoc\n" +
-		"	         ^^^^^^^^^\n" +
 		"Javadoc: Invalid member type qualification\n" +
 		"----------\n",
 		JavacTestOptions.Excuse.EclipseWarningConfiguredAsError
@@ -8953,6 +8940,72 @@ public void testBug206345m() {
 		"	          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n" +
 		"Javadoc: Missing closing brace for inline tag\n" +
 		"----------\n");
+}
+
+/**
+ * https://github.com/eclipse-jdt/eclipse.jdt.core/issues/517
+ * {@link Map.Entry} must not report "Invalid member type qualification"
+ * when Map is imported (valid per Documentation Comment Specification).
+ */
+public void testIssue517_mapEntryWithImport() {
+	runConformTest(
+		new String[] {
+			"bug/Bug.java",
+			"package bug;\n" +
+			"\n" +
+			"import java.util.Map;\n" +
+			"\n" +
+			"/** {@link Map.Entry} */\n" +
+			"class Bug {}\n"
+		}
+	);
+}
+
+/**
+ * https://github.com/eclipse-jdt/eclipse.jdt.core/issues/517
+ * Fully qualified nested type remains valid.
+ */
+public void testIssue517_mapEntryFullyQualified() {
+	runConformTest(
+		new String[] {
+			"bug/Bug.java",
+			"package bug;\n" +
+			"\n" +
+			"/** {@link java.util.Map.Entry} */\n" +
+			"class Bug {}\n"
+		}
+	);
+}
+
+/**
+ * https://github.com/eclipse-jdt/eclipse.jdt.core/issues/517
+ * Wrong outer type name for a member type is still reported.
+ */
+public void testIssue517_wrongOuterTypeStillInvalid() {
+	runNegativeTest(
+		new String[] {
+			"p1/Test.java",
+			"package p1;\n" +
+			"import p2.Foo;\n" +
+			"/**\n" +
+			" * {@link Test.Inner}\n" +
+			" */\n" +
+			"public class Test extends Foo {\n" +
+			"}\n",
+			"p2/Foo.java",
+			"package p2;\n" +
+			"public class Foo {\n" +
+			"	public static class Inner {}\n" +
+			"}\n"
+		},
+		"----------\n" +
+		"1. ERROR in p1\\Test.java (at line 4)\n" +
+		"	* {@link Test.Inner}\n" +
+		"	         ^^^^^^^^^^\n" +
+		"Javadoc: Invalid member type qualification\n" +
+		"----------\n",
+		JavacTestOptions.Excuse.EclipseWarningConfiguredAsError
+	);
 }
 }
 

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocTest_1_3.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocTest_1_3.java
@@ -361,17 +361,11 @@ public class JavadocTest_1_3 extends JavadocTest {
 			},
 			//comment6a\def\Test.java:6: warning - Tag @see: reference not found: Inner
 			//comment6a\test\Invalid.java:8: warning - Tag @link: reference not found: Inner
-			//comment6a\test\Invalid2.java:8: warning - Tag @see: reference not found: Test.Inner => bug ID: 4464323
+			// Invalid2 @see Test.Inner is valid via import (issue 517 / standard doclet)
 			"----------\n" +
 			"1. ERROR in comment6a\\test\\Invalid.java (at line 4)\n" +
 			"	* See also {@link Inner}\n" +
 			"	                  ^^^^^\n" +
-			"Javadoc: Invalid member type qualification\n" +
-			"----------\n" +
-			"----------\n" +
-			"1. ERROR in comment6a\\test\\Invalid2.java (at line 4)\n" +
-			"	* @see Test.Inner\n" +
-			"	       ^^^^^^^^^^\n" +
 			"Javadoc: Invalid member type qualification\n" +
 			"----------\n"
 		);
@@ -671,17 +665,11 @@ public class JavadocTest_1_3 extends JavadocTest {
 			},
 			//comment6a\def\Test.java:6: warning - Tag @see: reference not found: Inner
 			//comment6a\test\Invalid.java:8: warning - Tag @link: reference not found: Inner
-			//comment6a\test\Invalid2.java:8: warning - Tag @see: reference not found: Test.Inner => bug ID: 4464323
+			// Invalid2 @see Test.Inner is valid via import (issue 517 / standard doclet)
 			"----------\n" +
 			"1. ERROR in comment6a\\test\\Invalid.java (at line 4)\n" +
 			"	* See also {@link Inner}\n" +
 			"	                  ^^^^^\n" +
-			"Javadoc: Invalid member type qualification\n" +
-			"----------\n" +
-			"----------\n" +
-			"1. ERROR in comment6a\\test\\Invalid2.java (at line 4)\n" +
-			"	* @see Test.Inner\n" +
-			"	       ^^^^^^^^^^\n" +
 			"Javadoc: Invalid member type qualification\n" +
 			"----------\n"
 		);

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocTest_1_4.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocTest_1_4.java
@@ -349,17 +349,11 @@ public class JavadocTest_1_4 extends JavadocTest {
 			},
 			//comment6a\def\Test.java:6: warning - Tag @see: reference not found: Inner
 			//comment6a\test\Invalid.java:8: warning - Tag @link: reference not found: Inner
-			//comment6a\test\Invalid2.java:8: warning - Tag @see: reference not found: Test.Inner => bug ID: 4464323
+			// Invalid2 @see Test.Inner is valid via import (issue 517 / standard doclet)
 			"----------\n" +
 			"1. ERROR in comment6a\\test\\Invalid.java (at line 4)\n" +
 			"	* See also {@link Inner}\n" +
 			"	                  ^^^^^\n" +
-			"Javadoc: Invalid member type qualification\n" +
-			"----------\n" +
-			"----------\n" +
-			"1. ERROR in comment6a\\test\\Invalid2.java (at line 4)\n" +
-			"	* @see Test.Inner\n" +
-			"	       ^^^^^^^^^^\n" +
 			"Javadoc: Invalid member type qualification\n" +
 			"----------\n"
 		);
@@ -659,17 +653,11 @@ public class JavadocTest_1_4 extends JavadocTest {
 			},
 			//comment6a\def\Test.java:6: warning - Tag @see: reference not found: Inner
 			//comment6a\test\Invalid.java:8: warning - Tag @link: reference not found: Inner
-			//comment6a\test\Invalid2.java:8: warning - Tag @see: reference not found: Test.Inner => bug ID: 4464323
+			// Invalid2 @see Test.Inner is valid via import (issue 517 / standard doclet)
 			"----------\n" +
 			"1. ERROR in comment6a\\test\\Invalid.java (at line 4)\n" +
 			"	* See also {@link Inner}\n" +
 			"	                  ^^^^^\n" +
-			"Javadoc: Invalid member type qualification\n" +
-			"----------\n" +
-			"----------\n" +
-			"1. ERROR in comment6a\\test\\Invalid2.java (at line 4)\n" +
-			"	* @see Test.Inner\n" +
-			"	       ^^^^^^^^^^\n" +
 			"Javadoc: Invalid member type qualification\n" +
 			"----------\n"
 		);

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocTest_1_5.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavadocTest_1_5.java
@@ -2013,17 +2013,11 @@ public class JavadocTest_1_5 extends JavadocTest {
 				"}"
 			},
 			//comment6a\test\Invalid.java:8: warning - Tag @link: reference not found: Inner
-			//comment6a\test\Invalid2.java:8: warning - Tag @see: reference not found: Test.Inner => bug ID: 4464323
+			// Invalid2 @see Test.Inner is valid via import (issue 517 / standard doclet)
 			"----------\n" +
 			"1. ERROR in comment6a\\test\\Invalid.java (at line 4)\n" +
 			"	* See also {@link Inner}\n" +
 			"	                  ^^^^^\n" +
-			"Javadoc: Invalid member type qualification\n" +
-			"----------\n" +
-			"----------\n" +
-			"1. ERROR in comment6a\\test\\Invalid2.java (at line 4)\n" +
-			"	* @see Test.Inner\n" +
-			"	       ^^^^^^^^^^\n" +
 			"Javadoc: Invalid member type qualification\n" +
 			"----------\n",
 			JavacTestOptions.Excuse.EclipseWarningConfiguredAsError
@@ -2327,17 +2321,11 @@ public class JavadocTest_1_5 extends JavadocTest {
 				"}"
 			},
 			//comment6a\test\Invalid.java:8: warning - Tag @link: reference not found: Inner
-			//comment6a\test\Invalid2.java:8: warning - Tag @see: reference not found: Test.Inner => bug ID: 4464323
+			// Invalid2 @see Test.Inner is valid via import (issue 517 / standard doclet)
 			"----------\n" +
 			"1. ERROR in comment6a\\test\\Invalid.java (at line 4)\n" +
 			"	* See also {@link Inner}\n" +
 			"	                  ^^^^^\n" +
-			"Javadoc: Invalid member type qualification\n" +
-			"----------\n" +
-			"----------\n" +
-			"1. ERROR in comment6a\\test\\Invalid2.java (at line 4)\n" +
-			"	* @see Test.Inner\n" +
-			"	       ^^^^^^^^^^\n" +
 			"Javadoc: Invalid member type qualification\n" +
 			"----------\n",
 			JavacTestOptions.Excuse.EclipseWarningConfiguredAsError


### PR DESCRIPTION
## Summary

- Package omission in member type Javadoc references (e.g. `{@link Map.Entry}` with `import java.util.Map`) was only allowed within the same package.
- Allow package omission across packages as well, matching the [Documentation Comment Specification](https://docs.oracle.com/en/java/javase/19/docs/specs/javadoc/doc-comment-spec.html#References) and the standard doclet.
- Wrong outer types (e.g. `Test.Inner` when the type is `Foo.Inner`) are still rejected.
- Update related expectations (`testBug222188a`, `testBug221539b`) and add regression tests for issue 517.

Fixes #517

## Test plan

- [x] `JavadocBugsTest` (3682 tests) — all pass with the fix
- [x] Existing cases that expected "Invalid member type qualification" for valid `Type.Member` via import updated to conform
- [x] New tests: `Map.Entry` with import, fully qualified, and wrong outer type still invalid