### PR TITLE
ECJ fails to diagnose unchecked method invocation and consequently computes wrong method return type

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ASTNode.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ASTNode.java
@@ -354,6 +354,12 @@ public abstract class ASTNode implements Location, TypeConstants, TypeIds {
 			scope.problemReporter().unsafeTypeConversion(argument, argumentType, checkedParameterType);
 			return INVOCATION_ARGUMENT_UNCHECKED;
 		}
+		if (argument instanceof ReferenceExpression rExpression && rExpression.binding != null) {
+			TypeBinding returnType = rExpression.binding.returnType;
+			if (returnType.needsUncheckedConversion(rExpression.descriptor.returnType)) {
+    			return INVOCATION_ARGUMENT_UNCHECKED;
+			}
+		}
 		return INVOCATION_ARGUMENT_OK;
 	}
 	public static boolean checkInvocationArguments(BlockScope scope, Expression receiver, TypeBinding receiverType, MethodBinding method, Expression[] arguments, TypeBinding[] argumentTypes, boolean argsContainCast, InvocationSite invocationSite) {

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/MessageSend.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/MessageSend.java
@@ -1008,7 +1008,7 @@ public TypeBinding resolveType(BlockScope scope) {
 		scope.problemReporter().deprecatedMethod(this.binding, this);
 
 	TypeBinding returnType;
-	if ((this.bits & ASTNode.Unchecked) != 0 && this.genericTypeArguments == null) {
+	if ((this.bits & ASTNode.Unchecked) != 0 && (this.binding.typeVariables() == Binding.NO_TYPE_VARIABLES || this.genericTypeArguments != null)) {
 		// https://bugs.eclipse.org/bugs/show_bug.cgi?id=277643, align with javac on JLS 15.12.2.6
 		returnType = this.binding.returnType;
 		if (returnType != null) {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
@@ -2543,6 +2543,56 @@ public void testGH5219() {
 			"""},
 			"");
 }
+// https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5214
+public void testIssue5214() {
+	runNegativeTest(new String[] {"X.java",
+			"""
+			import java.util.List;
+			import java.util.function.Function;
+			import java.util.stream.Stream;
+
+			public class X {
+
+			    static class Parent<T> {}
+
+			    static class Child<T> extends Parent<T> {}
+
+			    interface A {}
+
+			    private static Stream<Child<A>> streamRelevant(List<Parent<A>> items) {
+			    	return items.stream()
+			                .<Child<A>>map(Child.class::cast) // <R> Stream<R> map(Function<? super T, ? extends R> mapper);
+			                .filter(X::isRelevant);
+			    }
+
+			    private static boolean isRelevant(Child<A> item) {
+			        return true;
+			    }
+			}
+			"""},
+			"----------\n"
+			+ "1. WARNING in X.java (at line 14)\n"
+			+ "	return items.stream()\n"
+			+ "                .<Child<A>>map(Child.class::cast) // <R> Stream<R> map(Function<? super T, ? extends R> mapper);\n"
+			+ "	       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n"
+			+ "Type safety: Unchecked invocation map(Function<? super X.Parent<X.A>,? extends X.Child<X.A>>) of the generic method map(Function<? super T,? extends R>) of type Stream<X.Parent<X.A>>\n"
+			+ "----------\n"
+			+ "2. ERROR in X.java (at line 16)\n"
+			+ "	.filter(X::isRelevant);\n"
+			+ "	 ^^^^^^\n"
+			+ "The method filter(Predicate) in the type Stream is not applicable for the arguments (X::isRelevant)\n"
+			+ "----------\n"
+			+ "3. ERROR in X.java (at line 16)\n"
+			+ "	.filter(X::isRelevant);\n"
+			+ "	        ^^^^^^^^^^^^^\n"
+			+ "The type X does not define isRelevant(Object) that is applicable here\n"
+			+ "----------\n"
+			+ "4. WARNING in X.java (at line 19)\n"
+			+ "	private static boolean isRelevant(Child<A> item) {\n"
+			+ "	                       ^^^^^^^^^^^^^^^^^^^^^^^^^\n"
+			+ "The method isRelevant(X.Child<X.A>) from the type X is never used locally\n"
+			+ "----------\n");
+}
 public static Class<GenericsRegressionTest_9> testClass() {
 	return GenericsRegressionTest_9.class;
 }

--- a/org.eclipse.jdt.core/eval/org/eclipse/jdt/internal/eval/CodeSnippetMessageSend.java
+++ b/org.eclipse.jdt.core/eval/org/eclipse/jdt/internal/eval/CodeSnippetMessageSend.java
@@ -343,7 +343,7 @@ public TypeBinding resolveType(BlockScope scope) {
 		TypeBinding returnType = this.binding.returnType;
 
 		if (returnType != null) {
-			if ((this.bits & ASTNode.Unchecked) != 0 && this.genericTypeArguments == null) {
+			if ((this.bits & ASTNode.Unchecked) != 0 && (this.binding.typeVariables() == Binding.NO_TYPE_VARIABLES || this.genericTypeArguments != null)) {
 				returnType = scope.environment().convertToRawType(returnType.erasure(), true);
 			}
 			returnType = returnType.capture(scope, this.sourceStart, this.sourceEnd);


### PR DESCRIPTION
* Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5214