### PR TITLE
Avoid ClassCastException for unresolved diamond types #5193

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AllocationExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/AllocationExpression.java
@@ -630,7 +630,7 @@ public MethodBinding inferConstructorOfElidedParameterizedType(final Scope scope
 		if (cached != null)
 			return cached;
 	}
-	MethodBinding constructor = inferDiamondConstructor(scope, this, this.type.resolvedType, this.argumentTypes);
+	MethodBinding constructor = inferDiamondConstructor(scope, this, this.resolvedType, this.argumentTypes);
 	if (constructor != null) {
 		if (this.expressionContext == INVOCATION_CONTEXT && this.typeExpected == null) { // not ready for invocation type inference
 			if (constructor instanceof PolyParameterizedGenericMethodBinding) {
@@ -647,8 +647,10 @@ public MethodBinding inferConstructorOfElidedParameterizedType(final Scope scope
 }
 
 public static MethodBinding inferDiamondConstructor(Scope scope, InvocationSite site, TypeBinding type, TypeBinding[] argumentTypes) {
-	ReferenceBinding genericType = ((ParameterizedTypeBinding) type).genericType();
-	ReferenceBinding enclosingType = type.enclosingType();
+	if (!(type instanceof ParameterizedTypeBinding parameterizedTypeBinding))
+		return null;
+	ReferenceBinding genericType = parameterizedTypeBinding.genericType();
+	ReferenceBinding enclosingType = parameterizedTypeBinding.enclosingType();
 	ParameterizedTypeBinding allocationType = scope.environment().createParameterizedType(genericType, genericType.typeVariables(), enclosingType);
 
 	// Given the allocation type and the arguments to the constructor, see if we can infer the constructor of the elided parameterized type.

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
@@ -17,8 +17,12 @@ import java.util.Map;
 import junit.framework.Test;
 import org.eclipse.jdt.core.tests.compiler.regression.AbstractRegressionTest.JavacTestOptions.Excuse;
 import org.eclipse.jdt.core.tests.compiler.regression.AbstractRegressionTest.JavacTestOptions.JavacHasABug;
+import org.eclipse.jdt.internal.compiler.ast.AllocationExpression;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
+import org.eclipse.jdt.internal.compiler.lookup.Binding;
+import org.eclipse.jdt.internal.compiler.lookup.ProblemReasons;
+import org.eclipse.jdt.internal.compiler.lookup.ProblemReferenceBinding;
 
 /**
  * Test class originally capturing issues specific to Java9, but meanwhile also just a continuation
@@ -36,6 +40,43 @@ public GenericsRegressionTest_9(String name) {
 }
 public static Test suite() {
 	return buildMinimalComplianceTestSuite(testClass(), F_9);
+}
+
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5193
+public void testGH5193() {
+	if (this.complianceLevel < ClassFileConstants.JDK10)
+		return; // uses 'var'
+	runNegativeTest(
+		new String[] {
+			"Sample.java",
+			"""
+			class Sample {
+			  void test() throws Exception {
+			    try (var value = new Missing<>() {}) {}
+			  }
+			}
+			"""
+		},
+		"""
+		----------
+		1. ERROR in Sample.java (at line 3)
+			try (var value = new Missing<>() {}) {}
+			     ^^^
+		The resource type Object does not implement java.lang.AutoCloseable
+		----------
+		2. ERROR in Sample.java (at line 3)
+			try (var value = new Missing<>() {}) {}
+			                     ^^^^^^^
+		Missing cannot be resolved to a type
+		----------
+		""");
+}
+
+public void testGH5193ProblemBindingCannotInferDiamondConstructor() {
+	ProblemReferenceBinding missingType = new ProblemReferenceBinding(
+		new char[][] { "Missing".toCharArray() }, null, ProblemReasons.NotFound);
+
+	assertNull(AllocationExpression.inferDiamondConstructor(null, null, missingType, Binding.NO_TYPES));
 }
 
 // ========= OPT-IN to run.javac mode: ===========


### PR DESCRIPTION
## What it does

Fixes #5193.

Error-tolerant compiler clients such as [Spoon](https://github.com/INRIA/spoon) can continue resolving an allocation after the named diamond type became a `ProblemReferenceBinding`. `AllocationExpression.inferDiamondConstructor(...)` unconditionally cast that binding to `ParameterizedTypeBinding`, causing `ClassCastException` instead of returning the unresolved-type diagnostics.

The change uses the allocation's recovered `resolvedType` when beginning diamond inference and returns no inferred constructor when the supplied binding is not parameterized. The guard also protects the sibling caller in `ReferenceExpression` without changing valid parameterized inference.

## How to test

- Before the fix, `testGH5193ProblemBindingCannotInferDiamondConstructor` fails with the reported `ProblemReferenceBinding` to `ParameterizedTypeBinding` cast at `AllocationExpression.java:650`.
- Run `GenericsRegressionTest_9`: 77 tests pass with no failures or errors.
- Run the full source reactor with compiler baseline replacement disabled, as in the repository Jenkinsfile: all 17 modules pass. Builder tests pass 386/386, and API analysis reports no errors or warnings.
- Build [StoneDetector](https://github.com/StoneDetector/StoneDetector) and [Spoon](https://github.com/INRIA/spoon) against the patched compiler, then analyze [EmbeddedImplClassLoaderTests.java](https://github.com/elastic/elasticsearch/blob/1b1acdd6b81464d626ce17c6899ecf6d38f819e3/libs/core/src/test/java/org/elasticsearch/core/internal/provider/EmbeddedImplClassLoaderTests.java) from [Elasticsearch](https://github.com/elastic/elasticsearch): the released compiler exits 2 with the exact `ClassCastException` and 0/1 ASTs; the patched compiler exits 0 with AST 1/1 and CFG, dominator-tree, and path results 28/28.
- A standalone [Spoon](https://github.com/INRIA/spoon) smoke test builds the no-classpath model. Full-classpath mode reports the expected unresolved-type `ModelBuildingException`. Neither mode throws `ClassCastException` with the patched compiler.

The normal baseline-replacement build intentionally installs the released compiler bundle and therefore re-exposes the direct regression. Compiler-source validation uses `-DcompilerBaselineMode=disable -DcompilerBaselineReplace=none`, matching the Jenkins PR build.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
