### PR TITLE
Propagate undefined array downward projections #5202

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ArrayBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ArrayBinding.java
@@ -212,6 +212,8 @@ public ArrayBinding upwardsProjection(Scope scope, TypeBinding[] mentionedTypeVa
 @Override
 public ArrayBinding downwardsProjection(Scope scope, TypeBinding[] mentionedTypeVariables) {
 	TypeBinding leafType = this.leafComponentType.downwardsProjection(scope, mentionedTypeVariables);
+	if (leafType == null)
+		return null;
 	return scope.environment().createArrayType(leafType, this.dimensions, this.typeAnnotations);
 }
 

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JEP286Test.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JEP286Test.java
@@ -1465,4 +1465,28 @@ public void testIssue600_4() {
 			+ "'var' cannot be used with type arguments\n"
 			+ "----------\n");
 }
+public void testIssue5202ArrayDownwardsProjection() {
+	this.runConformTest(
+		new String[] {
+			"ProjectedArrayType.java",
+			"""
+			class ProjectedArrayType {
+				interface Slot<T> {}
+				interface Message<T> {}
+				static class Reading {}
+
+				Slot<? extends Reading> readings;
+
+				<Element> Message<? super Element[]> expose(Slot<Element> source) {
+					return null;
+				}
+
+				void inspectProjection() {
+					var projected = expose(this.readings);
+					projected.toString();
+				}
+			}
+			"""
+		});
+}
 }


### PR DESCRIPTION
## What it does

Fixes #5202.

During local variable type inference, a `var` initializer can pass a captured generic value to a generic method whose return type contains an array of the inferred type. The regression uses independently designed `Slot`, `Message`, and `Reading` types: a `Slot<? extends Reading>` is passed to `<Element> Message<? super Element[]> expose(Slot<Element>)`.

A `var` declaration cannot expose JDT's internal captured type. JDT computes a _downward projection_, which is the source-representable type used in its place. For an array, `ArrayBinding.downwardsProjection(...)` first projects the leaf type and then rebuilds the array. The leaf in this input has no valid downward projection, so its projection returns `null`. The old code passed that `null` to `LookupEnvironment.createArrayType(...)` and threw `NullPointerException`.

The change returns `null` before array construction when the leaf projection is unavailable. The enclosing parameterized-type projection already handles that result by using an unbounded wildcard. When the leaf projection exists, the code creates the projected array and preserves its dimensions and type annotations.

The new conforming regression verifies that the independently designed `var` declaration compiles and that the projected value remains usable. Defined array projections keep their existing behavior. There is no public API change.

## How to test

- Before the fix, `testIssue5202ArrayDownwardsProjection` fails in `ArrayBinding.downwardsProjection(...)` while calling `createArrayType(null)`.
- Run the focused JEP 286 suite: 165 tests pass.
- The combined focused `JEP286Test`, `GenericsRegressionTest_1_8`, and `NestedLambdaInferenceTest` gate passes 6,586 tests with no failures, errors, or skipped tests.
- As separate reference validation, compile [TestBadArray.java](https://github.com/openjdk/jdk/blob/be40b6bcdab37368ea3c769e575b36e290d0c6a1/test/langtools/tools/javac/lvti/TestBadArray.java) from the pinned [OpenJDK](https://github.com/openjdk/jdk) corpus with the exact combined executable compiler JAR: it exits 0 and generates one class file.
- Install the patched compiler, rebuild [Spoon](https://github.com/INRIA/spoon), and rebuild [StoneDetector](https://github.com/StoneDetector/StoneDetector). The original source completes with exit 0, AST 1/1, and an empty error file.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
