### PR TITLE
Avoid ClassCastException for array capture erasures #5204

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BoundSet.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BoundSet.java
@@ -111,27 +111,18 @@ class BoundSet {
 		// pre: this.subBounds != null
 		public TypeBinding[] upperBounds(boolean onlyProper, InferenceVariable variable) {
 			TypeBinding[] rights = new TypeBinding[this.subBounds.size()];
-			TypeBinding simpleUpper = null;
 			Iterator<TypeBound> it = this.subBounds.iterator();
 			long nullHints = variable.nullHints;
 			int i = 0;
 			while(it.hasNext()) {
 				TypeBinding right=it.next().right;
 				if (!onlyProper || right.isProperType(true)) {
-					if (right instanceof ReferenceBinding) {
-						rights[i++] = right;
-						nullHints |= right.tagBits & TagBits.AnnotationNullMASK;
-					} else {
-						if (simpleUpper != null)
-							return Binding.NO_TYPES; // shouldn't
-						simpleUpper = right;
-					}
+					rights[i++] = right;
+					nullHints |= right.tagBits & TagBits.AnnotationNullMASK;
 				}
 			}
 			if (i == 0)
-				return simpleUpper != null ? new TypeBinding[] { simpleUpper } : Binding.NO_TYPES;
-			if (i == 1 && simpleUpper != null)
-				return new TypeBinding[] { simpleUpper }; // no nullHints since not a reference type
+				return Binding.NO_TYPES;
 			if (i < rights.length)
 				System.arraycopy(rights, 0, rights=new TypeBinding[i], 0, i);
 			useNullHints(nullHints, rights, variable.environment);
@@ -1287,6 +1278,12 @@ class BoundSet {
 	private void allSuperPairsWithCommonGenericTypeRecursive(TypeBinding s, TypeBinding t, List<Pair<TypeBinding>> result, HashSet<Integer> visited) {
 		if (s == null || s.id == TypeIds.T_JavaLangObject || t == null || t.id == TypeIds.T_JavaLangObject)
 			return;
+		if (s.isArrayType() && t.isArrayType()) {
+			// Common generic supertypes of array types are found through their component types.
+			allSuperPairsWithCommonGenericTypeRecursive(
+					((ArrayBinding) s).elementsType(), ((ArrayBinding) t).elementsType(), result, visited);
+			return;
+		}
 		if (!visited.add(s.id))
 			return;
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BoundSet.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BoundSet.java
@@ -1279,9 +1279,13 @@ class BoundSet {
 		if (s == null || s.id == TypeIds.T_JavaLangObject || t == null || t.id == TypeIds.T_JavaLangObject)
 			return;
 		if (s.isArrayType() && t.isArrayType()) {
+			ArrayBinding sArray = (ArrayBinding) s;
+			ArrayBinding tArray = (ArrayBinding) t;
+			if (sArray.dimensions() != tArray.dimensions())
+				return;
 			// Common generic supertypes of array types are found through their component types.
 			allSuperPairsWithCommonGenericTypeRecursive(
-					((ArrayBinding) s).elementsType(), ((ArrayBinding) t).elementsType(), result, visited);
+					sArray.elementsType(), tArray.elementsType(), result, visited);
 			return;
 		}
 		if (!visited.add(s.id))

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/CaptureBinding18.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/CaptureBinding18.java
@@ -40,22 +40,25 @@ public class CaptureBinding18 extends CaptureBinding {
 	}
 
 	public boolean setUpperBounds(TypeBinding[] upperBounds, ReferenceBinding javaLangObject) {
-		this.upperBounds = upperBounds;
-		if (upperBounds.length > 0)
-			this.firstBound = upperBounds[0];
 		int numReferenceInterfaces = 0;
 		if (!isConsistentIntersection(upperBounds, InferenceContext18.SIMULATE_BUG_JDK_8026527))
 			return false;
+		ReferenceBinding newSuperclass = this.superclass;
 		for (TypeBinding aBound : upperBounds) {
 			if (aBound instanceof ReferenceBinding) {
-				if (this.superclass == null && aBound.isClass())
-					this.superclass = (ReferenceBinding) aBound;
+				if (newSuperclass == null && aBound.isClass())
+					newSuperclass = (ReferenceBinding) aBound;
 				else if (aBound.isInterface())
 					numReferenceInterfaces++;
 			} else if (TypeBinding.equalsEquals(aBound.leafComponentType(), this)) {
 				return false; // cycle detected
 			}
 		}
+		// Publish the new state only after all bounds have passed validation.
+		this.upperBounds = upperBounds;
+		if (upperBounds.length > 0)
+			this.firstBound = upperBounds[0];
+		this.superclass = newSuperclass;
 		this.superInterfaces = new ReferenceBinding[numReferenceInterfaces];
 		int idx = 0;
 		for (TypeBinding aBound : upperBounds) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/CaptureBinding18.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/CaptureBinding18.java
@@ -40,25 +40,22 @@ public class CaptureBinding18 extends CaptureBinding {
 	}
 
 	public boolean setUpperBounds(TypeBinding[] upperBounds, ReferenceBinding javaLangObject) {
+		this.upperBounds = upperBounds;
+		if (upperBounds.length > 0)
+			this.firstBound = upperBounds[0];
 		int numReferenceInterfaces = 0;
 		if (!isConsistentIntersection(upperBounds, InferenceContext18.SIMULATE_BUG_JDK_8026527))
 			return false;
-		ReferenceBinding newSuperclass = this.superclass;
 		for (TypeBinding aBound : upperBounds) {
 			if (aBound instanceof ReferenceBinding) {
-				if (newSuperclass == null && aBound.isClass())
-					newSuperclass = (ReferenceBinding) aBound;
+				if (this.superclass == null && aBound.isClass())
+					this.superclass = (ReferenceBinding) aBound;
 				else if (aBound.isInterface())
 					numReferenceInterfaces++;
 			} else if (TypeBinding.equalsEquals(aBound.leafComponentType(), this)) {
 				return false; // cycle detected
 			}
 		}
-		// Publish the new state only after all bounds have passed validation.
-		this.upperBounds = upperBounds;
-		if (upperBounds.length > 0)
-			this.firstBound = upperBounds[0];
-		this.superclass = newSuperclass;
 		this.superInterfaces = new ReferenceBinding[numReferenceInterfaces];
 		int idx = 0;
 		for (TypeBinding aBound : upperBounds) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
@@ -2535,6 +2535,16 @@ public static boolean isConsistentIntersection(TypeBinding[] intersectingTypes, 
 		else
 			return false;
 	}
+	if (mostSpecific.isArrayType()) {
+		// Apart from array supertypes, an array subtype implements only Cloneable and Serializable.
+		for (TypeBinding intersectingType : intersectingTypes) {
+			if (intersectingType.isTypeVariable() || intersectingType.isWildcard()
+					|| !intersectingType.isProperType(true))
+				return false;
+			if (!mostSpecific.isCompatibleWith(intersectingType))
+				return false;
+		}
+	}
 	return true;
 }
 public ModuleBinding module() {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
@@ -2541,7 +2541,7 @@ public static boolean isConsistentIntersection(TypeBinding[] intersectingTypes, 
 			if (intersectingType.isTypeVariable() || intersectingType.isWildcard()
 					|| !intersectingType.isProperType(true))
 				return false;
-			if (!mostSpecific.isCompatibleWith(intersectingType))
+			if (!mostSpecific.isSubtypeOf(intersectingType, simulatingBugJDK8026527))
 				return false;
 		}
 	}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_1_8.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_1_8.java
@@ -10964,4 +10964,85 @@ public void testBug508834_comment0() {
 			"The method bar(One<Inner<?>>) in the type Bug is not applicable for the arguments (One<Inner<X>>)\n" +
 			"----------\n");
 	}
+	public void testIssue5204CompatibleArrayUpperBound() {
+		runConformTest(
+			new String[] {
+				"ArrayBoundInference.java",
+				"""
+				import java.util.concurrent.atomic.AtomicReference;
+				import java.util.function.Function;
+				import java.util.function.UnaryOperator;
+
+				class ArrayBoundInference {
+					static <Bound, Selection extends Bound> Selection read(AtomicReference<Bound> reference) {
+						throw new AssertionError();
+					}
+
+					UnaryOperator<String>[] compatible(AtomicReference<Function<?, ?>[]> reference) {
+						return read(reference);
+					}
+
+					UnaryOperator<String>[][] compatibleMatrix(AtomicReference<Function<?, ?>[][]> reference) {
+						return read(reference);
+					}
+				}
+				"""
+			});
+	}
+	public void testIssue5204IncompatibleArrayUpperBound() {
+		runNegativeTest(
+			new String[] {
+				"IncompatibleArrayBoundInference.java",
+				"""
+				import java.util.concurrent.atomic.AtomicReference;
+				import java.util.function.Function;
+				import java.util.function.UnaryOperator;
+
+				class IncompatibleArrayBoundInference {
+					static <Bound, Selection extends Bound> Selection read(AtomicReference<Bound> reference) {
+						throw new AssertionError();
+					}
+
+					UnaryOperator<String> incompatible(AtomicReference<Function<?, ?>[]> reference) {
+						return read(reference);
+					}
+				}
+				"""
+			},
+			"""
+			----------
+			1. ERROR in IncompatibleArrayBoundInference.java (at line 11)
+				return read(reference);
+				       ^^^^^^^^^^^^^^^
+			Type mismatch: cannot convert from Function<?,?>[] to UnaryOperator<String>
+			----------
+			""");
+	}
+	public void testIssue5204RejectsUnresolvedCaptureAsArrayUpperBound() {
+		runNegativeTest(
+			new String[] {
+				"UnresolvedArrayBoundInference.java",
+				"""
+				import java.util.concurrent.atomic.AtomicReference;
+
+				class UnresolvedArrayBoundInference {
+					static <Bound, Selection extends Bound> Selection read(AtomicReference<Bound> reference) {
+						throw new AssertionError();
+					}
+
+					CharSequence[] incompatible(AtomicReference<? extends AutoCloseable> reference) {
+						return read(reference);
+					}
+				}
+				"""
+			},
+			"""
+			----------
+			1. ERROR in UnresolvedArrayBoundInference.java (at line 9)
+				return read(reference);
+				       ^^^^^^^^^^^^^^^
+			Type mismatch: cannot convert from capture#1-of ? extends AutoCloseable to CharSequence[]
+			----------
+			""");
+	}
 }


### PR DESCRIPTION
## What it does

Fixes #5204.

The OpenJDK regression test [`T8062977.java`](https://github.com/openjdk/jdk/blob/be40b6bcdab37368ea3c769e575b36e290d0c6a1/test/langtools/tools/javac/generics/inference/8062977/T8062977.java) contains both valid and invalid assignments. ECJ previously rejected two valid array assignments and threw `ClassCastException` while checking two invalid assignments.

The failure started during generic method inference. ECJ kept only one upper bound whose type was not a `ReferenceBinding`. This lost an additional array bound and made inference fall back to an invalid capture. `CaptureBinding18.erasure()` later tried to cast the array binding to `ReferenceBinding`.

This change:

- keeps every proper upper bound so greatest-lower-bound reduction can select a compatible array type;
- checks array component types when it looks for common generic supertypes;
- rejects an intersection when its array type is incompatible with another bound;
- updates a capture only after all new upper bounds pass validation.

The valid assignments now compile. The invalid assignments produce normal type-mismatch diagnostics without an internal compiler exception. There is no public API change.

## How to test

- Run `GenericsRegressionTest_1_8`: 5,652 tests pass with no failures or errors.
- Run `GenericsRegressionTest`, `JEP286Test`, and `LambdaExpressionsTest`: 10,152 tests pass with no failures or errors.
- The new conforming test covers compatible one-dimensional and two-dimensional array upper bounds.
- The new negative tests cover an incompatible scalar target and an unresolved capture requested as an array type. Both produce ordinary type-mismatch diagnostics without an internal compiler exception.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
