### PR TITLE
[cleanup] - hardening Array Access on Potentially Empty Array 

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SyntheticMethodBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/SyntheticMethodBinding.java
@@ -92,7 +92,7 @@ public class SyntheticMethodBinding extends MethodBinding {
 		this.extendedTagBits |= ExtendedTagBits.AllAnnotationsResolved;
 		SourceTypeBinding declaringSourceType = (SourceTypeBinding) declaringClass;
 		SyntheticMethodBinding[] knownAccessMethods = declaringSourceType.syntheticMethods();
-		int methodId = knownAccessMethods == null ? 0 : knownAccessMethods[knownAccessMethods.length - 1].index + 1; //index may miss some numbers in between. get the highest index and assign next number.;
+		int methodId = nextSyntheticIndex(knownAccessMethods);
 		this.index = methodId;
 		this.selector = CharOperation.concat(TypeConstants.SYNTHETIC_ACCESS_METHOD_PREFIX, String.valueOf(methodId).toCharArray());
 		if (isReadAccess) {
@@ -195,7 +195,7 @@ public class SyntheticMethodBinding extends MethodBinding {
 		this.extendedTagBits |= ExtendedTagBits.AllAnnotationsResolved;
 		SourceTypeBinding declaringSourceType = (SourceTypeBinding) declaringClass;
 		SyntheticMethodBinding[] knownAccessMethods = declaringSourceType.syntheticMethods();
-		int methodId = knownAccessMethods == null ? 0 : knownAccessMethods[knownAccessMethods.length - 1].index + 1; //index may miss some numbers in between. get the highest index and assign next number.;
+		int methodId = nextSyntheticIndex(knownAccessMethods);
 		this.index = methodId;
 		this.selector = selector;
 		this.returnType = declaringSourceType.scope.createArrayType(TypeBinding.INT, 1);
@@ -322,9 +322,18 @@ public class SyntheticMethodBinding extends MethodBinding {
 	}
 
 	private int nextSmbIndex() {
-		SyntheticMethodBinding[] knownAccessMethods = ((SourceTypeBinding)this.declaringClass).syntheticMethods();
-		int methodId = knownAccessMethods == null ? 0 : knownAccessMethods[knownAccessMethods.length - 1].index + 1; //index may miss some numbers in between. get the highest index and assign next number.;
-		return methodId;
+		return nextSyntheticIndex(((SourceTypeBinding)this.declaringClass).syntheticMethods());
+	}
+
+	static int nextSyntheticIndex(SyntheticMethodBinding[] knownAccessMethods) {
+		int maxIndex = -1;
+		if (knownAccessMethods != null) {
+			for (SyntheticMethodBinding known : knownAccessMethods) {
+				if (known != null && known.index > maxIndex)
+					maxIndex = known.index;
+			}
+		}
+		return maxIndex + 1;
 	}
 
 	/**
@@ -551,7 +560,7 @@ public class SyntheticMethodBinding extends MethodBinding {
 		this.extendedTagBits |= ExtendedTagBits.AllAnnotationsResolved;
 		SourceTypeBinding sourceType = (SourceTypeBinding) accessedConstructor.declaringClass;
 		SyntheticMethodBinding[] knownSyntheticMethods = sourceType.syntheticMethods();   // returns synthetic methods sorted with index.
-		this.index = knownSyntheticMethods == null ? 0 : knownSyntheticMethods[knownSyntheticMethods.length - 1].index + 1; //index may miss some numbers in between. get the highest index and assign next number.
+		this.index = nextSyntheticIndex(knownSyntheticMethods);
 
 		this.selector = accessedConstructor.selector;
 		this.returnType = accessedConstructor.returnType;
@@ -636,7 +645,7 @@ public class SyntheticMethodBinding extends MethodBinding {
 		this.extendedTagBits |= ExtendedTagBits.AllAnnotationsResolved;
 		SourceTypeBinding declaringSourceType = (SourceTypeBinding) receiverType;
 		SyntheticMethodBinding[] knownAccessMethods = declaringSourceType.syntheticMethods();
-		int methodId = knownAccessMethods == null ? 0 : knownAccessMethods[knownAccessMethods.length - 1].index + 1; //index may miss some numbers in between. get the highest index and assign next number.
+		int methodId = nextSyntheticIndex(knownAccessMethods);
 		this.index = methodId;
 
 		this.selector = CharOperation.concat(TypeConstants.SYNTHETIC_ACCESS_METHOD_PREFIX, String.valueOf(methodId).toCharArray());

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/InnerEmulationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/InnerEmulationTest.java
@@ -6358,6 +6358,33 @@ public void testbug481793() {
 	};
 	this.runConformTest(sources);
 }
+// Test for Guards the hardened next-index computation in SyntheticMethodBinding
+public void testSyntheticAccessorIndexAssignment() {
+	String[] sources = new String[] {
+		"Outer.java",
+		"""
+		public class Outer {
+	        private int f1 = 1;
+	        private int f2 = 2;
+	        private int f3 = 3;
+	        private int add(int a, int b) { return a + b; }
+	        class Inner {
+	                int run() {
+	                        Outer.this.f1 = Outer.this.f1 + 10;
+	                        int s = Outer.this.add(Outer.this.f2, Outer.this.f3);
+	                        return Outer.this.f1 + s;
+	                }
+	        }
+	        public static void main(String[] args) {
+	                Outer o = new Outer();
+	                System.out.print(o.new Inner().run());
+	        }
+		}
+
+		"""
+	};
+	this.runConformTest(sources, "16"); // (1+10) + (2+3) = 16
+}
 public static Class testClass() {
 	return InnerEmulationTest.class;
 }


### PR DESCRIPTION

## What it does
 The fix code guards against  An empty array that will throws an unchecked ArrayIndexOutOfBoundsException crashing the compiler process 

## How to test
defensive programming - the test case provided tests access patterns.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
