### PR TITLE
Fix:@see tag incorrectly accepting text before markdown/javadoc link

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/AbstractCommentParser.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/parser/AbstractCommentParser.java
@@ -1652,6 +1652,23 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 				return false;
 			}
 
+				if (this.tagValue == TAG_SEE_VALUE) {
+					int lookAhead = this.index;
+					while (lookAhead < this.lineEnd && ScannerHelper.isWhitespace(this.source[lookAhead])) {
+				        lookAhead++;
+				    }
+
+					if (lookAhead < this.lineEnd && (this.source[lookAhead] == '[' || this.source[lookAhead] == '{' || isQualifiedName(lookAhead))) {
+						this.index = this.tokenPreviousPosition;
+						this.scanner.currentPosition = this.tokenPreviousPosition;
+						this.currentTokenType = TokenNameInvalid;
+						int end = this.starPosition == -1 ? this.lineEnd : this.starPosition;
+						if (this.source[end]=='\n') end--;
+						if (this.reportProblems) this.sourceParser.problemReporter().javadocMalformedSeeReference(typeRefStartPosition, end);
+						return false;
+					}
+				}
+
 			// Everything is OK, store reference
 			return pushSeeRef(reference);
 		}
@@ -1667,6 +1684,25 @@ public abstract class AbstractCommentParser implements JavadocTagConstants {
 		this.scanner.currentPosition = this.tokenPreviousPosition;
 		this.currentTokenType = TokenNameInvalid;
 		return false;
+	}
+
+	private boolean isQualifiedName(int start) throws InvalidInputException {
+	    int pos = start;
+	    boolean hasDot = false;
+	    while (pos < this.lineEnd && ScannerHelper.isJavaIdentifierPart(this.source[pos])) {
+	        pos++;
+	    }
+	    while (pos < this.lineEnd && this.source[pos] == '.') {
+	        hasDot = true;
+	        pos++;
+	        if (pos >= this.lineEnd || !ScannerHelper.isJavaIdentifierPart(this.source[pos])) {
+	            return false;
+	        }
+	        while (pos < this.lineEnd && ScannerHelper.isJavaIdentifierPart(this.source[pos])) {
+	            pos++;
+	        }
+	    }
+	    return hasDot;
 	}
 
 	protected boolean parseSnippet() throws InvalidInputException {

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterJavadocTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterJavadocTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2016 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -3814,5 +3814,57 @@ public class ASTConverterJavadocTest extends ConverterTestSetup {
 		assertTrue(textTag2.toString().equals(", "));
 		assertTrue(textTag3.toString().equals(","));
 		assertTrue(textTag4.toString().startsWith("are imaginary tags"));
+	}
+
+	public void testJavadocSupportSeeTag5299_01() throws JavaModelException {
+		this.workingCopies = new ICompilationUnit[1];
+		this.astLevel = AST.JLS25;
+		this.workingCopies[0] = getWorkingCopy("/Converter25/src/javadoc/Javadoc.java",
+			"""
+			  /**
+			   * @see see {@link java.util.ArrayList ArrayList}
+			   */
+			   public class Javadoc{}
+			"""
+		);
+		CompilationUnit compilUnit = (CompilationUnit) runConversion(this.workingCopies[0], true);
+		List unitComments = compilUnit.getCommentList();
+		assertEquals("Wrong number of comments", 1, unitComments.size());
+		Comment comment = (Comment) unitComments.get(0);
+		assertEquals("Comment should be javadoc", comment.getNodeType(), ASTNode.JAVADOC);
+		Javadoc docComment = (Javadoc) compilUnit.getCommentList().get(0);
+		assumeEquals("wrong number of tags", 1, docComment.tags().size());
+		TagElement parentTag = (TagElement) docComment.tags().get(0);
+		assertEquals("Invalid Element Count", 2, parentTag.fragments().size());
+		TextElement text = (TextElement) parentTag.fragments().get(0);
+		TagElement tag = (TagElement) parentTag.fragments().get(1);
+		assertEquals("Incorrect Text content", " see ", text.getText());
+		assertEquals("Invalid Tag", "@link", tag.getTagName());
+	}
+
+	public void testJavadocSupportSeeTag5299_02() throws JavaModelException {
+		this.workingCopies = new ICompilationUnit[1];
+		this.astLevel = AST.JLS25;
+		this.workingCopies[0] = getWorkingCopy("/Converter25/src/javadoc/Javadoc.java",
+			"""
+			  /**
+			   * @see see java.util.ArrayList
+			   */
+			   public class Javadoc{}
+			"""
+		);
+		CompilationUnit compilUnit = (CompilationUnit) runConversion(this.workingCopies[0], true);
+		List unitComments = compilUnit.getCommentList();
+		assertEquals("Wrong number of comments", 1, unitComments.size());
+		Comment comment = (Comment) unitComments.get(0);
+		assertEquals("Comment should be javadoc", comment.getNodeType(), ASTNode.JAVADOC);
+		Javadoc docComment = (Javadoc) compilUnit.getCommentList().get(0);
+		assumeEquals("wrong number of tags", 1, docComment.tags().size());
+		TagElement parentTag = (TagElement) docComment.tags().get(0);
+		List<?> childElements = parentTag.fragments();
+		assertEquals("Invalid Element Count", 1, childElements.size());
+		assertTrue("Invalid type of child", childElements.get(0) instanceof TextElement);
+		String text = ((TextElement)childElements.get(0)).getText();
+		assertEquals("Incorrect Text content", " see java.util.ArrayList", text);
 	}
 }

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterMarkdownTest.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/ASTConverterMarkdownTest.java
@@ -2493,4 +2493,64 @@ public class ASTConverterMarkdownTest extends ConverterTestSetup {
 			assumeEquals("Incorrect child content", "	@AnotherAnnotation", innerFrags.get(2).getText());
 		}
 	}
+
+	public void testMarkdownSupportSeeTag5299_01() throws JavaModelException {
+		String source = """
+				/// @see see [ArrayList](java.util.ArrayList)
+				public class Markdown {}
+				""";
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy("/Converter_25/src/markdown/Markdown.java", source, null);
+		if (this.docCommentSupport.equals(JavaCore.ENABLED)) {
+			CompilationUnit compilUnit = (CompilationUnit) runConversion(this.workingCopies[0], true);
+			TypeDeclaration typedeclaration =  (TypeDeclaration) compilUnit.types().get(0);
+			Javadoc javadoc = typedeclaration.getJavadoc();
+			TagElement parentTag = (TagElement)javadoc.tags().get(0);
+			assertEquals("Invalid Element Count", 2, parentTag.fragments().size());
+			TextElement text = (TextElement) parentTag.fragments().get(0);
+			TagElement tag = (TagElement) parentTag.fragments().get(1);
+			assertEquals("Incorrect Text content", " see ", text.getText());
+			assertEquals("Invalid Tag", "@link", tag.getTagName());
+		}
+	}
+
+	public void testMarkdownSupportSeeTag5299_02() throws JavaModelException {
+		String source = """
+				/// @see see {@link java.util.ArrayList ArrayList}
+				public class Markdown {}
+				""";
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy("/Converter_25/src/markdown/Markdown.java", source, null);
+		if (this.docCommentSupport.equals(JavaCore.ENABLED)) {
+			CompilationUnit compilUnit = (CompilationUnit) runConversion(this.workingCopies[0], true);
+			TypeDeclaration typedeclaration =  (TypeDeclaration) compilUnit.types().get(0);
+			Javadoc javadoc = typedeclaration.getJavadoc();
+			TagElement parentTag = (TagElement)javadoc.tags().get(0);
+			assertEquals("Invalid Element Count", 2, parentTag.fragments().size());
+			TextElement text = (TextElement) parentTag.fragments().get(0);
+			TagElement tag = (TagElement) parentTag.fragments().get(1);
+			assertEquals("Incorrect Text content", " see ", text.getText());
+			assertEquals("Invalid Tag", "@link", tag.getTagName());
+		}
+	}
+
+	public void testMarkdownSupportSeeTag5299_03() throws JavaModelException {
+		String source = """
+				/// @see see java.util.ArrayList
+				public class Markdown {}
+				""";
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy("/Converter_25/src/markdown/Markdown.java", source, null);
+		if (this.docCommentSupport.equals(JavaCore.ENABLED)) {
+			CompilationUnit compilUnit = (CompilationUnit) runConversion(this.workingCopies[0], true);
+			TypeDeclaration typedeclaration =  (TypeDeclaration) compilUnit.types().get(0);
+			Javadoc javadoc = typedeclaration.getJavadoc();
+			TagElement parentTag = (TagElement)javadoc.tags().get(0);
+			List<?> childElements = parentTag.fragments();
+			assertEquals("Invalid Element Count", 1, childElements.size());
+			assertTrue("Invalid type of child", childElements.get(0) instanceof TextElement);
+			String text = ((TextElement)childElements.get(0)).getText();
+			assertEquals("Incorrect Text content", " see java.util.ArrayList", text);
+		}
+	}
 }


### PR DESCRIPTION
Fix: The @see tag silently parsed invalid content placed before the reference
element without reporting any error.

Fix: https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5299

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
