### PR TITLE
Investigate a potential path traversal issue of Unsanitized String

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ExternalAnnotationSuperimposer.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ExternalAnnotationSuperimposer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 GK Software AG.
+ * Copyright (c) 2016, 2026 GK Software AG.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -25,6 +25,7 @@ import org.eclipse.jdt.internal.compiler.classfmt.ExternalAnnotationProvider;
 import org.eclipse.jdt.internal.compiler.env.IBinaryAnnotation;
 import org.eclipse.jdt.internal.compiler.env.ITypeAnnotationWalker;
 import org.eclipse.jdt.internal.compiler.util.Messages;
+import org.eclipse.jdt.internal.compiler.util.Util;
 
 /**
  * Used for superimposing external annotations (served by an {@link ITypeAnnotationWalker})
@@ -39,13 +40,28 @@ class ExternalAnnotationSuperimposer extends TypeBindingVisitor {
 				String binaryTypeName = String.valueOf(typeBinding.constantPoolName());
 				String relativeFileName = binaryTypeName.replace('.', '/')+ExternalAnnotationProvider.ANNOTATION_FILE_SUFFIX;
 
+				// Guard against path traversal: the relative file name is derived from the type's
+				// name and must never be able to escape the configured annotation base (bug: reading
+				// arbitrary files if the name were to contain "../" segments).
+				if (!Util.isSafeRelativePath(relativeFileName)) {
+					return;
+				}
+
 				try (ZipFile zipFile = annotationBase.isDirectory() ? null : new ZipFile(externalAnnotationPath)) {
 					ZipEntry zipEntry = (zipFile == null) ? null : zipFile.getEntry(relativeFileName);
 					if (zipFile != null && zipEntry == null) {
 						return;
 					}
+					InputStream fileInput = null;
+					if (zipFile == null) {
+						File annotationFile = Util.getFileWithinBaseDir(externalAnnotationPath, relativeFileName);
+						if (annotationFile == null) {
+							return; // unsafe or escaping path
+						}
+						fileInput = new FileInputStream(annotationFile);
+					}
 					try (InputStream input = (zipFile == null)
-							? new FileInputStream(externalAnnotationPath + '/' + relativeFileName)
+							? fileInput
 							: zipFile.getInputStream(zipEntry)) {
 						annotateType(typeBinding, new ExternalAnnotationProvider(input, binaryTypeName),
 								typeBinding.environment);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/util/Util.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/util/Util.java
@@ -23,6 +23,9 @@ import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -1606,20 +1609,20 @@ public class Util implements SuffixConstants {
 			return false;
 		// Reject any traversal irrespective of platform separators:
 		if (relativeFileName.indexOf("..") != -1) { //$NON-NLS-1$
-			java.nio.file.Path path;
+			Path path;
 			try {
-				path = java.nio.file.Paths.get(relativeFileName);
-			} catch (java.nio.file.InvalidPathException e) {
+				path = Paths.get(relativeFileName);
+			} catch (InvalidPathException e) {
 				return false;
 			}
-			for (java.nio.file.Path segment : path.normalize()) {
+			for (Path segment : path.normalize()) {
 				if (segment.toString().equals("..")) //$NON-NLS-1$
 					return false;
 			}
 		}
 		try {
-			return !java.nio.file.Paths.get(relativeFileName).isAbsolute();
-		} catch (java.nio.file.InvalidPathException e) {
+			return !Paths.get(relativeFileName).isAbsolute();
+		} catch (InvalidPathException e) {
 			return false;
 		}
 	}
@@ -1639,12 +1642,12 @@ public class Util implements SuffixConstants {
 		if (baseDirPath == null || !isSafeRelativePath(relativeFileName))
 			return null;
 		try {
-			java.nio.file.Path base = java.nio.file.Paths.get(baseDirPath).normalize();
-			java.nio.file.Path resolved = base.resolve(relativeFileName).normalize();
+			Path base = Paths.get(baseDirPath).normalize();
+			Path resolved = base.resolve(relativeFileName).normalize();
 			if (!resolved.startsWith(base))
 				return null;
 			return resolved.toFile();
-		} catch (java.nio.file.InvalidPathException e) {
+		} catch (InvalidPathException e) {
 			return null;
 		}
 	}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/util/Util.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/util/Util.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2023 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -1587,5 +1587,65 @@ public class Util implements SuffixConstants {
 
 	private static IllegalArgumentException newIllegalArgumentException(char[] string, int start) {
 		return new IllegalArgumentException("\"" + String.valueOf(string) + "\" at " + start); //$NON-NLS-1$ //$NON-NLS-2$
+	}
+
+	/**
+	 * Tells whether the given relative path is safe to resolve against a base
+	 * directory, i.e. it is not absolute and does not contain any {@code ".."}
+	 * segment that could be used to escape the base directory (path traversal).
+	 * <p>
+	 * The check is performed purely on the textual/logical form of the path and
+	 * does not touch the file system.
+	 * </p>
+	 *
+	 * @param relativeFileName a '/'-separated relative file name, may be {@code null}
+	 * @return {@code true} if the name is a safe relative path, {@code false} otherwise
+	 */
+	public static boolean isSafeRelativePath(String relativeFileName) {
+		if (relativeFileName == null || relativeFileName.isEmpty())
+			return false;
+		// Reject any traversal irrespective of platform separators:
+		if (relativeFileName.indexOf("..") != -1) { //$NON-NLS-1$
+			java.nio.file.Path path;
+			try {
+				path = java.nio.file.Paths.get(relativeFileName);
+			} catch (java.nio.file.InvalidPathException e) {
+				return false;
+			}
+			for (java.nio.file.Path segment : path.normalize()) {
+				if (segment.toString().equals("..")) //$NON-NLS-1$
+					return false;
+			}
+		}
+		try {
+			return !java.nio.file.Paths.get(relativeFileName).isAbsolute();
+		} catch (java.nio.file.InvalidPathException e) {
+			return false;
+		}
+	}
+
+	/**
+	 * Safely resolve a relative file name against a base directory, guarding
+	 * against path traversal. The returned file is guaranteed to be contained
+	 * within the (normalized) base directory.
+	 *
+	 * @param baseDirPath the base directory path
+	 * @param relativeFileName a '/'-separated relative file name
+	 * @return the resolved {@link File} if it stays within {@code baseDirPath},
+	 *         or {@code null} if the relative name is unsafe or would escape the
+	 *         base directory
+	 */
+	public static File getFileWithinBaseDir(String baseDirPath, String relativeFileName) {
+		if (baseDirPath == null || !isSafeRelativePath(relativeFileName))
+			return null;
+		try {
+			java.nio.file.Path base = java.nio.file.Paths.get(baseDirPath).normalize();
+			java.nio.file.Path resolved = base.resolve(relativeFileName).normalize();
+			if (!resolved.startsWith(base))
+				return null;
+			return resolved.toFile();
+		} catch (java.nio.file.InvalidPathException e) {
+			return null;
+		}
 	}
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/UtilTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/UtilTest.java
@@ -14,11 +14,15 @@
 package org.eclipse.jdt.core.tests.compiler.regression;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 //import junit.framework.AssertionFailedError;
 import junit.framework.Test;
 //import org.apache.tools.ant.types.selectors.SelectorUtils;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.compiler.CharOperation;
+import org.eclipse.jdt.internal.compiler.classfmt.ExternalAnnotationProvider;
+import org.eclipse.jdt.internal.compiler.util.Util;
 
 @SuppressWarnings({ "rawtypes" })
 public class UtilTest extends AbstractRegressionTest {
@@ -743,5 +747,64 @@ public void test73b() { // previous test cases but with 3.3 behavior
 }
 public static Class testClass() {
 	return UtilTest.class;
+}
+
+// --- Path-traversal safety of external annotation resolution (Util.isSafeRelativePath / getFileWithinBaseDir) ---
+
+// A benign, slash-separated relative annotation file name (as produced from a real type name) is safe.
+public void testSafeRelativePath_benign() {
+	assertTrue("benign name should be safe",
+		Util.isSafeRelativePath("org/example/Foo" + ExternalAnnotationProvider.ANNOTATION_FILE_SUFFIX));
+	assertTrue("top-level name should be safe",
+		Util.isSafeRelativePath("Foo" + ExternalAnnotationProvider.ANNOTATION_FILE_SUFFIX));
+	assertTrue("inner type name should be safe",
+		Util.isSafeRelativePath("org/example/Foo$Inner" + ExternalAnnotationProvider.ANNOTATION_FILE_SUFFIX));
+}
+
+// A relative name containing ".." segments must be rejected (path traversal).
+public void testSafeRelativePath_traversalRejected() {
+	assertFalse("leading traversal must be rejected",
+		Util.isSafeRelativePath("../../etc/passwd"));
+	assertFalse("embedded traversal must be rejected",
+		Util.isSafeRelativePath("org/../../etc/passwd"));
+	assertFalse("traversal with suffix must be rejected",
+		Util.isSafeRelativePath("../secret" + ExternalAnnotationProvider.ANNOTATION_FILE_SUFFIX));
+}
+
+// Absolute paths and empty/null must be rejected.
+public void testSafeRelativePath_absoluteAndEmptyRejected() {
+	assertFalse("null must be rejected", Util.isSafeRelativePath(null));
+	assertFalse("empty must be rejected", Util.isSafeRelativePath("")); //$NON-NLS-1$
+	String absolute = new File(File.listRoots()[0], "etc/passwd").getAbsolutePath(); //$NON-NLS-1$
+	assertFalse("absolute path must be rejected: " + absolute, Util.isSafeRelativePath(absolute));
+}
+
+// getFileWithinBaseDir returns a file contained in the base for benign names.
+public void testGetFileWithinBaseDir_benign() throws Exception {
+	Path base = Files.createTempDirectory("eea-base"); //$NON-NLS-1$
+	try {
+		String relative = "org/example/Foo" + ExternalAnnotationProvider.ANNOTATION_FILE_SUFFIX;
+		File resolved = Util.getFileWithinBaseDir(base.toString(), relative);
+		assertNotNull("benign name should resolve", resolved);
+		assertTrue("resolved file must stay within base directory",
+			resolved.getCanonicalPath().startsWith(base.toFile().getCanonicalPath()));
+	} finally {
+		Files.deleteIfExists(base);
+	}
+}
+
+// getFileWithinBaseDir returns null for names that would escape the base directory.
+public void testGetFileWithinBaseDir_traversalReturnsNull() throws Exception {
+	Path base = Files.createTempDirectory("eea-base"); //$NON-NLS-1$
+	try {
+		assertNull("traversal must not resolve to a file",
+			Util.getFileWithinBaseDir(base.toString(), "../../etc/passwd")); //$NON-NLS-1$
+		assertNull("embedded traversal must not resolve to a file",
+			Util.getFileWithinBaseDir(base.toString(), "org/../../etc/passwd")); //$NON-NLS-1$
+		assertNull("null base must return null",
+			Util.getFileWithinBaseDir(null, "Foo" + ExternalAnnotationProvider.ANNOTATION_FILE_SUFFIX));
+	} finally {
+		Files.deleteIfExists(base);
+	}
 }
 }


### PR DESCRIPTION
Concatenation in `ExternalAnnotationSuperimposer`

## What it does
The relativeFileName is derived from binaryTypeName via a simple character replacement and concatenated directly into a filesystem path without normalization or boundary validation.
String relativeFileName = binaryTypeName.replace('.', '/')
    + ExternalAnnotationProvider.ANNOTATION_FILE_SUFFIX;
// ...
new FileInputStream(externalAnnotationPath + '/' + relativeFileName)

Potential Risk
If binaryTypeName contains ../../etc/passwd, the resulting path escapes the intended annotation directory, allowing arbitrary file reads from the host filesystem.
Probable Remediation
Use Path.of(externalAnnotationPath, relativeFileName).normalize() and assert the result still starts with the base annotation path before opening.

After investigation, here is the result [Note: Co-pilot used extensively here]

- Reachability analysis — is the path traversal reachable?

Callers of `ExternalAnnotationSuperimposer.apply(...)`:

	•  ClassScope.java:490 — path from compilationUnit.getExternalAnnotationPath(...)
	•  LookupEnvironment.java:441 — path from answer.getExternalAnnotationPath()

externalAnnotationPath is a trusted configuration value (classpath attribute EXTERNAL_ANNOTATION_PATH), not attacker input.

Provenance of `binaryTypeName`: typeBinding.constantPoolName() → ReferenceBinding.constantPoolName() = CharOperation.concatWith(this.compoundName, '/'). The compoundName segments are package/type names, i.e. validated Java identifiers. A Java identifier can never be .. (nor contain / or path separators), so the tokenizer/parser cannot produce a compoundName that yields ../ in the derived file name.

Conclusion: In normal compilation the traversal is not reachable — it's a theoretical issue. The remediation is therefore justified as defense-in-depth (protects against future refactors, unusual IBinaryType/model-supplied names, or reuse of the helper in other contexts).

- Path coverage

All apply() branches accounted for: base-missing, directory (now guarded), zip (guarded + existing getEntry==null early return), FileNotFoundException, IOException (abort reporting), and memberTypes recursion. The new guard sits before both stream-opening paths.


## How to test
junit tests for the case above are part of the PR.


## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
