### PR TITLE
Prevent stale Java options cache publication after concurrent updates

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AllJavaModelTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AllJavaModelTests.java
@@ -139,6 +139,7 @@ private static Class[] getAllTestClasses() {
 
 		// Options tests
 		OptionTests.class,
+		OptionCacheTests.class,
 
 		// Type hierarchy tests
 		TypeHierarchyTests.class,

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/OptionCacheTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/OptionCacheTests.java
@@ -1,0 +1,356 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jdt.core.tests.model;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Proxy;
+import java.util.Hashtable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.formatter.DefaultCodeFormatterConstants;
+import org.eclipse.jdt.internal.core.JavaModelManager;
+
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+
+/** Tests the real options cache without creating projects, editors or builders. */
+public class OptionCacheTests extends TestCase {
+	private static final long TIMEOUT_SECONDS = 30;
+	private static final String KEY = DefaultCodeFormatterConstants.FORMATTER_INSERT_SPACE_AFTER_CLOSING_PAREN_IN_CAST;
+	private Hashtable<String, String> savedOptions;
+
+	public OptionCacheTests(String name) {
+		super(name);
+	}
+
+	public static Test suite() {
+		return new TestSuite(OptionCacheTests.class);
+	}
+
+	@Override
+	protected void setUp() throws Exception {
+		super.setUp();
+		assertTrue("These tests require an Eclipse runtime", Platform.isRunning());
+		this.savedOptions = JavaCore.getOptions();
+	}
+
+	@Override
+	protected void tearDown() throws Exception {
+		try {
+			if (this.savedOptions != null) {
+				JavaCore.setOptions(this.savedOptions);
+			}
+		} finally {
+			super.tearDown();
+		}
+	}
+
+	public void testCompletedSetOptionsCannotBeOverwritten() throws Exception {
+		assertLaterReadIsCurrent(Update.SET_OPTIONS);
+	}
+
+	public void testPreferenceInvalidationCannotBeUndone() throws Exception {
+		assertLaterReadIsCurrent(Update.PREFERENCE);
+	}
+
+	public void testRepeatedInvalidationCannotBeUndone() throws Exception {
+		assertLaterReadIsCurrent(Update.REPEATED_INVALIDATION);
+	}
+
+	public void testCompletedResetCannotBeOverwritten() throws Exception {
+		assertLaterReadIsCurrent(Update.RESET);
+	}
+
+	public void testReturnedOptionsAreIndependent() {
+		Hashtable<String, String> first = JavaCore.getOptions();
+		String expected = first.get(KEY);
+		first.put(KEY, "not a formatter value");
+		assertEquals(expected, JavaCore.getOptions().get(KEY));
+	}
+
+	public void testSequentialUpdates() {
+		setOption(JavaCore.DO_NOT_INSERT);
+		assertEquals(JavaCore.DO_NOT_INSERT, JavaCore.getOption(KEY));
+		assertEquals(JavaCore.DO_NOT_INSERT, JavaCore.getOptions().get(KEY));
+		setOption(JavaCore.INSERT);
+		assertEquals(JavaCore.INSERT, JavaCore.getOption(KEY));
+		assertEquals(JavaCore.INSERT, JavaCore.getOptions().get(KEY));
+	}
+
+	public void testCacheIsReused() throws Exception {
+		AtomicInteger reads = new AtomicInteger();
+		Thread testThread = Thread.currentThread();
+		try (PreferenceReads ignored = new PreferenceReads((key, value) -> {
+			if (Thread.currentThread() == testThread) {
+				reads.incrementAndGet();
+			}
+		})) {
+			invalidateWithValue(JavaCore.INSERT);
+			Hashtable<String, String> first = JavaCore.getOptions();
+			int coldReads = reads.get();
+			assertTrue("The cold read must access the real preferences", coldReads > 0);
+			for (int i = 0; i < 20; i++) {
+				Hashtable<String, String> next = JavaCore.getOptions();
+				assertNotSame(first, next);
+				assertEquals(first, next);
+			}
+			assertEquals("Do not fix the race by disabling the cache", coldReads, reads.get());
+		}
+	}
+
+	public void testReentrantPreferenceListener() throws Exception {
+		setOption(JavaCore.DO_NOT_INSERT);
+		AtomicInteger callbacks = new AtomicInteger();
+		AtomicReference<Throwable> callbackFailure = new AtomicReference<>();
+		IEclipsePreferences node = InstanceScope.INSTANCE.getNode(JavaCore.PLUGIN_ID);
+		IEclipsePreferences.IPreferenceChangeListener listener = event -> {
+			if (KEY.equals(event.getKey())) {
+				try {
+					JavaCore.getOptions();
+					callbacks.incrementAndGet();
+				} catch (Throwable failure) {
+					callbackFailure.set(failure);
+				}
+			}
+		};
+		ExecutorService executor = newExecutor();
+		node.addPreferenceChangeListener(listener);
+		try {
+			Hashtable<String, String> next = new Hashtable<>(this.savedOptions);
+			next.put(KEY, JavaCore.INSERT);
+			executor.submit(() -> JavaCore.setOptions(next)).get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+			assertNull("Preference callback failed", callbackFailure.get());
+			assertTrue("The preference callback must have reentered getOptions", callbacks.get() > 0);
+			assertEquals(JavaCore.INSERT, JavaCore.getOption(KEY));
+			assertEquals(JavaCore.INSERT, JavaCore.getOptions().get(KEY));
+		} finally {
+			node.removePreferenceChangeListener(listener);
+			stop(executor);
+		}
+	}
+
+	private enum Update {
+		SET_OPTIONS, PREFERENCE, REPEATED_INVALIDATION, RESET
+	}
+
+	private void assertLaterReadIsCurrent(Update update) throws Exception {
+		String expected = JavaCore.getDefaultOptions().get(KEY);
+		assertNotNull(expected);
+		String oldValue = opposite(expected);
+		setOption(oldValue);
+		CountDownLatch capturedOldValue = new CountDownLatch(1);
+		CountDownLatch resumeReader = new CountDownLatch(1);
+		AtomicBoolean intercepted = new AtomicBoolean();
+		AtomicReference<Thread> readerThread = new AtomicReference<>();
+		ExecutorService executor = newExecutor();
+		Future<Hashtable<String, String>> reader = null;
+		try (PreferenceReads ignored = new PreferenceReads((key, value) -> {
+			if (Thread.currentThread() == readerThread.get() && KEY.equals(key)
+					&& oldValue.equals(value) && intercepted.compareAndSet(false, true)) {
+				capturedOldValue.countDown();
+				assertTrue("Writer did not release the options reader",
+						resumeReader.await(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+			}
+		})) {
+			try {
+				// Invalidate through real preference events, not by modifying cache internals.
+				invalidateWithValue(oldValue);
+				reader = executor.submit(() -> {
+					readerThread.set(Thread.currentThread());
+					return JavaCore.getOptions();
+				});
+				assertTrue("Reader did not capture the old preference",
+						capturedOldValue.await(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+				IEclipsePreferences node = InstanceScope.INSTANCE.getNode(JavaCore.PLUGIN_ID);
+				switch (update) {
+					case SET_OPTIONS -> setOption(expected);
+					case PREFERENCE -> node.put(KEY, expected);
+					case REPEATED_INVALIDATION -> {
+						// null -> null invalidations must also invalidate an in-flight computation.
+						node.put(KEY, expected);
+						node.put(KEY, oldValue);
+						node.put(KEY, expected);
+					}
+					case RESET -> JavaCore.setOptions(null);
+				}
+				assertEquals("The update must be complete before resuming the reader", expected, JavaCore.getOption(KEY));
+				resumeReader.countDown();
+				reader.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+				// The overlapping read may observe the old value. Only this later read is asserted.
+				assertEquals("A completed " + update + " must not be undone by an older reader",
+						expected, JavaCore.getOptions().get(KEY));
+			} finally {
+				resumeReader.countDown();
+				try {
+					if (reader != null) {
+						reader.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+					}
+				} finally {
+					stop(executor);
+				}
+			}
+		}
+	}
+
+	public void testInstanceNodeRemovalInvalidatesCache() throws Exception {
+		Hashtable<String, String> preferences = saveInstancePreferences();
+		try {
+			String defaultValue = JavaCore.getDefaultOptions().get(KEY);
+			assertNotNull(defaultValue);
+			String oldValue = opposite(defaultValue);
+			setOption(oldValue);
+			assertEquals(oldValue, JavaCore.getOptions().get(KEY));
+
+			JavaModelManager manager = JavaModelManager.getJavaModelManager();
+			IEclipsePreferences removed = manager.getInstancePreferences();
+			removed.removeNode();
+			assertNotSame(removed, manager.getInstancePreferences());
+			assertEquals(defaultValue, JavaCore.getOption(KEY));
+			assertEquals("Removing the instance node must invalidate its cached options",
+					defaultValue, JavaCore.getOptions().get(KEY));
+		} finally {
+			restoreInstancePreferences(preferences);
+		}
+	}
+
+	public void testInstanceNodeReplacementKeepsInvalidatingCache() throws Exception {
+		Hashtable<String, String> preferences = saveInstancePreferences();
+		try {
+			String defaultValue = JavaCore.getDefaultOptions().get(KEY);
+			assertNotNull(defaultValue);
+			String newValue = opposite(defaultValue);
+			JavaModelManager manager = JavaModelManager.getJavaModelManager();
+			for (int i = 0; i < 2; i++) {
+				IEclipsePreferences removed = manager.getInstancePreferences();
+				removed.removeNode();
+				IEclipsePreferences replacement = manager.getInstancePreferences();
+				assertNotSame(removed, replacement);
+				setOption(defaultValue);
+				assertEquals(defaultValue, JavaCore.getOptions().get(KEY));
+				replacement.put(KEY, newValue);
+				assertEquals(newValue, JavaCore.getOption(KEY));
+				assertEquals("Preference changes must invalidate the cache after node replacement " + i,
+						newValue, JavaCore.getOptions().get(KEY));
+			}
+		} finally {
+			restoreInstancePreferences(preferences);
+		}
+	}
+
+	private static Hashtable<String, String> saveInstancePreferences() throws Exception {
+		IEclipsePreferences node = JavaModelManager.getJavaModelManager().getInstancePreferences();
+		Hashtable<String, String> preferences = new Hashtable<>();
+		for (String key : node.keys()) {
+			preferences.put(key, node.get(key, ""));
+		}
+		return preferences;
+	}
+
+	private static void restoreInstancePreferences(Hashtable<String, String> preferences) throws Exception {
+		// Node removal also affects non-option preferences, such as classpath variables.
+		IEclipsePreferences node = JavaModelManager.getJavaModelManager().getInstancePreferences();
+		node.clear();
+		preferences.forEach(node::put);
+	}
+
+	private void setOption(String value) {
+		Hashtable<String, String> options = new Hashtable<>(this.savedOptions);
+		options.put(KEY, value);
+		JavaCore.setOptions(options);
+	}
+
+	private static void invalidateWithValue(String value) {
+		IEclipsePreferences node = InstanceScope.INSTANCE.getNode(JavaCore.PLUGIN_ID);
+		node.put(KEY, opposite(value));
+		node.put(KEY, value);
+	}
+
+	private static String opposite(String value) {
+		return JavaCore.INSERT.equals(value) ? JavaCore.DO_NOT_INSERT : JavaCore.INSERT;
+	}
+
+	private static ExecutorService newExecutor() {
+		return Executors.newSingleThreadExecutor(runnable -> {
+			Thread thread = new Thread(runnable, "JDT options cache regression");
+			thread.setDaemon(true);
+			return thread;
+		});
+	}
+
+	private static void stop(ExecutorService executor) throws InterruptedException {
+		executor.shutdownNow();
+		assertTrue("Options worker did not terminate", executor.awaitTermination(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+	}
+
+	@FunctionalInterface
+	private interface AfterRead {
+		void accept(String key, Object value) throws Exception;
+	}
+
+	/**
+	 * Delays a real preference read after it has returned, without holding the
+	 * preference implementation's locks. No production manager or preference
+	 * values are mocked. Reflection is confined to installing this read barrier.
+	 */
+	private static final class PreferenceReads implements AutoCloseable {
+		private final IEclipsePreferences[] lookup;
+		private final IEclipsePreferences[] original;
+
+		PreferenceReads(AfterRead afterRead) throws ReflectiveOperationException {
+			Field field = JavaModelManager.class.getDeclaredField("preferencesLookup");
+			field.setAccessible(true);
+			this.lookup = (IEclipsePreferences[]) field.get(JavaModelManager.getJavaModelManager());
+			this.original = this.lookup.clone();
+			try {
+				for (int i = 0; i < this.lookup.length; i++) {
+					IEclipsePreferences delegate = this.original[i];
+					if (delegate != null) {
+						this.lookup[i] = (IEclipsePreferences) Proxy.newProxyInstance(
+								IEclipsePreferences.class.getClassLoader(), new Class<?>[] { IEclipsePreferences.class },
+								(proxy, method, arguments) -> {
+							Object result;
+							try {
+								result = method.invoke(delegate, arguments);
+							} catch (InvocationTargetException failure) {
+								throw failure.getCause();
+							}
+							if (method.getName().equals("get") && arguments != null && arguments.length == 2) {
+								afterRead.accept((String) arguments[0], result);
+							}
+							return result;
+						});
+					}
+				}
+			} catch (RuntimeException | Error failure) {
+				close();
+				throw failure;
+			}
+		}
+
+		@Override
+		public void close() {
+			System.arraycopy(this.original, 0, this.lookup, 0, this.lookup.length);
+		}
+	}
+}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelManager.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/JavaModelManager.java
@@ -347,6 +347,11 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 	Map<String, String[]> deprecatedOptions = new HashMap<>();
 	volatile Hashtable<String, String> optionsCache;
 
+	// Only cache publication and invalidation hold this lock. In particular,
+	// preference access and callbacks must remain outside it.
+	private final Object optionsCacheLock = new Object();
+	private volatile long optionsCacheGeneration;
+
 	// Preferences
 	public final IEclipsePreferences[] preferencesLookup = new IEclipsePreferences[2];
 	static final int PREF_INSTANCE = 0;
@@ -2423,7 +2428,32 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 		return UNKNOWN_OPTION;
 	}
 
+	/**
+	 * Publishes a writer's cache, or invalidates it. Advance the generation even
+	 * when the cache is already null: an older reader may still be building it.
+	 */
+	private void setOptionsCache(Hashtable<String, String> newCache) {
+		synchronized (this.optionsCacheLock) {
+			this.optionsCacheGeneration++;
+			this.optionsCache = newCache;
+		}
+	}
+
+	/**
+	 * A read overlapping an update may return its snapshot, but must not make
+	 * that snapshot the cache used by subsequent, non-overlapping reads.
+	 */
+	private void cacheOptions(Hashtable<String, String> options, long generation) {
+		synchronized (this.optionsCacheLock) {
+			if (this.optionsCacheGeneration == generation) {
+				this.optionsCache = options;
+			}
+		}
+	}
+
 	public Hashtable<String, String> getOptions() {
+		// Capture before reading either the cache or the preferences.
+		long generation = this.optionsCacheGeneration;
 
 		// return cached options if already computed
 		Hashtable<String, String> cachedOptions; // use a local variable to avoid race condition (see https://bugs.eclipse.org/bugs/show_bug.cgi?id=256329 )
@@ -2435,7 +2465,7 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 			if (VERBOSE) {
 				trace("Setting Java options cache"); //$NON-NLS-1$
 			}
-			this.optionsCache = defaults;
+			cacheOptions(defaults, generation);
 			return new Hashtable<>(defaults);
 		}
 		// init
@@ -2473,7 +2503,7 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 			trace("Setting Java options cache"); //$NON-NLS-1$
 		}
 		// store built map in cache
-		this.optionsCache = new Hashtable<>(options);
+		cacheOptions(new Hashtable<>(options), generation);
 		// return built map
 		return options;
 	}
@@ -3381,8 +3411,14 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 			@Override
 			public void removed(IEclipsePreferences.NodeChangeEvent event) {
 				if (event.getChild() == JavaModelManager.this.preferencesLookup[PREF_INSTANCE]) {
-					JavaModelManager.this.preferencesLookup[PREF_INSTANCE] = InstanceScope.INSTANCE.getNode(JavaCore.PLUGIN_ID);
-					JavaModelManager.this.preferencesLookup[PREF_INSTANCE].addPreferenceChangeListener(new EclipsePreferencesListener());
+					IEclipsePreferences preferences = InstanceScope.INSTANCE.getNode(JavaCore.PLUGIN_ID);
+					JavaModelManager.this.preferencesLookup[PREF_INSTANCE] = preferences;
+					preferences.addPreferenceChangeListener(JavaModelManager.this.instancePreferencesListener = new EclipsePreferencesListener());
+					// The old node's listeners are not transferred to its replacement.
+					if (JavaModelManager.this.propertyListener != null) {
+						preferences.addPreferenceChangeListener(JavaModelManager.this.propertyListener);
+					}
+					JavaModelManager.this.setOptionsCache(null);
 				}
 			}
 		};
@@ -5412,7 +5448,9 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 			}
 		}
 		if (cachedValue == null) {
-			// reset all options, optionsCache & fixTaskTags will be updated there
+			// Discard a cache built while the individual preferences were being
+			// cleared, and prevent an in-flight reader from publishing one later.
+			setOptionsCache(null);
 			getOptions();
 		} else {
 			Util.fixTaskTags(cachedValue);
@@ -5420,7 +5458,7 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 				trace("Setting Java options cache"); //$NON-NLS-1$
 			}
 			// update cache
-			this.optionsCache = cachedValue;
+			setOptionsCache(cachedValue);
 		}
 	}
 
@@ -5442,7 +5480,7 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 					if (VERBOSE) {
 						trace("Invalidating Java options cache"); //$NON-NLS-1$
 					}
-					JavaModelManager.this.optionsCache = null;
+					JavaModelManager.this.setOptionsCache(null);
 				}
 			};
 			InstanceScope.INSTANCE.getNode(JavaCore.PLUGIN_ID).addPreferenceChangeListener(this.propertyListener);
@@ -5455,7 +5493,7 @@ public class JavaModelManager implements ISaveParticipant, IContentTypeChangeLis
 						if (VERBOSE) {
 							trace("Invalidating Java options cache"); //$NON-NLS-1$
 						}
-						JavaModelManager.this.optionsCache = null;
+						JavaModelManager.this.setOptionsCache(null);
 					}
 				}
 			};


### PR DESCRIPTION
## What it does

Prevents an in-flight `JavaModelManager.getOptions()` call from publishing an obsolete options map after a concurrent update or cache invalidation has completed.

On a cache miss, the existing implementation reads preferences and then unconditionally stores the resulting map in `optionsCache`. This permits the following ordering:

```text
Reader A starts building a map and reads an old preference value.
Writer B updates the preferences and updates or invalidates the cache.
Writer B returns.
Reader A publishes its older map.
A subsequent reader receives the obsolete value from the cache.
```

The problem is the stale value returned to a subsequent reader after the concurrent operations have finished. An old value observed by the overlapping reader itself is not the failure being addressed. Defensive copies protect the cached map against caller modifications, but do not prevent this publication ordering.

## Background and scope

Related debugging was already documented by @trancexpress in [JDT UI #2811](https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2811#issuecomment-3967356378): resuming an indexing thread allowed it to publish an options map without the field-prefix preference previously set by a test. That investigation is relevant prior work for the cache-publication problem addressed here.

The investigation also relates to [JDT UI #1445](https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1445), which reports sporadic save-participant formatting failures. This PR does not claim to reproduce or resolve all symptoms of that issue, including the additional space before `=` and the reported `MalformedTreeException`.

[Bug 563771](https://bugs.eclipse.org/bugs/show_bug.cgi?id=563771) is included as related background from the [performance and options-copying discussion in #1445](https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/1445#issuecomment-2610200744). This PR does not replace the existing defensive copies, introduce a copy-on-write map, or claim to resolve that performance topic.

## Implementation

A reader captures the cache generation before reading the cache or preferences. It may publish a newly computed map only if the generation is still unchanged.

Writer updates and invalidations advance the generation under the same private lock used for the compare-and-publish operation. Invalidating an already-null cache also advances the generation, because an older computation may still be in progress. `setOptions(null)` invalidates again before its final rebuild so that a computation started before the reset cannot subsequently become the cached result.

The lock covers only cache publication and invalidation. Preference access, listener callbacks and map copying remain outside it. Cache hits do not acquire the new lock, and callers continue to receive independent, modifiable maps. This avoids serializing the entire options lookup or holding the new lock across preference callbacks.

The PR also addresses a separate invalidation gap when the instance preference node is removed. The replacement node receives the cache-invalidation listener, the stored instance-listener reference is updated, and the cache is invalidated. Two additional tests cover removal and subsequent changes on replacement nodes.

Production changes are limited to `JavaModelManager`. The PR also adds `OptionCacheTests` and registers it in `AllJavaModelTests`. There are no public API, formatter, editor, or build-configuration changes.

## How to test

Run `org.eclipse.jdt.core.tests.model.OptionCacheTests` as a **JUnit Plug-in Test**, using a disposable runtime workspace. It requires an Eclipse runtime and is also registered in `AllJavaModelTests`.

The current class contains **10 tests**:

| Tests | Coverage |
| ---: | --- |
| 4 | Cache rebuilding versus `setOptions()`, direct preference invalidation, repeated invalidation, and `setOptions(null)` |
| 2 | Instance preference-node removal and continued invalidation after node replacement |
| 4 | Independent returned maps, sequential updates, cache reuse, and a preference listener that reenters `getOptions()` |

The race tests use bounded `CountDownLatch` barriers rather than sleeps. A delegating preference proxy pauses a real preference read after the underlying method has returned. It does not hold the preference implementation's locks or invent preference values.

The writer completes its update before the paused reader resumes. The assertion then checks a fresh `getOptions()` call after both operations have finished. This distinguishes stale cache publication from an old value observed during an overlapping read.

`testCacheIsReused` checks that repeated cache hits do not reread preferences. It is a functional cache-reuse check, not a throughput, allocation, or contention benchmark.

## Before/after comparison and validation status

[Test-only PR #5366](https://github.com/eclipse-jdt/eclipse.jdt.core/pull/5366) contains the same test class and suite registration, but omits all production changes from this PR.

The comparison was prepared from this PR at `f38704d15668ca9bdd9c76a89c279e08aa95b661`, with both variants based on upstream commit `8c40c7d2ae12c0a32ab3cca1ab31b53956c65d51`.

An [earlier SDK-based diagnostic run](https://github.com/carstenartur/eclipse.jdt.core/actions/runs/33955492150) is retained as supplementary evidence. The previously reported eight-cache-test results must not be presented as results for the current ten-test version. That diagnostic setup is also distinct from a normal upstream Tycho regression-suite run.

The required comparison is the same stale-value assertions failing without the fix and passing with it, with all ten tests passing on the fixed version. Individual JUnit results and the tested revisions are needed to establish that comparison.

The [first Jenkins run of #5366](https://ci.eclipse.org/jdt/job/eclipse.jdt.core-Github/job/PR-5366/1/) ended with a pipeline timeout. That is not a JUnit regression result and is not evidence that the proposed fix makes a difference.

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)