### PR TITLE
Compilation errors when annotation-based null analysis is enabled

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/NullAnnotationMatching.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/NullAnnotationMatching.java
@@ -778,6 +778,7 @@ public class NullAnnotationMatching {
 	}
 
 	public static TypeBinding strongerType(TypeBinding type1, TypeBinding type2, LookupEnvironment environment) {
+		if (!TypeBinding.equalsEquals(type1, type2)) return type1; // don't change the unannotated type
 		if ((type1.tagBits & TagBits.AnnotationNonNull) != 0)
 			return mergeTypeAnnotations(type1, type2, true, environment);
 		return mergeTypeAnnotations(type2, type1, true, environment); // don't bother to distinguish unannotated vs. @Nullable, since both can accept null

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullTypeAnnotationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullTypeAnnotationTest.java
@@ -20225,4 +20225,32 @@ public void testGH5070_returnType() {
 		----------
 		""");
 }
+public void testGH5249() {
+	runConformTestWithLibs(true, new String[] {
+			"Test.java",
+			"""
+			import java.util.Collection;
+			import java.util.List;
+
+			public class Test {
+			    private ListValuedMap<String, String> multiMap;
+
+			    public Test() {
+			        List<String> values = multiMap.get("");
+			    }
+
+			    public static interface ListValuedMap<K, V> extends MultiValuedMap<K, V> {
+			        @Override
+			        List<V> get(K key);
+			    }
+
+			    public static interface MultiValuedMap<K, V> {
+			        Collection<V> get(K key);
+			    }
+			}
+			"""
+		},
+		getCompilerOptions(),
+		"");
+}
 }


### PR DESCRIPTION
Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5249
