### PR TITLE
test case checking different versions for testing Static Initializer In

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LocalVariableTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LocalVariableTest.java
@@ -23,7 +23,7 @@ import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 public class LocalVariableTest extends AbstractRegressionTest {
 
 static {
-//	TESTS_NAMES = new String[] { "testBug537033" };
+	TESTS_NAMES = new String[] { "testStaticInitializerInLocalClassAccessingOuterLocalVariable" };
 }
 public LocalVariableTest(String name) {
 	super(name);
@@ -1136,6 +1136,41 @@ public void testStaticInitializerInLocalClassAccessingOuterLocal() {
 		"Cannot make a static reference to the non-static variable parameter\n" +
 		"----------\n");
 }
+
+public void testStaticInitializerInLocalClassAccessingOuterLocalVariable() {
+	runNegativeTest(
+		new String[] {
+			"X.java",
+			"""
+			public class X {
+			    public static void main(String[] strArr) {
+			        int NUM = 10;
+			        class C {
+			            static {
+			                int a = NUM;
+			            }
+			        }
+			    }
+			}
+			"""
+		},
+		this.complianceLevel < ClassFileConstants.JDK16
+		?
+		"----------\n" +
+		"1. ERROR in X.java (at line 5)\n" +
+		"	static {\n" +
+		"	       ^\n" +
+		"Cannot define static initializer in inner type C\n" +
+		"----------\n"
+		:
+		"----------\n" +
+		"1. ERROR in X.java (at line 6)\n" +
+		"	int a = NUM;\n" +
+		"	        ^^^\n" +
+		"Cannot make a static reference to the non-static variable NUM\n" +
+		"----------\n");
+}
+
 public static Class testClass() {
 	return LocalVariableTest.class;
 }


### PR DESCRIPTION
A test case for Local Class Accessing Outer Local Variable with all the versions.


## What it does
pr #5198 already fixes #4019  as part of the #5145. Just adding the specific listed test case of 4019.

## How to test
This is a test only PR. To reproduce the issue, use the commit before PR #5198 merge.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
