### PR TITLE
Honor `join_lines_in_comments` option for markdown javadoc comments

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/formatter/FormatterMarkdownCommentsTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/formatter/FormatterMarkdownCommentsTests.java
@@ -909,4 +909,88 @@ public class FormatterMarkdownCommentsTests extends FormatterCommentsTests {
 		formatSource(input, expected);
 	}
 
+	public void testMarkdownAndClassicJoinLinesWhenJoinLinesInCommentsIsFalse() throws JavaModelException {
+		setComplianceLevel(CompilerOptions.VERSION_23);
+		this.formatterPrefs.join_lines_in_comments = false;
+		this.formatterPrefs.comment_line_length = 1000;
+		String input = """
+				class Test5 {
+					/// Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+					/// Duis sit amet diam nec libero accumsan blandit.
+					/// Quisque non ornare lacus. Suspendisse porta dolor id diam maximus, sed gravida nunc finibus.
+					/// Aenean vulputate, mi non iaculis sagittis, erat nibh gravida elit, eget feugiat purus tortor sed sem.
+					void main() {
+					}
+
+					/**
+					 * Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+					 * Duis sit amet diam nec libero accumsan blandit.
+					 * Quisque non ornare lacus. Suspendisse porta dolor id diam maximus, sed gravida nunc finibus.
+					 * Aenean vulputate, mi non iaculis sagittis, erat nibh gravida elit, eget feugiat purus tortor sed sem.
+					 */
+					void main2() {
+					}
+				}
+				""";
+		String expected = """
+				class Test5 {
+					/// Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+					/// Duis sit amet diam nec libero accumsan blandit.
+					/// Quisque non ornare lacus. Suspendisse porta dolor id diam maximus, sed gravida nunc finibus.
+					/// Aenean vulputate, mi non iaculis sagittis, erat nibh gravida elit, eget feugiat purus tortor sed sem.
+					void main() {
+					}
+
+					/**
+					 * Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+					 * Duis sit amet diam nec libero accumsan blandit.
+					 * Quisque non ornare lacus. Suspendisse porta dolor id diam maximus, sed gravida nunc finibus.
+					 * Aenean vulputate, mi non iaculis sagittis, erat nibh gravida elit, eget feugiat purus tortor sed sem.
+					 */
+					void main2() {
+					}
+				}
+				""";
+		formatSource(input, expected);
+	}
+
+	public void testMarkdownAndClassicJoinLinesWhenJoinLinesInCommentsIsTrue() throws JavaModelException {
+		setComplianceLevel(CompilerOptions.VERSION_23);
+		this.formatterPrefs.join_lines_in_comments = true;
+		this.formatterPrefs.comment_line_length = 1000;
+		String input = """
+				class Test5 {
+					/// Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+					/// Duis sit amet diam nec libero accumsan blandit.
+					/// Quisque non ornare lacus. Suspendisse porta dolor id diam maximus, sed gravida nunc finibus.
+					/// Aenean vulputate, mi non iaculis sagittis, erat nibh gravida elit, eget feugiat purus tortor sed sem.
+					void main() {
+					}
+
+					/**
+					 * Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+					 * Duis sit amet diam nec libero accumsan blandit.
+					 * Quisque non ornare lacus. Suspendisse porta dolor id diam maximus, sed gravida nunc finibus.
+					 * Aenean vulputate, mi non iaculis sagittis, erat nibh gravida elit, eget feugiat purus tortor sed sem.
+					 */
+					void main2() {
+					}
+				}
+				""";
+		String expected = """
+				class Test5 {
+					/// Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sit amet diam nec libero accumsan blandit. Quisque non ornare lacus. Suspendisse porta dolor id diam maximus, sed gravida nunc finibus. Aenean vulputate, mi non iaculis sagittis, erat nibh gravida elit, eget feugiat purus tortor sed sem.
+					void main() {
+					}
+
+					/**
+					 * Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis sit amet diam nec libero accumsan blandit. Quisque non ornare lacus. Suspendisse porta dolor id diam maximus, sed gravida nunc finibus. Aenean vulputate, mi non iaculis sagittis, erat nibh gravida elit, eget feugiat purus tortor sed sem.
+					 */
+					void main2() {
+					}
+				}
+				""";
+		formatSource(input, expected);
+	}
+
 }

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/CommentsPreparator.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/CommentsPreparator.java
@@ -1512,7 +1512,7 @@ public class CommentsPreparator extends ASTVisitor {
 						if (lineBreaks > 0) {
 							if (cleanBlankLines && !isMarkdown)
 								lineBreaks = 1;
-							if (lineBreaks > 1 || (!this.options.join_lines_in_comments && !isMarkdown))
+							if (lineBreaks > 1 || !this.options.join_lines_in_comments)
 								outputToken.putLineBreaksBefore(lineBreaks);
 						}
 						if (this.tm.charAt(tokenStart) == '@') {


### PR DESCRIPTION
Markdown javadoc comments ignored the join_lines_in_comments preference and always collapsed multi-line paragraphs into a single line regardless of its value.

Fix : https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5261

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
