### PR TITLE
Defer boundcheck for CaptureBinding18 until all are initialized

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/InferenceContext18.java
@@ -1384,6 +1384,10 @@ public class InferenceContext18 {
 				tmpBoundSet.addBound(new TypeBound(variable, yj, ReductionResult.SAME), this.environment);
 			toResolveSet.remove(variable);
 		}
+		for (CaptureBinding18 yj : ys) {
+			if (yj != null && !checkUpperVsLowerBounds(yj))
+				return false;
+		}
 		return true;
 	}
 
@@ -1431,16 +1435,20 @@ public class InferenceContext18 {
 			TypeBinding[] glbs = Scope.greaterLowerBound(substitutedUpperBounds, this.scope, this.environment);
 			if (glbs == null)
 				return false;
-			if (typeVariable.lowerBound != null) {
-				for (TypeBinding glb : glbs) {
-					if (!typeVariable.lowerBound.isCompatibleWith(glb))
-						return false; // not well-formed
-				}
-			}
 			// for deterministic results sort this array by id:
 			sortTypes(glbs);
 			if (!typeVariable.setUpperBounds(glbs, this.object))
 				return false;
+		}
+		return true;
+	}
+
+	boolean checkUpperVsLowerBounds(CaptureBinding18 typeVariable) {
+		if (typeVariable.lowerBound != null) {
+			for (TypeBinding upper : typeVariable.upperBounds) {
+				if (!typeVariable.lowerBound.isCompatibleWith(upper))
+					return false; // not well-formed
+			}
 		}
 		return true;
 	}


### PR DESCRIPTION
I detected a potential problem when experimenting with `BoundSet.captures` and `.allCaptures`, trying to eliminate our extra-constitutional inventions (like removing such bounds during incorporate): 

In that experiment `GenericsRegressionTest_9.testGH4984()` failed during `IC18.setUpperBounds()` :
* `typeVariable` = `<Y#0-T#0>`
* `glbs[0]` = `String`
* `glbs[1]` = `<Y#1-(? super T#0)#2>`

At the time of checking `typeVariable.lowerBound.isCompatibleWith(glb)` CaptureBinding18 `<Y#1-(? super T#0)#2>` was not yet initialized, causing a `false` from that check.

By deferring those compatibility checks until all fresh CaptureBinding18 have been initialized, a lower bound of `<Y#1-(? super T#0)#2>` asserts compatibility.

I am not aware of any examples where this change alone influences the outcome, but it may take some pressure from our tweaks regarding `captures` / `allCaptures`.