### PR TITLE
Fix formatting markdown java code block with empty lines

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/formatter/FormatterMarkdownCommentsTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/formatter/FormatterMarkdownCommentsTests.java
@@ -343,6 +343,34 @@ public class FormatterMarkdownCommentsTests extends FormatterCommentsTests {
 		formatSource(input, expected);
 	}
 
+	public void testMarkdownFencedCodeBlock2() throws JavaModelException {
+		setComplianceLevel(CompilerOptions.VERSION_23);
+		String input = """
+				/// A markdown comment, with a codeblock.
+				/// ```java
+				/// void foo() {
+				///
+				///   System.out.println("Hello, World!"); // 2 spaces indented
+				///
+				/// }
+				/// ```
+				class Foo { }
+				""";
+		String expected = """
+				/// A markdown comment, with a codeblock.
+				/// ```java
+				/// void foo() {
+				///
+				/// 	System.out.println("Hello, World!"); // 2 spaces indented
+				///
+				/// }
+				/// ```
+				class Foo {
+				}
+				""";
+		formatSource(input, expected);
+	}
+
 	public void testMarkdownFencedCodeBlockWithTilde() throws JavaModelException {
 		setComplianceLevel(CompilerOptions.VERSION_23);
 		String input = """

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/CommentsPreparator.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/CommentsPreparator.java
@@ -1691,7 +1691,8 @@ public class CommentsPreparator extends ASTVisitor {
 					if (c == '*')
 						lineStart = (this.ctm.charAt(i + 1) == ' ') ? i + 2 : i + 1;
 					if (c == '/' && isMarkdown)
-						lineStart = ((this.ctm.charAt(i + 1) == '/') && (this.ctm.charAt(i + 2) == '/')) ? i + 4
+						lineStart = ((this.ctm.charAt(i + 1) == '/') && (this.ctm.charAt(i + 2) == '/'))
+								? (this.ctm.charAt(i + 3) == ' ' ? i + 4 : i + 3)
 								: i + 1;
 					break;
 				}


### PR DESCRIPTION
- fix the line start calculation in CommentsPreparator.getCodeToFormat() which assumed a blank came after the markdown opening comment but does not in the case of an empty comment
- add new test to FormatterMarkdownCommentsTests
- fixes #5220

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
Fixes formatting a markdown comment with a java code block that has empty lines.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue or new test.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
