### PR TITLE
fix for file descriptor leak in GZIPOutStream

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaModelManagerTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaModelManagerTests.java
@@ -1,8 +1,19 @@
 package org.eclipse.jdt.core.tests.model;
 
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.zip.GZIPOutputStream;
 import junit.framework.Test;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
@@ -176,5 +187,86 @@ public class JavaModelManagerTests extends AbstractJavaModelTests {
 		}
 		String fatalProblemsAsText = sb.toString();
 		return fatalProblemsAsText;
+	}
+
+	// --- createInputStream(File) resource-safety tests (FD leak on non-ZipException) ---
+
+	private static InputStream invokeCreateInputStream(File file) throws Exception {
+		JavaModelManager mgr = JavaModelManager.getJavaModelManager();
+		Method m = JavaModelManager.class.getDeclaredMethod("createInputStream", File.class);
+		m.setAccessible(true);
+		try {
+			return (InputStream) m.invoke(mgr, file);
+		} catch (InvocationTargetException e) {
+			Throwable cause = e.getCause();
+			if (cause instanceof IOException) {
+				throw (IOException) cause;
+			}
+			if (cause instanceof RuntimeException) {
+				throw (RuntimeException) cause;
+			}
+			throw e;
+		}
+	}
+
+	private static byte[] readAll(InputStream in) throws IOException {
+		try (InputStream stream = in) {
+			ByteArrayOutputStream out = new ByteArrayOutputStream();
+			byte[] buf = new byte[1024];
+			int n;
+			while ((n = stream.read(buf)) != -1) {
+				out.write(buf, 0, n);
+			}
+			return out.toByteArray();
+		}
+	}
+
+	// gzip-compressed content is read back transparently.
+	public void testCreateInputStream_gzip() throws Exception {
+		File file = File.createTempFile("jmm-gzip", ".tmp");
+		try {
+			byte[] content = "HELLO GZIP CONTENT".getBytes(StandardCharsets.UTF_8);
+			try (OutputStream out = new GZIPOutputStream(new FileOutputStream(file))) {
+				out.write(content);
+			}
+			byte[] read = readAll(invokeCreateInputStream(file));
+			assertEquals("gzip content mismatch", new String(content, StandardCharsets.UTF_8), new String(read, StandardCharsets.UTF_8));
+		} finally {
+			assertTrue("temp file should be deletable (no leaked handle)", file.delete() || !file.exists());
+		}
+	}
+
+	// old plain (non-gzip) content triggers the ZipException fallback and is read back verbatim.
+	public void testCreateInputStream_oldPlainFormat() throws Exception {
+		File file = File.createTempFile("jmm-plain", ".tmp");
+		try {
+			byte[] content = "PLAINDATA-not-gzip".getBytes(StandardCharsets.UTF_8);
+			Files.write(file.toPath(), content);
+			byte[] read = readAll(invokeCreateInputStream(file));
+			assertEquals("plain content mismatch", new String(content, StandardCharsets.UTF_8), new String(read, StandardCharsets.UTF_8));
+		} finally {
+			assertTrue("temp file should be deletable (no leaked handle)", file.delete() || !file.exists());
+		}
+	}
+
+	public void testCreateInputStream_truncatedGzip_doesNotLeak() throws Exception {
+		File file = File.createTempFile("jmm-trunc", ".tmp");
+		try {
+			// 0x1f 0x8b = gzip magic, then EOF before the rest of the 10-byte header.
+			Files.write(file.toPath(), new byte[] { (byte) 0x1f, (byte) 0x8b });
+			try {
+				InputStream in = invokeCreateInputStream(file);
+				in.close();
+				fail("expected IOException for truncated gzip header");
+			} catch (IOException expected) {
+				// expected: truncated header
+			}
+			// Best-effort FD-leak check: on Windows a leaked handle would prevent deletion.
+			assertTrue("truncated file must be deletable -> underlying stream was closed (no FD leak)", file.delete());
+		} finally {
+			if (file.exists()) {
+				file.delete();
+			}
+		}
 	}
 }

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelManager.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2020 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -79,8 +79,8 @@ import org.eclipse.jdt.internal.core.search.AbstractSearchScope;
 import org.eclipse.jdt.internal.core.search.BasicSearchEngine;
 import org.eclipse.jdt.internal.core.search.IRestrictedAccessTypeRequestor;
 import org.eclipse.jdt.internal.core.search.JavaWorkspaceScope;
-import org.eclipse.jdt.internal.core.search.indexing.IndexManager;
 import org.eclipse.jdt.internal.core.search.indexing.DerivedSourceSearchParticipantRegistry;
+import org.eclipse.jdt.internal.core.search.indexing.IndexManager;
 import org.eclipse.jdt.internal.core.search.processing.IJob;
 import org.eclipse.jdt.internal.core.search.processing.JobManager;
 import org.eclipse.jdt.internal.core.util.DeduplicationUtil;
@@ -4435,8 +4435,14 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 
 	private InputStream createInputStream(File file) throws IOException {
 		InputStream in = new FileInputStream(file);
+		// Ownership of 'in' is transferred to the returned stream on success; on any abnormal
+		// exit (incl. a non-ZipException IOException such as EOFException from a truncated file)
+		// the finally block closes 'in' to avoid leaking the file descriptor.
+		boolean ownershipTransferred = false;
 		try {
-			return new BufferedInputStream(new java.util.zip.GZIPInputStream(in, 8192));
+			BufferedInputStream result = new BufferedInputStream(new java.util.zip.GZIPInputStream(in, 8192));
+			ownershipTransferred = true;
+			return result;
 		} catch (ZipException e) {
 			// probably not zipped (old format), but may also be corrupted.
 			in.close();
@@ -4448,12 +4454,26 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 				throw e; // corrupted
 			}
 			return new BufferedInputStream(new FileInputStream(file));
+		} finally {
+			if (!ownershipTransferred) {
+				in.close(); // idempotent: harmless if already closed on the ZipException path
+			}
 		}
 	}
 
 	private OutputStream createOutputStream(File file) throws IOException {
 		if (SAVE_ZIPPED) {
-			return new BufferedOutputStream(new java.util.zip.GZIPOutputStream(new FileOutputStream(file), 8192));
+			FileOutputStream fileOutput = new FileOutputStream(file);
+			boolean ownershipTransferred = false;
+			try {
+				BufferedOutputStream result = new BufferedOutputStream(new java.util.zip.GZIPOutputStream(fileOutput, 8192));
+				ownershipTransferred = true;
+				return result;
+			} finally {
+				if (!ownershipTransferred) {
+					fileOutput.close(); // avoids fd leak if GZIPOutputStream constructor throws
+				}
+			}
 		} else {
 			return new BufferedOutputStream(new FileOutputStream(file));
 		}


### PR DESCRIPTION
## What it does
Fixes the fd leak when GZIPInputStream throws a non-ZipException, the underlying FileInputStream created on the first line is never closed.
InputStream in = new FileInputStream(file);   // leaked on non-ZipException
try {
    return new BufferedInputStream(new GZIPInputStream(in, 8192));
} catch (ZipException e) {
    in.close();        // only ZipException path closes 'in'
    // IOException from GZIPInputStream leaks 'in' entirely
}


## How to test
junit tests provided

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
