### PR TITLE
OPTION_GenerateClassFiles silently ignores GENERATE/DO_NOT_GENERATE — accepts only enabled/disabled

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/impl/CompilerOptions.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/impl/CompilerOptions.java
@@ -2189,9 +2189,9 @@ public class CompilerOptions {
 			}
 		}
 		if ((optionValue = optionsMap.get(OPTION_GenerateClassFiles)) != null) {
-			if (ENABLED.equals(optionValue)) {
+			if (ENABLED.equals(optionValue) || GENERATE.equals(optionValue)) {
 				this.generateClassFiles = true;
-			} else if (DISABLED.equals(optionValue)) {
+			} else if (DISABLED.equals(optionValue) || DO_NOT_GENERATE.equals(optionValue)) {
 				this.generateClassFiles = false;
 			}
 		}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/parser/ParserTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/parser/ParserTest.java
@@ -823,4 +823,29 @@ public void testBug485477() {
 		"Syntax error, insert \". Identifier\" to complete Expression\n" +
 		"----------\n");
 }
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5217
+// OPTION_GenerateClassFiles silently ignores GENERATE/DO_NOT_GENERATE — accepts only enabled/disabled
+public void testIssue5217() {
+	CompilerOptions options = new CompilerOptions(Map.of(
+	        CompilerOptions.OPTION_GenerateClassFiles, CompilerOptions.DO_NOT_GENERATE));
+	if (options.generateClassFiles)
+		throw new AssertionError("Option processing broken!");
+
+	Map<String, String> optionsMap = options.getMap();
+
+	optionsMap.put(CompilerOptions.OPTION_GenerateClassFiles, CompilerOptions.GENERATE);
+	options.set(optionsMap);
+	if (!options.generateClassFiles)
+		throw new AssertionError("Option processing broken!");
+
+	optionsMap.put(CompilerOptions.OPTION_GenerateClassFiles, "disabled");
+	options.set(optionsMap);
+	if (options.generateClassFiles)
+		throw new AssertionError("Option processing broken!");
+
+	optionsMap.put(CompilerOptions.OPTION_GenerateClassFiles, "enabled");
+	options.set(optionsMap);
+	if (!options.generateClassFiles)
+		throw new AssertionError("Option processing broken!");
+}
 }


### PR DESCRIPTION
* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5217

