### PR TITLE
 Forbid attempts to synchronize on an instance of a value class

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.compiler.batch/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Main-Class: org.eclipse.jdt.internal.compiler.batch.Main
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse Compiler for Java(TM)
 Bundle-SymbolicName: org.eclipse.jdt.core.compiler.batch
-Bundle-Version: 3.46.100.qualifier
+Bundle-Version: 3.47.0.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: Eclipse.org
 Automatic-Module-Name: org.eclipse.jdt.core.compiler.batch

--- a/org.eclipse.jdt.core.compiler.batch/pom.xml
+++ b/org.eclipse.jdt.core.compiler.batch/pom.xml
@@ -17,7 +17,7 @@
     <version>4.41.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.eclipse.jdt.core.compiler.batch</artifactId>
-  <version>3.46.100-SNAPSHOT</version>
+  <version>3.47.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/core/compiler/IProblem.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/core/compiler/IProblem.java
@@ -2897,4 +2897,8 @@ void setSourceStart(int sourceStart);
 
 	/** @since 3.45 */
 	int CyclicStructureNonNullByDefault = Internal + 2104;
+
+	/** @since 3.47
+	 * @noreference preview feature error */
+	int IllegalValueInstanceSynchronization = PreviewRelated + 2105;
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ClassFile.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ClassFile.java
@@ -3401,6 +3401,9 @@ public class ClassFile implements TypeConstants, TypeIds {
 		for (int i = 0; i < numberOfInnerClasses; i++) {
 			ReferenceBinding innerClass = innerClasses[i];
 			int accessFlags = innerClass.getAccessFlags();
+			// https://download.java.net/java/early_access/jdk28/docs/specs/value-objects-jvms.html requires inner class attribute to mention AccIdentity,
+			// but javac doesn't do so ATM. We will likewise not for now.
+			accessFlags &= ~ClassFileConstants.AccIdentity;
 			int innerClassIndex = this.constantPool.literalIndexForType(innerClass.constantPoolName());
 			// inner class index
 			this.contents[localContentsOffset++] = (byte) (innerClassIndex >> 8);
@@ -5666,9 +5669,9 @@ public class ClassFile implements TypeConstants, TypeIds {
 					| ClassFileConstants.AccSynchronized
 					| ClassFileConstants.AccNative);
 
-		// set the AccSuper flag (has to be done after clearing AccSynchronized - since same value)
-		if (!aType.isInterface()) { // class or enum
-			accessFlags |= ClassFileConstants.AccSuper;
+		// set the AccIdentity flag (has to be done after clearing AccSynchronized - since same value)
+		if (!aType.isInterface() && !aType.isValueClass()) {
+			accessFlags |= ClassFileConstants.AccIdentity;
 		}
 		if (aType.isAnonymousType()) {
 			ReferenceBinding superClass = aType.superclass;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SynchronizedStatement.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/SynchronizedStatement.java
@@ -208,7 +208,9 @@ public void resolve(BlockScope upperScope) {
 				this.scope.problemReporter().invalidNullToSynchronize(this.expression);
 				break;
 			default :
-				if (type.hasValueBasedTypeAnnotation()) {
+				if (type.isValueClass()) {
+					this.scope.problemReporter().cantSynchronizeOnValueClass(this.expression, type);
+				} else if (type.hasValueBasedTypeAnnotation()) {
 					this.scope.problemReporter().discouragedValueBasedTypeToSynchronize(this.expression, type);
 				}
 			}

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/ClassFileConstants.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/ClassFileConstants.java
@@ -66,7 +66,6 @@ public interface ClassFileConstants {
 	/**
 	 * Other VM flags.
 	 */
-	int AccSuper = 0x0020;
 	int AccIdentity = 0x0020;
 
 	/**

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/ClassFileReader.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/classfmt/ClassFileReader.java
@@ -85,7 +85,7 @@ private static String printTypeModifiers(int modifiers) {
 	if ((modifiers & ClassFileConstants.AccPublic) != 0) print.print("public "); //$NON-NLS-1$
 	if ((modifiers & ClassFileConstants.AccPrivate) != 0) print.print("private "); //$NON-NLS-1$
 	if ((modifiers & ClassFileConstants.AccFinal) != 0) print.print("final "); //$NON-NLS-1$
-	if ((modifiers & ClassFileConstants.AccSuper) != 0) print.print("super "); //$NON-NLS-1$
+	if ((modifiers & ClassFileConstants.AccIdentity) != 0) print.print("identity "); //$NON-NLS-1$
 	if ((modifiers & ClassFileConstants.AccInterface) != 0) print.print("interface "); //$NON-NLS-1$
 	if ((modifiers & ClassFileConstants.AccAbstract) != 0) print.print("abstract "); //$NON-NLS-1$
 	if ((modifiers & ExtraCompilerModifiers.AccSealed) != 0) print.print("sealed "); //$NON-NLS-1$

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BinaryTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BinaryTypeBinding.java
@@ -68,6 +68,7 @@ import org.eclipse.jdt.internal.compiler.env.*;
 import org.eclipse.jdt.internal.compiler.impl.BooleanConstant;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jdt.internal.compiler.impl.Constant;
+import org.eclipse.jdt.internal.compiler.impl.JavaFeature;
 import org.eclipse.jdt.internal.compiler.problem.AbortCompilation;
 import org.eclipse.jdt.internal.compiler.problem.ProblemReporter;
 import org.eclipse.jdt.internal.compiler.util.Util;
@@ -130,6 +131,41 @@ public class BinaryTypeBinding extends ReferenceBinding {
 		}
 	}
 	public ExternalAnnotationStatus externalAnnotationStatus = ExternalAnnotationStatus.NOT_EEA_CONFIGURED; // unless proven differently
+
+	private String [] valhallaMigratedClasses = {
+			"java/lang/Number", //$NON-NLS-1$
+			"java/lang/Record", //$NON-NLS-1$
+			"java/util/Optional", //$NON-NLS-1$
+			"java/util/OptionalInt", //$NON-NLS-1$
+			"java/util/OptionalLong", //$NON-NLS-1$
+			"java/util/OptionalDouble", //$NON-NLS-1$
+			"java/time/LocalDate", //$NON-NLS-1$
+			"java/time/LocalDateTime", //$NON-NLS-1$
+			"java/time/LocalTime", //$NON-NLS-1$
+			"java/time/Duration", //$NON-NLS-1$
+			"java/time/Instant", //$NON-NLS-1$
+			"java/time/MonthDay", //$NON-NLS-1$
+			"java/time/ZonedDateTime", //$NON-NLS-1$
+			"java/time/OffsetDateTime", //$NON-NLS-1$
+			"java/time/OffsetTime", //$NON-NLS-1$
+			"java/time/YearMonth", //$NON-NLS-1$
+			"java/time/Year", //$NON-NLS-1$
+			"java/time/Period", //$NON-NLS-1$
+			"java/time/chrono/ChronoLocalDateImpl", //$NON-NLS-1$
+			"java/time/chrono/MinguoDate", //$NON-NLS-1$
+			"java/time/chrono/HijrahDate", //$NON-NLS-1$
+			"java/time/chrono/JapaneseDate", //$NON-NLS-1$
+			"java/time/chrono/ThaiBuddhistDate", //$NON-NLS-1$
+			"java/lang/Boolean", //$NON-NLS-1$
+			"java/lang/Character", //$NON-NLS-1$
+			"java/lang/Float", //$NON-NLS-1$
+			"java/lang/Double", //$NON-NLS-1$
+			"java/lang/Byte", //$NON-NLS-1$
+			"java/lang/Short", //$NON-NLS-1$
+			"java/lang/Integer", //$NON-NLS-1$
+			"java/lang/Long", //$NON-NLS-1$
+	};
+
 
 static Object convertMemberValue(Object binaryValue, LookupEnvironment env, char[][][] missingTypeNames, boolean resolveEnumConstants) {
 	if (binaryValue == null) return null;
@@ -311,6 +347,16 @@ public BinaryTypeBinding(PackageBinding packageBinding, IBinaryType binaryType, 
 
 	this.sourceName = binaryType.getSourceName();
 	this.modifiers = binaryType.getModifiers();
+
+	if (this.isValueClass() && JavaFeature.VALUE_CLASSES_AND_OBJECTS.isPreview() && !this.environment.globalOptions.enablePreviewFeatures) {
+		String name = new String(binaryType.getName());
+		for (int i = 0; i < this.valhallaMigratedClasses.length; i++) {
+			if (this.valhallaMigratedClasses[i].equals(name)) {
+				this.modifiers |= ClassFileConstants.AccIdentity;
+				break;
+			}
+		}
+	}
 
 	if ((binaryType.getTagBits() & TagBits.HierarchyHasProblems) != 0)
 		this.tagBits |= TagBits.HierarchyHasProblems;

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ClassScope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ClassScope.java
@@ -846,6 +846,8 @@ public class ClassScope extends Scope {
 			}
 		}
 
+		if (!sourceType.isInterface() && (modifiers & ExtraCompilerModifiers.AccValue) == 0)
+			modifiers |= ClassFileConstants.AccIdentity;
 		sourceType.modifiers = modifiers;
 	}
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ReferenceBinding.java
@@ -1829,6 +1829,11 @@ public final boolean isUsed() {
 	return (this.modifiers & ExtraCompilerModifiers.AccLocallyUsed) != 0;
 }
 
+@Override
+public boolean isValueClass() {
+	return this.isClass() && (this.modifiers & ClassFileConstants.AccIdentity) == 0;
+}
+
 public boolean isImplicitType() {
 	return false;
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/TypeBinding.java
@@ -1839,7 +1839,7 @@ public boolean isSealed() {
 	return false;
 }
 
-public boolean isValue() {
+public boolean isValueClass() {
 	return false;
 }
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Scanner.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/Scanner.java
@@ -4773,7 +4773,7 @@ private static class Goal {
 			TokenNameenum, TokenNameRestrictedIdentifierrecord };// Note: enum/record allowed as error flagging rules.
 	static TerminalToken[] PermittedTypesFollow =  { TokenNameLBRACE };
 	static TerminalToken[] PatternCaseLabelFollow = {TokenNameCOLON, TokenNameARROW, TokenNameCOMMA, TokenNameCaseArrow, TokenNameRestrictedIdentifierWhen};
-	static TerminalToken[] ValueModifierFollow =  { TokenNameclass, TokenNameenum, TokenNameRestrictedIdentifierrecord };
+	static TerminalToken[] ValueModifierFollow =  { TokenNameclass, TokenNameRestrictedIdentifierrecord };
 
 	static {
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
@@ -5005,6 +5005,17 @@ public void illegalTypeAnnotationsInStaticMemberAccess(Annotation first, Annotat
 			first.sourceStart,
 			last.sourceEnd);
 }
+public void cantSynchronizeOnValueClass(Expression expression, TypeBinding type) {
+	if (type.isParameterizedType()) {
+		type =  ((ParameterizedTypeBinding)type).actualType();
+	}
+	this.handle(
+		IProblem.IllegalValueInstanceSynchronization,
+		new String[] {new String(type.readableName())},
+		new String[] {new String(type.shortReadableName())},
+		expression.sourceStart,
+		expression.sourceEnd);
+}
 public void discouragedValueBasedTypeToSynchronize(Expression expression, TypeBinding type) {
 	if (type.isParameterizedType()) {
 		type =  ((ParameterizedTypeBinding)type).actualType();

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/messages.properties
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/messages.properties
@@ -1222,7 +1222,7 @@
 
 2103 = Inference for this invocation of method {1}({2}) from the type {0} refers to the missing type {3}
 2104 = Cannot fully evaluate null annotations due to cyclic structure involving {0}
-
+2105 = Illegal attempt to synchronize on an instance of a value class
 ### ELABORATIONS
 ## Access restrictions
 # Discouraged access

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/util/JRTUtil.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/util/JRTUtil.java
@@ -137,7 +137,7 @@ public class JRTUtil {
 		try {
 			FileSystem fs = JRT_FILE_SYSTEMS.computeIfAbsent(path.toAbsolutePath().normalize(), p -> {
 				try {
-					return FileSystems.newFileSystem(JRTUtil.JRT_URI, Map.of("java.home", p.toString())); //$NON-NLS-1$
+					return FileSystems.newFileSystem(JRTUtil.JRT_URI, Map.of("java.home", p.toString(), "previewMode", "true")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 				} catch (IOException e) {
 					throw new UncheckedIOException(e);
 				}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/CompilerInvocationTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/CompilerInvocationTests.java
@@ -1388,6 +1388,7 @@ public void test011_problem_categories() {
 	    expectedProblemAttributes.put("LocalMustBeEffectivelyFinal", new ProblemAttributes(CategorizedProblem.CAT_INTERNAL));
 	    expectedProblemAttributes.put("ResourceLocalMustBeEffectivelyFinal", new ProblemAttributes(CategorizedProblem.CAT_INTERNAL));
 	    expectedProblemAttributes.put("RecordAccessorMissingOverrideAnnotation", new ProblemAttributes(CategorizedProblem.CAT_TYPE));
+	    expectedProblemAttributes.put("IllegalValueInstanceSynchronization", new ProblemAttributes(CategorizedProblem.CAT_PREVIEW_RELATED));
 
 	    StringBuilder failures = new StringBuilder();
 		StringBuilder correctResult = new StringBuilder(70000);
@@ -2542,6 +2543,7 @@ public void test012_compiler_problems_tuning() {
 	    expectedProblemAttributes.put("LocalMustBeEffectivelyFinal", SKIP);
 	    expectedProblemAttributes.put("ResourceLocalMustBeEffectivelyFinal", SKIP);
 	    expectedProblemAttributes.put("RecordAccessorMissingOverrideAnnotation", SKIP);
+	    expectedProblemAttributes.put("IllegalValueInstanceSynchronization", SKIP);
 
 
 	    Map constantNamesIndex = new HashMap();

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ImplicitlyDeclaredClassesTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ImplicitlyDeclaredClassesTest.java
@@ -100,7 +100,6 @@ public class ImplicitlyDeclaredClassesTest extends AbstractRegressionTest9 {
 		this.complianceLevel = ClassFileConstants.JDK25;
 		/* using regular parser in DIET mode */
 		CompilerOptions options = new CompilerOptions(getCompilerOptions());
-		options.enablePreviewFeatures = true;
 		Parser parser =
 			new Parser(
 				new ProblemReporter(

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ValueClassesAndObjectsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ValueClassesAndObjectsTest.java
@@ -83,9 +83,10 @@ public class ValueClassesAndObjectsTest extends AbstractRegressionTestCommon {
 	protected JavacTestOptions getJavacTestOptions() {
 		return JAVAC_OPTIONS;
 	}
+
 	// =================================================
 	// https://cr.openjdk.org/~dlsmith/jep401/latest/
-  public void testValueTypes_001() {
+    public void testValueTypes_001() {
 		runNegativeTest(new String[] {
 			"X.java",
 				"""
@@ -104,7 +105,8 @@ public class ValueClassesAndObjectsTest extends AbstractRegressionTestCommon {
 			"\'value\' is not a valid type name; it is a restricted identifier and not allowed as a type identifier in Java 28\n" +
 			"----------\n");
 	}
-  public void testValueTypes_002() {
+
+    public void testValueTypes_002() {
 		runConformTest(new String[] {
 			"X.java",
 				"""
@@ -117,4 +119,229 @@ public class ValueClassesAndObjectsTest extends AbstractRegressionTestCommon {
 			},
 			"Ok!");
 	}
+
+    // Snippet from https://openjdk.org/jeps/401 illustrating or lack/presence of identity - with preview turned on for compiler and runtime
+    public void testValueness() {
+ 		runConformTest(new String[] {
+ 			"X.java",
+ 			"""
+			import java.time.LocalDate;
+			import java.util.Objects;
+
+			public class X {
+			  public static void main(String[] args){
+				  Integer x = 1996, y = 1996;
+				  System.out.println(x == y);
+				  System.out.println(Objects.hasIdentity(x));
+
+				  LocalDate d1 = LocalDate.of(1996, 1, 23);
+				  System.out.println(d1);
+				  LocalDate d2 = d1.plusYears(30);
+				  System.out.println(d2);
+				  LocalDate d3 = d2.minusYears(30);
+				  System.out.println(d3);
+				  System.out.println(d1 == d3);
+				  System.out.println(Objects.hasIdentity(d1));
+
+
+				  String s = "abcd";
+				  System.out.println(Objects.hasIdentity(s));
+				  String t = "aabcd".substring(1);
+				  System.out.println(s == t);
+				  System.out.println(s.equals(t));
+			  }
+			}
+ 			"""
+ 			},
+			"true\n" +
+			"false\n" +
+			"1996-01-23\n" +
+			"2026-01-23\n" +
+			"1996-01-23\n" +
+			"true\n" +
+			"false\n" +
+			"true\n" +
+			"false\n" +
+			"true");
+ 	}
+
+    // Same snippet as above but with preview turned off for both compiler and runtime
+    public void testIdentityfulness() {
+ 		runConformTest(new String[] {
+ 			"X.java",
+ 			"""
+			import java.time.LocalDate;
+			import java.util.Objects;
+
+			public class X {
+			  public static void main(String[] args){
+				  Integer x = 1996, y = 1996;
+				  System.out.println(x == y);
+				  System.out.println(Objects.hasIdentity(x));
+
+				  LocalDate d1 = LocalDate.of(1996, 1, 23);
+				  System.out.println(d1);
+				  LocalDate d2 = d1.plusYears(30);
+				  System.out.println(d2);
+				  LocalDate d3 = d2.minusYears(30);
+				  System.out.println(d3);
+				  System.out.println(d1 == d3);
+				  System.out.println(Objects.hasIdentity(d1));
+
+
+				  String s = "abcd";
+				  System.out.println(Objects.hasIdentity(s));
+				  String t = "aabcd".substring(1);
+				  System.out.println(s == t);
+				  System.out.println(s.equals(t));
+			  }
+			}
+ 			"""
+ 			},
+			"false\n" +
+			"true\n" +
+			"1996-01-23\n" +
+			"2026-01-23\n" +
+			"1996-01-23\n" +
+			"false\n" +
+			"true\n" +
+			"true\n" +
+			"false\n" +
+			"true",
+ 			getCompilerOptions(false), new String[] {}, new JavacTestOptions("-source 28"));
+ 	}
+
+    // Same snippet as above but with preview turned off for compiler and turned on for runtime
+    public void testValueness_without_compiler_preview_with_runtime_preview() {
+ 		runConformTest(new String[] {
+ 			"X.java",
+ 			"""
+			import java.time.LocalDate;
+			import java.util.Objects;
+
+			public class X {
+			  public static void main(String[] args){
+				  Integer x = 1996, y = 1996;
+				  System.out.println(x == y);
+				  System.out.println(Objects.hasIdentity(x));
+
+				  LocalDate d1 = LocalDate.of(1996, 1, 23);
+				  System.out.println(d1);
+				  LocalDate d2 = d1.plusYears(30);
+				  System.out.println(d2);
+				  LocalDate d3 = d2.minusYears(30);
+				  System.out.println(d3);
+				  System.out.println(d1 == d3);
+				  System.out.println(Objects.hasIdentity(d1));
+
+
+				  String s = "abcd";
+				  System.out.println(Objects.hasIdentity(s));
+				  String t = "aabcd".substring(1);
+				  System.out.println(s == t);
+				  System.out.println(s.equals(t));
+			  }
+			}
+ 			"""
+ 			},
+			"true\n" +
+			"false\n" +
+			"1996-01-23\n" +
+			"2026-01-23\n" +
+			"1996-01-23\n" +
+			"true\n" +
+			"false\n" +
+			"true\n" +
+			"false\n" +
+			"true",
+			getCompilerOptions(false), VMARGS, new JavacTestOptions("-source 28"));
+ 	}
+    // Same snippet as above but with preview turned on for compiler and turned off for runtime
+    public void testValueness_with_compiler_preview_without_runtime_preview() {
+		Runner runner = new Runner();
+		runner.customOptions = getCompilerOptions(true); // preview enabled
+		runner.testFiles = new String[] {
+				"X.java",
+				"""
+				import java.time.LocalDate;
+				import java.util.Objects;
+
+				public class X {
+				  public static void main(String[] args){
+					  Integer x = 1996, y = 1996;
+					  System.out.println(x == y);
+					  System.out.println(Objects.hasIdentity(x));
+
+					  LocalDate d1 = LocalDate.of(1996, 1, 23);
+					  System.out.println(d1);
+					  LocalDate d2 = d1.plusYears(30);
+					  System.out.println(d2);
+					  LocalDate d3 = d2.minusYears(30);
+					  System.out.println(d3);
+					  System.out.println(d1 == d3);
+					  System.out.println(Objects.hasIdentity(d1));
+
+
+					  String s = "abcd";
+					  System.out.println(Objects.hasIdentity(s));
+					  String t = "aabcd".substring(1);
+					  System.out.println(s == t);
+					  System.out.println(s.equals(t));
+				  }
+				}
+				"""
+			};
+		runner.javacTestOptions = JAVAC_OPTIONS;
+//		runner.vmArguments = VMARGS; not passing --enable-preview to java
+		runner.expectedErrorString =
+				"""
+				java.lang.UnsupportedClassVersionError: Preview features are not enabled for X (class file version 72.65535). Try running with '--enable-preview'
+				""";
+		runner.runConformTest();
+	}
+
+    // Snippet from https://openjdk.org/jeps/401 - test synchronization - compile time
+    public void testSynchronizationCompileTime() {
+    	runNegativeTest(new String [] {
+ 				"X.java",
+ 				"""
+ 				import java.time.LocalDate;
+
+ 				public class X {
+ 				  public static void main(String[] args){
+ 					  LocalDate d1 = LocalDate.of(1996, 1, 23);
+ 					  synchronized (d1) { d1.notify(); }
+ 				  }
+ 				}
+ 				"""},
+    			"----------\n" +
+				"1. ERROR in X.java (at line 6)\n" +
+				"	synchronized (d1) { d1.notify(); }\n" +
+				"	              ^^\n" +
+				"Illegal attempt to synchronize on an instance of a value class\n" +
+				"----------\n");
+
+ 	}
+    // Snippet from https://openjdk.org/jeps/401 - test synchronization - run time
+    public void testSynchronizationRunTime() {
+    	runConformTest(new String [] {
+ 				"X.java",
+ 				"""
+ 				import java.time.LocalDate;
+
+ 				public class X {
+ 				  public static void main(String[] args){
+ 					  LocalDate d1 = LocalDate.of(1996, 1, 23);
+ 					  Object o = d1;
+ 					  try {
+ 					      synchronized (o) { d1.notify(); }
+				      } catch (IdentityException e) {
+				          System.out.println("All well!");
+				      }
+ 				  }
+ 				}
+ 				"""},
+    			"All well!");
+
+ 	}
  }

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/BindingComparator.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/BindingComparator.java
@@ -305,8 +305,8 @@ class BindingComparator {
 				return CharOperation.equals(referenceBinding.compoundName, referenceBinding2.compoundName)
 					&& (!referenceBinding2.isGenericType())
 					&& (referenceBinding.isRawType() == referenceBinding2.isRawType())
-					&& ((referenceBinding.modifiers & ~ClassFileConstants.AccSuper) & (ExtraCompilerModifiers.AccJustFlag | ClassFileConstants.AccInterface | ClassFileConstants.AccEnum | ClassFileConstants.AccAnnotation))
-							== ((referenceBinding2.modifiers & ~ClassFileConstants.AccSuper) & (ExtraCompilerModifiers.AccJustFlag | ClassFileConstants.AccInterface | ClassFileConstants.AccEnum | ClassFileConstants.AccAnnotation))
+					&& (referenceBinding.modifiers & (ExtraCompilerModifiers.AccJustFlag | ClassFileConstants.AccInterface | ClassFileConstants.AccEnum | ClassFileConstants.AccAnnotation))
+							== (referenceBinding2.modifiers & (ExtraCompilerModifiers.AccJustFlag | ClassFileConstants.AccInterface | ClassFileConstants.AccEnum | ClassFileConstants.AccAnnotation))
 					&& isEqual(referenceBinding.enclosingType(), referenceBinding2.enclosingType(), visitedTypes);
 		}
 	}

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/TypeBinding.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/TypeBinding.java
@@ -601,7 +601,7 @@ class TypeBinding implements ITypeBinding {
 			if (referenceBinding.isNonSealed()) {
 				return accessFlags | Modifier.NON_SEALED;
 			}
-			if (referenceBinding.isValue()) {
+			if (referenceBinding.isValueClass()) {
 				return accessFlags | Modifier.VALUE;
 			}
 			if (referenceBinding.isAnonymousType()) {

--- a/org.eclipse.jdt.core/eval/org/eclipse/jdt/internal/eval/CodeSnippetClassFile.java
+++ b/org.eclipse.jdt.core/eval/org/eclipse/jdt/internal/eval/CodeSnippetClassFile.java
@@ -71,8 +71,8 @@ public CodeSnippetClassFile(
 	this.constantPool = new ConstantPool(this);
 	int accessFlags = aType.getAccessFlags();
 
-	if (!aType.isInterface()) { // class or enum
-		accessFlags |= ClassFileConstants.AccSuper;
+	if (!aType.isInterface() && !aType.isValueClass()) {
+		accessFlags |= ClassFileConstants.AccIdentity;
 	}
 	if (aType.isNestedType()) {
 		if (aType.isStatic()) {

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/core/Flags.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/core/Flags.java
@@ -108,7 +108,7 @@ public final class Flags {
 	 * Super property flag. See The Java Virtual Machine Specification for more details.
 	 * @since 2.0
 	 */
-	public static final int AccSuper = ClassFileConstants.AccSuper;
+	public static final int AccSuper = ClassFileConstants.AccIdentity;
 	/**
 	 * Synthetic property flag. See The Java Virtual Machine Specification for more details.
 	 * @since 2.0

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/BinaryType.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/BinaryType.java
@@ -355,8 +355,7 @@ public IField getRecordComponent(String compName) {
 }
 @Override
 public int getFlags() throws JavaModelException {
-	IBinaryType info = getElementInfo();
-	return info.getModifiers() & ~ClassFileConstants.AccSuper;
+	return getElementInfo().getModifiers();
 }
 
 @Override


### PR DESCRIPTION
* Forbid attempts to synchronize on an instance of a value class. (synchronized instance methods are still not complained about)
* Wrap various snippets from the JEP document into test cases
* Kludge for preview Java runtime access

