### PR TITLE
external annotations translated to type annotation even if null annotations lack TYPE_USE target

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BinaryTypeBinding.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/BinaryTypeBinding.java
@@ -609,6 +609,11 @@ private void cachePartsFrom2(IBinaryType binaryType, boolean needFieldsAndMethod
 				if (iFields != null) {
 					for (int i = 0; i < iFields.length; i++) {
 						ITypeAnnotationWalker fieldWalker = ITypeAnnotationWalker.EMPTY_ANNOTATION_WALKER;
+						if (!this.environment.usesNullTypeAnnotations()) {
+							// using TYPE_USE annots, eea are applied already during createMethod();
+							// for declaration annotations re-create walker without default but with eea:
+							fieldWalker = binaryType.enrichWithExternalAnnotationsFor(fieldWalker, iFields[i], this.environment);
+						}
 						scanFieldForNullAnnotation(iFields[i], this.fields[i], this.isEnum(), fieldWalker);
 					}
 				}
@@ -617,6 +622,11 @@ private void cachePartsFrom2(IBinaryType binaryType, boolean needFieldsAndMethod
 						// (not using walker, which has defaultNullness, because defaults on parameters & return will be applied
 						//  by ImplicitNullAnnotationVerifier, triggered per invocation via MessageSend.resolveType() et al)
 						ITypeAnnotationWalker methodWalker = ITypeAnnotationWalker.EMPTY_ANNOTATION_WALKER;
+						if (!this.environment.usesNullTypeAnnotations()) {
+							// using TYPE_USE annots, eea are applied already during createMethod();
+							// for declaration annotations re-create walker without default but with eea:
+							methodWalker = binaryType.enrichWithExternalAnnotationsFor(methodWalker, iMethods[i], this.environment);
+						}
 						scanMethodForNullAnnotation(iMethods[i], this.methods[i], methodWalker, canUseNullTypeAnnotations);
 					}
 				}

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ExternalAnnotations17Test.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/ExternalAnnotations17Test.java
@@ -894,8 +894,6 @@ public class ExternalAnnotations17Test extends ExternalAnnotations18Test {
 				true, new NullProgressMonitor()).getWorkingCopy(new NullProgressMonitor());
 		CompilationUnit reconciled = unit.reconcile(getJLS8(), true, null, new NullProgressMonitor());
 		IProblem[] problems = reconciled.getProblems();
-		assertProblems(problems, new String[] {
-				"Pb(912) Null type safety: The expression of type 'E' needs unchecked conversion to conform to '@NonNull E'",
-		}, new int[] { 12 });
+		assertNoProblems(problems);
 	}
 }


### PR DESCRIPTION
+ re-introduce specific eea-walkers for scanField/Method*

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/2746
