### PR TITLE
Add options cache regression tests without the fix

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AllJavaModelTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AllJavaModelTests.java
@@ -139,6 +139,7 @@ private static Class[] getAllTestClasses() {
 
 		// Options tests
 		OptionTests.class,
+		OptionCacheTests.class,
 
 		// Type hierarchy tests
 		TypeHierarchyTests.class,

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/OptionCacheTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/OptionCacheTests.java
@@ -1,0 +1,356 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jdt.core.tests.model;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Proxy;
+import java.util.Hashtable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.core.runtime.preferences.InstanceScope;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.formatter.DefaultCodeFormatterConstants;
+import org.eclipse.jdt.internal.core.JavaModelManager;
+
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+
+/** Tests the real options cache without creating projects, editors or builders. */
+public class OptionCacheTests extends TestCase {
+	private static final long TIMEOUT_SECONDS = 30;
+	private static final String KEY = DefaultCodeFormatterConstants.FORMATTER_INSERT_SPACE_AFTER_CLOSING_PAREN_IN_CAST;
+	private Hashtable<String, String> savedOptions;
+
+	public OptionCacheTests(String name) {
+		super(name);
+	}
+
+	public static Test suite() {
+		return new TestSuite(OptionCacheTests.class);
+	}
+
+	@Override
+	protected void setUp() throws Exception {
+		super.setUp();
+		assertTrue("These tests require an Eclipse runtime", Platform.isRunning());
+		this.savedOptions = JavaCore.getOptions();
+	}
+
+	@Override
+	protected void tearDown() throws Exception {
+		try {
+			if (this.savedOptions != null) {
+				JavaCore.setOptions(this.savedOptions);
+			}
+		} finally {
+			super.tearDown();
+		}
+	}
+
+	public void testCompletedSetOptionsCannotBeOverwritten() throws Exception {
+		assertLaterReadIsCurrent(Update.SET_OPTIONS);
+	}
+
+	public void testPreferenceInvalidationCannotBeUndone() throws Exception {
+		assertLaterReadIsCurrent(Update.PREFERENCE);
+	}
+
+	public void testRepeatedInvalidationCannotBeUndone() throws Exception {
+		assertLaterReadIsCurrent(Update.REPEATED_INVALIDATION);
+	}
+
+	public void testCompletedResetCannotBeOverwritten() throws Exception {
+		assertLaterReadIsCurrent(Update.RESET);
+	}
+
+	public void testReturnedOptionsAreIndependent() {
+		Hashtable<String, String> first = JavaCore.getOptions();
+		String expected = first.get(KEY);
+		first.put(KEY, "not a formatter value");
+		assertEquals(expected, JavaCore.getOptions().get(KEY));
+	}
+
+	public void testSequentialUpdates() {
+		setOption(JavaCore.DO_NOT_INSERT);
+		assertEquals(JavaCore.DO_NOT_INSERT, JavaCore.getOption(KEY));
+		assertEquals(JavaCore.DO_NOT_INSERT, JavaCore.getOptions().get(KEY));
+		setOption(JavaCore.INSERT);
+		assertEquals(JavaCore.INSERT, JavaCore.getOption(KEY));
+		assertEquals(JavaCore.INSERT, JavaCore.getOptions().get(KEY));
+	}
+
+	public void testCacheIsReused() throws Exception {
+		AtomicInteger reads = new AtomicInteger();
+		Thread testThread = Thread.currentThread();
+		try (PreferenceReads ignored = new PreferenceReads((key, value) -> {
+			if (Thread.currentThread() == testThread) {
+				reads.incrementAndGet();
+			}
+		})) {
+			invalidateWithValue(JavaCore.INSERT);
+			Hashtable<String, String> first = JavaCore.getOptions();
+			int coldReads = reads.get();
+			assertTrue("The cold read must access the real preferences", coldReads > 0);
+			for (int i = 0; i < 20; i++) {
+				Hashtable<String, String> next = JavaCore.getOptions();
+				assertNotSame(first, next);
+				assertEquals(first, next);
+			}
+			assertEquals("Do not fix the race by disabling the cache", coldReads, reads.get());
+		}
+	}
+
+	public void testReentrantPreferenceListener() throws Exception {
+		setOption(JavaCore.DO_NOT_INSERT);
+		AtomicInteger callbacks = new AtomicInteger();
+		AtomicReference<Throwable> callbackFailure = new AtomicReference<>();
+		IEclipsePreferences node = InstanceScope.INSTANCE.getNode(JavaCore.PLUGIN_ID);
+		IEclipsePreferences.IPreferenceChangeListener listener = event -> {
+			if (KEY.equals(event.getKey())) {
+				try {
+					JavaCore.getOptions();
+					callbacks.incrementAndGet();
+				} catch (Throwable failure) {
+					callbackFailure.set(failure);
+				}
+			}
+		};
+		ExecutorService executor = newExecutor();
+		node.addPreferenceChangeListener(listener);
+		try {
+			Hashtable<String, String> next = new Hashtable<>(this.savedOptions);
+			next.put(KEY, JavaCore.INSERT);
+			executor.submit(() -> JavaCore.setOptions(next)).get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+			assertNull("Preference callback failed", callbackFailure.get());
+			assertTrue("The preference callback must have reentered getOptions", callbacks.get() > 0);
+			assertEquals(JavaCore.INSERT, JavaCore.getOption(KEY));
+			assertEquals(JavaCore.INSERT, JavaCore.getOptions().get(KEY));
+		} finally {
+			node.removePreferenceChangeListener(listener);
+			stop(executor);
+		}
+	}
+
+	private enum Update {
+		SET_OPTIONS, PREFERENCE, REPEATED_INVALIDATION, RESET
+	}
+
+	private void assertLaterReadIsCurrent(Update update) throws Exception {
+		String expected = JavaCore.getDefaultOptions().get(KEY);
+		assertNotNull(expected);
+		String oldValue = opposite(expected);
+		setOption(oldValue);
+		CountDownLatch capturedOldValue = new CountDownLatch(1);
+		CountDownLatch resumeReader = new CountDownLatch(1);
+		AtomicBoolean intercepted = new AtomicBoolean();
+		AtomicReference<Thread> readerThread = new AtomicReference<>();
+		ExecutorService executor = newExecutor();
+		Future<Hashtable<String, String>> reader = null;
+		try (PreferenceReads ignored = new PreferenceReads((key, value) -> {
+			if (Thread.currentThread() == readerThread.get() && KEY.equals(key)
+					&& oldValue.equals(value) && intercepted.compareAndSet(false, true)) {
+				capturedOldValue.countDown();
+				assertTrue("Writer did not release the options reader",
+						resumeReader.await(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+			}
+		})) {
+			try {
+				// Invalidate through real preference events, not by modifying cache internals.
+				invalidateWithValue(oldValue);
+				reader = executor.submit(() -> {
+					readerThread.set(Thread.currentThread());
+					return JavaCore.getOptions();
+				});
+				assertTrue("Reader did not capture the old preference",
+						capturedOldValue.await(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+				IEclipsePreferences node = InstanceScope.INSTANCE.getNode(JavaCore.PLUGIN_ID);
+				switch (update) {
+					case SET_OPTIONS -> setOption(expected);
+					case PREFERENCE -> node.put(KEY, expected);
+					case REPEATED_INVALIDATION -> {
+						// null -> null invalidations must also invalidate an in-flight computation.
+						node.put(KEY, expected);
+						node.put(KEY, oldValue);
+						node.put(KEY, expected);
+					}
+					case RESET -> JavaCore.setOptions(null);
+				}
+				assertEquals("The update must be complete before resuming the reader", expected, JavaCore.getOption(KEY));
+				resumeReader.countDown();
+				reader.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+				// The overlapping read may observe the old value. Only this later read is asserted.
+				assertEquals("A completed " + update + " must not be undone by an older reader",
+						expected, JavaCore.getOptions().get(KEY));
+			} finally {
+				resumeReader.countDown();
+				try {
+					if (reader != null) {
+						reader.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+					}
+				} finally {
+					stop(executor);
+				}
+			}
+		}
+	}
+
+	public void testInstanceNodeRemovalInvalidatesCache() throws Exception {
+		Hashtable<String, String> preferences = saveInstancePreferences();
+		try {
+			String defaultValue = JavaCore.getDefaultOptions().get(KEY);
+			assertNotNull(defaultValue);
+			String oldValue = opposite(defaultValue);
+			setOption(oldValue);
+			assertEquals(oldValue, JavaCore.getOptions().get(KEY));
+
+			JavaModelManager manager = JavaModelManager.getJavaModelManager();
+			IEclipsePreferences removed = manager.getInstancePreferences();
+			removed.removeNode();
+			assertNotSame(removed, manager.getInstancePreferences());
+			assertEquals(defaultValue, JavaCore.getOption(KEY));
+			assertEquals("Removing the instance node must invalidate its cached options",
+					defaultValue, JavaCore.getOptions().get(KEY));
+		} finally {
+			restoreInstancePreferences(preferences);
+		}
+	}
+
+	public void testInstanceNodeReplacementKeepsInvalidatingCache() throws Exception {
+		Hashtable<String, String> preferences = saveInstancePreferences();
+		try {
+			String defaultValue = JavaCore.getDefaultOptions().get(KEY);
+			assertNotNull(defaultValue);
+			String newValue = opposite(defaultValue);
+			JavaModelManager manager = JavaModelManager.getJavaModelManager();
+			for (int i = 0; i < 2; i++) {
+				IEclipsePreferences removed = manager.getInstancePreferences();
+				removed.removeNode();
+				IEclipsePreferences replacement = manager.getInstancePreferences();
+				assertNotSame(removed, replacement);
+				setOption(defaultValue);
+				assertEquals(defaultValue, JavaCore.getOptions().get(KEY));
+				replacement.put(KEY, newValue);
+				assertEquals(newValue, JavaCore.getOption(KEY));
+				assertEquals("Preference changes must invalidate the cache after node replacement " + i,
+						newValue, JavaCore.getOptions().get(KEY));
+			}
+		} finally {
+			restoreInstancePreferences(preferences);
+		}
+	}
+
+	private static Hashtable<String, String> saveInstancePreferences() throws Exception {
+		IEclipsePreferences node = JavaModelManager.getJavaModelManager().getInstancePreferences();
+		Hashtable<String, String> preferences = new Hashtable<>();
+		for (String key : node.keys()) {
+			preferences.put(key, node.get(key, ""));
+		}
+		return preferences;
+	}
+
+	private static void restoreInstancePreferences(Hashtable<String, String> preferences) throws Exception {
+		// Node removal also affects non-option preferences, such as classpath variables.
+		IEclipsePreferences node = JavaModelManager.getJavaModelManager().getInstancePreferences();
+		node.clear();
+		preferences.forEach(node::put);
+	}
+
+	private void setOption(String value) {
+		Hashtable<String, String> options = new Hashtable<>(this.savedOptions);
+		options.put(KEY, value);
+		JavaCore.setOptions(options);
+	}
+
+	private static void invalidateWithValue(String value) {
+		IEclipsePreferences node = InstanceScope.INSTANCE.getNode(JavaCore.PLUGIN_ID);
+		node.put(KEY, opposite(value));
+		node.put(KEY, value);
+	}
+
+	private static String opposite(String value) {
+		return JavaCore.INSERT.equals(value) ? JavaCore.DO_NOT_INSERT : JavaCore.INSERT;
+	}
+
+	private static ExecutorService newExecutor() {
+		return Executors.newSingleThreadExecutor(runnable -> {
+			Thread thread = new Thread(runnable, "JDT options cache regression");
+			thread.setDaemon(true);
+			return thread;
+		});
+	}
+
+	private static void stop(ExecutorService executor) throws InterruptedException {
+		executor.shutdownNow();
+		assertTrue("Options worker did not terminate", executor.awaitTermination(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+	}
+
+	@FunctionalInterface
+	private interface AfterRead {
+		void accept(String key, Object value) throws Exception;
+	}
+
+	/**
+	 * Delays a real preference read after it has returned, without holding the
+	 * preference implementation's locks. No production manager or preference
+	 * values are mocked. Reflection is confined to installing this read barrier.
+	 */
+	private static final class PreferenceReads implements AutoCloseable {
+		private final IEclipsePreferences[] lookup;
+		private final IEclipsePreferences[] original;
+
+		PreferenceReads(AfterRead afterRead) throws ReflectiveOperationException {
+			Field field = JavaModelManager.class.getDeclaredField("preferencesLookup");
+			field.setAccessible(true);
+			this.lookup = (IEclipsePreferences[]) field.get(JavaModelManager.getJavaModelManager());
+			this.original = this.lookup.clone();
+			try {
+				for (int i = 0; i < this.lookup.length; i++) {
+					IEclipsePreferences delegate = this.original[i];
+					if (delegate != null) {
+						this.lookup[i] = (IEclipsePreferences) Proxy.newProxyInstance(
+								IEclipsePreferences.class.getClassLoader(), new Class<?>[] { IEclipsePreferences.class },
+								(proxy, method, arguments) -> {
+							Object result;
+							try {
+								result = method.invoke(delegate, arguments);
+							} catch (InvocationTargetException failure) {
+								throw failure.getCause();
+							}
+							if (method.getName().equals("get") && arguments != null && arguments.length == 2) {
+								afterRead.accept((String) arguments[0], result);
+							}
+							return result;
+						});
+					}
+				}
+			} catch (RuntimeException | Error failure) {
+				close();
+				throw failure;
+			}
+		}
+
+		@Override
+		public void close() {
+			System.arraycopy(this.original, 0, this.lookup, 0, this.lookup.length);
+		}
+	}
+}


### PR DESCRIPTION
## What it does

Provides the test-only comparison for [#5364](https://github.com/eclipse-jdt/eclipse.jdt.core/pull/5364), as [requested by @jukzi](https://github.com/eclipse-jdt/eclipse.jdt.core/pull/5364#issuecomment-5555308377).

**This PR is for regression validation only and is not intended to be merged on its own.**

It copies `OptionCacheTests` and its registration in `AllJavaModelTests` unchanged from #5364. All `JavaModelManager` changes are deliberately omitted. No production code or build configuration is changed.

The assertions still require correct behavior. They have not been inverted, weakened, disabled, or changed to accept obsolete option values.

### Comparison revisions

| Variant | Commit |
| --- | --- |
| Common upstream base | `8c40c7d2ae12c0a32ab3cca1ab31b53956c65d51` |
| Tests with the proposed fix, #5364 | `f38704d15668ca9bdd9c76a89c279e08aa95b661` |
| Identical tests without the fix, this PR | `c25a340d3b2d61c9777125a4361e6d52747e880f` |

The explanation of the production changes and links to the earlier investigations, including JDT UI #2811, JDT UI #1445 and Bug 563771, are in [#5364](https://github.com/eclipse-jdt/eclipse.jdt.core/pull/5364).

## How to test

Run `org.eclipse.jdt.core.tests.model.OptionCacheTests` as a **JUnit Plug-in Test** on each comparison revision. Use the same runtime and launch configuration, with a fresh disposable runtime workspace for each variant. The class requires an Eclipse runtime and is also included in `AllJavaModelTests`.

The current class contains **10 tests**. The four cache-publication race tests are:

```text
testCompletedSetOptionsCannotBeOverwritten
testPreferenceInvalidationCannotBeUndone
testRepeatedInvalidationCannotBeUndone
testCompletedResetCannotBeOverwritten
```

These tests pause a reader after it has read an old preference value, complete an update or invalidation, and then resume the reader. They assert the value returned by a subsequent `getOptions()` call after both operations have finished.

Two additional tests cover instance preference-node removal and continued invalidation after node replacement. The remaining four check independent returned maps, sequential updates, cache reuse, and reentrant preference callbacks.

The intended regression evidence is a stale-value assertion failure without the fix, followed by the same assertion passing with the fix. All ten tests should pass on the fixed revision. These are the expected comparison criteria, not a claim that the current upstream comparison has completed.

## Validation status

The [first Jenkins run](https://ci.eclipse.org/jdt/job/eclipse.jdt.core-Github/job/PR-5366/1/) ended with `Timeout has been exceeded` in the pipeline's `sh` step.

**That timeout is not a JUnit assertion failure and does not demonstrate the cache defect.**

The comparison still needs individual results for `OptionCacheTests`, including the test names, assertion failures, and tested revisions. An overall green check, a build timeout, a test-barrier timeout, or a failure before the relevant assertion is reached is not a substitute for that evidence.

The suite registration is intentional: the purpose of this PR is to execute the unchanged regression tests against unpatched production code, not to keep this diagnostic branch green by omitting them.

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
