### PR TITLE
VerifyError: Instruction type does not match stack map with for loop in switch

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/StackMapFrame.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/codegen/StackMapFrame.java
@@ -14,6 +14,7 @@
 package org.eclipse.jdt.internal.compiler.codegen;
 
 import java.text.MessageFormat;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import org.eclipse.jdt.internal.compiler.lookup.Scope;
@@ -43,6 +44,9 @@ public class StackMapFrame {
 	   it should not!
 	*/
 	public boolean adoptStackShape = true;
+
+	// if the textually preceding stack frame shape is not adopted, we know nothing about this frame's verification types.
+	private static final VerificationTypeInfo [] UNKNOWN_STACK_ITEMS = new VerificationTypeInfo[0];
 
 	public StackMapFrame(int initialLocalSize) {
 		this.locals = new VerificationTypeInfo[initialLocalSize];
@@ -118,6 +122,8 @@ public class StackMapFrame {
 				final VerificationTypeInfo verificationTypeInfo = this.stackItems[i];
 				result.stackItems[i] = getCachedValue(cache, verificationTypeInfo);
 			}
+		} else if (!this.adoptStackShape) {
+			result.stackItems = UNKNOWN_STACK_ITEMS;
 		}
 		return result;
 	}
@@ -404,6 +410,8 @@ public class StackMapFrame {
 			for (int i = 0, max = this.numberOfStackItems; i < max; i++) {
 				this.stackItems[i] = this.stackItems[i].merge(frame.stackItems[i], scope);
 			}
+		} else if (this.stackItems == UNKNOWN_STACK_ITEMS) {
+			this.stackItems = Arrays.copyOf(frame.stackItems, this.numberOfStackItems = frame.numberOfStackItems);
 		}
 		return this;
 	}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchExpressionsYieldTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SwitchExpressionsYieldTest.java
@@ -8604,4 +8604,71 @@ public class SwitchExpressionsYieldTest extends AbstractRegressionTest {
 				},
 				"");
 	}
+
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5201
+	// VerifyError: Instruction type does not match stack map with for loop in switch
+	public void testIssue5201() {
+		this.runConformTest(
+				new String[] {
+						"X.java",
+						"""
+						public class X {
+							public static void main(String[] args) {
+								System.out.println(10 + switch ("B") {
+								default -> {
+									for (int i = 0; i < 10; i++)
+										System.out.println(i);
+									yield "A";
+								}
+								case "B" -> "B";
+								});
+							}
+						}
+						"""
+				},
+				"10B");
+	}
+
+	// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5201
+	// VerifyError: Instruction type does not match stack map with for loop in switch
+	public void testIssue5201_full() {
+		this.runConformTest(
+				new String[] {
+						"X.java",
+						"""
+						import java.util.Collection;
+						import java.util.Set;
+
+						public class X {
+
+							public static class Dummy {
+
+							}
+
+							public static class ExtendedDummy extends Dummy {
+
+							}
+
+							public static void main(String[] args) {
+								test(ExtendedDummy.class, switch ("B") {
+								case "A" -> {
+									for (int i = 0; i < 10; i++)
+										System.out.println(i);
+
+									yield Set.of("NoopA");
+								}
+								case "B" -> Set.of("NoopB");
+								default -> throw new IllegalArgumentException();
+								});
+							}
+
+							public static <T extends Dummy> void test(Class<T> cls, Collection<String> entities) {
+								entities.forEach(e -> System.out.println(e));
+							}
+						}
+						"""
+				},
+				"NoopB");
+	}
+
 }


### PR DESCRIPTION
* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5201

