### PR TITLE
docs: add GetMerged maintainer review scorecard badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ If you do not provide the implementation yourself (or pay someone to do it for y
 If it is a serious bug, other people than you might care enough to provide a fix.
 
 [![Create Eclipse Development Environment for JDT Core](https://download.eclipse.org/oomph/www/setups/svg/JDT_Core.svg)](
+[![GetMerged Scorecard](https://getmerged.abhishekco.de/api/badge/eclipse-jdt/eclipse.jdt.core)](https://getmerged.abhishekco.de/eclipse-jdt/eclipse.jdt.core)
 https://www.eclipse.org/setups/installer/?url=https://raw.githubusercontent.com/eclipse-jdt/eclipse.jdt.core/master/org.eclipse.jdt.core.setup/JdtCoreConfiguration.setup&show=true
 "Click to open Eclipse-Installer Auto Launch or drag into your running installer")
 


### PR DESCRIPTION
Hi there! 👋

I'm Abhishek, working on [GetMerged](https://getmerged.abhishekco.de) — an open-source index tracking maintainer review responsiveness and PR acceptance rates.

Most developers look at GitHub stars to find active projects, but stars often reflect past hype rather than current maintainer velocity. Your project is currently ranking in the **S-Tier** with solid review speed.

I put together this quick PR to add your project's live review scorecard badge to the README:

[![GetMerged Scorecard](https://getmerged.abhishekco.de/api/badge/eclipse-jdt/eclipse.jdt.core)](https://getmerged.abhishekco.de/eclipse-jdt/eclipse.jdt.core)

Hope this helps prospective contributors find and contribute to your project! (Full scorecard: https://getmerged.abhishekco.de/eclipse-jdt/eclipse.jdt.core)
