### PR TITLE
Ignore classpath container library module for non-modular projects during search

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchBugs9Tests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchBugs9Tests.java
@@ -27,6 +27,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import junit.framework.Test;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.NullProgressMonitor;
@@ -42,6 +44,7 @@ import org.eclipse.jdt.core.search.SearchPattern;
 import org.eclipse.jdt.core.search.TypeReferenceMatch;
 import org.eclipse.jdt.core.tests.model.ClasspathTests.TestContainer;
 import org.eclipse.jdt.core.tests.util.Util;
+import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jdt.internal.core.ClasspathEntry;
 import org.eclipse.jdt.internal.core.JavaElement;
 import org.eclipse.jdt.internal.core.LocalVariable;
@@ -5048,6 +5051,126 @@ public void testNoMatchesInModularJarOnClasspathBugGh935() throws Exception {
 				"libGh935.jar void test.Test2.testCaller() EXACT_MATCH");
 	} finally {
 		deleteProject(projectName);
+	}
+}
+
+/*
+ * Test for call hierarchy of a method with an argument type coming from a container,
+ * where the containers library entry is not modular.
+ * Furthermore a project exports the same library, also with a non-modular entry.
+ * https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5361
+ */
+public void testModuleJarOnContainerNonModularEntrySearchBugGh5361() throws Exception {
+	doTestModuleJarOnContainerSearchBugGh5361("gh5361ModuleJarOnContainerNonModularSearchTest", null);
+}
+
+/*
+ * Test for call hierarchy of a method with an argument type coming from a container,
+ * where the containers library entry is modular.
+ * Furthermore a project exports the same library, also with a modular entry.
+ * https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5361
+ */
+public void testModuleJarOnContainerModularEntrySearchBugGh5361() throws Exception {
+	doTestModuleJarOnContainerSearchBugGh5361("gh5361ModuleJarOnContainerModularSearchTest", moduleAttribute());
+}
+
+private void doTestModuleJarOnContainerSearchBugGh5361(String name, IClasspathAttribute[] attributes) throws Exception {
+	String p1Name = name + "_Declaration";
+	String p2Name = name + "_Export";
+	String p3Name = name + "_Caller";
+	try {
+		IJavaProject p1 = createJava9Project(p1Name);
+		IJavaProject p2 = createJava9Project(p2Name);
+		IJavaProject p3 = createJava9Project(p3Name);
+
+		addClasspathEntry(p1, JavaCore.newProjectEntry(p2.getPath()));
+
+		IPath p1Jar = p1.getProject().getLocation().append("dummy.jar");
+		Util.createJar(
+			new String[] {
+					"module-info.java",
+					"""
+					module dummymodule {
+						exports dummy;
+					}
+					""",
+					"dummy/Dummy.java",
+					"""
+					package dummy;
+					public class Dummy {
+						public Dummy() {}
+					}
+					""",
+			},
+			p1Jar.toOSString(),
+			CompilerOptions.VERSION_9
+		);
+		IPath p2Jar = p2.getProject().getLocation().append("dummy.jar");
+		IFile jarFile = p1.getProject().getFile("dummy.jar");
+		jarFile.refreshLocal(IResource.DEPTH_ZERO, null);
+		jarFile.copy(p2.getProject().getFile("dummy.jar").getFullPath(), true, null);
+
+		addClasspathEntry(p1, JavaCore.newContainerEntry(new Path("container/p1"), ClasspathEntry.NO_ACCESS_RULES, new IClasspathAttribute[0], false));
+		JavaCore.setClasspathContainer(
+				new Path("container/p1"),
+				new IJavaProject[] { p1 },
+				new IClasspathContainer[] {
+					new TestContainer(
+						new Path("container/p1"),
+						new IClasspathEntry[] {
+								JavaCore.newLibraryEntry(p1Jar, null, null, null, attributes, false),
+						})
+				},
+				null);
+		String p1Package = "/" + p1Name + "/src/p1";
+		createFolder(p1Package);
+		String p1Source =
+				"""
+				package p1;
+				public class Declaration {
+				    public void someMethod(dummy.Dummy dummy) {}
+				};
+				""";
+		createFile(p1Package + "/Declaration.java", p1Source);
+
+		addLibraryEntry(p1, p2Jar, null, null, null, null, attributes, true);
+
+		addClasspathEntry(p3, JavaCore.newContainerEntry(new Path("container/p3"), ClasspathEntry.NO_ACCESS_RULES, new IClasspathAttribute[0], false));
+		JavaCore.setClasspathContainer(
+				new Path("container/p3"),
+				new IJavaProject[] { p3 },
+				new IClasspathContainer[] {
+					new TestContainer(
+						new Path("container/p3"),
+						new IClasspathEntry[] {
+								JavaCore.newLibraryEntry(p1Jar, null, null, null, attributes, false),
+								JavaCore.newProjectEntry(p1.getPath()),
+						})
+				},
+				null);
+		String p3Package = "/" + p3Name + "/src/p3";
+		createFolder(p3Package);
+		String p3Source =
+				"""
+				package p3;
+				public class Caller {
+				    public void call() {
+                        new p1.Declaration().someMethod(new dummy.Dummy());
+				    }
+				};
+				""";
+		createFile(p3Package + "/Caller.java", p3Source);
+
+		buildAndExpectNoProblems(p2, p1, p3);
+
+		IType type = p1.findType("p1.Declaration");
+		IMethod method = type.getMethod("someMethod", new String[] { "Qdummy.Dummy;" });
+		search(method, REFERENCES, EXACT_RULE, SearchEngine.createWorkspaceScope(), this.resultCollector);
+		assertSearchResults("src/p3/Caller.java void p3.Caller.call() [someMethod(new dummy.Dummy())] EXACT_MATCH");
+	} finally {
+		deleteProject(p1Name);
+		deleteProject(p2Name);
+		deleteProject(p3Name);
 	}
 }
 // Add more tests here

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/JavaSearchNameEnvironment.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/JavaSearchNameEnvironment.java
@@ -617,6 +617,14 @@ private static IModuleDescription computeModuleFor(PackageFragmentRoot root, IMo
 		 */
 		int entryKind = classpathEntry.getEntryKind();
 		if (entryKind == IClasspathEntry.CPE_SOURCE || entryKind == IClasspathEntry.CPE_CONTAINER) {
+			/*
+			 * We only care about the module of the classpath entry if it is modular or if the project itself is modular.
+			 * If neither is the case, return no module. See: https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5361
+			 */
+			IClasspathEntry resolvedClasspathEntry = root.getResolvedClasspathEntry();
+			if (defaultModule == null && !ClasspathEntry.isModular(resolvedClasspathEntry)) {
+				return null;
+			}
 			return rootModule != null? rootModule : defaultModule;
 		}
 	} catch (JavaModelException e) {


### PR DESCRIPTION
This change adjusts the fix for https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1039 in `JavaSearchNameEnvironment.computeModuleFor()` to apply only for modular projects and modular classpath entries in the classpath container.

Otherwise search results are inaccurate for types from a modular library, where the library is both exported from a project and contained in a classpath container - without being on the module path in either case.

Fixes: https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5361
