### PR TITLE
Let insert_new_line_before_closing_brace_in_array_initializer support NEXT_LINE_ON_WRAP

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/formatter/FormatterBugsTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/formatter/FormatterBugsTests.java
@@ -13408,4 +13408,40 @@ public void testIssue4122() {
 		""";
 	formatSource(source);
 }
+
+/**
+ * https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5195
+ * insert_new_line_before_closing_brace_in_array_initializer should support NEXT_LINE_ON_WRAP,
+ * mirroring brace_position_for_array_initializer: closing brace goes on its own line only if
+ * the array initializer's content itself wrapped across multiple lines.
+ */
+public void testIssue5195_shortArrayStaysInline() {
+	this.formatterPrefs.insert_new_line_before_closing_brace_in_array_initializer_on_wrap = true;
+	String source =
+		"""
+		public class A {
+			int[] shortArr = { 1, 2, 3 };
+		}
+		""";
+	formatSource(source);
+}
+public void testIssue5195_wrappedArrayGetsOwnLine() {
+	this.formatterPrefs.page_width = 40;
+	this.formatterPrefs.insert_new_line_before_closing_brace_in_array_initializer_on_wrap = true;
+	String source =
+		"""
+		public class A {
+			int[] longArr = { 1111111111, 2222222222, 3333333333, 4444444444 };
+		}
+		""";
+	formatSource(source,
+		"""
+		public class A {
+			int[] longArr = { 1111111111,
+					2222222222, 3333333333,
+					4444444444
+			};
+		}
+		""");
+}
 }

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/formatter/FormatterBugsTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/formatter/FormatterBugsTests.java
@@ -13444,4 +13444,78 @@ public void testIssue5195_wrappedArrayGetsOwnLine() {
 		}
 		""");
 }
+
+/**
+ * https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5195
+ * With NEXT_LINE_ON_WRAP, an existing new line before the closing brace is removed when the
+ * initializer's elements are not wrapped - here because wrapping is disabled altogether.
+ */
+public void testIssue5195_noWrappingRemovesNewLineBeforeClosingBrace() {
+	this.formatterPrefs.insert_new_line_before_closing_brace_in_array_initializer_on_wrap = true;
+	this.formatterPrefs.alignment_for_expressions_in_array_initializer = Alignment.M_NO_ALIGNMENT;
+	String source =
+		"""
+		public class A {
+			int[] arr = { 1111111111, 2222222222,
+					3333333333
+			};
+		}
+		""";
+	formatSource(source,
+		"""
+		public class A {
+			int[] arr = { 1111111111, 2222222222, 3333333333 };
+		}
+		""");
+}
+
+/**
+ * https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5195
+ * Same as above, but with "wrap where necessary": the elements fit on a single line, so no
+ * wrapping happens and the new line before the closing brace is removed.
+ */
+public void testIssue5195_wrapWhereNecessaryRemovesNewLineBeforeClosingBrace() {
+	this.formatterPrefs.insert_new_line_before_closing_brace_in_array_initializer_on_wrap = true;
+	this.formatterPrefs.alignment_for_expressions_in_array_initializer = Alignment.M_COMPACT_SPLIT;
+	String source =
+		"""
+		public class A {
+			int[] arr = { 1111111111, 2222222222,
+					3333333333
+			};
+		}
+		""";
+	formatSource(source,
+		"""
+		public class A {
+			int[] arr = { 1111111111, 2222222222, 3333333333 };
+		}
+		""");
+}
+
+/**
+ * https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5195
+ * With forced wrapping the elements always wrap, so the closing brace always gets its own line,
+ * even for an initializer that would otherwise fit on a single line.
+ */
+public void testIssue5195_forcedWrappingGetsOwnLine() {
+	this.formatterPrefs.insert_new_line_before_closing_brace_in_array_initializer_on_wrap = true;
+	this.formatterPrefs.alignment_for_expressions_in_array_initializer = Alignment.M_ONE_PER_LINE_SPLIT | Alignment.M_FORCE;
+	String source =
+		"""
+		public class A {
+			int[] arr = { 1, 2, 3 };
+		}
+		""";
+	formatSource(source,
+		"""
+		public class A {
+			int[] arr = {
+					1,
+					2,
+					3
+			};
+		}
+		""");
+}
 }

--- a/org.eclipse.jdt.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.core; singleton:=true
-Bundle-Version: 3.47.0.qualifier
+Bundle-Version: 3.47.100.qualifier
 Bundle-Activator: org.eclipse.jdt.core.JavaCore
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/core/formatter/DefaultCodeFormatterConstants.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/core/formatter/DefaultCodeFormatterConstants.java
@@ -2416,13 +2416,17 @@ public class DefaultCodeFormatterConstants {
 	public static final String FORMATTER_INSERT_NEW_LINE_BEFORE_CATCH_IN_TRY_STATEMENT = JavaCore.PLUGIN_ID + ".formatter.insert_new_line_before_catch_in_try_statement";	//$NON-NLS-1$
 	/**
 	 * <pre>
-	 * FORMATTER / Option to insert a new line before the closing brace in an array initializer
+	 * FORMATTER / Option to insert a new line before the closing brace in an array initializer.
+	 * When set to NEXT_LINE_ON_WRAP, the new line is inserted only if the array initializer's
+	 * content itself was wrapped onto multiple lines; otherwise the closing brace stays on the
+	 * same line as the last element, mirroring brace_position_for_array_initializer's NEXT_LINE_ON_WRAP.
 	 *     - option id:         "org.eclipse.jdt.core.formatter.insert_new_line_before_closing_brace_in_array_initializer"
-	 *     - possible values:   { INSERT, DO_NOT_INSERT }
+	 *     - possible values:   { INSERT, DO_NOT_INSERT, NEXT_LINE_ON_WRAP }
 	 *     - default:           DO_NOT_INSERT
 	 * </pre>
 	 * @see JavaCore#INSERT
 	 * @see JavaCore#DO_NOT_INSERT
+	 * @see #NEXT_LINE_ON_WRAP
 	 * @since 3.0
 	 */
 	public static final String FORMATTER_INSERT_NEW_LINE_BEFORE_CLOSING_BRACE_IN_ARRAY_INITIALIZER = JavaCore.PLUGIN_ID + ".formatter.insert_new_line_before_closing_brace_in_array_initializer";//$NON-NLS-1$

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/core/formatter/DefaultCodeFormatterConstants.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/core/formatter/DefaultCodeFormatterConstants.java
@@ -2429,13 +2429,17 @@ public class DefaultCodeFormatterConstants {
 	public static final String FORMATTER_INSERT_NEW_LINE_BEFORE_CATCH_IN_TRY_STATEMENT = JavaCore.PLUGIN_ID + ".formatter.insert_new_line_before_catch_in_try_statement";	//$NON-NLS-1$
 	/**
 	 * <pre>
-	 * FORMATTER / Option to insert a new line before the closing brace in an array initializer
+	 * FORMATTER / Option to insert a new line before the closing brace in an array initializer.
+	 * When set to NEXT_LINE_ON_WRAP, the new line is inserted only if the array initializer's
+	 * content itself was wrapped onto multiple lines; otherwise the closing brace stays on the
+	 * same line as the last element, mirroring brace_position_for_array_initializer's NEXT_LINE_ON_WRAP.
 	 *     - option id:         "org.eclipse.jdt.core.formatter.insert_new_line_before_closing_brace_in_array_initializer"
-	 *     - possible values:   { INSERT, DO_NOT_INSERT }
+	 *     - possible values:   { INSERT, DO_NOT_INSERT, NEXT_LINE_ON_WRAP }
 	 *     - default:           DO_NOT_INSERT
 	 * </pre>
 	 * @see JavaCore#INSERT
 	 * @see JavaCore#DO_NOT_INSERT
+	 * @see #NEXT_LINE_ON_WRAP
 	 * @since 3.0
 	 */
 	public static final String FORMATTER_INSERT_NEW_LINE_BEFORE_CLOSING_BRACE_IN_ARRAY_INITIALIZER = JavaCore.PLUGIN_ID + ".formatter.insert_new_line_before_closing_brace_in_array_initializer";//$NON-NLS-1$

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/DefaultCodeFormatterOptions.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/DefaultCodeFormatterOptions.java
@@ -289,6 +289,7 @@ public class DefaultCodeFormatterOptions {
 	public boolean insert_new_line_at_end_of_file_if_missing;
 	public boolean insert_new_line_before_catch_in_try_statement;
 	public boolean insert_new_line_before_closing_brace_in_array_initializer;
+	public boolean insert_new_line_before_closing_brace_in_array_initializer_on_wrap;
 	public boolean insert_new_line_before_else_in_if_statement;
 	public boolean insert_new_line_before_finally_in_try_statement;
 	public boolean insert_new_line_before_while_in_do_statement;
@@ -729,7 +730,9 @@ public class DefaultCodeFormatterOptions {
 		options.put(DefaultCodeFormatterConstants.FORMATTER_INSERT_NEW_LINE_AFTER_OPENING_BRACE_IN_ARRAY_INITIALIZER, this.insert_new_line_after_opening_brace_in_array_initializer? JavaCore.INSERT : JavaCore.DO_NOT_INSERT);
 		options.put(DefaultCodeFormatterConstants.FORMATTER_INSERT_NEW_LINE_AT_END_OF_FILE_IF_MISSING, this.insert_new_line_at_end_of_file_if_missing ? JavaCore.INSERT : JavaCore.DO_NOT_INSERT);
 		options.put(DefaultCodeFormatterConstants.FORMATTER_INSERT_NEW_LINE_BEFORE_CATCH_IN_TRY_STATEMENT, this.insert_new_line_before_catch_in_try_statement? JavaCore.INSERT : JavaCore.DO_NOT_INSERT);
-		options.put(DefaultCodeFormatterConstants.FORMATTER_INSERT_NEW_LINE_BEFORE_CLOSING_BRACE_IN_ARRAY_INITIALIZER, this.insert_new_line_before_closing_brace_in_array_initializer? JavaCore.INSERT : JavaCore.DO_NOT_INSERT);
+		options.put(DefaultCodeFormatterConstants.FORMATTER_INSERT_NEW_LINE_BEFORE_CLOSING_BRACE_IN_ARRAY_INITIALIZER,
+			this.insert_new_line_before_closing_brace_in_array_initializer_on_wrap ? DefaultCodeFormatterConstants.NEXT_LINE_ON_WRAP
+					: (this.insert_new_line_before_closing_brace_in_array_initializer ? JavaCore.INSERT : JavaCore.DO_NOT_INSERT));
 		options.put(DefaultCodeFormatterConstants.FORMATTER_INSERT_NEW_LINE_BEFORE_ELSE_IN_IF_STATEMENT, this.insert_new_line_before_else_in_if_statement? JavaCore.INSERT : JavaCore.DO_NOT_INSERT);
 		options.put(DefaultCodeFormatterConstants.FORMATTER_INSERT_NEW_LINE_BEFORE_FINALLY_IN_TRY_STATEMENT, this.insert_new_line_before_finally_in_try_statement? JavaCore.INSERT : JavaCore.DO_NOT_INSERT);
 		options.put(DefaultCodeFormatterConstants.FORMATTER_INSERT_NEW_LINE_BEFORE_WHILE_IN_DO_STATEMENT, this.insert_new_line_before_while_in_do_statement? JavaCore.INSERT : JavaCore.DO_NOT_INSERT);
@@ -1729,6 +1732,7 @@ public class DefaultCodeFormatterOptions {
 		final Object insertNewLineBeforeClosingBraceInArrayInitializerOption = settings.get(DefaultCodeFormatterConstants.FORMATTER_INSERT_NEW_LINE_BEFORE_CLOSING_BRACE_IN_ARRAY_INITIALIZER);
 		if (insertNewLineBeforeClosingBraceInArrayInitializerOption != null) {
 			this.insert_new_line_before_closing_brace_in_array_initializer = JavaCore.INSERT.equals(insertNewLineBeforeClosingBraceInArrayInitializerOption);
+			this.insert_new_line_before_closing_brace_in_array_initializer_on_wrap = DefaultCodeFormatterConstants.NEXT_LINE_ON_WRAP.equals(insertNewLineBeforeClosingBraceInArrayInitializerOption);
 		}
 		final Object insertNewLineBeforeElseInIfStatementOption = settings.get(DefaultCodeFormatterConstants.FORMATTER_INSERT_NEW_LINE_BEFORE_ELSE_IN_IF_STATEMENT);
 		if (insertNewLineBeforeElseInIfStatementOption != null) {
@@ -3140,6 +3144,7 @@ public class DefaultCodeFormatterOptions {
 		this.insert_new_line_at_end_of_file_if_missing = false;
 		this.insert_new_line_before_catch_in_try_statement = false;
 		this.insert_new_line_before_closing_brace_in_array_initializer = false;
+		this.insert_new_line_before_closing_brace_in_array_initializer_on_wrap = false;
 		this.insert_new_line_before_else_in_if_statement = false;
 		this.insert_new_line_before_finally_in_try_statement = false;
 		this.insert_new_line_before_while_in_do_statement = false;
@@ -3547,6 +3552,7 @@ public class DefaultCodeFormatterOptions {
 		this.insert_new_line_at_end_of_file_if_missing = false;
 		this.insert_new_line_before_catch_in_try_statement = false;
 		this.insert_new_line_before_closing_brace_in_array_initializer = false;
+		this.insert_new_line_before_closing_brace_in_array_initializer_on_wrap = false;
 		this.insert_new_line_before_else_in_if_statement = false;
 		this.insert_new_line_before_finally_in_try_statement = false;
 		this.insert_new_line_before_while_in_do_statement = false;

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/DefaultCodeFormatterOptions.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/DefaultCodeFormatterOptions.java
@@ -290,6 +290,7 @@ public class DefaultCodeFormatterOptions {
 	public boolean insert_new_line_at_end_of_file_if_missing;
 	public boolean insert_new_line_before_catch_in_try_statement;
 	public boolean insert_new_line_before_closing_brace_in_array_initializer;
+	public boolean insert_new_line_before_closing_brace_in_array_initializer_on_wrap;
 	public boolean insert_new_line_before_else_in_if_statement;
 	public boolean insert_new_line_before_finally_in_try_statement;
 	public boolean insert_new_line_before_while_in_do_statement;
@@ -731,7 +732,9 @@ public class DefaultCodeFormatterOptions {
 		options.put(DefaultCodeFormatterConstants.FORMATTER_INSERT_NEW_LINE_AFTER_OPENING_BRACE_IN_ARRAY_INITIALIZER, this.insert_new_line_after_opening_brace_in_array_initializer? JavaCore.INSERT : JavaCore.DO_NOT_INSERT);
 		options.put(DefaultCodeFormatterConstants.FORMATTER_INSERT_NEW_LINE_AT_END_OF_FILE_IF_MISSING, this.insert_new_line_at_end_of_file_if_missing ? JavaCore.INSERT : JavaCore.DO_NOT_INSERT);
 		options.put(DefaultCodeFormatterConstants.FORMATTER_INSERT_NEW_LINE_BEFORE_CATCH_IN_TRY_STATEMENT, this.insert_new_line_before_catch_in_try_statement? JavaCore.INSERT : JavaCore.DO_NOT_INSERT);
-		options.put(DefaultCodeFormatterConstants.FORMATTER_INSERT_NEW_LINE_BEFORE_CLOSING_BRACE_IN_ARRAY_INITIALIZER, this.insert_new_line_before_closing_brace_in_array_initializer? JavaCore.INSERT : JavaCore.DO_NOT_INSERT);
+		options.put(DefaultCodeFormatterConstants.FORMATTER_INSERT_NEW_LINE_BEFORE_CLOSING_BRACE_IN_ARRAY_INITIALIZER,
+			this.insert_new_line_before_closing_brace_in_array_initializer_on_wrap ? DefaultCodeFormatterConstants.NEXT_LINE_ON_WRAP
+					: (this.insert_new_line_before_closing_brace_in_array_initializer ? JavaCore.INSERT : JavaCore.DO_NOT_INSERT));
 		options.put(DefaultCodeFormatterConstants.FORMATTER_INSERT_NEW_LINE_BEFORE_ELSE_IN_IF_STATEMENT, this.insert_new_line_before_else_in_if_statement? JavaCore.INSERT : JavaCore.DO_NOT_INSERT);
 		options.put(DefaultCodeFormatterConstants.FORMATTER_INSERT_NEW_LINE_BEFORE_FINALLY_IN_TRY_STATEMENT, this.insert_new_line_before_finally_in_try_statement? JavaCore.INSERT : JavaCore.DO_NOT_INSERT);
 		options.put(DefaultCodeFormatterConstants.FORMATTER_INSERT_NEW_LINE_BEFORE_WHILE_IN_DO_STATEMENT, this.insert_new_line_before_while_in_do_statement? JavaCore.INSERT : JavaCore.DO_NOT_INSERT);
@@ -1731,6 +1734,7 @@ public class DefaultCodeFormatterOptions {
 		final Object insertNewLineBeforeClosingBraceInArrayInitializerOption = settings.get(DefaultCodeFormatterConstants.FORMATTER_INSERT_NEW_LINE_BEFORE_CLOSING_BRACE_IN_ARRAY_INITIALIZER);
 		if (insertNewLineBeforeClosingBraceInArrayInitializerOption != null) {
 			this.insert_new_line_before_closing_brace_in_array_initializer = JavaCore.INSERT.equals(insertNewLineBeforeClosingBraceInArrayInitializerOption);
+			this.insert_new_line_before_closing_brace_in_array_initializer_on_wrap = DefaultCodeFormatterConstants.NEXT_LINE_ON_WRAP.equals(insertNewLineBeforeClosingBraceInArrayInitializerOption);
 		}
 		final Object insertNewLineBeforeElseInIfStatementOption = settings.get(DefaultCodeFormatterConstants.FORMATTER_INSERT_NEW_LINE_BEFORE_ELSE_IN_IF_STATEMENT);
 		if (insertNewLineBeforeElseInIfStatementOption != null) {
@@ -3151,6 +3155,7 @@ public class DefaultCodeFormatterOptions {
 		this.insert_new_line_at_end_of_file_if_missing = false;
 		this.insert_new_line_before_catch_in_try_statement = false;
 		this.insert_new_line_before_closing_brace_in_array_initializer = false;
+		this.insert_new_line_before_closing_brace_in_array_initializer_on_wrap = false;
 		this.insert_new_line_before_else_in_if_statement = false;
 		this.insert_new_line_before_finally_in_try_statement = false;
 		this.insert_new_line_before_while_in_do_statement = false;
@@ -3559,6 +3564,7 @@ public class DefaultCodeFormatterOptions {
 		this.insert_new_line_at_end_of_file_if_missing = false;
 		this.insert_new_line_before_catch_in_try_statement = false;
 		this.insert_new_line_before_closing_brace_in_array_initializer = false;
+		this.insert_new_line_before_closing_brace_in_array_initializer_on_wrap = false;
 		this.insert_new_line_before_else_in_if_statement = false;
 		this.insert_new_line_before_finally_in_try_statement = false;
 		this.insert_new_line_before_while_in_do_statement = false;

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/LineBreaksPreparator.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/LineBreaksPreparator.java
@@ -421,6 +421,8 @@ public class LineBreaksPreparator extends ASTVisitor {
 				openBraceToken.breakAfter();
 			if (this.options.insert_new_line_before_closing_brace_in_array_initializer)
 				closeBraceToken.breakBefore();
+			else if (this.options.insert_new_line_before_closing_brace_in_array_initializer_on_wrap)
+				closeBraceToken.setNextLineOnWrap();
 		}
 		return true;
 	}

--- a/org.eclipse.jdt.core/pom.xml
+++ b/org.eclipse.jdt.core/pom.xml
@@ -17,7 +17,7 @@
     <version>4.42.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.eclipse.jdt.core</artifactId>
-  <version>3.47.0-SNAPSHOT</version>
+  <version>3.47.100-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>


### PR DESCRIPTION
Fixes #5195

## What
`brace_position_for_array_initializer` already supports `NEXT_LINE_ON_WRAP` for the opening brace: it moves to its own line only if the array initializer's content wraps across multiple lines, staying inline otherwise. The closing brace had no equivalent — `insert_new_line_before_closing_brace_in_array_initializer` only accepted `INSERT`/`DO_NOT_INSERT`, so it was all-or-nothing regardless of whether the content actually wrapped.

This PR adds `NEXT_LINE_ON_WRAP` as a third accepted value for `insert_new_line_before_closing_brace_in_array_initializer`, reusing the deferred `Token.setNextLineOnWrap()` / `isNextLineOnWrap()` mechanism already used for the opening brace, resolved later by `WrapExecutor` once wrapping is decided.

Before (with `brace_position_for_array_initializer=NEXT_LINE_ON_WRAP`, closing brace unconditional):
```java
int[] shortArr = { 1, 2, 3 };

int[] longArr = {
    1111111111,
    2222222222,
    3333333333 };   // stuck to the last element regardless of wrapping
```
After (with the new value on the closing-brace option too):
```java
int[] shortArr = { 1, 2, 3 };   // unwrapped: unchanged

int[] longArr = {
    1111111111,
    2222222222,
    3333333333
};                               // wrapped: closing brace gets its own line
```

## How
- `DefaultCodeFormatterOptions` gains a new `insert_new_line_before_closing_brace_in_array_initializer_on_wrap` boolean field, kept separate from the existing `insert_new_line_before_closing_brace_in_array_initializer` field so none of the existing call sites that set the old field directly (in `FormatterBugsTests`/`FormatterRegressionTests`) need to change.
- `LineBreaksPreparator.visit(ArrayInitializer)` calls `closeBraceToken.setNextLineOnWrap()` instead of the unconditional `breakBefore()` when the new flag is set.
- `DefaultCodeFormatterConstants` javadoc updated to document the new value.

## Testing
Added `testIssue5195_shortArrayStaysInline` and `testIssue5195_wrappedArrayGetsOwnLine` to `FormatterBugsTests`, covering both the unwrapped (no-op) and wrapped (brace gets its own line) cases. I also verified backward compatibility of the existing `INSERT`/`DO_NOT_INSERT` values is unaffected — both still produce identical output to before this change.

I wasn't able to run the full Tycho-based test suite in my environment (this repo depends on a sibling `eclipse-platform-parent` checkout for its build), so I instead verified the formatter behavior directly: compiled the three modified classes against the released 3.43.0 artifacts (`org.eclipse.jdt.core`, `ecj`, `org.eclipse.jface.text`, `org.eclipse.text`), loaded them ahead of the stock jar via `ToolFactory.createCodeFormatter`, and confirmed the output for both the wrapped and unwrapped cases matches what's shown above, plus regression-checked the untouched `INSERT`/`DO_NOT_INSERT` paths produce byte-identical output to the unpatched formatter. Happy to have a maintainer confirm against the full test suite, and to adjust naming/approach based on review feedback.

---
*This PR was drafted with assistance from Claude (Anthropic).*
