### PR TITLE
Fix native library filtering for Android ART in Util.java

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/util/Util.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/util/Util.java
@@ -729,11 +729,29 @@ public class Util implements SuffixConstants {
 	/**
 	 * Returns whether the given name is a native library file name
 	 * (.so, .dll, .dylib).
+	 * <p>
+	 * The name may be a simple file name, a file system path, or a jar entry
+	 * path. Comparison is done character-by-character to avoid extra string
+	 * allocations, consistent with {@link #isClassFileName}.
+	 * </p>
+	 * <p>
+	 * This check prevents native libraries from being misclassified as ZIP/JMOD
+	 * archives or from being added to the bootclasspath.
+	 * See <a href="https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5253">issue 5253</a>.
+	 * </p>
+	 *
+	 * @param name the file name or path to check; must not be {@code null}
+	 * @return {@code true} if the name ends with a native library extension
 	 */
 	private static boolean isNativeLibrary(String name) {
 		int lastDot = name.lastIndexOf('.');
 		if (lastDot == -1)
 			return false;
+		// Reject if the last dot belongs to a directory segment rather than
+		// a file extension (e.g. "some.dir/file.so" is still valid because
+		// the separator is before the last dot, but "dir.so/file" is not).
+		// On Android/Linux File.separatorChar is '/', so jar-style paths are
+		// handled correctly for the primary target platform.
 		if (name.lastIndexOf(File.separatorChar) > lastDot)
 			return false;
 		int length = name.length();
@@ -1145,6 +1163,8 @@ public class Util implements SuffixConstants {
 			StringTokenizer tokenizer = new StringTokenizer(bootclasspathProperty, File.pathSeparator);
 			while (tokenizer.hasMoreTokens()) {
 				String path = tokenizer.nextToken();
+				// Exclude native libraries (.so, .dll, .dylib) from the bootclasspath.
+				// See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5253
 				if (!isNativeLibrary(path)) {
 					filePaths.add(path);
 				}
@@ -1171,6 +1191,8 @@ public class Util implements SuffixConstants {
 					for (File[] current : systemLibrariesJars) {
 						if (current != null) {
 							for (File file : current) {
+								// Exclude native libraries (.so, .dll, .dylib) from the bootclasspath.
+								// See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5253
 								if (!isNativeLibrary(file.getAbsolutePath())) {
 									filePaths.add(file.getAbsolutePath());
 								}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/util/Util.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/util/Util.java
@@ -668,6 +668,9 @@ public class Util implements SuffixConstants {
 			}
 			return false; // it is a ".class" file, it cannot be a zip archive name
 		}
+		if (isNativeLibrary(name)) {
+			return false;
+		}
 		return true; // it is neither a ".java" file nor a ".class" file, so this is a potential archive name
 	}
 
@@ -705,6 +708,9 @@ public class Util implements SuffixConstants {
 			}
 			return -1; // it is a ".class" file, it cannot be a zip archive name
 		}
+		if (isNativeLibrary(name)) {
+			return -1;
+		}
 		if (extensionLength == EXTENSION_jmod.length()) {
 			for (int i = extensionLength-1; i >=0; i--) {
 				if (Character.toLowerCase(name.charAt(length - extensionLength + i)) != EXTENSION_jmod.charAt(i)) {
@@ -720,6 +726,43 @@ public class Util implements SuffixConstants {
 	 * Returns true iff str.toLowerCase().endsWith(".class")
 	 * implementation is not creating extra strings.
 	 */
+	/**
+	 * Returns whether the given name is a native library file name
+	 * (.so, .dll, .dylib).
+	 */
+	private static boolean isNativeLibrary(String name) {
+		int lastDot = name.lastIndexOf('.');
+		if (lastDot == -1)
+			return false;
+		if (name.lastIndexOf(File.separatorChar) > lastDot)
+			return false;
+		int length = name.length();
+		int extensionLength = length - lastDot - 1;
+		if (extensionLength == 2) { // .so
+			if ((name.charAt(length - 2) == 's' || name.charAt(length - 2) == 'S')
+					&& (name.charAt(length - 1) == 'o' || name.charAt(length - 1) == 'O')) {
+				return true;
+			}
+		}
+		if (extensionLength == 3) { // .dll
+			if ((name.charAt(length - 3) == 'd' || name.charAt(length - 3) == 'D')
+					&& (name.charAt(length - 2) == 'l' || name.charAt(length - 2) == 'L')
+					&& (name.charAt(length - 1) == 'l' || name.charAt(length - 1) == 'L')) {
+				return true;
+			}
+		}
+		if (extensionLength == 5) { // .dylib
+			if ((name.charAt(length - 5) == 'd' || name.charAt(length - 5) == 'D')
+					&& (name.charAt(length - 4) == 'y' || name.charAt(length - 4) == 'Y')
+					&& (name.charAt(length - 3) == 'l' || name.charAt(length - 3) == 'L')
+					&& (name.charAt(length - 2) == 'i' || name.charAt(length - 2) == 'I')
+					&& (name.charAt(length - 1) == 'b' || name.charAt(length - 1) == 'B')) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 	public final static boolean isClassFileName(char[] name) {
 		int nameLength = name == null ? 0 : name.length;
 		int suffixLength = SUFFIX_CLASS.length;
@@ -1101,7 +1144,10 @@ public class Util implements SuffixConstants {
 		if ((bootclasspathProperty != null) && (bootclasspathProperty.length() != 0)) {
 			StringTokenizer tokenizer = new StringTokenizer(bootclasspathProperty, File.pathSeparator);
 			while (tokenizer.hasMoreTokens()) {
-				filePaths.add(tokenizer.nextToken());
+				String path = tokenizer.nextToken();
+				if (!isNativeLibrary(path)) {
+					filePaths.add(path);
+				}
 			}
 		} else {
 			// try to get all jars inside the lib folder of the java home
@@ -1125,7 +1171,9 @@ public class Util implements SuffixConstants {
 					for (File[] current : systemLibrariesJars) {
 						if (current != null) {
 							for (File file : current) {
-								filePaths.add(file.getAbsolutePath());
+								if (!isNativeLibrary(file.getAbsolutePath())) {
+									filePaths.add(file.getAbsolutePath());
+								}
 							}
 						}
 					}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->



**AI Statement:
This contribution was developed with the assistance of AI tools and has been manually reviewed by me.(including Code)**



## What it does
<!-- Include relevant issues and describe how they are addressed. -->

Prevents native libraries (`.so`, `.dll`, `.dylib`) from being misidentified as ZIP/JMOD archives or added to the bootclasspath. Fixes #5253.

On Android ART, the bootclasspath may contain native library paths (e.g. `/system/lib64/libart.so`). ECJ currently treats these as potential ZIP archives because they have an unrecognized file extension, which can lead to unnecessary file probing or classpath pollution.

Changes:
- Add `isNativeLibrary(String)` helper with zero-allocation, case-insensitive character comparison (consistent with existing `isClassFileName` / `isJavaFileName` style).
- Filter native libraries in `isPotentialZipArchive()` → returns `false`.
- Filter native libraries in `archiveFormat()` → returns `-1`.
- Exclude native libraries from `collectPlatformLibraries()` bootclasspath collection, both when parsing `sun.boot.class.path` / `vm.boot.class.path` and when scanning `javaHome/lib`.


## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

I have pulled the changes from this PR and successfully compiled them locally using the following command:
```bash
mvn clean package -DskipTests -T 2 \
  -Dtycho.disableP2Mirrors=false \
  -Dp2.repo.url=https://download.eclipse.org/releases/latest/ \
  -pl org.eclipse.jdt.core.compiler.batch -am
```
And built locally with:
```bash
  mvn clean compile -Pbuild-individual-bundles
  mvn test -Pbuild-individual-bundles
```

Full test suite was not run locally due to resource constraints (Termux on Android). I rely on CI for complete testing.



## Known limitations / Follow-up work

- **Unit tests**: No new JUnit tests are included in this PR. Adding tests for `isNativeLibrary` with various path formats (simple name, absolute path, jar entry path) is recommended as a follow-up.
- **Path separator**: `isNativeLibrary` checks `File.separatorChar` for directory/extension disambiguation. On Android/Linux (primary target) this is `'/'` and works correctly for both file-system paths and jar entry paths. Windows paths using `'/'` as an alternative separator are not explicitly handled; this is consistent with existing methods in `Util` but could be improved if cross-platform path mixing is a concern.
- **RegionMatches**: Character-by-character comparison was chosen to stay consistent with `isClassFileName` / `isJavaFileName` and avoid temporary string allocations. `String.regionMatches` could be considered later for readability without sacrificing performance.



## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)