### PR TITLE
Fix name resolution when a type parameter shadows a inherited type

### DIFF
--- a/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Scope.java
+++ b/org.eclipse.jdt.core.compiler.batch/src/org/eclipse/jdt/internal/compiler/lookup/Scope.java
@@ -3422,6 +3422,18 @@ public abstract class Scope {
 						if (!insideTypeAnnotation) {
 							// 6.5.5.1 - member types have precedence over top-level type in same unit
 							ReferenceBinding memberType = findMemberType(name, sourceType);
+							if (memberType != null
+									&& !(memberType.isValidBinding() && TypeBinding.equalsEquals(memberType.enclosingType(), sourceType))) {
+								// A type variable shadows an inherited member type of the same name,
+								// while a member type declared by the class itself takes precedence over
+								// the type variable. According to JDK-8193583.
+								TypeVariableBinding typeVariable = sourceType.getTypeVariable(name);
+								if (typeVariable != null) {
+									if (insideStaticContext)
+										return new ProblemReferenceBinding(new char[][]{name}, typeVariable, ProblemReasons.NonStaticReferenceInStaticContext);
+									return typeVariable;
+								}
+							}
 							if (memberType != null) { // skip it if we did not find anything
 								if (memberType.problemId() == ProblemReasons.Ambiguous) {
 									if (foundType == null || foundType.problemId() == ProblemReasons.NotVisible)

--- a/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericTypeTest.java
+++ b/org.eclipse.jdt.core.tests.compiler/src/org/eclipse/jdt/core/tests/compiler/regression/GenericTypeTest.java
@@ -50243,6 +50243,35 @@ public void testBugBug571785_001() {
 		});
 }
 
+// https://github.com/redhat-developer/vscode-java/issues/3816
+public void testTypeVariableShadowsInheritedMemberType() {
+	this.runConformTest(
+		new String[] {
+			"X.java",
+			"interface BinaryExpr {\n" +
+			"	interface Op { }\n" +
+			"	Op getOperator();\n" +
+			"}\n" +
+			"abstract class AbstractBinaryExpr<Op extends BinaryExpr.Op> implements BinaryExpr {\n" +
+			"	private final Op op;\n" +
+			"	public AbstractBinaryExpr(Op op) { this.op = op; }\n" +
+			"	@Override public Op getOperator() { return this.op; }\n" +
+			"}\n" +
+			"final class ArithExpr extends AbstractBinaryExpr<ArithExpr.Op> {\n" +
+			"	enum Op implements BinaryExpr.Op { ADD, SUB }\n" +
+			"	public ArithExpr(Op op) { super(op); }\n" +
+			"}\n" +
+			"public class X {\n" +
+			"	public static void main(String[] args) {\n" +
+			"		ArithExpr e = new ArithExpr(ArithExpr.Op.ADD);\n" +
+			"		ArithExpr.Op o = e.getOperator();\n" + // must be substituted to ArithExpr.Op, not resolved to BinaryExpr.Op
+			"		System.out.print(o == ArithExpr.Op.ADD ? \"SUCCESS\" : \"FAIL\");\n" +
+			"	}\n" +
+			"}\n"
+		},
+		"SUCCESS");
+}
+
 protected void assertCompileTimes(final List<Duration> shortTimes, final double factor, final List<Duration> longTimes) {
 	final double shortTimesAverage = minExcludingBoundaries(shortTimes);
 	final double longTimesAverage = minExcludingBoundaries(longTimes);


### PR DESCRIPTION

Closes #5384.

## The problem

For code like

```java
interface BinaryExpr {
    interface Op { }
    Op getOperator();
}

abstract class AbstractBinaryExpr<Op extends BinaryExpr.Op> implements BinaryExpr {
    @Override
    public Op getOperator() { ... }
}
```

ECJ resolves the simple name `Op` inside the body of `AbstractBinaryExpr` to the **inherited** member type `BinaryExpr.Op` instead of the class's own **type parameter** `Op`. Downstream this surfaces as bogus diagnostics on valid code, e.g. in

```java
switch (e.getOperator()) {   // e is ArithExpr extends AbstractBinaryExpr<ArithExpr.Op>
    case ADD -> "+" ...
```

ECJ reports *"A switch expression should have a default case"* and *"ADD cannot be resolved to a variable"*, because the selector type was resolved to the interface `BinaryExpr.Op` instead of the enum `ArithExpr.Op`. javac compiles and runs the same code.

## Root cause

The function that JDT uses to classify a simple name used as a type is `Scope.getTypeOrPackage()`. In its `CLASS_SCOPE` branch it first calls `findMemberType(name, sourceType)`, which searches member types declared by the class as well as those inherited from all supertypes, and only afterwards consults `sourceType.getTypeVariable(name)`. As a result, an inherited member type always takes precedence over a type variable of the class.

## Why this contradicts the language

Both `BinaryExpr.Op` (via inheritance) and the type parameter `Op` are type declarations whose scopes ([JLS §6.3](https://docs.oracle.com/javase/specs/jls/se8/html/jls-6.html#jls-6.3)) cover the class body, so [§6.5.5.1](https://docs.oracle.com/javase/specs/jls/se8/html/jls-6.html#jls-6.5.5.1) ("exactly one declaration … in scope") must be resolved via shadowing ([§6.4.1](https://docs.oracle.com/javase/specs/jls/se8/html/jls-6.html#jls-6.4.1)). However, [§6.4.1](https://docs.oracle.com/javase/specs/jls/se8/html/jls-6.html#jls-6.4.1) does not explicitly define the shadowing precedence between type parameters and inherited types.

The de-facto normative semantics is the reference compiler. The javac side repeatedly dealt with this class of shadowing questions:

- [JDK-5060485](https://bugs.java.com/bugdatabase/JDK-5060485): scope of a class type parameter vs. surrounding type declarations
- [JDK-7118412](https://bugs.java.com/bugdatabase/JDK-7118412): scope of a class type parameter vs. surrounding type declarations
- [JDK-8035259](https://bugs.java.com/bugdatabase/JDK-8035259): member class of an enclosing class vs. type parameter
- [JDK-8193583](https://bugs.java.com/bugdatabase/JDK-8193583): member type inherited from a supertype vs. type parameter

These efforts converged on a precedence order, pinned down by the regression test [`ShadowingTest.java`](https://github.com/openjdk/jdk/blob/master/test/langtools/tools/javac/7118412/ShadowingTest.java) and implemented in [`Resolve.java`](https://github.com/openjdk/jdk/blob/master/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java#L2400): in `findType` (LOC 2400), each class environment first collects the type variable via `tyvar = findTypeVar(...)` (LOC 2408) and looks up only member types **declared by that very class** via `sym = findImmediateMemberType(...)` (LOC 2410). If `tyvar` exists but `sym` does not exist, the `sym == typeNotFound` guards (LOC 2416) fire and the type variable `tyvar` is returned, otherwise if `sym` exists, `sym` is returned. Only when **both** `tyvar` and `sym` are absent does resolution fall through to `findInheritedMemberType` (LOC 2425), which walks the supertype hierarchy. `findType` applies these steps at every enclosing class level of the scope chain, and only after all enclosing class scopes are exhausted does it fall back to the compilation-unit scope. I.e. javac's full order is:

`member type declared by the class itself  >  type variable of the class  >  member type inherited by the class  >  (the same triplet applied to each enclosing class, innermost first)  >  top-level types and imports visible at the compilation-unit scope`

ECJ's current behaviour inverts the `type variable of the class  >  member type inherited by the class` part of this order.

## The fix

In `Scope.getTypeOrPackage`, right after

```java
ReferenceBinding memberType = findMemberType(name, sourceType);
```

we now check whether the hit is a member type declared by this class (`memberType.isValidBinding() && TypeBinding.equalsEquals(memberType.enclosingType(), sourceType)`). Only then is it allowed to precede a type variable. Otherwise we look up the class's type variable first and return it if present; if there is no type variable, the original code path runs unchanged. This replicates javac's precedence.