### PR TITLE
Enforce subtyping rules for value classes

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/core/compiler/IProblem.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/core/compiler/IProblem.java
@@ -2901,4 +2901,9 @@ void setSourceStart(int sourceStart);
 	/** @since 3.47
 	 * @noreference preview feature error */
 	int IllegalValueInstanceSynchronization = PreviewRelated + 2105;
+
+	/** @since 3.47
+	 * @noreference preview feature error */
+	int ValueClassExtendsIdentityClass = PreviewRelated + 2106;
+
 }

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ClassScope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ClassScope.java
@@ -846,8 +846,12 @@ public class ClassScope extends Scope {
 			}
 		}
 
-		if (!sourceType.isInterface() && (modifiers & ExtraCompilerModifiers.AccValue) == 0)
-			modifiers |= ClassFileConstants.AccIdentity;
+		if (!sourceType.isInterface()) {
+			if ((modifiers & ExtraCompilerModifiers.AccValue) == 0)
+				modifiers |= ClassFileConstants.AccIdentity;
+			else if ((modifiers & ClassFileConstants.AccAbstract) == 0)
+				modifiers |= ClassFileConstants.AccFinal;
+		}
 		sourceType.modifiers = modifiers;
 	}
 
@@ -1124,6 +1128,10 @@ public class ClassScope extends Scope {
 				sourceType.setSuperClass(superclass);
 				sourceType.tagBits |= TagBits.HierarchyHasProblems; // propagate if missing supertype
 				return superclassRef.resolvedType.isValidBinding(); // reported some error against the source type ?
+			} else if (sourceType.isValueClass() && superclass.id != TypeIds.T_JavaLangObject && (superclass.modifiers & ClassFileConstants.AccIdentity) != 0) {
+				sourceType.setSuperClass(superclass);
+				problemReporter().valueClassExtendsIdentityClass(sourceType, superclassRef, superclass);
+				return false;
 			} else {
 				// only want to reach here when no errors are reported
 				sourceType.setSuperClass(superclass);

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/ProblemReporter.java
@@ -5016,6 +5016,14 @@ public void cantSynchronizeOnValueClass(Expression expression, TypeBinding type)
 		expression.sourceStart,
 		expression.sourceEnd);
 }
+public void valueClassExtendsIdentityClass(SourceTypeBinding type, TypeReference superclassRef, ReferenceBinding superType) {
+	this.handle(
+			IProblem.ValueClassExtendsIdentityClass,
+			new String[] {new String(superType.readableName()), new String(type.sourceName())},
+			new String[] {new String(superType.shortReadableName()), new String(type.sourceName())},
+			superclassRef.sourceStart,
+			superclassRef.sourceEnd);
+}
 public void discouragedValueBasedTypeToSynchronize(Expression expression, TypeBinding type) {
 	if (type.isParameterizedType()) {
 		type =  ((ParameterizedTypeBinding)type).actualType();

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/messages.properties
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/problem/messages.properties
@@ -1223,6 +1223,7 @@
 2103 = Inference for this invocation of method {1}({2}) from the type {0} refers to the missing type {3}
 2104 = Cannot fully evaluate null annotations due to cyclic structure involving {0}
 2105 = Illegal attempt to synchronize on an instance of a value class
+2106 = A value class may extend either java.lang.Object or an abstract value class, but not an identity class.
 ### ELABORATIONS
 ## Access restrictions
 # Discouraged access

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/CompilerInvocationTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/CompilerInvocationTests.java
@@ -1389,6 +1389,7 @@ public void test011_problem_categories() {
 	    expectedProblemAttributes.put("ResourceLocalMustBeEffectivelyFinal", new ProblemAttributes(CategorizedProblem.CAT_INTERNAL));
 	    expectedProblemAttributes.put("RecordAccessorMissingOverrideAnnotation", new ProblemAttributes(CategorizedProblem.CAT_TYPE));
 	    expectedProblemAttributes.put("IllegalValueInstanceSynchronization", new ProblemAttributes(CategorizedProblem.CAT_PREVIEW_RELATED));
+	    expectedProblemAttributes.put("ValueClassExtendsIdentityClass", new ProblemAttributes(CategorizedProblem.CAT_PREVIEW_RELATED));
 
 	    StringBuilder failures = new StringBuilder();
 		StringBuilder correctResult = new StringBuilder(70000);
@@ -2544,6 +2545,7 @@ public void test012_compiler_problems_tuning() {
 	    expectedProblemAttributes.put("ResourceLocalMustBeEffectivelyFinal", SKIP);
 	    expectedProblemAttributes.put("RecordAccessorMissingOverrideAnnotation", SKIP);
 	    expectedProblemAttributes.put("IllegalValueInstanceSynchronization", SKIP);
+	    expectedProblemAttributes.put("ValueClassExtendsIdentityClass", SKIP);
 
 
 	    Map constantNamesIndex = new HashMap();

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ValueClassesAndObjectsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ValueClassesAndObjectsTest.java
@@ -342,6 +342,99 @@ public class ValueClassesAndObjectsTest extends AbstractRegressionTestCommon {
  				}
  				"""},
     			"All well!");
+ 	}
+    // Test subclassing - legal and illegal scenarios
+    // Snippet from https://openjdk.org/jeps/401 - test synchronization - compile time
+    public void testSubclassing() {
+    	runNegativeTest(new String [] {
+ 				"X.java",
+ 				"""
+				import java.io.IOException;
+
+				// Legal subclassing scenarios
+				value class V1 {} // implicit extension of jlO
+				abstract value class V2 extends Object {} // explicit extension of jlO
+				value class V3 extends java.lang.Object {} // explicit extension of explicitly spelled out jlO
+				value class V4 extends java.lang.Number { // concrete extension of abstract value class
+
+					private static final long serialVersionUID = 1L;
+
+					@Override
+					public int intValue() {
+						return 0;
+					}
+
+					@Override
+					public long longValue() {
+						return 0;
+					}
+
+					@Override
+					public float floatValue() {
+						return 0;
+					}
+
+					@Override
+					public double doubleValue() {
+						return 0;
+					}
+				}
+				abstract value class V5 extends Number { // abstract extension of abstract value class
+					private static final long serialVersionUID = 1L;
+				}
+
+				value class V6 implements java.io.Serializable { // A value class may implement interfaces
+					private static final long serialVersionUID = 1L;
+				}
+				class I1 extends V2 {} // identity class may subclass an abstract value class
+				value record VPoint(int x, int y) {} // Legal value record
+
+				// negative tests below
+				value class V7 extends String {} // cannot subclass concrete identity class
+				value class V8 extends java.util.Map<String, String> {} // a super class must be a class
+				value class V9 extends java.io.InputStream { // cannot subclass abstract identity class
+
+				    @Override
+				    public int read() throws IOException {
+				        return 0;
+				    }}
+				value class V10 extends V3 {} // cannot subclass a concrete value class
+				class I2 extends V1 {} // identity class cannot subclass a concrete value class.
+				abstract value class V11 extends java.util.ArrayList<String> { // abstract value class may not subclass concrete identity class
+					private static final long serialVersionUID = 1L;
+				}
+ 				"""},
+    			"----------\n" +
+				"1. ERROR in X.java (at line 42)\n" +
+				"	value class V7 extends String {} // cannot subclass concrete identity class\n" +
+				"	                       ^^^^^^\n" +
+				"The type V7 cannot subclass the final class String\n" +
+				"----------\n" +
+				"2. ERROR in X.java (at line 43)\n" +
+				"	value class V8 extends java.util.Map<String, String> {} // a super class must be a class\n" +
+				"	                       ^^^^^^^^^^^^^\n" +
+				"The type Map<String,String> cannot be the superclass of V8; a superclass must be a class\n" +
+				"----------\n" +
+				"3. ERROR in X.java (at line 44)\n" +
+				"	value class V9 extends java.io.InputStream { // cannot subclass abstract identity class\n" +
+				"	                       ^^^^^^^^^^^^^^^^^^^\n" +
+				"A value class may extend either java.lang.Object or an abstract value class, but not an identity class.\n" +
+				"----------\n" +
+				"4. ERROR in X.java (at line 50)\n" +
+				"	value class V10 extends V3 {} // cannot subclass a concrete value class\n" +
+				"	                        ^^\n" +
+				"The type V10 cannot subclass the final class V3\n" +
+				"----------\n" +
+				"5. ERROR in X.java (at line 51)\n" +
+				"	class I2 extends V1 {} // identity class cannot subclass a concrete value class.\n" +
+				"	                 ^^\n" +
+				"The type I2 cannot subclass the final class V1\n" +
+				"----------\n" +
+				"6. ERROR in X.java (at line 52)\n" +
+				"	abstract value class V11 extends java.util.ArrayList<String> { // abstract value class may not subclass concrete identity class\n" +
+				"	                                 ^^^^^^^^^^^^^^^^^^^\n" +
+				"A value class may extend either java.lang.Object or an abstract value class, but not an identity class.\n" +
+				"----------\n");
 
  	}
  }


### PR DESCRIPTION
* A value class can extend either java.lang.Object or an abstract value class, but not an identity class.