### PR TITLE
Fix to Ensure CaptureBinding.initializeBounds is called only once per

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/CaptureBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/CaptureBinding.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -40,6 +40,7 @@ public class CaptureBinding extends TypeVariableBinding {
 	public int start;
 	public int end;
 	public ASTNode cud; // to facilitate recaptures.
+	private boolean boundsInitialized;
 
 	TypeBinding pendingSubstitute; // for substitution of recursive captures, see https://bugs.eclipse.org/456924
 
@@ -92,6 +93,7 @@ public class CaptureBinding extends TypeVariableBinding {
 		this.lowerBound = prototype.lowerBound;
 		this.tagBits |= (prototype.tagBits & TagBits.HasCapturedWildcard);
 		this.cud = prototype.cud;
+		this.boundsInitialized = prototype.boundsInitialized;
 	}
 
 	// Captures may get cloned and annotated during type inference.
@@ -163,6 +165,9 @@ public class CaptureBinding extends TypeVariableBinding {
 	 * {@code X<U, V extends X<U, V>>, capture(X<E,?>) = X<E,capture>,} where {@code capture extends X<E,capture>}
 	 */
 	public void initializeBounds(Scope scope, ParameterizedTypeBinding capturedParameterizedType) {
+		if (this.boundsInitialized)
+			return;
+		this.boundsInitialized = true;
 		TypeVariableBinding wildcardVariable = this.wildcard.typeVariable();
 		if (wildcardVariable == null) {
 			// error resilience when capturing Zork<?>

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/CaptureBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/CaptureBinding.java
@@ -160,6 +160,11 @@ public class CaptureBinding extends TypeVariableBinding {
 		}
 	}
 
+	/** Answer whether {@link #initializeBounds(Scope, ParameterizedTypeBinding)} has already been performed for this capture. */
+	public boolean isBoundsInitialized() {
+		return this.boundsInitialized;
+	}
+
 	/**
 	 * Initialize capture bounds using substituted supertypes e.g. given
 	 * {@code X<U, V extends X<U, V>>, capture(X<E,?>) = X<E,capture>,} where {@code capture extends X<E,capture>}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ParameterizedTypeBinding.java
@@ -208,8 +208,9 @@ public class ParameterizedTypeBinding extends ReferenceBinding implements Substi
 					if (wildcard.boundKind == Wildcard.SUPER && wildcard.bound.id == TypeIds.T_JavaLangObject) {
 						capturedArguments[i] = wildcard.bound;
 					} else {
-						capturedArguments[i] = this.environment.createCapturedWildcard(wildcard, contextType, start, end, cud, compilationUnitScope::nextCaptureID);
-						freshCaptures[i] = true;
+						CaptureBinding capture = this.environment.createCapturedWildcard(wildcard, contextType, start, end, cud, compilationUnitScope::nextCaptureID);
+						capturedArguments[i] = capture;
+						freshCaptures[i] = !capture.isBoundsInitialized();
 					}
 				} else {
 					capturedArguments[i] = argument;

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
@@ -2593,6 +2593,37 @@ public void testIssue5214() {
 			+ "The method isRelevant(X.Child<X.A>) from the type X is never used locally\n"
 			+ "----------\n");
 }
+public void testCaptureReinitialization() {
+	runConformTest(new String[] {
+		"X.java",
+		"""
+		public class X {
+
+			public static class A<I extends C<I, ?>> {}
+
+			public static class B<I extends C<I, ?>, J> {
+				public B(A<I> a) {}
+				public B(A<I> a, int dummy) {}
+			}
+
+			public static class C<I extends C<I, J>, J> {}
+
+			static <I extends C<I, ?>> B<I, ?> make(A<I> a) {
+				return new B<>(a);
+			}
+			static <I extends C<I, ?>> B<I, ?> make(A<I> a, int dummy) {
+				return new B<>(a, dummy);
+			}
+
+			public static void test(A<?> a) {
+				make(a);
+				make(a, 0);
+				new B<>(a);
+			}
+		}
+		"""
+	});
+}
 public static Class<GenericsRegressionTest_9> testClass() {
 	return GenericsRegressionTest_9.class;
 }


### PR DESCRIPTION
fixes #4869 

## What it does
Ensures CaptureBinding.initializeBounds is called only once per binding

## How to test
a junit test provided

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
