### PR TITLE
Annotation Based Resource Analysis: Cannot read field "tagBits" because "field.binding" is null

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypeDeclaration.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/TypeDeclaration.java
@@ -824,7 +824,8 @@ private void internalAnalyseCode(FlowContext flowContext, FlowInfo flowInfo) {
 					this.initializerScope.problemReporter().initializerMustCompleteNormally(field);
 					nonStaticFieldInfo = FlowInfo.initial(this.maxFieldCount).setReachMode(FlowInfo.UNREACHABLE_OR_DEAD);
 				}
-				if (fieldNeedingClose == null && useOwningAnnotations && isCloseable && (field.binding.tagBits & TagBits.AnnotationOwning) != 0) {
+				if (fieldNeedingClose == null && useOwningAnnotations && isCloseable
+						&& !(field instanceof Initializer) && (field.binding.tagBits & TagBits.AnnotationOwning) != 0) {
 					fieldNeedingClose = field;
 				}
 			}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ResourceLeakAnnotatedTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ResourceLeakAnnotatedTests.java
@@ -1844,4 +1844,35 @@ public void testGH3278_missingAnnotations() {
 		options,
 		false);
 }
+public void testGH4899() {
+	runLeakTestWithAnnotations(new String[] {
+			"X.java",
+			"""
+			import org.eclipse.jdt.annotation.Owning;
+
+			@interface NonNull {}
+
+			interface AC extends AutoCloseable {
+
+			  @Owning
+			  public static @NonNull AC acquire() {
+			    return new AC() {
+			      {
+			        // this initializer is causing the crash
+			      }
+
+			      @Override
+			      public void close() {
+			        throw new UnsupportedOperationException();
+			      }
+			    };
+			  }
+			}
+			public class X {
+			}
+			"""
+		},
+		"",
+		getCompilerOptions());
+}
 }


### PR DESCRIPTION
Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4899
