### PR TITLE
Fix compatible multi-release JAR lookup

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/ClasspathMultiReleaseJar.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/ClasspathMultiReleaseJar.java
@@ -2,14 +2,13 @@ package org.eclipse.jdt.internal.compiler.batch;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.DirectoryStream;
-import java.nio.file.FileVisitResult;
-import java.nio.file.FileVisitor;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.Enumeration;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.zip.ZipEntry;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileReader;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFormatException;
@@ -18,97 +17,90 @@ import org.eclipse.jdt.internal.compiler.env.AccessRuleSet;
 import org.eclipse.jdt.internal.compiler.env.IBinaryType;
 import org.eclipse.jdt.internal.compiler.env.NameEnvironmentAnswer;
 import org.eclipse.jdt.internal.compiler.lookup.BinaryTypeBinding.ExternalAnnotationStatus;
-import org.eclipse.jdt.internal.compiler.util.JRTUtil;
 import org.eclipse.jdt.internal.compiler.util.SuffixConstants;
 import org.eclipse.jdt.internal.compiler.util.Util;
 
 public class ClasspathMultiReleaseJar extends ClasspathJar {
-	private java.nio.file.FileSystem fs = null;
-	Path releasePath = null;
-	String compliance = null;
+	/** Applicable META-INF/versions directory names, sorted in descending order. */
+	private List<String> releaseVersions;
+	private final int releaseVersion;
 
 	public ClasspathMultiReleaseJar(File file, boolean closeZipFileAtEnd,
 			AccessRuleSet accessRuleSet, String destinationPath, String compliance) {
 		super(file, closeZipFileAtEnd, accessRuleSet, destinationPath);
-		this.compliance = compliance;
-	}
-	@Override
-	public void initialize() throws IOException {
-		super.initialize();
-		if (this.file.exists()) {
-			this.fs = JRTUtil.getJarFileSystem(this.file.toPath());
-			this.releasePath = this.fs.getPath("/", "META-INF", "versions", this.compliance); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
-			if (!Files.exists(this.releasePath)) {
-				this.releasePath = null;
-			}
+		this.releaseVersions = Collections.emptyList();
+		int version;
+		try {
+			version = Integer.parseInt(compliance);
+		} catch (NumberFormatException e) {
+			version = 0;
 		}
+		this.releaseVersion = version;
+	}
+
+	/**
+	 * Populates the package cache and applicable release versions with one pass over the JAR.
+	 * JEP 238 requires class lookup to start at the requested release, continue through lower
+	 * versioned directories down to 9, and finally fall back to the JAR root.
+	 *
+	 * @see <a href="https://openjdk.org/jeps/238">JEP 238: Multi-Release JAR Files</a>
+	 * @see <a href="https://docs.oracle.com/en/java/javase/17/docs/specs/jar/jar.html#multi-release-jar-files">
+	 *      JAR File Specification: Multi-release JAR files</a>
+	 */
+	private void initializeMultiReleaseIndex() {
+		this.packageCache = new HashSet<>(41);
+		this.packageCache.add(Util.EMPTY_STRING);
+		int prefixLength = Util.METAINF_VERSIONS.length();
+		Set<Integer> versions = new HashSet<>();
+		for (Enumeration<? extends ZipEntry> entries = this.zipFile.entries(); entries.hasMoreElements();) {
+			String fileName = entries.nextElement().getName();
+			if (fileName.startsWith(Util.METAINF_VERSIONS)) {
+				int separator = fileName.indexOf('/', prefixLength);
+				if (separator == -1) {
+					continue;
+				}
+				String versionSegment = fileName.substring(prefixLength, separator);
+				try {
+					int version = Integer.parseInt(versionSegment);
+					if (version < 9 || version > this.releaseVersion) {
+						continue;
+					}
+					// The JAR specification requires N to match {1-9}{0-9}*, excluding signs and leading zeroes.
+					if (!Integer.toString(version).equals(versionSegment)) {
+						continue;
+					}
+					versions.add(version);
+					fileName = fileName.substring(separator + 1);
+				} catch (NumberFormatException e) {
+					// Ignore malformed version directories as required by the JAR specification.
+					continue;
+				}
+			}
+			addToPackageCache(fileName, false);
+		}
+		List<Integer> sortedVersions = new ArrayList<>(versions);
+		sortedVersions.sort(Comparator.reverseOrder());
+		List<String> result = new ArrayList<>(sortedVersions.size());
+		for (Integer version : sortedVersions) {
+			result.add(version.toString());
+		}
+		this.releaseVersions = result;
 	}
 
 	@Override
 	public synchronized char[][] getModulesDeclaringPackage(String qualifiedPackageName, String moduleName) {
-		if (this.releasePath == null) {
-			return super.getModulesDeclaringPackage(qualifiedPackageName, moduleName);
-		}
-		if (this.packageCache != null)
-			return singletonModuleNameIf(this.packageCache.contains(qualifiedPackageName));
-
-		this.packageCache = new HashSet<>(41);
-		this.packageCache.add(Util.EMPTY_STRING);
-
-		for (Enumeration<? extends ZipEntry> e = this.zipFile.entries(); e.hasMoreElements(); ) {
-			String fileName = e.nextElement().getName();
-			addToPackageCache(fileName, false);
-		}
-		try {
-			if (this.releasePath != null && Files.exists(this.releasePath)) {
-				// go through the packages
-				try (DirectoryStream<java.nio.file.Path> stream = Files.newDirectoryStream(this.releasePath)) {
-					for (final java.nio.file.Path subdir: stream) {
-						Files.walkFileTree(subdir, new FileVisitor<java.nio.file.Path>() {
-							@Override
-							public FileVisitResult preVisitDirectory(java.nio.file.Path dir, BasicFileAttributes attrs)
-									throws IOException {
-								return FileVisitResult.CONTINUE;
-							}
-							@Override
-							public FileVisitResult visitFile(java.nio.file.Path f, BasicFileAttributes attrs)
-									throws IOException {
-								Path p = ClasspathMultiReleaseJar.this.releasePath.relativize(f);
-								addToPackageCache(p.toString(), false);
-								return FileVisitResult.CONTINUE;
-							}
-
-							@Override
-							public FileVisitResult visitFileFailed(java.nio.file.Path f, IOException exc) throws IOException {
-								return FileVisitResult.CONTINUE;
-							}
-
-							@Override
-							public FileVisitResult postVisitDirectory(java.nio.file.Path dir, IOException exc)
-									throws IOException {
-								return FileVisitResult.CONTINUE;
-							}
-						});
-					}
-				}
-			}
-		} catch (Exception e) {
-			e.printStackTrace();
-			// move on;
+		if (this.packageCache == null) {
+			initializeMultiReleaseIndex();
 		}
 		return singletonModuleNameIf(this.packageCache.contains(qualifiedPackageName));
 	}
 	@Override
 	public NameEnvironmentAnswer findClass(char[] binaryFileName, String qualifiedPackageName, String moduleName, String qualifiedBinaryFileName, boolean asBinaryOnly) {
 		if (!isPackage(qualifiedPackageName, moduleName)) return null; // most common case
-		if (this.releasePath != null) {
+		for (String version : this.releaseVersions) {
 			try {
-				Path p = this.releasePath.resolve(qualifiedBinaryFileName);
-				byte[] content = Files.readAllBytes(p);
-				IBinaryType reader = null;
-				if (content != null) {
-					reader = new ClassFileReader(p.toUri(), content, qualifiedBinaryFileName.toCharArray());
-				}
+				String entryName = Util.METAINF_VERSIONS + version + '/' + qualifiedBinaryFileName;
+				IBinaryType reader = ClassFileReader.read(this.zipFile, entryName);
 				if (reader != null) {
 					char[] modName = this.module == null ? null : this.module.name();
 					if (reader instanceof ClassFileReader) {
@@ -150,5 +142,11 @@ public class ClasspathMultiReleaseJar extends ClasspathJar {
 			}
 		}
 		return super.findClass(binaryFileName, qualifiedPackageName, moduleName, qualifiedBinaryFileName, asBinaryOnly);
+	}
+
+	@Override
+	public void reset() {
+		super.reset();
+		this.releaseVersions = Collections.emptyList();
 	}
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/ModuleFinder.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/batch/ModuleFinder.java
@@ -243,12 +243,24 @@ public class ModuleFinder {
 	private static IModule extractModuleFromArchive(File file, Classpath pathEntry, String path, String release) {
 		try (ZipFile zipFile = new ZipFile(file)) {
 			if (release != null) {
-				String releasePath = Util.METAINF_VERSIONS + release + "/" + path; //$NON-NLS-1$
-				ZipEntry entry = zipFile.getEntry(releasePath);
-				if (entry != null) {
-					path = releasePath;
+				// A versioned module descriptor is selected like any other entry in an MR-JAR:
+				// https://docs.oracle.com/en/java/javase/17/docs/specs/jar/jar.html#modular-multi-release-jar-files
+				int releaseVersion;
+				try {
+					releaseVersion = Integer.parseInt(release);
+				} catch (NumberFormatException e) {
+					releaseVersion = 0;
+				}
+				for (int version = releaseVersion; version >= 9; version--) {
+					String releasePath = Util.METAINF_VERSIONS + version + "/" + path; //$NON-NLS-1$
+					ZipEntry entry = zipFile.getEntry(releasePath);
+					if (entry != null) {
+						path = releasePath;
+						break;
+					}
 				}
 			}
+			// If no applicable versioned descriptor was found, path still names module-info.class in the JAR root.
 			ClassFileReader reader = ClassFileReader.read(zipFile, path);
 			IModule module = getModule(reader);
 			if (module != null) {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/MultiReleaseJarTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/MultiReleaseJarTests.java
@@ -1,8 +1,10 @@
 package org.eclipse.jdt.core.tests.compiler.regression;
 
 import java.io.File;
+import java.io.IOException;
 import javax.lang.model.SourceVersion;
 import junit.framework.Test;
+import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.tests.util.Util;
 
 public class MultiReleaseJarTests extends AbstractBatchCompilerTest {
@@ -31,6 +33,104 @@ public class MultiReleaseJarTests extends AbstractBatchCompilerTest {
 	public static Class<?> testClass() {
 		return MultiReleaseJarTests.class;
 	}
+
+	private static String createMultiReleaseJar() throws IOException {
+		return createMultiReleaseJar(false);
+	}
+
+	/**
+	 * Creates a JAR containing:
+	 * <pre>
+	 * base/Root.class
+	 * module-info.class                                  (if {@code moduleDescriptorInRoot})
+	 * META-INF/versions/9/internal/VersionedOnly.class
+	 * META-INF/versions/9/internal/Precedence.class      (returns {@link Object})
+	 * META-INF/versions/9/module-info.class              (otherwise)
+	 * META-INF/versions/11/internal/Precedence.class     (returns {@link String})
+	 * </pre>
+	 */
+	private static String createMultiReleaseJar(boolean moduleDescriptorInRoot) throws IOException {
+		File baseClasses = new File(LIB_DIR, "mrjar-base");
+		File moduleClasses = new File(LIB_DIR, "mrjar-module");
+		File version9Classes = new File(LIB_DIR, "mrjar-version9");
+		File version11Classes = new File(LIB_DIR, "mrjar-version11");
+		File jarContent = new File(LIB_DIR, "mrjar-content");
+		Util.createClassFolder(
+				new String[] {
+						"base/Root.java",
+						"package base;\n" +
+						"public class Root {\n" +
+						"}\n"
+				},
+				baseClasses.getAbsolutePath(),
+				JavaCore.VERSION_1_8);
+		Util.createClassFolder(
+				new String[] {
+						"module-info.java",
+						"module org.slf4j {\n" +
+						"}\n"
+				},
+				moduleClasses.getAbsolutePath(),
+				JavaCore.VERSION_9);
+		Util.createClassFolder(
+				new String[] {
+						"internal/VersionedOnly.java",
+						"package internal;\n" +
+						"public class VersionedOnly {\n" +
+						"}\n",
+						"internal/Precedence.java",
+						"package internal;\n" +
+						"public class Precedence {\n" +
+						"  public Object value() { return null; }\n" +
+						"}\n"
+				},
+				version9Classes.getAbsolutePath(),
+				JavaCore.VERSION_9);
+		Util.createClassFolder(
+				new String[] {
+						"internal/Precedence.java",
+						"package internal;\n" +
+						"public class Precedence {\n" +
+						"  public String value() { return \"11\"; }\n" +
+						"}\n"
+				},
+				version11Classes.getAbsolutePath(),
+				JavaCore.VERSION_11);
+
+		if (jarContent.exists()) {
+			if (!Util.flushDirectoryContent(jarContent)) {
+				throw new IOException("Could not clear " + jarContent);
+			}
+		} else if (!jarContent.mkdirs()) {
+			throw new IOException("Could not create " + jarContent);
+		}
+		Util.copy(baseClasses.getAbsolutePath(), jarContent.getAbsolutePath());
+		if (moduleDescriptorInRoot) {
+			Util.copy(moduleClasses.getAbsolutePath(), jarContent.getAbsolutePath());
+		}
+		File version9Content = new File(jarContent, "META-INF" + File.separator + "versions" + File.separator + "9");
+		if (!version9Content.mkdirs()) {
+			throw new IOException("Could not create " + version9Content);
+		}
+		Util.copy(version9Classes.getAbsolutePath(), version9Content.getAbsolutePath());
+		if (!moduleDescriptorInRoot) {
+			Util.copy(moduleClasses.getAbsolutePath(), version9Content.getAbsolutePath());
+		}
+		File version11Content = new File(jarContent, "META-INF" + File.separator + "versions" + File.separator + "11");
+		if (!version11Content.mkdirs()) {
+			throw new IOException("Could not create " + version11Content);
+		}
+		Util.copy(version11Classes.getAbsolutePath(), version11Content.getAbsolutePath());
+		Util.createFile(
+				new File(jarContent, "META-INF" + File.separator + "MANIFEST.MF").getAbsolutePath(),
+				"Manifest-Version: 1.0\n" +
+				"Multi-Release: true\n");
+
+		String jarPath = LIB_DIR + File.separator + "slf4j-api-2.0.12.jar";
+		Util.zip(jarContent, jarPath);
+		return jarPath;
+	}
+
 	public void test001() {
 		String path = this.getCompilerTestsPluginDirectoryPath() + File.separator + "workspace" + File.separator + "multi.jar";
 		String[] libs = new String[1];
@@ -213,5 +313,83 @@ public class MultiReleaseJarTests extends AbstractBatchCompilerTest {
 			"",
 			false
 		   );
+	}
+
+	public void test007_moduleDescriptorFromLowerRelease() throws IOException {
+		String path = createMultiReleaseJar();
+		runConformTest(
+			new String[] {
+				"src/module-info.java",
+				"module consumer {\n" +
+				"  requires org.slf4j;\n" +
+				"}\n",
+				"src/test/X.java",
+				"package test;\n" +
+				"public class X {\n" +
+				"}\n"
+			},
+			" -d \"" + OUTPUT_DIR + File.separator + "out\"" +
+			" \"" + OUTPUT_DIR + File.separator + "src" + File.separator + "module-info.java\"" +
+			" \"" + OUTPUT_DIR + File.separator + "src" + File.separator + "test" + File.separator + "X.java\"" +
+			" --module-path \"" + path + "\" --release 17 ",
+			"",
+			"",
+			false);
+	}
+
+	public void test008_classFromLowerRelease() throws IOException {
+		String path = createMultiReleaseJar();
+		runConformTest(
+			new String[] {
+				"src/X.java",
+				"import internal.VersionedOnly;\n" +
+				"public class X {\n" +
+				"  VersionedOnly value;\n" +
+				"}\n"
+			},
+			"\"" + OUTPUT_DIR + File.separator + "src" + File.separator + "X.java\"" +
+			" -classpath \"" + path + "\" --release 17 ",
+			"",
+			"",
+			false);
+	}
+
+	public void test009_highestCompatibleVersionWins() throws IOException {
+		String path = createMultiReleaseJar();
+		runConformTest(
+			new String[] {
+				"src/X.java",
+				"import internal.Precedence;\n" +
+				"public class X {\n" +
+				"  String value = new Precedence().value();\n" +
+				"}\n"
+			},
+			"\"" + OUTPUT_DIR + File.separator + "src" + File.separator + "X.java\"" +
+			" -classpath \"" + path + "\" --release 17 ",
+			"",
+			"",
+			false);
+	}
+
+	public void test010_moduleDescriptorFallsBackToRoot() throws IOException {
+		String path = createMultiReleaseJar(true);
+		runConformTest(
+			new String[] {
+				"src/module-info.java",
+				"module consumer {\n" +
+				"  requires org.slf4j;\n" +
+				"}\n",
+				"src/test/X.java",
+				"package test;\n" +
+				"public class X {\n" +
+				"}\n"
+			},
+			" -d \"" + OUTPUT_DIR + File.separator + "out\"" +
+			" \"" + OUTPUT_DIR + File.separator + "src" + File.separator + "module-info.java\"" +
+			" \"" + OUTPUT_DIR + File.separator + "src" + File.separator + "test" + File.separator + "X.java\"" +
+			" --module-path \"" + path + "\" --release 17 ",
+			"",
+			"",
+			false);
 	}
 }


### PR DESCRIPTION
## What it does

Fixes https://github.com/codehaus-plexus/plexus-compiler/issues/380 and fixes #2778.

ECJ previously looked only in the exact `META-INF/versions/<release>` directory of a multi-release JAR. As a result, compiling for Java 17 did not find a `module-info.class` or class present in `META-INF/versions/9`, even though JEP 238 requires selecting the highest applicable version not greater than the requested release.

For module descriptors, this change probes candidate paths directly from the requested release down to 9, falling back to the descriptor in the JAR root. For ordinary classes, it builds the package cache and descending applicable-version index together during one lazy archive scan.

The regression tests build a multi-release JAR with Java 8 base content, a module descriptor and class in the Java 9 versioned directory, and a competing class in the Java 11 directory. They verify lower-compatible lookup with `--release 17` and that the highest compatible version wins.

AI assistance: OpenAI Codex helped investigate, implement, and test this change; the assistance is also recorded in the commit trailers.

## How to test

- Run `MultiReleaseJarTests`; 27 compliance-expanded tests pass, including `test007_moduleDescriptorFromLowerRelease`, `test008_classFromLowerRelease`, and `test009_highestCompatibleVersionWins`.
- A complete 17-module reactor run of the original fix passed 187,881 tests. After the archive-scan optimizations, the compiler suite passed 58,541 tests and the builder suite passed 386 tests; the model suite had one transient failure in unrelated `JavaProjectTests.testChangeZIPArchive3`, and all 117 `JavaProjectTests` passed on rerun in the Tycho/OSGi harness.
- The original Plexus Compiler issue reproducer was rerun on Java 17 with the newly built `ecj.jar` and compiled successfully.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
