### PR TITLE
Fix native library filtering for Android ART in Util.java

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/util/Util.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/util/Util.java
@@ -668,6 +668,9 @@ public class Util implements SuffixConstants {
 			}
 			return false; // it is a ".class" file, it cannot be a zip archive name
 		}
+		if (isNativeLibrary(name)) {
+			return false;
+		}
 		return true; // it is neither a ".java" file nor a ".class" file, so this is a potential archive name
 	}
 
@@ -705,6 +708,9 @@ public class Util implements SuffixConstants {
 			}
 			return -1; // it is a ".class" file, it cannot be a zip archive name
 		}
+		if (isNativeLibrary(name)) {
+			return -1;
+		}
 		if (extensionLength == EXTENSION_jmod.length()) {
 			for (int i = extensionLength-1; i >=0; i--) {
 				if (Character.toLowerCase(name.charAt(length - extensionLength + i)) != EXTENSION_jmod.charAt(i)) {
@@ -720,6 +726,61 @@ public class Util implements SuffixConstants {
 	 * Returns true iff str.toLowerCase().endsWith(".class")
 	 * implementation is not creating extra strings.
 	 */
+	/**
+	 * Returns whether the given name is a native library file name
+	 * (.so, .dll, .dylib).
+	 * <p>
+	 * The name may be a simple file name, a file system path, or a jar entry
+	 * path. Comparison is done character-by-character to avoid extra string
+	 * allocations, consistent with {@link #isClassFileName}.
+	 * </p>
+	 * <p>
+	 * This check prevents native libraries from being misclassified as ZIP/JMOD
+	 * archives or from being added to the bootclasspath.
+	 * See <a href="https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5253">issue 5253</a>.
+	 * </p>
+	 *
+	 * @param name the file name or path to check; must not be {@code null}
+	 * @return {@code true} if the name ends with a native library extension
+	 */
+	private static boolean isNativeLibrary(String name) {
+		int lastDot = name.lastIndexOf('.');
+		if (lastDot == -1)
+			return false;
+		// Reject if the last dot belongs to a directory segment rather than
+		// a file extension (e.g. "some.dir/file.so" is still valid because
+		// the separator is before the last dot, but "dir.so/file" is not).
+		// On Android/Linux File.separatorChar is '/', so jar-style paths are
+		// handled correctly for the primary target platform.
+		if (name.lastIndexOf(File.separatorChar) > lastDot)
+			return false;
+		int length = name.length();
+		int extensionLength = length - lastDot - 1;
+		if (extensionLength == 2) { // .so
+			if ((name.charAt(length - 2) == 's' || name.charAt(length - 2) == 'S')
+					&& (name.charAt(length - 1) == 'o' || name.charAt(length - 1) == 'O')) {
+				return true;
+			}
+		}
+		if (extensionLength == 3) { // .dll
+			if ((name.charAt(length - 3) == 'd' || name.charAt(length - 3) == 'D')
+					&& (name.charAt(length - 2) == 'l' || name.charAt(length - 2) == 'L')
+					&& (name.charAt(length - 1) == 'l' || name.charAt(length - 1) == 'L')) {
+				return true;
+			}
+		}
+		if (extensionLength == 5) { // .dylib
+			if ((name.charAt(length - 5) == 'd' || name.charAt(length - 5) == 'D')
+					&& (name.charAt(length - 4) == 'y' || name.charAt(length - 4) == 'Y')
+					&& (name.charAt(length - 3) == 'l' || name.charAt(length - 3) == 'L')
+					&& (name.charAt(length - 2) == 'i' || name.charAt(length - 2) == 'I')
+					&& (name.charAt(length - 1) == 'b' || name.charAt(length - 1) == 'B')) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 	public final static boolean isClassFileName(char[] name) {
 		int nameLength = name == null ? 0 : name.length;
 		int suffixLength = SUFFIX_CLASS.length;
@@ -1101,7 +1162,12 @@ public class Util implements SuffixConstants {
 		if ((bootclasspathProperty != null) && (bootclasspathProperty.length() != 0)) {
 			StringTokenizer tokenizer = new StringTokenizer(bootclasspathProperty, File.pathSeparator);
 			while (tokenizer.hasMoreTokens()) {
-				filePaths.add(tokenizer.nextToken());
+				String path = tokenizer.nextToken();
+				// Exclude native libraries (.so, .dll, .dylib) from the bootclasspath.
+				// See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5253
+				if (!isNativeLibrary(path)) {
+					filePaths.add(path);
+				}
 			}
 		} else {
 			// try to get all jars inside the lib folder of the java home
@@ -1125,7 +1191,11 @@ public class Util implements SuffixConstants {
 					for (File[] current : systemLibrariesJars) {
 						if (current != null) {
 							for (File file : current) {
-								filePaths.add(file.getAbsolutePath());
+								// Exclude native libraries (.so, .dll, .dylib) from the bootclasspath.
+								// See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5253
+								if (!isNativeLibrary(file.getAbsolutePath())) {
+									filePaths.add(file.getAbsolutePath());
+								}
 							}
 						}
 					}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/util/Util.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/util/Util.java
@@ -640,7 +640,8 @@ public class Util implements SuffixConstants {
 	}
 	/**
 	 * Returns whether the given name is potentially a zip archive file name
-	 * (it has a file extension and it is not ".java" nor ".class")
+	 * (it has a file extension and it is neither ".java", ".class" nor a
+	 * native library extension)
 	 */
 	public final static boolean isPotentialZipArchive(String name) {
 		int lastDot = name.lastIndexOf('.');
@@ -648,6 +649,8 @@ public class Util implements SuffixConstants {
 			return false; // no file extension, it cannot be a zip archive name
 		if (name.lastIndexOf(File.separatorChar) > lastDot)
 			return false; // dot was before the last file separator, it cannot be a zip archive name
+		if (isNativeLibrary(name))
+			return false; // native libraries are no archives
 		int length = name.length();
 		int extensionLength = length - lastDot - 1;
 		if (extensionLength == EXTENSION_java.length()) {
@@ -668,7 +671,7 @@ public class Util implements SuffixConstants {
 			}
 			return false; // it is a ".class" file, it cannot be a zip archive name
 		}
-		return true; // it is neither a ".java" file nor a ".class" file, so this is a potential archive name
+		return true; // this is a potential archive name
 	}
 
 	public static final int ZIP_FILE = 0;
@@ -684,6 +687,8 @@ public class Util implements SuffixConstants {
 			return -1; // no file extension, it cannot be a zip archive name
 		if (name.lastIndexOf(File.separatorChar) > lastDot)
 			return -1; // dot was before the last file separator, it cannot be a zip archive name
+		if (isNativeLibrary(name))
+			return -1; // native libraries are no archives
 		int length = name.length();
 		int extensionLength = length - lastDot - 1;
 
@@ -713,7 +718,49 @@ public class Util implements SuffixConstants {
 			}
 			return JMOD_FILE;
 		}
-		return ZIP_FILE; // it is neither a ".java" file nor a ".class" file, so this is a potential archive name
+		return ZIP_FILE; // this is a potential archive name
+	}
+
+	/**
+	 * Native library file extensions (without the leading dot).
+	 */
+	private static final String[] NATIVE_LIBRARY_EXTENSIONS = { "so", "dll", "dylib" }; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+
+	/**
+	 * Returns whether the given name is a native library file name
+	 * (.so, .dll, .dylib).
+	 * <p>
+	 * The name may be a simple file name, a file system path, or a jar entry
+	 * path: only the part behind the last dot is considered, so a dot inside a
+	 * directory segment (e.g. {@code "dir.so/file"}) can never match, because
+	 * the remainder would still contain a path separator.
+	 * </p>
+	 * <p>
+	 * The comparison is case insensitive and does not allocate intermediate
+	 * strings.
+	 * </p>
+	 * <p>
+	 * This check prevents native libraries from being misclassified as ZIP/JMOD
+	 * archives or from being added to the bootclasspath.
+	 * See <a href="https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5253">issue 5253</a>.
+	 * </p>
+	 *
+	 * @param name the file name or path to check; must not be {@code null}
+	 * @return {@code true} if the name ends with a native library extension
+	 */
+	public static boolean isNativeLibrary(String name) {
+		int lastDot = name.lastIndexOf('.');
+		if (lastDot == -1) {
+			return false; // no file extension, it cannot be a native library name
+		}
+		int extensionLength = name.length() - lastDot - 1;
+		for (String extension : NATIVE_LIBRARY_EXTENSIONS) {
+			if (extensionLength == extension.length()
+					&& name.regionMatches(true, lastDot + 1, extension, 0, extensionLength)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**
@@ -1101,7 +1148,11 @@ public class Util implements SuffixConstants {
 		if ((bootclasspathProperty != null) && (bootclasspathProperty.length() != 0)) {
 			StringTokenizer tokenizer = new StringTokenizer(bootclasspathProperty, File.pathSeparator);
 			while (tokenizer.hasMoreTokens()) {
-				filePaths.add(tokenizer.nextToken());
+				String path = tokenizer.nextToken();
+				// Exclude native libraries (.so, .dll, .dylib) from the bootclasspath.
+				if (!isNativeLibrary(path)) {
+					filePaths.add(path);
+				}
 			}
 		} else {
 			// try to get all jars inside the lib folder of the java home
@@ -1122,6 +1173,8 @@ public class Util implements SuffixConstants {
 				}
 				File[][] systemLibrariesJars = Main.getLibrariesFiles(directoriesToCheck);
 				if (systemLibrariesJars != null) {
+					// native libraries (.so, .dll, .dylib) are already filtered out by
+					// Main.getLibrariesFiles() via Util.archiveFormat()
 					for (File[] current : systemLibrariesJars) {
 						if (current != null) {
 							for (File file : current) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/util/Util.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/util/Util.java
@@ -1191,11 +1191,12 @@ public class Util implements SuffixConstants {
 					for (File[] current : systemLibrariesJars) {
 						if (current != null) {
 							for (File file : current) {
-								// Exclude native libraries (.so, .dll, .dylib) from the bootclasspath.
-								// See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5253
-								if (!isNativeLibrary(file.getAbsolutePath())) {
-									filePaths.add(file.getAbsolutePath());
-								}
+										// Exclude native libraries (.so, .dll, .dylib) from the bootclasspath.
+										// See https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5253
+										String absolutePath = file.getAbsolutePath();
+										if (!isNativeLibrary(absolutePath)) {
+											filePaths.add(absolutePath);
+										}
 							}
 						}
 					}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TestAll.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TestAll.java
@@ -272,6 +272,7 @@ public static Test suite() {
 	all.addTest(new TestSuite(StandAloneASTParserTest.class));
 	all.addTest(new TestSuite(HashtableOfObjectTest.class));
 	all.addTest(new TestSuite(JrtUtilTest.class));
+	all.addTest(new TestSuite(org.eclipse.jdt.core.tests.compiler.util.UtilTest.class));
 
 	int possibleComplianceLevels = AbstractCompilerTest.getPossibleComplianceLevels();
 

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/util/UtilTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/util/UtilTest.java
@@ -1,0 +1,201 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Andrey Loskutov, and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Andrey Loskutov (loskutov@gmx.de) - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.core.tests.compiler.util;
+
+import java.io.File;
+import org.eclipse.jdt.core.tests.junit.extension.TestCase;
+import org.eclipse.jdt.internal.compiler.util.Util;
+import org.junit.Test;
+
+/**
+ * Tests for {@link Util#archiveFormat(String)} and
+ * {@link Util#isPotentialZipArchive(String)}, in particular the exclusion of
+ * native libraries (.so, .dll, .dylib), see
+ * https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5253
+ */
+public class UtilTest extends TestCase {
+
+	private static final int NO_ARCHIVE = -1;
+
+	public UtilTest(String name) {
+		super(name);
+	}
+
+	private static void assertArchiveFormat(int expected, String name) {
+		assertEquals("Unexpected archive format for: " + name, expected, Util.archiveFormat(name));
+	}
+
+	private static void assertPotentialZipArchive(boolean expected, String name) {
+		assertEquals("Unexpected zip archive classification for: " + name, expected,
+				Util.isPotentialZipArchive(name));
+	}
+
+	private static void assertNativeLibrary(boolean expected, String name) {
+		assertEquals("Unexpected native library classification for: " + name, expected,
+				Util.isNativeLibrary(name));
+	}
+
+	/** Asserts that the given name is neither an archive nor a potential zip archive. */
+	private static void assertNotAnArchive(String name) {
+		assertArchiveFormat(NO_ARCHIVE, name);
+		assertPotentialZipArchive(false, name);
+	}
+
+	/** Asserts that the given name is a plain zip archive candidate. */
+	private static void assertZipArchive(String name) {
+		assertArchiveFormat(Util.ZIP_FILE, name);
+		assertPotentialZipArchive(true, name);
+	}
+
+	@Test
+	public void testArchives() {
+		assertZipArchive("foo.jar");
+		assertZipArchive("foo.zip");
+		assertZipArchive("jrt-fs.jar");
+		assertArchiveFormat(Util.JMOD_FILE, "java.base.jmod");
+		assertPotentialZipArchive(true, "java.base.jmod");
+	}
+
+	@Test
+	public void testSourceAndClassFiles() {
+		assertNotAnArchive("Foo.java");
+		assertNotAnArchive("Foo.JAVA");
+		assertNotAnArchive("Foo.class");
+		assertNotAnArchive("Foo.CLASS");
+	}
+
+	@Test
+	public void testNoExtension() {
+		assertNotAnArchive("foo");
+		assertNotAnArchive("");
+	}
+
+	/**
+	 * Names without any dot have no extension at all and must never be
+	 * classified as native libraries, even if the name itself equals a native
+	 * library extension. Such names reach
+	 * {@link Util#isNativeLibrary(String)} via the bootclasspath handling in
+	 * {@code Util#collectPlatformLibraries(java.io.File)}, where entries may be
+	 * plain directories.
+	 */
+	@Test
+	public void testNativeLibraryWithoutExtension() {
+		assertNativeLibrary(false, "so");
+		assertNativeLibrary(false, "dll");
+		assertNativeLibrary(false, "dylib");
+		assertNativeLibrary(false, "SO");
+		assertNativeLibrary(false, "DYLIB");
+		assertNativeLibrary(false, "libso");
+		assertNativeLibrary(false, "foo");
+		assertNativeLibrary(false, "");
+		assertNativeLibrary(false, "usr" + File.separator + "lib" + File.separator + "so");
+		assertNativeLibrary(false, File.separator + "so");
+	}
+
+	@Test
+	public void testIsNativeLibrary() {
+		assertNativeLibrary(true, "libfoo.so");
+		assertNativeLibrary(true, "foo.dll");
+		assertNativeLibrary(true, "libfoo.dylib");
+		assertNativeLibrary(true, ".so");
+		assertNativeLibrary(true, "libfoo.DyLiB");
+		assertNativeLibrary(true, "usr" + File.separator + "lib" + File.separator + "libjvm.so");
+		assertNativeLibrary(true, "some.dir" + File.separator + "libjvm.dylib");
+
+		assertNativeLibrary(false, "foo.jar");
+		assertNativeLibrary(false, "Foo.class");
+		assertNativeLibrary(false, "Foo.java");
+		assertNativeLibrary(false, "foo.sox");
+		assertNativeLibrary(false, "foo.dlls");
+		assertNativeLibrary(false, "foo.dylibx");
+	}
+
+	/**
+	 * Only the part behind the last dot is the extension: if a path separator
+	 * follows the last dot, that dot belongs to a directory segment and the
+	 * name is not a native library.
+	 */
+	@Test
+	public void testNativeLibraryWithSeparatorAfterLastDot() {
+		assertNativeLibrary(false, "dir.so" + File.separator + "file");
+		assertNativeLibrary(false, "dir.so/file");
+		assertNativeLibrary(false, "dir.dll/file");
+		assertNativeLibrary(false, "dir.dylib/file");
+		assertNativeLibrary(false, "dir.so" + File.separator);
+		assertNativeLibrary(false, "dir.so/");
+		assertNativeLibrary(false, "libfoo.so/");
+		assertNativeLibrary(false, "a.s/o");
+		assertNativeLibrary(false, "a.d/ll");
+	}
+
+	@Test
+	public void testNativeLibrariesAreNoArchives() {
+		// see https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5253
+		assertNotAnArchive("libfoo.so");
+		assertNotAnArchive("foo.dll");
+		assertNotAnArchive("libfoo.dylib");
+		assertNotAnArchive("x.so");
+		assertNotAnArchive(".so");
+		assertNotAnArchive(".dll");
+		assertNotAnArchive(".dylib");
+	}
+
+	@Test
+	public void testNativeLibrariesAreDetectedCaseInsensitive() {
+		assertNotAnArchive("libfoo.SO");
+		assertNotAnArchive("FOO.DLL");
+		assertNotAnArchive("libfoo.DYLIB");
+		assertNotAnArchive("libfoo.DyLiB");
+	}
+
+	@Test
+	public void testNativeLibrariesWithPath() {
+		String nativeLibrary = "usr" + File.separator + "lib" + File.separator + "libjvm.so";
+		assertNotAnArchive(nativeLibrary);
+		assertNotAnArchive("some.dir" + File.separator + "libjvm.dylib");
+		assertNotAnArchive("some.dir" + File.separator + "jvm.dll");
+		// a dot in a directory segment must not turn a jar into a native library
+		assertZipArchive("some.dir" + File.separator + "foo.jar");
+	}
+
+	/**
+	 * Extensions of the same length as "class" (5) or "jmod" (4) must not be
+	 * confused with native libraries and vice versa.
+	 */
+	@Test
+	public void testExtensionsOfSameLength() {
+		// 5 characters, like "class" and "dylib"
+		assertZipArchive("foo.solar");
+		assertZipArchive("foo.zzzzz");
+		// 3 characters, like "dll"
+		assertZipArchive("foo.dl");
+		assertZipArchive("foo.dlx");
+		// 2 characters, like "so"
+		assertZipArchive("foo.sx");
+	}
+
+	/**
+	 * A file whose extension only starts with a native library extension is a
+	 * regular archive candidate.
+	 */
+	@Test
+	public void testNamesSimilarToNativeLibraries() {
+		assertZipArchive("foo.sox");
+		assertZipArchive("foo.dlls");
+		assertZipArchive("foo.dylibx");
+		assertZipArchive("foo.libso");
+		// no extension at all
+		assertNotAnArchive("libso");
+	}
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->



**AI Statement:
This contribution was developed with the assistance of AI tools and has been manually reviewed by me.(including Code)**



## What it does
<!-- Include relevant issues and describe how they are addressed. -->

Prevents native libraries (`.so`, `.dll`, `.dylib`) from being misidentified as ZIP/JMOD archives or added to the bootclasspath. Fixes #5253.

On Android ART, the bootclasspath may contain native library paths (e.g. `/system/lib64/libart.so`). ECJ currently treats these as potential ZIP archives because they have an unrecognized file extension, which can lead to unnecessary file probing or classpath pollution.

Changes:
- Add `isNativeLibrary(String)` helper with zero-allocation, case-insensitive character comparison (consistent with existing `isClassFileName` / `isJavaFileName` style).
- Filter native libraries in `isPotentialZipArchive()` → returns `false`.
- Filter native libraries in `archiveFormat()` → returns `-1`.
- Exclude native libraries from `collectPlatformLibraries()` bootclasspath collection, both when parsing `sun.boot.class.path` / `vm.boot.class.path` and when scanning `javaHome/lib`.


## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

I have pulled the changes from this PR and successfully compiled them locally using the following command:
```bash
mvn clean package -DskipTests -T 2 \
  -Dtycho.disableP2Mirrors=false \
  -Dp2.repo.url=https://download.eclipse.org/releases/latest/ \
  -pl org.eclipse.jdt.core.compiler.batch -am
```
And built locally with:
```bash
  mvn clean compile -Pbuild-individual-bundles
  mvn test -Pbuild-individual-bundles
```

Full test suite was not run locally due to resource constraints (Termux on Android). I rely on CI for complete testing.



## Known limitations / Follow-up work

- **Unit tests**: No new JUnit tests are included in this PR. Adding tests for `isNativeLibrary` with various path formats (simple name, absolute path, jar entry path) is recommended as a follow-up.
- **Path separator**: `isNativeLibrary` checks `File.separatorChar` for directory/extension disambiguation. On Android/Linux (primary target) this is `'/'` and works correctly for both file-system paths and jar entry paths. Windows paths using `'/'` as an alternative separator are not explicitly handled; this is consistent with existing methods in `Util` but could be improved if cross-platform path mixing is a concern.
- **RegionMatches**: Character-by-character comparison was chosen to stay consistent with `isClassFileName` / `isJavaFileName` and avoid temporary string allocations. `String.regionMatches` could be considered later for readability without sacrificing performance.



## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)