### PR TITLE
Disable indexing for restricted binary files

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/IndexManagerTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/IndexManagerTests.java
@@ -27,6 +27,7 @@ import junit.framework.Test;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
@@ -186,6 +187,7 @@ public class IndexManagerTests extends ModifyingResourceTests {
 
 	public void testDisableIndexingForRestrictedFile() throws Exception {
 		if (SKIP_TESTS) return;
+		startLogListening();
 		this.indexDisabledForTest = true;
 		IEclipsePreferences node = InstanceScope.INSTANCE.getNode(JavaCore.PLUGIN_ID);
 		String pref = JavaModelManager.DISABLE_RESTRICTED_FILE_INDEXING_PREFERENCE;
@@ -199,6 +201,11 @@ public class IndexManagerTests extends ModifyingResourceTests {
 			IFile file1 = createFile("/IndexProject/src/p/TestClass1.java", "package p;\n public class TestClass1 {\n" + "}");
 			createFile("/IndexProject/src/p/TestClass2.java", "package p;\n public class TestClass2 {\n" + "}");
 			file1.setContentRestricted(true);
+
+			// create a broken binary file, expect that indexing skips it and doesn't run into errors
+			IFile binaryFile = createFile("/IndexProject/src/p/TestBroken.class", "");
+			binaryFile.setContentRestricted(true);
+
 			JavaModelManager.getIndexManager().indexAll(this.project.getProject());
 			waitUntilIndexesReady();
 
@@ -214,7 +221,14 @@ public class IndexManagerTests extends ModifyingResourceTests {
 			assertSearchResults(
 				"src/p/TestClass2.java p.TestClass2 [TestClass2]",
 				collector);
+
+			// ensure we disabled indexing for the binary file as well
+			String binaryIndexerMessage = "Could not index empty /IndexProject/src/p/TestBroken.class";
+			List<IStatus> logs = this.logListener.getLogs();
+			boolean unexpectedLog = logs.stream().map(IStatus::getMessage).anyMatch(m -> binaryIndexerMessage.equals(m));
+			assertFalse("Expected no log from binary indexer", unexpectedLog);
 		} finally {
+			stopLogListening();
 			if (wasIndexerEnabled) {
 				enableIndexer();
 			}

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/AbstractIndexer.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/AbstractIndexer.java
@@ -13,6 +13,13 @@
  *******************************************************************************/
 package org.eclipse.jdt.internal.core.search.indexing;
 
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.Signature;
 import org.eclipse.jdt.core.compiler.CharOperation;
 import org.eclipse.jdt.core.search.SearchDocument;
@@ -284,5 +291,26 @@ public abstract class AbstractIndexer implements IIndexConstants {
 	public abstract void indexDocument();
 	public void indexResolvedDocument() {
 		// subtypes should implement where it makes sense.
+	}
+
+	protected static IFile getDocumentFile(SearchDocument document) {
+		IFile file;
+		IPath path = new Path(document.getPath());
+		IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
+		file = root.getFile(path);
+		return file;
+	}
+
+	protected static boolean isContentRestricted(IFile file) {
+		try {
+			return file.isContentRestricted();
+		} catch (CoreException e) {
+			JavaCore.getPlugin().getLog().log(e.getStatus());
+			/*
+			 * Assume indexing is disabled for the file, since the preference for disabling is set
+			 * but we cannot determine if the file is restricted.
+			 */
+			return true;
+		}
 	}
 }

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/BinaryIndexer.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/BinaryIndexer.java
@@ -17,6 +17,7 @@ import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
+import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.jdt.core.Flags;
@@ -42,6 +43,7 @@ import org.eclipse.jdt.internal.compiler.env.IModule.IService;
 import org.eclipse.jdt.internal.compiler.lookup.TagBits;
 import org.eclipse.jdt.internal.compiler.lookup.TypeConstants;
 import org.eclipse.jdt.internal.compiler.util.SuffixConstants;
+import org.eclipse.jdt.internal.core.JavaModelManager;
 import org.eclipse.jdt.internal.core.util.Util;
 
 public class BinaryIndexer extends AbstractIndexer implements SuffixConstants {
@@ -675,6 +677,9 @@ public class BinaryIndexer extends AbstractIndexer implements SuffixConstants {
 
 	@Override
 	public void indexDocument() {
+		if (disabledForFile()) {
+			return;
+		}
 		try {
 			final byte[] contents = this.document.getByteContents();
 			// see https://bugs.eclipse.org/bugs/show_bug.cgi?id=107124
@@ -972,5 +977,13 @@ public class BinaryIndexer extends AbstractIndexer implements SuffixConstants {
 			}
 		}
 		return array;
+	}
+
+	private boolean disabledForFile() {
+		if (JavaModelManager.disableRestrictedFileIndexing()) {
+			IFile file = getDocumentFile(this.document);
+			return isContentRestricted(file);
+		}
+		return false;
 	}
 }

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/SourceIndexer.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/indexing/SourceIndexer.java
@@ -17,9 +17,7 @@ import static org.eclipse.jdt.internal.core.JavaModelManager.trace;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
-import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
-import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.ILog;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
@@ -470,20 +468,9 @@ public class SourceIndexer extends AbstractIndexer implements ITypeRequestor, Su
 		if (JavaModelManager.disableRestrictedFileIndexing()) {
 			IFile file = getJavaSearchFile();
 			if (file == null) {
-				IPath path = new Path(this.document.getPath());
-				IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
-				file = root.getFile(path);
+				file = getDocumentFile(this.document);
 			}
-			try {
-				return file.isContentRestricted();
-			} catch (CoreException e) {
-				JavaCore.getPlugin().getLog().log(e.getStatus());
-				/*
-				 * Assume indexing is disabled for the file, since the preference for disabling is set
-				 * but we cannot determine if the file is restricted.
-				 */
-				return true;
-			}
+			return isContentRestricted(file);
 		}
 		return false;
 	}


### PR DESCRIPTION
Indexing for restricted files is so far disabled only for sources, not for binary files. This change ensures also restricted binary files are not indexed.

Fixes: https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4970