### PR TITLE
Regression tests for recent javac bugs.

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractRegressionTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractRegressionTest.java
@@ -1203,7 +1203,11 @@ protected static class JavacTestOptions {
 			JavacBug8365676 = // https://bugs.openjdk.org/browse/JDK-8365676
 					new JavacHasABug(MismatchType.EclipseErrorsJavacNone, ClassFileConstants.JDK26, 0000),
 			JavacBug8361641 = // https://bugs.openjdk.org/browse/JDK-8361641
-					new JavacHasABug(MismatchType.JavacErrorsEclipseNone, ClassFileConstants.JDK25, 0000);
+					new JavacHasABug(MismatchType.JavacErrorsEclipseNone, ClassFileConstants.JDK25, 0000),
+			JavacBug8383563 = // https://bugs.openjdk.org/browse/JDK-8383563
+					new JavacHasABug(MismatchType.JavacErrorsEclipseNone),
+			JavacBug8375572 = // https://bugs.openjdk.org/browse/JDK-8375572
+					new JavacHasABug(MismatchType.JavacErrorsEclipseNone);
 
 		// bugs that have been fixed but that we've not identified
 		public static JavacHasABug

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
@@ -2483,7 +2483,45 @@ public void testGH4893() throws Exception  {
 		"""
 	});
 }
+public void testJDK8375572() {
+	if (this.complianceLevel < ClassFileConstants.JDK16)
+		return;
+	Runner runner = new Runner();
+	runner.testFiles = new String[] { "MethodRefStuck3.java",
+			"""
+			class MethodRefStuck3 {
+				interface Interface<A> {
+					interface Factory<A extends Interface<B>,B> {
+						Interface<B> create(B obj);
+					}
+				}
 
+				record Klass(String value, int otherValue) implements Interface<String> {
+					public Klass(String thing) {
+						this(thing, -1);
+					}
+				}
+
+				interface InterfaceB<A extends Interface<B>,B> {}
+
+				record KlassB<A extends Interface<B>,B>(Class<A> cls, Interface.Factory<A,B> factory) implements InterfaceB<A,B> {}
+
+				private interface InterfaceC<A extends Interface<B>,B> {
+					InterfaceB<A,B> getInterfaceB();
+				}
+
+				private static class KlassC implements InterfaceC<Klass,String> {
+					@Override
+					public InterfaceB<Klass, String> getInterfaceB() {
+						return new KlassB<>(Klass.class, Klass::new);
+					}
+				}
+			}
+			"""
+		};
+	runner.javacTestOptions = JavacHasABug.JavacBug8375572;
+	runner.runConformTest();
+}
 public static Class<GenericsRegressionTest_9> testClass() {
 	return GenericsRegressionTest_9.class;
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordPatternTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RecordPatternTest.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.util.Map;
 import junit.framework.Test;
 import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.tests.compiler.regression.AbstractRegressionTest.JavacTestOptions.JavacHasABug;
 import org.eclipse.jdt.core.tests.util.Util;
 import org.eclipse.jdt.internal.compiler.batch.FileSystem;
 import org.eclipse.jdt.internal.compiler.env.INameEnvironment;
@@ -5084,5 +5085,23 @@ public class RecordPatternTest extends AbstractRegressionTest9 {
 			"Record component with type Integer is not compatible with type String\n" +
 			"----------\n");
 	}
-
+	public void testJDK8383563() {
+		Runner runner = new Runner();
+		runner.testFiles = new String[] { "PairBox.java",
+			"""
+			interface PairI<A, B> {}
+			record PairBox<A, B>(A a, B b) implements PairI<A, B> {
+				int selfSuperInference(PairI<A, B> p) {
+					if (p instanceof PairBox(var a, var b)) {
+						A aa = a;
+						B bb = b;
+						return 1;
+					}
+					return -1;
+				}
+			}
+			"""};
+		runner.javacTestOptions = JavacHasABug.JavacBug8383563;
+		runner.runConformTest();
+	}
 }


### PR DESCRIPTION
Covers:
* https://bugs.openjdk.org/browse/JDK-8383563
* https://bugs.openjdk.org/browse/JDK-8375572

Both tests are accepted by ecj.