### PR TITLE
Compiler crashes with NullPointerException when enabling null analysis, annotations silently not compiled to bytecode

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ASTNode.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/ASTNode.java
@@ -855,6 +855,10 @@ public abstract class ASTNode implements Location, TypeConstants, TypeIds {
 							// need to fill the instances array
 							for (int j = 0; j < length; j++) {
 								Annotation annot = sourceAnnotations[j];
+								if (annot.recipient == null || annot.resolvedType == null) {
+									annot.recipient = recipient;
+									annot.resolveType(scope);
+								}
 								annotations[j] = annot.getCompilerAnnotation();
 							}
 						}

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullTypeAnnotationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullTypeAnnotationTest.java
@@ -20253,4 +20253,24 @@ public void testGH5249() {
 		getCompilerOptions(),
 		"");
 }
+public void testGH5316() throws Exception {
+	runConformTestWithLibs(new String[] {
+			"MyInnocentClass.java",
+			"""
+			import java.util.Map;
+
+			import org.eclipse.jdt.annotation.NonNullByDefault;
+			import org.eclipse.jdt.annotation.Nullable;
+
+			@SuppressWarnings("unused")
+			public class MyInnocentClass {
+				@NonNullByDefault
+				@Nullable
+				private Map<String, String> aTotallyNormalMap;
+			}
+			"""
+		},
+		getCompilerOptions(),
+		"");
+}
 }


### PR DESCRIPTION
Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5316
