### PR TITLE
JDT issue in spring-security project

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/CapturingContext.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/CapturingContext.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2025 GK Software, and others.
+ * Copyright (c) 2025, 2026 GK Software, and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -37,6 +37,8 @@ public class CapturingContext {
 		this.end = end;
 		this.scope = scope;
 		this.previous = previous;
+		if (previous != null)
+			this.isCaptureInProgress = previous.isCaptureInProgress;
 	}
 
 	public static void enter(int start, int end, Scope scope) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/LookupEnvironment.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/LookupEnvironment.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -1541,7 +1541,6 @@ public WildcardBinding createWildcard(ReferenceBinding genericType, int rank, Ty
 }
 
 public CaptureBinding createCapturedWildcard(WildcardBinding wildcard, ReferenceBinding contextType, int start, int end, ASTNode cud, Supplier<Integer> idSupplier) {
-	wildcard = normalizeWildcard(wildcard);
 	return this.typeSystem.getCapturedWildcard(wildcard, contextType, start, end, cud, idSupplier);
 }
 
@@ -1557,13 +1556,6 @@ private TypeBinding normalizeWildcardBound(TypeBinding bound, int boundKind) {
 			return capture.firstBound;
 	}
 	return bound;
-}
-private WildcardBinding normalizeWildcard(WildcardBinding wildcard) {
-	if (wildcard.boundKind == Wildcard.EXTENDS
-			&& wildcard.bound instanceof CaptureBinding wildCap
-			&& wildCap.wildcard != null) // null happens for CaptureBinding18
-		return wildCap.wildcard;
-	return wildcard;
 }
 
 /**

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_1_8.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_1_8.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2023 GK Software SE, and others.
+ * Copyright (c) 2013, 2026 GK Software SE, and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -11044,5 +11044,34 @@ public void testBug508834_comment0() {
 			Type mismatch: cannot convert from capture#1-of ? extends AutoCloseable to CharSequence[]
 			----------
 			""");
+	}
+
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4867
+	public void testGH4867() {
+		runConformTest(
+			new String[] {
+				"MessageExpressionVoterTests.java",
+				"""
+				public class MessageExpressionVoterTests {
+					MessageMatcher<?> matcher = new MessageMatcher<String>() {
+					};
+
+					public boolean voteGranted() {
+						return this.matcher.matcher(ArgumentMatchers.any());
+					}
+				}
+				interface MessageMatcher<T> {
+					default boolean matcher(Message<? extends T> message) {
+						return true;
+					}
+				}
+				interface Message<T> {}
+				class ArgumentMatchers {
+					public static <T> T any() {
+						return null;
+					}
+				}
+				"""
+			});
 	}
 }


### PR DESCRIPTION
+ remove "normalization" of wildcards
+ prevent creation of infinite types by propagating CapturingContext.isCaptureInProgress

Uses @snjeza's test case from #4868, thanks!

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4867
