### PR TITLE
Extending an inner interface can cause a bounds mismatch error

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ClassScope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ClassScope.java
@@ -1460,24 +1460,25 @@ public class ClassScope extends Scope {
 	}
 
 	public boolean detectHierarchyCycle(TypeBinding superType, TypeReference reference) {
-		if (!(superType instanceof ReferenceBinding)) return false;
 
-		if (reference == this.superTypeReference) { // see findSuperType()
-			if (superType.isTypeVariable())
-				return false; // error case caught in resolveSuperType()
-			// abstract class X<K,V> implements java.util.Map<K,V>
-			//    static abstract class M<K,V> implements Entry<K,V>
-			if (superType.isParameterizedType())
-				superType = ((ParameterizedTypeBinding) superType).genericType();
-			compilationUnitScope().recordSuperTypeReference(superType); // to record supertypes
-			return detectHierarchyCycle(this.referenceContext.binding, (ReferenceBinding) superType, reference);
+		if (this.referenceContext.binding.isHierarchyBeingActivelyConnected() && superType instanceof ReferenceBinding) {
+			if (reference == this.superTypeReference) { // see findSuperType()
+				if (superType.isTypeVariable())
+					return false; // error case caught in resolveSuperType()
+				// abstract class X<K,V> implements java.util.Map<K,V>
+				// static abstract class M<K,V> implements Entry<K,V>
+				if (superType.isParameterizedType())
+					superType = ((ParameterizedTypeBinding) superType).genericType();
+				compilationUnitScope().recordSuperTypeReference(superType); // to record supertypes
+				return detectHierarchyCycle(this.referenceContext.binding, (ReferenceBinding) superType, reference);
+			}
+			// Reinstate the code deleted by the fix for https://bugs.eclipse.org/bugs/show_bug.cgi?id=205235
+			// For details, see https://bugs.eclipse.org/bugs/show_bug.cgi?id=294057.
+			if ((superType.tagBits & TagBits.BeginHierarchyCheck) == 0 && superType instanceof SourceTypeBinding)
+				// ensure if this is a source superclass that it has already been checked
+				((SourceTypeBinding) superType).scope.connectTypeHierarchyWithoutMembers();
+
 		}
-		// Reinstate the code deleted by the fix for https://bugs.eclipse.org/bugs/show_bug.cgi?id=205235
-		// For details, see https://bugs.eclipse.org/bugs/show_bug.cgi?id=294057.
-		if ((superType.tagBits & TagBits.BeginHierarchyCheck) == 0 && superType instanceof SourceTypeBinding)
-			// ensure if this is a source superclass that it has already been checked
-			((SourceTypeBinding) superType).scope.connectTypeHierarchyWithoutMembers();
-
 		return false;
 	}
 

--- a/org.eclipse.jdt.core.tests.builder/src/org/eclipse/jdt/core/tests/builder/Java50Tests.java
+++ b/org.eclipse.jdt.core.tests.builder/src/org/eclipse/jdt/core/tests/builder/Java50Tests.java
@@ -315,6 +315,7 @@ public class Java50Tests extends BuilderTests {
 		);
 	}
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=294057
+	// NOTE: This test was broken and was fixed by https://github.com/eclipse-jdt/eclipse.jdt.core/pull/5257
 	public void testHierarchyNonCycle() throws JavaModelException {
 		IPath projectPath = env.addProject("Project", CompilerOptions.getFirstSupportedJavaVersion());
 		env.addExternalJars(projectPath, Util.getJavaClassLibs());
@@ -340,15 +341,10 @@ public class Java50Tests extends BuilderTests {
 		);
 
 		fullBuild(projectPath);
-		expectingProblemsFor(
-				projectPath,
-				"Problem : Bound mismatch: The type SubInterface.SubInterfaceGetter is not a valid substitute for the bounded parameter <G extends SuperInterface.SuperInterfaceGetter> of the type SuperInterface<G,S> [ resource : </Project/subint/SubInterface.java> range : <105,136> category : <40> severity : <2>]\n" +
-				"Problem : Bound mismatch: The type SubInterface.SubInterfaceSetter is not a valid substitute for the bounded parameter <S extends SuperInterface.SuperInterfaceSetter> of the type SuperInterface<G,S> [ resource : </Project/subint/SubInterface.java> range : <157,188> category : <40> severity : <2>]\n" +
-				"Problem : SuperInterfaceGetter cannot be resolved to a type [ resource : </Project/subint/SubInterface.java> range : <244,264> category : <40> severity : <2>]\n" +
-				"Problem : SuperInterfaceSetter cannot be resolved to a type [ resource : </Project/subint/SubInterface.java> range : <320,340> category : <40> severity : <2>]"
-			);
+		expectingNoProblems();
 	}
 	// https://bugs.eclipse.org/bugs/show_bug.cgi?id=294057 (variation)
+	// NOTE: This test was broken and was fixed by https://github.com/eclipse-jdt/eclipse.jdt.core/pull/5257
 	public void testHierarchyNonCycle2() throws JavaModelException {
 		IPath projectPath = env.addProject("Project", CompilerOptions.getFirstSupportedJavaVersion());
 		env.addExternalJars(projectPath, Util.getJavaClassLibs());
@@ -376,7 +372,10 @@ public class Java50Tests extends BuilderTests {
 		);
 
 		fullBuild(projectPath);
-		expectingNoProblems();
+		expectingProblemsFor(
+				projectPath,
+				"Problem : The import superint.SuperInterface.SuperInterfaceGetter is never used [ resource : </Project/subint/SubInterface.java> range : <55,99> category : <120> severity : <1>]\n" +
+				"Problem : The import superint.SuperInterface.SuperInterfaceSetter is never used [ resource : </Project/subint/SubInterface.java> range : <108,152> category : <120> severity : <1>]");
 	}
 
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/InnerClass15Test.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/InnerClass15Test.java
@@ -24,7 +24,7 @@ public InnerClass15Test(String name) {
 }
 static {
 //	TESTS_NUMBERS = new int[] { 2 };
-//	TESTS_NAMES = new String[] {"testIssue1069", "testIssue5197", "testIssue4733"};
+	//TESTS_NAMES = new String[] {"testBug520874"};
 }
 public static Test suite() {
 	return buildMinimalComplianceTestSuite(testClass(), FIRST_SUPPORTED_JAVA_VERSION);
@@ -979,6 +979,84 @@ public void testIssue4733() {
 		},
 		"Ok!");
 }
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4889
+// Eclipse 4.39.0 RC1: Unable to resolve inner abstract class
+public void testIssue4889() {
+	runConformTest(
+		new String[] {
+				"eiab/DocumentsStore.java",
+				"""
+				package eiab;
+
+				import eiab.DocumentsStore.DocumentsStoreConfiguration;
+
+				import java.time.Duration;
+
+				public class DocumentsStore extends AbstractStore<Integer, Boolean, DocumentsStoreConfiguration> {
+				    protected DocumentsStore(final DocumentsStoreConfiguration configuration) {
+				        super(configuration);
+				    }
+
+				    public static class DocumentsStoreConfiguration extends BaseConfiguration {}
+
+				    public static void main(String [] args) {
+						System.out.println("Ok!");
+				   }
+				}
+				""",
+				"eiab/AbstractStore.java",
+				"""
+				package eiab;
+
+				import eiab.AbstractStore.BaseConfiguration;
+
+				import java.util.LinkedHashMap;
+				import java.util.Map;
+
+				public abstract class AbstractStore<KEY, VALUE, CONFIGURATION extends BaseConfiguration> {
+					abstract static class BaseConfiguration {
+						private boolean cacheEnabled = true;
+						public boolean isCacheEnabled() {
+							return cacheEnabled;
+						}
+						public void setCacheEnabled(boolean cacheEnabled) {
+							this.cacheEnabled = cacheEnabled;
+						}
+					}
+
+				    private final CONFIGURATION configuration;
+				    private final Map<KEY, VALUE> store;
+
+				    protected AbstractStore(final CONFIGURATION configuration) {
+				        this.configuration = configuration;
+				        this.store = new LinkedHashMap<>();
+				    }
+
+				    protected void put(final KEY key, final VALUE value) {
+				        this.store.put(key, value);
+				    }
+
+				    protected void remove(final KEY key) {
+				        this.store.remove(key);
+				    }
+
+				    public void clear() {
+				        this.store.clear();
+				    }
+
+				    boolean contains(final KEY key) {
+				        if (!configuration.isCacheEnabled()) {
+				            return false;
+				        }
+
+				        return this.store.containsKey(key);
+				    }
+				}
+				"""
+			},
+			"Ok!");
+}
+
 
 
 

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/InnerClass15Test.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/InnerClass15Test.java
@@ -24,7 +24,7 @@ public InnerClass15Test(String name) {
 }
 static {
 //	TESTS_NUMBERS = new int[] { 2 };
-	//TESTS_NAMES = new String[] {"testBug520874"};
+//	TESTS_NAMES = new String[] {"testIssue1069", "testIssue5197", "testIssue4733"};
 }
 public static Test suite() {
 	return buildMinimalComplianceTestSuite(testClass(), FIRST_SUPPORTED_JAVA_VERSION);
@@ -825,6 +825,162 @@ public void testIssue3842_2() {
 		"Local variable x is required to be final or effectively final based on its usage\n" +
 		"----------\n");
 }
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1069
+// Extending an inner interface can cause a bounds mismatch error
+public void testIssue1069() {
+	runConformTest(
+		new String[] {
+			"X.java",
+			"""
+			public interface X<T> {
+				interface I {
+				}
+				public static void main(String [] args) {
+					System.out.println("Ok!");
+				}
+			}
+
+			interface Y extends X<Y.J> {
+				interface J extends I {
+				}
+			}
+			"""
+		},
+		"Ok!");
+}
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1069
+// Extending an inner interface can cause a bounds mismatch error
+public void testIssue1069_reported() {
+	runConformTest(
+		new String[] {
+			"org/dominokit/test/ParentInterface.java",
+			"""
+			package org.dominokit.test;
+
+			import org.dominokit.test.ParentInterface.ParentInterfaceHandler;
+
+			public interface ParentInterface<U extends ParentInterfaceHandler> {
+
+			  interface ParentInterfaceHandler {
+
+			  }
+			  public static void main(String [] args) {
+					System.out.println("Ok!");
+			  }
+			}
+			""",
+			"org/dominokit/test/ChildInterface.java",
+			"""
+			package org.dominokit.test;
+
+			import org.dominokit.test.ChildInterface.ChildInterfaceHandler;
+
+			public interface ChildInterface extends ParentInterface<ChildInterfaceHandler> {
+
+			  interface ChildInterfaceHandler extends ParentInterfaceHandler {
+			  }
+			}
+			"""
+		},
+		"Ok!");
+}
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5197
+// Compilation error with JDT but ok with JavaC
+public void testIssue5197() {
+	runConformTest(
+		new String[] {
+			"repro/AbstractTestIT.java",
+			"""
+			package repro;
+
+			import repro.AbstractTestIT.ExecuteAction;
+			import repro.AbstractTestIT.ZoomB;
+
+			public abstract class AbstractTestIT<T extends ZoomB & ExecuteAction> {
+
+			  interface ExecuteAction {
+
+			    void executerAction(Object req);
+
+			  }
+
+			  public abstract T get();
+
+			  static public class ZoomA {
+
+			  }
+
+			  static public class ZoomB extends ZoomA {
+
+			  }
+
+			  public static void main(String [] args) {
+					System.out.println("Ok!");
+			  }
+
+			}
+			""",
+			"repro/TestITZoom.java",
+			"""
+			package repro;
+
+			import repro.TestITZoom.ZoomC;
+
+			public class TestITZoom
+			    extends AbstractTestIT<ZoomC> {
+
+			  @Override
+			  public ZoomC get() {
+			    return null;
+			  }
+
+			  static class ZoomC extends repro.AbstractTestIT.ZoomB implements ExecuteAction {
+
+			    @Override
+			    public void executerAction(Object req) {
+			    }
+
+			  }
+
+			}
+			"""
+
+		},
+		"Ok!");
+}
+
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4733
+// compile error when self-import references a nested class that is used as a type argument
+public void testIssue4733() {
+	runConformTest(
+		new String[] {
+			"demo/NestedGenericImport.java",
+			"""
+			package demo;
+
+			import demo.NestedGenericImport.Concrete.ConcreteInner;
+
+			public class NestedGenericImport {
+
+			    abstract static class Base<S extends Base.BaseInner> {
+			        abstract static class BaseInner {}
+			    }
+
+			    static class Concrete extends Base<ConcreteInner> {
+			        static class ConcreteInner extends BaseInner {}
+			    }
+
+			    public static void main(String [] args) {
+					System.out.println("Ok!");
+			    }
+			}
+			"""
+
+		},
+		"Ok!");
+}
+
+
 
 public static Class<InnerClass15Test> testClass() {
 	return InnerClass15Test.class;


### PR DESCRIPTION
* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1069
* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5197
* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4733
* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4889


