### PR TITLE
Revert "Workspace compliance level is not properly "inherited" by

### DIFF
--- a/org.eclipse.jdt.core.tests.builder/src/org/eclipse/jdt/core/tests/builder/BuilderTests11.java
+++ b/org.eclipse.jdt.core.tests.builder/src/org/eclipse/jdt/core/tests/builder/BuilderTests11.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, 2026 Andrey Loskutov (loskutov@gmx.de) and others.
+ * Copyright (c) 2022, Andrey Loskutov (loskutov@gmx.de) and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -13,7 +13,6 @@
  *******************************************************************************/
 package org.eclipse.jdt.core.tests.builder;
 
-import java.util.Hashtable;
 import junit.framework.Test;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.jdt.core.JavaCore;
@@ -55,44 +54,6 @@ public class BuilderTests11 extends BuilderTests {
 	public void testBuildWithRelease_11() throws JavaModelException, Exception {
 		String compliance = "11";
 		runTest(compliance);
-	}
-
-	/**
-	 * https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5281
-	 * The release option is enabled only at the workspace level (not per project).
-	 * The builder must still honor it and restrict the JRT system library to the
-	 * targeted release's API. Here we target release 8 and reference {@code List.of()},
-	 * which was only added in Java 9 - so it must be flagged as an error.
-	 * If the workspace-level release option is ignored (the bug), the full JDK 11 JRT
-	 * is visible, {@code List.of()} resolves and no problem is reported.
-	 */
-	public void testReleaseOptionFromWorkspace() throws JavaModelException, Exception {
-		Hashtable<String, String> defaultOptions = JavaCore.getOptions();
-		try {
-			// Enable the release option only at the workspace level
-			Hashtable<String, String> wkspOptions = JavaCore.getOptions();
-			wkspOptions.put(JavaCore.COMPILER_RELEASE, JavaCore.ENABLED);
-			JavaCore.setOptions(wkspOptions);
-
-			// Create a project targeting release 8, WITHOUT setting the release option per project
-			IPath projectPath = env.addProject("ReleaseFromWorkspace", "1.8");
-			env.removePackageFragmentRoot(projectPath, "");
-			IPath src = env.addPackageFragmentRoot(projectPath, "src");
-			env.addExternalJars(projectPath, Util.getJavaClassLibs());
-			IPath classA = env.addClass(src, "bug", "X",
-					"package bug;\n" +
-					"import java.util.List;\n" +
-					"public class X {\n" +
-					"	List<String> l = List.of(\"a\");\n" + // List.of() is Java 9+
-					"}\n");
-			fullBuild();
-
-			// The Java 9+ API must not be resolvable when targeting release 8
-			expectingProblemsFor(classA,
-					"Problem : The method of(String) is undefined for the type List [ resource : </ReleaseFromWorkspace/src/bug/X.java> range : <76,78> category : <50> severity : <2>]");
-		} finally {
-			JavaCore.setOptions(defaultOptions);
-		}
 	}
 
 	/**

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/NameEnvironment.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/NameEnvironment.java
@@ -145,7 +145,7 @@ private void computeClasspathLocations(
 		isReleaseEnabled = true;
 	} else {
 		compliance = javaProject.getOption(JavaCore.COMPILER_COMPLIANCE, true);
-		isReleaseEnabled = JavaCore.ENABLED.equals(javaProject.getOption(JavaCore.COMPILER_RELEASE, true));
+		isReleaseEnabled = JavaCore.ENABLED.equals(javaProject.getOption(JavaCore.COMPILER_RELEASE, false));
 	}
 	if (CompilerOptions.versionToJdkLevel(compliance) >= ClassFileConstants.JDK9) {
 		moduleEntries = new LinkedHashMap<>(classpathEntries.length);


### PR DESCRIPTION
projects #5281 (#5283)"

This reverts commit bd8c1aa2e504b600d845ac842c0b94811b00be3b as it caused regression.

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5328
