### PR TITLE
Fix DocCommentParser to properly handle markdown links in inline return

### DIFF
--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/DocCommentParser.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/DocCommentParser.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2004, 2024 IBM Corporation and others.
+ * Copyright (c) 2004, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -1127,6 +1127,13 @@ class DocCommentParser extends AbstractCommentParser {
 			} else {
 				previousTag = (TagElement) this.astStack[this.astPtr];
 				previousStart = previousTag.getStartPosition();
+			}
+			if (previousTag.fragments.size() > 0 && this.tagValue == TAG_LINK_VALUE) {
+				ASTNode lastNode= (ASTNode)previousTag.fragments.get(previousTag.fragments.size() - 1);
+				if (lastNode instanceof TagElement lastTag && lastTag.getTagName().equals(TagElement.TAG_RETURN)) {
+					previousTag= lastTag;
+					previousStart= lastTag.getStartPosition();
+				}
 			}
 			previousTag.fragments().add(seeTag);
 			previousTag.setSourceRange(previousStart, end-previousStart+1);


### PR DESCRIPTION
- add similar logic from addFragmentToInlineReturn() method to pushSeeRef() to ensure that new link is added as fragment of inline return and not a sibling of the inline return
- needed for: https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/3092

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See referred JDT UI issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See referred JDT UI issue.  A new test will be added to JDT UI once this PR is merged.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
