### PR TITLE
Support snippet inline tags in Markdown

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/AbstractCommentParser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/AbstractCommentParser.java
@@ -104,6 +104,7 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 	protected boolean snippetInlineTagStarted = false;
 	private int nonRegionTagCount, inlineTagCount;
 	final static String SINGLE_LINE_COMMENT = "//"; //$NON-NLS-1$
+	final static String MARKDOWN_COMMENT = "///"; //$NON-NLS-1$
 
 	protected IMarkdownCommentHelper markdownHelper;
 
@@ -1872,36 +1873,6 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 							this.textStart = -1;
 						}
 						break;
-					case TokenNameCOMMENT_MARKDOWN:
-						if (this.markdown) {
-							String markdownTokenString = this.scanner.getCurrentTokenString();
-							String[] elements = markdownTokenString.split("\\r?\\n", -1); //$NON-NLS-1$
-							int elmentStart = this.scanner.getCurrentTokenStartPosition();
-							int elementEnd = 0;
-							try {
-								for (int i = 0; i < elements.length; i++) {
-									if (elementEnd != 0 ) {
-										elmentStart = elementEnd + 1; // +1 because of new line
-									}
-									int pos = elements[i].indexOf("///"); //$NON-NLS-1$
-									if (pos != -1) {
-										elmentStart = elmentStart + 3 + pos;
-										String element = elements[i].substring(3 + pos);
-										elementEnd = elmentStart + element.length();
-										if (element.stripLeading().startsWith("}")) { //$NON-NLS-1$
-											break;
-										}
-									}
-									pushText(elmentStart, elementEnd);
-								}
-								if (elements.length > 0)
-									markdownSnippetIsValid = true;
-							} catch (Exception e) {
-								markdownSnippetIsValid = false;
-							}
-
-						}
-						break;
 					case TokenNameCOMMENT_LINE:
 						String tokenString = this.scanner.getCurrentTokenString();
 						boolean handleNow = handleCommentLineForCurrentLine(tokenString);
@@ -1913,9 +1884,6 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 						if (!handleNow) {
 							this.nonRegionTagCount = 0;
 							this.inlineTagCount = 0;
-						}
-						if (this.markdown) {
-							markdownSnippetIsValid = true;
 						}
 						Object innerTag = parseSnippetInlineTags(indexOfLastComment == -1 ? tokenString : tokenString.substring(indexOfLastComment+2), snippetTag, this.scanner);
 						if (innerTag != null) {
@@ -1992,6 +1960,211 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 			}
 		}
 		return retVal;
+	}
+
+	protected boolean parseSnippetForMarkdown() throws InvalidInputException {
+		boolean tokenWhiteSpace = this.scanner.tokenizeWhiteSpace;
+		boolean tokenizeComments = this.scanner.tokenizeComments;
+		this.scanner.tokenizeWhiteSpace = true;
+		this.scanner.tokenizeComments = true;
+		boolean parsingJava23Plus = this.scanner != null ? this.scanner.sourceLevel >= ClassFileConstants.JDK23 : false;
+		boolean valid = true;
+		boolean markdownSnippetIsValid = false;
+		int closingBracePosition = -1;
+		if (!parsingJava23Plus) {
+			throw Scanner.invalidInput();
+		}
+		Object snippetTag = null;
+		this.nonRegionTagCount = 0;
+		this.inlineTagCount = 0;
+		try {
+			snippetTag = createSnippetTag();
+			Map<String, String> snippetAttributes = new HashMap();
+			if (!parseTillColon(snippetAttributes)) {
+				valid = false;
+			} else {
+				if (this.index < this.scanner.eofPosition) {
+					TerminalToken token = readTokenSafely();
+					if (token == TerminalToken.TokenNameWHITESPACE) {
+						if (containsNewLine(this.scanner.getCurrentTokenString())) {
+							consumeToken();
+						} else {
+							valid = false;
+							if (this.reportProblems) {
+								this.sourceParser.problemReporter().javadocInvalidSnippetContentNewLine(this.index, this.lineEnd);
+							}
+							this.setSnippetIsValid(snippetTag, false);
+							this.setSnippetError(snippetTag, "Snippet content should be in a new line"); //$NON-NLS-1$
+						}
+					}
+				} else {
+					valid = false;
+				}
+			}
+			if (hasID(snippetAttributes)) {
+				this.setSnippetID(snippetTag, getID(snippetAttributes));
+			}
+			TerminalToken token;
+			while (this.index < this.scanner.eofPosition) {
+				this.index = this.scanner.currentPosition;
+				token = readTokenSafely();
+				if (token == TerminalToken.TokenNameEOF) {
+					break;
+				}
+				boolean closingBraceFound = false;
+				switch (token) {
+					case TokenNameCOMMENT_LINE:
+						// JavadocParser path: each "/// ..." line is a separate COMMENT_LINE token.
+						try {
+							String rawLine = this.scanner.getCurrentTokenString();
+							int slashPos = rawLine.indexOf(MARKDOWN_COMMENT);
+							if (slashPos == -1) {
+								break;
+							}
+							String lineContent = rawLine.substring(slashPos + 3);
+							int lineContentEnd = lineContent.length();
+							while (lineContentEnd > 0) {
+								char c = lineContent.charAt(lineContentEnd - 1);
+								if (c == '\n' || c == '\r') lineContentEnd--;
+								else break;
+							}
+							lineContent = lineContent.substring(0, lineContentEnd);
+							if (lineContent.stripLeading().startsWith("}")) { //$NON-NLS-1$
+								markdownSnippetIsValid = true;
+								// Record the position of '}' so commentParse() can see it
+								int tokenStart = this.scanner.getCurrentTokenStartPosition();
+								closingBracePosition = tokenStart + slashPos + 3
+										+ lineContent.indexOf('}');
+								closingBraceFound = true;
+								break;
+							}
+							markdownSnippetIsValid = true;
+							int contentStart = this.scanner.getCurrentTokenStartPosition() + slashPos + 3;
+							int contentEnd = contentStart + lineContentEnd;
+							processMarkdownSnippetLine(lineContent, contentStart, contentEnd, snippetTag);
+						} catch (Exception e) {
+							markdownSnippetIsValid = false;
+						}
+						break;
+
+					case TokenNameCOMMENT_MARKDOWN:
+						// DocCommentParser path: the entire markdown block is one token.
+						try {
+							String markdownBlock = this.scanner.getCurrentTokenString();
+							String[] lines = markdownBlock.split("\\r?\\n", -1); //$NON-NLS-1$
+							int lineStart = this.scanner.getCurrentTokenStartPosition();
+							for (int i = 0; i < lines.length; i++) {
+								if (i > 0) {
+									lineStart += lines[i - 1].length();
+									if (lineStart < this.scanner.getCurrentTokenEndPosition()
+											&& this.source[lineStart] == '\r') {
+										lineStart++;
+									}
+									lineStart++;
+								}
+								String rawLine = lines[i];
+								int slashPos = rawLine.indexOf(MARKDOWN_COMMENT);
+								if (slashPos == -1) {
+									continue;
+								}
+								String lineContent = rawLine.substring(slashPos + 3);
+								if (lineContent.stripLeading().startsWith("}")) { //$NON-NLS-1$
+									markdownSnippetIsValid = true;
+									// Record the position of '}' so commentParse() can see it
+									closingBracePosition = lineStart + slashPos + 3
+											+ lineContent.indexOf('}');
+									closingBraceFound = true;
+									break;
+								}
+								markdownSnippetIsValid = true;
+								processMarkdownSnippetLine(lineContent,
+										lineStart + slashPos + 3,
+										lineStart + rawLine.length(),
+										snippetTag);
+							}
+						} catch (Exception e) {
+							markdownSnippetIsValid = false;
+						}
+						break;
+
+					default:
+						break;
+				}
+				consumeToken();
+				if (closingBraceFound) {
+					break;
+				}
+			}
+		} finally {
+			if (!areRegionsClosed()) {
+				if (this.reportProblems) {
+					this.sourceParser.problemReporter().javadocInvalidSnippetRegionNotClosed(this.index, this.lineEnd);
+				}
+				this.setSnippetError(snippetTag, "Region not closed"); //$NON-NLS-1$
+				this.setSnippetIsValid(snippetTag, false);
+			}
+			this.scanner.tokenizeWhiteSpace = tokenWhiteSpace;
+			this.scanner.tokenizeComments = tokenizeComments;
+		}
+		boolean retVal = valid && markdownSnippetIsValid;
+		if (snippetTag != null) {
+			this.setSnippetIsValid(snippetTag, retVal);
+		}
+		// Reposition to the '}' so commentParse() can close the inline tag naturally
+		if (retVal && closingBracePosition >= 0) {
+			this.index = closingBracePosition;
+			this.scanner.currentPosition = closingBracePosition;
+		}
+		return retVal;
+	}
+
+	private void processMarkdownSnippetLine(String lineContent, int contentStart, int contentEnd,
+			Object snippetTag) {
+		int noSingleLineComm = getNumberOfSingleLineCommentInSnippetTag(lineContent);
+		int indexOfLastComment = -1;
+		if (noSingleLineComm > 0) {
+			indexOfLastComment = indexOfLastSingleComment(lineContent, noSingleLineComm);
+		}
+		boolean handleNow = handleCommentLineForCurrentLine(SINGLE_LINE_COMMENT + lineContent);
+		if (!handleNow) {
+			this.nonRegionTagCount = 0;
+			this.inlineTagCount = 0;
+		}
+		String inlineTagStr = indexOfLastComment == -1
+				? (SINGLE_LINE_COMMENT + lineContent)
+				: (SINGLE_LINE_COMMENT + lineContent.substring(indexOfLastComment + 2));
+		int savedStartPosition = this.scanner.startPosition;
+		this.scanner.startPosition = indexOfLastComment >= 0
+				? contentStart + indexOfLastComment
+				: contentStart - 1;
+		Object innerTag = parseSnippetInlineTags(inlineTagStr, snippetTag, this.scanner);
+		this.scanner.startPosition = savedStartPosition;
+		boolean lvalid = innerTag != null;
+		// TextElement spans from contentStart up to (but not including) the "// @tag"
+		int textEnd = contentEnd;
+		if (lvalid && indexOfLastComment >= 0) {
+			textEnd = contentStart + indexOfLastComment;
+		}
+		if (lvalid && handleNow && innerTag != snippetTag) {
+			addSnippetInnerTag(innerTag, snippetTag);
+			this.snippetInlineTagStarted = true;
+		}
+		if (contentStart < textEnd) {
+			pushSnippetText(this.source, contentStart, textEnd, true, snippetTag);
+			if (handleNow) {
+				this.nonRegionTagCount = 0;
+				this.inlineTagCount = 0;
+			}
+		}
+		if (lvalid && innerTag != snippetTag) {
+			setSnippetInnerTagRange(innerTag, contentStart, contentEnd);
+		}
+		if (lvalid && !handleNow) {
+			if (innerTag != snippetTag) {
+				addSnippetInnerTag(innerTag, snippetTag);
+			}
+			this.snippetInlineTagStarted = true;
+		}
 	}
 
 	private Path getFilePathFromFileName(String fileName) {
@@ -2404,7 +2577,8 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 							token = readTokenSafely();
 							if (token == TerminalToken.TokenNameMULTIPLY) {
 								consumeToken();
-							} else {
+							} else if (!this.markdown) {
+								// markdown: no * expected after newline, leave token unconsumed
 								isValid = false;
 							}
 						} else {
@@ -3328,6 +3502,10 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 	protected abstract void addTagProperties(Object Tag, Map<String, Object> map, int tagCount);
 
 	protected abstract void addSnippetInnerTag(Object tag, Object snippetTag);
+
+	protected void setSnippetInnerTagRange(Object tag, int start, int end) {
+		// do nothing
+	}
 
 	protected abstract void setSnippetError(Object tag, String value);
 

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/JavadocParser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/JavadocParser.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2024 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -866,7 +866,7 @@ public class JavadocParser extends AbstractCommentParser {
 					this.tagValue = TAG_SNIPPET_VALUE;
 					this.tagWaitingForDescription = this.tagValue;
 					if (this.inlineTagStarted) {
-						valid = parseSnippet();
+						valid = this.markdown ? parseSnippetForMarkdown() : parseSnippet();
 					}
 				}else if (length> TAG_SNIPPET_LENGTH && CharOperation.prefixEquals(TAG_SNIPPET, tagName)) {
 					if (this.reportProblems ) {
@@ -1096,7 +1096,10 @@ public class JavadocParser extends AbstractCommentParser {
 	protected void refreshInlineTagPosition(int previousPosition) {
 
 		// Signal tag missing description if necessary
-		if (this.tagWaitingForDescription!= NO_TAG_VALUE) {
+		// For markdown snippet, the body is on subsequent lines processed in separate
+		// commentParse() calls, so skip the description check to avoid false errors.
+		if (this.tagWaitingForDescription != NO_TAG_VALUE
+				&& !(this.markdown && this.tagWaitingForDescription == TAG_SNIPPET_VALUE)) {
 			this.sourceParser.problemReporter().javadocMissingTagDescription(TAG_NAMES[this.tagWaitingForDescription], this.tagSourceStart, this.tagSourceEnd, this.sourceParser.modifiers);
 			this.tagWaitingForDescription = NO_TAG_VALUE;
 		}
@@ -1138,6 +1141,11 @@ public class JavadocParser extends AbstractCommentParser {
 				}
 				break;
 			case NO_TAG_VALUE:
+				break;
+			case TAG_SNIPPET_VALUE:
+				if (!this.inlineTagStarted && !this.markdown) {
+					this.sourceParser.problemReporter().javadocMissingTagDescription(TAG_NAMES[this.tagWaitingForDescription], this.tagSourceStart, this.tagSourceEnd, this.sourceParser.modifiers);
+				}
 				break;
 			default:
 				if (!this.inlineTagStarted) {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/MarkdownCommentsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/MarkdownCommentsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2024 IBM Corporation and others.
+ * Copyright (c) 2024, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -348,7 +348,7 @@ public class MarkdownCommentsTest extends JavadocTest {
 					"""
 					public class X {
 						/// Some text here without the necessary tags for main method
-						/// @param arguments\s 
+						/// @param arguments\s
 
 						// This line will be ignored and the previous block will be considered as the Javadoc
 						public static void main(String[] arguments) {
@@ -705,5 +705,24 @@ public class MarkdownCommentsTest extends JavadocTest {
 		} finally {
 			this.reportMissingJavadocTags = bkup;
 		}
+	}
+
+	public void testMarkdownSupportForInlineTags_5010() {
+		this.runConformTest(new String[] { "X.java", """
+	            public class X {
+	                /// {@snippet :
+					///   	System.out.println("Hello"); // @highlight substring="println"
+					///   	items.add("Java 18");        // @highlight substring="items.add" type="highlighted"
+					///   	System.out.println("Item: " + items.get(0)); // @highlight regex="\".*\""
+					///   	System.out.println("Item: " + items.get(0)); // @highlight regex="\".*\"" type="highlighted"
+					///   	List<String> list = new ArrayList<>(); // @link substring="ArrayList" target="java.util.ArrayList"
+					///   	List<String> list = new ArrayList<>(); // @link regex="ArrayList" target="java.util.ArrayList"
+					///   	Object obj = new Object(); // @replace substring="Object" replacement="MyClass"
+					///   	String s = "foo bar"; // @replace regex="foo" replacement="baz"
+					/// }
+	                public static void main(String... args) {}
+	            }
+	            """ },
+	            "");
 	}
 }

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterMarkdownSnippetTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterMarkdownSnippetTest.java
@@ -33,7 +33,9 @@ import org.eclipse.jdt.core.dom.ASTNode;
 import org.eclipse.jdt.core.dom.ASTParser;
 import org.eclipse.jdt.core.dom.CompilationUnit;
 import org.eclipse.jdt.core.dom.Javadoc;
+import org.eclipse.jdt.core.dom.QualifiedName;
 import org.eclipse.jdt.core.dom.TagElement;
+import org.eclipse.jdt.core.dom.TagProperty;
 import org.eclipse.jdt.core.dom.TextElement;
 import org.eclipse.jdt.internal.compiler.parser.JavadocTagConstants;
 import org.eclipse.jdt.internal.compiler.parser.ScannerHelper;
@@ -103,6 +105,8 @@ public class ASTConverterMarkdownSnippetTest extends ConverterTestSetup {
 		Map savedOptions = null;
 
 		private static String SNIPPET_TAG = '@' + new String(JavadocTagConstants.TAG_SNIPPET);
+
+		protected String newline = System.lineSeparator();
 
 		public ASTConverterMarkdownSnippetTest(String name, String support, String unix) {
 			super(name);
@@ -555,7 +559,7 @@ public class ASTConverterMarkdownSnippetTest extends ConverterTestSetup {
 			TagElement snippetTag = getSnippetTag(javadoc);
 			List<TextElement> frags = snippetTag.fragments();
 			assertEquals("Fragments should be 1", 1, frags.size());
-			assertEquals("Incorrect text content", " 	int x = 2;", frags.get(0).getText());
+			assertEquals("Incorrect text content", " 	int x = 2;" + this.newline, frags.get(0).getText());
 		}
 	}
 
@@ -580,11 +584,9 @@ public class ASTConverterMarkdownSnippetTest extends ConverterTestSetup {
 			Javadoc javadoc = (Javadoc) unitComments.get(0);
 			TagElement snippetTag = getSnippetTag(javadoc);
 			List<TextElement> frags = snippetTag.fragments();
-			assertEquals("Fragments should be 4", 4, frags.size());
-			assertEquals("Incorrect text content", "", frags.get(0).getText());
-			assertEquals("Incorrect text content", " 	int a = 1;", frags.get(1).getText());
-			assertEquals("Incorrect text content", "", frags.get(2).getText());
-			assertEquals("Incorrect text content", "		int b = 2;", frags.get(3).getText());
+			assertEquals("Fragments should be 2", 2, frags.size());
+			assertEquals("Incorrect text content", " 	int a = 1;" + this.newline, frags.get(0).getText());
+			assertEquals("Incorrect text content", "		int b = 2;" + this.newline, frags.get(1).getText());
 		}
 	}
 
@@ -607,7 +609,7 @@ public class ASTConverterMarkdownSnippetTest extends ConverterTestSetup {
 			TagElement snippetTag = getSnippetTag(javadoc);
 			List<TextElement> frags = snippetTag.fragments();
 			assertEquals("Fragments should be 1", 1, frags.size());
-			assertEquals("Incorrect text content", "   {@code int a = 0;}", frags.get(0).getText());
+			assertEquals("Incorrect text content", "   {@code int a = 0;}" + this.newline, frags.get(0).getText());
 		}
 	}
 
@@ -634,7 +636,129 @@ public class ASTConverterMarkdownSnippetTest extends ConverterTestSetup {
 			Javadoc javadoc = (Javadoc) unitComments.get(0);
 			TagElement snippetTag = getSnippetTag(javadoc);
 			assertFalse("Wrong number of elements", snippetTag.fragments().size() == 5);
-			System.out.println("sasi");
+		}
+	}
+
+	public void testMarkdownSupportInlineTags5010_01() throws JavaModelException {
+		String source = """
+				/// {@snippet :
+				///   	System.out.println("Hello"); // @highlight substring="println"
+				///   	items.add("Java 18");        // @highlight substring="items.add" type="highlighted"
+				///   	System.out.println("Item: " + items.get(0)); // @highlight regex="\".*\""
+				///   	System.out.println("Item: " + items.get(0)); // @highlight regex="\".*\"" type="highlighted"
+				///   	List<String> list = new ArrayList<>(); // @link substring="ArrayList" target="java.util.ArrayList"
+				///   	List<String> list = new ArrayList<>(); // @link regex="ArrayList" target="java.util.ArrayList"
+				///   	Object obj = new Object(); // @replace substring="Object" replacement="MyClass"
+				///   	String s = "foo bar"; // @replace regex="foo" replacement="baz"
+				/// }
+				public class Markdown {}
+				""";
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy("/Converter_26/src/markdown/Markdown.java", source, null);
+		if (this.docCommentSupport.equals(JavaCore.ENABLED)) {
+			CompilationUnit compilUnit = verifyComments(this.workingCopies[0]);
+			List unitComments = compilUnit.getCommentList();
+			int size = unitComments.size();
+			assertEquals("Wrong number of comments", 1, size);
+
+			Javadoc javadoc = (Javadoc) unitComments.get(0);
+			TagElement snippetTag = getSnippetTag(javadoc);
+			assertNotNull("Snippet tag should not be null", snippetTag);
+
+			List<TagElement> snippetFrags = snippetTag.fragments();
+			assertEquals("Invalid snippet tag frags", 8, snippetFrags.size());
+
+			TagElement highlighSubstring 					= snippetFrags.get(0);
+			TagElement highlightSubstringTypeHighlighted 	= snippetFrags.get(1);
+			TagElement highlightRegex 						= snippetFrags.get(2);
+			TagElement highlightRegexTypeHighlighted 		= snippetFrags.get(3);
+			TagElement linkSubstring 						= snippetFrags.get(4);
+			TagElement linkRegex 							= snippetFrags.get(5);
+			TagElement replaceSubstring 					= snippetFrags.get(6);
+			TagElement replaceRegex 						= snippetFrags.get(7);
+
+			// System.out.println("Hello"); // @highlight substring="println"
+			TextElement highlighSubstringChild = (TextElement) (highlighSubstring.fragments()).get(0);
+			List<TagProperty> highlighSubstringTagProperty = highlighSubstring.tagProperties();
+			assertEquals("Incorrect optional Tag", "@highlight", highlighSubstring.getTagName());
+			assertEquals("Incorrect Child TextElement", "   	System.out.println(\"Hello\");" + this.newline, highlighSubstringChild.getText());
+			assertEquals("Incorrect TagProperty name", "substring", highlighSubstringTagProperty.get(0).getName());
+			assertEquals("Incorrect TagProperty string_value", "println", highlighSubstringTagProperty.get(0).getStringValue());
+
+			// items.add("Java 18");        // @highlight substring="items.add" type="highlighted"
+			TextElement highlightSubstringTypeHighlightedChild = (TextElement) (highlightSubstringTypeHighlighted.fragments()).get(0);
+			List<TagProperty> highlightSubstringTypeHighlightedTagProperty = highlightSubstringTypeHighlighted.tagProperties();
+			assertEquals("Incorrect optional Tag", "@highlight", highlightSubstringTypeHighlighted.getTagName());
+			assertEquals("Incorrect Child TextElement", "   	items.add(\"Java 18\");" + this.newline, highlightSubstringTypeHighlightedChild.getText());
+			assertEquals("Incorrect number of TagProperties", 2, highlightSubstringTypeHighlightedTagProperty.size());
+			assertEquals("Incorrect TagProperty name", "type", highlightSubstringTypeHighlightedTagProperty.get(0).getName());
+			assertEquals("Incorrect TagProperty string_value", "highlighted", highlightSubstringTypeHighlightedTagProperty.get(0).getStringValue());
+			assertEquals("Incorrect TagProperty name", "substring", highlightSubstringTypeHighlightedTagProperty.get(1).getName());
+			assertEquals("Incorrect TagProperty string_value", "items.add", highlightSubstringTypeHighlightedTagProperty.get(1).getStringValue());
+
+			// System.out.println("Item: " + items.get(0)); // @highlight regex="\".*\""
+			TextElement highlightRegexChild = (TextElement) (highlightRegex.fragments()).get(0);
+			List<TagProperty> highlightRegexTagProperty = highlightRegex.tagProperties();
+			assertEquals("Incorrect optional Tag", "@highlight", highlightRegex.getTagName());
+			assertEquals("Incorrect Child TextElement", "   	System.out.println(\"Item: \" + items.get(0));" + this.newline, highlightRegexChild.getText());
+			assertEquals("Incorrect TagProperty name", "regex", highlightRegexTagProperty.get(0).getName());
+			assertEquals("Incorrect TagProperty string_value", "\"\"", highlightRegexTagProperty.get(0).getStringValue());
+
+			// System.out.println("Item: " + items.get(0)); // @highlight regex="\".*\"" type="highlighted"
+			TextElement highlightRegexTypeHighlightedChild = (TextElement) (highlightRegexTypeHighlighted.fragments()).get(0);
+			List<TagProperty> highlightRegexTypeHighlightedTagProperty = highlightRegexTypeHighlighted.tagProperties();
+			assertEquals("Incorrect optional Tag", "@highlight", highlightRegexTypeHighlighted.getTagName());
+			assertEquals("Incorrect Child TextElement", "   	System.out.println(\"Item: \" + items.get(0));" + this.newline, highlightRegexTypeHighlightedChild.getText());
+			assertEquals("Incorrect TagProperty name", "regex", highlightRegexTypeHighlightedTagProperty.get(0).getName());
+			assertEquals("Incorrect TagProperty string_value", "\"\"", highlightRegexTypeHighlightedTagProperty.get(0).getStringValue());
+
+			// List<String> list = new ArrayList<>(); // @link substring="ArrayList" target="java.util.ArrayList"
+			TextElement linkSubstringChild = (TextElement) (linkSubstring.fragments()).get(0);
+			List<TagProperty> linkSubstringTagProperty = linkSubstring.tagProperties();
+			QualifiedName qualifiedName = (QualifiedName) linkSubstringTagProperty.get(1).getNodeValue();
+			assertEquals("Incorrect optional Tag", "@link", linkSubstring.getTagName());
+			assertEquals("Incorrect Child TextElement", "   	List<String> list = new ArrayList<>();" + this.newline, linkSubstringChild.getText());
+			assertEquals("Incorrect number of TagProperties", 2, linkSubstringTagProperty.size());
+			assertEquals("Incorrect TagProperty name", "substring", linkSubstringTagProperty.get(0).getName());
+			assertEquals("Incorrect TagProperty string_value", "ArrayList", linkSubstringTagProperty.get(0).getStringValue());
+			assertEquals("Incorrect TagProperty name", "target", linkSubstringTagProperty.get(1).getName());
+			assertEquals("Incorrect TagProperty string_value", null, linkSubstringTagProperty.get(1).getStringValue());
+			assertTrue("incorrect SimpleName", qualifiedName.getName().getNodeType() == ASTNode.SIMPLE_NAME && qualifiedName.getName().toString().equals("ArrayList"));
+			assertTrue("incorrect Qualifier", qualifiedName.getQualifier().getNodeType() == ASTNode.QUALIFIED_NAME && qualifiedName.getQualifier().toString().equals("java.util"));
+
+			// List<String> list = new ArrayList<>(); // @link regex="ArrayList" target="java.util.ArrayList"
+			TextElement linkRegexChild = (TextElement) (linkRegex.fragments()).get(0);
+			List<TagProperty> linkRegexTagProperty = linkRegex.tagProperties();
+			qualifiedName = (QualifiedName) linkRegexTagProperty.get(1).getNodeValue();
+			assertEquals("Incorrect optional Tag", "@link", linkRegex.getTagName());
+			assertEquals("Incorrect Child TextElement", "   	List<String> list = new ArrayList<>();" + this.newline, linkRegexChild.getText());
+			assertEquals("Incorrect number of TagProperties", 2, linkRegexTagProperty.size());
+			assertEquals("Incorrect TagProperty name", "regex", linkRegexTagProperty.get(0).getName());
+			assertEquals("Incorrect TagProperty string_value", "ArrayList", linkRegexTagProperty.get(0).getStringValue());
+			assertEquals("Incorrect TagProperty name", "target", linkRegexTagProperty.get(1).getName());
+			assertEquals("Incorrect TagProperty string_value", null, linkRegexTagProperty.get(1).getStringValue());
+			assertTrue("incorrect SimpleName", qualifiedName.getName().getNodeType() == ASTNode.SIMPLE_NAME && qualifiedName.getName().toString().equals("ArrayList"));
+			assertTrue("incorrect Qualifier", qualifiedName.getQualifier().getNodeType() == ASTNode.QUALIFIED_NAME && qualifiedName.getQualifier().toString().equals("java.util"));
+
+			// Object obj = new Object(); // @replace substring="Object" replacement="MyClass"
+			TextElement replaceSubstringChild = (TextElement) (replaceSubstring.fragments()).get(0);
+			List<TagProperty> replaceSubstringTagProperty = replaceSubstring.tagProperties();
+			assertEquals("Incorrect TextElement", "   	Object obj = new Object();" + this.newline, replaceSubstringChild.getText());
+			assertEquals("Incorrect number of TagProperties", 2, replaceSubstringTagProperty.size());
+			assertEquals("Incorrect TagProperty name", "replacement", replaceSubstringTagProperty.get(0).getName());
+			assertEquals("Incorrect TagProperty string_value", "MyClass", replaceSubstringTagProperty.get(0).getStringValue());
+			assertEquals("Incorrect TagProperty name", "substring", replaceSubstringTagProperty.get(1).getName());
+			assertEquals("Incorrect TagProperty string_value", "Object", replaceSubstringTagProperty.get(1).getStringValue());
+
+			// String s = "foo bar"; // @replace regex="foo" replacement="baz"
+			TextElement replaceRegexChild = (TextElement) (replaceRegex.fragments()).get(0);
+			List<TagProperty> replaceRegexTagProperty = replaceRegex.tagProperties();
+			assertEquals("Incorrect TextElement", "   	String s = \"foo bar\";" + this.newline, replaceRegexChild.getText());
+			assertEquals("Incorrect number of TagProperties", 2, replaceRegexTagProperty.size());
+			assertEquals("Incorrect TagProperty name", "regex", replaceRegexTagProperty.get(0).getName());
+			assertEquals("Incorrect TagProperty string_value", "foo", replaceRegexTagProperty.get(0).getStringValue());
+			assertEquals("Incorrect TagProperty name", "replacement", replaceRegexTagProperty.get(1).getName());
+			assertEquals("Incorrect TagProperty string_value", "baz", replaceRegexTagProperty.get(1).getStringValue());
 		}
 	}
 }

--- a/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/DocCommentParser.java
+++ b/org.eclipse.jdt.core/dom/org/eclipse/jdt/core/dom/DocCommentParser.java
@@ -521,6 +521,12 @@ class DocCommentParser extends AbstractCommentParser {
 		}
 	}
 
+	@Override
+	protected void setSnippetInnerTagRange(Object tag, int start, int end) {
+		if (tag instanceof TagElement tagElement) {
+			tagElement.setSourceRange(start, end - start);
+		}
+	}
 
 	@Override
 	protected Object createTypeReference(TerminalToken primitiveToken, boolean canBeModule) {
@@ -949,7 +955,7 @@ class DocCommentParser extends AbstractCommentParser {
 								valid = false;
 							} else {
 								this.tagValue = TAG_SNIPPET_VALUE;
-								valid = parseSnippet();
+								valid = this.markdown ? parseSnippetForMarkdown() : parseSnippet();
 							}
 						} else {
 							this.tagValue = TAG_OTHERS_VALUE;
@@ -1196,10 +1202,14 @@ class DocCommentParser extends AbstractCommentParser {
 
 	@Override
 	protected void pushSnippetText(char[] text, int start, int end, boolean addNewLine, Object snippetTag) {
-		pushSnippetText(text, start, end, addNewLine, snippetTag, false);
+		pushSnippetText(text, start, end, addNewLine, snippetTag, false, this.markdown);
 	}
 
 	private void pushSnippetText(char[] text, int start, int end, boolean addNewLine, Object snippetTag, boolean isExternalSnippet) {
+		pushSnippetText(text, start, end, addNewLine, snippetTag, isExternalSnippet, false);
+	}
+
+	private void pushSnippetText(char[] text, int start, int end, boolean addNewLine, Object snippetTag, boolean isExternalSnippet, boolean isMarkdown) {
 		// Create text element
 		String textToBeAdded= new String( text, start, end-start).stripTrailing();
 		AbstractTextElement textElem= null;
@@ -1215,7 +1225,7 @@ class DocCommentParser extends AbstractCommentParser {
 			if (addNewLine) {
 				textToBeAdded += System.lineSeparator();
 			}
-		} else if (isExternalSnippet){
+		} else if (isExternalSnippet || isMarkdown) {
 			if (addNewLine) {
 				textToBeAdded += System.lineSeparator();
 			}


### PR DESCRIPTION
Add support for snippet inline tags in Markdown Javadoc comments.

This enables tags such as @highlight, @link, etc. and related snippet tags to be handled consistently with regular Javadoc comments.

Fix: https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5010

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
