### PR TITLE
Fix erroneous text pushing for Javadoc comments

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/AbstractCommentParser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/AbstractCommentParser.java
@@ -643,7 +643,7 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 	 * @see Scanner#getLineNumber(int) We cannot directly use this method
 	 * when linePtr field is not initialized.
 	 */
-	private int getLineNumber(int position) {
+	protected int getLineNumber(int position) {
 
 		if (this.scanner.linePtr != -1) {
 			return Util.getLineNumber(position, this.scanner.lineEnds, 0, this.scanner.linePtr);

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/DocCommentParser.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/DocCommentParser.java
@@ -1192,6 +1192,16 @@ class DocCommentParser extends AbstractCommentParser {
 					previousStart = previousTag.getStartPosition();
 				}
 			}
+		} else {
+			if (TagElement.TAG_SEE.equals(previousTag.getTagName()) ||
+					TagElement.TAG_RETURN.equals(previousTag.getTagName())) {
+				if (getLineNumber(previousStart) < getLineNumber(start)) {
+					previousTag = this.ast.newTagElement();
+					previousTag.setSourceRange(start, end-start);
+					previousStart= start;
+					pushOnAstStack(previousTag, true);
+				}
+			}
 		}
 
 		// Add the text

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/DocCommentParser.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/DocCommentParser.java
@@ -1193,14 +1193,13 @@ class DocCommentParser extends AbstractCommentParser {
 				}
 			}
 		} else {
-			if (TagElement.TAG_SEE.equals(previousTag.getTagName()) ||
-					TagElement.TAG_RETURN.equals(previousTag.getTagName())) {
-				if (getLineNumber(previousStart) < getLineNumber(start)) {
-					previousTag = this.ast.newTagElement();
-					previousTag.setSourceRange(start, end-start);
-					previousStart= start;
-					pushOnAstStack(previousTag, true);
-				}
+			if (TagElement.TAG_RETURN.equals(previousTag.getTagName())
+					&& this.source[previousStart] == '{') {
+				// previous tag is a completed inline return tag so don't add text to it
+				previousTag = this.ast.newTagElement();
+				previousTag.setSourceRange(start, end-start);
+				previousStart= start;
+				pushOnAstStack(previousTag, true);
 			}
 		}
 


### PR DESCRIPTION
- make AbstractCommentParser.getLineNumber() protected
- in DocCommentParser.pushText(), do not put text in fragment of previous tag if the previous tag is @see or @return and the text appears on a subsequent line (those tags are single-line) and instead create a sibling tag element with the text as fragment
- for #5300

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->
See issue.

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See issue.  UI tests will be added in the future.

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
