### PR TITLE
Preserve covariant return types when merging null annotations

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/NullAnnotationMatching.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/ast/NullAnnotationMatching.java
@@ -856,9 +856,12 @@ public class NullAnnotationMatching {
 		if (count < 2)
 			return current;
 		TypeBinding[] parameters = weakerTypes(moreSpecific[0].parameters, moreSpecific[1].parameters, environment);
-		TypeBinding returnType = strongerType(moreSpecific[0].returnType, moreSpecific[1].returnType, environment);
 		for (int i = 2; i < count; i++) {
 			parameters = weakerTypes(parameters, moreSpecific[i].parameters, environment);
+		}
+		// Preserve the covariant return type selected by method resolution.
+		TypeBinding returnType = current.returnType;
+		for (int i = 0; i < count; i++) {
 			returnType = strongerType(returnType, moreSpecific[i].returnType, environment);
 		}
 		if (parameters != current.parameters || returnType != current.returnType) { //$IDENTITY-COMPARISON$

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullTypeAnnotationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/NullTypeAnnotationTest.java
@@ -20291,6 +20291,71 @@ public void testGH5249() {
 		getCompilerOptions(),
 		"");
 }
+public void testGH5249_inheritedBuilders() {
+	String client = """
+		public class Test {
+			Builders.Child build(Builders.ChildBuilder builder) {
+				return builder.build();
+			}
+			Builders.Child buildReversed(Builders.ReversedChildBuilder builder) {
+				return builder.build();
+			}
+		}
+		""";
+	runConformTestWithLibs(new String[] {
+			"Builders.java",
+			"""
+			public class Builders {
+				public static class Parent {}
+				public static class Child extends Parent {}
+				public interface ParentBuilder {
+					Parent build();
+				}
+				public interface GenericBuilder<T> {
+					T build();
+				}
+				public interface ChildBuilder extends ParentBuilder, GenericBuilder<Child> {}
+				public interface ReversedChildBuilder extends GenericBuilder<Child>, ParentBuilder {}
+			}
+			""",
+			"Test.java",
+			client
+		},
+		getCompilerOptions(),
+		"");
+	runConformTestWithLibs(false, new String[] { "Test.java", client }, getCompilerOptions(), "");
+}
+public void testGH5249_inheritedNullAnnotations() {
+	runConformTestWithLibs(new String[] {
+			"Test.java",
+			"""
+			import org.eclipse.jdt.annotation.*;
+
+			public class Test {
+				interface ParentBuilder {
+					Object build();
+				}
+				interface NullableBuilder {
+					@Nullable String build();
+				}
+				interface NonNullBuilder {
+					@NonNull String build();
+				}
+				interface Builder extends ParentBuilder, NullableBuilder, NonNullBuilder {}
+				interface ReversedBuilder extends NonNullBuilder, NullableBuilder, ParentBuilder {}
+
+				@NonNull String build(Builder builder) {
+					return builder.build();
+				}
+				@NonNull String buildReversed(ReversedBuilder builder) {
+					return builder.build();
+				}
+			}
+			"""
+		},
+		getCompilerOptions(),
+		"");
+}
 public void testGH5316() throws Exception {
 	runConformTestWithLibs(new String[] {
 			"MyInnocentClass.java",


### PR DESCRIPTION
## Summary

Preserve the covariant return type already selected by Java method resolution when merging null annotations from override-equivalent inherited methods.

Addresses redhat-developer/vscode-java#4500. This is a follow-up to eclipse-jdt/eclipse.jdt.core#5250, not a change to the language server's null-analysis settings.

## Root cause

`Scope.mostSpecificMethodBinding()` can select a method whose return type is more specific than the first entry in `moreSpecific`. However, `methodWithMergedNullAnnotations()` initializes the merged return type from `moreSpecific[0]`, rather than from the selected method.

Since `strongerType()` deliberately preserves its first argument's underlying Java type, merging annotations can replace the selected subtype with a supertype. In AWS SDK 2.42.26, this makes `GetParametersByPathRequest.builder().build()` appear to return `SsmRequest` when annotation-based null analysis is enabled.

The fix starts with `current.returnType` and merges annotations from every candidate onto that type. Parameter annotation merging is unchanged.

## Regression history

Historical ECJ builds using the same AWS input and null-analysis settings show:

| Revision | Result |
| --- | --- |
| `27f2d7a`, parent of eclipse-jdt/eclipse.jdt.core#5237 | Compiles |
| `62bd2a3`, eclipse-jdt/eclipse.jdt.core#5237 | Fails with an `Object` return type |
| `618869e`, eclipse-jdt/eclipse.jdt.core#5250 | Fails with an `SsmRequest` return type |

The earlier follow-up fixed the explicit covariant override reported in eclipse-jdt/eclipse.jdt.core#5249, but did not cover the separately inherited generic builder methods used by the AWS SDK.

## Regression coverage

- `testGH5249_inheritedBuilders`: generic and covariant `build()` declarations in both interface orders, resolved from source and then from class files.
- `testGH5249_inheritedNullAnnotations`: preserve the covariant Java type while merging the strongest return nullness from three interfaces, in both orders.

The tests do not depend on the AWS SDK.

## Validation

The Maven/Tycho compiler reactor succeeded, and `NullTypeAnnotationTest` reported **958 tests, 0 failures, 0 errors**. The Maven-built ECJ also compiles both original AWS expressions with null analysis enabled.

```text
mvn -B -ntp -pl org.eclipse.jdt.core.tests.compiler -am verify
  "-Dtest=NullTypeAnnotationTest#testGH5249*+testGH5070*"
  -DfailIfNoTests=false
  "-Dtycho.surefire.argLine=--add-modules ALL-SYSTEM -Dcompliance=1.8,21 -Djdt.performance.asserts=disabled"
  -DcompilerBaselineMode=disable -DcompilerBaselineReplace=none
```

The test provider ran the full `NullTypeAnnotationTest` suite for this invocation.

This draft fixes the compiler. The downstream VS Code issue will additionally require consuming the fixed JDT Core version through JDT LS.
