### PR TITLE
Updates for run.javac modes

### DIFF
--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractRegressionTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AbstractRegressionTest.java
@@ -4187,6 +4187,9 @@ protected void runNegativeTest(
 	@Override
 	protected void setUp() throws Exception {
 		System.out.println(this.getClass().getName()+'.'+ getName());
+		if (getClass().getAnnotation(RunJavac.class) != null) {
+			this.runJavacOptIn = true;
+		}
 		super.setUp();
 		if (this.verifier == null) {
 			this.verifier = new TestVerifier(true);
@@ -4293,6 +4296,7 @@ protected void runNegativeTest(
 			printJavacResultsSummary();
 			javacUsePathOption(" -classpath ");
 		}
+		this.runJavacOptIn = false;
 	}
 	/**
 	 * Returns the OS path to the directory that contains this plugin.

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AnnotationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AnnotationTest.java
@@ -64,6 +64,7 @@ import org.eclipse.jdt.internal.compiler.lookup.ReferenceBinding;
 import org.eclipse.jdt.internal.compiler.problem.DefaultProblemFactory;
 import org.junit.Assert;
 
+@RunJavac
 public class AnnotationTest extends AbstractComparableTest {
 
 	// Static initializer to specify tests subset using TESTS_* static variables
@@ -107,13 +108,11 @@ public class AnnotationTest extends AbstractComparableTest {
 		return super.getNameEnvironment(testFiles, classPaths, options);
 	}
 
-	// ========= OPT-IN to run.javac mode: ===========
 	/* (non-Javadoc)
 	 * @see junit.framework.TestCase#setUp()
 	 */
 	@Override
 	protected void setUp() throws Exception {
-		this.runJavacOptIn = true;
 		super.setUp();
 		this.reportMissingJavadocComments = null;
 		this.repeatableIntroText =
@@ -122,12 +121,6 @@ public class AnnotationTest extends AbstractComparableTest {
 		". Only annotation types marked @Repeatable can be used multiple times at one target.\n";
 		this.javaClassLib = null; // use only in selected tests
 	}
-	@Override
-	protected void tearDown() throws Exception {
-		super.tearDown();
-		this.runJavacOptIn = false; // do it last, so super can still clean up
-	}
-	// =================================================
 
 	public void test001() {
 		this.runConformTest(

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AssertionTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/AssertionTest.java
@@ -16,6 +16,7 @@ package org.eclipse.jdt.core.tests.compiler.regression;
 import junit.framework.Test;
 
 @SuppressWarnings({ "rawtypes" })
+@RunJavac
 public class AssertionTest extends AbstractRegressionTest {
 //	 Static initializer to specify tests subset using TESTS_* static variables
 //	 All specified tests which does not belong to the class are skipped...
@@ -35,18 +36,6 @@ public class AssertionTest extends AbstractRegressionTest {
 	public static Class testClass() {
 		return AssertionTest.class;
 	}
-	// ========= OPT-IN to run.javac mode: ===========
-	@Override
-	protected void setUp() throws Exception {
-		this.runJavacOptIn = true;
-		super.setUp();
-	}
-	@Override
-	protected void tearDown() throws Exception {
-		super.tearDown();
-		this.runJavacOptIn = false; // do it last, so super can still clean up
-	}
-	// =================================================
 
 	public void test001() {
 		this.runNegativeTest(

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/Deprecated9Test.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/Deprecated9Test.java
@@ -23,6 +23,7 @@ import org.eclipse.jdt.internal.compiler.batch.FileSystem;
 import org.eclipse.jdt.internal.compiler.env.INameEnvironment;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 
+@RunJavac
 public class Deprecated9Test extends AbstractRegressionTest9 {
 	public Deprecated9Test(String name) {
 		super(name);
@@ -34,18 +35,6 @@ public class Deprecated9Test extends AbstractRegressionTest9 {
 	static {
 //		TESTS_NAMES = new String[] { "testGH4579" };
 	}
-	// ========= OPT-IN to run.javac mode: ===========
-	@Override
-	protected void setUp() throws Exception {
-		this.runJavacOptIn = true;
-		super.setUp();
-	}
-	@Override
-	protected void tearDown() throws Exception {
-		super.tearDown();
-		this.runJavacOptIn = false; // do it last, so super can still clean up
-	}
-	// =================================================
 
 	@Override
 	protected INameEnvironment[] getClassLibs(boolean useDefaultClasspaths) {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/DubiousOutcomeTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/DubiousOutcomeTest.java
@@ -26,6 +26,7 @@ import org.eclipse.jdt.core.tests.compiler.regression.AbstractRegressionTest.Jav
  * <li>if the new outcome is good, thus removing the doubt, then move the test to a 'regular' suite class
  * </ol>
  */
+@RunJavac
 public class DubiousOutcomeTest extends AbstractRegressionTest {
 
 	static {
@@ -43,18 +44,6 @@ public class DubiousOutcomeTest extends AbstractRegressionTest {
 	public static Test suite() {
 		return buildMinimalComplianceTestSuite(testClass(), F_1_8);
 	}
-	// ========= OPT-IN to run.javac mode: ===========
-	@Override
-	protected void setUp() throws Exception {
-		this.runJavacOptIn = true;
-		super.setUp();
-	}
-	@Override
-	protected void tearDown() throws Exception {
-		super.tearDown();
-		this.runJavacOptIn = false; // do it last, so super can still clean up
-	}
-	// =================================================
 
 	public void testGH1591() {
 		// javac accepts

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericsRegressionTest_9.java
@@ -28,6 +28,7 @@ import org.eclipse.jdt.internal.compiler.lookup.ProblemReferenceBinding;
  * Test class originally capturing issues specific to Java9, but meanwhile also just a continuation
  * of GenericsRegressionTest_1_8.
  */
+@RunJavac
 public class GenericsRegressionTest_9 extends AbstractRegressionTest9 {
 
 static {
@@ -78,19 +79,6 @@ public void testGH5193ProblemBindingCannotInferDiamondConstructor() {
 
 	assertNull(AllocationExpression.inferDiamondConstructor(null, null, missingType, Binding.NO_TYPES));
 }
-
-// ========= OPT-IN to run.javac mode: ===========
-@Override
-protected void setUp() throws Exception {
-	this.runJavacOptIn = true;
-	super.setUp();
-}
-@Override
-protected void tearDown() throws Exception {
-	super.tearDown();
-	this.runJavacOptIn = false; // do it last, so super can still clean up
-}
-// =================================================
 
 // vanilla test case
 public void testBug488663_001() {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ImplicitlyDeclaredClassesTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ImplicitlyDeclaredClassesTest.java
@@ -31,6 +31,7 @@ import org.eclipse.jdt.internal.compiler.problem.DefaultProblemFactory;
 import org.eclipse.jdt.internal.compiler.problem.ProblemReporter;
 import org.junit.Test;
 
+@RunJavac
 public class ImplicitlyDeclaredClassesTest extends AbstractRegressionTest9 {
 	public static boolean optimizeStringLiterals = false;
 	private static final JavacTestOptions JAVAC_OPTIONS = new JavacTestOptions("-source 25");
@@ -42,19 +43,6 @@ public class ImplicitlyDeclaredClassesTest extends AbstractRegressionTest9 {
 	public ImplicitlyDeclaredClassesTest(String testName){
 		super(testName);
 	}
-
-	// ========= OPT-IN to run.javac mode: ===========
-	@Override
-	protected void setUp() throws Exception {
-		this.runJavacOptIn = true;
-		super.setUp();
- 	}
-	@Override
-	protected void tearDown() throws Exception {
-		super.tearDown();
-		this.runJavacOptIn = false; // do it last, so super can still clean up
-	}
-	// =================================================
 
 	public static Class<?> testClass() {
 		return ImplicitlyDeclaredClassesTest.class;

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/InnerEmulationTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/InnerEmulationTest.java
@@ -29,6 +29,7 @@ import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 import org.eclipse.jdt.internal.compiler.impl.JavaFeature;
 
 @SuppressWarnings({ "unchecked", "rawtypes" })
+@RunJavac
 public class InnerEmulationTest extends AbstractRegressionTest {
 static {
 //		TESTS_NAMES = new String[] { "Bug58069" };
@@ -39,19 +40,12 @@ public InnerEmulationTest(String name) {
 	super(name);
 }
 
-// ========= OPT-IN to run.javac mode: ===========
 @Override
 protected void setUp() throws Exception {
-	if (this.complianceLevel >= ClassFileConstants.JDK25)
-		this.runJavacOptIn = true;
 	super.setUp();
+	if (this.complianceLevel < ClassFileConstants.JDK25)
+		this.runJavacOptIn = false;
 }
-@Override
-protected void tearDown() throws Exception {
-	super.tearDown();
-	this.runJavacOptIn = false; // do it last, so super can still clean up
-}
-// =================================================
 
 @Override
 protected Map getCompilerOptions() {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/InterfaceMethodsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/InterfaceMethodsTest.java
@@ -29,6 +29,7 @@ import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 // See https://bugs.eclipse.org/380501
 // Bug 380501 - [1.8][compiler] Add support for default methods (JSR 335)
 @SuppressWarnings({ "unchecked", "rawtypes" })
+@RunJavac
 public class InterfaceMethodsTest extends AbstractComparableTest {
 
 // Static initializer to specify tests subset using TESTS_* static variables
@@ -57,19 +58,6 @@ public class InterfaceMethodsTest extends AbstractComparableTest {
 	public InterfaceMethodsTest(String name) {
 		super(name);
 	}
-
-	// ========= OPT-IN to run.javac mode: ===========
-	@Override
-	protected void setUp() throws Exception {
-		this.runJavacOptIn = true;
-		super.setUp();
-	}
-	@Override
-	protected void tearDown() throws Exception {
-		super.tearDown();
-		this.runJavacOptIn = false; // do it last, so super can still clean up
-	}
-	// =================================================
 
 	// default methods with various modifiers, positive cases
 	public void testModifiers1() {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavaNonLanguageTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/JavaNonLanguageTests.java
@@ -18,6 +18,7 @@ import org.eclipse.jdt.internal.compiler.batch.FileSystem;
 import org.eclipse.jdt.internal.compiler.env.INameEnvironment;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 
+@RunJavac
 public class JavaNonLanguageTests extends AbstractRegressionTest9 {
 
 	private static final JavacTestOptions JAVAC_OPTIONS = new JavacTestOptions("--enable-preview -source 25");
@@ -37,19 +38,6 @@ public class JavaNonLanguageTests extends AbstractRegressionTest9 {
 	public JavaNonLanguageTests(String testName) {
 		super(testName);
 	}
-
-	// ========= OPT-IN to run.javac mode: ===========
-	@Override
-	protected void setUp() throws Exception {
-		this.runJavacOptIn = true;
-		super.setUp();
-	}
-	@Override
-	protected void tearDown() throws Exception {
-		super.tearDown();
-		this.runJavacOptIn = false; // do it last, so super can still clean up
-	}
-	// =================================================
 
 	// Enables the tests to run individually
 	protected Map<String, String> getCompilerOptions(boolean preview) {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LocalEnumTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/LocalEnumTest.java
@@ -31,6 +31,7 @@ import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 
 @SuppressWarnings({ "unchecked", "rawtypes" })
+@RunJavac
 public class LocalEnumTest extends AbstractComparableTest {
 
 	String reportMissingJavadocComments = null;
@@ -73,24 +74,16 @@ public class LocalEnumTest extends AbstractComparableTest {
 		return options;
 	}
 
-	// ========= OPT-IN to run.javac mode: ===========
 	@Override
 	protected void setUp() throws Exception {
-		this.runJavacOptIn = true;
 		super.setUp();
 		this.reportMissingJavadocComments = null;
 	}
 	@Override
-	protected void tearDown() throws Exception {
-		super.tearDown();
-		this.runJavacOptIn = false; // do it last, so super can still clean up
-	}
-	// =================================================
-
-	@Override
 	protected void runConformTest(String[] testFiles) {
 		runConformTest(testFiles, "", getCompilerOptions());
 	}
+
 	@Override
 	protected void runConformTest(String[] testFiles, String expectedOutput) {
 		runConformTest(testFiles, expectedOutput, getCompilerOptions());

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ModuleImportTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/ModuleImportTests.java
@@ -22,6 +22,7 @@ import org.eclipse.jdt.core.util.ClassFileBytesDisassembler;
 import org.eclipse.jdt.core.util.ClassFormatException;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 
+@RunJavac
 public class ModuleImportTests extends AbstractModuleCompilationTest {
 
 	static {
@@ -33,19 +34,6 @@ public class ModuleImportTests extends AbstractModuleCompilationTest {
 	public ModuleImportTests(String name) {
 		super(name);
 	}
-
-	// ========= OPT-IN to run.javac mode: ===========
-	@Override
-	protected void setUp() throws Exception {
-		this.runJavacOptIn = true;
-		super.setUp();
-	}
-	@Override
-	protected void tearDown() throws Exception {
-		super.tearDown();
-		this.runJavacOptIn = false; // do it last, so super can still clean up
-	}
-	// =================================================
 
 	public static Test suite() {
 		return buildMinimalComplianceTestSuite(testClass(), F_23);

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PolymorphicSignatureTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PolymorphicSignatureTest.java
@@ -19,6 +19,7 @@ import org.eclipse.jdt.core.tests.compiler.regression.AbstractRegressionTest.Jav
 import org.eclipse.jdt.core.util.ClassFormatException;
 
 @SuppressWarnings({ "rawtypes" })
+@RunJavac
 public class PolymorphicSignatureTest extends AbstractRegressionTest {
 	static {
 //		TESTS_NAMES = new String[] { "testBug515863" };
@@ -26,19 +27,6 @@ public class PolymorphicSignatureTest extends AbstractRegressionTest {
 	public PolymorphicSignatureTest(String name) {
 		super(name);
 	}
-
-	// ========= OPT-IN to run.javac mode: ===========
-	@Override
-	protected void setUp() throws Exception {
-		this.runJavacOptIn = true;
-		super.setUp();
-	}
-	@Override
-	protected void tearDown() throws Exception {
-		super.tearDown();
-		this.runJavacOptIn = false; // do it last, so super can still clean up
-	}
-	// =================================================
 
 	public static Test suite() {
 		return buildMinimalComplianceTestSuite(testClass(), FIRST_SUPPORTED_JAVA_VERSION);

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PreviewFlagTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PreviewFlagTest.java
@@ -23,6 +23,7 @@ import org.eclipse.jdt.internal.compiler.env.INameEnvironment;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 
 @PreviewTest
+@RunJavac
 public class PreviewFlagTest extends AbstractRegressionTest9 {
 
 	private static final JavacTestOptions JAVAC_OPTIONS = new JavacTestOptions("--enable-preview -source 26");
@@ -43,19 +44,6 @@ public class PreviewFlagTest extends AbstractRegressionTest9 {
 	public PreviewFlagTest(String testName) {
 		super(testName);
 	}
-
-	// ========= OPT-IN to run.javac mode: ===========
-	@Override
-	protected void setUp() throws Exception {
-		this.runJavacOptIn = true;
-		super.setUp();
-	}
-	@Override
-	protected void tearDown() throws Exception {
-		super.tearDown();
-		this.runJavacOptIn = false; // do it last, so super can still clean up
-	}
-	// =================================================
 
 	// Enables the tests to run individually
 	protected Map<String, String> getCompilerOptions(boolean preview) {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PrimitiveInPatternsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PrimitiveInPatternsTest.java
@@ -23,6 +23,7 @@ import org.eclipse.jdt.internal.compiler.env.INameEnvironment;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 
 @PreviewTest
+@RunJavac
 public class PrimitiveInPatternsTest extends AbstractRegressionTest9 {
 
 	private static final JavacTestOptions JAVAC_OPTIONS = new JavacTestOptions("--enable-preview -source 26");
@@ -42,19 +43,6 @@ public class PrimitiveInPatternsTest extends AbstractRegressionTest9 {
 	public PrimitiveInPatternsTest(String testName) {
 		super(testName);
 	}
-
-	// ========= OPT-IN to run.javac mode: ===========
-	@Override
-	protected void setUp() throws Exception {
-		this.runJavacOptIn = true;
-		super.setUp();
-	}
-	@Override
-	protected void tearDown() throws Exception {
-		super.tearDown();
-		this.runJavacOptIn = false; // do it last, so super can still clean up
-	}
-	// =================================================
 
 	// Enables the tests to run individually
 	protected Map<String, String> getCompilerOptions(boolean preview) {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PrimitiveInPatternsTestSH.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/PrimitiveInPatternsTestSH.java
@@ -24,6 +24,7 @@ import org.eclipse.jdt.internal.compiler.env.INameEnvironment;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 
 @PreviewTest
+@RunJavac
 public class PrimitiveInPatternsTestSH extends AbstractRegressionTest9 {
 
 	private static final JavacTestOptions JAVAC_OPTIONS = new JavacTestOptions("--enable-preview -source 26 -Xlint:-preview");
@@ -87,19 +88,6 @@ public class PrimitiveInPatternsTestSH extends AbstractRegressionTest9 {
 	public PrimitiveInPatternsTestSH(String testName) {
 		super(testName);
 	}
-
-	// ========= OPT-IN to run.javac mode: ===========
-	@Override
-	protected void setUp() throws Exception {
-		this.runJavacOptIn = true;
-		super.setUp();
-	}
-	@Override
-	protected void tearDown() throws Exception {
-		super.tearDown();
-		this.runJavacOptIn = false; // do it last, so super can still clean up
-	}
-	// =================================================
 
 	// Enables the tests to run individually
 	protected Map<String, String> getCompilerOptions(boolean preview) {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RunJavac.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/RunJavac.java
@@ -13,21 +13,10 @@
  *******************************************************************************/
 package org.eclipse.jdt.core.tests.compiler.regression;
 
-import junit.framework.Test;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 
-/**
- * This test class exists for the sole purpose of printing statistics about tests run as comparison of ecj vs javac.
- * It is be integrated in {@link TestAll} as the very last test in the suite.
- */
-@RunJavac
-public class PrintRunJavacStats extends AbstractRegressionTest {
-	public PrintRunJavacStats(String name) {
-		super(name);
-	}
-	public static Test suite() {
-		return buildMinimalComplianceTestSuite(PrintRunJavacStats.class, FIRST_SUPPORTED_JAVA_VERSION);
-	}
-	public void testPrint() {
-		printRunJavacStats();
-	}
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RunJavac {
+
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SealedTypesTests.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SealedTypesTests.java
@@ -26,6 +26,7 @@ import org.eclipse.jdt.core.util.ClassFormatException;
 import org.eclipse.jdt.internal.compiler.classfmt.ClassFileConstants;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 
+@RunJavac
 public class SealedTypesTests extends AbstractRegressionTest9 {
 
 	static {
@@ -43,19 +44,6 @@ public class SealedTypesTests extends AbstractRegressionTest9 {
 	public SealedTypesTests(String testName){
 		super(testName);
 	}
-
-	// ========= OPT-IN to run.javac mode: ===========
-	@Override
-	protected void setUp() throws Exception {
-		this.runJavacOptIn = true;
-		super.setUp();
-	}
-	@Override
-	protected void tearDown() throws Exception {
-		super.tearDown();
-		this.runJavacOptIn = false; // do it last, so super can still clean up
-	}
-	// =================================================
 
 	// Enables the tests to run individually
 	protected Map<String, String> getCompilerOptions() {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SuperAfterStatementsTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/SuperAfterStatementsTest.java
@@ -22,6 +22,7 @@ import org.eclipse.jdt.internal.compiler.batch.FileSystem;
 import org.eclipse.jdt.internal.compiler.env.INameEnvironment;
 import org.eclipse.jdt.internal.compiler.impl.CompilerOptions;
 
+@RunJavac
 public class SuperAfterStatementsTest extends AbstractRegressionTest9 {
 
 	static {
@@ -40,19 +41,6 @@ public class SuperAfterStatementsTest extends AbstractRegressionTest9 {
 	public SuperAfterStatementsTest(String testName) {
 		super(testName);
 	}
-
-	// ========= OPT-IN to run.javac mode: ===========
-	@Override
-	protected void setUp() throws Exception {
-		this.runJavacOptIn = true;
-		super.setUp();
-	}
-	@Override
-	protected void tearDown() throws Exception {
-		super.tearDown();
-		this.runJavacOptIn = false; // do it last, so super can still clean up
-	}
-	// =================================================
 
 	// Enables the tests to run individually
 	protected Map<String, String> getCompilerOptions(boolean preview) {

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TestAllRunJavac.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/TestAllRunJavac.java
@@ -14,20 +14,16 @@
 package org.eclipse.jdt.core.tests.compiler.regression;
 
 import junit.framework.Test;
+import org.eclipse.jdt.core.tests.util.AbstractCompilerTest;
 
-/**
- * This test class exists for the sole purpose of printing statistics about tests run as comparison of ecj vs javac.
- * It is be integrated in {@link TestAll} as the very last test in the suite.
- */
-@RunJavac
-public class PrintRunJavacStats extends AbstractRegressionTest {
-	public PrintRunJavacStats(String name) {
-		super(name);
+public class TestAllRunJavac extends TestAll {
+
+	public TestAllRunJavac(String testName) {
+		super(testName);
 	}
+
 	public static Test suite() {
-		return buildMinimalComplianceTestSuite(PrintRunJavacStats.class, FIRST_SUPPORTED_JAVA_VERSION);
-	}
-	public void testPrint() {
-		printRunJavacStats();
+		AbstractCompilerTest.testClassFilter = c -> c.getAnnotation(RunJavac.class) != null;
+		return TestAll.suite();
 	}
 }

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/util/AbstractCompilerTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/util/AbstractCompilerTest.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 import junit.framework.Test;
 import junit.framework.TestSuite;
 import org.eclipse.core.runtime.IPath;
@@ -90,6 +91,8 @@ public class AbstractCompilerTest extends TestCase {
 	protected static boolean isJRE25Plus = false;
 	protected static boolean isJRE26Plus = false;
 	protected static boolean reflectNestedClassUseDollar;
+
+	public static Predicate<Class<?>> testClassFilter;
 
 	public static int[][] complianceTestLevelMapping = new int[][] {
 		new int[] {F_1_8, ClassFileConstants.MAJOR_VERSION_1_8},
@@ -186,6 +189,9 @@ public class AbstractCompilerTest extends TestCase {
 	 * @return built test suite (see {@link TestSuite}
 	 */
 	private static Test buildComplianceTestSuite(List testClasses, Class setupClass, long complianceLevel) {
+		if (testClassFilter != null) {
+			testClasses = testClasses.stream().filter(testClassFilter).toList();
+		}
 		// call the setup constructor with the compliance level
 		TestSuite complianceSuite = null;
 		try {


### PR DESCRIPTION
Change implementation of mode run.javac=optIn: use an annotation

Provide special suite TestAllRunJavac that invokes only optIn tests.
