### PR TITLE
Fix CCE in MatchLocator when OrPattern contains non-VariablePattern

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchBugs15Tests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JavaSearchBugs15Tests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c)  2020, 2022 IBM Corporation and others.
+ * Copyright (c)  2020, 2026 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -1773,4 +1773,33 @@ public class JavaSearchBugs15Tests extends AbstractJavaSearchTests {
 					elements
 				);
 			}
+
+
+	// https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/3141
+	public void testGH3141() throws CoreException {
+		this.workingCopies = new ICompilationUnit[1];
+		this.workingCopies[0] = getWorkingCopy(
+			"/JavaSearchBugs/src/gh3141/Point.java",
+			"package gh3141;\n" +
+			"record Point(int x, int y) {\n" +
+			"	static int count = 15;\n" +
+			"}\n" +
+			"class T1 {\n" +
+			"	public static void main(String[] args) {\n" +
+			"		Point.count++;\n" +
+			"		System.out.println(Point.count);\n" +
+			"	}\n" +
+			"}\n"
+		);
+		IType type = this.workingCopies[0].getType("Point");
+		IField field = type.getField("count");
+		this.resultCollector.showAccess();
+		this.resultCollector.showAccuracy(false);
+		search(field, ALL_OCCURRENCES, EXACT_RULE, getJavaSearchWorkingCopiesScope(), this.resultCollector);
+		assertSearchResults(
+			"src/gh3141/Point.java gh3141.Point.count [count]\n" +
+			"src/gh3141/Point.java void gh3141.T1.main(String[]) [count] READ/WRITE ACCESS\n" +
+			"src/gh3141/Point.java void gh3141.T1.main(String[]) [count] READ ACCESS"
+		);
+	}
 }

--- a/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/MatchLocator.java
+++ b/org.eclipse.jdt.core/search/org/eclipse/jdt/internal/core/search/matching/MatchLocator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2025 IBM Corporation and others.
+ * Copyright (c) 2000, 2026 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -1801,9 +1801,11 @@ public FieldReferenceMatch newFieldReferenceMatch(
 			if (this.pattern instanceof OrPattern) {
 				SearchPattern[] patterns = ((OrPattern) this.pattern).patterns;
 				for (SearchPattern p : patterns) {
-					if (!this.patternLocator.matchesName(((VariablePattern)p).name, lastToken)) {
-			        	isWriteAccess = false;
-			        	isReadAccess = true;
+					if(p instanceof VariablePattern variablePattern) {
+						if (!this.patternLocator.matchesName(variablePattern.name, lastToken)) {
+				        	isWriteAccess = false;
+				        	isReadAccess = true;
+						}
 					}
 				}
 			} else if (!this.patternLocator.matchesName(((VariablePattern)this.pattern).name, lastToken)) {


### PR DESCRIPTION
Guard cast to VariablePattern with instanceof to avoid CCE when OrPattern contains a MethodPattern

Fixes : https://github.com/eclipse-jdt/eclipse.jdt.ui/issues/3141


With fix 
<img width="1080" height="810" alt="fix" src="https://github.com/user-attachments/assets/b7d58388-1ab8-4100-a189-bd11e3e635d1" />

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
