### PR TITLE
 flagging more useful error for locals and static interplays - fixes 5145

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/NameReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/NameReference.java
@@ -20,16 +20,10 @@
 package org.eclipse.jdt.internal.compiler.ast;
 
 import org.eclipse.jdt.internal.compiler.ASTVisitor;
+import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 import org.eclipse.jdt.internal.compiler.codegen.CodeStream;
 import org.eclipse.jdt.internal.compiler.impl.Constant;
-import org.eclipse.jdt.internal.compiler.lookup.Binding;
-import org.eclipse.jdt.internal.compiler.lookup.BlockScope;
-import org.eclipse.jdt.internal.compiler.lookup.FieldBinding;
-import org.eclipse.jdt.internal.compiler.lookup.InferenceContext18;
-import org.eclipse.jdt.internal.compiler.lookup.InvocationSite;
-import org.eclipse.jdt.internal.compiler.lookup.ReferenceBinding;
-import org.eclipse.jdt.internal.compiler.lookup.Scope;
-import org.eclipse.jdt.internal.compiler.lookup.TypeBinding;
+import org.eclipse.jdt.internal.compiler.lookup.*;
 
 public abstract class NameReference extends Reference implements InvocationSite {
 
@@ -46,6 +40,32 @@ public abstract class NameReference extends Reference implements InvocationSite 
 	//no changeClass in java.
 public NameReference() {
 	this.bits |= Binding.TYPE | Binding.VARIABLE; // restrictiveFlag
+}
+
+protected void checkLocalStaticClassVariables(BlockScope scope, VariableBinding variable) {
+	// Compile-time constant variables are inlined and can be legally accessed from a static
+	// context (e.g. an annotation on a local class, or a static method of a local class), so
+	// they are not subject to the outer-local reference restriction of JLS 8.1.3.
+	if (variable.constant(scope) != Constant.NotAConstant)
+		return;
+	// Check if we're in a local type (either static local class OR non-static local class with static method)
+	if (this.actualReceiverType.isLocalType()) {
+		MethodScope currentMethodScope = scope instanceof MethodScope ? (MethodScope) scope : scope.enclosingMethodScope();
+		// Check if either the local class is static OR the current method is static
+		boolean inStaticContext = this.actualReceiverType.isStatic() || (currentMethodScope != null && currentMethodScope.isStatic);
+
+		if (inStaticContext &&
+				(variable.modifiers & ClassFileConstants.AccStatic) == 0 &&
+				(this.bits & ASTNode.IsCapturedOuterLocal) != 0) {
+			BlockScope declaringScope = ((LocalVariableBinding) this.binding).declaringScope;
+			MethodScope declaringMethodScope = declaringScope instanceof MethodScope ? (MethodScope)declaringScope :
+				declaringScope.enclosingMethodScope();
+			ClassScope declaringClassScope = declaringMethodScope != null ? declaringMethodScope.classScope() : null;
+			ClassScope currentClassScope = currentMethodScope != null ? currentMethodScope.classScope() : null;
+			if (declaringClassScope != currentClassScope)
+				scope.problemReporter().recordStaticReferenceToOuterLocalVariable((LocalVariableBinding)variable, this);
+		}
+	}
 }
 
 /**

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/NameReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/NameReference.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -43,6 +43,10 @@ public NameReference() {
 }
 
 protected void checkLocalStaticClassVariables(BlockScope scope, VariableBinding variable) {
+	// Only check for static methods accessing outer locals in Java 16+ (when static methods in local classes are allowed)
+	if (scope.compilerOptions().sourceLevel < ClassFileConstants.JDK16)
+		return;
+
 	// Compile-time constant variables are inlined and can be legally accessed from a static
 	// context (e.g. an annotation on a local class, or a static method of a local class), so
 	// they are not subject to the outer-local reference restriction of JLS 8.1.3.

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/QualifiedNameReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/QualifiedNameReference.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -1188,12 +1188,17 @@ public VariableBinding nullAnnotatedVariableBinding(boolean supportTypeAnnotatio
 }
 
 private void checkLocalStaticClassVariables(BlockScope scope, VariableBinding variable) {
+	// Compile-time constant variables are inlined and can be legally accessed from a static
+	// context (e.g. an annotation on a local class, or a static method of a local class), so
+	// they are not subject to the outer-local reference restriction of JLS 8.1.3.
+	if (variable.constant(scope) != Constant.NotAConstant)
+		return;
 	// Check if we're in a local type (either static local class OR non-static local class with static method)
 	if (this.actualReceiverType.isLocalType()) {
 		MethodScope currentMethodScope = scope instanceof MethodScope ? (MethodScope) scope : scope.enclosingMethodScope();
 		// Check if either the local class is static OR the current method is static
 		boolean inStaticContext = this.actualReceiverType.isStatic() || (currentMethodScope != null && currentMethodScope.isStatic);
-		
+
 		if (inStaticContext &&
 				(variable.modifiers & ClassFileConstants.AccStatic) == 0 &&
 				(this.bits & ASTNode.IsCapturedOuterLocal) != 0) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/QualifiedNameReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/QualifiedNameReference.java
@@ -1018,6 +1018,10 @@ public TypeBinding resolveType(BlockScope scope) {
 						// only complain if field reference (for local, its type got flagged already)
 						return null;
 					}
+					// Only check for static methods accessing outer locals in Java 16+ (when static methods in local classes are allowed)
+					if (scope.compilerOptions().sourceLevel >= ClassFileConstants.JDK16) {
+						checkLocalStaticClassVariables(scope, local);
+					}
 					this.resolvedType = getOtherFieldBindings(scope);
 					if (this.resolvedType != null && (this.resolvedType.tagBits & TagBits.HasMissingType) != 0) {
 						FieldBinding lastField = this.otherBindings[this.otherBindings.length - 1];
@@ -1181,5 +1185,26 @@ public VariableBinding nullAnnotatedVariableBinding(boolean supportTypeAnnotatio
 		}
 	}
 	return null;
+}
+
+private void checkLocalStaticClassVariables(BlockScope scope, VariableBinding variable) {
+	// Check if we're in a local type (either static local class OR non-static local class with static method)
+	if (this.actualReceiverType.isLocalType()) {
+		MethodScope currentMethodScope = scope instanceof MethodScope ? (MethodScope) scope : scope.enclosingMethodScope();
+		// Check if either the local class is static OR the current method is static
+		boolean inStaticContext = this.actualReceiverType.isStatic() || (currentMethodScope != null && currentMethodScope.isStatic);
+		
+		if (inStaticContext &&
+				(variable.modifiers & ClassFileConstants.AccStatic) == 0 &&
+				(this.bits & ASTNode.IsCapturedOuterLocal) != 0) {
+			BlockScope declaringScope = ((LocalVariableBinding) this.binding).declaringScope;
+			MethodScope declaringMethodScope = declaringScope instanceof MethodScope ? (MethodScope)declaringScope :
+				declaringScope.enclosingMethodScope();
+			ClassScope declaringClassScope = declaringMethodScope != null ? declaringMethodScope.classScope() : null;
+			ClassScope currentClassScope = currentMethodScope != null ? currentMethodScope.classScope() : null;
+			if (declaringClassScope != currentClassScope)
+				scope.problemReporter().recordStaticReferenceToOuterLocalVariable((LocalVariableBinding)variable, this);
+		}
+	}
 }
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/QualifiedNameReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/QualifiedNameReference.java
@@ -1018,10 +1018,9 @@ public TypeBinding resolveType(BlockScope scope) {
 						// only complain if field reference (for local, its type got flagged already)
 						return null;
 					}
-					// Only check for static methods accessing outer locals in Java 16+ (when static methods in local classes are allowed)
-					if (scope.compilerOptions().sourceLevel >= ClassFileConstants.JDK16) {
-						checkLocalStaticClassVariables(scope, local);
-					}
+
+					checkLocalStaticClassVariables(scope, local);
+
 					this.resolvedType = getOtherFieldBindings(scope);
 					if (this.resolvedType != null && (this.resolvedType.tagBits & TagBits.HasMissingType) != 0) {
 						FieldBinding lastField = this.otherBindings[this.otherBindings.length - 1];

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/QualifiedNameReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/QualifiedNameReference.java
@@ -1187,29 +1187,4 @@ public VariableBinding nullAnnotatedVariableBinding(boolean supportTypeAnnotatio
 	return null;
 }
 
-private void checkLocalStaticClassVariables(BlockScope scope, VariableBinding variable) {
-	// Compile-time constant variables are inlined and can be legally accessed from a static
-	// context (e.g. an annotation on a local class, or a static method of a local class), so
-	// they are not subject to the outer-local reference restriction of JLS 8.1.3.
-	if (variable.constant(scope) != Constant.NotAConstant)
-		return;
-	// Check if we're in a local type (either static local class OR non-static local class with static method)
-	if (this.actualReceiverType.isLocalType()) {
-		MethodScope currentMethodScope = scope instanceof MethodScope ? (MethodScope) scope : scope.enclosingMethodScope();
-		// Check if either the local class is static OR the current method is static
-		boolean inStaticContext = this.actualReceiverType.isStatic() || (currentMethodScope != null && currentMethodScope.isStatic);
-
-		if (inStaticContext &&
-				(variable.modifiers & ClassFileConstants.AccStatic) == 0 &&
-				(this.bits & ASTNode.IsCapturedOuterLocal) != 0) {
-			BlockScope declaringScope = ((LocalVariableBinding) this.binding).declaringScope;
-			MethodScope declaringMethodScope = declaringScope instanceof MethodScope ? (MethodScope)declaringScope :
-				declaringScope.enclosingMethodScope();
-			ClassScope declaringClassScope = declaringMethodScope != null ? declaringMethodScope.classScope() : null;
-			ClassScope currentClassScope = currentMethodScope != null ? currentMethodScope.classScope() : null;
-			if (declaringClassScope != currentClassScope)
-				scope.problemReporter().recordStaticReferenceToOuterLocalVariable((LocalVariableBinding)variable, this);
-		}
-	}
-}
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SingleNameReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SingleNameReference.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -1060,12 +1060,17 @@ public TypeBinding resolveType(BlockScope scope) {
 }
 
 private void checkLocalStaticClassVariables(BlockScope scope, VariableBinding variable) {
+	// Compile-time constant variables are inlined and can be legally accessed from a static
+	// context (e.g. an annotation on a local class, or a static method of a local class), so
+	// they are not subject to the outer-local reference restriction of JLS 8.1.3.
+	if (variable.constant(scope) != Constant.NotAConstant)
+		return;
 	// Check if we're in a local type (either static local class OR non-static local class with static method)
 	if (this.actualReceiverType.isLocalType()) {
 		MethodScope currentMethodScope = scope instanceof MethodScope ? (MethodScope) scope : scope.enclosingMethodScope();
 		// Check if either the local class is static OR the current method is static
 		boolean inStaticContext = this.actualReceiverType.isStatic() || (currentMethodScope != null && currentMethodScope.isStatic);
-		
+
 		if (inStaticContext &&
 				(variable.modifiers & ClassFileConstants.AccStatic) == 0 &&
 				(this.bits & ASTNode.IsCapturedOuterLocal) != 0) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SingleNameReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SingleNameReference.java
@@ -28,7 +28,6 @@ package org.eclipse.jdt.internal.compiler.ast;
 
 import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.internal.compiler.ASTVisitor;
-import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 import org.eclipse.jdt.internal.compiler.codegen.CodeStream;
 import org.eclipse.jdt.internal.compiler.codegen.Opcodes;
 import org.eclipse.jdt.internal.compiler.flow.FlowContext;
@@ -1015,10 +1014,7 @@ public TypeBinding resolveType(BlockScope scope) {
 							localVariable.type = null;
 							localVariable.useFlag = LocalVariableBinding.UNUSED; // quell further errors.
 						}
-						// Only check for static methods accessing outer locals in Java 16+ (when static methods in local classes are allowed)
-						if (scope.compilerOptions().sourceLevel >= ClassFileConstants.JDK16) {
-							checkLocalStaticClassVariables(scope, variable);
-						}
+						checkLocalStaticClassVariables(scope, variable);
 						variableType = variable.type;
 						this.constant = (this.bits & ASTNode.IsStrictlyAssigned) == 0 ? variable.constant(scope) : Constant.NotAConstant;
 					} else {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SingleNameReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SingleNameReference.java
@@ -1015,7 +1015,10 @@ public TypeBinding resolveType(BlockScope scope) {
 							localVariable.type = null;
 							localVariable.useFlag = LocalVariableBinding.UNUSED; // quell further errors.
 						}
-						checkLocalStaticClassVariables(scope, variable);
+						// Only check for static methods accessing outer locals in Java 16+ (when static methods in local classes are allowed)
+						if (scope.compilerOptions().sourceLevel >= ClassFileConstants.JDK16) {
+							checkLocalStaticClassVariables(scope, variable);
+						}
 						variableType = variable.type;
 						this.constant = (this.bits & ASTNode.IsStrictlyAssigned) == 0 ? variable.constant(scope) : Constant.NotAConstant;
 					} else {
@@ -1057,17 +1060,22 @@ public TypeBinding resolveType(BlockScope scope) {
 }
 
 private void checkLocalStaticClassVariables(BlockScope scope, VariableBinding variable) {
-	if (this.actualReceiverType.isStatic() && this.actualReceiverType.isLocalType()) {
-		if ((variable.modifiers & ClassFileConstants.AccStatic) == 0 &&
+	// Check if we're in a local type (either static local class OR non-static local class with static method)
+	if (this.actualReceiverType.isLocalType()) {
+		MethodScope currentMethodScope = scope instanceof MethodScope ? (MethodScope) scope : scope.enclosingMethodScope();
+		// Check if either the local class is static OR the current method is static
+		boolean inStaticContext = this.actualReceiverType.isStatic() || (currentMethodScope != null && currentMethodScope.isStatic);
+		
+		if (inStaticContext &&
+				(variable.modifiers & ClassFileConstants.AccStatic) == 0 &&
 				(this.bits & ASTNode.IsCapturedOuterLocal) != 0) {
 			BlockScope declaringScope = ((LocalVariableBinding) this.binding).declaringScope;
 			MethodScope declaringMethodScope = declaringScope instanceof MethodScope ? (MethodScope)declaringScope :
 				declaringScope.enclosingMethodScope();
-			MethodScope currentMethodScope = scope instanceof MethodScope ? (MethodScope) scope : scope.enclosingMethodScope();
 			ClassScope declaringClassScope = declaringMethodScope != null ? declaringMethodScope.classScope() : null;
 			ClassScope currentClassScope = currentMethodScope != null ? currentMethodScope.classScope() : null;
 			if (declaringClassScope != currentClassScope)
-			scope.problemReporter().recordStaticReferenceToOuterLocalVariable((LocalVariableBinding)variable, this);
+				scope.problemReporter().recordStaticReferenceToOuterLocalVariable((LocalVariableBinding)variable, this);
 		}
 	}
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SingleNameReference.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SingleNameReference.java
@@ -1059,32 +1059,6 @@ public TypeBinding resolveType(BlockScope scope) {
 	return this.resolvedType = reportError(scope);
 }
 
-private void checkLocalStaticClassVariables(BlockScope scope, VariableBinding variable) {
-	// Compile-time constant variables are inlined and can be legally accessed from a static
-	// context (e.g. an annotation on a local class, or a static method of a local class), so
-	// they are not subject to the outer-local reference restriction of JLS 8.1.3.
-	if (variable.constant(scope) != Constant.NotAConstant)
-		return;
-	// Check if we're in a local type (either static local class OR non-static local class with static method)
-	if (this.actualReceiverType.isLocalType()) {
-		MethodScope currentMethodScope = scope instanceof MethodScope ? (MethodScope) scope : scope.enclosingMethodScope();
-		// Check if either the local class is static OR the current method is static
-		boolean inStaticContext = this.actualReceiverType.isStatic() || (currentMethodScope != null && currentMethodScope.isStatic);
-
-		if (inStaticContext &&
-				(variable.modifiers & ClassFileConstants.AccStatic) == 0 &&
-				(this.bits & ASTNode.IsCapturedOuterLocal) != 0) {
-			BlockScope declaringScope = ((LocalVariableBinding) this.binding).declaringScope;
-			MethodScope declaringMethodScope = declaringScope instanceof MethodScope ? (MethodScope)declaringScope :
-				declaringScope.enclosingMethodScope();
-			ClassScope declaringClassScope = declaringMethodScope != null ? declaringMethodScope.classScope() : null;
-			ClassScope currentClassScope = currentMethodScope != null ? currentMethodScope.classScope() : null;
-			if (declaringClassScope != currentClassScope)
-				scope.problemReporter().recordStaticReferenceToOuterLocalVariable((LocalVariableBinding)variable, this);
-		}
-	}
-}
-
 @Override
 public void traverse(ASTVisitor visitor, BlockScope scope) {
 	visitor.visit(this, scope);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/CodeStream.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/CodeStream.java
@@ -2213,7 +2213,9 @@ public void generateInlinedValue(short inlinedValue) {
 public void generateOuterAccess(Object[] mappingSequence, ASTNode invocationSite, Binding target, Scope scope) {
 	if (mappingSequence == null) {
 		if (target instanceof LocalVariableBinding) {
-			scope.problemReporter().needImplementation(invocationSite); //TODO (philippe) should improve local emulation failure reporting
+			// Safety net: report proper error for static reference to outer local variable
+			// This should have been caught during semantic analysis, but provide clear error as fallback
+			scope.problemReporter().recordStaticReferenceToOuterLocalVariable((LocalVariableBinding)target, invocationSite);
 		} else {
 			scope.problemReporter().noSuchEnclosingInstance((ReferenceBinding)target, invocationSite, false);
 		}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LocalVariableTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LocalVariableTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2014 IBM Corporation and others.
+ * Copyright (c) 2005, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -907,6 +907,233 @@ public void testBug537033() {
 		"	x.x(val - 1);\n" +
 		"	^\n" +
 		"The local variable x may not have been initialized\n" +
+		"----------\n");
+}
+// Test for static method in non-static local class accessing outer local variable
+// Per JLS 8.1.3, static methods cannot reference local variables from enclosing methods
+// Note: static methods in local classes are only allowed in Java 16+
+public void testStaticMethodInLocalClassAccessingOuterLocal() {
+	runNegativeTest(
+		new String[] {
+			"X.java",
+			"""
+			public class X {
+			  public static void combine(Object parameter) {
+			    class Local {
+			      static void method() {
+			        System.out.println(parameter);
+			      }
+			    }
+			  }
+			}
+			"""
+		},
+		this.complianceLevel < ClassFileConstants.JDK16
+		?
+		"----------\n" +
+		"1. WARNING in X.java (at line 3)\n" +
+		"	class Local {\n" +
+		"	      ^^^^^\n" +
+		"The type Local is never used locally\n" +
+		"----------\n" +
+		"2. ERROR in X.java (at line 4)\n" +
+		"	static void method() {\n" +
+		"	            ^^^^^^^^\n" +
+		"The method method cannot be declared static; static methods can only be declared in a static or top level type\n" +
+		"----------\n"
+		:
+		"----------\n" +
+		"1. WARNING in X.java (at line 3)\n" +
+		"	class Local {\n" +
+		"	      ^^^^^\n" +
+		"The type Local is never used locally\n" +
+		"----------\n" +
+		"2. ERROR in X.java (at line 5)\n" +
+		"	System.out.println(parameter);\n" +
+		"	                   ^^^^^^^^^\n" +
+		"Cannot make a static reference to the non-static variable parameter\n" +
+		"----------\n");
+}
+// Test for static method in non-static local class accessing outer local variable (field reference)
+public void testStaticMethodInLocalClassAccessingOuterLocal2() {
+	runNegativeTest(
+		new String[] {
+			"X.java",
+			"""
+			public class X {
+			  public void test(String value) {
+			    class Local {
+			      static void staticMethod() {
+			        String s = value;
+			      }
+			    }
+			  }
+			}
+			"""
+		},
+		this.complianceLevel < ClassFileConstants.JDK16
+		?
+		"----------\n" +
+		"1. WARNING in X.java (at line 3)\n" +
+		"	class Local {\n" +
+		"	      ^^^^^\n" +
+		"The type Local is never used locally\n" +
+		"----------\n" +
+		"2. ERROR in X.java (at line 4)\n" +
+		"	static void staticMethod() {\n" +
+		"	            ^^^^^^^^^^^^^^\n" +
+		"The method staticMethod cannot be declared static; static methods can only be declared in a static or top level type\n" +
+		"----------\n"
+		:
+		"----------\n" +
+		"1. WARNING in X.java (at line 3)\n" +
+		"	class Local {\n" +
+		"	      ^^^^^\n" +
+		"The type Local is never used locally\n" +
+		"----------\n" +
+		"2. ERROR in X.java (at line 5)\n" +
+		"	String s = value;\n" +
+		"	           ^^^^^\n" +
+		"Cannot make a static reference to the non-static variable value\n" +
+		"----------\n");
+}
+// Test for QualifiedNameReference - static method accessing outer local variable with field access
+public void testStaticMethodInLocalClassAccessingOuterLocalQualified() {
+	runNegativeTest(
+		new String[] {
+			"X.java",
+			"""
+			public class X {
+			  static class Holder { public String data; }
+			  public void test(Holder holder) {
+			    class Local {
+			      static void staticMethod() {
+			        String s = holder.data;
+			      }
+			    }
+			  }
+			}
+			"""
+		},
+		this.complianceLevel < ClassFileConstants.JDK16
+		?
+		"----------\n" +
+		"1. WARNING in X.java (at line 4)\n" +
+		"	class Local {\n" +
+		"	      ^^^^^\n" +
+		"The type Local is never used locally\n" +
+		"----------\n" +
+		"2. ERROR in X.java (at line 5)\n" +
+		"	static void staticMethod() {\n" +
+		"	            ^^^^^^^^^^^^^^\n" +
+		"The method staticMethod cannot be declared static; static methods can only be declared in a static or top level type\n" +
+		"----------\n"
+		:
+		"----------\n" +
+		"1. WARNING in X.java (at line 4)\n" +
+		"	class Local {\n" +
+		"	      ^^^^^\n" +
+		"The type Local is never used locally\n" +
+		"----------\n" +
+		"2. ERROR in X.java (at line 6)\n" +
+		"	String s = holder.data;\n" +
+		"	           ^^^^^^^^^^^\n" +
+		"Cannot make a static reference to the non-static variable holder\n" +
+		"----------\n");
+}
+// Test for QualifiedNameReference - accessing multiple fields starting with outer local
+public void testStaticMethodInLocalClassAccessingOuterLocalQualified2() {
+	runNegativeTest(
+		new String[] {
+			"X.java",
+			"""
+			public class X {
+			  static class A { public B b; }
+			  static class B { public String value; }
+			  public void test(A a) {
+			    class Local {
+			      static void staticMethod() {
+			        String s = a.b.value;
+			      }
+			    }
+			  }
+			}
+			"""
+		},
+		this.complianceLevel < ClassFileConstants.JDK16
+		?
+		"----------\n" +
+		"1. WARNING in X.java (at line 5)\n" +
+		"	class Local {\n" +
+		"	      ^^^^^\n" +
+		"The type Local is never used locally\n" +
+		"----------\n" +
+		"2. ERROR in X.java (at line 6)\n" +
+		"	static void staticMethod() {\n" +
+		"	            ^^^^^^^^^^^^^^\n" +
+		"The method staticMethod cannot be declared static; static methods can only be declared in a static or top level type\n" +
+		"----------\n"
+		:
+		"----------\n" +
+		"1. WARNING in X.java (at line 5)\n" +
+		"	class Local {\n" +
+		"	      ^^^^^\n" +
+		"The type Local is never used locally\n" +
+		"----------\n" +
+		"2. ERROR in X.java (at line 7)\n" +
+		"	String s = a.b.value;\n" +
+		"	           ^^^^^^^^^\n" +
+		"Cannot make a static reference to the non-static variable a\n" +
+		"----------\n");
+}
+// Test that non-static methods can still access outer locals (to ensure we didn't break the normal case)
+public void testNonStaticMethodInLocalClassAccessingOuterLocal() {
+	runConformTest(
+		new String[] {
+			"X.java",
+			"""
+			public class X {
+			  public void test(String value) {
+			    class Local {
+			      void nonStaticMethod() {
+			        System.out.println(value);
+			      }
+			    }
+			    new Local().nonStaticMethod();
+			  }
+			  public static void main(String[] args) {
+			    new X().test("OK");
+			  }
+			}
+			"""
+		},
+		"OK");
+}
+// Test for static initializer block in local class accessing outer local variable.
+// This exercises the safety net in CodeStream.generateOuterAccess (line 2218)
+// where mappingSequence is null for a LocalVariableBinding target.
+public void testStaticInitializerInLocalClassAccessingOuterLocal() {
+	if (this.complianceLevel < ClassFileConstants.JDK16) return;
+	runNegativeTest(
+		new String[] {
+			"X.java",
+			"""
+			public class X {
+			  public static void combine(Object parameter) {
+			    class Local {
+			      static {
+			        System.out.println(parameter);
+			      }
+			    }
+			  }
+			}
+			"""
+		},
+		"----------\n" +
+		"1. ERROR in X.java (at line 5)\n" +
+		"	System.out.println(parameter);\n" +
+		"	                   ^^^^^^^^^\n" +
+		"Cannot make a static reference to the non-static variable parameter\n" +
 		"----------\n");
 }
 public static Class testClass() {


### PR DESCRIPTION
## What it does
fixes #5145 

- error flagged at resolution phase itself instead of codegen
- codegen part of the code kept only as a safety net.
- SingleNR and QNR access conditions are taken care
- test cases added.

## How to test
junits are provided in LocalVariableTest

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
