### PR TITLE
Fix handling of embedded links in inline return

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/AbstractCommentParser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/AbstractCommentParser.java
@@ -388,7 +388,10 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 								annotationAtSymbolHandling= false;
 							}
 							if (this.inlineReturn) {
-								if (this.inlineTagStart > this.inlineReturnStart) {
+								if (this.inlineReturnOpenBraces > 0) {
+									--this.inlineReturnOpenBraces;
+									setInlineTagStarted(true);
+								} else if (this.inlineTagStart > this.inlineReturnStart) {
 									setInlineTagStarted(true);
 									this.inlineTagStart= this.inlineReturnStart;
 								} else {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/AbstractCommentParser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/AbstractCommentParser.java
@@ -95,6 +95,7 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 	protected boolean lineStarted = false;
 	protected boolean inlineTagStarted = false;
 	protected boolean inlineReturn= false;
+	protected int inlineReturnStart= -1;
 	protected int inlineReturnOpenBraces= 0;
 	protected boolean abort = false;
 	protected int kind;
@@ -387,11 +388,12 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 								annotationAtSymbolHandling= false;
 							}
 							if (this.inlineReturn) {
-								if (this.inlineReturnOpenBraces > 0) {
-									--this.inlineReturnOpenBraces;
+								if (this.inlineTagStart > this.inlineReturnStart) {
 									setInlineTagStarted(true);
+									this.inlineTagStart= this.inlineReturnStart;
 								} else {
-									addFragmentToInlineReturn();
+									this.inlineReturn= false;
+									this.inlineReturnStart= -1;
 								}
 							}
 						} else {
@@ -416,6 +418,7 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 						} else if (this.inlineTagStarted) {
 							if (this.tagValue == TAG_RETURN_VALUE) {
 								this.inlineReturn= true;
+								this.inlineReturnStart= this.inlineTagStart;
 							}
 							if (this.inlineReturn && peekChar() != '@') {
 								++this.inlineReturnOpenBraces;

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/DocCommentParser.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/DocCommentParser.java
@@ -1109,6 +1109,7 @@ class DocCommentParser extends AbstractCommentParser {
 		seeTag.fragments().add(node);
 		int end = node.getStartPosition()+node.getLength();
 		if (this.inlineTagStarted) {
+			System.out.println("setting sourcerange " + this.inlineTagStart + " " + (end - this.inlineTagStart + 1));
 			seeTag.setSourceRange(this.inlineTagStart, end-this.inlineTagStart+1);
 			switch (this.tagValue) {
 				case TAG_LINK_VALUE:
@@ -1142,7 +1143,7 @@ class DocCommentParser extends AbstractCommentParser {
 			previousTag.setSourceRange(previousStart, end-previousStart+1);
 		} else {
 			seeTag.setTagName(TagElement.TAG_SEE);
-			seeTag.setSourceRange(this.tagSourceStart, end-this.tagSourceStart+1);
+			seeTag.setSourceRange(this.tagSourceStart, end-this.tagSourceStart);
 			pushOnAstStack(seeTag, true);
 		}
 		return true;

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/DocCommentParser.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/DocCommentParser.java
@@ -1109,7 +1109,6 @@ class DocCommentParser extends AbstractCommentParser {
 		seeTag.fragments().add(node);
 		int end = node.getStartPosition()+node.getLength();
 		if (this.inlineTagStarted) {
-			System.out.println("setting sourcerange " + this.inlineTagStart + " " + (end - this.inlineTagStart + 1));
 			seeTag.setSourceRange(this.inlineTagStart, end-this.inlineTagStart+1);
 			switch (this.tagValue) {
 				case TAG_LINK_VALUE:

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/DocCommentParser.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/DocCommentParser.java
@@ -767,6 +767,8 @@ class DocCommentParser extends AbstractCommentParser {
 		int eofBkup = this.scanner.eofPosition;
 		this.scanner.eofPosition = this.index - 1;
 		this.scanner.resetTo(start, this.javadocEnd);
+		boolean oldInlineTagStarted= this.inlineTagStarted;
+		int oldInlineTagStart= this.inlineTagStart;
 		this.inlineTagStarted = true;
 		this.inlineTagStart = previousPosition;
 		this.tagValue = TAG_LINK_VALUE;
@@ -804,8 +806,8 @@ class DocCommentParser extends AbstractCommentParser {
 			previousTag.fragments().add(0, text);
 		}
 		this.tagValue = NO_TAG_VALUE;
-		this.inlineTagStarted = false;
-		this.inlineTagStart = -1;
+		this.inlineTagStarted = oldInlineTagStarted;
+		this.inlineTagStart = oldInlineTagStarted ? oldInlineTagStart : -1;
 		this.scanner.eofPosition = eofBkup;
 		return valid;
 	}
@@ -1105,7 +1107,7 @@ class DocCommentParser extends AbstractCommentParser {
 		TagElement seeTag = this.ast.newTagElement();
 		ASTNode node = (ASTNode) statement;
 		seeTag.fragments().add(node);
-		int end = node.getStartPosition()+node.getLength()-1;
+		int end = node.getStartPosition()+node.getLength();
 		if (this.inlineTagStarted) {
 			seeTag.setSourceRange(this.inlineTagStart, end-this.inlineTagStart+1);
 			switch (this.tagValue) {
@@ -1133,6 +1135,7 @@ class DocCommentParser extends AbstractCommentParser {
 				if (lastNode instanceof TagElement lastTag && lastTag.getTagName().equals(TagElement.TAG_RETURN)) {
 					previousTag= lastTag;
 					previousStart= lastTag.getStartPosition();
+
 				}
 			}
 			previousTag.fragments().add(seeTag);
@@ -1393,30 +1396,6 @@ class DocCommentParser extends AbstractCommentParser {
 		}
 	}
 
-	@Override
-	protected void addFragmentToInlineReturn() {
-		TagElement currTag= (TagElement) this.astStack[this.astPtr];
-		List fragments= currTag.fragments();
-		int size= fragments.size();
-		if (size > 1) {
-			ASTNode lastNode= (ASTNode) fragments.get(size - 1);
-			if (lastNode instanceof TagElement lastTag) {
-				if (!lastTag.getTagName().equals(TagElement.TAG_RETURN)) {
-					ASTNode secondLastNode= (ASTNode) fragments.get(size - 2);
-					if (secondLastNode instanceof TagElement prevTag && prevTag.getTagName().equals(TagElement.TAG_RETURN)) {
-						fragments.remove(size - 1);
-						prevTag.fragments().add(lastNode);
-						this.inlineTagStart= prevTag.getStartPosition();
-						this.inlineTagStarted= true;
-						prevTag.setSourceRange(prevTag.getStartPosition(), lastNode.getStartPosition() + lastNode.getLength() - prevTag.getStartPosition());
-					}
-				} else {
-					this.inlineReturn= false;
-					this.inlineReturnOpenBraces= 0;
-				}
-			}
-		}
-	}
 	/*
 	 * Add stored tag elements to associated comment.
 	 */


### PR DESCRIPTION
- add new field to record the inline return tag start
- in AbstractCommentParser.commentParse() set inlineTagStarted to true if we have an inline tag that has a start after the inline return tag start and if not, reset inlineReturn and inlineReturnStart
- in DocCommentParser.parseMarkdownLinkTags keep track of previous inlineTagStarted and inlineTagStart and refresh them at the end if they are set
- in DocCommentParser.pushSeeRef() fix the setting of end position so the closing character gets accounted for
- remove overridden addFragmentToInlineReturn() which is no longer needed
- fixes https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/3092

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
