### PR TITLE
[cleanup] Exception Handling Array Access Without Bounds Check

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/flow/ExceptionHandlingFlowContext.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/flow/ExceptionHandlingFlowContext.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -111,7 +111,7 @@ ExceptionHandlingFlowContext(
 		!this.isMethodContext || scope.compilerOptions().reportUnusedDeclaredThrownExceptionExemptExceptionAndThrowable;
 	for (int i = 0; i < count; i++) {
 		ReferenceBinding handledException = handledExceptions[i];
-		int catchBlock = this.exceptionToCatchBlockMap != null? this.exceptionToCatchBlockMap[i] : i;
+		int catchBlock = catchBlockIndex(i);
 		this.indexes.put(handledException, i); // key type  -> value index
 		if (handledException.isUncheckedException(true)) {
 			if (markExceptionsAndThrowableAsReached ||
@@ -191,7 +191,7 @@ private ASTNode getExceptionType(int index) {
 	if (this.exceptionToCatchBlockMap == null) {
 		return this.catchArguments[index].type;
 	}
-	int catchBlock = this.exceptionToCatchBlockMap[index];
+	int catchBlock = catchBlockIndex(index);
 	ASTNode node = this.catchArguments[catchBlock].type;
 	if (node instanceof UnionTypeReference) {
 		TypeReference[] typeRefs = ((UnionTypeReference)node).typeReferences;
@@ -200,6 +200,13 @@ private ASTNode getExceptionType(int index) {
 		}
 	}
 	return node;
+}
+
+private int catchBlockIndex(int index) {
+	if (this.exceptionToCatchBlockMap != null && index >= 0 && index < this.exceptionToCatchBlockMap.length) {
+		return this.exceptionToCatchBlockMap[index];
+	}
+	return index;
 }
 
 @Override
@@ -224,7 +231,7 @@ public String individualToString() {
 		} else {
 			buffer.append("-not reached"); //$NON-NLS-1$
 		}
-		int catchBlock = this.exceptionToCatchBlockMap != null? this.exceptionToCatchBlockMap[i] : i;
+		int catchBlock = catchBlockIndex(i);
 		buffer.append('-').append(this.initsOnExceptions[catchBlock].toString()).append(']');
 	}
 	buffer.append("[initsOnReturn -").append(this.initsOnReturn.toString()).append(']'); //$NON-NLS-1$
@@ -284,7 +291,7 @@ public void recordHandlingException(
 		this.isNeeded[cacheIndex] |= bitMask;
 	}
 	this.isReached[cacheIndex] |= bitMask;
-	int catchBlock = this.exceptionToCatchBlockMap != null? this.exceptionToCatchBlockMap[index] : index;
+	int catchBlock = catchBlockIndex(index);
 	if (caughtException != null && this.catchArguments != null && this.catchArguments.length > 0 && !wasAlreadyDefinitelyCaught) {
 		CatchParameterBinding catchParameter = (CatchParameterBinding) this.catchArguments[catchBlock].binding;
 		catchParameter.setPreciseType(caughtException);

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TryStatement17Test.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TryStatement17Test.java
@@ -1321,6 +1321,35 @@ public void testBug488569_001() {
 	}
 }
 
+public void testMultiCatchMapIndexing() {
+	this.runConformTest(
+		new String[] {
+			"X.java",
+			"""
+			import java.io.IOException;
+			public class X {
+			        static int m(int which) throws IOException {
+			                final int a;
+			                try {
+			                        if (which == 0) throw new IOException();
+			                        if (which == 1) throw new IllegalStateException();
+			                        throw new NumberFormatException();
+			                } catch (IOException | IllegalStateException e) { // 2 handled types -> 1 catch block
+			                        a = 1;
+			                } catch (RuntimeException e) {
+			                        a = 2;
+			                }
+			                return a; // definite assignment across all catch blocks must hold
+			        }
+			        public static void main(String[] args) throws IOException {
+			                System.out.print("" + m(0) + m(1) + m(2));
+			        }
+			}
+
+			"""
+		},
+		"112"); // IOException->1, IllegalStateException->1, NumberFormatException(RuntimeException)->2
+}
 public static Class testClass() {
 	return TryStatement17Test.class;
 }


### PR DESCRIPTION

## What it does

in File: …flow/ExceptionHandlingFlowContext.java
The map array is accessed by index after only a null check, with no check that index < array.length.
int catchBlock = this.exceptionToCatchBlockMap != null
    ? this.exceptionToCatchBlockMap[index]  // no bounds check on index
    : index;
Risk
An out-of-range index throws an unchecked ArrayIndexOutOfBoundsException during compilation — DoS in build-server or compiler-service contexts

Note that it is found that this is not reachable with the current code. However, de-duplication and added defensive programming against any future refactorings. categorizing this as cleanup.

## How to test
junit test provided

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
