### PR TITLE
Fix nested lambda inference memory growth #5206

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LambdaExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LambdaExpression.java
@@ -47,6 +47,7 @@ package org.eclipse.jdt.internal.compiler.ast;
 
 import static org.eclipse.jdt.internal.compiler.ast.ExpressionContext.INVOCATION_CONTEXT;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -1116,12 +1117,64 @@ public class LambdaExpression extends FunctionalExpression implements IPolyExpre
 		if (copy != null) { // ==> syntax errors == null
 			if (copy.sourceStart != this.sourceStart || copy.sourceEnd != this.sourceEnd)
 				return null; // something wrong
-			copy.original = this;
+			shareInferenceCaches(copy);
 			copy.assistNode = this.assistNode;
 			copy.enclosingScope = this.enclosingScope;
 			copy.text = this.text; // discard redundant textual copy
 		}
 		return copy;
+	}
+
+	private void shareInferenceCaches(LambdaExpression copy) {
+		// A speculative copy can contain nested lambdas. Keep each nested copy linked to its
+		// source lambda when no enclosing lambda declares parameters, so overload checks can
+		// reuse the existing per-target inference cache without reusing parameter bindings.
+		List<CollectedLambda> sourceLambdas = collectLambdas(this);
+		List<CollectedLambda> copiedLambdas = collectLambdas(copy);
+		if (sourceLambdas.size() != copiedLambdas.size())
+			throw new CopyFailureException();
+		for (int i = 0; i < sourceLambdas.size(); i++) {
+			CollectedLambda source = sourceLambdas.get(i);
+			LambdaExpression sourceLambda = source.lambda();
+			LambdaExpression copiedLambda = copiedLambdas.get(i).lambda();
+			if (sourceLambda.sourceStart != copiedLambda.sourceStart || sourceLambda.sourceEnd != copiedLambda.sourceEnd)
+				throw new CopyFailureException();
+			if (!source.cacheShareable()) {
+				if (i == 0)
+					copiedLambda.original = this;
+				continue;
+			}
+			LambdaExpression originalLambda = sourceLambda.original;
+			copiedLambda.original = originalLambda;
+			if (originalLambda.copiesPerTargetType == null)
+				originalLambda.copiesPerTargetType = new HashMap<>();
+			sourceLambda.copiesPerTargetType = originalLambda.copiesPerTargetType;
+			copiedLambda.copiesPerTargetType = originalLambda.copiesPerTargetType;
+		}
+	}
+
+	private record CollectedLambda(LambdaExpression lambda, boolean cacheShareable) {}
+
+	private static List<CollectedLambda> collectLambdas(LambdaExpression root) {
+		List<CollectedLambda> lambdas = new ArrayList<>();
+		root.traverse(new ASTVisitor() {
+			private int parameterizedLambdaDepth;
+
+			@Override
+			public boolean visit(LambdaExpression lambda, BlockScope skope) {
+				if (lambda.arguments.length > 0)
+					this.parameterizedLambdaDepth++;
+				lambdas.add(new CollectedLambda(lambda, this.parameterizedLambdaDepth == 0));
+				return true;
+			}
+
+			@Override
+			public void endVisit(LambdaExpression lambda, BlockScope skope) {
+				if (lambda.arguments.length > 0)
+					this.parameterizedLambdaDepth--;
+			}
+		}, root.enclosingScope);
+		return lambdas;
 	}
 
 	public void returnsExpression(Expression expression, TypeBinding resultType) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LambdaExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LambdaExpression.java
@@ -986,9 +986,7 @@ public class LambdaExpression extends FunctionalExpression implements IPolyExpre
 					return null;
 
 				targetType = copy.expectedType; // possibly updated local types
-				if (this.copiesPerTargetType == null)
-					this.copiesPerTargetType = new HashMap<>();
-				this.copiesPerTargetType.put(targetType, copy);
+				this.copiesPerTargetType.put(targetType, copy); // copy() has linked this lambda to the original's cache
 			}
 			if (!requireExceptionAnalysis)
 				return copy;
@@ -1126,28 +1124,22 @@ public class LambdaExpression extends FunctionalExpression implements IPolyExpre
 	}
 
 	private void shareInferenceCaches(LambdaExpression copy) {
-		// A speculative copy can contain nested lambdas. Keep each nested copy linked to its
-		// source lambda when no enclosing lambda declares parameters, so overload checks can
-		// reuse the existing per-target inference cache without reusing parameter bindings.
-		// Both traversals start with their root and then visit nested lambdas in source order.
-		List<CollectedLambda> sourceLambdas = collectLambdas(this);
-		List<CollectedLambda> copiedLambdas = collectLambdas(copy);
+		// A speculative copy can contain nested lambdas. Link each collected lambda to its
+		// original lambda and share the per-target inference cache.
+		// A cache entry is a resolved lambda copy and owns its parameter bindings. Nested
+		// lambdas may use parameters from an enclosing lambda, so collectLambdas() stops
+		// below a lambda with parameters. Caches below that point stay local to the
+		// enclosing copy.
+		// Both traversals start at the root and visit nested lambdas in source order.
+		List<LambdaExpression> sourceLambdas = collectLambdas(this);
+		List<LambdaExpression> copiedLambdas = collectLambdas(copy);
 		if (sourceLambdas.size() != copiedLambdas.size())
 			throw new CopyFailureException();
 		for (int i = 0; i < sourceLambdas.size(); i++) {
-			CollectedLambda source = sourceLambdas.get(i);
-			LambdaExpression sourceLambda = source.lambda();
-			LambdaExpression copiedLambda = copiedLambdas.get(i).lambda();
+			LambdaExpression sourceLambda = sourceLambdas.get(i);
+			LambdaExpression copiedLambda = copiedLambdas.get(i);
 			if (sourceLambda.sourceStart != copiedLambda.sourceStart || sourceLambda.sourceEnd != copiedLambda.sourceEnd)
 				throw new CopyFailureException();
-			if (!source.cacheShareable()) {
-				// The root is the copy requested by the caller. Nested lambdas below a
-				// parameterized lambda are local sources for copies that use the enclosing
-				// copy's parameter bindings, so their inference caches stay in that context.
-				if (sourceLambda == this)
-					copiedLambda.original = this;
-				continue;
-			}
 			LambdaExpression originalLambda = sourceLambda.original;
 			copiedLambda.original = originalLambda;
 			if (originalLambda.copiesPerTargetType == null)
@@ -1157,25 +1149,13 @@ public class LambdaExpression extends FunctionalExpression implements IPolyExpre
 		}
 	}
 
-	private record CollectedLambda(LambdaExpression lambda, boolean cacheShareable) {}
-
-	private static List<CollectedLambda> collectLambdas(LambdaExpression root) {
-		List<CollectedLambda> lambdas = new ArrayList<>();
+	private static List<LambdaExpression> collectLambdas(LambdaExpression root) {
+		List<LambdaExpression> lambdas = new ArrayList<>();
 		root.traverse(new ASTVisitor() {
-			private int parameterizedLambdaDepth;
-
 			@Override
 			public boolean visit(LambdaExpression lambda, BlockScope skope) {
-				if (lambda.arguments.length > 0)
-					this.parameterizedLambdaDepth++;
-				lambdas.add(new CollectedLambda(lambda, this.parameterizedLambdaDepth == 0));
-				return true;
-			}
-
-			@Override
-			public void endVisit(LambdaExpression lambda, BlockScope skope) {
-				if (lambda.arguments.length > 0)
-					this.parameterizedLambdaDepth--;
+				lambdas.add(lambda);
+				return lambda.arguments.length == 0; // nested lambdas may use these parameters
 			}
 		}, root.enclosingScope);
 		return lambdas;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LambdaExpression.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/LambdaExpression.java
@@ -1129,6 +1129,7 @@ public class LambdaExpression extends FunctionalExpression implements IPolyExpre
 		// A speculative copy can contain nested lambdas. Keep each nested copy linked to its
 		// source lambda when no enclosing lambda declares parameters, so overload checks can
 		// reuse the existing per-target inference cache without reusing parameter bindings.
+		// Both traversals start with their root and then visit nested lambdas in source order.
 		List<CollectedLambda> sourceLambdas = collectLambdas(this);
 		List<CollectedLambda> copiedLambdas = collectLambdas(copy);
 		if (sourceLambdas.size() != copiedLambdas.size())
@@ -1140,7 +1141,10 @@ public class LambdaExpression extends FunctionalExpression implements IPolyExpre
 			if (sourceLambda.sourceStart != copiedLambda.sourceStart || sourceLambda.sourceEnd != copiedLambda.sourceEnd)
 				throw new CopyFailureException();
 			if (!source.cacheShareable()) {
-				if (i == 0)
+				// The root is the copy requested by the caller. Nested lambdas below a
+				// parameterized lambda are local sources for copies that use the enclosing
+				// copy's parameter bindings, so their inference caches stay in that context.
+				if (sourceLambda == this)
 					copiedLambda.original = this;
 				continue;
 			}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NestedLambdaInferenceTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NestedLambdaInferenceTest.java
@@ -1,0 +1,94 @@
+/*******************************************************************************
+ * Copyright (c) 2026 François Martin and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     François Martin - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.core.tests.compiler.regression;
+
+import junit.framework.Test;
+
+public class NestedLambdaInferenceTest extends AbstractRegressionTest {
+	private static final int NESTING_DEPTH = 24;
+
+	public NestedLambdaInferenceTest(String name) {
+		super(name);
+	}
+
+	public static Test suite() {
+		return buildMinimalComplianceTestSuite(NestedLambdaInferenceTest.class, F_1_8);
+	}
+
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5206
+	public void testIssue5206GenericRouteChain() {
+		runNestedLambdaTest("GenericRouteChain", """
+			<V extends Red> V route(Red marker, Work<V> work) { return null; }
+			<V extends Blue> V route(Blue marker, Work<V> work) { return null; }
+			<V extends Green> V route(Green marker, Work<V> work) { return null; }
+			<V extends Gold> V route(Gold marker, Work<V> work) { return null; }
+			<V> V route(Object marker, Work<V> work) { return null; }
+
+			<V extends Red> V select(Red marker, Work<V> work) { return null; }
+			<V extends Blue> V select(Blue marker, Work<V> work) { return null; }
+			<V extends Green> V select(Green marker, Work<V> work) { return null; }
+			<V extends Gold> V select(Gold marker, Work<V> work) { return null; }
+			<V> V select(Object marker, Work<V> work) { return null; }
+			""");
+	}
+
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5206
+	public void testIssue5206ConcreteRouteChain() {
+		runNestedLambdaTest("ConcreteRouteChain", """
+			String route(Red marker, Work<Red> work) { return ""; }
+			String route(Blue marker, Work<Blue> work) { return ""; }
+			String route(Green marker, Work<Green> work) { return ""; }
+			String route(Gold marker, Work<Gold> work) { return ""; }
+			String route(Object marker, Work<String> work) { return ""; }
+
+			String select(Red marker, Work<Red> work) { return ""; }
+			String select(Blue marker, Work<Blue> work) { return ""; }
+			String select(Green marker, Work<Green> work) { return ""; }
+			String select(Gold marker, Work<Gold> work) { return ""; }
+			String select(Object marker, Work<String> work) { return ""; }
+			""");
+	}
+
+	private void runNestedLambdaTest(String className, String overloads) {
+		this.runConformTest(new String[] {
+			className + ".java",
+			"""
+			class %s {
+			    interface Work<V> {
+			        V perform();
+			    }
+			    static final Work<String> TERMINAL = null;
+
+			    void test() {
+			        %s;
+			    }
+			    static class Red { }
+			    static class Blue { }
+			    static class Green { }
+			    static class Gold { }
+			%s
+			}
+			""".formatted(className, createNestedInvocation(), overloads.indent(4).stripTrailing())
+		});
+	}
+
+	private static String createNestedInvocation() {
+		String invocation = "route(null, TERMINAL)";
+		for (int level = 1; level < NESTING_DEPTH; level++) {
+			String selector = level % 2 == 0 ? "route" : "select";
+			invocation = selector + "(null, () -> " + invocation + ")";
+		}
+		return invocation;
+	}
+}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NestedLambdaInferenceTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NestedLambdaInferenceTest.java
@@ -60,6 +60,40 @@ public class NestedLambdaInferenceTest extends AbstractRegressionTest {
 			""");
 	}
 
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5206
+	public void testIssue5206InterleavedParameterizedLambdas() {
+		this.runConformTest(new String[] {
+			"InterleavedLambdas.java",
+			"""
+			public class InterleavedLambdas {
+			    interface Producer<T> {
+			        T produce();
+			    }
+			    interface Mapper<T, R> {
+			        R map(T value);
+			    }
+
+			    static <T> T produce(Producer<T> producer) {
+			        return producer.produce();
+			    }
+			    static <T, R> R map(T value, Mapper<T, R> mapper) {
+			        return mapper.map(value);
+			    }
+
+			    public static void main(String[] args) {
+			        String result = produce(() ->
+			            map("left", left ->
+			                produce(() ->
+			                    map(7, number -> left + number)))
+			            + produce(() -> "!"));
+			        System.out.print(result);
+			    }
+			}
+			"""
+		},
+		"left7!");
+	}
+
 	private void runNestedLambdaTest(String className, String overloads) {
 		this.runConformTest(new String[] {
 			className + ".java",

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TestAll.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TestAll.java
@@ -131,6 +131,7 @@ public static Test suite() {
 	standardTests.add(NullTypeAnnotationTest.class);
 	standardTests.add(NegativeLambdaExpressionsTest.class);
 	standardTests.add(LambdaExpressionsTest.class);
+	standardTests.add(NestedLambdaInferenceTest.class);
 	standardTests.add(LambdaRegressionTest.class);
 	standardTests.add(SerializableLambdaTest.class);
 	standardTests.add(OverloadResolutionTest8.class);


### PR DESCRIPTION
## What it does

Fixes #5206.

During _speculative overload resolution_, ECJ tries each overload candidate without committing to one. It reparses the outer lambda to create a separate copy for that candidate. Each source lambda stores inference results for the target functional-interface types against which ECJ has already tested it. The lambda from which a copy was made is its _original lambda_.

The outer speculative copy kept that source link, but nested lambdas inside the copy were treated as new originals. They therefore did not reuse the existing per-target results from their original lambdas. Repeating inference for every candidate at every nested level caused combinatorial memory growth and exhausted the heap.

The change links nested speculative copies to their original lambdas. On each branch, it shares the per-target inference cache down to and including the first lambda with parameters. A cache entry is a resolved copy of that lambda and owns its parameter bindings. Nested lambdas may use those bindings, so traversal stops below it and their caches stay local to the enclosing copy. No global cache or shared parser state is introduced.

The source lambda and the copy created by parsing the source again are traversed in the same source order. Each traversal records the current lambda, then stops below it when it has parameters. `shareInferenceCaches()` therefore receives only lambdas allowed by this parameter-binding rule, so no separate eligibility flag is needed.

The independently designed regression suite has three tests. Two generate a generic and a concrete source. Each source contains 24 nested method calls and 23 parameterless lambdas, alternates between `route` and `select`, provides five overload candidates for each selector, and ends at a `Work<String>` field. The two variants exercise the original missing cache reuse with different inference pressure.

The third test compiles and runs code that mixes lambdas with and without parameters. It includes a nested lambda that reads an enclosing parameter and a separate parameterless sibling. There is no public API change.

The linked [NestedLambdaGenerics.java](https://github.com/openjdk/jdk/blob/be40b6bcdab37368ea3c769e575b36e290d0c6a1/test/langtools/tools/javac/lambda/speculative/NestedLambdaGenerics.java) and [NestedLambdaNoGenerics.java](https://github.com/openjdk/jdk/blob/be40b6bcdab37368ea3c769e575b36e290d0c6a1/test/langtools/tools/javac/lambda/speculative/NestedLambdaNoGenerics.java) files provide separate reference validation for the reported behavior; they are not copied into the regression suite.

## How to test

- On unpatched JDT commit `792a9156c119d28063904c85726e486ec2fb2206`, compiling each linked OpenJDK source separately with `-25` and a 1 GiB heap reproduces #5206.
- With the compiler from this PR, the same commands exit 0 and generate six class files each, with no `OutOfMemoryError` or internal compiler error.
- Run `NestedLambdaInferenceTest` across Java 8 through Java 25 compliance levels: 54 tests pass.
- Run `GenericsRegressionTest_1_8` together with `NestedLambdaInferenceTest`: 5,670 tests pass, including the parameterized-lambda regression `testBug496578`.
- Run the full compiler suite (`parser/TestAll`, `regression/TestAll`, and `eval/TestAll`): 263,722 tests pass with no failures, errors, or skipped tests.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
