### PR TITLE
Avoid delayed snapshot waits when jobs are scheduled after wakeUp

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AbstractJavaModelTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AbstractJavaModelTests.java
@@ -4157,8 +4157,7 @@ public abstract class AbstractJavaModelTests extends SuiteOfTestCases {
 		boolean wasInterrupted = false;
 		do {
 			try {
-				Job.getJobManager().wakeUp(ResourcesPlugin.FAMILY_SNAPSHOT);
-				Job.getJobManager().join(ResourcesPlugin.FAMILY_SNAPSHOT, null);
+				JobFamilyWait.join(Job.getJobManager(), ResourcesPlugin.FAMILY_SNAPSHOT);
 				wasInterrupted = false;
 			} catch (OperationCanceledException e) {
 				e.printStackTrace();

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AllJavaModelTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AllJavaModelTests.java
@@ -39,6 +39,9 @@ private static Class[] getAllTestClasses() {
 
 		// Enter each test here, grouping the tests that are related
 
+		// Test infrastructure
+		JobFamilyWaitTests.class,
+
 		// Binding key tests
 		BindingKeyTests.class,
 

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JobFamilyWait.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JobFamilyWait.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jdt.core.tests.model;
+
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.OperationCanceledException;
+import org.eclipse.core.runtime.jobs.IJobManager;
+
+/** Waits for a job family without retaining delays introduced after wakeUp(). */
+final class JobFamilyWait {
+	private static final long WAKE_UP_INTERVAL_NANOS = TimeUnit.SECONDS.toNanos(1);
+
+	private JobFamilyWait() {
+		// Not instantiable.
+	}
+
+	static void join(IJobManager manager, Object family) throws InterruptedException {
+		while (true) {
+			manager.wakeUp(family);
+			RetryMonitor monitor = new RetryMonitor();
+			try {
+				manager.join(family, monitor);
+				return;
+			} catch (OperationCanceledException e) {
+				if (!monitor.retryRequested) {
+					throw e;
+				}
+				// Only this wait was cancelled, not the jobs. Wake any jobs scheduled
+				// after the previous wakeUp, then keep waiting for the whole family.
+			}
+		}
+	}
+
+	private static final class RetryMonitor extends NullProgressMonitor {
+		private final long start = System.nanoTime();
+		private boolean retryRequested;
+
+		@Override
+		public boolean isCanceled() {
+			this.retryRequested |= System.nanoTime() - this.start >= WAKE_UP_INTERVAL_NANOS;
+			return this.retryRequested;
+		}
+	}
+}

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JobFamilyWaitTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JobFamilyWaitTests.java
@@ -1,0 +1,261 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jdt.core.tests.model;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.OperationCanceledException;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.jobs.IJobManager;
+import org.eclipse.core.runtime.jobs.Job;
+
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+
+public class JobFamilyWaitTests extends TestCase {
+	private static final long TIMEOUT_SECONDS = 10;
+	private static final long DELAY_MILLIS = TimeUnit.MINUTES.toMillis(5);
+	private final List<Job> jobs = new ArrayList<>();
+	private ExecutorService executor;
+
+	public JobFamilyWaitTests(String name) {
+		super(name);
+	}
+
+	public static Test suite() {
+		return new TestSuite(JobFamilyWaitTests.class);
+	}
+
+	@Override
+	protected void setUp() throws Exception {
+		super.setUp();
+		this.executor = Executors.newSingleThreadExecutor(runnable -> {
+			Thread thread = new Thread(runnable, "job-family-wait-test");
+			thread.setDaemon(true);
+			return thread;
+		});
+	}
+
+	@Override
+	protected void tearDown() throws Exception {
+		try {
+			for (Job job : this.jobs) {
+				job.cancel();
+			}
+			this.executor.shutdownNow();
+			assertTrue("Waiter thread did not terminate",
+					this.executor.awaitTermination(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+			for (Job job : this.jobs) {
+				assertTrue("Test job did not terminate: " + job,
+						job.join(TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS), null));
+			}
+		} finally {
+			super.tearDown();
+		}
+	}
+
+	public void testEmptyFamily() throws Exception {
+		await(waitFor(Job.getJobManager(), new Object()));
+	}
+
+	public void testSleepingJobRunsWithoutBeingCancelled() throws Exception {
+		Object family = new Object();
+		AtomicBoolean ran = new AtomicBoolean();
+		AtomicBoolean cancelled = new AtomicBoolean();
+		Job job = job(family, monitor -> {
+			ran.set(true);
+			cancelled.set(monitor.isCanceled());
+		});
+		job.schedule(DELAY_MILLIS);
+		await(waitFor(Job.getJobManager(), family));
+		assertTrue("The sleeping job must execute", ran.get());
+		assertFalse("Do not cancel the job to make the wait finish", cancelled.get());
+	}
+
+	public void testJobScheduledAfterWakeUpDoesNotWaitForItsDelay() throws Exception {
+		Object family = new Object();
+		AtomicBoolean ran = new AtomicBoolean();
+		Job job = job(family, monitor -> ran.set(true));
+		AtomicBoolean scheduled = new AtomicBoolean();
+		IJobManager manager = beforeJoin(() -> {
+			if (scheduled.compareAndSet(false, true)) {
+				// This is the exact gap between the initial wakeUp and family join.
+				// The scheduler and the wait below are real, not simulated jobs.
+				job.schedule(DELAY_MILLIS);
+				assertEquals(Job.SLEEPING, job.getState());
+			}
+		});
+		await(waitFor(manager, family));
+		assertTrue("The late sleeping job must execute before returning", ran.get());
+	}
+
+	public void testRunningJobIsStillJoined() throws Exception {
+		Object family = new Object();
+		CountDownLatch running = new CountDownLatch(1);
+		CountDownLatch release = new CountDownLatch(1);
+		CountDownLatch joining = new CountDownLatch(1);
+		Job job = job(family, monitor -> {
+			running.countDown();
+			assertTrue("Test did not release the running job",
+					release.await(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+		});
+		try {
+			job.schedule();
+			assertTrue(running.await(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+			Future<?> wait = waitFor(beforeJoin(joining::countDown), family);
+			assertTrue(joining.await(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+			assertFalse("A running job must not be treated as finished", wait.isDone());
+			release.countDown();
+			await(wait);
+			assertEquals(Status.OK_STATUS, job.getResult());
+		} finally {
+			release.countDown();
+		}
+	}
+
+	public void testUnrelatedFamilyIsNotWoken() throws Exception {
+		Object family = new Object();
+		AtomicBoolean unrelatedRan = new AtomicBoolean();
+		Job unrelated = job(new Object(), monitor -> unrelatedRan.set(true));
+		unrelated.schedule(DELAY_MILLIS);
+		Job selected = job(family, monitor -> { });
+		selected.schedule(DELAY_MILLIS);
+		await(waitFor(Job.getJobManager(), family));
+		assertFalse(unrelatedRan.get());
+		assertEquals(Job.SLEEPING, unrelated.getState());
+	}
+
+	public void testInterruptedJoinIsPropagated() throws Exception {
+		InterruptedException expected = new InterruptedException("test interruption");
+		try {
+			JobFamilyWait.join(beforeJoin(() -> { throw expected; }), new Object());
+			fail("Expected interruption");
+		} catch (InterruptedException actual) {
+			assertSame(expected, actual);
+		}
+	}
+
+	public void testCancellationNotCausedByRetryIsPropagated() throws Exception {
+		OperationCanceledException expected = new OperationCanceledException("test cancellation");
+		try {
+			JobFamilyWait.join(beforeJoin(() -> { throw expected; }), new Object());
+			fail("Expected cancellation");
+		} catch (OperationCanceledException actual) {
+			assertSame(expected, actual);
+		}
+	}
+
+	public void testRunningJobRemainsJoinedAcrossWakeUpRetry() throws Exception {
+		Object family = new Object();
+		CountDownLatch running = new CountDownLatch(1);
+		CountDownLatch release = new CountDownLatch(1);
+		CountDownLatch retry = new CountDownLatch(1);
+		AtomicInteger joins = new AtomicInteger();
+		Job job = job(family, monitor -> {
+			running.countDown();
+			assertTrue("Test did not release the running job",
+					release.await(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+		});
+		try {
+			job.schedule();
+			assertTrue(running.await(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+			Future<?> wait = waitFor(beforeJoin(() -> {
+				if (joins.incrementAndGet() == 2) {
+					retry.countDown();
+				}
+			}), family);
+			assertTrue("Expected another wait after the wake-up interval",
+					retry.await(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+			assertFalse("A retry must not be treated as successful completion", wait.isDone());
+			release.countDown();
+			await(wait);
+			assertEquals(Status.OK_STATUS, job.getResult());
+		} finally {
+			release.countDown();
+		}
+	}
+
+	private Future<?> waitFor(IJobManager manager, Object family) {
+		return this.executor.submit(() -> {
+			JobFamilyWait.join(manager, family);
+			return null;
+		});
+	}
+
+	private void await(Future<?> wait) throws Exception {
+		try {
+			wait.get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+		} catch (TimeoutException e) {
+			fail("Family wait retained the delayed schedule instead of waking the job");
+		}
+	}
+
+	private Job job(Object family, JobBody body) {
+		Job job = new Job("JobFamilyWaitTests") {
+			@Override
+			public boolean belongsTo(Object candidate) {
+				return candidate == family;
+			}
+
+			@Override
+			protected IStatus run(IProgressMonitor monitor) {
+				try {
+					body.run(monitor);
+					return Status.OK_STATUS;
+				} catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+					return Status.CANCEL_STATUS;
+				}
+			}
+		};
+		this.jobs.add(job);
+		return job;
+	}
+
+	private IJobManager beforeJoin(BeforeJoin action) {
+		IJobManager delegate = Job.getJobManager();
+		return (IJobManager) Proxy.newProxyInstance(IJobManager.class.getClassLoader(),
+				new Class<?>[] { IJobManager.class }, (proxy, method, arguments) -> {
+					if ("join".equals(method.getName())) {
+						action.run();
+					}
+					try {
+						return method.invoke(delegate, arguments);
+					} catch (InvocationTargetException e) {
+						throw e.getCause();
+					}
+				});
+	}
+
+	@FunctionalInterface
+	private interface BeforeJoin {
+		void run() throws InterruptedException;
+	}
+
+	@FunctionalInterface
+	private interface JobBody {
+		void run(IProgressMonitor monitor) throws InterruptedException;
+	}
+}

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JobFamilyWaitTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/JobFamilyWaitTests.java
@@ -22,17 +22,17 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-
+import junit.framework.AssertionFailedError;
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.IJobManager;
 import org.eclipse.core.runtime.jobs.Job;
-
-import junit.framework.Test;
-import junit.framework.TestCase;
-import junit.framework.TestSuite;
+import org.junit.runners.model.MultipleFailureException;
 
 public class JobFamilyWaitTests extends TestCase {
 	private static final long TIMEOUT_SECONDS = 10;
@@ -60,20 +60,37 @@ public class JobFamilyWaitTests extends TestCase {
 
 	@Override
 	protected void tearDown() throws Exception {
-		try {
-			for (Job job : this.jobs) {
-				job.cancel();
-			}
-			this.executor.shutdownNow();
-			assertTrue("Waiter thread did not terminate",
-					this.executor.awaitTermination(TIMEOUT_SECONDS, TimeUnit.SECONDS));
-			for (Job job : this.jobs) {
-				assertTrue("Test job did not terminate: " + job,
-						job.join(TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS), null));
-			}
-		} finally {
-			super.tearDown();
+		List<Throwable> failures = new ArrayList<>();
+		for (Job job : this.jobs) {
+			collectCleanupFailure(failures, () -> job.cancel());
 		}
+		collectCleanupFailure(failures, () -> this.executor.shutdownNow());
+		collectCleanupFailure(failures, this::awaitExecutorTermination);
+		for (Job job : this.jobs) {
+			collectCleanupFailure(failures, () -> awaitJobTermination(job));
+		}
+		collectCleanupFailure(failures, () -> super.tearDown());
+		for (Throwable failure : failures) {
+			if (failure instanceof InterruptedException) {
+				Thread.currentThread().interrupt();
+				break;
+			}
+		}
+		MultipleFailureException.assertEmpty(failures);
+	}
+
+	private static void collectCleanupFailure(List<Throwable> failures, CleanupStep step) {
+		try {
+			step.run();
+		} catch (Throwable failure) {
+			// Report after attempting the remaining cleanup, including assertion errors.
+			failures.add(failure);
+		}
+	}
+
+	@FunctionalInterface
+	private interface CleanupStep {
+		void run() throws Exception;
 	}
 
 	public void testEmptyFamily() throws Exception {
@@ -150,7 +167,9 @@ public class JobFamilyWaitTests extends TestCase {
 	public void testInterruptedJoinIsPropagated() throws Exception {
 		InterruptedException expected = new InterruptedException("test interruption");
 		try {
-			JobFamilyWait.join(beforeJoin(() -> { throw expected; }), new Object());
+			JobFamilyWait.join(beforeJoin(() -> {
+				throw expected;
+			}), new Object());
 			fail("Expected interruption");
 		} catch (InterruptedException actual) {
 			assertSame(expected, actual);
@@ -160,7 +179,9 @@ public class JobFamilyWaitTests extends TestCase {
 	public void testCancellationNotCausedByRetryIsPropagated() throws Exception {
 		OperationCanceledException expected = new OperationCanceledException("test cancellation");
 		try {
-			JobFamilyWait.join(beforeJoin(() -> { throw expected; }), new Object());
+			JobFamilyWait.join(beforeJoin(() -> {
+				throw expected;
+			}), new Object());
 			fail("Expected cancellation");
 		} catch (OperationCanceledException actual) {
 			assertSame(expected, actual);
@@ -195,6 +216,70 @@ public class JobFamilyWaitTests extends TestCase {
 		} finally {
 			release.countDown();
 		}
+	}
+
+
+	public void testCleanupContinuesAfterExecutorFailure() throws Exception {
+		assertCleanupContinues(true, false);
+	}
+
+	public void testCleanupContinuesAfterJobFailure() throws Exception {
+		assertCleanupContinues(false, true);
+	}
+
+	public void testCleanupRetainsMultipleFailures() throws Exception {
+		assertCleanupContinues(true, true);
+	}
+
+	private void assertCleanupContinues(boolean executorFails, boolean jobFails) throws Exception {
+		AssertionFailedError executorFailure = new AssertionFailedError("executor cleanup failure");
+		AssertionFailedError jobFailure = new AssertionFailedError("job cleanup failure");
+		List<Job> joined = new ArrayList<>();
+		JobFamilyWaitTests fixture = new JobFamilyWaitTests("cleanup fixture") {
+			@Override
+			void awaitExecutorTermination() throws InterruptedException {
+				super.awaitExecutorTermination();
+				if (executorFails) {
+					throw executorFailure;
+				}
+			}
+
+			@Override
+			void awaitJobTermination(Job job) throws InterruptedException {
+				joined.add(job);
+				super.awaitJobTermination(job);
+				if (jobFails && joined.size() == 1) {
+					throw jobFailure;
+				}
+			}
+		};
+		fixture.setUp();
+		fixture.job(new Object(), monitor -> { });
+		fixture.job(new Object(), monitor -> { });
+		Throwable observed = null;
+		try {
+			fixture.tearDown();
+		} catch (Throwable failure) {
+			observed = failure;
+		}
+		assertEquals("Every owned job must be joined even after a cleanup failure", fixture.jobs, joined);
+		if (executorFails && jobFails) {
+			assertTrue("Both cleanup failures must be retained", observed instanceof MultipleFailureException);
+			MultipleFailureException multiple = (MultipleFailureException) observed;
+			assertEquals(List.of(executorFailure, jobFailure), multiple.getFailures());
+		} else {
+			assertSame("Preserve the original cleanup failure", executorFails ? executorFailure : jobFailure, observed);
+		}
+	}
+
+	void awaitExecutorTermination() throws InterruptedException {
+		assertTrue("Waiter thread did not terminate",
+				this.executor.awaitTermination(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+	}
+
+	void awaitJobTermination(Job job) throws InterruptedException {
+		assertTrue("Test job did not terminate: " + job,
+				job.join(TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS), null));
 	}
 
 	private Future<?> waitFor(IJobManager manager, Object family) {


### PR DESCRIPTION
## What it does

Updates `AbstractJavaModelTests.waitForSnapShot()` to keep waking the
snapshot job family while waiting for it to finish.

The previous implementation performs two separate operations:

1. Wake the snapshot job family.
2. Join the snapshot job family.

A delayed snapshot job scheduled between these operations can retain
its original delay while the join waits for it. The initial `wakeUp()`
does not cover jobs scheduled afterwards.

This change introduces a package-private `JobFamilyWait` helper. It
uses a monotonic, one-second retry threshold to periodically cancel
only the current join operation, wake the family again, and resume
waiting.

The existing intention is preserved: snapshot jobs should be woken
and allowed to finish before the test continues. Specifically, the
helper:

- does not cancel the jobs themselves or wake unrelated job families;
- does not treat a retry as successful completion;
- continues waiting for running jobs, including across retries;
- propagates interruption and cancellation not initiated by its
  retry monitor.

The implementation introduces neither an additional worker thread nor
an overall timeout that would allow the test to continue with unfinished
snapshot work.

This addresses a reproducible scheduling gap in the test infrastructure.
It is not a general deadlock detector and does not claim to explain
every observed JDT Core timeout.

## How to test

Run `JobFamilyWaitTests` in the JDT Core test environment. The class is
also registered in `AllJavaModelTests`.

The eight regression tests exercise real Eclipse jobs and the real job
manager. A proxy is used only to inject controlled sequencing or
exceptions at the join boundary.

Coverage includes an empty family, sleeping jobs, a delayed job
scheduled after the initial wake-up, running jobs, a running job
spanning a retry, unrelated job families, interruption, and unrelated
cancellation.

The key regression test schedules a five-minute delayed job between
the initial `wakeUp()` and `join()`. With the fix, the job must be woken
by a subsequent iteration rather than retaining its original delay.

Focused before/after validation has already been performed:

- **Without the fix:** the initial seven-test suite produced exactly
  one failure. The test inserting the delayed job between `wakeUp()`
  and `join()` exceeded its ten-second guard; the other six tests
  passed.
- **With the fix:** all eight tests passed on Java 21 and in five
  repeated runs on Java 26.

Validation runs:

- [Baseline without the fix](https://github.com/carstenartur/eclipse.jdt.core/actions/runs/34678721981)
- [Focused candidate QA](https://github.com/carstenartur/eclipse.jdt.core/actions/runs/34679157443)

The focused tests used a standalone Maven harness with
`org.eclipse.core.jobs:3.15.900`. These results do not establish that the
complete JDT Core Tycho/PDE suite or the original Windows CI environment
passes; that integration validation remains outstanding.

The standalone QA harness and workflow are not included in this PR.

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
- [x] I have read the [contribution guidelines](https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md)

Assisted-by: OpenAI ChatGPT
Assisted-by: GitHub Copilot