### PR TITLE
Keep headless Core timeout diagnostics independent of screenshots

### DIFF
--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/RunAllJdtModelTestsTracing.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/RunAllJdtModelTestsTracing.java
@@ -22,6 +22,7 @@ import org.junit.runners.Suite.SuiteClasses;
 
 @RunWith(TracingSuite.class)
 @SuiteClasses({ RunFormatterTests.class, RunAllTests.class, AllJavaModelTests.class })
-@TracingOptions(stackDumpTimeoutSeconds = 60)
+// These headless tests have no UI to capture. Keep timeout thread dumps without requiring X11.
+@TracingOptions(stackDumpTimeoutSeconds = 60, maxScreenshotCount = 0)
 public class RunAllJdtModelTestsTracing {
 }

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/RunAllTestsTracing.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/dom/RunAllTestsTracing.java
@@ -20,6 +20,7 @@ import org.junit.runners.Suite.SuiteClasses;
 
 @RunWith(TracingSuite.class)
 @SuiteClasses(RunAllTests.class)
-@TracingOptions(stackDumpTimeoutSeconds = 60)
+// These headless tests have no UI to capture. Keep timeout thread dumps without requiring X11.
+@TracingOptions(stackDumpTimeoutSeconds = 60, maxScreenshotCount = 0)
 public class RunAllTestsTracing {
 }

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AllJavaModelTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AllJavaModelTests.java
@@ -85,6 +85,9 @@ private static Class[] getAllTestClasses() {
 		WorkingCopyNotInClasspathTests.class,
 		HierarchyOnWorkingCopiesTests.class,
 
+		// Headless tracing configuration
+		TracingSuiteConfigurationTests.class,
+
 		// test IJavaModel
 		JavaModelTests.class,
 

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AllJavaModelTestsTracing.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/AllJavaModelTestsTracing.java
@@ -20,6 +20,7 @@ import org.junit.runners.Suite.SuiteClasses;
 
 @RunWith(TracingSuite.class)
 @SuiteClasses(AllJavaModelTests.class)
-@TracingOptions(stackDumpTimeoutSeconds = 60)
+// These headless tests have no UI to capture. Keep timeout thread dumps without requiring X11.
+@TracingOptions(stackDumpTimeoutSeconds = 60, maxScreenshotCount = 0)
 public class AllJavaModelTestsTracing {
 }

--- a/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/TracingSuiteConfigurationTests.java
+++ b/org.eclipse.jdt.core.tests.model/src/org/eclipse/jdt/core/tests/model/TracingSuiteConfigurationTests.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *******************************************************************************/
+package org.eclipse.jdt.core.tests.model;
+
+import org.eclipse.jdt.core.tests.RunAllJdtModelTestsTracing;
+import org.eclipse.jdt.core.tests.dom.RunAllTestsTracing;
+import org.eclipse.test.TracingSuite.TracingOptions;
+
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+
+public class TracingSuiteConfigurationTests extends TestCase {
+	public TracingSuiteConfigurationTests(String name) {
+		super(name);
+	}
+
+	public static Test suite() {
+		return new TestSuite(TracingSuiteConfigurationTests.class);
+	}
+
+	public void testCombinedTracingSuite() {
+		assertHeadlessTracing(RunAllJdtModelTestsTracing.class);
+	}
+
+	public void testDomTracingSuite() {
+		assertHeadlessTracing(RunAllTestsTracing.class);
+	}
+
+	public void testModelTracingSuite() {
+		assertHeadlessTracing(AllJavaModelTestsTracing.class);
+	}
+
+	private void assertHeadlessTracing(Class<?> suite) {
+		TracingOptions options = suite.getAnnotation(TracingOptions.class);
+		assertNotNull("Explicit tracing options are required for " + suite.getName(), options);
+		assertEquals("Headless Core tests must not depend on a display server", 0, options.maxScreenshotCount());
+		assertEquals("Keep the existing timeout diagnostics", 60L, options.stackDumpTimeoutSeconds());
+		assertTrue("Keep reporting test starts", options.logTestStart());
+	}
+}


### PR DESCRIPTION
## What it does

Disables optional timeout screenshots in the three headless JDT Core
tracing entrypoints:

- `RunAllJdtModelTestsTracing`
- `RunAllTestsTracing`
- `AllJavaModelTestsTracing`

Each entrypoint explicitly specifies:

```java
@TracingOptions(stackDumpTimeoutSeconds = 60, maxScreenshotCount = 0)
```

The existing 60-second timeout threshold, thread dumps, and test-start
logging remain unchanged.

The Platform `TracingSuite` timeout task can attempt to capture a
screenshot while running on its diagnostic timer thread. If screenshot
capture throws an unchecked exception, that exception can escape the
timeout task and terminate the timer thread. Subsequent timeout
monitoring can then be lost, and further scheduling on that timer can
fail.

For these headless Core suites, screenshot capture introduces a
dependency on display infrastructure without providing an application
UI to inspect.

This PR takes a narrowly scoped JDT-side approach: explicitly disable
that optional diagnostic feature for these entrypoints rather than
change shared Platform test infrastructure or the behavior of UI test
suites.

This mitigates a secondary failure in timeout diagnostics. It does not
fix the underlying reason why an individual test timed out, suppress
test assertions, or increase timeout limits.

## How to test

Run `TracingSuiteConfigurationTests` in the JDT Core test environment.
The class is also registered in `AllJavaModelTests`.

The three configuration tests verify that each tracing entrypoint:

- explicitly disables screenshots;
- retains its 60-second timeout;
- retains test-start logging.

Additional focused before/after QA used the unchanged Platform
`TracingSuite` implementation from revision
`76f1695ed861a4073fab2df42a2996d88e233468`, together with the actual JDT
entrypoint sources.

That QA harness uses placeholder child suites and a QA-only screenshot
replacement that throws a controlled runtime exception. In addition
to the three configuration tests, a timer-survival test checks that
timeout diagnostics complete and that the same timer remains able to
execute a subsequent task.

Before the change, all four checks failed as expected. After the
change, all four passed on Java 21 and Java 26.

[Focused before/after QA](https://github.com/carstenartur/eclipse.jdt.core/actions/runs/34679157443)

The screenshot failure was deliberately injected. This validation
demonstrates the controlled failure path; it is not an end-to-end
reproduction of an actual X11 or display-server failure.

The focused harness does not run the complete JDT test suite. Full
Tycho/PDE integration and validation in the original Windows CI
environment remain outstanding.

Only the entrypoint configuration changes and the three configuration
tests are included in this PR. The additional timer-survival test,
fault-injection harness, and QA workflow are not included.

## Author checklist

- [ ] I have thoroughly tested my changes
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
- [x] I have read the [contribution guidelines](https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md)

Assisted-by: OpenAI ChatGPT
Assisted-by: GitHub Copilot