### PR TITLE
Workspace compliance level is not properly "inherited" by projects

### DIFF
--- a/org.eclipse.jdt.core.tests.builder/src/org/eclipse/jdt/core/tests/builder/BuilderTests11.java
+++ b/org.eclipse.jdt.core.tests.builder/src/org/eclipse/jdt/core/tests/builder/BuilderTests11.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2022, Andrey Loskutov (loskutov@gmx.de) and others.
+ * Copyright (c) 2022, 2026 Andrey Loskutov (loskutov@gmx.de) and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package org.eclipse.jdt.core.tests.builder;
 
+import java.util.Hashtable;
 import junit.framework.Test;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.jdt.core.JavaCore;
@@ -54,6 +55,44 @@ public class BuilderTests11 extends BuilderTests {
 	public void testBuildWithRelease_11() throws JavaModelException, Exception {
 		String compliance = "11";
 		runTest(compliance);
+	}
+
+	/**
+	 * https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5281
+	 * The release option is enabled only at the workspace level (not per project).
+	 * The builder must still honor it and restrict the JRT system library to the
+	 * targeted release's API. Here we target release 8 and reference {@code List.of()},
+	 * which was only added in Java 9 - so it must be flagged as an error.
+	 * If the workspace-level release option is ignored (the bug), the full JDK 11 JRT
+	 * is visible, {@code List.of()} resolves and no problem is reported.
+	 */
+	public void testReleaseOptionFromWorkspace() throws JavaModelException, Exception {
+		Hashtable<String, String> defaultOptions = JavaCore.getOptions();
+		try {
+			// Enable the release option only at the workspace level
+			Hashtable<String, String> wkspOptions = JavaCore.getOptions();
+			wkspOptions.put(JavaCore.COMPILER_RELEASE, JavaCore.ENABLED);
+			JavaCore.setOptions(wkspOptions);
+
+			// Create a project targeting release 8, WITHOUT setting the release option per project
+			IPath projectPath = env.addProject("ReleaseFromWorkspace", "1.8");
+			env.removePackageFragmentRoot(projectPath, "");
+			IPath src = env.addPackageFragmentRoot(projectPath, "src");
+			env.addExternalJars(projectPath, Util.getJavaClassLibs());
+			IPath classA = env.addClass(src, "bug", "X",
+					"package bug;\n" +
+					"import java.util.List;\n" +
+					"public class X {\n" +
+					"	List<String> l = List.of(\"a\");\n" + // List.of() is Java 9+
+					"}\n");
+			fullBuild();
+
+			// The Java 9+ API must not be resolvable when targeting release 8
+			expectingProblemsFor(classA,
+					"Problem : The method of(String) is undefined for the type List [ resource : </ReleaseFromWorkspace/src/bug/X.java> range : <76,78> category : <50> severity : <2>]");
+		} finally {
+			JavaCore.setOptions(defaultOptions);
+		}
 	}
 
 	/**

--- a/org.eclipse.jdt.core.tests.builder/src/org/eclipse/jdt/core/tests/builder/TestingEnvironment.java
+++ b/org.eclipse.jdt.core.tests.builder/src/org/eclipse/jdt/core/tests/builder/TestingEnvironment.java
@@ -41,6 +41,7 @@ import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.tests.util.AbstractCompilerTest;
 import org.eclipse.jdt.core.tests.util.Util;
+import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jdt.internal.core.ClasspathEntry;
 import org.eclipse.jdt.internal.core.JavaModelManager;
@@ -228,7 +229,7 @@ public void addClassFolder(IPath projectPath, IPath classFolderPath, boolean isE
 	public IPath addProject(String projectName, String compliance){
 		checkAssertion("a workspace must be open", this.isOpen); //$NON-NLS-1$
 		IProject project = createProject(projectName);
-		int requiredComplianceFlag = 0;
+		long requiredComplianceFlag = 0;
 		String compilerVersion = null;
 		if ("1.8".equals(compliance)) {
 			requiredComplianceFlag = AbstractCompilerTest.F_1_8;
@@ -268,8 +269,29 @@ public void addClassFolder(IPath projectPath, IPath classFolderPath, boolean isE
 			requiredComplianceFlag = AbstractCompilerTest.F_18;
 			compilerVersion = CompilerOptions.VERSION_18;
 		} else if ("19".equals(compliance)) {
-			requiredComplianceFlag = AbstractCompilerTest.F_19;
+			requiredComplianceFlag = ClassFileConstants.JDK19;
 			compilerVersion = CompilerOptions.VERSION_19;
+		} else if ("20".equals(compliance)) {
+			requiredComplianceFlag = ClassFileConstants.JDK20;
+			compilerVersion = CompilerOptions.VERSION_20;
+		} else if ("21".equals(compliance)) {
+			requiredComplianceFlag = ClassFileConstants.JDK21;
+			compilerVersion = CompilerOptions.VERSION_21;
+		} else if ("22".equals(compliance)) {
+			requiredComplianceFlag = ClassFileConstants.JDK22;
+			compilerVersion = CompilerOptions.VERSION_22;
+		} else if ("23".equals(compliance)) {
+			requiredComplianceFlag = ClassFileConstants.JDK23;
+			compilerVersion = CompilerOptions.VERSION_23;
+		} else if ("24".equals(compliance)) {
+			requiredComplianceFlag = ClassFileConstants.JDK24;
+			compilerVersion = CompilerOptions.VERSION_24;
+		} else if ("25".equals(compliance)) {
+			requiredComplianceFlag = ClassFileConstants.JDK25;
+			compilerVersion = CompilerOptions.VERSION_25;
+		} else if ("26".equals(compliance)) {
+			requiredComplianceFlag = ClassFileConstants.JDK26;
+			compilerVersion = CompilerOptions.VERSION_26;
 		} else {
 			throw new UnsupportedOperationException("Test framework doesn't support compliance level: " + compliance);
 		}

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/ClasspathLocation.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/ClasspathLocation.java
@@ -167,9 +167,9 @@ public static ClasspathJrt forJrtSystem(String jrtPath, AccessRuleSet accessRule
 		} catch (IOException e) {
 			throw new CoreException(new Status(IStatus.ERROR, ClasspathLocation.class, "Failed to detect JDK release for: " + jrtPath, e)); //$NON-NLS-1$
 		}
-		boolean sameRelease = JavaCore.compareJavaVersions(jrtVersion, release) == 0;
-		if(sameRelease) {
-			useRelease = false;
+		boolean sameOrHigherRelease = JavaCore.compareJavaVersions(release, jrtVersion) >= 0;
+		if(sameOrHigherRelease) {
+			useRelease = false; // either not needed or illegal
 		}
 	}
 	return useRelease ? new ClasspathJrtWithReleaseOption(jrtPath, accessRuleSet, annotationsPath, release)

--- a/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/NameEnvironment.java
+++ b/org.eclipse.jdt.core/model/org/eclipse/jdt/internal/core/builder/NameEnvironment.java
@@ -145,7 +145,7 @@ private void computeClasspathLocations(
 		isReleaseEnabled = true;
 	} else {
 		compliance = javaProject.getOption(JavaCore.COMPILER_COMPLIANCE, true);
-		isReleaseEnabled = JavaCore.ENABLED.equals(javaProject.getOption(JavaCore.COMPILER_RELEASE, false));
+		isReleaseEnabled = JavaCore.ENABLED.equals(javaProject.getOption(JavaCore.COMPILER_RELEASE, true));
 	}
 	if (CompilerOptions.versionToJdkLevel(compliance) >= ClassFileConstants.JDK9) {
 		moduleEntries = new LinkedHashMap<>(classpathEntries.length);


### PR DESCRIPTION
The --release option should default to workspace setting if not set

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
Fixes #5281

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
