### PR TITLE
[Generics] Switching the order of extended interfaces alters the result of @NonNull annotation analysis

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/NullAnnotationMatching.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/NullAnnotationMatching.java
@@ -851,4 +851,20 @@ public class NullAnnotationMatching {
 		buf.append(" nullStatus="+this.nullStatus); //$NON-NLS-1$
 		return buf.toString();
 	}
+	public static MethodBinding methodWithMergedNullAnnotations(MethodBinding current, MethodBinding[] moreSpecific, int count, LookupEnvironment environment) {
+		if (count < 2)
+			return current;
+		TypeBinding[] parameters = weakerTypes(moreSpecific[0].parameters, moreSpecific[1].parameters, environment);
+		TypeBinding returnType = strongerType(moreSpecific[0].returnType, moreSpecific[1].returnType, environment);
+		for (int i = 2; i < count; i++) {
+			parameters = weakerTypes(parameters, moreSpecific[i].parameters, environment);
+			returnType = strongerType(returnType, moreSpecific[i].returnType, environment);
+		}
+		if (parameters != current.parameters || returnType != current.returnType) { //$IDENTITY-COMPARISON$
+			current = current.copy();
+			current.parameters = parameters;
+			current.returnType = returnType;
+		}
+		return current;
+	}
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MethodBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/MethodBinding.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -125,6 +125,23 @@ public MethodBinding(MethodBinding initialMethodBinding, ReferenceBinding declar
 	this.thrownExceptions = initialMethodBinding.thrownExceptions;
 	this.declaringClass = declaringClass;
 	declaringClass.storeAnnotationHolder(this, initialMethodBinding.declaringClass.retrieveAnnotationHolder(initialMethodBinding, true));
+}
+protected void copyFieldsFrom(MethodBinding other) {
+	this.modifiers = other.modifiers;
+	this.selector = other.selector;
+	this.returnType = other.returnType;
+	this.parameters = other.parameters;
+	this.thrownExceptions = other.thrownExceptions;
+	this.declaringClass = other.declaringClass;
+	this.extendedTagBits = other.extendedTagBits;
+	this.tagBits = other.tagBits;
+	this.typeAnnotations = other.typeAnnotations;
+	this.typeVariables = other.typeVariables;
+}
+public MethodBinding copy() {
+	MethodBinding copy = new MethodBinding();
+	copy.copyFieldsFrom(this);
+	return copy;
 }
 /* Answer true if the argument types & the receiver's parameters have the same erasure
 */

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedMethodBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedMethodBinding.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2017 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -297,6 +297,14 @@ public class ParameterizedMethodBinding extends MethodBinding {
 
 	public ParameterizedMethodBinding() {
 		// no init
+	}
+
+	@Override
+	public MethodBinding copy() {
+		ParameterizedMethodBinding copy = new ParameterizedMethodBinding();
+		copy.copyFieldsFrom(this);
+		copy.originalMethod = this.originalMethod;
+		return copy;
 	}
 
 	/**

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Scope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Scope.java
@@ -4695,132 +4695,116 @@ public abstract class Scope {
 		if (receiverType != null)
 			receiverType = receiverType instanceof CaptureBinding ? receiverType : (ReferenceBinding) receiverType.erasure();
 
-		boolean hasConsideredNullContract = false;
-		// perform 1 or 2 attempts, the second being the safety net, in case considering null contracts may have prevented finding a solution.
-		for (int attempt = 0; attempt < 2; attempt++) {
-			nextSpecific : for (int i = 0; i < visibleSize; i++) {
-				MethodBinding current = moreSpecific[i];
-				if (current != null) {
-					ReferenceBinding[] mostSpecificExceptions = null;
-					MethodBinding original = current.original();
-					boolean shouldIntersectExceptions = original.declaringClass.isAbstract() && original.thrownExceptions != Binding.NO_EXCEPTIONS; // only needed when selecting from interface methods
-					for (int j = 0; j < visibleSize; j++) {
-						MethodBinding next = moreSpecific[j];
-						if (next == null || i == j) continue;
-						MethodBinding original2 = next.original();
-						if (TypeBinding.equalsEquals(original.declaringClass, original2.declaringClass))
-							break nextSpecific; // duplicates thru substitution
+		nextSpecific : for (int i = 0; i < visibleSize; i++) {
+			MethodBinding current = moreSpecific[i];
+			if (current != null) {
+				ReferenceBinding[] mostSpecificExceptions = null;
+				MethodBinding original = current.original();
+				boolean shouldIntersectExceptions = original.declaringClass.isAbstract() && original.thrownExceptions != Binding.NO_EXCEPTIONS; // only needed when selecting from interface methods
+				for (int j = 0; j < visibleSize; j++) {
+					MethodBinding next = moreSpecific[j];
+					if (next == null || i == j) continue;
+					MethodBinding original2 = next.original();
+					if (TypeBinding.equalsEquals(original.declaringClass, original2.declaringClass))
+						break nextSpecific; // duplicates thru substitution
 
-						if (!original.isAbstract()) {
-							if (original2.isAbstract() || original2.isDefaultMethod())
-								continue; // only compare current against other concrete methods
+					if (!original.isAbstract()) {
+						if (original2.isAbstract() || original2.isDefaultMethod())
+							continue; // only compare current against other concrete methods
 
-							original2 = original.findOriginalInheritedMethod(original2);
-							if (original2 == null)
-								continue nextSpecific; // current's declaringClass is not a subtype of next's declaringClass
-							if (current.hasSubstitutedParameters() || original.typeVariables != Binding.NO_TYPE_VARIABLES) {
-								if (!environment().methodVerifier().isParameterSubsignature(original, original2))
-									continue nextSpecific; // current does not override next
-							}
-						} else if (receiverType != null) { // should not be null if original isAbstract, but be safe
-							TypeBinding superType = receiverType.findSuperTypeOriginatingFrom(original.declaringClass.erasure());
-							if (TypeBinding.equalsEquals(original.declaringClass, superType) || !(superType instanceof ReferenceBinding)) {
-								// keep original
-							} else {
-								// must find inherited method with the same substituted variables
-								MethodBinding[] superMethods = ((ReferenceBinding) superType).getMethods(original.selector, argumentTypes.length);
-								for (MethodBinding superMethod : superMethods) {
-									if (superMethod.original() == original) {
-										original = superMethod;
-										break;
-									}
-								}
-							}
-							superType = receiverType.findSuperTypeOriginatingFrom(original2.declaringClass.erasure());
-							if (TypeBinding.equalsEquals(original2.declaringClass, superType) || !(superType instanceof ReferenceBinding)) {
-								// keep original2
-							} else {
-								// must find inherited method with the same substituted variables
-								MethodBinding[] superMethods = ((ReferenceBinding) superType).getMethods(original2.selector, argumentTypes.length);
-								for (MethodBinding superMethod : superMethods) {
-									if (superMethod.original() == original2) {
-										original2 = superMethod;
-										break;
-									}
-								}
-							}
-							if (original.typeVariables != Binding.NO_TYPE_VARIABLES)
-								original2 = original.computeSubstitutedMethod(original2, environment());
-							if (original2 == null || !original.areParameterErasuresEqual(original2))
+						original2 = original.findOriginalInheritedMethod(original2);
+						if (original2 == null)
+							continue nextSpecific; // current's declaringClass is not a subtype of next's declaringClass
+						if (current.hasSubstitutedParameters() || original.typeVariables != Binding.NO_TYPE_VARIABLES) {
+							if (!environment().methodVerifier().isParameterSubsignature(original, original2))
 								continue nextSpecific; // current does not override next
-							if (TypeBinding.notEquals(original.returnType, original2.returnType)) {
-								if (next.original().typeVariables != Binding.NO_TYPE_VARIABLES) {
-									if (original.returnType.erasure().findSuperTypeOriginatingFrom(original2.returnType.erasure()) == null)
-										continue nextSpecific;
-								} else if (!current.returnType.isCompatibleWith(next.returnType)) {
-									continue nextSpecific;
+						}
+					} else if (receiverType != null) { // should not be null if original isAbstract, but be safe
+						TypeBinding superType = receiverType.findSuperTypeOriginatingFrom(original.declaringClass.erasure());
+						if (TypeBinding.equalsEquals(original.declaringClass, superType) || !(superType instanceof ReferenceBinding)) {
+							// keep original
+						} else {
+							// must find inherited method with the same substituted variables
+							MethodBinding[] superMethods = ((ReferenceBinding) superType).getMethods(original.selector, argumentTypes.length);
+							for (MethodBinding superMethod : superMethods) {
+								if (superMethod.original() == original) {
+									original = superMethod;
+									break;
 								}
-								// continue with original 15.12.2.5
 							}
-							if (attempt == 0
-									&& compilerOptions().isAnnotationBasedNullAnalysisEnabled
-									&& j > i // don't go backwards
-									&& NullAnnotationMatching.hasMoreSpecificNullness(next, current))
-							{
-								// In this case we want to prefer 'next' among equivalent methods.
-								// (the case where JLS 15.12.2.5 says "...is chosen arbitrarily...")
-								// To try if 'next' matches all criteria, skip outer loop to j (after increment):
-								i = j -1 ;
-								hasConsideredNullContract = true;
+						}
+						superType = receiverType.findSuperTypeOriginatingFrom(original2.declaringClass.erasure());
+						if (TypeBinding.equalsEquals(original2.declaringClass, superType) || !(superType instanceof ReferenceBinding)) {
+							// keep original2
+						} else {
+							// must find inherited method with the same substituted variables
+							MethodBinding[] superMethods = ((ReferenceBinding) superType).getMethods(original2.selector, argumentTypes.length);
+							for (MethodBinding superMethod : superMethods) {
+								if (superMethod.original() == original2) {
+									original2 = superMethod;
+									break;
+								}
+							}
+						}
+						if (original.typeVariables != Binding.NO_TYPE_VARIABLES)
+							original2 = original.computeSubstitutedMethod(original2, environment());
+						if (original2 == null || !original.areParameterErasuresEqual(original2))
+							continue nextSpecific; // current does not override next
+						if (TypeBinding.notEquals(original.returnType, original2.returnType)) {
+							if (next.original().typeVariables != Binding.NO_TYPE_VARIABLES) {
+								if (original.returnType.erasure().findSuperTypeOriginatingFrom(original2.returnType.erasure()) == null)
+									continue nextSpecific;
+							} else if (!current.returnType.isCompatibleWith(next.returnType)) {
 								continue nextSpecific;
 							}
-							if (shouldIntersectExceptions && original2.declaringClass.isInterface()) {
-								if (current.thrownExceptions != next.thrownExceptions) {
-									if (next.thrownExceptions == Binding.NO_EXCEPTIONS) {
-										mostSpecificExceptions = Binding.NO_EXCEPTIONS;
-									} else {
-										if (mostSpecificExceptions == null) {
-											mostSpecificExceptions = current.thrownExceptions;
-										}
-										int mostSpecificLength = mostSpecificExceptions.length;
-										ReferenceBinding[] nextExceptions = getFilteredExceptions(next);
-										int nextLength = nextExceptions.length;
-										SimpleSet temp = new SimpleSet(mostSpecificLength);
-										boolean changed = false;
-										nextException : for (int t = 0; t < mostSpecificLength; t++) {
-											ReferenceBinding exception = mostSpecificExceptions[t];
-											for (int s = 0; s < nextLength; s++) {
-												ReferenceBinding nextException = nextExceptions[s];
-												if (exception.isCompatibleWith(nextException)) {
-													temp.add(exception);
-													continue nextException;
-												} else if (nextException.isCompatibleWith(exception)) {
-													temp.add(nextException);
-													changed = true;
-													continue nextException;
-												} else {
-													changed = true;
-												}
+							// continue with original 15.12.2.5
+						}
+						if (shouldIntersectExceptions && original2.declaringClass.isInterface()) {
+							if (current.thrownExceptions != next.thrownExceptions) {
+								if (next.thrownExceptions == Binding.NO_EXCEPTIONS) {
+									mostSpecificExceptions = Binding.NO_EXCEPTIONS;
+								} else {
+									if (mostSpecificExceptions == null) {
+										mostSpecificExceptions = current.thrownExceptions;
+									}
+									int mostSpecificLength = mostSpecificExceptions.length;
+									ReferenceBinding[] nextExceptions = getFilteredExceptions(next);
+									int nextLength = nextExceptions.length;
+									SimpleSet temp = new SimpleSet(mostSpecificLength);
+									boolean changed = false;
+									nextException : for (int t = 0; t < mostSpecificLength; t++) {
+										ReferenceBinding exception = mostSpecificExceptions[t];
+										for (int s = 0; s < nextLength; s++) {
+											ReferenceBinding nextException = nextExceptions[s];
+											if (exception.isCompatibleWith(nextException)) {
+												temp.add(exception);
+												continue nextException;
+											} else if (nextException.isCompatibleWith(exception)) {
+												temp.add(nextException);
+												changed = true;
+												continue nextException;
+											} else {
+												changed = true;
 											}
 										}
-										if (changed) {
-											mostSpecificExceptions = temp.elementSize == 0 ? Binding.NO_EXCEPTIONS : new ReferenceBinding[temp.elementSize];
-											temp.asArray(mostSpecificExceptions);
-										}
+									}
+									if (changed) {
+										mostSpecificExceptions = temp.elementSize == 0 ? Binding.NO_EXCEPTIONS : new ReferenceBinding[temp.elementSize];
+										temp.asArray(mostSpecificExceptions);
 									}
 								}
 							}
 						}
 					}
-					if (mostSpecificExceptions != null && mostSpecificExceptions != current.thrownExceptions) {
-						return new MostSpecificExceptionMethodBinding(current, mostSpecificExceptions);
-					}
-					return current;
 				}
+				if (mostSpecificExceptions != null && mostSpecificExceptions != current.thrownExceptions) {
+					return new MostSpecificExceptionMethodBinding(current, mostSpecificExceptions);
+				}
+				if (environment().usesNullTypeAnnotations()) {
+					return NullAnnotationMatching.methodWithMergedNullAnnotations(current, moreSpecific, count, environment());
+				}
+				return current;
 			}
-			if (!hasConsideredNullContract)
-				break;
-			// otherwise retry without considering null contracts
 		}
 		return new ProblemMethodBinding(visible[0], visible[0].selector, visible[0].parameters, ProblemReasons.Ambiguous);
 	}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullTypeAnnotationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullTypeAnnotationTest.java
@@ -20162,5 +20162,67 @@ public void testGH4297_3() {
 		----------
 		""");
 }
+public void testGH5070() {
+	runConformTestWithLibs(new String[] {
+			"GenericsOrder.java",
+			"""
+			import org.eclipse.jdt.annotation.NonNull;
 
+			public class GenericsOrder {
+				public <T extends a & b> void test1(T my) { // 1: a & b
+					if (my != null)
+						my.method(null);
+				}
+				public <T extends b & a> void test2(T my) { // 2: b & a
+					if (my != null)
+						my.method(null);
+				}
+			}
+
+			interface a { int method(@NonNull String a); }
+			interface b { int method(String a); }
+			"""
+		},
+		getCompilerOptions(),
+		"");
+}
+public void testGH5070_returnType() {
+	runNegativeTestWithLibs(new String[] {
+			"GenericsOrder.java",
+			"""
+			import org.eclipse.jdt.annotation.*;
+
+			public class GenericsOrder {
+				public <T extends a & b & c> @NonNull String test1(T my) { // 1: a & b & c
+					if (my != null)
+						return my.method(null);
+					return "";
+				}
+				public <T extends c & b & a> @NonNull String test2(T my) { // 2: c & b & a
+					if (my != null)
+						return my.method(null);
+					return "";
+				}
+			}
+
+			interface a { String method(@NonNull String a); }
+			interface b { @Nullable String method(@NonNull String a); }
+			interface c { @NonNull String method(@NonNull String a); }
+			"""
+		},
+		getCompilerOptions(),
+		"""
+		----------
+		1. ERROR in GenericsOrder.java (at line 6)
+			return my.method(null);
+			                 ^^^^
+		Null type mismatch: required '@NonNull String' but the provided value is null
+		----------
+		2. ERROR in GenericsOrder.java (at line 11)
+			return my.method(null);
+			                 ^^^^
+		Null type mismatch: required '@NonNull String' but the provided value is null
+		----------
+		""");
+}
 }


### PR DESCRIPTION
+ no longer try to find the most specific method based on null annotations
+ but create a view of the method with merged null annotations

The former strategy stems from #2327, were we used null annotations to steer the "arbitrary selection" in case of multiple maximally specific methods. This strategy was incomplete for cases where none of the maximally specific methods was null-compatible to all others. Also modifying the already-complex logic in `mostSpecificMethodBinding()` led to trouble of its own.

The new strategy lets `mostSpecificMethodBinding()` (almost) complete without considering null annotations. Only right when returning the selected method, and if we found several most specific methods, then we create a view of the selected method with null annotations merged from all candidates: pick the weakest parameter types and the strongest return type.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4297
