### PR TITLE
Reject non-exhaustive nested sealed record patterns in switch #5182

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SwitchStatement.java
@@ -148,7 +148,9 @@ public class SwitchStatement extends Expression {
 		}
 
 		void addPattern(Pattern p) {
-			if (p instanceof RecordPattern rp && TypeBinding.equalsEquals(this.type, rp.type.resolvedType) && this.firstComponent != null)
+			if (p instanceof RecordPattern rp && rp.type.resolvedType != null
+					&& TypeBinding.equalsEquals(this.type.erasure(), rp.type.resolvedType.erasure())
+					&& this.firstComponent != null)
 				this.firstComponent.addPattern(rp, 0);
 		}
 
@@ -269,7 +271,7 @@ public class SwitchStatement extends Expression {
 				}
 			}
 			if (node.type instanceof ReferenceBinding ref && ref.isSealed()) {
-				this.covers &= caseElementsCoverSealedType(ref, availableTypes);
+				this.covers &= caseElementsCoverSealedType(ref, availableTypes, false);
 				return this.covers;
 			}
 			return this.covers = false; // no need to visit further.
@@ -413,7 +415,8 @@ public class SwitchStatement extends Expression {
 			return;
 		}
 
-		if (JavaFeature.PATTERN_MATCHING_IN_SWITCH.isSupported(compilerOptions) && selectorType.isSealed() && caseElementsCoverSealedType((ReferenceBinding) selectorType, this.caseLabelElementTypes))
+		if (JavaFeature.PATTERN_MATCHING_IN_SWITCH.isSupported(compilerOptions) && selectorType.isSealed()
+				&& caseElementsCoverSealedType((ReferenceBinding) selectorType, this.caseLabelElementTypes, true))
 			this.switchBits |= SwitchStatement.Exhaustive;
 		else if (selectorType.isRecordWithComponents() && this.containsRecordPatterns && caseElementsCoverRecordType(upperScope, compilerOptions, (ReferenceBinding) selectorType))
 			this.switchBits |= SwitchStatement.Exhaustive;
@@ -490,7 +493,14 @@ public class SwitchStatement extends Expression {
 		return ccv.covers;
 	}
 
-	private boolean caseElementsCoverSealedType(ReferenceBinding sealedType,  List<TypeBinding> listedTypes) {
+	/**
+	 * @param checkRecordPatterns when true (top-level sealed selector), a permitted record
+	 *        is covered only if case patterns fully cover it — including nested components.
+	 *        When false (nested CoverageCheckerVisitor), {@code listedTypes} are already the
+	 *        component pattern types and the simple name check is enough.
+	 */
+	private boolean caseElementsCoverSealedType(ReferenceBinding sealedType, List<TypeBinding> listedTypes,
+			boolean checkRecordPatterns) {
 		List<ReferenceBinding> allAllowedTypes = sealedType.getAllEnumerableAvatars();
 		Iterator<ReferenceBinding> iterator = allAllowedTypes.iterator();
 		while (iterator.hasNext()) {
@@ -511,6 +521,12 @@ public class SwitchStatement extends Expression {
 					continue;
 				}
 			}
+			if (checkRecordPatterns && this.containsRecordPatterns && next.isRecord()) {
+				// Absolute(GlobalPosition) must not count as covering Absolute when Position is sealed
+				if (isRecordTypeFullyCoveredByCasePatterns(next))
+					iterator.remove();
+				continue;
+			}
 			for (TypeBinding type : listedTypes) {
 				// permits specifies classes, not parameterizations
 				if (next.erasure().isCompatibleWith(type.erasure())) {
@@ -520,6 +536,27 @@ public class SwitchStatement extends Expression {
 			}
 		}
 		return allAllowedTypes.size() == 0;
+	}
+
+	/** Type pattern covers the record, or record patterns collectively cover nested components. */
+	private boolean isRecordTypeFullyCoveredByCasePatterns(ReferenceBinding recordType) {
+		ReferenceBinding patternRecordType = null;
+		for (Pattern pattern : this.caseLabelElements) {
+			if (pattern instanceof RecordPattern rp) {
+				if (rp.resolvedType instanceof ReferenceBinding ref
+						&& TypeBinding.equalsEquals(recordType.erasure(), ref.erasure())) {
+					patternRecordType = ref; // use pattern's parameterization for RNode matching
+				}
+			} else if (pattern.resolvedType != null
+					&& recordType.erasure().isCompatibleWith(pattern.resolvedType.erasure())
+					&& pattern.coversType(pattern.resolvedType, this.scope)) {
+				return true; // case Absolute a
+			}
+		}
+		if (patternRecordType == null)
+			return false;
+		// Reuse record-selector coverage (RNode + CoverageCheckerVisitor)
+		return caseElementsCoverRecordType(this.scope, null, patternRecordType);
 	}
 
 	private void reserveSecretVariablesSlot() { // may be released later if unused.

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchPatternTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchPatternTest.java
@@ -10038,4 +10038,108 @@ public class SwitchPatternTest extends AbstractRegressionTest9 {
 				"""
 			});
 	}
+
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5182
+	// ECJ accepts a non-exhaustive switch over nested sealed record patterns that javac rejects
+	public void testIssue5182() {
+		runNegativeTest(
+				new String[] {
+					"ExhaustivenessGap.java",
+					"""
+					public class ExhaustivenessGap {
+
+						sealed interface Position permits GlobalPosition, StartPosition {}
+						record GlobalPosition(long index) implements Position {}
+						record StartPosition() implements Position {}
+
+						sealed interface SourcingStrategy permits Absolute, Snapshot {}
+						record Absolute(Position position) implements SourcingStrategy {}
+						record Snapshot(Position maximumPosition) implements SourcingStrategy {}
+
+						// Absolute(GlobalPosition) does not cover Absolute(StartPosition)
+						static long toIndex(SourcingStrategy strategy) {
+							return switch (strategy) {
+								case Absolute(GlobalPosition p) -> p.index();
+								case Snapshot(Position p) -> p instanceof GlobalPosition g ? g.index() : -1;
+							};
+						}
+					}
+					"""
+				},
+				"----------\n" +
+				"1. ERROR in ExhaustivenessGap.java (at line 13)\n" +
+				"	return switch (strategy) {\n" +
+				"	               ^^^^^^^^\n" +
+				"A switch expression should have a default case\n" +
+				"----------\n");
+	}
+
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5182
+	// Nested sealed components are exhaustive when every permitted subtype is covered
+	public void testIssue5182_exhaustive() {
+		runConformTest(
+				new String[] {
+					"ExhaustivenessGap.java",
+					"""
+					public class ExhaustivenessGap {
+
+						sealed interface Position permits GlobalPosition, StartPosition {}
+						record GlobalPosition(long index) implements Position {}
+						record StartPosition() implements Position {}
+
+						sealed interface SourcingStrategy permits Absolute, Snapshot {}
+						record Absolute(Position position) implements SourcingStrategy {}
+						record Snapshot(Position maximumPosition) implements SourcingStrategy {}
+
+						static long toIndex(SourcingStrategy strategy) {
+							return switch (strategy) {
+								case Absolute(GlobalPosition p) -> p.index();
+								case Absolute(StartPosition s) -> -1;
+								case Snapshot(Position p) -> p instanceof GlobalPosition g ? g.index() : -1;
+							};
+						}
+
+						public static void main(String[] args) {
+							System.out.print(toIndex(new Absolute(new GlobalPosition(42))));
+							System.out.print(toIndex(new Absolute(new StartPosition())));
+							System.out.print(toIndex(new Snapshot(new StartPosition())));
+						}
+					}
+					"""
+				},
+				"42-1-1");
+	}
+
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5182
+	// Type pattern (no nested narrowing) still covers the permitted record
+	public void testIssue5182_typePatternCoversRecord() {
+		runConformTest(
+				new String[] {
+					"ExhaustivenessGap.java",
+					"""
+					public class ExhaustivenessGap {
+
+						sealed interface Position permits GlobalPosition, StartPosition {}
+						record GlobalPosition(long index) implements Position {}
+						record StartPosition() implements Position {}
+
+						sealed interface SourcingStrategy permits Absolute, Snapshot {}
+						record Absolute(Position position) implements SourcingStrategy {}
+						record Snapshot(Position maximumPosition) implements SourcingStrategy {}
+
+						static long toIndex(SourcingStrategy strategy) {
+							return switch (strategy) {
+								case Absolute a -> a.position() instanceof GlobalPosition g ? g.index() : -1;
+								case Snapshot(Position p) -> p instanceof GlobalPosition g ? g.index() : -1;
+							};
+						}
+
+						public static void main(String[] args) {
+							System.out.print(toIndex(new Absolute(new StartPosition())));
+						}
+					}
+					"""
+				},
+				"-1");
+	}
 }


### PR DESCRIPTION
## Summary

- Fixes incorrect exhaustiveness for switches on sealed types when a case uses a **record pattern that only covers some nested sealed subtypes** of a component (e.g. `case Absolute(GlobalPosition p)` without covering `Absolute(StartPosition)`).
- ECJ previously treated the permitted record type as covered by type name alone, accepted the switch, and deferred failure to a runtime `MatchException`. `javac` correctly rejects the same code.
- For permitted record types, reuse existing record-pattern coverage (`RNode` / `CoverageCheckerVisitor`) so nested components are checked (JLS 14.11.1.1). Type patterns such as `case Absolute a` still fully cover the record.
- Adds regression tests in `SwitchPatternTest`.

Fixes #5182

## Test plan

- [x] Reproduced with ECJ (accepted) vs `javac` (rejected) using the issue sample
- [x] After fix, ECJ reports non-exhaustive switch expression for the sample
- [x] Exhaustive nested cases and type-pattern coverage still compile
- [x] `SwitchPatternTest` — 334 tests, 0 failures