### PR TITLE
Fix formatter crash for empty leading region

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/RunFormatterTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/RunFormatterTests.java
@@ -63,6 +63,7 @@ public class RunFormatterTests extends junit.framework.TestCase {
 		if (type == null || !type.equals("javadoc")) {
 			allClasses.add(FormatterRegressionTests.class);
 			allClasses.add(FormatterBugsTests.class);
+			allClasses.add(FormatterRegionTests.class);
 		}
 		allClasses.add(CommentsTestSuite.class);
 		allClasses.add(FormatterJSR335Tests.class);

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/formatter/FormatterRegionTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/formatter/FormatterRegionTests.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Carsten Hammer and others.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Carsten Hammer - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.jdt.core.tests.formatter;
+
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+import org.eclipse.jdt.core.formatter.CodeFormatter;
+import org.eclipse.jdt.internal.formatter.DefaultCodeFormatter;
+import org.eclipse.jface.text.IRegion;
+import org.eclipse.jface.text.Region;
+import org.eclipse.text.edits.TextEdit;
+
+public class FormatterRegionTests extends TestCase {
+
+	public static Test suite() {
+		return new TestSuite(FormatterRegionTests.class);
+	}
+
+	public FormatterRegionTests(String name) {
+		super(name);
+	}
+
+	/**
+	 * Regression test for https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2499.
+	 * <p>
+	 * A zero-length changed line at the start of the document followed by another changed
+	 * region used to make the formatter pass {@code -1} to
+	 * {@code TokenManager.countLineBreaksBetween()}.
+	 */
+	public void testEmptyFirstRegionAtDocumentStart() {
+		String source = "\nclass A {\n\tvoid foo() {\n\t}\n}\n";
+		IRegion[] regions = {
+				new Region(0, 0),
+				new Region(1, source.length() - 1)
+		};
+
+		TextEdit edit = new DefaultCodeFormatter().format(CodeFormatter.K_COMPILATION_UNIT, source, regions, 0, "\n");
+
+		assertNotNull(edit);
+	}
+}

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/formatter/FormatterRegionTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/formatter/FormatterRegionTests.java
@@ -17,6 +17,7 @@ import junit.framework.Test;
 import junit.framework.TestCase;
 import junit.framework.TestSuite;
 import org.eclipse.jdt.core.formatter.CodeFormatter;
+import org.eclipse.jdt.core.formatter.DefaultCodeFormatterConstants;
 import org.eclipse.jdt.internal.formatter.DefaultCodeFormatter;
 import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.IRegion;
@@ -41,40 +42,50 @@ public class FormatterRegionTests extends TestCase {
 	 * {@code TokenManager.countLineBreaksBetween()}.
 	 */
 	public void testEmptyFirstRegionAtDocumentStart() throws Exception {
-		String source = "\nclass A {\n\tvoid foo() {\n\t}\n}\n";
-		assertEmptyLeadingRegionIsNeutral(source, 1, "\n");
+		assertEmptyLeadingRegionIsNeutral("\n");
 	}
 
 	public void testEmptyFirstRegionAtDocumentStartWithCrLf() throws Exception {
-		String source = "\r\nclass A {\r\n\tvoid foo() {\r\n\t}\r\n}\r\n";
-		assertEmptyLeadingRegionIsNeutral(source, 2, "\r\n");
+		assertEmptyLeadingRegionIsNeutral("\r\n");
 	}
 
 	public void testSingleEmptyRegionAtDocumentStartDoesNotChangeSource() throws Exception {
-		String source = "\nclass A {\n\tvoid foo() {\n\t}\n}\n";
+		String source = "\nclass A{void foo(){int x=1;}}\n";
 
 		assertEquals(source, formatAndApply(source, new IRegion[] { new Region(0, 0) }, "\n"));
 	}
 
 	public void testSingleEmptyRegionAfterDocumentStartDoesNotChangeSource() throws Exception {
-		String source = "class A {\n\tvoid foo() {\n\t}\n}\n";
+		String source = "class A{void foo(){int x=1;}}\n";
 		int offset = source.indexOf("void");
 
 		assertTrue(offset > 0);
 		assertEquals(source, formatAndApply(source, new IRegion[] { new Region(offset, 0) }, "\n"));
 	}
 
-	private void assertEmptyLeadingRegionIsNeutral(String source, int nextRegionOffset, String lineSeparator) throws Exception {
-		IRegion followingRegion = new Region(nextRegionOffset, source.length() - nextRegionOffset);
-		String expected = formatAndApply(source, new IRegion[] { followingRegion }, lineSeparator);
-		String actual = formatAndApply(source, new IRegion[] { new Region(0, 0), followingRegion }, lineSeparator);
+	private void assertEmptyLeadingRegionIsNeutral(String lineSeparator) throws Exception {
+		String source = lineSeparator + "class A{void foo(){int x=1;}}" + lineSeparator;
+		String expected = lineSeparator
+				+ "class A {" + lineSeparator
+				+ "\tvoid foo() {" + lineSeparator
+				+ "\t\tint x = 1;" + lineSeparator
+				+ "\t}" + lineSeparator
+				+ "}" + lineSeparator;
+		IRegion followingRegion = new Region(lineSeparator.length(), source.length() - lineSeparator.length());
+		String withoutEmptyRegion = formatAndApply(source, new IRegion[] { followingRegion }, lineSeparator);
 
-		assertEquals(expected, actual);
-		assertTrue(actual.startsWith(lineSeparator));
+		assertEquals("The nonempty region must be formatted", expected, withoutEmptyRegion);
+		assertFalse("The fixture must require formatting", source.equals(withoutEmptyRegion));
+		String withEmptyRegion = formatAndApply(source,
+				new IRegion[] { new Region(0, 0), followingRegion }, lineSeparator);
+
+		assertEquals(expected, withEmptyRegion);
+		assertEquals(withoutEmptyRegion, withEmptyRegion);
 	}
 
 	private String formatAndApply(String source, IRegion[] regions, String lineSeparator) throws Exception {
-		TextEdit edit = new DefaultCodeFormatter().format(CodeFormatter.K_COMPILATION_UNIT, source, regions, 0, lineSeparator);
+		DefaultCodeFormatter formatter = new DefaultCodeFormatter(DefaultCodeFormatterConstants.getEclipseDefaultSettings());
+		TextEdit edit = formatter.format(CodeFormatter.K_COMPILATION_UNIT, source, regions, 0, lineSeparator);
 		assertNotNull(edit);
 		Document document = new Document(source);
 		edit.apply(document);

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/formatter/FormatterRegionTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/formatter/FormatterRegionTests.java
@@ -18,6 +18,7 @@ import junit.framework.TestCase;
 import junit.framework.TestSuite;
 import org.eclipse.jdt.core.formatter.CodeFormatter;
 import org.eclipse.jdt.internal.formatter.DefaultCodeFormatter;
+import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.Region;
 import org.eclipse.text.edits.TextEdit;
@@ -39,15 +40,44 @@ public class FormatterRegionTests extends TestCase {
 	 * region used to make the formatter pass {@code -1} to
 	 * {@code TokenManager.countLineBreaksBetween()}.
 	 */
-	public void testEmptyFirstRegionAtDocumentStart() {
+	public void testEmptyFirstRegionAtDocumentStart() throws Exception {
 		String source = "\nclass A {\n\tvoid foo() {\n\t}\n}\n";
-		IRegion[] regions = {
-				new Region(0, 0),
-				new Region(1, source.length() - 1)
-		};
+		assertEmptyLeadingRegionIsNeutral(source, 1, "\n");
+	}
 
-		TextEdit edit = new DefaultCodeFormatter().format(CodeFormatter.K_COMPILATION_UNIT, source, regions, 0, "\n");
+	public void testEmptyFirstRegionAtDocumentStartWithCrLf() throws Exception {
+		String source = "\r\nclass A {\r\n\tvoid foo() {\r\n\t}\r\n}\r\n";
+		assertEmptyLeadingRegionIsNeutral(source, 2, "\r\n");
+	}
 
+	public void testSingleEmptyRegionAtDocumentStartDoesNotChangeSource() throws Exception {
+		String source = "\nclass A {\n\tvoid foo() {\n\t}\n}\n";
+
+		assertEquals(source, formatAndApply(source, new IRegion[] { new Region(0, 0) }, "\n"));
+	}
+
+	public void testSingleEmptyRegionAfterDocumentStartDoesNotChangeSource() throws Exception {
+		String source = "class A {\n\tvoid foo() {\n\t}\n}\n";
+		int offset = source.indexOf("void");
+
+		assertTrue(offset > 0);
+		assertEquals(source, formatAndApply(source, new IRegion[] { new Region(offset, 0) }, "\n"));
+	}
+
+	private void assertEmptyLeadingRegionIsNeutral(String source, int nextRegionOffset, String lineSeparator) throws Exception {
+		IRegion followingRegion = new Region(nextRegionOffset, source.length() - nextRegionOffset);
+		String expected = formatAndApply(source, new IRegion[] { followingRegion }, lineSeparator);
+		String actual = formatAndApply(source, new IRegion[] { new Region(0, 0), followingRegion }, lineSeparator);
+
+		assertEquals(expected, actual);
+		assertTrue(actual.startsWith(lineSeparator));
+	}
+
+	private String formatAndApply(String source, IRegion[] regions, String lineSeparator) throws Exception {
+		TextEdit edit = new DefaultCodeFormatter().format(CodeFormatter.K_COMPILATION_UNIT, source, regions, 0, lineSeparator);
 		assertNotNull(edit);
+		Document document = new Document(source);
+		edit.apply(document);
+		return document.get();
 	}
 }

--- a/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/linewrap/WrapPreparator.java
+++ b/org.eclipse.jdt.core/formatter/org/eclipse/jdt/internal/formatter/linewrap/WrapPreparator.java
@@ -1479,7 +1479,7 @@ public class WrapPreparator extends ASTVisitor {
 					next.breakBefore();
 				token = next;
 			}
-			previousRegionEnd = region.getOffset() + region.getLength() - 1;
+			previousRegionEnd = Math.max(0, region.getOffset() + region.getLength() - 1);
 		}
 	}
 


### PR DESCRIPTION
## What it does

Fixes a formatter crash when partial formatting contains a zero-length first region at document offset `0` followed by another formatting region.

This matches the failure reported for the JDT UI **Format edited lines** save action in:

- https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5412
- https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2598

Both reports fail with:

```text
StringIndexOutOfBoundsException: Index -1
    at TokenManager.countLineBreaksBetween(...)
    at WrapPreparator.applyBreaksOutsideRegions(...)
```

### Root cause

A zero-length region is valid input to the regional `CodeFormatter` API. It can also arise naturally from JDT UI's changed-line calculation: for a single changed line, `EditorUtility.calculateChangedLineRegions()` uses the document's line information directly, and an empty first line can therefore result in:

```java
new Region(0, 0)
```

`WrapPreparator.applyBreaksOutsideRegions()` converts each region to an inclusive end position using:

```java
previousRegionEnd = region.getOffset() + region.getLength() - 1;
```

For `Region(0, 0)` this produces `-1`.

If another formatting region follows, that value is subsequently passed to `TokenManager.countLineBreaksBetween()`, which eventually evaluates `source.charAt(-1)` and produces the exception reported in eclipse-jdt/eclipse.jdt.core#5412 and eclipse-jdt/eclipse.jdt.ui#2598.

The fix prevents `WrapPreparator` from creating a position before the beginning of the source:

```java
previousRegionEnd = Math.max(0, region.getOffset() + region.getLength() - 1);
```

For normal regions the result is unchanged. A zero-length region at an offset greater than zero also keeps the previous behavior. Only the boundary case `(0, 0)`, which would otherwise produce `-1`, changes.

The check is deliberately applied where the invalid internal position is created instead of adding generic bounds handling to `TokenManager`, which could hide unrelated formatter bugs.

### Why this is a Core fix

The original reports occur through the JDT UI save participant, but the failure can be reproduced directly through `DefaultCodeFormatter` with input accepted by the formatter API.

Therefore a UI race condition is not required to trigger the reported exception.

This is relevant to https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/2778, which proposed a broader UI-side `DocumentDirtyTracker` solution based on the hypothesis that changed regions become stale. The deterministic Core reproducer shows that the same `Index -1` can be produced by the formatter itself from a zero-length leading region.

### Related issues

Directly related:

- https://github.com/eclipse-jdt/eclipse.jdt.core/issues/5412 — original Eclipse 4.37 report
- https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/2598 — same `Index -1` and the same `TokenManager` / `WrapPreparator` stack on Eclipse 4.38
- https://github.com/eclipse-jdt/eclipse.jdt.ui/pull/2778 — earlier UI-side attempt to fix eclipse-jdt/eclipse.jdt.core#5412

Related to the same **Format edited lines** / partial-formatting area, but not claimed to be fixed by this PR:

- https://github.com/eclipse-jdt/eclipse.jdt.core/issues/4470
- https://github.com/eclipse-jdt/eclipse.jdt.core/issues/1020
- https://bugs.eclipse.org/bugs/show_bug.cgi?id=201063
- https://bugs.eclipse.org/bugs/show_bug.cgi?id=234583
- https://bugs.eclipse.org/bugs/show_bug.cgi?id=237453
- https://bugs.eclipse.org/bugs/show_bug.cgi?id=280255
- https://bugs.eclipse.org/bugs/show_bug.cgi?id=560889
- https://bugs.eclipse.org/bugs/show_bug.cgi?id=563487

These are included as historical/contextual references only because they concern the same partial-formatting infrastructure or `Format edited lines` behavior. They report different symptoms and may have different root causes.

## How to test

The added `FormatterRegionTests.testEmptyFirstRegionAtDocumentStart()` exercises the problematic boundary directly:

```java
IRegion[] regions = {
    new Region(0, 0),
    new Region(1, source.length() - 1)
};
```

Without the fix, processing the first region makes `previousRegionEnd == -1`, and processing the following region fails in `TokenManager.countLineBreaksBetween()`.

With the fix, the formatter completes normally and returns a `TextEdit`.

The regression test exercises the Core formatter directly so the failure is deterministic and independent of the UI save-participant lifecycle.

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
