### PR TITLE
BatchCompilerTest.test017d() fails on Windows

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/BatchCompilerTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/BatchCompilerTest.java
@@ -1452,7 +1452,7 @@ public void test017d(){
 		new Matcher() {
 			@Override
 			boolean match(String effective) {
-				lines: for (String line : effective.split("\n")) {
+				lines: for (String line : effective.replace("\r\n", "\n").split("\n")) {
 					if (line.startsWith("File provided via -endorseddirs is not a valid jar:")) {
 						for (String suffix : new String[] {"test017dout.txt", "test017derr.txt", "not.zip"} ) {
 							if (line.endsWith(suffix))


### PR DESCRIPTION
+ normalize line ends before comparison

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5211
