### PR TITLE
allows static members in inner and anonymous classes - issue #2860

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ClassScope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ClassScope.java
@@ -255,9 +255,10 @@ public class ClassScope extends Scope {
 		LocalTypeBinding localType = new LocalTypeBinding(this, enclosingType, enclosingSwitchLabel());
 		this.referenceContext.binding = localType;
 		// A local type declared as a member of another (local/anonymous) type is a member type (JLS 16 8.1.3);
-		// mark it as such up-front so that checkAndSetModifiers() classifies it correctly. Such an inner class
-		// may declare and inherit static members even though it is not itself static.
-		if (this.parent instanceof ClassScope)
+		// mark it as such up-front so that checkAndSetModifiers() classifies it correctly. From Java 16 such an
+		// inner class may declare and inherit static members even though it is not itself static. Restricted to
+		// 16+ so that the pre-16 diagnostics (which reject static members of inner classes) are preserved.
+		if (this.parent instanceof ClassScope && compilerOptions().sourceLevel >= ClassFileConstants.JDK16)
 			localType.setAsMemberType();
 		checkAndSetModifiers();
 		buildTypeVariables();
@@ -1346,7 +1347,12 @@ public class ClassScope extends Scope {
 			}
 		} finally {
 			if (sourceType.isNonSealed() && !hasSealedSupertype) {
-				if (!sourceType.isRecord() && !sourceType.isLocalType() && !sourceType.isEnum() && !sourceType.isSealed()) // avoid double jeopardy
+				// A genuine local type (declared in a block) already gets illegalModifierForLocalClass via the
+				// hierarchySealed handling in checkAndSetModifiers, so skip it here to avoid double jeopardy. A member
+				// type of a local/anonymous class (JLS 16 8.1.3) goes through the member-type path instead, so it must
+				// still be validated here just like any other member type.
+				boolean genuineLocalType = sourceType.isLocalType() && !sourceType.isMemberType();
+				if (!sourceType.isRecord() && !genuineLocalType && !sourceType.isEnum() && !sourceType.isSealed())
 					problemReporter().disallowedNonSealedModifier(sourceType, this.referenceContext);
 			}
 		}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ClassScope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ClassScope.java
@@ -254,6 +254,11 @@ public class ClassScope extends Scope {
 		// build the binding or the local type
 		LocalTypeBinding localType = new LocalTypeBinding(this, enclosingType, enclosingSwitchLabel());
 		this.referenceContext.binding = localType;
+		// A local type declared as a member of another (local/anonymous) type is a member type (JLS 16 8.1.3);
+		// mark it as such up-front so that checkAndSetModifiers() classifies it correctly. Such an inner class
+		// may declare and inherit static members even though it is not itself static.
+		if (this.parent instanceof ClassScope)
+			localType.setAsMemberType();
 		checkAndSetModifiers();
 		buildTypeVariables();
 

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LocalStaticsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LocalStaticsTest.java
@@ -1807,7 +1807,7 @@ public class LocalStaticsTest extends AbstractRegressionTest {
 			"1. ERROR in X.java (at line 4)\n" +
 			"	static class Foo2 {}\n" +
 			"	             ^^^^\n" +
-			"The member type Foo2 cannot be declared static; static types can only be declared in static or top level types\n" +
+			"Illegal modifier for the local class Foo2; only abstract or final is permitted\n" +
 			"----------\n",
 			null,
 			true,

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LocalStaticsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LocalStaticsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020, 2021 IBM Corporation and others.
+ * Copyright (c) 2020, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -1730,5 +1730,87 @@ public class LocalStaticsTest extends AbstractRegressionTest {
 					"""
 				},
 			"OK!");
+	}
+	// JLS 16 8.1.3: an inner class (here an anonymous class) may declare static members.
+	public void testIssue2860StaticMembersInAnonymousClass() throws Exception {
+		runConformTest(
+			new String[] {
+					"X.java",
+					"""
+					public class X {
+					  public void m() {
+					    Object o = new Object() {
+					      private record Foo() {}
+					      private static class Foo2 {}
+					      private class Foo3 {}
+					      Foo f = new Foo();
+					      Foo2 f2 = new Foo2();
+					      Foo3 f3 = new Foo3();
+					    };
+					    System.out.println(o != null);
+					  }
+					  public static void main(String[] args) {
+					    new X().m();
+					  }
+					}
+					"""
+				},
+			"true");
+	}
+	// JLS 16 8.1.3: an inner class (here a named local class) may declare static members.
+	public void testIssue2860StaticMembersInLocalClass() throws Exception {
+		runConformTest(
+			new String[] {
+					"X.java",
+					"""
+					public class X {
+					  public void m() {
+					    class Local {
+					      private record Foo() {}
+					      private static class Foo2 {}
+					      private class Foo3 {}
+					      void use() {
+					        Foo f = new Foo();
+					        Foo2 f2 = new Foo2();
+					        Foo3 f3 = new Foo3();
+					        System.out.println(f != null && f2 != null && f3 != null);
+					      }
+					    }
+					    new Local().use();
+					  }
+					  public static void main(String[] args) {
+					    new X().m();
+					  }
+					}
+					"""
+				},
+			"true");
+	}
+	// A static class member of a local/anonymous class is illegal before source 16.
+	public void testIssue2860StaticMembersInLocalClassPre16() throws Exception {
+		Map<String, String> options = getCompilerOptions();
+		options.put(CompilerOptions.OPTION_Compliance, CompilerOptions.VERSION_15);
+		options.put(CompilerOptions.OPTION_Source, CompilerOptions.VERSION_15);
+		options.put(CompilerOptions.OPTION_TargetPlatform, CompilerOptions.VERSION_15);
+		this.runNegativeTest(
+			new String[] {
+					"X.java",
+					"public class X {\n"+
+					"  public void m() {\n"+
+					"    class Local {\n"+
+					"      static class Foo2 {}\n"+
+					"    }\n"+
+					"  }\n"+
+					"}\n"
+				},
+			"----------\n" +
+			"1. ERROR in X.java (at line 4)\n" +
+			"	static class Foo2 {}\n" +
+			"	             ^^^^\n" +
+			"The member type Foo2 cannot be declared static; static types can only be declared in static or top level types\n" +
+			"----------\n",
+			null,
+			true,
+			options);
 	}
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SealedTypesTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SealedTypesTests.java
@@ -6542,4 +6542,315 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 		runner.javacTestOptions = JavacHasABug.JavacBug8343306;
 		runner.runNegativeTest();
 	}
+
+	public void testNonSealedGenericLocalClassInRecord() {
+		Runner runner = new Runner();
+		runner.testFiles = new String[] {
+				"X.java",
+				"""
+				record R(int x) {
+				    void m() {
+				        non-sealed class Local<T> {}
+				    }
+				}
+				public class X {}
+				"""};
+		runner.expectedCompilerLog =
+				"""
+				----------
+				1. ERROR in X.java (at line 3)
+					non-sealed class Local<T> {}
+					                 ^^^^^
+				Illegal modifier for the local class Local; only abstract or final is permitted
+				----------
+				""";
+		runner.runNegativeTest();
+	}
+
+	public void testNonSealedGenericMemberClassOfLocalInRecord() {
+		Runner runner = new Runner();
+		runner.testFiles = new String[] {
+				"X.java",
+				"""
+				record R(int x) {
+				    void m() {
+				        class Outer {
+				            non-sealed class Local<T> {}
+				        }
+				    }
+				}
+				public class X {}
+				"""};
+		runner.expectedCompilerLog =
+				"""
+				----------
+				1. ERROR in X.java (at line 4)
+					non-sealed class Local<T> {}
+					                 ^^^^^
+				The non-sealed class Local must have a sealed direct supertype
+				----------
+				""";
+		runner.runNegativeTest();
+	}
+
+
+	// record + non-generic + direct-local
+	public void testNonSealedLocalClassInRecord() {
+		Runner runner = new Runner();
+		runner.testFiles = new String[] {
+				"X.java",
+				"""
+				record R(int x) {
+				    void m() {
+				        non-sealed class Local {}
+				    }
+				}
+				public class X {}
+				"""};
+		runner.expectedCompilerLog =
+				"""
+				----------
+				1. ERROR in X.java (at line 3)
+					non-sealed class Local {}
+					                 ^^^^^
+				Illegal modifier for the local class Local; only abstract or final is permitted
+				----------
+				""";
+		runner.runNegativeTest();
+	}
+
+	// record + non-generic + member-of-local
+	public void testNonSealedMemberClassOfLocalInRecord() {
+		Runner runner = new Runner();
+		runner.testFiles = new String[] {
+				"X.java",
+				"""
+				record R(int x) {
+				    void m() {
+				        class Outer {
+				            non-sealed class Local {}
+				        }
+				    }
+				}
+				public class X {}
+				"""};
+		runner.expectedCompilerLog =
+				"""
+				----------
+				1. ERROR in X.java (at line 4)
+					non-sealed class Local {}
+					                 ^^^^^
+				The non-sealed class Local must have a sealed direct supertype
+				----------
+				""";
+		runner.runNegativeTest();
+	}
+
+	// class + generic + direct-local
+	public void testNonSealedGenericLocalClassInClass() {
+		Runner runner = new Runner();
+		runner.testFiles = new String[] {
+				"X.java",
+				"""
+				public class X {
+				    void m() {
+				        non-sealed class Local<T> {}
+				    }
+				}
+				"""};
+		runner.expectedCompilerLog =
+				"""
+				----------
+				1. ERROR in X.java (at line 3)
+					non-sealed class Local<T> {}
+					                 ^^^^^
+				Illegal modifier for the local class Local; only abstract or final is permitted
+				----------
+				""";
+		runner.runNegativeTest();
+	}
+
+	// class + non-generic + direct-local
+	public void testNonSealedLocalClassInClass() {
+		Runner runner = new Runner();
+		runner.testFiles = new String[] {
+				"X.java",
+				"""
+				public class X {
+				    void m() {
+				        non-sealed class Local {}
+				    }
+				}
+				"""};
+		runner.expectedCompilerLog =
+				"""
+				----------
+				1. ERROR in X.java (at line 3)
+					non-sealed class Local {}
+					                 ^^^^^
+				Illegal modifier for the local class Local; only abstract or final is permitted
+				----------
+				""";
+		runner.runNegativeTest();
+	}
+
+	// class + generic + member-of-local
+	public void testNonSealedGenericMemberClassOfLocalInClass() {
+		Runner runner = new Runner();
+		runner.testFiles = new String[] {
+				"X.java",
+				"""
+				public class X {
+				    void m() {
+				        class Outer {
+				            non-sealed class Local<T> {}
+				        }
+				    }
+				}
+				"""};
+		runner.expectedCompilerLog =
+				"""
+				----------
+				1. ERROR in X.java (at line 4)
+					non-sealed class Local<T> {}
+					                 ^^^^^
+				The non-sealed class Local must have a sealed direct supertype
+				----------
+				""";
+		runner.runNegativeTest();
+	}
+
+	// class + non-generic + member-of-local
+	public void testNonSealedMemberClassOfLocalInClass() {
+		Runner runner = new Runner();
+		runner.testFiles = new String[] {
+				"X.java",
+				"""
+				public class X {
+				    void m() {
+				        class Outer {
+				            non-sealed class Local {}
+				        }
+				    }
+				}
+				"""};
+		runner.expectedCompilerLog =
+				"""
+				----------
+				1. ERROR in X.java (at line 4)
+					non-sealed class Local {}
+					                 ^^^^^
+				The non-sealed class Local must have a sealed direct supertype
+				----------
+				""";
+		runner.runNegativeTest();
+	}
+
+	// enum + generic + direct-local
+	public void testNonSealedGenericLocalClassInEnum() {
+		Runner runner = new Runner();
+		runner.testFiles = new String[] {
+				"X.java",
+				"""
+				enum E {
+				    A, B;
+				    void m() {
+				        non-sealed class Local<T> {}
+				    }
+				}
+				public class X {}
+				"""};
+		runner.expectedCompilerLog =
+				"""
+				----------
+				1. ERROR in X.java (at line 4)
+					non-sealed class Local<T> {}
+					                 ^^^^^
+				Illegal modifier for the local class Local; only abstract or final is permitted
+				----------
+				""";
+		runner.runNegativeTest();
+	}
+
+	// enum + non-generic + direct-local
+	public void testNonSealedLocalClassInEnum() {
+		Runner runner = new Runner();
+		runner.testFiles = new String[] {
+				"X.java",
+				"""
+				enum E {
+				    A, B;
+				    void m() {
+				        non-sealed class Local {}
+				    }
+				}
+				public class X {}
+				"""};
+		runner.expectedCompilerLog =
+				"""
+				----------
+				1. ERROR in X.java (at line 4)
+					non-sealed class Local {}
+					                 ^^^^^
+				Illegal modifier for the local class Local; only abstract or final is permitted
+				----------
+				""";
+		runner.runNegativeTest();
+	}
+
+	// enum + generic + member-of-local
+	public void testNonSealedGenericMemberClassOfLocalInEnum() {
+		Runner runner = new Runner();
+		runner.testFiles = new String[] {
+				"X.java",
+				"""
+				enum E {
+				    A, B;
+				    void m() {
+				        class Outer {
+				            non-sealed class Local<T> {}
+				        }
+				    }
+				}
+				public class X {}
+				"""};
+		runner.expectedCompilerLog =
+				"""
+				----------
+				1. ERROR in X.java (at line 5)
+					non-sealed class Local<T> {}
+					                 ^^^^^
+				The non-sealed class Local must have a sealed direct supertype
+				----------
+				""";
+		runner.runNegativeTest();
+	}
+
+	// enum + non-generic + member-of-local
+	public void testNonSealedMemberClassOfLocalInEnum() {
+		Runner runner = new Runner();
+		runner.testFiles = new String[] {
+				"X.java",
+				"""
+				enum E {
+				    A, B;
+				    void m() {
+				        class Outer {
+				            non-sealed class Local {}
+				        }
+				    }
+				}
+				public class X {}
+				"""};
+		runner.expectedCompilerLog =
+				"""
+				----------
+				1. ERROR in X.java (at line 5)
+					non-sealed class Local {}
+					                 ^^^^^
+				The non-sealed class Local must have a sealed direct supertype
+				----------
+				""";
+		runner.runNegativeTest();
+	}
 }


### PR DESCRIPTION
## What it does
fixes #2860

jls 16 onwards an inner class may declare and inherit static members ([§8.2](https://docs.oracle.com/javase/specs/jls/se16/html/jls-8.html#jls-8.2)), and declare static initializers ([§8.7](https://docs.oracle.com/javase/specs/jls/se16/html/jls-8.html#jls-8.7)), even though the inner class itself is not static

## How to test
junits are provided.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
