### PR TITLE
Type inference misses null hint from null value

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.compiler.batch/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Main-Class: org.eclipse.jdt.internal.compiler.batch.Main
 Bundle-ManifestVersion: 2
 Bundle-Name: Eclipse Compiler for Java(TM)
 Bundle-SymbolicName: org.eclipse.jdt.core.compiler.batch
-Bundle-Version: 3.46.100.qualifier
+Bundle-Version: 3.46.200.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: Eclipse.org
 Automatic-Module-Name: org.eclipse.jdt.core.compiler.batch

--- a/org.eclipse.jdt.core.compiler.batch/pom.xml
+++ b/org.eclipse.jdt.core.compiler.batch/pom.xml
@@ -17,7 +17,7 @@
     <version>4.42.0-SNAPSHOT</version>
   </parent>
   <artifactId>org.eclipse.jdt.core.compiler.batch</artifactId>
-  <version>3.46.100-SNAPSHOT</version>
+  <version>3.46.200-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 
   <properties>

--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ConstraintTypeFormula.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/ConstraintTypeFormula.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2025 GK Software AG, and others
+ * Copyright (c) 2013, 2026 GK Software AG, and others
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -253,10 +253,16 @@ class ConstraintTypeFormula extends ConstraintFormula {
 				return TRUE;
 			return FALSE;
 		}
-		if (subCandidate.id == TypeIds.T_null)
+		if (subCandidate.id == TypeIds.T_null) {
+			if (superCandidate instanceof InferenceVariable ivar && scope.environment().usesNullTypeAnnotations())
+				ivar.nullHints |= TagBits.AnnotationNullable;
 			return TRUE;
-		if (superCandidate.id == TypeIds.T_null)
+		}
+		if (superCandidate.id == TypeIds.T_null) {
+			if (subCandidate instanceof InferenceVariable ivar && scope.environment().usesNullTypeAnnotations())
+				ivar.nullHints |= TagBits.AnnotationNullable;
 			return FALSE;
+		}
 		if (subCandidate instanceof InferenceVariable)
 			return new TypeBound((InferenceVariable)subCandidate, superCandidate, SUBTYPE, this.isSoft);
 		if (superCandidate instanceof InferenceVariable)

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullTypeAnnotationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullTypeAnnotationTest.java
@@ -12660,7 +12660,7 @@ public void testBug489978() {
 		""
 	);
 }
-public void testBug489245() {
+public void testBug489245_info() {
 	Map compilerOptions = getCompilerOptions();
 	compilerOptions.put(CompilerOptions.OPTION_PessimisticNullAnalysisForFreeTypeVariables, JavaCore.INFO);
 	runWarningTestWithLibs(
@@ -12687,7 +12687,8 @@ public void testBug489245() {
 			"\n" +
 			"	static <T> void h(@NonNull T t) {\n" +
 			"		get(() -> {\n" +
-			"			return null; // correctly reported (but twice with the bug)\n" +
+			"			T tmp = null; // correctly reported (but twice with the bug)\n" +
+			"			return tmp;\n" +
 			"		}, t);\n" +
 			"	}\n" +
 			"}\n" +
@@ -12696,10 +12697,47 @@ public void testBug489245() {
 		compilerOptions,
 		"----------\n" +
 		"1. INFO in test\\TestBogusProblemReportOnlyAsInfo.java (at line 21)\n" +
-		"	return null; // correctly reported (but twice with the bug)\n" +
-		"	       ^^^^\n" +
+		"	T tmp = null; // correctly reported (but twice with the bug)\n" +
+		"	        ^^^^\n" +
 		"Null type mismatch (type annotations): \'null\' is not compatible to the free type variable \'T\'\n" +
 		"----------\n"
+	);
+}
+public void testBug489245_improvedNullInference() {
+	Map compilerOptions = getCompilerOptions();
+	compilerOptions.put(CompilerOptions.OPTION_PessimisticNullAnalysisForFreeTypeVariables, JavaCore.INFO);
+	runConformTestWithLibs(
+		true/*flush*/,
+		new String[] {
+			"test/TestBogusProblemReportOnlyAsInfo.java",
+			"package test;\n" +
+			"\n" +
+			"import java.util.function.Supplier;\n" +
+			"\n" +
+			"import org.eclipse.jdt.annotation.NonNull;\n" +
+			"import org.eclipse.jdt.annotation.NonNullByDefault;\n" +
+			"\n" +
+			"@NonNullByDefault\n" +
+			"public class TestBogusProblemReportOnlyAsInfo {\n" +
+			"	static <U> void get(Supplier<U> supplier, @NonNull U defaultValue) {\n" +
+			"	}\n" +
+			"\n" +
+			"	static void f() {\n" +
+			"		get(() -> {\n" +
+			"			return null; // bogus problem report only as info\n" +
+			"		}, \"\");\n" +
+			"	}\n" +
+			"\n" +
+			"	static <T> void h(@NonNull T t) {\n" +
+			"		get(() -> {\n" +
+			"			return null; // no longer a problem with improved null inference\n" +
+			"		}, t);\n" +
+			"	}\n" +
+			"}\n" +
+			"",
+		},
+		compilerOptions,
+		""
 	);
 }
 public void testBug489674() {
@@ -20269,6 +20307,30 @@ public void testGH5316() throws Exception {
 				private Map<String, String> aTotallyNormalMap;
 			}
 			"""
+		},
+		getCompilerOptions(),
+		"");
+}
+public void testGH5340() throws Exception {
+	runConformTestWithLibs(new String[] {
+		"X.java",
+		"""
+		import org.eclipse.jdt.annotation.*;
+		import java.util.*;
+		import java.util.stream.*;
+		public class X {
+			void test(String[] array) {
+				List<@NonNull Object> tokens = Arrays.stream(array)
+					.map(string -> {
+							if (string.isEmpty())
+								return null;
+							return new Object();
+						})
+					.filter(Objects::nonNull)
+					.collect(Collectors.toList());
+			}
+		}
+		"""
 		},
 		getCompilerOptions(),
 		"");


### PR DESCRIPTION
+ collect nullhint from `null` value
+ split one existing test into two
  - slight variation to challenge the original problem
  - original test case is no conform due to improved null inference

Fixes https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5340
