### PR TITLE
Pathological regex triggering catastrophic backtracking 

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AllJavaModelTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AllJavaModelTests.java
@@ -73,6 +73,9 @@ private static Class[] getAllTestClasses() {
 
 		IndexManagerTests.class,
 
+		// Regex ReDoS protection in the search index
+		IndexReDoSTest.class,
+
 		// Tests for the new index - disabled because the index is not used anymore
 		// See bug 572976 and bug 544898
 		// RunIndexTests.class,

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/IndexReDoSTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/IndexReDoSTest.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.jdt.core.tests.model;
 
+import java.io.File;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -23,6 +24,8 @@ import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
 import org.eclipse.jdt.core.search.SearchPattern;
+import org.eclipse.jdt.internal.core.index.EntryResult;
+import org.eclipse.jdt.internal.core.index.FileIndexLocation;
 import org.eclipse.jdt.internal.core.index.Index;
 
 /**
@@ -42,6 +45,14 @@ import org.eclipse.jdt.internal.core.index.Index;
  * treating a timeout as a non-match. Invalid patterns are likewise treated as a non-match
  * instead of propagating a {@link java.util.regex.PatternSyntaxException}. These tests verify
  * that behaviour.
+ * </p>
+ * <p>
+ * There are two regex-matching paths in the index, both of which must be protected: the direct
+ * {@link Index#isMatch(char[], char[], int)} entry point, and the dedicated
+ * {@code R_REGEXP_MATCH} case in {@code DiskIndex.addQueryResults}, which is the path actually
+ * taken by the real {@link org.eclipse.jdt.core.search.SearchEngine} query flow
+ * ({@code Index.query} &rarr; {@code DiskIndex.addQueryResults}). The final test exercises the
+ * disk-query path end-to-end.
  * </p>
  *
  * @see Index#isMatch(char[], char[], int)
@@ -190,6 +201,167 @@ public class IndexReDoSTest extends TestCase {
 		} catch (java.util.regex.PatternSyntaxException e) {
 			fail("Invalid regex should be handled gracefully, but PatternSyntaxException propagated: "
 					+ e.getMessage());
+		}
+	}
+
+	// ---------------------------------------------------------------------------------------------
+	// Coverage for the non-regex branches of Index.isMatch. These match rules are unaffected by the
+	// ReDoS change, but are included so that every path of isMatch has a direct unit test.
+	// ---------------------------------------------------------------------------------------------
+
+	/** {@code pattern == null} is treated as "match anything". */
+	public void testNullPatternMatchesAnything() {
+		assertTrue(Index.isMatch(null, "anything".toCharArray(), SearchPattern.R_EXACT_MATCH));
+	}
+
+	/** An empty pattern matches for any rule except exact match. */
+	public void testEmptyPatternGuards() {
+		char[] word = "abc".toCharArray();
+		assertFalse("Empty pattern must not exact-match",
+				Index.isMatch(new char[0], word, SearchPattern.R_EXACT_MATCH));
+		assertTrue("Empty pattern is a wildcard for prefix match",
+				Index.isMatch(new char[0], word, SearchPattern.R_PREFIX_MATCH));
+	}
+
+	/** An empty word only matches the pattern-match wildcard {@code "*"}. */
+	public void testEmptyWordGuards() {
+		char[] emptyWord = new char[0];
+		assertTrue("'*' pattern-matches the empty word",
+				Index.isMatch("*".toCharArray(), emptyWord, SearchPattern.R_PATTERN_MATCH));
+		assertFalse("A non-'*' pattern does not match the empty word",
+				Index.isMatch("x".toCharArray(), emptyWord, SearchPattern.R_PATTERN_MATCH));
+	}
+
+	/** {@code R_SUBSTRING_MATCH} pre-filter (case-insensitive contains). */
+	public void testSubstringMatch() {
+		assertTrue(Index.isMatch("array".toCharArray(), "myArrayList".toCharArray(),
+				SearchPattern.R_SUBSTRING_MATCH));
+		assertFalse(Index.isMatch("zzz".toCharArray(), "myArrayList".toCharArray(),
+				SearchPattern.R_SUBSTRING_MATCH));
+	}
+
+	/** {@code R_SUBWORD_MATCH} pre-filter (case-insensitive subword). */
+	public void testSubwordMatch() {
+		assertTrue(Index.isMatch("list".toCharArray(), "myArrayList".toCharArray(),
+				SearchPattern.R_SUBWORD_MATCH));
+	}
+
+	/** {@code R_EXACT_MATCH} (case-insensitive). */
+	public void testExactMatchCaseInsensitive() {
+		assertTrue(Index.isMatch("arraylist".toCharArray(), "ArrayList".toCharArray(),
+				SearchPattern.R_EXACT_MATCH));
+		assertFalse(Index.isMatch("arraylists".toCharArray(), "ArrayList".toCharArray(),
+				SearchPattern.R_EXACT_MATCH));
+	}
+
+	/** {@code R_PREFIX_MATCH} (case-insensitive). */
+	public void testPrefixMatchCaseInsensitive() {
+		assertTrue(Index.isMatch("array".toCharArray(), "ArrayList".toCharArray(),
+				SearchPattern.R_PREFIX_MATCH));
+		assertFalse(Index.isMatch("list".toCharArray(), "ArrayList".toCharArray(),
+				SearchPattern.R_PREFIX_MATCH));
+	}
+
+	/** {@code R_PATTERN_MATCH} (wildcards, case-insensitive). */
+	public void testPatternMatchCaseInsensitive() {
+		assertTrue(Index.isMatch("array*".toCharArray(), "ArrayList".toCharArray(),
+				SearchPattern.R_PATTERN_MATCH));
+		assertFalse(Index.isMatch("xyz*".toCharArray(), "ArrayList".toCharArray(),
+				SearchPattern.R_PATTERN_MATCH));
+	}
+
+	/** {@code R_CAMELCASE_MATCH}. */
+	public void testCamelCaseMatch() {
+		assertTrue(Index.isMatch("NPE".toCharArray(), "NullPointerException".toCharArray(),
+				SearchPattern.R_CAMELCASE_MATCH));
+	}
+
+	/** {@code R_EXACT_MATCH | R_CASE_SENSITIVE}. */
+	public void testExactMatchCaseSensitive() {
+		int rule = SearchPattern.R_EXACT_MATCH | SearchPattern.R_CASE_SENSITIVE;
+		assertTrue(Index.isMatch("ArrayList".toCharArray(), "ArrayList".toCharArray(), rule));
+		assertFalse(Index.isMatch("arrayList".toCharArray(), "ArrayList".toCharArray(), rule));
+	}
+
+	/** {@code R_PREFIX_MATCH | R_CASE_SENSITIVE}. */
+	public void testPrefixMatchCaseSensitive() {
+		int rule = SearchPattern.R_PREFIX_MATCH | SearchPattern.R_CASE_SENSITIVE;
+		assertTrue(Index.isMatch("Array".toCharArray(), "ArrayList".toCharArray(), rule));
+		assertFalse(Index.isMatch("array".toCharArray(), "ArrayList".toCharArray(), rule));
+	}
+
+	/** {@code R_PATTERN_MATCH | R_CASE_SENSITIVE}. */
+	public void testPatternMatchCaseSensitive() {
+		int rule = SearchPattern.R_PATTERN_MATCH | SearchPattern.R_CASE_SENSITIVE;
+		assertTrue(Index.isMatch("Array*".toCharArray(), "ArrayList".toCharArray(), rule));
+		assertFalse(Index.isMatch("array*".toCharArray(), "ArrayList".toCharArray(), rule));
+	}
+
+	/** {@code R_CAMELCASE_MATCH | R_CASE_SENSITIVE}. */
+	public void testCamelCaseMatchCaseSensitive() {
+		int rule = SearchPattern.R_CAMELCASE_MATCH | SearchPattern.R_CASE_SENSITIVE;
+		assertTrue(Index.isMatch("NPE".toCharArray(), "NullPointerException".toCharArray(), rule));
+		assertFalse(Index.isMatch("nPE".toCharArray(), "NullPointerException".toCharArray(), rule));
+	}
+
+	/**
+	 * Exercises the <em>real</em> query path used by {@link org.eclipse.jdt.core.search.SearchEngine}:
+	 * {@code Index.query} &rarr; {@code DiskIndex.addQueryResults}, which has its own dedicated
+	 * {@code R_REGEXP_MATCH} case separate from {@link Index#isMatch(char[], char[], int)}.
+	 * <p>
+	 * A real on-disk index is populated with a word that would trigger catastrophic backtracking,
+	 * then queried with the pathological pattern {@code (a+)+$}. The query must complete within the
+	 * time budget rather than hanging, proving the disk-query path is also ReDoS-protected.
+	 * </p>
+	 */
+	public void testReDoSViaDiskIndexQueryPath() throws Exception {
+		File indexFile = File.createTempFile("redos", ".index"); //$NON-NLS-1$ //$NON-NLS-2$
+		indexFile.delete(); // let the Index create a fresh file
+		indexFile.deleteOnExit();
+
+		char[] category = "typeDecl".toCharArray(); //$NON-NLS-1$
+
+		// Word stored in the index: 40 'a' characters followed by '!' (non-matching tail).
+		StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < 40; i++) {
+			sb.append('a');
+		}
+		sb.append('!');
+		char[] word = sb.toString().toCharArray();
+		char[] pattern = "(a+)+$".toCharArray(); //$NON-NLS-1$
+
+		Index index = new Index(new FileIndexLocation(indexFile), indexFile.getPath(), false);
+		index.addIndexEntry(category, word, "Foo.java"); //$NON-NLS-1$
+		index.save(); // merge into the disk index so the query hits DiskIndex.addQueryResults
+
+		ExecutorService executor = Executors.newSingleThreadExecutor();
+		try {
+			Future<EntryResult[]> future = executor.submit(() -> {
+				index.startQuery();
+				try {
+					return index.query(new char[][] { category }, pattern, SearchPattern.R_REGEXP_MATCH);
+				} finally {
+					index.stopQuery();
+				}
+			});
+
+			try {
+				future.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+				// Completing at all (without timing out) proves the disk-query path is guarded.
+			} catch (TimeoutException e) {
+				future.cancel(true);
+				fail("ReDoS vulnerability detected on the DiskIndex query path: a search with " +
+					"pathological regex '(a+)+$' did not complete within " + TIMEOUT_SECONDS +
+					" seconds. DiskIndex.addQueryResults must also route through the ReDoS guard.");
+			} catch (ExecutionException e) {
+				fail("Unexpected exception during disk-index query: " + e.getCause().getMessage());
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				fail("Test interrupted");
+			}
+		} finally {
+			executor.shutdownNow();
+			indexFile.delete();
 		}
 	}
 }

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/IndexReDoSTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/IndexReDoSTest.java
@@ -1,0 +1,195 @@
+/*******************************************************************************
+ * Copyright (c) 2026 IBM Corporation and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.core.tests.model;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+import org.eclipse.jdt.core.search.SearchPattern;
+import org.eclipse.jdt.internal.core.index.Index;
+
+/**
+ * Tests for the ReDoS (Regular Expression Denial of Service) protection in
+ * {@link Index#isMatch(char[], char[], int)} and related regex matching code.
+ * <p>
+ * The JDT search index uses {@link java.util.regex.Pattern} to compile and match
+ * user-supplied regex patterns against index entries when {@link SearchPattern#R_REGEXP_MATCH}
+ * is used. Since Java's regex engine uses backtracking (NFA-based), pathological
+ * patterns like {@code (a+)+$} can cause catastrophic backtracking, consuming
+ * 100% CPU and effectively creating a Denial of Service condition.
+ * </p>
+ * <p>
+ * {@code Index.isMatch} guards against this by wrapping the input in a deadline-checking
+ * {@code CharSequence} that aborts a runaway match after a bounded time budget
+ * (configurable via the {@code jdt.core.index.regexpMatchTimeoutMillis} system property),
+ * treating a timeout as a non-match. Invalid patterns are likewise treated as a non-match
+ * instead of propagating a {@link java.util.regex.PatternSyntaxException}. These tests verify
+ * that behaviour.
+ * </p>
+ *
+ * @see Index#isMatch(char[], char[], int)
+ */
+public class IndexReDoSTest extends TestCase {
+
+	private static final int TIMEOUT_SECONDS = 5;
+
+	public static Test suite() {
+		return new TestSuite(IndexReDoSTest.class);
+	}
+
+	public IndexReDoSTest(String name) {
+		super(name);
+	}
+
+	/**
+	 * Demonstrates that a normal regex match completes quickly.
+	 * This is the baseline — no ReDoS, normal behavior.
+	 */
+	public void testNormalRegexMatchCompletes() {
+		char[] pattern = "module\\..*".toCharArray();
+		char[] word = "module.java.base".toCharArray();
+
+		boolean result = Index.isMatch(pattern, word, SearchPattern.R_REGEXP_MATCH);
+		assertTrue("Normal regex should match", result);
+	}
+
+	/**
+	 * Demonstrates that a non-matching normal regex also completes quickly.
+	 */
+	public void testNormalRegexNonMatchCompletes() {
+		char[] pattern = "module\\.foo.*".toCharArray();
+		char[] word = "module.java.base".toCharArray();
+
+		boolean result = Index.isMatch(pattern, word, SearchPattern.R_REGEXP_MATCH);
+		assertFalse("Non-matching regex should return false", result);
+	}
+
+	/**
+	 * Verifies that the pathological regex {@code (a+)+$} matched against a string of
+	 * 'a' characters followed by a non-matching character does NOT cause catastrophic
+	 * backtracking. Without the ReDoS guard this would take minutes/hours (O(2^n)); with
+	 * the guard it aborts within the configured time budget and returns {@code false}.
+	 *
+	 * @see <a href="https://owasp.org/www-community/attacks/Regular_expression_Denial_of_Service_-_ReDoS">OWASP ReDoS</a>
+	 */
+	public void testReDoSWithCatastrophicBacktracking() {
+		// Pathological regex pattern: nested quantifiers cause exponential backtracking
+		char[] pattern = "(a+)+$".toCharArray();
+
+		// Input: 40 'a' characters followed by '!' (a non-matching tail).
+		// Without protection the engine would try 2^40 combinations before failing.
+		StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < 40; i++) {
+			sb.append('a');
+		}
+		sb.append('!');
+		char[] word = sb.toString().toCharArray();
+
+		// Run the match in a separate thread with a timeout
+		ExecutorService executor = Executors.newSingleThreadExecutor();
+		try {
+			Future<Boolean> future = executor.submit(() ->
+				Index.isMatch(pattern, word, SearchPattern.R_REGEXP_MATCH)
+			);
+
+			try {
+				Boolean result = future.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+				// The guard aborts the runaway match and reports a non-match.
+				assertFalse("Pathological pattern must report a non-match", result.booleanValue());
+			} catch (TimeoutException e) {
+				future.cancel(true);
+				fail("ReDoS vulnerability detected: Index.isMatch with pathological regex " +
+					"'(a+)+$' did not complete within " + TIMEOUT_SECONDS + " seconds. " +
+					"A caller can cause Denial of Service by supplying a pathological regex pattern " +
+					"via SearchPattern.R_REGEXP_MATCH. The regex engine's backtracking causes " +
+					"exponential time complexity (O(2^n)) on non-matching inputs.");
+			} catch (ExecutionException e) {
+				// Unexpected exception during matching
+				fail("Unexpected exception during regex match: " + e.getCause().getMessage());
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				fail("Test interrupted");
+			}
+		} finally {
+			executor.shutdownNow();
+		}
+	}
+
+	/**
+	 * Another ReDoS variant using a different pathological pattern.
+	 * The pattern {@code (.*a){20}} causes catastrophic backtracking when
+	 * the input has many 'a' characters but doesn't fully match. The guard
+	 * must abort within the time budget and return {@code false}.
+	 */
+	public void testReDoSWithNestedWildcard() {
+		// Pathological regex: repeated greedy wildcard
+		char[] pattern = "(.*a){20}".toCharArray();
+
+		// Input that partially matches: enough 'a' characters to be ambiguous
+		StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < 20; i++) {
+			sb.append("aXa");
+		}
+		sb.append('!');
+		char[] word = sb.toString().toCharArray();
+
+		ExecutorService executor = Executors.newSingleThreadExecutor();
+		try {
+			Future<Boolean> future = executor.submit(() ->
+				Index.isMatch(pattern, word, SearchPattern.R_REGEXP_MATCH)
+			);
+
+			try {
+				Boolean result = future.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+				assertFalse("Pathological pattern must report a non-match", result.booleanValue());
+			} catch (TimeoutException e) {
+				future.cancel(true);
+				fail("ReDoS vulnerability detected: Index.isMatch with pathological regex " +
+					"'(.*a){20}' did not complete within " + TIMEOUT_SECONDS + " seconds.");
+			} catch (ExecutionException e) {
+				fail("Unexpected exception during regex match: " + e.getCause().getMessage());
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				fail("Test interrupted");
+			}
+		} finally {
+			executor.shutdownNow();
+		}
+	}
+
+	/**
+	 * Verifies that an invalid regex pattern (e.g. an unclosed group) is handled
+	 * gracefully: {@code Index.isMatch} returns {@code false} instead of propagating
+	 * an unchecked {@link java.util.regex.PatternSyntaxException} that could abort the
+	 * enclosing search operation.
+	 */
+	public void testInvalidRegexIsHandledGracefully() {
+		char[] pattern = "(unclosed[group".toCharArray();
+		char[] word = "anything".toCharArray();
+
+		try {
+			boolean result = Index.isMatch(pattern, word, SearchPattern.R_REGEXP_MATCH);
+			assertFalse("Invalid regex must be treated as a non-match", result);
+		} catch (java.util.regex.PatternSyntaxException e) {
+			fail("Invalid regex should be handled gracefully, but PatternSyntaxException propagated: "
+					+ e.getMessage());
+		}
+	}
+}

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchBugs9Tests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchBugs9Tests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 IBM Corporation and others.
+ * Copyright (c) 2016, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -19,6 +19,12 @@ import static org.eclipse.jdt.core.search.IJavaSearchScope.SOURCES;
 import static org.eclipse.jdt.core.search.IJavaSearchScope.SYSTEM_LIBRARIES;
 
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import junit.framework.Test;
 import org.eclipse.core.runtime.CoreException;
@@ -3801,6 +3807,55 @@ public void testBug528059_001() throws Exception {
 	finally {
 		deleteProject("JavaSearchBugs9");
 		deleteProject("second");
+	}
+}
+
+public void testReDoSModuleSearchViaSearchEngine() throws Exception {
+	try {
+		IJavaProject project1 = createJavaProject("JavaSearchBugs9", new String[] {"src"}, new String[] {"JCL19_LIB"}, "bin", "9");
+		project1.open(null);
+		addClasspathEntry(project1, JavaCore.newContainerEntry(new Path("org.eclipse.jdt.MODULE_PATH")));
+
+		// Module name = 40 'a's + ".b": a valid module name that is a NON-match for (a+)+$ and
+		// therefore forces exponential backtracking in an unguarded regex engine.
+		StringBuilder name = new StringBuilder();
+		for (int i = 0; i < 40; i++) {
+			name.append('a');
+		}
+		name.append(".b");
+		String moduleName = name.toString();
+		createFile("/JavaSearchBugs9/src/module-info.java",
+				"module " + moduleName + " {\n}\n");
+
+		String needle = "(a+)+$"; // user-typed pathological regex
+		SearchPattern pattern = SearchPattern.createPattern(needle, IJavaSearchConstants.MODULE, DECLARATIONS, SearchPattern.R_REGEXP_MATCH);
+		IJavaSearchScope scope = SearchEngine.createJavaSearchScope(new IJavaProject[] { project1 });
+
+		// Run the search on a background thread so a regression (a hang) fails the test via timeout
+		// instead of blocking the whole suite indefinitely.
+		ExecutorService executor = Executors.newSingleThreadExecutor();
+		try {
+			Future<Void> future = executor.submit(() -> {
+				search(pattern, scope, this.resultCollector);
+				return null;
+			});
+			try {
+				future.get(30, TimeUnit.SECONDS);
+			} catch (TimeoutException e) {
+				future.cancel(true);
+				fail("ReDoS via SearchEngine: a module search with the pathological regex '(a+)+$' " +
+					"did not complete within 30 seconds. The index regex path must be ReDoS-guarded.");
+			} catch (ExecutionException e) {
+				throw (e.getCause() instanceof Exception) ? (Exception) e.getCause() : e;
+			}
+		} finally {
+			executor.shutdownNow();
+		}
+		// The pathological pattern must not match the module name; the search simply completes.
+		assertSearchResults("", this.resultCollector);
+	}
+	finally {
+		deleteProject("JavaSearchBugs9");
 	}
 }
 

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/index/DiskIndex.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/index/DiskIndex.java
@@ -227,19 +227,21 @@ HashtableOfObject addQueryResults(char[][] categories, char[] key, int matchRule
 				}
 				break;
 			case SearchPattern.R_REGEXP_MATCH:
-				Pattern pattern = Pattern.compile(new String(key));
-				for (char[] category : categories) {
-					HashtableOfObject wordsToDocNumbers = readCategoryTable(category, false);
-					if (wordsToDocNumbers != null) {
-						char[][] words = wordsToDocNumbers.keyTable;
-						Object[] values = wordsToDocNumbers.valueTable;
-						for (int j = 0, m = words.length; j < m; j++) {
-							char[] word = words[j];
-							if (word != null && pattern.matcher(new String(word)).matches())
-								results = addQueryResult(results, word, values[j], memoryIndex, prevResults);
+				Pattern pattern = Index.compileRegexp(key);
+				if (pattern != null) { // skip entirely when the user supplied an invalid regex
+					for (char[] category : categories) {
+						HashtableOfObject wordsToDocNumbers = readCategoryTable(category, false);
+						if (wordsToDocNumbers != null) {
+							char[][] words = wordsToDocNumbers.keyTable;
+							Object[] values = wordsToDocNumbers.valueTable;
+							for (int j = 0, m = words.length; j < m; j++) {
+								char[] word = words[j];
+								if (word != null && Index.regexpMatch(pattern, word))
+									results = addQueryResult(results, word, values[j], memoryIndex, prevResults);
+							}
 						}
+						prevResults = results != null;
 					}
-					prevResults = results != null;
 				}
 				break;
 			default:

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/index/Index.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/index/Index.java
@@ -18,7 +18,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.core.search.IJavaSearchScope;
 import org.eclipse.jdt.core.search.SearchPattern;
@@ -86,8 +88,7 @@ public static boolean isMatch(char[] pattern, char[] word, int matchRule) {
 		case SearchPattern.R_PREFIX_MATCH :
 			return patternLength <= wordLength && CharOperation.prefixEquals(pattern, word, false);
 		case SearchPattern.R_REGEXP_MATCH :
-			Pattern regexPattern = Pattern.compile(new String(pattern));
-			return regexPattern.matcher(new String(word)).matches();
+			return regexpMatch(pattern, word);
 		case SearchPattern.R_PATTERN_MATCH :
 			return CharOperation.match(pattern, word, false);
 		case SearchPattern.R_CAMELCASE_MATCH:
@@ -109,6 +110,104 @@ public static boolean isMatch(char[] pattern, char[] word, int matchRule) {
 			return (pattern[0] == word[0] && CharOperation.camelCaseMatch(pattern, word, false));
 	}
 	return false;
+}
+
+/**
+ * Default time budget (in milliseconds) allowed for a single {@link SearchPattern#R_REGEXP_MATCH}
+ * match against one index entry. Since {@link #isMatch(char[], char[], int)} is invoked once per
+ * indexed word in a tight loop, this is intentionally a per-entry (not per-query) budget.
+ * <p>
+ * Can be overridden with the system property {@code jdt.core.index.regexpMatchTimeoutMillis}.
+ * A value {@code <= 0} disables the guard (not recommended).
+ * </p>
+ */
+private static final long REGEXP_MATCH_TIMEOUT_MS =
+		Long.getLong("jdt.core.index.regexpMatchTimeoutMillis", 1000L).longValue(); //$NON-NLS-1$
+
+/**
+ * Matches {@code word} against the user-supplied regular expression {@code pattern} while
+ * guarding against ReDoS (Regular Expression Denial of Service).
+ * <p>
+ * Java's {@link Pattern} engine is NFA-based and uses backtracking, so pathological patterns
+ * such as {@code (a+)+$} can trigger catastrophic (exponential) backtracking on non-matching
+ * input. To bound the cost without the overhead of spawning a thread per call, the input is
+ * wrapped in a {@link DeadlineCharSequence} which throws once a time budget is exceeded: the
+ * matcher probes the input via {@link CharSequence#charAt(int)} during backtracking, so this
+ * effectively interrupts a runaway match. On timeout, or when the pattern is syntactically
+ * invalid, the entry is treated as a non-match rather than propagating an exception that could
+ * abort the whole search.
+ * </p>
+ */
+private static boolean regexpMatch(char[] pattern, char[] word) {
+	Pattern regexPattern;
+	try {
+		regexPattern = Pattern.compile(new String(pattern));
+	} catch (PatternSyntaxException e) {
+		// Invalid regex supplied by the caller: do not match and do not let the unchecked
+		// exception propagate and abort the enclosing search.
+		return false;
+	}
+	CharSequence input = REGEXP_MATCH_TIMEOUT_MS > 0
+			? DeadlineCharSequence.withTimeout(new String(word), REGEXP_MATCH_TIMEOUT_MS)
+			: new String(word);
+	try {
+		return regexPattern.matcher(input).matches();
+	} catch (RegexpTimeoutException e) {
+		// A pathological pattern caused catastrophic backtracking beyond the allotted budget.
+		// Treat as a non-match to avoid a denial-of-service.
+		return false;
+	}
+}
+
+/**
+ * Signals that a regular expression match exceeded its allotted time budget.
+ * Carries no stack trace to keep throwing cheap on the regex hot path.
+ */
+private static final class RegexpTimeoutException extends RuntimeException {
+	private static final long serialVersionUID = 1L;
+	RegexpTimeoutException() {
+		super(null, null, false, false);
+	}
+}
+
+/**
+ * A {@link CharSequence} wrapper that aborts (by throwing {@link RegexpTimeoutException}) once a
+ * deadline has passed. Used to bound the running time of a regex match without a helper thread.
+ * The deadline is only sampled every so often to keep {@link #charAt(int)} cheap.
+ */
+private static final class DeadlineCharSequence implements CharSequence {
+	/** Sample the clock only once per this many {@code charAt} calls (power-of-two mask). */
+	private static final int CHECK_MASK = 0x3FF;
+	private final CharSequence inner;
+	private final long deadlineNanos;
+	private int checkCounter;
+
+	static DeadlineCharSequence withTimeout(CharSequence inner, long timeoutMillis) {
+		return new DeadlineCharSequence(inner, System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMillis));
+	}
+	private DeadlineCharSequence(CharSequence inner, long deadlineNanos) {
+		this.inner = inner;
+		this.deadlineNanos = deadlineNanos;
+	}
+	@Override
+	public int length() {
+		return this.inner.length();
+	}
+	@Override
+	public char charAt(int index) {
+		if ((this.checkCounter++ & CHECK_MASK) == 0 && System.nanoTime() > this.deadlineNanos) {
+			throw new RegexpTimeoutException();
+		}
+		return this.inner.charAt(index);
+	}
+	@Override
+	public CharSequence subSequence(int start, int end) {
+		return new DeadlineCharSequence(this.inner.subSequence(start, end), this.deadlineNanos);
+	}
+	@Override
+	public String toString() {
+		return this.inner.toString();
+	}
 }
 
 

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/index/Index.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/index/Index.java
@@ -139,14 +139,40 @@ private static final long REGEXP_MATCH_TIMEOUT_MS =
  * </p>
  */
 private static boolean regexpMatch(char[] pattern, char[] word) {
-	Pattern regexPattern;
-	try {
-		regexPattern = Pattern.compile(new String(pattern));
-	} catch (PatternSyntaxException e) {
-		// Invalid regex supplied by the caller: do not match and do not let the unchecked
-		// exception propagate and abort the enclosing search.
+	Pattern regexPattern = compileRegexp(pattern);
+	if (regexPattern == null) {
 		return false;
 	}
+	return regexpMatch(regexPattern, word);
+}
+
+/**
+ * Compiles the given regular expression, returning {@code null} instead of propagating a
+ * {@link PatternSyntaxException} when the pattern is invalid. Callers should treat a {@code null}
+ * result as "no possible match" rather than letting the unchecked exception abort the search.
+ * <p>
+ * Provided as a shared entry point so that every regex-matching path in the index (both
+ * {@link #isMatch(char[], char[], int)} and {@code DiskIndex.addQueryResults}) benefits from the
+ * same ReDoS protection.
+ * </p>
+ */
+static Pattern compileRegexp(char[] pattern) {
+	try {
+		return Pattern.compile(new String(pattern));
+	} catch (PatternSyntaxException e) {
+		return null;
+	}
+}
+
+/**
+ * Matches {@code word} against an already-compiled {@code regexPattern} under the ReDoS time
+ * guard. Compiling once and reusing the {@link Pattern} across many words (as callers iterating
+ * over a category table do) avoids repeated compilation while still bounding each individual
+ * match. A timeout is reported as a non-match.
+ *
+ * @see #compileRegexp(char[])
+ */
+static boolean regexpMatch(Pattern regexPattern, char[] word) {
 	CharSequence input = REGEXP_MATCH_TIMEOUT_MS > 0
 			? DeadlineCharSequence.withTimeout(new String(word), REGEXP_MATCH_TIMEOUT_MS)
 			: new String(word);


### PR DESCRIPTION
## What it does
Search index keys are compiled directly into Pattern objects with no complexity or length limits.
Pattern pattern = Pattern.compile(new String(key));
return regexPattern.matcher(new String(word)).matches();
Risk
A caller supplying a pathological regex (e.g. (a+)+$) triggers catastrophic backtracking, consuming 100% CPU — Denial of Service via ReDoS.
Enforce maximum pattern length; use a timeout wrapper or RE2J library for externally-supplied patterns. - Will discuss the approach of the patch in the following comment?

References
This looks like a direct reference to [CWE-1333](https://cwe.mitre.org/data/definitions/1333.html)

## How to test
junit tests provided 

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
