### PR TITLE
Enable CompletionEngine debug mode during CompletionTests16

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests16.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/CompletionTests16.java
@@ -19,6 +19,7 @@ import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.internal.codeassist.CompletionEngine;
 
 public class CompletionTests16 extends AbstractJavaModelCompletionTests {
 
@@ -38,6 +39,13 @@ public class CompletionTests16 extends AbstractJavaModelCompletionTests {
 		}
 		COMPLETION_PROJECT.setOption(JavaCore.COMPILER_PB_ENABLE_PREVIEW_FEATURES, JavaCore.ENABLED);
 		super.setUpSuite();
+		CompletionEngine.DEBUG = true;
+	}
+
+	@Override
+	public void tearDownSuite() throws Exception {
+		CompletionEngine.DEBUG = false;
+		super.tearDownSuite();
 	}
 
 	public static Test suite() {


### PR DESCRIPTION
`CompletionTests16.testBug564828_2()` fails sporadically in I-builds, this change enables the `CompletionEngine` debug/verbose mode during the test case. This will hopefully provide context to analyze the failures.

See: https://github.com/eclipse-jdt/eclipse.jdt.core/issues/3230
