### PR TITLE
Version bump for new stream

### DIFF
--- a/org.eclipse.jdt.core.tests.builder/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.tests.builder/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.core.tests.builder; singleton:=true
-Bundle-Version: 3.12.1200.qualifier
+Bundle-Version: 3.12.1300.qualifier
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.jdt.core.tests.builder

--- a/org.eclipse.jdt.core.tests.builder/pom.xml
+++ b/org.eclipse.jdt.core.tests.builder/pom.xml
@@ -18,7 +18,7 @@
     <relativePath>../tests-pom/</relativePath>
   </parent>
   <artifactId>org.eclipse.jdt.core.tests.builder</artifactId>
-  <version>3.12.1200-SNAPSHOT</version>
+  <version>3.12.1300-SNAPSHOT</version>
   <packaging>eclipse-test-plugin</packaging>
 
   <properties>


### PR DESCRIPTION
Reported at
https://download.eclipse.org/eclipse/downloads/drops4/I20260809-2300/buildlogs/reporeports/reports/versionChecks.html and would better be clean for M3:

IUs in current repo that increase versions but with qualifier only

Count: 2
IU id	Reference (old) version	Current (new) version org.eclipse.jdt.core.tests.builder	3.12.1200.v20260327-0504	3.12.1200.v20260731-0907 org.eclipse.jdt.core.tests.builder.source	3.12.1200.v20260327-0504	3.12.1200.v20260731-0907

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
